### PR TITLE
fix(cli): fall back to uv pip when pip is unavailable

### DIFF
--- a/nanobot/apps/cli/service.py
+++ b/nanobot/apps/cli/service.py
@@ -734,7 +734,7 @@ class CliAppManager:
         if self._pip_available():
             prefix = [sys.executable, "-m", "pip", "uninstall", "-y"]
         elif shutil.which("uv"):
-            prefix = ["uv", "pip", "uninstall", "--python", sys.executable, "-y"]
+            prefix = ["uv", "pip", "uninstall", "--python", sys.executable]
         else:
             raise CliAppError("pip is not available and uv is not installed")
         distribution = str((installed_entry or {}).get("pip_distribution") or "").strip()

--- a/nanobot/apps/cli/service.py
+++ b/nanobot/apps/cli/service.py
@@ -723,7 +723,7 @@ class CliAppManager:
             if pip_available:
                 prefix.extend(["--upgrade", "--force-reinstall"])
             else:
-                prefix.append("--upgrade")
+                prefix.extend(["--upgrade", "--reinstall"])
         return prefix + args
 
     def _pip_uninstall_argv(

--- a/nanobot/apps/cli/service.py
+++ b/nanobot/apps/cli/service.py
@@ -699,15 +699,31 @@ class CliAppManager:
             return None
         return args[0]
 
+    @staticmethod
+    def _pip_available() -> bool:
+        """Return True if pip is importable for the current interpreter."""
+        from importlib.util import find_spec
+
+        return find_spec("pip") is not None
+
     def _pip_install_argv(self, app: dict[str, Any], *, update: bool = False) -> list[str]:
         install_cmd = str(app.get("install_cmd") or "")
         if not _is_pip_install_command(install_cmd) or _has_shell_meta(install_cmd):
             raise CliAppError("unsupported pip install command")
         tokens = shlex.split(install_cmd)
         args = tokens[2:] if tokens[:2] == ["pip", "install"] else tokens[4:]
-        prefix = [sys.executable, "-m", "pip", "install"]
+        pip_available = self._pip_available()
+        if pip_available:
+            prefix = [sys.executable, "-m", "pip", "install"]
+        elif shutil.which("uv"):
+            prefix = ["uv", "pip", "install", "--python", sys.executable]
+        else:
+            raise CliAppError("pip is not available and uv is not installed")
         if update:
-            prefix.extend(["--upgrade", "--force-reinstall"])
+            if pip_available:
+                prefix.extend(["--upgrade", "--force-reinstall"])
+            else:
+                prefix.append("--upgrade")
         return prefix + args
 
     def _pip_uninstall_argv(
@@ -715,18 +731,24 @@ class CliAppManager:
         app: dict[str, Any],
         installed_entry: dict[str, Any] | None = None,
     ) -> list[str]:
+        if self._pip_available():
+            prefix = [sys.executable, "-m", "pip", "uninstall", "-y"]
+        elif shutil.which("uv"):
+            prefix = ["uv", "pip", "uninstall", "--python", sys.executable, "-y"]
+        else:
+            raise CliAppError("pip is not available and uv is not installed")
         distribution = str((installed_entry or {}).get("pip_distribution") or "").strip()
         if distribution:
-            return [sys.executable, "-m", "pip", "uninstall", "-y", distribution]
+            return [*prefix, distribution]
         uninstall_cmd = str(app.get("uninstall_cmd") or "")
         packages = _pip_uninstall_args_from_command(uninstall_cmd)
         if packages:
-            return [sys.executable, "-m", "pip", "uninstall", "-y", *packages]
+            return [*prefix, *packages]
         package = str(app.get("pip_package") or "").strip() or self._pip_package_from_install(app)
         if not package:
             entry_point = str(app.get("entry_point") or "").strip()
             package = entry_point if entry_point.startswith("cli-anything-") else f"cli-anything-{_brand_key(str(app['name']))}"
-        return [sys.executable, "-m", "pip", "uninstall", "-y", package]
+        return [*prefix, package]
 
     def _npm_argv(self, app: dict[str, Any], action: str) -> list[str]:
         npm = shutil.which("npm")

--- a/tests/cli_apps/test_service.py
+++ b/tests/cli_apps/test_service.py
@@ -843,6 +843,5 @@ def test_uninstall_uses_uv_pip_when_pip_unavailable(
         "uninstall",
         "--python",
         sys.executable,
-        "-y",
         "suno-cli",
     ]

--- a/tests/cli_apps/test_service.py
+++ b/tests/cli_apps/test_service.py
@@ -815,6 +815,34 @@ def test_install_uses_uv_pip_when_pip_unavailable(
     ]
 
 
+def test_update_uses_uv_pip_reinstall_when_pip_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _manager(tmp_path)
+    monkeypatch.setattr(CliAppManager, "_pip_available", staticmethod(lambda: False))
+    monkeypatch.setattr(
+        "nanobot.apps.cli.service.shutil.which",
+        lambda command: "/usr/bin/uv" if command == "uv" else None,
+    )
+
+    argv = manager._pip_install_argv(
+        {"name": "gimp", "install_cmd": "pip install cli-anything-gimp"},
+        update=True,
+    )
+
+    assert argv == [
+        "uv",
+        "pip",
+        "install",
+        "--python",
+        sys.executable,
+        "--upgrade",
+        "--reinstall",
+        "cli-anything-gimp",
+    ]
+
+
 def test_uninstall_uses_uv_pip_when_pip_unavailable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/cli_apps/test_service.py
+++ b/tests/cli_apps/test_service.py
@@ -283,6 +283,7 @@ def test_install_dispatches_safe_pip_and_installs_skill(
         return subprocess.CompletedProcess(argv, 0, stdout="ok", stderr="")
 
     monkeypatch.setattr(manager, "_run_argv", fake_run)
+    monkeypatch.setattr(manager, "_pip_available", staticmethod(lambda: True))
     monkeypatch.setattr(
         manager,
         "_fetch_skill_content",
@@ -572,6 +573,7 @@ def test_uninstall_uses_safe_python_m_pip_uninstall_command(
         return subprocess.CompletedProcess(argv, 0, stdout="ok", stderr="")
 
     monkeypatch.setattr(manager, "_run_argv", fake_run)
+    monkeypatch.setattr(manager, "_pip_available", staticmethod(lambda: True))
 
     payload = manager.uninstall("suno")
 
@@ -599,6 +601,7 @@ def test_uninstall_uses_recorded_pip_distribution(
         return subprocess.CompletedProcess(argv, 0, stdout="ok", stderr="")
 
     monkeypatch.setattr(manager, "_run_argv", fake_run)
+    monkeypatch.setattr(manager, "_pip_available", staticmethod(lambda: True))
 
     payload = manager.uninstall("gimp")
 
@@ -621,6 +624,7 @@ def test_uninstall_keeps_state_when_entry_point_still_available(
         "_run_argv",
         lambda argv, *, timeout: subprocess.CompletedProcess(argv, 0, stdout="ok", stderr=""),
     )
+    monkeypatch.setattr(manager, "_pip_available", staticmethod(lambda: True))
     monkeypatch.setattr(
         "nanobot.apps.cli.service.shutil.which",
         lambda command: "/usr/local/bin/cli-anything-gimp" if command == "cli-anything-gimp" else None,

--- a/tests/cli_apps/test_service.py
+++ b/tests/cli_apps/test_service.py
@@ -777,3 +777,68 @@ def test_run_blocks_working_dir_outside_workspace(tmp_path: Path) -> None:
 
     with pytest.raises(CliAppError, match="outside the configured workspace"):
         manager.run("gimp", working_dir="/etc", restrict_to_workspace=True)
+
+
+def test_install_uses_uv_pip_when_pip_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _manager(tmp_path)
+    _seed_catalog(manager)
+    calls: list[list[str]] = []
+
+    def fake_run(argv: list[str], *, timeout: int) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(CliAppManager, "_pip_available", staticmethod(lambda: False))
+    monkeypatch.setattr(
+        "nanobot.apps.cli.service.shutil.which",
+        lambda command: "/usr/bin/uv" if command == "uv" else None,
+    )
+    monkeypatch.setattr(manager, "_run_argv", fake_run)
+    monkeypatch.setattr(manager, "_fetch_skill_content", lambda app: None)
+
+    manager.install("gimp")
+
+    assert calls[0][:6] == [
+        "uv",
+        "pip",
+        "install",
+        "--python",
+        sys.executable,
+        "cli-anything-gimp",
+    ]
+
+
+def test_uninstall_uses_uv_pip_when_pip_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _manager(tmp_path)
+    _seed_catalog(manager)
+    manager._save_installed({"suno": {"entry_point": "suno"}})
+    calls: list[list[str]] = []
+
+    def fake_run(argv: list[str], *, timeout: int) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(CliAppManager, "_pip_available", staticmethod(lambda: False))
+    monkeypatch.setattr(
+        "nanobot.apps.cli.service.shutil.which",
+        lambda command: "/usr/bin/uv" if command == "uv" else None,
+    )
+    monkeypatch.setattr(manager, "_run_argv", fake_run)
+
+    manager.uninstall("suno")
+
+    assert calls[0] == [
+        "uv",
+        "pip",
+        "uninstall",
+        "--python",
+        sys.executable,
+        "-y",
+        "suno-cli",
+    ]


### PR DESCRIPTION
Fixes #4158

## What changed

When nanobot is installed via `uv tool install`, `sys.executable` points to a Python that does not have `pip` available as a module. The `CliAppManager._pip_install_argv()` and `_pip_uninstall_argv()` methods always used `[sys.executable, "-m", "pip", ...]`, which fails in that environment with `ModuleNotFoundError`.

The fix adds a `_pip_available()` helper that checks `importlib.util.find_spec("pip")`. When pip is not available and `uv` is on PATH, the install and uninstall commands fall back to:

```
uv pip install --python <sys.executable> <packages>
uv pip uninstall --python <sys.executable> -y <packages>
```

If neither pip nor uv is available, a clear `CliAppError` is raised.

**Files changed:**
- `nanobot/apps/cli/service.py` -- added `_pip_available()`, updated `_pip_install_argv()` and `_pip_uninstall_argv()` with uv fallback
- `tests/cli_apps/test_service.py` -- added two tests: install and uninstall with pip unavailable and uv available

## Verification

```
ruff check nanobot/apps/cli/service.py tests/cli_apps/test_service.py  -- All checks passed
pytest tests/cli_apps/test_service.py -v  -- 24/24 passed (including 2 new tests)
```

No shell execution introduced. No dependencies added. Existing behavior is unchanged when pip is available.
