### PR TITLE
feat(webui): add new chat keyboard shortcut

### DIFF
--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -813,6 +813,7 @@ function Shell({
     navigate(defaultShellRoute());
     setDraftWorkspaceScope(null);
     setWorkspaceError(null);
+    setSessionSearchOpen(false);
     setMobileSidebarOpen(false);
   }, [navigate]);
 

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -1007,6 +1007,13 @@ function Shell({
   useEffect(() => {
     const handleKeyDown = (event: globalThis.KeyboardEvent) => {
       if (event.defaultPrevented) return;
+      const commandShiftO =
+        (event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey;
+      if (commandShiftO && event.key.toLowerCase() === "o") {
+        event.preventDefault();
+        onNewChat();
+        return;
+      }
       const plainCommandK =
         (event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey;
       if (!plainCommandK) return;
@@ -1017,7 +1024,7 @@ function Shell({
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [onOpenSessionSearch]);
+  }, [onNewChat, onOpenSessionSearch]);
 
   const onSelectSearchResult = useCallback(
     (key: string) => {

--- a/webui/src/components/Sidebar.tsx
+++ b/webui/src/components/Sidebar.tsx
@@ -124,6 +124,7 @@ export function Sidebar(props: SidebarProps) {
           label={t("sidebar.newChat")}
           onClick={props.onNewChat}
           icon={<SquarePen className="h-4 w-4" />}
+          shortcut="Cmd/Ctrl+Shift+O"
         />
         <SidebarActionButton
           collapsed={collapsed}
@@ -213,6 +214,7 @@ function SidebarActionButton({
   onClick,
   active = false,
   className,
+  shortcut,
 }: {
   collapsed: boolean;
   label: string;
@@ -220,14 +222,17 @@ function SidebarActionButton({
   onClick: () => void;
   active?: boolean;
   className?: string;
+  shortcut?: string;
 }) {
+  const title = shortcut ? `${label} (${shortcut})` : collapsed ? label : undefined;
+
   return (
     <Button
       type="button"
       variant="ghost"
       aria-label={label}
       aria-current={active ? "page" : undefined}
-      title={collapsed ? label : undefined}
+      title={title}
       onClick={() => onClick()}
       className={cn(
         "group h-8 min-w-0 gap-2 overflow-hidden rounded-full font-medium text-sidebar-foreground/85 hover:bg-sidebar-accent/75 hover:text-sidebar-foreground",

--- a/webui/src/components/Sidebar.tsx
+++ b/webui/src/components/Sidebar.tsx
@@ -55,12 +55,29 @@ interface SidebarProps {
   hostChromeInset?: boolean;
 }
 
+type NavigatorWithUserAgentData = Navigator & {
+  userAgentData?: { platform?: string };
+};
+
+function isApplePlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const platform = navigator.platform || "";
+  const userAgentPlatform =
+    (navigator as NavigatorWithUserAgentData).userAgentData?.platform || "";
+  return /mac|iphone|ipad|ipod/i.test(`${platform} ${userAgentPlatform}`);
+}
+
+function newChatShortcutLabel(): string {
+  return isApplePlatform() ? "⌘⇧O" : "Ctrl+Shift+O";
+}
+
 export function Sidebar(props: SidebarProps) {
   const { t } = useTranslation();
   const [menuPortalContainer, setMenuPortalContainer] =
     useState<HTMLElement | null>(null);
   const collapsed = Boolean(props.collapsed);
   const toggleLabel = t("thread.header.toggleSidebar");
+  const newChatShortcut = newChatShortcutLabel();
 
   return (
     <nav
@@ -124,7 +141,8 @@ export function Sidebar(props: SidebarProps) {
           label={t("sidebar.newChat")}
           onClick={props.onNewChat}
           icon={<SquarePen className="h-4 w-4" />}
-          shortcut="Cmd/Ctrl+Shift+O"
+          shortcut={newChatShortcut}
+          ariaKeyShortcuts="Meta+Shift+O Control+Shift+O"
         />
         <SidebarActionButton
           collapsed={collapsed}
@@ -215,6 +233,7 @@ function SidebarActionButton({
   active = false,
   className,
   shortcut,
+  ariaKeyShortcuts,
 }: {
   collapsed: boolean;
   label: string;
@@ -223,6 +242,7 @@ function SidebarActionButton({
   active?: boolean;
   className?: string;
   shortcut?: string;
+  ariaKeyShortcuts?: string;
 }) {
   const title = shortcut ? `${label} (${shortcut})` : collapsed ? label : undefined;
 
@@ -232,6 +252,7 @@ function SidebarActionButton({
       variant="ghost"
       aria-label={label}
       aria-current={active ? "page" : undefined}
+      aria-keyshortcuts={ariaKeyShortcuts}
       title={title}
       onClick={() => onClick()}
       className={cn(

--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -1354,7 +1354,10 @@ describe("App layout", () => {
     expect(createChatSpy).not.toHaveBeenCalled();
   });
 
-  it("starts a new chat from the keyboard shortcut", async () => {
+  it.each([
+    ["Command", { metaKey: true }],
+    ["Control", { ctrlKey: true }],
+  ])("starts a new chat from the %s keyboard shortcut", async (_label, modifier) => {
     mockSessions = [
       {
         key: "websocket:chat-a",
@@ -1369,9 +1372,47 @@ describe("App layout", () => {
     render(<App />);
 
     await waitFor(() => expect(connectSpy).toHaveBeenCalled());
-    fireEvent.keyDown(window, { key: "O", shiftKey: true, metaKey: true });
+    fireEvent.keyDown(window, { key: "O", shiftKey: true, ...modifier });
 
     expect(window.location.hash).toBe("#/new");
+  });
+
+  it("closes search when starting a new chat from the keyboard shortcut", async () => {
+    mockSessions = [
+      {
+        key: "websocket:chat-a",
+        channel: "websocket",
+        chatId: "chat-a",
+        createdAt: "2026-04-16T10:00:00Z",
+        updatedAt: "2026-04-16T10:00:00Z",
+        preview: "Existing chat",
+      },
+    ];
+
+    render(<App />);
+
+    await waitFor(() => expect(connectSpy).toHaveBeenCalled());
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    expect(await screen.findByRole("dialog", { name: "Search" })).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "O", shiftKey: true, metaKey: true });
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Search" })).not.toBeInTheDocument(),
+    );
+    expect(window.location.hash).toBe("#/new");
+  });
+
+  it("exposes the new chat keyboard shortcut in the sidebar title", async () => {
+    render(<App />);
+
+    await waitFor(() => expect(connectSpy).toHaveBeenCalled());
+    const sidebar = screen.getByRole("navigation", { name: "Sidebar navigation" });
+
+    expect(within(sidebar).getByRole("button", { name: "New chat" })).toHaveAttribute(
+      "title",
+      "New chat (Cmd/Ctrl+Shift+O)",
+    );
   });
 
   it("keeps large sidebars light while search still covers every chat", async () => {

--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -1354,6 +1354,26 @@ describe("App layout", () => {
     expect(createChatSpy).not.toHaveBeenCalled();
   });
 
+  it("starts a new chat from the keyboard shortcut", async () => {
+    mockSessions = [
+      {
+        key: "websocket:chat-a",
+        channel: "websocket",
+        chatId: "chat-a",
+        createdAt: "2026-04-16T10:00:00Z",
+        updatedAt: "2026-04-16T10:00:00Z",
+        preview: "Existing chat",
+      },
+    ];
+
+    render(<App />);
+
+    await waitFor(() => expect(connectSpy).toHaveBeenCalled());
+    fireEvent.keyDown(window, { key: "O", shiftKey: true, metaKey: true });
+
+    expect(window.location.hash).toBe("#/new");
+  });
+
   it("keeps large sidebars light while search still covers every chat", async () => {
     mockSessions = Array.from({ length: 170 }, (_, index) => {
       const chatId = `chat-${index}`;

--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -15,6 +15,13 @@ let mockSessions: ChatSummary[] = [];
 const HERO_GREETING_PATTERN =
   /What should we work on\?|Where should we start\?|What are we building today\?|What should we tackle together\?/;
 
+function setNavigatorPlatform(platform: string): void {
+  Object.defineProperty(window.navigator, "platform", {
+    configurable: true,
+    value: platform,
+  });
+}
+
 function jsonResponse(body: unknown): Response {
   return {
     ok: true,
@@ -200,6 +207,7 @@ describe("App layout", () => {
     attachSpy.mockReset();
     runStatusHandlers.clear();
     window.history.replaceState(null, "", "/");
+    setNavigatorPlatform("Linux x86_64");
     localStorage.removeItem("nanobot-webui.sidebar.completed-runs.v1");
     vi.mocked(fetchBootstrap).mockReset().mockResolvedValue({
       token: "tok",
@@ -1409,9 +1417,27 @@ describe("App layout", () => {
     await waitFor(() => expect(connectSpy).toHaveBeenCalled());
     const sidebar = screen.getByRole("navigation", { name: "Sidebar navigation" });
 
+    const newChatButton = within(sidebar).getByRole("button", { name: "New chat" });
+    expect(newChatButton).toHaveAttribute(
+      "title",
+      "New chat (Ctrl+Shift+O)",
+    );
+    expect(newChatButton).toHaveAttribute(
+      "aria-keyshortcuts",
+      "Meta+Shift+O Control+Shift+O",
+    );
+  });
+
+  it("uses macOS shortcut glyphs in the sidebar title", async () => {
+    setNavigatorPlatform("MacIntel");
+    render(<App />);
+
+    await waitFor(() => expect(connectSpy).toHaveBeenCalled());
+    const sidebar = screen.getByRole("navigation", { name: "Sidebar navigation" });
+
     expect(within(sidebar).getByRole("button", { name: "New chat" })).toHaveAttribute(
       "title",
-      "New chat (Cmd/Ctrl+Shift+O)",
+      "New chat (⌘⇧O)",
     );
   });
 


### PR DESCRIPTION
## Summary

Adds Cmd/Ctrl+Shift+O to start a new chat, matching the convention used by ChatGPT, Claude.ai, and Gemini. Also closes the session search dialog when the shortcut navigates to the blank chat route and exposes the shortcut through the sidebar button title for discoverability.

### WebUI

- **feat(webui): add new chat keyboard shortcut** — wires Cmd/Ctrl+Shift+O keydown handler to start a new chat. (#4181)
- **fix: close search when starting new chats** — closes the search dialog on navigation and adds shortcut hint to sidebar button tooltip. (#4181)

@axelray-dev thanks for your contribution