### PR TITLE
fix(session): reset out-of-range last_consolidated to recover hidden history (#4066)

### DIFF
--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -101,7 +101,11 @@ class Session:
 
     def __post_init__(self) -> None:
         # An out-of-range offset (corrupt metadata) would hide all history; reset it.
-        if not 0 <= self.last_consolidated <= len(self.messages):
+        if (
+            isinstance(self.last_consolidated, bool)
+            or not isinstance(self.last_consolidated, int)
+            or not 0 <= self.last_consolidated <= len(self.messages)
+        ):
             self.last_consolidated = 0
 
     @staticmethod

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -99,6 +99,11 @@ class Session:
     metadata: dict[str, Any] = field(default_factory=dict)
     last_consolidated: int = 0  # Number of messages already consolidated to files
 
+    def __post_init__(self) -> None:
+        # An out-of-range offset (corrupt metadata) would hide all history; reset it.
+        if not 0 <= self.last_consolidated <= len(self.messages):
+            self.last_consolidated = 0
+
     @staticmethod
     def _annotate_message_time(message: dict[str, Any], content: Any) -> Any:
         """Expose persisted turn timestamps to the model for relative-date reasoning.

--- a/tests/agent/test_session_atomic.py
+++ b/tests/agent/test_session_atomic.py
@@ -205,7 +205,8 @@ class TestRepairCorruptFile:
 
         session = mgr._load("test:badts")
         assert session is not None
-        assert session.last_consolidated == 5
+        # offset 5 exceeds the single loaded message; reset to avoid hiding history (#4066)
+        assert session.last_consolidated == 0
         assert isinstance(session.created_at, datetime)
 
     def test_read_session_file_repairs_corrupt_jsonl(self, tmp_path: Path):

--- a/tests/session/test_consolidated_offset_clamp.py
+++ b/tests/session/test_consolidated_offset_clamp.py
@@ -1,9 +1,12 @@
 """Reset a corrupt last_consolidated offset instead of hiding history (#4066)."""
 
-from nanobot.session.manager import Session
+import json
+from pathlib import Path
+
+from nanobot.session.manager import Session, SessionManager
 
 
-def _session(count: int, last_consolidated: int) -> Session:
+def _session(count: int, last_consolidated: object) -> Session:
     msgs = [{"role": "user", "content": f"msg{i}"} for i in range(count)]
     return Session(key="chan:chat", messages=msgs, last_consolidated=last_consolidated)
 
@@ -11,6 +14,44 @@ def _session(count: int, last_consolidated: int) -> Session:
 def test_out_of_range_offset_is_reset():
     assert _session(10, 999).last_consolidated == 0
     assert _session(3, -5).last_consolidated == 0
+
+
+def test_non_integer_offset_is_reset():
+    for offset in ("999", None, 0.5, True):
+        assert _session(3, offset).last_consolidated == 0
+
+
+def test_loaded_corrupt_offset_keeps_messages(tmp_path: Path):
+    offsets = {
+        "string": "999",
+        "null": None,
+        "float": 0.5,
+        "bool": True,
+    }
+
+    for name, offset in offsets.items():
+        manager = SessionManager(tmp_path / name)
+        path = manager._get_session_path("chan:chat")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        message = {"role": "user", "content": f"survived {name}"}
+        path.write_text(
+            "\n".join([
+                json.dumps({
+                    "_type": "metadata",
+                    "key": "chan:chat",
+                    "metadata": {},
+                    "last_consolidated": offset,
+                }),
+                json.dumps(message),
+            ]) + "\n",
+            encoding="utf-8",
+        )
+
+        session = manager.get_or_create("chan:chat")
+
+        assert session.messages == [message]
+        assert session.last_consolidated == 0
+        assert session.get_history(max_messages=10) == [message]
 
 
 def test_valid_offset_is_preserved():

--- a/tests/session/test_consolidated_offset_clamp.py
+++ b/tests/session/test_consolidated_offset_clamp.py
@@ -1,0 +1,19 @@
+"""Reset a corrupt last_consolidated offset instead of hiding history (#4066)."""
+
+from nanobot.session.manager import Session
+
+
+def _session(count: int, last_consolidated: int) -> Session:
+    msgs = [{"role": "user", "content": f"msg{i}"} for i in range(count)]
+    return Session(key="chan:chat", messages=msgs, last_consolidated=last_consolidated)
+
+
+def test_out_of_range_offset_is_reset():
+    assert _session(10, 999).last_consolidated == 0
+    assert _session(3, -5).last_consolidated == 0
+
+
+def test_valid_offset_is_preserved():
+    session = _session(10, 4)
+    assert session.last_consolidated == 4
+    assert len(session.get_history()) == 6


### PR DESCRIPTION
Closes #4066

A corrupt or desynced `last_consolidated` offset (e.g. larger than the message count) made `get_history()` slice the whole history away, leaving the agent with an empty session. Now an out-of-range offset is treated as untrustworthy and reset to 0 in `Session.__post_init__`, re-exposing the messages.
