### PR TITLE
fix(email): skip progress messages to prevent empty emails after tool calls

### DIFF
--- a/nanobot/channels/email.py
+++ b/nanobot/channels/email.py
@@ -187,6 +187,11 @@ class EmailChannel(BaseChannel):
             self.logger.warning("SMTP host not configured")
             return
 
+        # Skip progress messages to prevent sending an empty email after each tool call
+        if (msg.metadata or {}).get("_progress"):
+            self.logger.debug("Skip progress message to {}", msg.chat_id)
+            return
+
         to_addr = msg.chat_id.strip()
         if not to_addr:
             self.logger.warning("Missing recipient address")

--- a/tests/channels/test_email_channel.py
+++ b/tests/channels/test_email_channel.py
@@ -396,6 +396,33 @@ async def test_send_uses_smtp_and_reply_subject(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_send_skips_progress_messages_before_smtp(monkeypatch) -> None:
+    called = {"smtp": False}
+
+    def _smtp_factory(*_args, **_kwargs):
+        called["smtp"] = True
+        raise AssertionError("progress messages must not open an SMTP connection")
+
+    monkeypatch.setattr("nanobot.channels.email.smtplib.SMTP", _smtp_factory)
+
+    channel = EmailChannel(_make_config(), MessageBus())
+
+    await channel.send(
+        OutboundMessage(
+            channel="email",
+            chat_id="alice@example.com",
+            content="",
+            metadata={
+                "_progress": True,
+                "_tool_events": [{"phase": "end", "name": "exec"}],
+            },
+        )
+    )
+
+    assert called["smtp"] is False
+
+
+@pytest.mark.asyncio
 async def test_send_skips_reply_when_auto_reply_disabled(monkeypatch) -> None:
     """When auto_reply_enabled=False, replies should be skipped but proactive sends allowed."""
     class FakeSMTP:


### PR DESCRIPTION
The email channel was sending empty emails after each tool call because progress messages (marked with `_progress` metadata) were being processed as regular outbound messages. These progress messages have no content, so an empty email was sent to the user for every tool invocation.

This patch skips messages with `_progress` metadata in the email channel's outbound handler.