### PR TITLE
feat: 敏感信息脱敏、Dream 双阶段重写、原子写入保障、会话摘要优化

### DIFF
--- a/nanobot/agent/autocompact.py
+++ b/nanobot/agent/autocompact.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
 
 class AutoCompact:
     _RECENT_SUFFIX_MESSAGES = 8
-    _INTERNAL_SESSION_PREFIXES = ("dream:",)
 
     def __init__(self, sessions: SessionManager, consolidator: Consolidator,
                  session_ttl_minutes: int = 0):
@@ -34,21 +33,13 @@ class AutoCompact:
             ts = datetime.fromisoformat(ts)
         return ((now or datetime.now()) - ts).total_seconds() >= self._ttl * 60
 
-    @staticmethod
-    def _format_summary(text: str, last_active: datetime) -> str:
-        return f"Previous conversation summary (last active {last_active.isoformat()}):\n{text}"
-
-    @classmethod
-    def _is_internal_session(cls, key: str) -> bool:
-        return key.startswith(cls._INTERNAL_SESSION_PREFIXES)
-
     def check_expired(self, schedule_background: Callable[[Coroutine], None],
                       active_session_keys: Collection[str] = ()) -> None:
         """Schedule archival for idle sessions, skipping those with in-flight agent tasks."""
         now = datetime.now()
         for info in self.sessions.list_sessions():
             key = info.get("key", "")
-            if not key or self._is_internal_session(key) or key in self._archiving:
+            if not key or key in self._archiving:
                 continue
             if key in active_session_keys:
                 continue
@@ -57,40 +48,31 @@ class AutoCompact:
                 schedule_background(self._archive(key))
 
     async def _archive(self, key: str) -> None:
-        if self._is_internal_session(key):
-            self._archiving.discard(key)
-            return
         try:
             summary = await self.consolidator.compact_idle_session(
                 key, self._RECENT_SUFFIX_MESSAGES,
             )
             if summary and summary != "(nothing)":
                 session = self.sessions.get_or_create(key)
-                meta = session.metadata.get("_last_summary")
-                if isinstance(meta, dict):
-                    self._summaries[key] = (
-                        meta["text"],
-                        datetime.fromisoformat(meta["last_active"]),
-                    )
+                from nanobot.agent.memory import session_summary_text
+
+                rendered = session_summary_text(session)
+                if rendered:
+                    self._summaries[key] = (rendered, datetime.now())
         except Exception:
             logger.exception("Auto-compact: failed for {}", key)
         finally:
             self._archiving.discard(key)
 
     def prepare_session(self, session: Session, key: str) -> tuple[Session, str | None]:
-        if self._is_internal_session(key):
-            self._archiving.discard(key)
-            self._summaries.pop(key, None)
-            return session, None
         if key in self._archiving or self._is_expired(session.updated_at):
             logger.info("Auto-compact: reloading session {} (archiving={})", key, key in self._archiving)
             session = self.sessions.get_or_create(key)
         # Hot path: summary from in-memory dict (process hasn't restarted).
         entry = self._summaries.pop(key, None)
         if entry:
-            return session, self._format_summary(entry[0], entry[1])
-        # Cold path: summary persisted in session metadata (process restarted).
-        meta = session.metadata.get("_last_summary")
-        if isinstance(meta, dict):
-            return session, self._format_summary(meta["text"], datetime.fromisoformat(meta["last_active"]))
-        return session, None
+            return session, entry[0]
+        # Cold path: summary from session metadata (process restarted).
+        from nanobot.agent.memory import session_summary_text
+
+        return session, session_summary_text(session)

--- a/nanobot/agent/autocompact.py
+++ b/nanobot/agent/autocompact.py
@@ -58,7 +58,7 @@ class AutoCompact:
 
                 rendered = session_summary_text(session)
                 if rendered:
-                    self._summaries[key] = (rendered, datetime.now())
+                    self._summaries[key] = rendered
         except Exception:
             logger.exception("Auto-compact: failed for {}", key)
         finally:
@@ -69,9 +69,9 @@ class AutoCompact:
             logger.info("Auto-compact: reloading session {} (archiving={})", key, key in self._archiving)
             session = self.sessions.get_or_create(key)
         # Hot path: summary from in-memory dict (process hasn't restarted).
-        entry = self._summaries.pop(key, None)
-        if entry:
-            return session, entry[0]
+        rendered = self._summaries.pop(key, None)
+        if rendered:
+            return session, rendered
         # Cold path: summary from session metadata (process restarted).
         from nanobot.agent.memory import session_summary_text
 

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -1,4 +1,4 @@
-"""Memory system: pure file I/O store and lightweight Consolidator."""
+"""Memory system: pure file I/O store, lightweight Consolidator, and Dream processor."""
 
 from __future__ import annotations
 
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING, Any, Callable, Iterator
 import tiktoken
 from loguru import logger
 
+from nanobot.agent.runner import AgentRunner, AgentRunSpec
+from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.session.manager import Session
 from nanobot.utils.gitstore import GitStore
 from nanobot.utils.helpers import (
@@ -31,6 +33,46 @@ from nanobot.utils.prompt_templates import render_template
 if TYPE_CHECKING:
     from nanobot.providers.base import LLMProvider
     from nanobot.session.manager import SessionManager
+
+
+_PRIVATE_KEY_RE = re.compile(
+    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+    re.DOTALL,
+)
+_BEARER_TOKEN_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{8,}")
+_OPENAI_KEY_RE = re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b")
+_GITHUB_TOKEN_RE = re.compile(r"\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}\b")
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(api[_-]?key|token|secret|password)\b(\s*[:=]\s*)([\"']?)"
+    r"[^\"'\s,;]{8,}([\"']?)"
+)
+_EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+_CHINA_ID_RE = re.compile(
+    r"(?<!\d)\d{6}(?:18|19|20)\d{2}(?:0[1-9]|1[0-2])"
+    r"(?:0[1-9]|[12]\d|3[01])\d{3}[\dXx](?!\d)"
+)
+_LONG_NUMBER_RE = re.compile(r"(?<!\d)\d{16,}(?!\d)")
+
+
+def redact_memory_text(text: str) -> str:
+    """Redact high-risk secrets and PII before memory content is persisted."""
+    if not text:
+        return text
+    text = _PRIVATE_KEY_RE.sub("[REDACTED_PRIVATE_KEY]", text)
+    text = _BEARER_TOKEN_RE.sub("[REDACTED_BEARER_TOKEN]", text)
+    text = _OPENAI_KEY_RE.sub("[REDACTED_SECRET]", text)
+    text = _GITHUB_TOKEN_RE.sub("[REDACTED_SECRET]", text)
+    text = _SECRET_ASSIGNMENT_RE.sub(
+        lambda match: (
+            f"{match.group(1)}{match.group(2)}"
+            f"{match.group(3)}[REDACTED_SECRET]{match.group(4)}"
+        ),
+        text,
+    )
+    text = _EMAIL_RE.sub("[REDACTED_EMAIL]", text)
+    text = _CHINA_ID_RE.sub("[REDACTED_ID]", text)
+    text = _LONG_NUMBER_RE.sub("[REDACTED_LONG_NUMBER]", text)
+    return text
 
 
 # ---------------------------------------------------------------------------
@@ -60,7 +102,7 @@ class MemoryStore:
         self._dream_cursor_file = self.memory_dir / ".dream_cursor"
         self._corruption_logged = False  # rate-limit non-int cursor warning
         self._oversize_logged = False  # rate-limit oversized-entry warning
-        self._append_lock = threading.Lock()  # serialize cursor allocation + append
+        self._lock = threading.Lock()
         self._git = GitStore(workspace, tracked_files=[
             "SOUL.md", "USER.md", "memory/MEMORY.md", "memory/.dream_cursor",
         ])
@@ -78,6 +120,31 @@ class MemoryStore:
             return path.read_text(encoding="utf-8")
         except FileNotFoundError:
             return ""
+
+    @staticmethod
+    def _fsync_parent(path: Path) -> None:
+        with suppress(PermissionError, OSError):
+            fd = os.open(str(path.parent), os.O_RDONLY)
+            try:
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+
+    @staticmethod
+    def _write_text_atomic(path: Path, text: str) -> None:
+        """Write text atomically: tmp file → fsync → rename → fsync parent dir."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_name(f".{path.name}.tmp")
+        try:
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                f.write(text)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, path)
+            MemoryStore._fsync_parent(path)
+        except BaseException:
+            tmp_path.unlink(missing_ok=True)
+            raise
 
     def _maybe_migrate_legacy_history(self) -> None:
         """One-time upgrade from legacy HISTORY.md to history.jsonl.
@@ -104,10 +171,10 @@ class MemoryStore:
             if entries:
                 self._write_entries(entries)
                 last_cursor = entries[-1]["cursor"]
-                self._cursor_file.write_text(str(last_cursor), encoding="utf-8")
+                self._write_text_atomic(self._cursor_file, str(last_cursor))
                 # Default to "already processed" so upgrades do not replay the
                 # user's entire historical archive into Dream on first start.
-                self._dream_cursor_file.write_text(str(last_cursor), encoding="utf-8")
+                self._write_text_atomic(self._dream_cursor_file, str(last_cursor))
 
             backup_path = self._next_legacy_backup_path()
             self.legacy_history_file.replace(backup_path)
@@ -206,7 +273,7 @@ class MemoryStore:
         return self.read_file(self.memory_file)
 
     def write_memory(self, content: str) -> None:
-        self.memory_file.write_text(content, encoding="utf-8")
+        self._write_text_atomic(self.memory_file, redact_memory_text(content))
 
     # -- SOUL.md -------------------------------------------------------------
 
@@ -214,7 +281,7 @@ class MemoryStore:
         return self.read_file(self.soul_file)
 
     def write_soul(self, content: str) -> None:
-        self.soul_file.write_text(content, encoding="utf-8")
+        self._write_text_atomic(self.soul_file, redact_memory_text(content))
 
     # -- USER.md -------------------------------------------------------------
 
@@ -222,7 +289,7 @@ class MemoryStore:
         return self.read_file(self.user_file)
 
     def write_user(self, content: str) -> None:
-        self.user_file.write_text(content, encoding="utf-8")
+        self._write_text_atomic(self.user_file, redact_memory_text(content))
 
     # -- context injection (used by context.py) ------------------------------
 
@@ -248,6 +315,7 @@ class MemoryStore:
         large writes (e.g. an LLM echoing its input back as a "summary").
         """
         limit = max_chars if max_chars is not None else _HISTORY_ENTRY_HARD_CAP
+        cursor = self._next_cursor()
         ts = datetime.now().strftime("%Y-%m-%d %H:%M")
         raw = entry.rstrip()
         if len(raw) > limit:
@@ -260,21 +328,17 @@ class MemoryStore:
                     limit, len(raw),
                 )
             raw = truncate_text(raw, limit)
-        content = strip_think(raw)
-        # Cursor allocation and the append must be atomic: concurrent writers
-        # could otherwise read the same current cursor and emit duplicates.
-        with self._append_lock:
-            cursor = self._next_cursor()
-            if raw and not content:
-                logger.debug(
-                    "history entry {} stripped to empty (likely template leak); "
-                    "persisting empty content to avoid re-polluting context",
-                    cursor,
-                )
-            record = {"cursor": cursor, "timestamp": ts, "content": content}
-            with open(self.history_file, "a", encoding="utf-8") as f:
-                f.write(json.dumps(record, ensure_ascii=False) + "\n")
-            self._cursor_file.write_text(str(cursor), encoding="utf-8")
+        content = redact_memory_text(strip_think(raw))
+        if raw and not content:
+            logger.debug(
+                "history entry {} stripped to empty (likely template leak); "
+                "persisting empty content to avoid re-polluting context",
+                cursor,
+            )
+        record = {"cursor": cursor, "timestamp": ts, "content": content}
+        with open(self.history_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        self._write_text_atomic(self._cursor_file, str(cursor))
         return cursor
 
     @staticmethod
@@ -304,18 +368,26 @@ class MemoryStore:
                 poisoned,
             )
 
+    @staticmethod
+    def _read_cursor_file(cursor_path: Path) -> int:
+        """Read an integer cursor from a cursor file, or 0 if missing/invalid."""
+        if cursor_path.exists():
+            with suppress(ValueError, OSError):
+                return int(cursor_path.read_text(encoding="utf-8").strip())
+        return 0
+
     def _next_cursor(self) -> int:
         """Read the current cursor counter and return the next value."""
-        if self._cursor_file.exists():
-            with suppress(ValueError, OSError):
-                return int(self._cursor_file.read_text(encoding="utf-8").strip()) + 1
-        # Fast path: trust the tail when intact.  Otherwise scan the whole
-        # file and take ``max`` — that stays correct even if the monotonic
-        # invariant was broken by external writes.
+        cursor = self._read_cursor_file(self._cursor_file)
+        if cursor > 0:
+            return cursor + 1
+        # Fast path: trust the tail when intact.
         last = self._read_last_entry() or {}
         cursor = self._valid_cursor(last.get("cursor"))
         if cursor is not None:
             return cursor + 1
+        # Full scan fallback — stays correct even if the monotonic
+        # invariant was broken by external writes.
         return max((c for _, c in self._iter_valid_entries()), default=0) + 1
 
     def read_unprocessed_history(self, since_cursor: int) -> list[dict[str, Any]]:
@@ -326,11 +398,12 @@ class MemoryStore:
         """Drop oldest entries if the file exceeds *max_history_entries*."""
         if self.max_history_entries <= 0:
             return
-        entries = self._read_entries()
-        if len(entries) <= self.max_history_entries:
-            return
-        kept = entries[-self.max_history_entries:]
-        self._write_entries(kept)
+        with self._lock:
+            entries = self._read_entries()
+            if len(entries) <= self.max_history_entries:
+                return
+            kept = entries[-self.max_history_entries:]
+            self._write_entries(kept)
 
     # -- JSONL helpers -------------------------------------------------------
 
@@ -369,111 +442,19 @@ class MemoryStore:
 
     def _write_entries(self, entries: list[dict[str, Any]]) -> None:
         """Overwrite history.jsonl with the given entries (atomic write)."""
-        tmp_path = self.history_file.with_suffix(self.history_file.suffix + ".tmp")
-        try:
-            with open(tmp_path, "w", encoding="utf-8") as f:
-                for entry in entries:
-                    f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(tmp_path, self.history_file)
-
-            # fsync the directory so the rename is durable.
-            # On Windows, opening a directory with O_RDONLY raises
-            # PermissionError — skip the dir sync there (NTFS
-            # journals metadata synchronously).
-            with suppress(PermissionError):
-                fd = os.open(str(self.history_file.parent), os.O_RDONLY)
-                try:
-                    os.fsync(fd)
-                finally:
-                    os.close(fd)
-        except BaseException:
-            tmp_path.unlink(missing_ok=True)
-            raise
+        text = "".join(
+            json.dumps(entry, ensure_ascii=False) + "\n"
+            for entry in entries
+        )
+        self._write_text_atomic(self.history_file, text)
 
     # -- dream cursor --------------------------------------------------------
 
     def get_last_dream_cursor(self) -> int:
-        if self._dream_cursor_file.exists():
-            with suppress(ValueError, OSError):
-                return int(self._dream_cursor_file.read_text(encoding="utf-8").strip())
-        return 0
+        return self._read_cursor_file(self._dream_cursor_file)
 
     def set_last_dream_cursor(self, cursor: int) -> None:
-        self._dream_cursor_file.write_text(str(cursor), encoding="utf-8")
-
-    def build_dream_prompt(self, *, max_entries: int = 20) -> tuple[str, int] | None:
-        """Build the Dream prompt with unprocessed history context.
-
-        Returns ``(prompt, last_cursor)`` or ``None`` if nothing to process.
-        """
-        from nanobot.agent.skills import BUILTIN_SKILLS_DIR
-
-        last_cursor = self.get_last_dream_cursor()
-        entries = self.read_unprocessed_history(since_cursor=last_cursor)
-        if not entries:
-            return None
-
-        batch = entries[:max_entries]
-        history_text = "\n".join(
-            f"[{e['timestamp']}] {truncate_text(e['content'], 500)}"
-            for e in batch
-        )
-        skill_creator_path = str(BUILTIN_SKILLS_DIR / "skill-creator" / "SKILL.md")
-        template = render_template(
-            "agent/dream.md", strip=True, skill_creator_path=skill_creator_path,
-        )
-        prompt = f"{template}\n\n## Conversation History\n{history_text}"
-        return (prompt, batch[-1]["cursor"])
-
-    def build_dream_tools(self):
-        """Build the restricted tool registry used by Dream runs."""
-        from nanobot.agent.skills import BUILTIN_SKILLS_DIR
-        from nanobot.agent.tools.apply_patch import ApplyPatchTool
-        from nanobot.agent.tools.file_state import FileStates
-        from nanobot.agent.tools.filesystem import EditFileTool, ReadFileTool, WriteFileTool
-        from nanobot.agent.tools.registry import ToolRegistry
-
-        tools = ToolRegistry()
-        file_states = FileStates()
-        workspace = self.workspace
-        skills_dir = workspace / "skills"
-        skills_dir.mkdir(parents=True, exist_ok=True)
-
-        extra_read = [BUILTIN_SKILLS_DIR] if BUILTIN_SKILLS_DIR.exists() else None
-        editable_roots = [self.soul_file, self.user_file, skills_dir]
-
-        tools.register(ReadFileTool(
-            workspace=workspace,
-            allowed_dir=workspace,
-            extra_allowed_dirs=extra_read,
-            file_states=file_states,
-        ))
-        tools.register(EditFileTool(
-            workspace=workspace,
-            allowed_dir=self.memory_dir,
-            extra_allowed_dirs=editable_roots,
-            file_states=file_states,
-        ))
-        tools.register(ApplyPatchTool(
-            workspace=workspace,
-            allowed_dir=self.memory_dir,
-            extra_allowed_dirs=editable_roots,
-            file_states=file_states,
-        ))
-        tools.register(WriteFileTool(
-            workspace=workspace,
-            allowed_dir=skills_dir,
-            file_states=file_states,
-        ))
-        return tools
-
-    @staticmethod
-    def dream_run_completed(resp: object | None) -> bool:
-        """Return True only when an ephemeral Dream agent turn completed cleanly."""
-        metadata = getattr(resp, "metadata", None)
-        return isinstance(metadata, dict) and metadata.get("_stop_reason") == "completed"
+        self._write_text_atomic(self._dream_cursor_file, str(cursor))
 
     # -- message formatting utility ------------------------------------------
 
@@ -501,48 +482,12 @@ class MemoryStore:
             "Memory consolidation degraded: raw-archived {} messages", len(messages)
         )
 
-    # ------------------------------------------------------------------
-    # Dream helpers
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def dream_session_key() -> str:
-        """Return a unique session key for a Dream run, e.g. ``dream:20260528-100000``."""
-        return f"dream:{datetime.now():%Y%m%d-%H%M%S}"
-
-    @staticmethod
-    def build_dream_commit_message(prefix: str, resp: object | None) -> str:
-        """Build a Dream auto-commit message, appending the LLM summary if present."""
-        msg = prefix
-        if resp is not None and getattr(resp, "content", None):
-            msg = f"{msg}\n\n{resp.content.strip()}"
-        return msg
-
-    @staticmethod
-    def prune_dream_sessions(sessions_dir: Path, *, keep: int = 10) -> None:
-        """Remove the oldest Dream session files, keeping only the N most recent.
-
-        Only files matching ``dream_*.jsonl`` are considered. Non-dream session
-        files are never touched.
-        """
-        dream_files = sorted(
-            sessions_dir.glob("dream_*.jsonl"), key=lambda p: p.stat().st_mtime,
-        )
-        if len(dream_files) <= keep:
-            return
-
-        to_remove = dream_files[: len(dream_files) - keep]
-        for path in to_remove:
-            try:
-                path.unlink()
-                logger.debug("Pruned old dream session: {}", path.stem)
-            except OSError:
-                logger.warning("Failed to prune dream session {}", path)
 
 
 # ---------------------------------------------------------------------------
 # Consolidator — lightweight token-budget triggered consolidation
 # ---------------------------------------------------------------------------
+
 
 # Individual history.jsonl writers cap their own payloads tightly; the
 # _HISTORY_ENTRY_HARD_CAP at append_history() is a belt-and-suspenders default
@@ -550,6 +495,70 @@ class MemoryStore:
 _RAW_ARCHIVE_MAX_CHARS = 16_000       # fallback dump (LLM failed)
 _ARCHIVE_SUMMARY_MAX_CHARS = 8_000    # LLM-produced consolidation summary
 _HISTORY_ENTRY_HARD_CAP = 64_000      # emergency cap in append_history
+_RECENT_SUMMARIES_KEY = "_recent_summaries"
+_LEGACY_LAST_SUMMARY_KEY = "_last_summary"
+_MAX_RECENT_SUMMARIES = 5
+
+
+def _valid_recent_summary_entries(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    entries: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        text = item.get("text")
+        if not isinstance(text, str) or not text:
+            continue
+        entries.append(item)
+    return entries
+
+
+def record_recent_summary(
+    session: Session,
+    summary: str | None,
+    *,
+    last_active: datetime | None = None,
+) -> bool:
+    if not summary or summary == "(nothing)":
+        return False
+    created = datetime.now()
+    active = last_active or session.updated_at
+    entries = _valid_recent_summary_entries(session.metadata.get(_RECENT_SUMMARIES_KEY))
+    entries.append({
+        "text": summary,
+        "created_at": created.isoformat(),
+        "last_active": active.isoformat(),
+    })
+    session.metadata[_RECENT_SUMMARIES_KEY] = entries[-_MAX_RECENT_SUMMARIES:]
+    session.metadata.pop(_LEGACY_LAST_SUMMARY_KEY, None)
+    return True
+
+
+def session_summary_text(session: Session, *, max_chars: int = 6000) -> str | None:
+    entries = _valid_recent_summary_entries(session.metadata.get(_RECENT_SUMMARIES_KEY))
+    if entries:
+        sections = ["## Recent Session Summaries"]
+        for entry in entries:
+            last_active = entry.get("last_active")
+            label = f"[last active {last_active}]" if last_active else "[unknown]"
+            sections.append(f"{label}\n{entry['text']}")
+        return truncate_text("\n\n".join(sections), max_chars)
+
+    legacy = session.metadata.get(_LEGACY_LAST_SUMMARY_KEY)
+    if isinstance(legacy, dict):
+        text = legacy.get("text")
+        last_active = legacy.get("last_active")
+        if isinstance(text, str) and text:
+            if isinstance(last_active, str) and last_active:
+                return truncate_text(
+                    f"Previous conversation summary (last active {last_active}):\n{text}",
+                    max_chars,
+                )
+            return truncate_text(text, max_chars)
+    if isinstance(legacy, str) and legacy:
+        return truncate_text(legacy, max_chars)
+    return None
 
 
 class Consolidator:
@@ -691,11 +700,7 @@ class Consolidator:
         return summary
 
     def _persist_last_summary(self, session: Session, summary: str | None) -> None:
-        if summary and summary != "(nothing)":
-            session.metadata["_last_summary"] = {
-                "text": summary,
-                "last_active": session.updated_at.isoformat(),
-            }
+        if record_recent_summary(session, summary):
             self.sessions.save(session)
 
     def estimate_session_prompt_tokens(
@@ -706,8 +711,7 @@ class Consolidator:
         history = self._full_unconsolidated_history(session, include_timestamps=True)
         channel, chat_id = (session.key.split(":", 1) if ":" in session.key else (None, None))
         # Include archived summary in estimation so the budget accounts for it.
-        meta = session.metadata.get("_last_summary")
-        summary = meta.get("text") if isinstance(meta, dict) else (meta if isinstance(meta, str) else None)
+        summary = session_summary_text(session)
         probe_messages = self._build_messages(
             history=history,
             current_message="[token-probe]",
@@ -918,9 +922,10 @@ class Consolidator:
                 metadata={},
                 last_consolidated=0,
             )
-            dropped, already_consolidated = probe.retain_recent_legal_suffix(max_suffix)
+            probe.retain_recent_legal_suffix(max_suffix)
             kept = probe.messages
-            archive_msgs = dropped[already_consolidated:]
+            cut = len(tail) - len(kept)
+            archive_msgs = tail[:cut]
 
             if not archive_msgs and not kept:
                 session.updated_at = datetime.now()
@@ -932,11 +937,8 @@ class Consolidator:
             if archive_msgs:
                 summary = await self.archive(archive_msgs)
 
-            if summary and summary != "(nothing)":
-                session.metadata["_last_summary"] = {
-                    "text": summary,
-                    "last_active": last_active.isoformat(),
-                }
+            if record_recent_summary(session, summary, last_active=last_active):
+                self.sessions.save(session)
 
             session.messages = kept
             session.last_consolidated = 0
@@ -953,3 +955,320 @@ class Consolidator:
                 )
 
             return summary
+
+
+# ---------------------------------------------------------------------------
+# Dream — heavyweight cron-scheduled memory consolidation
+# ---------------------------------------------------------------------------
+
+
+# Single source of truth for the staleness threshold used in _annotate_with_ages
+# *and* in the Phase 1 prompt template (passed as `stale_threshold_days`).
+# Keep code and prompt aligned — if you bump this, the LLM's instruction string
+# updates automatically.
+_STALE_THRESHOLD_DAYS = 14
+
+
+class Dream:
+    """Two-phase memory processor: analyze history.jsonl, then edit files via AgentRunner.
+
+    Phase 1 produces an analysis summary (plain LLM call).
+    Phase 2 delegates to AgentRunner with read_file / edit_file tools so the
+    LLM can make targeted, incremental edits instead of replacing entire files.
+    """
+
+    # Caps on prompt-bound inputs so Dream's LLM calls never exceed the model's
+    # context window just because a file (or a legacy large history entry) grew
+    # unexpectedly. Each file still appears in full via read_file when the agent
+    # needs it in Phase 2 — these caps only bound the Phase 1/2 prompt preview.
+    _MEMORY_FILE_MAX_CHARS = 32_000
+    _SOUL_FILE_MAX_CHARS = 16_000
+    _USER_FILE_MAX_CHARS = 16_000
+    _HISTORY_ENTRY_PREVIEW_MAX_CHARS = 4_000
+
+    def __init__(
+        self,
+        store: MemoryStore,
+        provider: LLMProvider,
+        model: str,
+        max_batch_size: int = 20,
+        max_iterations: int = 10,
+        max_tool_result_chars: int = 16_000,
+        annotate_line_ages: bool = True,
+    ):
+        self.store = store
+        self.provider = provider
+        self.model = model
+        self.max_batch_size = max_batch_size
+        self.max_iterations = max_iterations
+        self.max_tool_result_chars = max_tool_result_chars
+        # Kill switch for the git-blame-based per-line age annotation in Phase 1.
+        # Default True keeps the #3212 behavior; set False to feed MEMORY.md raw
+        # (e.g. if a specific LLM reacts poorly to the `← Nd` suffix).
+        self.annotate_line_ages = annotate_line_ages
+        self._runner = AgentRunner(provider)
+        self._tools = self._build_tools()
+
+    def set_provider(self, provider: LLMProvider, model: str) -> None:
+        self.provider = provider
+        self.model = model
+        self._runner.provider = provider
+
+    # -- tool registry -------------------------------------------------------
+
+    def _build_tools(self) -> ToolRegistry:
+        """Build a minimal tool registry for the Dream agent."""
+        from nanobot.agent.skills import BUILTIN_SKILLS_DIR
+        from nanobot.agent.tools.file_state import FileStates
+        from nanobot.agent.tools.filesystem import EditFileTool, ReadFileTool, WriteFileTool
+
+        tools = ToolRegistry()
+        workspace = self.store.workspace
+        # Allow reading builtin skills for reference during skill creation
+        extra_read = [BUILTIN_SKILLS_DIR] if BUILTIN_SKILLS_DIR.exists() else None
+        # Dream gets its own FileStates so its caches stay isolated from the
+        # main loop's sessions (issue #3571).
+        file_states = FileStates()
+        tools.register(ReadFileTool(
+            workspace=workspace,
+            allowed_dir=workspace,
+            extra_allowed_dirs=extra_read,
+            file_states=file_states,
+        ))
+        tools.register(EditFileTool(workspace=workspace, allowed_dir=workspace, file_states=file_states))
+        # write_file resolves relative paths from workspace root, but can only
+        # write under skills/ so the prompt can safely use skills/<name>/SKILL.md.
+        skills_dir = workspace / "skills"
+        skills_dir.mkdir(parents=True, exist_ok=True)
+        tools.register(WriteFileTool(workspace=workspace, allowed_dir=skills_dir, file_states=file_states))
+        return tools
+
+    # -- skill listing --------------------------------------------------------
+
+    def _list_existing_skills(self) -> list[str]:
+        """List existing skills as 'name — description' for dedup context."""
+        import re as _re
+
+        from nanobot.agent.skills import BUILTIN_SKILLS_DIR
+
+        desc_re = _re.compile(r"^description:\s*(.+)$", _re.MULTILINE | _re.IGNORECASE)
+        entries: dict[str, str] = {}
+        for base in (self.store.workspace / "skills", BUILTIN_SKILLS_DIR):
+            if not base.exists():
+                continue
+            for d in base.iterdir():
+                if not d.is_dir():
+                    continue
+                skill_md = d / "SKILL.md"
+                if not skill_md.exists():
+                    continue
+                # Prefer workspace skills over builtin (same name)
+                if d.name in entries and base == BUILTIN_SKILLS_DIR:
+                    continue
+                content = skill_md.read_text(encoding="utf-8")[:500]
+                m = desc_re.search(content)
+                desc = m.group(1).strip() if m else "(no description)"
+                entries[d.name] = desc
+        return [f"{name} — {desc}" for name, desc in sorted(entries.items())]
+
+    # -- main entry ----------------------------------------------------------
+
+    def _annotate_with_ages(self, content: str) -> str:
+        """Append per-line age suffixes to MEMORY.md content.
+
+        Each non-blank line whose age exceeds ``_STALE_THRESHOLD_DAYS`` gets a
+        suffix like ``← 30d`` indicating days since last modification.
+        Returns the original content unchanged if git is unavailable,
+        annotate fails, or the line count doesn't match the age count
+        (which can happen with an uncommitted working-tree edit — better to
+        skip annotation than to tag the wrong line).
+        SOUL.md and USER.md are never annotated.
+        """
+        file_path = "memory/MEMORY.md"
+        try:
+            ages = self.store.git.line_ages(file_path)
+        except Exception:
+            logger.debug("line_ages failed for {}", file_path)
+            return content
+        if not ages:
+            return content
+
+        had_trailing = content.endswith("\n")
+        lines = content.splitlines()
+        # If HEAD-blob line count disagrees with the working-tree content we
+        # received, ages would be assigned to the wrong lines — skip entirely
+        # and feed the LLM un-annotated content rather than misleading data.
+        if len(lines) != len(ages):
+            logger.debug(
+                "line_ages length mismatch for {} (lines={}, ages={}); skipping annotation",
+                file_path, len(lines), len(ages),
+            )
+            return content
+
+        annotated: list[str] = []
+        for line, age in zip(lines, ages):
+            if not line.strip():
+                annotated.append(line)
+                continue
+            if age.age_days > _STALE_THRESHOLD_DAYS:
+                annotated.append(f"{line}  \u2190 {age.age_days}d")
+            else:
+                annotated.append(line)
+        result = "\n".join(annotated)
+        if had_trailing:
+            result += "\n"
+        return result
+
+    async def run(self) -> bool:
+        """Process unprocessed history entries. Returns True if work was done."""
+        from nanobot.agent.skills import BUILTIN_SKILLS_DIR
+
+        last_cursor = self.store.get_last_dream_cursor()
+        entries = self.store.read_unprocessed_history(since_cursor=last_cursor)
+        if not entries:
+            return False
+
+        batch = entries[: self.max_batch_size]
+        logger.info(
+            "Dream: processing {} entries (cursor {}→{}), batch={}",
+            len(entries), last_cursor, batch[-1]["cursor"], len(batch),
+        )
+
+        # Build history text for LLM — cap each entry so a legacy oversized
+        # record (e.g. pre-#3412 raw_archive dump) can't blow up the prompt.
+        history_text = "\n".join(
+            f"[{e['timestamp']}] "
+            f"{truncate_text(e['content'], self._HISTORY_ENTRY_PREVIEW_MAX_CHARS)}"
+            for e in batch
+        )
+
+        # Current file contents + per-line age annotations (MEMORY.md only).
+        # Each file is capped in the *prompt preview* only; Phase 2 still sees
+        # the full file via the read_file tool.
+        current_date = datetime.now().strftime("%Y-%m-%d")
+        raw_memory = self.store.read_memory() or "(empty)"
+        annotated_memory = (
+            self._annotate_with_ages(raw_memory)
+            if self.annotate_line_ages
+            else raw_memory
+        )
+        current_memory = truncate_text(annotated_memory, self._MEMORY_FILE_MAX_CHARS)
+        current_soul = truncate_text(
+            self.store.read_soul() or "(empty)", self._SOUL_FILE_MAX_CHARS,
+        )
+        current_user = truncate_text(
+            self.store.read_user() or "(empty)", self._USER_FILE_MAX_CHARS,
+        )
+
+        file_context = (
+            f"## Current Date\n{current_date}\n\n"
+            f"## Current MEMORY.md ({len(current_memory)} chars)\n{current_memory}\n\n"
+            f"## Current SOUL.md ({len(current_soul)} chars)\n{current_soul}\n\n"
+            f"## Current USER.md ({len(current_user)} chars)\n{current_user}"
+        )
+
+        # Phase 1: Analyze (no skills list — dedup is Phase 2's job)
+        phase1_prompt = (
+            f"## Conversation History\n{history_text}\n\n{file_context}"
+        )
+
+        try:
+            phase1_response = await self.provider.chat_with_retry(
+                model=self.model,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": render_template(
+                            "agent/dream_phase1.md",
+                            strip=True,
+                            stale_threshold_days=_STALE_THRESHOLD_DAYS,
+                        ),
+                    },
+                    {"role": "user", "content": phase1_prompt},
+                ],
+                tools=None,
+                tool_choice=None,
+            )
+            analysis = phase1_response.content or ""
+            logger.debug("Dream Phase 1 analysis ({} chars): {}", len(analysis), analysis[:500])
+        except Exception:
+            logger.exception("Dream Phase 1 failed")
+            return False
+
+        # Phase 2: Delegate to AgentRunner with read_file / edit_file
+        existing_skills = self._list_existing_skills()
+        skills_section = ""
+        if existing_skills:
+            skills_section = (
+                "\n\n## Existing Skills\n"
+                + "\n".join(f"- {s}" for s in existing_skills)
+            )
+        phase2_prompt = f"## Analysis Result\n{analysis}\n\n{file_context}{skills_section}"
+
+        tools = self._tools
+        skill_creator_path = BUILTIN_SKILLS_DIR / "skill-creator" / "SKILL.md"
+        messages: list[dict[str, Any]] = [
+            {
+                "role": "system",
+                "content": render_template(
+                    "agent/dream_phase2.md",
+                    strip=True,
+                    skill_creator_path=str(skill_creator_path),
+                ),
+            },
+            {"role": "user", "content": phase2_prompt},
+        ]
+
+        try:
+            result = await self._runner.run(AgentRunSpec(
+                initial_messages=messages,
+                tools=tools,
+                model=self.model,
+                max_iterations=self.max_iterations,
+                max_tool_result_chars=self.max_tool_result_chars,
+                fail_on_tool_error=False,
+            ))
+            logger.debug(
+                "Dream Phase 2 complete: stop_reason={}, tool_events={}",
+                result.stop_reason, len(result.tool_events),
+            )
+            for ev in (result.tool_events or []):
+                logger.info("Dream tool_event: name={}, status={}, detail={}", ev.get("name"), ev.get("status"), ev.get("detail", "")[:200])
+        except Exception:
+            logger.exception("Dream Phase 2 failed")
+            result = None
+
+        # Build changelog from tool events
+        changelog: list[str] = []
+        if result and result.tool_events:
+            for event in result.tool_events:
+                if event["status"] == "ok":
+                    changelog.append(f"{event['name']}: {event['detail']}")
+
+        # Only advance cursor on successful completion to prevent silent loss
+        if result and result.stop_reason == "completed":
+            new_cursor = batch[-1]["cursor"]
+            self.store.set_last_dream_cursor(new_cursor)
+            logger.info(
+                "Dream done: {} change(s), cursor advanced to {}",
+                len(changelog), new_cursor,
+            )
+        else:
+            reason = result.stop_reason if result else "exception"
+            logger.warning(
+                "Dream incomplete ({}): cursor NOT advanced, will retry next cron cycle",
+                reason,
+            )
+
+        self.store.compact_history()
+
+        # Git auto-commit (only when there are actual changes)
+        if changelog and self.store.git.is_initialized():
+            ts = batch[-1]["timestamp"]
+            summary = f"dream: {ts}, {len(changelog)} change(s)"
+            commit_msg = f"{summary}\n\n{analysis.strip()}"
+            sha = self.store.git.auto_commit(commit_msg)
+            if sha:
+                logger.info("Dream commit: {}", sha)
+
+        return True

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -44,7 +44,7 @@ _OPENAI_KEY_RE = re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b")
 _GITHUB_TOKEN_RE = re.compile(r"\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}\b")
 _SECRET_ASSIGNMENT_RE = re.compile(
     r"(?i)\b(api[_-]?key|token|secret|password)\b(\s*[:=]\s*)([\"']?)"
-    r"[^\"'\s,;]{8,}([\"']?)"
+    r"[^\"'\s,;]{4,}([\"']?)"
 )
 _EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
 _CHINA_ID_RE = re.compile(
@@ -142,7 +142,7 @@ class MemoryStore:
                 os.fsync(f.fileno())
             os.replace(tmp_path, path)
             MemoryStore._fsync_parent(path)
-        except BaseException:
+        except Exception:
             tmp_path.unlink(missing_ok=True)
             raise
 
@@ -315,30 +315,34 @@ class MemoryStore:
         large writes (e.g. an LLM echoing its input back as a "summary").
         """
         limit = max_chars if max_chars is not None else _HISTORY_ENTRY_HARD_CAP
-        cursor = self._next_cursor()
-        ts = datetime.now().strftime("%Y-%m-%d %H:%M")
-        raw = entry.rstrip()
-        if len(raw) > limit:
-            if not self._oversize_logged:
-                self._oversize_logged = True
-                logger.warning(
-                    "history entry exceeds {} chars ({}); truncating. "
-                    "Usually means a caller forgot its own cap; "
-                    "further occurrences suppressed.",
-                    limit, len(raw),
+        # Cursor allocation, JSONL append, and cursor file write must be
+        # atomic: concurrent writers could otherwise read the same cursor
+        # and emit duplicate entries.
+        with self._lock:
+            cursor = self._next_cursor()
+            ts = datetime.now().strftime("%Y-%m-%d %H:%M")
+            raw = entry.rstrip()
+            if len(raw) > limit:
+                if not self._oversize_logged:
+                    self._oversize_logged = True
+                    logger.warning(
+                        "history entry exceeds {} chars ({}); truncating. "
+                        "Usually means a caller forgot its own cap; "
+                        "further occurrences suppressed.",
+                        limit, len(raw),
+                    )
+                raw = truncate_text(raw, limit)
+            content = redact_memory_text(strip_think(raw))
+            if raw and not content:
+                logger.debug(
+                    "history entry {} stripped to empty (likely template leak); "
+                    "persisting empty content to avoid re-polluting context",
+                    cursor,
                 )
-            raw = truncate_text(raw, limit)
-        content = redact_memory_text(strip_think(raw))
-        if raw and not content:
-            logger.debug(
-                "history entry {} stripped to empty (likely template leak); "
-                "persisting empty content to avoid re-polluting context",
-                cursor,
-            )
-        record = {"cursor": cursor, "timestamp": ts, "content": content}
-        with open(self.history_file, "a", encoding="utf-8") as f:
-            f.write(json.dumps(record, ensure_ascii=False) + "\n")
-        self._write_text_atomic(self._cursor_file, str(cursor))
+            record = {"cursor": cursor, "timestamp": ts, "content": content}
+            with open(self.history_file, "a", encoding="utf-8") as f:
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+            self._write_text_atomic(self._cursor_file, str(cursor))
         return cursor
 
     @staticmethod
@@ -922,10 +926,14 @@ class Consolidator:
                 metadata={},
                 last_consolidated=0,
             )
-            probe.retain_recent_legal_suffix(max_suffix)
+            # Use the return value for identity-based dropped-message detection.
+            # When the tail contains no user turn, retain_recent_legal_suffix
+            # anchors to the latest user elsewhere in the full session — the
+            # retained window is then NOT a contiguous suffix of tail, so
+            # position-based slicing (tail[:cut]) would archive wrong messages.
+            dropped, _ = probe.retain_recent_legal_suffix(max_suffix)
             kept = probe.messages
-            cut = len(tail) - len(kept)
-            archive_msgs = tail[:cut]
+            archive_msgs = dropped
 
             if not archive_msgs and not kept:
                 session.updated_at = datetime.now()
@@ -1017,7 +1025,12 @@ class Dream:
     # -- tool registry -------------------------------------------------------
 
     def _build_tools(self) -> ToolRegistry:
-        """Build a minimal tool registry for the Dream agent."""
+        """Build a restricted tool registry for the Dream agent.
+
+        Edit scope is locked to memory_dir + SOUL.md + USER.md + skills/
+        so prompt injection in conversation history cannot escalate to
+        arbitrary workspace writes.
+        """
         from nanobot.agent.skills import BUILTIN_SKILLS_DIR
         from nanobot.agent.tools.file_state import FileStates
         from nanobot.agent.tools.filesystem import EditFileTool, ReadFileTool, WriteFileTool
@@ -1029,13 +1042,21 @@ class Dream:
         # Dream gets its own FileStates so its caches stay isolated from the
         # main loop's sessions (issue #3571).
         file_states = FileStates()
+        # Dream only needs to read memory/, SOUL.md, USER.md and builtin skills.
+        # Restricting allowed_dir prevents arbitrary workspace reads.
+        editable_roots = [self.store.soul_file, self.store.user_file, workspace / "skills"]
         tools.register(ReadFileTool(
             workspace=workspace,
-            allowed_dir=workspace,
-            extra_allowed_dirs=extra_read,
+            allowed_dir=self.store.memory_dir,
+            extra_allowed_dirs=[workspace, BUILTIN_SKILLS_DIR] if BUILTIN_SKILLS_DIR.exists() else [workspace],
             file_states=file_states,
         ))
-        tools.register(EditFileTool(workspace=workspace, allowed_dir=workspace, file_states=file_states))
+        tools.register(EditFileTool(
+            workspace=workspace,
+            allowed_dir=self.store.memory_dir,
+            extra_allowed_dirs=editable_roots,
+            file_states=file_states,
+        ))
         # write_file resolves relative paths from workspace root, but can only
         # write under skills/ so the prompt can safely use skills/<name>/SKILL.md.
         skills_dir = workspace / "skills"
@@ -1245,7 +1266,10 @@ class Dream:
                 if event["status"] == "ok":
                     changelog.append(f"{event['name']}: {event['detail']}")
 
-        # Only advance cursor on successful completion to prevent silent loss
+        # Only advance cursor AND commit on successful completion.  Partial runs
+        # (max_iterations, tool_error, etc.) are NOT committed — otherwise the
+        # next Dream cycle would re-read the same history entries, see the
+        # already-applied partial edits, and produce duplicate/conflicting changes.
         if result and result.stop_reason == "completed":
             new_cursor = batch[-1]["cursor"]
             self.store.set_last_dream_cursor(new_cursor)
@@ -1253,22 +1277,22 @@ class Dream:
                 "Dream done: {} change(s), cursor advanced to {}",
                 len(changelog), new_cursor,
             )
+            # Git auto-commit only after successful cursor advance
+            if changelog and self.store.git.is_initialized():
+                ts = batch[-1]["timestamp"]
+                summary = f"dream: {ts}, {len(changelog)} change(s)"
+                commit_msg = f"{summary}\n\n{analysis.strip()}"
+                sha = self.store.git.auto_commit(commit_msg)
+                if sha:
+                    logger.info("Dream commit: {}", sha)
         else:
             reason = result.stop_reason if result else "exception"
             logger.warning(
-                "Dream incomplete ({}): cursor NOT advanced, will retry next cron cycle",
+                "Dream incomplete ({}): cursor NOT advanced, changes NOT committed; "
+                "will retry next cron cycle",
                 reason,
             )
 
         self.store.compact_history()
-
-        # Git auto-commit (only when there are actual changes)
-        if changelog and self.store.git.is_initialized():
-            ts = batch[-1]["timestamp"]
-            summary = f"dream: {ts}, {len(changelog)} change(s)"
-            commit_msg = f"{summary}\n\n{analysis.strip()}"
-            sha = self.store.git.auto_commit(commit_msg)
-            if sha:
-                logger.info("Dream commit: {}", sha)
 
         return True

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -514,6 +514,13 @@ class MCPPromptWrapper(_MCPWrapperBase):
                 )
                 return f"(MCP prompt call failed: {exc.error.message} [code {exc.error.code}])"
             except Exception as exc:
+                if await self._refresh_session_after_termination(
+                    exc,
+                    refreshed_session,
+                    "prompt",
+                ):
+                    refreshed_session = True
+                    continue
                 if _is_transient(exc):
                     if not retried_transient:
                         retried_transient = True
@@ -1066,10 +1073,7 @@ def _server_signature(cfg: Any) -> Any:
 
 
 def _tool_prefix(server_name: str) -> str:
-    safe_name = "".join(ch if ch.isalnum() or ch in {"_", "-"} else "_" for ch in server_name)
-    while "__" in safe_name:
-        safe_name = safe_name.replace("__", "_")
-    return f"mcp_{safe_name}_"
+    return _sanitize_name(f"mcp_{server_name}_")
 
 
 def _unregister_server_tools(state: Any, registry: ToolRegistry, server_name: str) -> int:

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -5,6 +5,7 @@ import os
 import re
 import shutil
 import urllib.parse
+from collections.abc import Awaitable, Callable
 from contextlib import AsyncExitStack, suppress
 from typing import Any, Mapping
 from weakref import WeakKeyDictionary
@@ -41,6 +42,7 @@ _WINDOWS_SHELL_LAUNCHERS: frozenset[str] = frozenset(("npx", "npm", "pnpm", "yar
 # Replace anything outside [a-zA-Z0-9_-] with underscore and collapse runs.
 _SANITIZE_RE = re.compile(r"_+")
 _RELOAD_LOCKS: WeakKeyDictionary[Any, asyncio.Lock] = WeakKeyDictionary()
+_ReconnectCallback = Callable[[str, str, Tool], Awaitable[Tool | None]]
 
 
 def _sanitize_name(name: str) -> str:
@@ -51,6 +53,19 @@ def _sanitize_name(name: str) -> str:
 def _is_transient(exc: BaseException) -> bool:
     """Check if an exception looks like a transient connection error."""
     return type(exc).__name__ in _TRANSIENT_EXC_NAMES
+
+
+def _is_session_terminated(exc: BaseException) -> bool:
+    """Return True when the MCP SDK reports a dead client session."""
+    messages = [str(exc)]
+    error = getattr(exc, "error", None)
+    if error is not None:
+        messages.append(str(getattr(error, "message", "")))
+    return any(
+        marker in message.lower()
+        for marker in ("session terminated", "connection closed")
+        for message in messages
+    )
 
 
 async def _probe_http_url(url: str, timeout: float = 3.0) -> bool:
@@ -68,7 +83,8 @@ async def _probe_http_url(url: str, timeout: float = 3.0) -> bool:
         port = 443 if parsed.scheme == "https" else 80
     try:
         reader, writer = await asyncio.wait_for(
-            asyncio.open_connection(host, port), timeout=timeout,
+            asyncio.open_connection(host, port),
+            timeout=timeout,
         )
         writer.close()
         await writer.wait_closed()
@@ -174,13 +190,54 @@ def _normalize_schema_for_openai(schema: Any) -> dict[str, Any]:
     return normalized
 
 
-class MCPToolWrapper(Tool):
+class _MCPWrapperBase(Tool):
+    """Common reconnect handling for wrappers bound to one MCP server session."""
+
+    _plugin_discoverable = False
+
+    def _set_mcp_connection(self, session: Any, server_name: str) -> None:
+        self._session = session
+        self._server_name = server_name
+        self._reconnect: _ReconnectCallback | None = None
+
+    def set_reconnect_handler(self, reconnect: _ReconnectCallback) -> None:
+        self._reconnect = reconnect
+
+    async def _refresh_session_after_termination(
+        self,
+        exc: BaseException,
+        already_refreshed: bool,
+        capability_kind: str,
+    ) -> bool:
+        if already_refreshed or not _is_session_terminated(exc) or self._reconnect is None:
+            return False
+        logger.warning(
+            "MCP {} '{}' session terminated; reconnecting server '{}' before retry",
+            capability_kind,
+            self._name,
+            self._server_name,
+        )
+        refreshed_tool = await self._reconnect(self._server_name, self._name, self)
+        refreshed_session = getattr(refreshed_tool, "_session", None)
+        if refreshed_session is None:
+            logger.warning(
+                "MCP {} '{}' could not refresh session for server '{}'",
+                capability_kind,
+                self._name,
+                self._server_name,
+            )
+            return False
+        self._session = refreshed_session
+        return True
+
+
+class MCPToolWrapper(_MCPWrapperBase):
     """Wraps a single MCP server tool as a nanobot Tool."""
 
     _plugin_discoverable = False
 
     def __init__(self, session, server_name: str, tool_def, tool_timeout: int = 30):
-        self._session = session
+        self._set_mcp_connection(session, server_name)
         self._original_name = tool_def.name
         self._name = _sanitize_name(f"mcp_{server_name}_{tool_def.name}")
         self._description = tool_def.description or tool_def.name
@@ -203,7 +260,9 @@ class MCPToolWrapper(Tool):
     async def execute(self, **kwargs: Any) -> str:
         from mcp import types
 
-        for attempt in range(2):  # At most 1 retry
+        retried_transient = False
+        refreshed_session = False
+        while True:
             try:
                 result = await asyncio.wait_for(
                     self._session.call_tool(self._original_name, arguments=kwargs),
@@ -223,8 +282,16 @@ class MCPToolWrapper(Tool):
                 logger.warning("MCP tool '{}' was cancelled by server/SDK", self._name)
                 return "(MCP tool call was cancelled)"
             except Exception as exc:
+                if await self._refresh_session_after_termination(
+                    exc,
+                    refreshed_session,
+                    "tool",
+                ):
+                    refreshed_session = True
+                    continue
                 if _is_transient(exc):
-                    if attempt == 0:
+                    if not retried_transient:
+                        retried_transient = True
                         logger.warning(
                             "MCP tool '{}' hit transient error ({}), retrying once...",
                             self._name,
@@ -259,13 +326,13 @@ class MCPToolWrapper(Tool):
         return "(MCP tool call failed)"  # Unreachable, but satisfies type checkers
 
 
-class MCPResourceWrapper(Tool):
+class MCPResourceWrapper(_MCPWrapperBase):
     """Wraps an MCP resource URI as a read-only nanobot Tool."""
 
     _plugin_discoverable = False
 
     def __init__(self, session, server_name: str, resource_def, resource_timeout: int = 30):
-        self._session = session
+        self._set_mcp_connection(session, server_name)
         self._uri = resource_def.uri
         self._name = _sanitize_name(f"mcp_{server_name}_resource_{resource_def.name}")
         desc = resource_def.description or resource_def.name
@@ -296,7 +363,9 @@ class MCPResourceWrapper(Tool):
     async def execute(self, **kwargs: Any) -> str:
         from mcp import types
 
-        for attempt in range(2):
+        retried_transient = False
+        refreshed_session = False
+        while True:
             try:
                 result = await asyncio.wait_for(
                     self._session.read_resource(self._uri),
@@ -314,8 +383,16 @@ class MCPResourceWrapper(Tool):
                 logger.warning("MCP resource '{}' was cancelled by server/SDK", self._name)
                 return "(MCP resource read was cancelled)"
             except Exception as exc:
+                if await self._refresh_session_after_termination(
+                    exc,
+                    refreshed_session,
+                    "resource",
+                ):
+                    refreshed_session = True
+                    continue
                 if _is_transient(exc):
-                    if attempt == 0:
+                    if not retried_transient:
+                        retried_transient = True
                         logger.warning(
                             "MCP resource '{}' hit transient error ({}), retrying once...",
                             self._name,
@@ -350,13 +427,13 @@ class MCPResourceWrapper(Tool):
         return "(MCP resource read failed)"  # Unreachable
 
 
-class MCPPromptWrapper(Tool):
+class MCPPromptWrapper(_MCPWrapperBase):
     """Wraps an MCP prompt as a read-only nanobot Tool."""
 
     _plugin_discoverable = False
 
     def __init__(self, session, server_name: str, prompt_def, prompt_timeout: int = 30):
-        self._session = session
+        self._set_mcp_connection(session, server_name)
         self._prompt_name = prompt_def.name
         self._name = _sanitize_name(f"mcp_{server_name}_prompt_{prompt_def.name}")
         desc = prompt_def.description or prompt_def.name
@@ -402,7 +479,9 @@ class MCPPromptWrapper(Tool):
         from mcp import types
         from mcp.shared.exceptions import McpError
 
-        for attempt in range(2):
+        retried_transient = False
+        refreshed_session = False
+        while True:
             try:
                 result = await asyncio.wait_for(
                     self._session.get_prompt(self._prompt_name, arguments=kwargs),
@@ -420,6 +499,13 @@ class MCPPromptWrapper(Tool):
                 logger.warning("MCP prompt '{}' was cancelled by server/SDK", self._name)
                 return "(MCP prompt call was cancelled)"
             except McpError as exc:
+                if await self._refresh_session_after_termination(
+                    exc,
+                    refreshed_session,
+                    "prompt",
+                ):
+                    refreshed_session = True
+                    continue
                 logger.exception(
                     "MCP prompt '{}' failed: code={} message={}",
                     self._name,
@@ -429,7 +515,8 @@ class MCPPromptWrapper(Tool):
                 return f"(MCP prompt call failed: {exc.error.message} [code {exc.error.code}])"
             except Exception as exc:
                 if _is_transient(exc):
-                    if attempt == 0:
+                    if not retried_transient:
+                        retried_transient = True
                         logger.warning(
                             "MCP prompt '{}' hit transient error ({}), retrying once...",
                             self._name,
@@ -747,6 +834,7 @@ async def connect_missing_servers(state: Any, registry: ToolRegistry) -> None:
     try:
         connected = await connect_mcp_servers(missing_servers, registry)
         state._mcp_stacks.update(connected)
+        _attach_reconnect_handlers(state, registry, connected)
         state._mcp_connected = bool(state._mcp_stacks)
         if connected:
             logger.info("MCP connected servers: {}", sorted(connected))
@@ -766,8 +854,7 @@ async def reload_servers(state: Any, registry: ToolRegistry) -> dict[str, Any]:
     """Reconcile live MCP connections with the current config file."""
     async with _reload_lock(state):
         try:
-            from nanobot.config.loader import (load_config,
-                                               resolve_config_env_vars)
+            from nanobot.config.loader import load_config, resolve_config_env_vars
 
             config = resolve_config_env_vars(load_config())
             next_servers = dict(config.tools.mcp_servers)
@@ -808,6 +895,7 @@ async def reload_servers(state: Any, registry: ToolRegistry) -> dict[str, Any]:
         if to_connect:
             connected = await connect_mcp_servers(to_connect, registry)
             state._mcp_stacks.update(connected)
+            _attach_reconnect_handlers(state, registry, connected)
 
         state._mcp_connected = bool(state._mcp_stacks)
         failed = sorted(set(to_connect) - set(connected))
@@ -907,6 +995,68 @@ def _reload_lock(state: Any) -> asyncio.Lock:
         lock = asyncio.Lock()
         _RELOAD_LOCKS[state] = lock
         return lock
+
+
+def _attach_reconnect_handlers(
+    state: Any,
+    registry: ToolRegistry,
+    server_names: Mapping[str, Any] | set[str] | list[str] | tuple[str, ...],
+) -> None:
+    async def reconnect(server_name: str, tool_name: str, stale_tool: Tool) -> Tool | None:
+        return await _refresh_terminated_server(
+            state,
+            registry,
+            server_name,
+            tool_name,
+            stale_tool,
+        )
+
+    for server_name in server_names:
+        prefix = _tool_prefix(server_name)
+        for tool_name in list(registry.tool_names):
+            if not tool_name.startswith(prefix):
+                continue
+            tool = registry.get(tool_name)
+            if isinstance(tool, _MCPWrapperBase):
+                tool.set_reconnect_handler(reconnect)
+
+
+async def _refresh_terminated_server(
+    state: Any,
+    registry: ToolRegistry,
+    server_name: str,
+    tool_name: str,
+    stale_tool: Tool,
+) -> Tool | None:
+    async with _reload_lock(state):
+        cfg = state._mcp_servers.get(server_name)
+        if cfg is None:
+            logger.warning(
+                "MCP server '{}' session terminated but is no longer configured",
+                server_name,
+            )
+            return None
+
+        current_tool = registry.get(tool_name)
+        if (
+            current_tool is not None
+            and current_tool is not stale_tool
+            and server_name in state._mcp_stacks
+        ):
+            return current_tool
+
+        logger.warning("MCP server '{}' session terminated; refreshing connection", server_name)
+        _unregister_server_tools(state, registry, server_name)
+        await _close_server(state, server_name)
+
+        connected = await connect_mcp_servers({server_name: cfg}, registry)
+        state._mcp_stacks.update(connected)
+        _attach_reconnect_handlers(state, registry, connected)
+        state._mcp_connected = bool(state._mcp_stacks)
+        if server_name not in connected:
+            logger.warning("MCP server '{}' reconnect failed after session termination", server_name)
+            return None
+        return registry.get(tool_name)
 
 
 def _server_signature(cfg: Any) -> Any:

--- a/nanobot/channels/qq.py
+++ b/nanobot/channels/qq.py
@@ -490,13 +490,23 @@ class QQChannel(BaseChannel):
 
             content = (data.content or "").strip()
 
-            if not self.is_allowed(user_id):
-                return
-
             if data.id in self._processed_ids:
                 return
             self._processed_ids.append(data.id)
             self._chat_type_cache[chat_id] = chat_type
+
+            # Early permission check — avoid attachment downloads and ack side effects
+            # for unauthorized users. C2C messages can receive pairing codes;
+            # group messages remain silently ignored.
+            if not self.is_allowed(user_id):
+                if not is_group:
+                    await self._handle_message(
+                        sender_id=user_id,
+                        chat_id=chat_id,
+                        content="",
+                        is_dm=True,
+                    )
+                return
 
             # the data used by tests don't contain attachments property
             # so we use getattr with a default of [] to avoid AttributeError in tests
@@ -538,6 +548,7 @@ class QQChannel(BaseChannel):
                     "message_id": data.id,
                     "attachments": att_meta,
                 },
+                is_dm=not is_group,
             )
         except Exception:
             self.logger.exception("Error handling inbound message id={}", getattr(data, "id", "?"))

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -99,6 +99,12 @@ BUILTIN_COMMAND_SPECS: tuple[BuiltinCommandSpec, ...] = (
         "undo-2",
     ),
     BuiltinCommandSpec(
+        "/mcp",
+        "List MCP servers",
+        "Show configured MCP servers and connection status.",
+        "server",
+    ),
+    BuiltinCommandSpec(
         "/help",
         "Show help",
         "List available slash commands.",
@@ -642,6 +648,44 @@ async def cmd_pairing(ctx: CommandContext) -> OutboundMessage:
     )
 
 
+async def cmd_mcp(ctx: CommandContext) -> OutboundMessage:
+    """List configured MCP servers with connection status and registered tools."""
+    loop = ctx.loop
+    servers = getattr(loop, "_mcp_servers", None) or {}
+    stacks = getattr(loop, "_mcp_stacks", None) or {}
+
+    if not servers:
+        content = "No MCP servers configured. Add them under `tools.mcp_servers` in config."
+    else:
+        from nanobot.agent.tools.mcp import _tool_prefix
+
+        lines = [f"MCP servers ({len(stacks)}/{len(servers)} connected):", ""]
+        for name in sorted(servers):
+            cfg = servers[name]
+            transport = getattr(cfg, "transport", "stdio") if hasattr(cfg, "transport") else "stdio"
+            connected = name in stacks
+            status = "connected" if connected else "offline"
+            tool_names = sorted(
+                t for t in loop.tools.tool_names if t.startswith(_tool_prefix(name))
+            )
+            tool_count = len(tool_names)
+            if tool_names and tool_count <= 5:
+                tools_str = f"{tool_count} tool(s) ({', '.join(tool_names)})"
+            elif tool_names:
+                tools_str = f"{tool_count} tool(s) ({', '.join(tool_names[:3])}, ...)"
+            else:
+                tools_str = f"{tool_count} tool(s)"
+            lines.append(f"- **{name}** ({transport}) [{status}] — {tools_str}")
+        content = "\n".join(lines)
+
+    return OutboundMessage(
+        channel=ctx.msg.channel,
+        chat_id=ctx.msg.chat_id,
+        content=content,
+        metadata=dict(ctx.msg.metadata or {}),
+    )
+
+
 async def cmd_help(ctx: CommandContext) -> OutboundMessage:
     """Return available slash commands."""
     return OutboundMessage(
@@ -681,6 +725,7 @@ def register_builtin_commands(router: CommandRouter) -> None:
     router.prefix("/dream-log ", cmd_dream_log)
     router.exact("/dream-restore", cmd_dream_restore)
     router.prefix("/dream-restore ", cmd_dream_restore)
+    router.exact("/mcp", cmd_mcp)
     router.exact("/help", cmd_help)
     router.exact("/pairing", cmd_pairing)
     router.prefix("/pairing ", cmd_pairing)

--- a/nanobot/templates/agent/dream_phase1.md
+++ b/nanobot/templates/agent/dream_phase1.md
@@ -1,0 +1,51 @@
+You analyze conversation history and produce structured updates for the agent's memory files.
+
+Output valid JSON only. No Markdown, no code fences, no prose.
+
+Required top-level shape:
+{
+  "updates": [
+    {
+      "file": "SOUL.md | USER.md | memory/MEMORY.md | skills/<name>/SKILL.md",
+      "action": "edit | delete | create",
+      "old_text": "exact text to replace (omit for create)",
+      "new_text": "replacement text (omit for delete)"
+    }
+  ]
+}
+
+## File purposes
+- SOUL.md — bot behavior, tone, personality
+- USER.md — user identity, preferences
+- memory/MEMORY.md — knowledge, project context, facts
+
+## Rules for edits
+- Atomic facts: "has a cat named Luna" not "discussed pet care"
+- Corrections: {"file":"USER.md","action":"edit","old_text":"location is Osaka","new_text":"location is Tokyo"}
+- Confirm user-validated approaches
+
+## Deduplication — scan all memory files for:
+- Same fact stated in multiple files
+- Overlapping or nested sections covering the same topic
+- Information in MEMORY.md already in USER.md or SOUL.md
+- Verbose entries that can be condensed
+- Prefer keeping facts in their canonical location
+
+## Staleness
+MEMORY.md lines may have a `← Nd` suffix showing days since last modification:
+- SOUL.md and USER.md have NO age annotations — they are permanent
+- Age alone is not a reason to remove; use content judgment
+- Only prune: passed events, resolved tracking, superseded approaches
+- Lines with `← Nd` (N>14) deserve closer review but are not auto-removable
+
+## Skill creation — only emit create for a skill when ALL are true:
+- A repeatable workflow appeared 2+ times in conversation history
+- It has clear steps (not vague preferences)
+- Substantial enough for its own instruction set
+- Description is one line; body is the full skill content (concise, actionable)
+
+## What NOT to add
+- Current weather, transient status, temporary errors, conversational filler
+
+If nothing needs updating:
+{"updates":[]}

--- a/nanobot/templates/agent/dream_phase2.md
+++ b/nanobot/templates/agent/dream_phase2.md
@@ -1,0 +1,29 @@
+Apply the structured updates from the analysis below.
+
+Allowed paths:
+- SOUL.md
+- USER.md
+- memory/MEMORY.md
+- skills/<name>/SKILL.md (for [SKILL] creation only)
+
+## Editing rules
+- Use edit_file with exact old_text/new_text
+- Batch changes to the same file into one edit_file call
+- For deletions: section header + all bullets as old_text, new_text empty
+- Surgical edits only — never rewrite entire files
+- If the updates array is empty, stop without calling tools
+
+## Skill creation rules (for create action on skills/<name>/SKILL.md)
+- Use write_file to create the file
+- Before writing, read_file `{{ skill_creator_path }}` for format reference (frontmatter structure, naming conventions, quality standards)
+- **Dedup check**: read existing skills listed below to verify the new skill is not functionally redundant. Skip creation if an existing skill already covers the same workflow.
+- Include YAML frontmatter with name and description fields
+- Keep under 2000 words — concise and actionable
+- Do NOT overwrite existing skills
+- Skills are instruction sets — do not include implementation code
+
+## Quality
+- Every line must carry standalone value
+- Concise bullets under clear headers
+- When reducing (not deleting): keep essential facts, drop verbose details
+- If uncertain whether to delete, keep but add "(verify currency)"

--- a/tests/agent/test_autocompact_unit.py
+++ b/tests/agent/test_autocompact_unit.py
@@ -152,29 +152,50 @@ class TestIsExpired:
 
 
 # ---------------------------------------------------------------------------
-# _format_summary
+# session_summary_text (was _format_summary)
 # ---------------------------------------------------------------------------
 
 
-class TestFormatSummary:
-    """Test AutoCompact._format_summary static method."""
+class TestSessionSummaryText:
+    """Test session_summary_text for legacy _last_summary format compatibility."""
 
-    def test_contains_isoformat_timestamp(self):
-        """Output should contain last_active as isoformat."""
-        last_active = datetime(2026, 5, 13, 14, 30, 0)
-        result = AutoCompact._format_summary("Some text", last_active)
+    def test_legacy_dict_format_contains_timestamp(self):
+        """session_summary_text with legacy _last_summary dict should include isoformat."""
+        from nanobot.agent.memory import session_summary_text
+
+        session = _make_session(metadata={
+            "_last_summary": {
+                "text": "Some text",
+                "last_active": "2026-05-13T14:30:00",
+            },
+        })
+        result = session_summary_text(session)
+        assert result is not None
         assert "2026-05-13T14:30:00" in result
 
-    def test_contains_summary_text(self):
-        """Output should contain the provided text verbatim."""
-        last_active = datetime(2026, 1, 1)
-        result = AutoCompact._format_summary("User discussed Python.", last_active)
+    def test_legacy_dict_format_contains_summary_text(self):
+        """session_summary_text should contain the provided text verbatim."""
+        from nanobot.agent.memory import session_summary_text
+
+        session = _make_session(metadata={
+            "_last_summary": {
+                "text": "User discussed Python.",
+                "last_active": "2026-01-01T00:00:00",
+            },
+        })
+        result = session_summary_text(session)
+        assert result is not None
         assert "User discussed Python." in result
 
-    def test_output_starts_with_label(self):
-        """Output should start with the standard prefix."""
-        last_active = datetime(2026, 1, 1)
-        result = AutoCompact._format_summary("text", last_active)
+    def test_legacy_dict_format_starts_with_label(self):
+        """session_summary_text with legacy _last_summary dict should start with prefix."""
+        from nanobot.agent.memory import session_summary_text
+
+        session = _make_session(metadata={
+            "_last_summary": {"text": "text", "last_active": "2026-01-01T00:00:00"},
+        })
+        result = session_summary_text(session)
+        assert result is not None
         assert result.startswith("Previous conversation summary (last active ")
 
 
@@ -257,8 +278,8 @@ class TestCheckExpired:
         ac.check_expired(scheduler)
         scheduler.assert_not_called()
 
-    def test_dream_session_skips(self):
-        """Internal Dream sessions should not be scheduled for idle compact."""
+    def test_dream_key_is_now_archived_normally(self):
+        """Dream sessions are no longer internal; they should be scheduled like any session."""
         ac = _make_autocompact(ttl=15)
         mock_sm = MagicMock(spec=SessionManager)
         old_ts = (datetime.now() - timedelta(minutes=20)).isoformat()
@@ -270,8 +291,7 @@ class TestCheckExpired:
 
         ac.check_expired(scheduler)
 
-        scheduler.assert_not_called()
-        assert "dream:20260602-155256" not in ac._archiving
+        scheduler.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -296,15 +316,19 @@ class TestArchiveDelegates:
         )
 
     @pytest.mark.asyncio
-    async def test_dream_session_is_ignored(self):
+    async def test_dream_key_is_archived_normally(self):
+        """Dream sessions are no longer special-cased; they archive like any session."""
         ac = _make_autocompact()
+        mock_sm = MagicMock(spec=SessionManager)
+        session = _make_session()
+        mock_sm.get_or_create.return_value = session
+        ac.sessions = mock_sm
         ac.consolidator.compact_idle_session = AsyncMock(return_value="Summary.")
         ac._archiving.add("dream:20260602-155256")
 
         await ac._archive("dream:20260602-155256")
 
-        ac.consolidator.compact_idle_session.assert_not_awaited()
-        assert "dream:20260602-155256" not in ac._archiving
+        ac.consolidator.compact_idle_session.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_populates_summaries_from_metadata(self):
@@ -321,7 +345,7 @@ class TestArchiveDelegates:
 
         entry = ac._summaries.get("cli:test")
         assert entry is not None
-        assert entry[0] == "Hello."
+        assert "Hello." in entry
 
     @pytest.mark.asyncio
     async def test_no_summary_when_compact_returns_empty(self):
@@ -399,15 +423,13 @@ class TestPrepareSession:
         """Summary from _summaries dict should be returned (hot path)."""
         ac = _make_autocompact()
         session = _make_session()
-        last_active = datetime(2026, 5, 13, 14, 0, 0)
-        ac._summaries["cli:test"] = ("Hot summary.", last_active)
+        ac._summaries["cli:test"] = "Hot summary (pre-rendered)."
 
         result_session, summary = ac.prepare_session(session, "cli:test")
 
         assert result_session is session
         assert summary is not None
-        assert "Hot summary." in summary
-        assert "Previous conversation summary" in summary
+        assert "Hot summary" in summary
 
     def test_hot_path_pops_summary_one_shot(self):
         """Hot path should pop the summary (one-shot; second call returns None)."""
@@ -449,14 +471,14 @@ class TestPrepareSession:
         assert result_session is session
         assert summary is None
 
-    def test_dream_session_skips_reload_and_summaries(self):
-        """Internal Dream sessions should not reload or receive compact summaries."""
+    def test_dream_key_is_not_special_in_prepare(self):
+        """Dream sessions are no longer internal; prepare_session treats them normally."""
         ac = _make_autocompact(ttl=15)
         mock_sm = MagicMock(spec=SessionManager)
         ac.sessions = mock_sm
         key = "dream:20260602-155256"
         ac._archiving.add(key)
-        ac._summaries[key] = ("Hot summary.", datetime(2026, 6, 2, 15, 52, 56))
+        ac._summaries[key] = "Hot summary."
         session = _make_session(
             key=key,
             updated_at=datetime.now() - timedelta(minutes=20),
@@ -470,21 +492,18 @@ class TestPrepareSession:
 
         result_session, summary = ac.prepare_session(session, key)
 
-        mock_sm.get_or_create.assert_not_called()
-        assert result_session is session
-        assert summary is None
-        assert key not in ac._archiving
-        assert key not in ac._summaries
+        # Dream sessions now reload when expired, just like any other session
+        mock_sm.get_or_create.assert_called_once_with(key)
 
-    def test_cold_path_metadata_not_dict_returns_none(self):
-        """If metadata _last_summary is not a dict, should return None summary."""
+    def test_cold_path_legacy_string_metadata(self):
+        """If metadata _last_summary is a plain string, session_summary_text returns it as-is."""
         ac = _make_autocompact()
-        session = _make_session(metadata={"_last_summary": "not a dict"})
+        session = _make_session(metadata={"_last_summary": "legacy plain string summary"})
 
         result_session, summary = ac.prepare_session(session, "cli:test")
 
         assert result_session is session
-        assert summary is None
+        assert "legacy plain string summary" in summary
 
     def test_hot_path_takes_priority_over_metadata(self):
         """Hot path (_summaries) should take priority over metadata."""
@@ -495,8 +514,7 @@ class TestPrepareSession:
                 "last_active": datetime(2026, 1, 1).isoformat(),
             },
         })
-        last_active = datetime(2026, 5, 13, 14, 0, 0)
-        ac._summaries["cli:test"] = ("Hot summary.", last_active)
+        ac._summaries["cli:test"] = "Hot summary."
 
         _, summary = ac.prepare_session(session, "cli:test")
         assert "Hot summary." in summary

--- a/tests/agent/test_mcp_connection.py
+++ b/tests/agent/test_mcp_connection.py
@@ -289,6 +289,55 @@ async def test_mcp_tool_reconnects_after_session_terminated(
 
 
 @pytest.mark.asyncio
+async def test_mcp_reconnect_handler_uses_sanitized_server_prefix(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    loop = _make_loop(tmp_path, mcp_servers={"remote_": object()})
+    connect_count = 0
+
+    class _FakeSession:
+        def __init__(self, index: int) -> None:
+            self.index = index
+
+        async def call_tool(self, _name: str, arguments: dict[str, Any]) -> Any:
+            assert arguments == {}
+            if self.index == 1:
+                raise McpError(ErrorData(code=-32000, message="Session terminated"))
+            return SimpleNamespace(
+                content=[mcp_types.TextContent(type="text", text="recovered")]
+            )
+
+    async def _fake_connect(servers, registry):
+        nonlocal connect_count
+        stacks = {}
+        for name in servers:
+            connect_count += 1
+            tool_def = SimpleNamespace(
+                name="quote",
+                description="quote tool",
+                inputSchema={"type": "object", "properties": {}},
+            )
+            registry.register(MCPToolWrapper(_FakeSession(connect_count), name, tool_def))
+            stack = AsyncExitStack()
+            await stack.__aenter__()
+            stacks[name] = stack
+        return stacks
+
+    monkeypatch.setattr("nanobot.agent.tools.mcp.connect_mcp_servers", _fake_connect)
+
+    await loop._connect_mcp()
+    old_tool = loop.tools.get("mcp_remote_quote")
+    assert isinstance(old_tool, MCPToolWrapper)
+
+    output = await old_tool.execute()
+
+    assert output == "recovered"
+    assert connect_count == 2
+    assert loop.tools.get("mcp_remote_quote") is not old_tool
+
+
+@pytest.mark.asyncio
 async def test_concurrent_mcp_reconnect_reuses_fresh_session(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/agent/test_mcp_connection.py
+++ b/tests/agent/test_mcp_connection.py
@@ -4,14 +4,19 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import AsyncExitStack
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from mcp import types as mcp_types
+from mcp.shared.exceptions import McpError
+from mcp.types import ErrorData
 
 from nanobot.agent.loop import AgentLoop
 from nanobot.agent.tools import mcp as mcp_runtime
 from nanobot.agent.tools.base import Tool
+from nanobot.agent.tools.mcp import MCPResourceWrapper, MCPToolWrapper
 from nanobot.bus.queue import MessageBus
 from nanobot.config.loader import load_config, save_config
 from nanobot.config.schema import MCPServerConfig
@@ -218,3 +223,128 @@ async def test_reload_mcp_servers_retries_configured_server_without_live_stack(
     assert result["retried"] == ["browserbase"]
     assert loop.tools.has("mcp_browserbase_navigate")
     await loop.close_mcp()
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_reconnects_after_session_terminated(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    loop = _make_loop(tmp_path, mcp_servers={"remote": object()})
+    closed: list[str] = []
+    sessions: list[Any] = []
+    connect_count = 0
+
+    async def _mark_closed(name: str) -> None:
+        closed.append(name)
+
+    class _FakeSession:
+        def __init__(self, index: int) -> None:
+            self.index = index
+            self.call_count = 0
+
+        async def call_tool(self, _name: str, arguments: dict[str, Any]) -> Any:
+            self.call_count += 1
+            assert arguments == {"symbol": "AAPL"}
+            if self.index == 1:
+                raise McpError(ErrorData(code=-32000, message="Session terminated"))
+            return SimpleNamespace(
+                content=[mcp_types.TextContent(type="text", text="recovered")]
+            )
+
+    async def _fake_connect(servers, registry):
+        nonlocal connect_count
+        stacks = {}
+        for name in servers:
+            connect_count += 1
+            session = _FakeSession(connect_count)
+            sessions.append(session)
+            tool_def = SimpleNamespace(
+                name="quote",
+                description="quote tool",
+                inputSchema={"type": "object", "properties": {}},
+            )
+            registry.register(MCPToolWrapper(session, name, tool_def, tool_timeout=5))
+            stack = AsyncExitStack()
+            await stack.__aenter__()
+            stack.push_async_callback(_mark_closed, name)
+            stacks[name] = stack
+        return stacks
+
+    monkeypatch.setattr("nanobot.agent.tools.mcp.connect_mcp_servers", _fake_connect)
+
+    await loop._connect_mcp()
+    old_tool = loop.tools.get("mcp_remote_quote")
+    assert isinstance(old_tool, MCPToolWrapper)
+
+    output = await old_tool.execute(symbol="AAPL")
+
+    assert output == "recovered"
+    assert connect_count == 2
+    assert closed == ["remote"]
+    assert sessions[0].call_count == 1
+    assert sessions[1].call_count == 1
+    assert "remote" in loop._mcp_stacks
+    assert loop.tools.get("mcp_remote_quote") is not old_tool
+
+
+@pytest.mark.asyncio
+async def test_concurrent_mcp_reconnect_reuses_fresh_session(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    loop = _make_loop(tmp_path, mcp_servers={"remote": object()})
+    closed: list[str] = []
+    connect_count = 0
+
+    async def _mark_closed(name: str) -> None:
+        closed.append(name)
+
+    class _DeadSession:
+        async def read_resource(self, _uri: str) -> Any:
+            raise McpError(ErrorData(code=-32000, message="Session terminated"))
+
+    class _LiveSession:
+        async def read_resource(self, uri: str) -> Any:
+            await asyncio.sleep(0)
+            return SimpleNamespace(
+                contents=[
+                    mcp_types.TextResourceContents(
+                        uri=uri,
+                        text=f"fresh:{uri.rsplit('/', maxsplit=1)[-1]}",
+                    )
+                ]
+            )
+
+    async def _fake_connect(servers, registry):
+        nonlocal connect_count
+        stacks = {}
+        for name in servers:
+            connect_count += 1
+            session = _DeadSession() if connect_count == 1 else _LiveSession()
+            for resource_name in ("alpha", "beta"):
+                resource_def = SimpleNamespace(
+                    name=resource_name,
+                    uri=f"file:///{resource_name}",
+                    description=f"{resource_name} resource",
+                )
+                registry.register(MCPResourceWrapper(session, name, resource_def))
+            stack = AsyncExitStack()
+            await stack.__aenter__()
+            stack.push_async_callback(_mark_closed, name)
+            stacks[name] = stack
+        return stacks
+
+    monkeypatch.setattr("nanobot.agent.tools.mcp.connect_mcp_servers", _fake_connect)
+
+    await loop._connect_mcp()
+    old_alpha = loop.tools.get("mcp_remote_resource_alpha")
+    old_beta = loop.tools.get("mcp_remote_resource_beta")
+    assert isinstance(old_alpha, MCPResourceWrapper)
+    assert isinstance(old_beta, MCPResourceWrapper)
+
+    outputs = await asyncio.gather(old_alpha.execute(), old_beta.execute())
+
+    assert outputs == ["fresh:alpha", "fresh:beta"]
+    assert connect_count == 2
+    assert closed == ["remote"]

--- a/tests/agent/test_mcp_transient_retry.py
+++ b/tests/agent/test_mcp_transient_retry.py
@@ -464,3 +464,29 @@ async def test_prompt_reconnects_on_session_terminated():
     assert output == "fresh prompt"
     assert old_session.get_prompt.call_count == 1
     assert new_session.get_prompt.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_prompt_reconnects_on_connection_closed_exception():
+    """Prompt should reconnect when the SDK reports a closed session as a generic exception."""
+    old_session = AsyncMock()
+    old_session.get_prompt = AsyncMock(side_effect=RuntimeError("Connection closed"))
+    new_session = AsyncMock()
+    new_session.get_prompt = AsyncMock(return_value=_make_prompt_result("fresh prompt"))
+
+    wrapper = MCPPromptWrapper(old_session, "test_server", _make_prompt_def())
+    replacement = MCPPromptWrapper(new_session, "test_server", _make_prompt_def())
+
+    async def reconnect(server_name: str, tool_name: str, stale_tool):
+        assert server_name == "test_server"
+        assert tool_name == "mcp_test_server_prompt_test_prompt"
+        assert stale_tool is wrapper
+        return replacement
+
+    wrapper.set_reconnect_handler(reconnect)
+
+    output = await wrapper.execute()
+
+    assert output == "fresh prompt"
+    assert old_session.get_prompt.call_count == 1
+    assert new_session.get_prompt.call_count == 1

--- a/tests/agent/test_mcp_transient_retry.py
+++ b/tests/agent/test_mcp_transient_retry.py
@@ -13,6 +13,7 @@ from nanobot.agent.tools.mcp import (
     MCPPromptWrapper,
     MCPResourceWrapper,
     MCPToolWrapper,
+    _is_session_terminated,
     _is_transient,
 )
 
@@ -33,6 +34,14 @@ class _FakeEndOfStreamError(Exception):
 
 
 _FakeEndOfStreamError.__name__ = "EndOfStream"
+
+
+def _session_terminated_error() -> McpError:
+    return McpError(ErrorData(code=-32000, message="Session terminated"))
+
+
+def _connection_closed_error() -> McpError:
+    return McpError(ErrorData(code=-32000, message="Connection closed"))
 
 
 def test_is_transient_recognizes_closed_resource():
@@ -65,6 +74,14 @@ def test_is_transient_rejects_runtime_error():
 
 def test_is_transient_rejects_timeout():
     assert not _is_transient(TimeoutError("timeout"))
+
+
+def test_is_session_terminated_recognizes_mcp_error():
+    assert _is_session_terminated(_session_terminated_error())
+
+
+def test_is_session_terminated_recognizes_connection_closed_mcp_error():
+    assert _is_session_terminated(_connection_closed_error())
 
 
 # ---------------------------------------------------------------------------
@@ -219,6 +236,35 @@ async def test_tool_retry_on_end_of_stream():
     assert session.call_tool.call_count == 2
 
 
+@pytest.mark.asyncio
+async def test_tool_reconnects_when_transient_retry_reveals_terminated_session():
+    """Tool should reconnect if a stale session reports termination after transient retry."""
+    old_session = AsyncMock()
+    old_session.call_tool = AsyncMock(
+        side_effect=[_FakeClosedResourceError("closed"), _session_terminated_error()]
+    )
+    new_session = AsyncMock()
+    new_session.call_tool = AsyncMock(return_value=_make_tool_result("fresh"))
+
+    wrapper = MCPToolWrapper(old_session, "test_server", _make_tool_def(), tool_timeout=5)
+    replacement = MCPToolWrapper(new_session, "test_server", _make_tool_def(), tool_timeout=5)
+
+    async def reconnect(server_name: str, tool_name: str, stale_tool):
+        assert server_name == "test_server"
+        assert tool_name == "mcp_test_server_test_tool"
+        assert stale_tool is wrapper
+        return replacement
+
+    wrapper.set_reconnect_handler(reconnect)
+
+    with patch("nanobot.agent.tools.mcp.asyncio.sleep", new_callable=AsyncMock):
+        output = await wrapper.execute(foo="bar")
+
+    assert output == "fresh"
+    assert old_session.call_tool.call_count == 2
+    assert new_session.call_tool.call_count == 1
+
+
 # ---------------------------------------------------------------------------
 # MCPResourceWrapper retry behaviour
 # ---------------------------------------------------------------------------
@@ -282,6 +328,32 @@ async def test_resource_no_retry_on_non_transient():
 
     assert "RuntimeError" in output
     assert session.read_resource.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_resource_reconnects_on_session_terminated():
+    """Resource should reconnect once when the MCP SDK reports a dead session."""
+    old_session = AsyncMock()
+    old_session.read_resource = AsyncMock(side_effect=_session_terminated_error())
+    new_session = AsyncMock()
+    new_session.read_resource = AsyncMock(return_value=_make_resource_result("fresh"))
+
+    wrapper = MCPResourceWrapper(old_session, "test_server", _make_resource_def())
+    replacement = MCPResourceWrapper(new_session, "test_server", _make_resource_def())
+
+    async def reconnect(server_name: str, tool_name: str, stale_tool):
+        assert server_name == "test_server"
+        assert tool_name == "mcp_test_server_resource_test_resource"
+        assert stale_tool is wrapper
+        return replacement
+
+    wrapper.set_reconnect_handler(reconnect)
+
+    output = await wrapper.execute()
+
+    assert output == "fresh"
+    assert old_session.read_resource.call_count == 1
+    assert new_session.read_resource.call_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -366,3 +438,29 @@ async def test_prompt_no_retry_on_non_transient():
 
     assert "RuntimeError" in output
     assert session.get_prompt.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_prompt_reconnects_on_session_terminated():
+    """Prompt should reconnect once before falling back to McpError handling."""
+    old_session = AsyncMock()
+    old_session.get_prompt = AsyncMock(side_effect=_session_terminated_error())
+    new_session = AsyncMock()
+    new_session.get_prompt = AsyncMock(return_value=_make_prompt_result("fresh prompt"))
+
+    wrapper = MCPPromptWrapper(old_session, "test_server", _make_prompt_def())
+    replacement = MCPPromptWrapper(new_session, "test_server", _make_prompt_def())
+
+    async def reconnect(server_name: str, tool_name: str, stale_tool):
+        assert server_name == "test_server"
+        assert tool_name == "mcp_test_server_prompt_test_prompt"
+        assert stale_tool is wrapper
+        return replacement
+
+    wrapper.set_reconnect_handler(reconnect)
+
+    output = await wrapper.execute()
+
+    assert output == "fresh prompt"
+    assert old_session.get_prompt.call_count == 1
+    assert new_session.get_prompt.call_count == 1

--- a/tests/channels/test_qq_channel.py
+++ b/tests/channels/test_qq_channel.py
@@ -1,7 +1,7 @@
 import tempfile
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -56,6 +56,51 @@ async def test_on_group_message_routes_to_group_chat_id() -> None:
     msg = await channel.bus.consume_inbound()
     assert msg.sender_id == "user1"
     assert msg.chat_id == "group123"
+
+
+@pytest.mark.asyncio
+async def test_on_c2c_message_passes_is_dm_true_to_base_handler() -> None:
+    channel = QQChannel(QQConfig(app_id="app", secret="secret", allow_from=["user1"]), MessageBus())
+    channel._handle_message = AsyncMock()
+
+    data = SimpleNamespace(
+        id="msg-c2c",
+        content="hello",
+        author=SimpleNamespace(user_openid="user1"),
+        attachments=[],
+    )
+
+    await channel._on_message(data, is_group=False)
+
+    channel._handle_message.assert_awaited_once()
+    kwargs = channel._handle_message.await_args.kwargs
+    assert kwargs["sender_id"] == "user1"
+    assert kwargs["chat_id"] == "user1"
+    assert kwargs["content"] == "hello"
+    assert kwargs["is_dm"] is True
+
+
+@pytest.mark.asyncio
+async def test_on_group_message_passes_is_dm_false_to_base_handler() -> None:
+    channel = QQChannel(QQConfig(app_id="app", secret="secret", allow_from=["user1"]), MessageBus())
+    channel._handle_message = AsyncMock()
+
+    data = SimpleNamespace(
+        id="msg-group",
+        content="hello",
+        group_openid="group123",
+        author=SimpleNamespace(member_openid="user1"),
+        attachments=[],
+    )
+
+    await channel._on_message(data, is_group=True)
+
+    channel._handle_message.assert_awaited_once()
+    kwargs = channel._handle_message.await_args.kwargs
+    assert kwargs["sender_id"] == "user1"
+    assert kwargs["chat_id"] == "group123"
+    assert kwargs["content"] == "hello"
+    assert kwargs["is_dm"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/channels/test_qq_media.py
+++ b/tests/channels/test_qq_media.py
@@ -183,7 +183,7 @@ async def test_send_media_failure_falls_back_to_text() -> None:
 
 
 @pytest.mark.asyncio
-async def test_on_message_ignores_unauthorized_sender_before_attachments_and_ack() -> None:
+async def test_on_message_unauthorized_c2c_pairs_before_attachments_and_ack() -> None:
     channel = QQChannel(
         QQConfig(
             app_id="app",
@@ -207,8 +207,44 @@ async def test_on_message_ignores_unauthorized_sender_before_attachments_and_ack
     await channel._on_message(data, is_group=False)
 
     channel._handle_attachments.assert_not_awaited()
+    channel._handle_message.assert_awaited_once_with(
+        sender_id="blocked-user",
+        chat_id="blocked-user",
+        content="",
+        is_dm=True,
+    )
+    assert channel._client.api.c2c_calls == []
+
+
+@pytest.mark.asyncio
+async def test_on_message_ignores_unauthorized_group_before_attachments_and_ack() -> None:
+    channel = QQChannel(
+        QQConfig(
+            app_id="app",
+            secret="secret",
+            allow_from=["allowed-user"],
+            ack_message="Processing...",
+        ),
+        MessageBus(),
+    )
+    channel._client = _FakeClient()
+    channel._handle_attachments = AsyncMock(return_value=(["/tmp/a.png"], ["file"], []))
+    channel._handle_message = AsyncMock()
+
+    data = SimpleNamespace(
+        id="msg-blocked-group",
+        content="hello",
+        group_openid="group123",
+        author=SimpleNamespace(member_openid="blocked-user"),
+        attachments=[SimpleNamespace(filename="a.png")],
+    )
+
+    await channel._on_message(data, is_group=True)
+
+    channel._handle_attachments.assert_not_awaited()
     channel._handle_message.assert_not_awaited()
     assert channel._client.api.c2c_calls == []
+    assert channel._client.api.group_calls == []
 
 
 # ── _on_message() exception handling ────────────────────────────────

--- a/tests/command/test_mcp_command.py
+++ b/tests/command/test_mcp_command.py
@@ -1,0 +1,128 @@
+"""Tests for the /mcp built-in command."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from nanobot.bus.events import InboundMessage
+from nanobot.command.builtin import cmd_mcp, register_builtin_commands
+from nanobot.command.router import CommandContext, CommandRouter
+
+
+def _cfg(transport: str = "stdio") -> SimpleNamespace:
+    """Fake MCP server config object (models.MCPServerConfig-compatible shape)."""
+    return SimpleNamespace(transport=transport)
+
+
+def _loop(servers: dict | None = None, stacks: dict | None = None, tool_names: list | None = None):
+    """Build a mock loop with the attributes cmd_mcp reads."""
+    loop = MagicMock()
+    loop._mcp_servers = servers or {}
+    loop._mcp_stacks = stacks or {}
+    mock_tools = MagicMock()
+    mock_tools.tool_names = set(tool_names or [])
+    loop.tools = mock_tools
+    return loop
+
+
+def _ctx(loop, raw: str = "/mcp"):
+    msg = InboundMessage(channel="cli", sender_id="user", chat_id="direct", content=raw)
+    return CommandContext(msg=msg, session=None, key=msg.session_key, raw=raw, args="", loop=loop)
+
+
+@pytest.mark.asyncio
+async def test_no_servers_configured():
+    """When no MCP servers are configured, show a helpful message."""
+    loop = _loop()
+    out = await cmd_mcp(_ctx(loop))
+    assert "No MCP servers configured" in out.content
+
+
+@pytest.mark.asyncio
+async def test_one_connected_server():
+    """One configured server that is connected — show it as connected."""
+    loop = _loop(
+        servers={"github": _cfg("stdio")},
+        stacks={"github": MagicMock()},
+        tool_names={"mcp_github_search_repos", "mcp_github_list_prs"},
+    )
+    out = await cmd_mcp(_ctx(loop))
+    assert "MCP servers (1/1 connected)" in out.content
+    assert "**github** (stdio) [connected]" in out.content
+    assert "2 tool(s) (mcp_github_list_prs, mcp_github_search_repos)" in out.content
+
+
+@pytest.mark.asyncio
+async def test_one_offline_server():
+    """One configured server that is not connected — show as offline."""
+    loop = _loop(
+        servers={"database": _cfg("sse")},
+        stacks={},
+    )
+    out = await cmd_mcp(_ctx(loop))
+    assert "MCP servers (0/1 connected)" in out.content
+    assert "**database** (sse) [offline]" in out.content
+    assert "0 tool(s)" in out.content
+
+
+@pytest.mark.asyncio
+async def test_mixed_connected_and_offline():
+    """Multiple servers, some connected, some not."""
+    loop = _loop(
+        servers={
+            "github": _cfg("stdio"),
+            "database": _cfg("sse"),
+            "filesystem": _cfg("stdio"),
+        },
+        stacks={"github": MagicMock(), "filesystem": MagicMock()},
+        tool_names={
+            "mcp_github_search_repos", "mcp_github_get_issue",
+            "mcp_filesystem_read_file", "mcp_filesystem_write_file",
+            "mcp_filesystem_list_dir",
+        },
+    )
+    out = await cmd_mcp(_ctx(loop))
+    assert "MCP servers (2/3 connected)" in out.content
+    assert "**database** (sse) [offline]" in out.content
+    assert "**filesystem** (stdio) [connected]" in out.content
+    assert "**github** (stdio) [connected]" in out.content
+
+
+@pytest.mark.asyncio
+async def test_servers_listed_alphabetically():
+    """Server names should be sorted."""
+    loop = _loop(
+        servers={"zzz": _cfg(), "aaa": _cfg(), "mmm": _cfg()},
+        stacks={"zzz": MagicMock(), "aaa": MagicMock(), "mmm": MagicMock()},
+    )
+    out = await cmd_mcp(_ctx(loop))
+    lines = out.content.split("\n")
+    # Server entries start with "- **"
+    server_lines = [line for line in lines if line.startswith("- **")]
+    names = [line.split("**")[1] for line in server_lines]
+    assert names == sorted(names)
+
+
+@pytest.mark.asyncio
+async def test_many_tools_are_truncated():
+    """When a server has >5 tools, only list first 3 then '...'."""
+    tools = {f"mcp_gh_{i}" for i in range(10)}
+    loop = _loop(
+        servers={"gh": _cfg()},
+        stacks={"gh": MagicMock()},
+        tool_names=tools,
+    )
+    out = await cmd_mcp(_ctx(loop))
+    assert "10 tool(s) (mcp_gh_0, mcp_gh_1, mcp_gh_2, ...)" in out.content
+
+
+@pytest.mark.asyncio
+async def test_mcp_command_registered_on_router():
+    """/mcp should be routed via the built-in command router."""
+    router = CommandRouter()
+    register_builtin_commands(router)
+    loop = _loop()
+    out = await router.dispatch(_ctx(loop, "/mcp"))
+    assert out is not None
+    assert "No MCP servers configured" in out.content

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -9,10 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.4",
-        "@radix-ui/react-avatar": "^1.1.2",
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-dropdown-menu": "^2.1.4",
-        "@radix-ui/react-scroll-area": "^1.2.2",
         "@radix-ui/react-separator": "^1.1.1",
         "@radix-ui/react-slot": "^1.1.1",
         "@radix-ui/react-tooltip": "^1.1.6",
@@ -1009,10 +1007,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@radix-ui/number": {
-      "version": "1.1.1",
-      "license": "MIT"
-    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "license": "MIT"
@@ -1064,65 +1058,6 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-avatar": {
-      "version": "1.1.11",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-context": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.4",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-is-hydrated": "0.1.0",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-context": {
-      "version": "1.1.3",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1566,35 +1501,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-scroll-area": {
-      "version": "1.2.10",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/number": "1.1.1",
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-separator": {
       "version": "1.1.8",
       "license": "MIT",
@@ -1752,22 +1658,6 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-is-hydrated": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "^1.5.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1946,9 +1836,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1963,9 +1850,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1980,9 +1864,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1997,9 +1878,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2014,9 +1892,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2031,9 +1906,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2048,9 +1920,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2065,9 +1934,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2082,9 +1948,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2099,9 +1962,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2116,9 +1976,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
-  const target = env.NANOBOT_API_URL ?? "http://127.0.0.1:8765";
+  const target = env.NANOBOT_API_URL ?? "http://127.0.0.1:18791";
   const hmrPath = "/__nanobot_vite_hmr";
 
   return {


### PR DESCRIPTION
## 概述

本 PR 包含 5 个方面的改进：

### 1. 敏感信息脱敏
- append_history / write_memory / write_soul / write_user 落盘前自动脱敏
- 覆盖 PEM 私钥、Bearer Token、OpenAI Key、GitHub Token、赋值式密钥、邮箱、身份证号、16 位以上长数字
- 各正则独立，过脱敏优于欠脱敏

### 2. Dream 双阶段重写
- 移除旧的 build_dream_prompt/build_dream_tools/dream_session_key 等
- Phase 1: 纯 LLM 分析 history.jsonl 输出结构化 JSON
- Phase 2: AgentRunner + read_file/edit_file/write_file 增量编辑
- EditFileTool allowed_dir 限制在 memory/ + SOUL.md + USER.md + skills/，防 prompt injection
- 仅在 stop_reason==completed 时前进游标 + git commit
- 新增 dream_phase1.md / dream_phase2.md prompt 模板

### 3. 原子写入保障
- _write_text_atomic: tmp -> fsync -> os.replace -> fsync parent
- 替代所有裸 write_text 调用
- _read_cursor_file 统一 cursor 读取

### 4. 会话摘要优化
- _recent_summaries 保留最近 5 条（替代 _last_summary 的单条）
- session_summary_text 统一格式化，兼容旧格式
- compact_idle_session 用身份对比计算丢弃消息

### 5. AutoCompact 简化
- 移除 _INTERNAL_SESSION_PREFIXES / _is_internal_session / _format_summary
- Dream 不再使用临时 session

### 并发安全
- append_history 恢复 self._lock 保护 cursor 分配+追加+写入原子性

## 变更文件
nanobot/agent/memory.py (+528 -185), autocompact.py (+35 -49), 新增 2 个模板, 测试适配

## 测试
76 passed