### PR TITLE
fix(qq): send pairing codes for unauthorized C2C users

### DIFF
--- a/nanobot/channels/qq.py
+++ b/nanobot/channels/qq.py
@@ -490,13 +490,23 @@ class QQChannel(BaseChannel):
 
             content = (data.content or "").strip()
 
-            if not self.is_allowed(user_id):
-                return
-
             if data.id in self._processed_ids:
                 return
             self._processed_ids.append(data.id)
             self._chat_type_cache[chat_id] = chat_type
+
+            # Early permission check — avoid attachment downloads and ack side effects
+            # for unauthorized users. C2C messages can receive pairing codes;
+            # group messages remain silently ignored.
+            if not self.is_allowed(user_id):
+                if not is_group:
+                    await self._handle_message(
+                        sender_id=user_id,
+                        chat_id=chat_id,
+                        content="",
+                        is_dm=True,
+                    )
+                return
 
             # the data used by tests don't contain attachments property
             # so we use getattr with a default of [] to avoid AttributeError in tests
@@ -538,6 +548,7 @@ class QQChannel(BaseChannel):
                     "message_id": data.id,
                     "attachments": att_meta,
                 },
+                is_dm=not is_group,
             )
         except Exception:
             self.logger.exception("Error handling inbound message id={}", getattr(data, "id", "?"))

--- a/tests/channels/test_qq_channel.py
+++ b/tests/channels/test_qq_channel.py
@@ -1,7 +1,7 @@
 import tempfile
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -56,6 +56,51 @@ async def test_on_group_message_routes_to_group_chat_id() -> None:
     msg = await channel.bus.consume_inbound()
     assert msg.sender_id == "user1"
     assert msg.chat_id == "group123"
+
+
+@pytest.mark.asyncio
+async def test_on_c2c_message_passes_is_dm_true_to_base_handler() -> None:
+    channel = QQChannel(QQConfig(app_id="app", secret="secret", allow_from=["user1"]), MessageBus())
+    channel._handle_message = AsyncMock()
+
+    data = SimpleNamespace(
+        id="msg-c2c",
+        content="hello",
+        author=SimpleNamespace(user_openid="user1"),
+        attachments=[],
+    )
+
+    await channel._on_message(data, is_group=False)
+
+    channel._handle_message.assert_awaited_once()
+    kwargs = channel._handle_message.await_args.kwargs
+    assert kwargs["sender_id"] == "user1"
+    assert kwargs["chat_id"] == "user1"
+    assert kwargs["content"] == "hello"
+    assert kwargs["is_dm"] is True
+
+
+@pytest.mark.asyncio
+async def test_on_group_message_passes_is_dm_false_to_base_handler() -> None:
+    channel = QQChannel(QQConfig(app_id="app", secret="secret", allow_from=["user1"]), MessageBus())
+    channel._handle_message = AsyncMock()
+
+    data = SimpleNamespace(
+        id="msg-group",
+        content="hello",
+        group_openid="group123",
+        author=SimpleNamespace(member_openid="user1"),
+        attachments=[],
+    )
+
+    await channel._on_message(data, is_group=True)
+
+    channel._handle_message.assert_awaited_once()
+    kwargs = channel._handle_message.await_args.kwargs
+    assert kwargs["sender_id"] == "user1"
+    assert kwargs["chat_id"] == "group123"
+    assert kwargs["content"] == "hello"
+    assert kwargs["is_dm"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/channels/test_qq_media.py
+++ b/tests/channels/test_qq_media.py
@@ -183,7 +183,7 @@ async def test_send_media_failure_falls_back_to_text() -> None:
 
 
 @pytest.mark.asyncio
-async def test_on_message_ignores_unauthorized_sender_before_attachments_and_ack() -> None:
+async def test_on_message_unauthorized_c2c_pairs_before_attachments_and_ack() -> None:
     channel = QQChannel(
         QQConfig(
             app_id="app",
@@ -207,8 +207,44 @@ async def test_on_message_ignores_unauthorized_sender_before_attachments_and_ack
     await channel._on_message(data, is_group=False)
 
     channel._handle_attachments.assert_not_awaited()
+    channel._handle_message.assert_awaited_once_with(
+        sender_id="blocked-user",
+        chat_id="blocked-user",
+        content="",
+        is_dm=True,
+    )
+    assert channel._client.api.c2c_calls == []
+
+
+@pytest.mark.asyncio
+async def test_on_message_ignores_unauthorized_group_before_attachments_and_ack() -> None:
+    channel = QQChannel(
+        QQConfig(
+            app_id="app",
+            secret="secret",
+            allow_from=["allowed-user"],
+            ack_message="Processing...",
+        ),
+        MessageBus(),
+    )
+    channel._client = _FakeClient()
+    channel._handle_attachments = AsyncMock(return_value=(["/tmp/a.png"], ["file"], []))
+    channel._handle_message = AsyncMock()
+
+    data = SimpleNamespace(
+        id="msg-blocked-group",
+        content="hello",
+        group_openid="group123",
+        author=SimpleNamespace(member_openid="blocked-user"),
+        attachments=[SimpleNamespace(filename="a.png")],
+    )
+
+    await channel._on_message(data, is_group=True)
+
+    channel._handle_attachments.assert_not_awaited()
     channel._handle_message.assert_not_awaited()
     assert channel._client.api.c2c_calls == []
+    assert channel._client.api.group_calls == []
 
 
 # ── _on_message() exception handling ────────────────────────────────


### PR DESCRIPTION
## Summary                                                                                                                                                                                             
                                                                                                                                                                                                           
Fix QQ channel pairing-only behavior for unauthorized C2C users.                                                                                                                                       
                                                                                                                                                                                                           
Previously, `QQChannel._on_message()` returned immediately when `is_allowed(user_id)` was false. This caused unauthorized QQ C2C/private-chat users to be silently ignored before reaching `BaseChannel._handle_message(..., is_dm=True)`, so they never received a pairing code in pairing-only mode.                                                                                              
                                                                                                                                                                                                           
This PR updates QQ inbound handling so that:                                                                                                                                                           
                                                                                                                                                                                                           
- unauthorized C2C users are routed to the shared BaseChannel pairing flow                                                                                                                             
- unauthorized group users remain silently ignored                                                                                                                                                     
- unauthorized users do not trigger attachment downloads or ack messages                                                                                                                               
- authorized C2C/group messages pass the correct `is_dm` flag to the base handler                                                                                                                      
                                                                                                                                                                                                           
## Changes                                                                                                                                                                                             
                                                                                                                                                                                                           
- Move QQ inbound duplicate-message and chat-type bookkeeping before the early permission gate.                                                                                                        
- For unauthorized C2C messages, call `_handle_message(..., content="", is_dm=True)` to send a pairing code through the existing shared pairing logic.                                                 
- Keep unauthorized group messages ignored without pairing.                                                                                                                                            
- Pass `is_dm=not is_group` for normal authorized QQ messages.                                                                                                                                         
                                                                                                                                                                                                           
## Test Cases Added                                                                                                                                                                                    
                                                                                                                                                                                                           
Added/updated regression coverage for QQ inbound pairing and DM/group routing:                                                                                                                         
                                                                                                                                                                                                           
`test_on_c2c_message_passes_is_dm_true_to_base_handler`                                                                                                                                              
Verifies authorized QQ C2C messages are forwarded to the base handler with `is_dm=True`.                                                                                                           
                                                                                                                                                                                                           
`test_on_group_message_passes_is_dm_false_to_base_handler`                                                                                                                                           
Verifies authorized QQ group messages are forwarded to the base handler with `is_dm=False`.                                                                                                        
                                                                                                                                                                                                           
`test_on_message_unauthorized_c2c_pairs_before_attachments_and_ack`                                                                                                                                  
 Verifies unauthorized QQ C2C messages enter the pairing path via `_handle_message(..., content="", is_dm=True)`.                                                                                   
Also verifies unauthorized C2C messages do not trigger attachment handling or ack side effects.                                                                                                    

`test_on_message_ignores_unauthorized_group_before_attachments_and_ack`                                                                                                                              
Verifies unauthorized QQ group messages are still silently ignored.                                                                                                                                
Also verifies unauthorized group messages do not trigger pairing, attachment handling, or ack side effects. 