### PR TITLE
feat(webui): add new chat keyboard shortcut

### DIFF
--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -813,6 +813,7 @@ function Shell({
     navigate(defaultShellRoute());
     setDraftWorkspaceScope(null);
     setWorkspaceError(null);
+    setSessionSearchOpen(false);
     setMobileSidebarOpen(false);
   }, [navigate]);
 

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -1007,6 +1007,13 @@ function Shell({
   useEffect(() => {
     const handleKeyDown = (event: globalThis.KeyboardEvent) => {
       if (event.defaultPrevented) return;
+      const commandShiftO =
+        (event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey;
+      if (commandShiftO && event.key.toLowerCase() === "o") {
+        event.preventDefault();
+        onNewChat();
+        return;
+      }
       const plainCommandK =
         (event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey;
       if (!plainCommandK) return;
@@ -1017,7 +1024,7 @@ function Shell({
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [onOpenSessionSearch]);
+  }, [onNewChat, onOpenSessionSearch]);
 
   const onSelectSearchResult = useCallback(
     (key: string) => {

--- a/webui/src/components/Sidebar.tsx
+++ b/webui/src/components/Sidebar.tsx
@@ -124,6 +124,7 @@ export function Sidebar(props: SidebarProps) {
           label={t("sidebar.newChat")}
           onClick={props.onNewChat}
           icon={<SquarePen className="h-4 w-4" />}
+          shortcut="Cmd/Ctrl+Shift+O"
         />
         <SidebarActionButton
           collapsed={collapsed}
@@ -213,6 +214,7 @@ function SidebarActionButton({
   onClick,
   active = false,
   className,
+  shortcut,
 }: {
   collapsed: boolean;
   label: string;
@@ -220,14 +222,17 @@ function SidebarActionButton({
   onClick: () => void;
   active?: boolean;
   className?: string;
+  shortcut?: string;
 }) {
+  const title = shortcut ? `${label} (${shortcut})` : collapsed ? label : undefined;
+
   return (
     <Button
       type="button"
       variant="ghost"
       aria-label={label}
       aria-current={active ? "page" : undefined}
-      title={collapsed ? label : undefined}
+      title={title}
       onClick={() => onClick()}
       className={cn(
         "group h-8 min-w-0 gap-2 overflow-hidden rounded-full font-medium text-sidebar-foreground/85 hover:bg-sidebar-accent/75 hover:text-sidebar-foreground",

--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -1354,7 +1354,10 @@ describe("App layout", () => {
     expect(createChatSpy).not.toHaveBeenCalled();
   });
 
-  it("starts a new chat from the keyboard shortcut", async () => {
+  it.each([
+    ["Command", { metaKey: true }],
+    ["Control", { ctrlKey: true }],
+  ])("starts a new chat from the %s keyboard shortcut", async (_label, modifier) => {
     mockSessions = [
       {
         key: "websocket:chat-a",
@@ -1369,9 +1372,47 @@ describe("App layout", () => {
     render(<App />);
 
     await waitFor(() => expect(connectSpy).toHaveBeenCalled());
-    fireEvent.keyDown(window, { key: "O", shiftKey: true, metaKey: true });
+    fireEvent.keyDown(window, { key: "O", shiftKey: true, ...modifier });
 
     expect(window.location.hash).toBe("#/new");
+  });
+
+  it("closes search when starting a new chat from the keyboard shortcut", async () => {
+    mockSessions = [
+      {
+        key: "websocket:chat-a",
+        channel: "websocket",
+        chatId: "chat-a",
+        createdAt: "2026-04-16T10:00:00Z",
+        updatedAt: "2026-04-16T10:00:00Z",
+        preview: "Existing chat",
+      },
+    ];
+
+    render(<App />);
+
+    await waitFor(() => expect(connectSpy).toHaveBeenCalled());
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    expect(await screen.findByRole("dialog", { name: "Search" })).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "O", shiftKey: true, metaKey: true });
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Search" })).not.toBeInTheDocument(),
+    );
+    expect(window.location.hash).toBe("#/new");
+  });
+
+  it("exposes the new chat keyboard shortcut in the sidebar title", async () => {
+    render(<App />);
+
+    await waitFor(() => expect(connectSpy).toHaveBeenCalled());
+    const sidebar = screen.getByRole("navigation", { name: "Sidebar navigation" });
+
+    expect(within(sidebar).getByRole("button", { name: "New chat" })).toHaveAttribute(
+      "title",
+      "New chat (Cmd/Ctrl+Shift+O)",
+    );
   });
 
   it("keeps large sidebars light while search still covers every chat", async () => {

--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -1354,6 +1354,26 @@ describe("App layout", () => {
     expect(createChatSpy).not.toHaveBeenCalled();
   });
 
+  it("starts a new chat from the keyboard shortcut", async () => {
+    mockSessions = [
+      {
+        key: "websocket:chat-a",
+        channel: "websocket",
+        chatId: "chat-a",
+        createdAt: "2026-04-16T10:00:00Z",
+        updatedAt: "2026-04-16T10:00:00Z",
+        preview: "Existing chat",
+      },
+    ];
+
+    render(<App />);
+
+    await waitFor(() => expect(connectSpy).toHaveBeenCalled());
+    fireEvent.keyDown(window, { key: "O", shiftKey: true, metaKey: true });
+
+    expect(window.location.hash).toBe("#/new");
+  });
+
   it("keeps large sidebars light while search still covers every chat", async () => {
     mockSessions = Array.from({ length: 170 }, (_, index) => {
       const chatId = `chat-${index}`;


### PR DESCRIPTION
Addresses #4178.

## Summary

Adds Cmd/Ctrl+Shift+O to start a new chat, matching the convention used by ChatGPT, Claude.ai, and Gemini. The shortcut is wired in the same useEffect that already handles Cmd/Ctrl+K for search.

Two files changed:
- webui/src/App.tsx (+7/-1): new keydown branch calling onNewChat, dependency array updated
- webui/src/tests/app-layout.test.tsx (+20/-0): one regression test asserting navigation to #/new

## Verification

- npm run test (webui): 20/20 pass
- npm run lint (webui): 0 warnings
- git diff --check: clean