### PR TITLE
feat(transcription): add Xiaomi MiMo ASR provider (mimo-v2.5-asr)

### DIFF
--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -50,7 +50,7 @@ class BaseChannel(ABC):
         self._running = False
 
     async def transcribe_audio(self, file_path: str | Path) -> str:
-        """Transcribe an audio file (Whisper or Xiaomi MiMo ASR). Returns empty string on failure."""
+        """Transcribe an audio file via Whisper (OpenAI or Groq) or Xiaomi MiMo ASR. Returns empty string on failure."""
         if not self.transcription_api_key:
             return ""
         try:

--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -50,13 +50,20 @@ class BaseChannel(ABC):
         self._running = False
 
     async def transcribe_audio(self, file_path: str | Path) -> str:
-        """Transcribe an audio file via Whisper (OpenAI or Groq). Returns empty string on failure."""
+        """Transcribe an audio file (Whisper or Xiaomi MiMo ASR). Returns empty string on failure."""
         if not self.transcription_api_key:
             return ""
         try:
             if self.transcription_provider == "openai":
                 from nanobot.providers.transcription import OpenAITranscriptionProvider
                 provider = OpenAITranscriptionProvider(
+                    api_key=self.transcription_api_key,
+                    api_base=self.transcription_api_base or None,
+                    language=self.transcription_language or None,
+                )
+            elif self.transcription_provider == "xiaomi":
+                from nanobot.providers.transcription import XiaomiASRTranscriptionProvider
+                provider = XiaomiASRTranscriptionProvider(
                     api_key=self.transcription_api_key,
                     api_base=self.transcription_api_base or None,
                     language=self.transcription_language or None,

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -148,6 +148,8 @@ class ChannelManager:
         try:
             if provider == "openai":
                 return self.config.providers.openai.api_key
+            if provider == "xiaomi":
+                return self.config.providers.xiaomi_mimo.api_key
             return self.config.providers.groq.api_key
         except AttributeError:
             return ""
@@ -157,6 +159,8 @@ class ChannelManager:
         try:
             if provider == "openai":
                 return self.config.providers.openai.api_base or ""
+            if provider == "xiaomi":
+                return self.config.providers.xiaomi_mimo.api_base or ""
             return self.config.providers.groq.api_base or ""
         except AttributeError:
             return ""

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -39,7 +39,7 @@ class ChannelsConfig(Base):
     show_reasoning: bool = True  # surface model reasoning when channel implements it
     extract_document_text: bool = True  # extract text from document attachments before sending to the model
     send_max_retries: int = Field(default=3, ge=0, le=10)  # Max delivery attempts (initial send included)
-    transcription_provider: str = "groq"  # Voice transcription backend: "groq" or "openai"
+    transcription_provider: str = "groq"  # Voice transcription backend: "groq", "openai", or "xiaomi"
     transcription_language: str | None = Field(default=None, pattern=r"^[a-z]{2,3}$")  # Optional ISO-639-1 hint for audio transcription
 
 

--- a/nanobot/providers/transcription.py
+++ b/nanobot/providers/transcription.py
@@ -258,7 +258,15 @@ async def _post_xiaomi_asr_with_retry(
 
     # Determine MIME type from file extension
     suffix = path.suffix.lower()
-    mime_map = {".wav": "audio/wav", ".mp3": "audio/mpeg"}
+    mime_map = {
+        ".wav": "audio/wav",
+        ".mp3": "audio/mpeg",
+        ".ogg": "audio/ogg",
+        ".opus": "audio/ogg",
+        ".m4a": "audio/mp4",
+        ".webm": "audio/webm",
+        ".flac": "audio/flac",
+    }
     mime_type = mime_map.get(suffix, "audio/wav")
 
     headers = {

--- a/nanobot/providers/transcription.py
+++ b/nanobot/providers/transcription.py
@@ -1,6 +1,8 @@
-"""Voice transcription providers (Groq and OpenAI Whisper)."""
+"""Voice transcription providers (Groq, OpenAI Whisper, Xiaomi MiMo ASR)."""
 
 import asyncio
+import base64
+import json
 import os
 from pathlib import Path
 
@@ -8,6 +10,7 @@ import httpx
 from loguru import logger
 
 _TRANSCRIPTIONS_PATH = "audio/transcriptions"
+_CHAT_COMPLETIONS_PATH = "chat/completions"
 
 
 def _resolve_transcription_url(api_base: str | None, default_url: str) -> str:
@@ -217,5 +220,174 @@ class GroqTranscriptionProvider:
             path=path,
             model="whisper-large-v3",
             provider_label="Groq",
+            language=self.language,
+        )
+
+
+def _resolve_chat_completions_url(api_base: str | None, default_url: str) -> str:
+    """Resolve the chat completions endpoint URL for Xiaomi ASR."""
+    if not api_base:
+        return default_url
+    base = api_base.rstrip("/")
+    if base.endswith(_CHAT_COMPLETIONS_PATH):
+        return base
+    return f"{base}/{_CHAT_COMPLETIONS_PATH}"
+
+
+async def _post_xiaomi_asr_with_retry(
+    url: str,
+    *,
+    api_key: str | None,
+    path: Path,
+    model: str,
+    provider_label: str,
+    language: str | None = None,
+) -> str:
+    """POST audio to Xiaomi MiMo ASR endpoint via chat completions API.
+
+    Xiaomi MiMo ASR uses the /v1/chat/completions endpoint with base64-encoded
+    audio in input_audio format, rather than the standard Whisper multipart upload.
+    """
+    try:
+        data = path.read_bytes()
+    except OSError as e:
+        logger.exception("{} transcription error: cannot read audio file: {}", provider_label, e)
+        return ""
+
+    audio_b64 = base64.b64encode(data).decode("ascii")
+
+    # Determine MIME type from file extension
+    suffix = path.suffix.lower()
+    mime_map = {".wav": "audio/wav", ".mp3": "audio/mpeg"}
+    mime_type = mime_map.get(suffix, "audio/wav")
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    body: dict = {
+        "model": model,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_audio",
+                        "input_audio": {
+                            "data": f"data:{mime_type};base64,{audio_b64}",
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+    if language:
+        body["asr_options"] = {"language": language}
+
+    async with httpx.AsyncClient() as client:
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                response = await client.post(
+                    url, headers=headers, content=json.dumps(body), timeout=60.0
+                )
+            except _RETRYABLE_EXCEPTIONS as e:
+                if attempt < _MAX_RETRIES:
+                    logger.warning(
+                        "{} transcription transient error (attempt {}/{}): {}",
+                        provider_label,
+                        attempt + 1,
+                        _MAX_RETRIES + 1,
+                        e,
+                    )
+                    await asyncio.sleep(_BACKOFF_S[attempt])
+                    continue
+                logger.exception(
+                    "{} transcription error after {} attempts: {}",
+                    provider_label,
+                    _MAX_RETRIES + 1,
+                    e,
+                )
+                return ""
+            except Exception as e:
+                logger.exception("{} transcription error: {}", provider_label, e)
+                return ""
+
+            if response.status_code in _RETRYABLE_STATUS and attempt < _MAX_RETRIES:
+                logger.warning(
+                    "{} transcription transient HTTP {} (attempt {}/{})",
+                    provider_label,
+                    response.status_code,
+                    attempt + 1,
+                    _MAX_RETRIES + 1,
+                )
+                await asyncio.sleep(_BACKOFF_S[attempt])
+                continue
+
+            try:
+                response.raise_for_status()
+            except Exception as e:
+                logger.exception("{} transcription error: {}", provider_label, e)
+                return ""
+
+            try:
+                payload = response.json()
+            except Exception as e:
+                logger.exception(
+                    "{} transcription error: malformed response body: {}",
+                    provider_label,
+                    e,
+                )
+                return ""
+
+            # Extract text from chat completions response format
+            try:
+                return payload["choices"][0]["message"]["content"]
+            except (KeyError, IndexError, TypeError):
+                logger.error(
+                    "{} transcription error: unexpected response shape: {!r}",
+                    provider_label,
+                    payload,
+                )
+                return ""
+
+
+class XiaomiASRTranscriptionProvider:
+    """Voice transcription provider using Xiaomi MiMo ASR API.
+
+    Unlike Whisper-compatible providers, Xiaomi MiMo ASR uses the
+    /v1/chat/completions endpoint with base64-encoded audio input.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        api_base: str | None = None,
+        language: str | None = None,
+    ):
+        self.api_key = api_key or os.environ.get("MIMO_API_KEY")
+        self.api_url = _resolve_chat_completions_url(
+            api_base or os.environ.get("MIMO_API_BASE"),
+            "https://api.xiaomimimo.com/v1/chat/completions",
+        )
+        self.language = language or "zh"
+        logger.debug("Xiaomi ASR transcription endpoint: {}", self.api_url)
+
+    async def transcribe(self, file_path: str | Path) -> str:
+        if not self.api_key:
+            logger.warning("Xiaomi API key not configured for transcription")
+            return ""
+
+        path = Path(file_path)
+        if not path.exists():
+            logger.error("Audio file not found: {}", file_path)
+            return ""
+
+        return await _post_xiaomi_asr_with_retry(
+            self.api_url,
+            api_key=self.api_key,
+            path=path,
+            model="mimo-v2.5-asr",
+            provider_label="Xiaomi ASR",
             language=self.language,
         )


### PR DESCRIPTION
## Summary

Add support for Xiaomi MiMo ASR (`mimo-v2.5-asr`) as a transcription provider, alongside the existing Groq and OpenAI Whisper options.

Closes #4172

## Motivation

Xiaomi's MiMo ASR model offers strong Chinese speech recognition performance and uses a different API format (chat completions with base64 audio input) compared to the standard Whisper-compatible endpoints.

## API Format

Unlike Groq/OpenAI Whisper (`/v1/audio/transcriptions`), MiMo ASR uses `/v1/chat/completions`:

```json
{
  "model": "mimo-v2.5-asr",
  "messages": [{
    "role": "user",
    "content": [{
      "type": "input_audio",
      "input_audio": { "data": "data:audio/ogg;base64,..." }
    }]
  }],
  "asr_options": { "language": "zh" }
}
```

## Changes

| File | Change |
|------|--------|
| `providers/transcription.py` | New `XiaomiASRTranscriptionProvider` with 429 retry/backoff |
| `channels/base.py` | Route `"xiaomi"` provider in `transcribe_audio()` |
| `channels/manager.py` | Resolve API key/base from `xiaomi_mimo` provider config |
| `config/schema.py` | Allow `"xiaomi"` as valid `transcription_provider` value |

## Config

```json
{
  "channels": {
    "transcriptionProvider": "xiaomi",
    "transcriptionLanguage": "zh"
  }
}
```

`transcriptionApiKey` and `transcriptionApiBase` are auto-resolved from the `xiaomi_mimo` provider config.

## Testing

Verified locally with Telegram voice messages — Chinese transcription works correctly with `mimo-v2.5-asr`.