### PR TITLE
feat(image): support custom image generation provider

### DIFF
--- a/docs/image-generation.md
+++ b/docs/image-generation.md
@@ -46,7 +46,7 @@ The WebUI hides provider storage details from the user. The agent sees the saved
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `tools.imageGeneration.enabled` | boolean | `false` | Register the `generate_image` tool |
-| `tools.imageGeneration.provider` | string | `"openrouter"` | Image provider name. Supported values: `openrouter`, `aihubmix`, `minimax`, `gemini`, `ollama`, `stepfun`, `zhipu` |
+| `tools.imageGeneration.provider` | string | `"openrouter"` | Image provider name. Supported values: `openrouter`, `custom`, `aihubmix`, `minimax`, `gemini`, `ollama`, `stepfun`, `zhipu` |
 | `tools.imageGeneration.model` | string | `"openai/gpt-5.4-image-2"` | Provider model name |
 | `tools.imageGeneration.defaultAspectRatio` | string | `"1:1"` | Default ratio when the prompt/tool call does not specify one |
 | `tools.imageGeneration.defaultImageSize` | string | `"1K"` | Default size hint, for example `1K`, `2K`, `4K`, or `1024x1024` |
@@ -83,6 +83,32 @@ OpenRouter uses a chat-completions style image response. Configure:
 ```
 
 Use a model that supports image generation and image editing if you want reference-image edits.
+
+### Custom (OpenAI-compatible)
+
+Any OpenAI-compatible image generation API can be used with the `custom` provider. This includes local Stable Diffusion servers, Replicate, Agnes AI, and similar services that expose the `/v1/images/generations` endpoint.
+
+Configure:
+
+```json
+{
+  "providers": {
+    "custom": {
+      "apiKey": "${CUSTOM_IMAGE_API_KEY}",
+      "apiBase": "https://api.example.com/v1"
+    }
+  },
+  "tools": {
+    "imageGeneration": {
+      "enabled": true,
+      "provider": "custom",
+      "model": "your-model-name"
+    }
+  }
+}
+```
+
+The `apiBase` is required. The provider sends requests to `{apiBase}/images/generations` using the OpenAI Images API format with `response_format: "b64_json"`.
 
 ### AIHubMix
 

--- a/docs/image-generation.md
+++ b/docs/image-generation.md
@@ -108,7 +108,7 @@ Configure:
 }
 ```
 
-The `apiBase` is required. The provider sends requests to `{apiBase}/images/generations` using the OpenAI Images API format with `response_format: "b64_json"`.
+The `apiBase` is required. The provider sends requests to `{apiBase}/images/generations` using the OpenAI Images API format with `response_format: "b64_json"`. The `apiKey` is optional for local or unauthenticated endpoints.
 
 ### AIHubMix
 
@@ -350,7 +350,7 @@ Use the reference image. Keep the same robot and composition, change the palette
 |---------|-------|
 | `generate_image` is not available | Set `tools.imageGeneration.enabled` to `true` and restart the gateway |
 | Missing API key error | Configure `providers.<provider>.apiKey`; if using `${VAR_NAME}`, confirm the environment variable is visible to the gateway process |
-| `unsupported image generation provider` | Use `openrouter`, `aihubmix`, `minimax`, `gemini`, `ollama`, `stepfun`, or `zhipu` |
+| `unsupported image generation provider` | Use `openrouter`, `custom`, `aihubmix`, `minimax`, `gemini`, `ollama`, `stepfun`, or `zhipu` |
 | AIHubMix says `Incorrect model ID` | Use `model: "gpt-image-2-free"`; nanobot expands it to the required `openai/gpt-image-2-free` model path internally |
 | Generation times out | Try a smaller/default image size, set AIHubMix `extraBody.quality` to `"low"`, or retry later |
 | Reference image rejected | Reference image paths must be inside the workspace or nanobot media directory and must be valid image files |

--- a/docs/image-generation.md
+++ b/docs/image-generation.md
@@ -23,7 +23,7 @@ The feature is disabled by default. Enable it in `~/.nanobot/config.json`, confi
 }
 ```
 
-See [Provider Notes](#provider-notes) for AIHubMix, MiniMax, Gemini, Ollama, StepFun, and Zhipu configuration examples.
+See [Provider Notes](#provider-notes) for Custom, AIHubMix, MiniMax, Gemini, Ollama, StepFun, and Zhipu configuration examples.
 
 > [!TIP]
 > Prefer environment variables for API keys. nanobot resolves `${VAR_NAME}` values from the environment at startup.
@@ -86,7 +86,13 @@ Use a model that supports image generation and image editing if you want referen
 
 ### Custom (OpenAI-compatible)
 
-Any OpenAI-compatible image generation API can be used with the `custom` provider. This includes local Stable Diffusion servers, Replicate, Agnes AI, and similar services that expose the `/v1/images/generations` endpoint.
+Use the `custom` provider for services that implement the synchronous OpenAI Images API:
+
+```text
+POST /v1/images/generations
+```
+
+The response must include generated images in `data[].b64_json` or `data[].url`. Native prediction APIs, such as Replicate's `/v1/models/{owner}/{model}/predictions`, are not directly compatible unless you put an OpenAI-compatible gateway in front of them.
 
 Configure:
 
@@ -108,7 +114,15 @@ Configure:
 }
 ```
 
-The `apiBase` is required. The provider sends requests to `{apiBase}/images/generations` using the OpenAI Images API format with `response_format: "b64_json"`. The `apiKey` is optional for local or unauthenticated endpoints.
+The `apiBase` is required. The provider sends requests to `{apiBase}/images/generations` using the OpenAI Images API format with `response_format: "b64_json"`. The `apiKey` is optional for local or unauthenticated endpoints. Reference-image edits are not supported by the generic `custom` provider.
+
+`extraBody` can adapt provider-specific quirks because it is merged last into the request body. Examples:
+
+- Agnes AI documents URL responses, so use `"extraBody": {"response_format": "url"}`.
+- Together AI documents `"response_format": "base64"`, so override the default.
+- Volcengine Ark Seedream models may require size hints such as `"2K"`, `"3K"`, `"4K"`, or explicit dimensions. Set `tools.imageGeneration.defaultImageSize` or `providers.custom.extraBody.size` to a value supported by the selected model.
+
+For compatibility with the default nanobot setting, custom maps `defaultImageSize: "1K"` to `1024x1024`. Other explicit size hints are passed through unchanged.
 
 ### AIHubMix
 

--- a/nanobot/providers/image_generation.py
+++ b/nanobot/providers/image_generation.py
@@ -1046,7 +1046,13 @@ class CustomImageGenerationClient(ImageGenerationProvider):
 
     @staticmethod
     def _custom_size(aspect_ratio: str | None, image_size: str | None) -> str:
-        return _openai_size("gpt-image-2", aspect_ratio, image_size)
+        if image_size:
+            requested = image_size.strip()
+            if requested:
+                if requested.lower() == "1k":
+                    return "1024x1024"
+                return requested
+        return _openai_size("gpt-image-2", aspect_ratio, None)
 
     async def generate(
         self,

--- a/nanobot/providers/image_generation.py
+++ b/nanobot/providers/image_generation.py
@@ -1033,6 +1033,92 @@ class OpenAIImageGenerationClient(ImageGenerationProvider):
         return GeneratedImageResponse(images=images, content="", raw=payload)
 
 
+class CustomImageGenerationClient(ImageGenerationProvider):
+    """OpenAI-compatible Images API for user-configured custom providers."""
+
+    provider_name = "custom"
+    missing_key_message = (
+        "Custom image generation API key is not configured. Set providers.custom.apiKey."
+    )
+
+    def _default_base_url(self) -> str:
+        return ""
+
+    @staticmethod
+    def _custom_size(aspect_ratio: str | None, image_size: str | None) -> str:
+        return _openai_size("gpt-image-2", aspect_ratio, image_size)
+
+    async def generate(
+        self,
+        *,
+        prompt: str,
+        model: str,
+        reference_images: list[str] | None = None,
+        aspect_ratio: str | None = None,
+        image_size: str | None = None,
+    ) -> GeneratedImageResponse:
+        if not self.api_key:
+            raise ImageGenerationError(self.missing_key_message)
+
+        if reference_images:
+            logger.warning(
+                "Custom image generation does not support reference images; "
+                "ignoring {} reference image(s) for {}",
+                len(reference_images),
+                model,
+            )
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            **self.extra_headers,
+        }
+
+        body: dict[str, Any] = {
+            "model": model,
+            "prompt": prompt,
+            "response_format": "b64_json",
+            "n": 1,
+            "size": self._custom_size(aspect_ratio, image_size),
+        }
+        body.update(self.extra_body)
+
+        logger.info("Custom Images API request: POST {}/images/generations body={}", self.api_base, body)
+
+        response = await self._http_post(
+            f"{self.api_base}/images/generations",
+            headers=headers,
+            body=body,
+        )
+
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            detail = response.text[:1000]
+            logger.error("Custom Images API error ({}): {}", response.status_code, detail)
+            raise ImageGenerationError(
+                f"Custom image generation failed (HTTP {response.status_code}): {detail}"
+            ) from exc
+
+        payload = response.json()
+        logger.info("Custom Images API response ({}): {}", response.status_code,
+                       {k: v for k, v in payload.items() if k != "data"})
+
+        client = self._client
+        owns_client = client is None
+        if owns_client:
+            client = httpx.AsyncClient(timeout=self.timeout)
+        try:
+            images = await _openai_images_from_payload(client, payload)
+        finally:
+            if owns_client:
+                await client.aclose()
+
+        self._require_images(images, payload)
+
+        return GeneratedImageResponse(images=images, content="", raw=payload)
+
+
 # ---------------------------------------------------------------------------
 # OpenAI Codex image generation
 # ---------------------------------------------------------------------------
@@ -1594,6 +1680,7 @@ async def _zhipu_images_from_payload(
 
 register_image_gen_provider(AIHubMixImageGenerationClient)
 register_image_gen_provider(CodexImageGenerationClient)
+register_image_gen_provider(CustomImageGenerationClient)
 register_image_gen_provider(GeminiImageGenerationClient)
 register_image_gen_provider(OllamaImageGenerationClient)
 register_image_gen_provider(MiniMaxImageGenerationClient)

--- a/nanobot/providers/image_generation.py
+++ b/nanobot/providers/image_generation.py
@@ -1037,8 +1037,8 @@ class CustomImageGenerationClient(ImageGenerationProvider):
     """OpenAI-compatible Images API for user-configured custom providers."""
 
     provider_name = "custom"
-    missing_key_message = (
-        "Custom image generation API key is not configured. Set providers.custom.apiKey."
+    missing_base_message = (
+        "Custom image generation API base is not configured. Set providers.custom.apiBase."
     )
 
     def _default_base_url(self) -> str:
@@ -1057,8 +1057,8 @@ class CustomImageGenerationClient(ImageGenerationProvider):
         aspect_ratio: str | None = None,
         image_size: str | None = None,
     ) -> GeneratedImageResponse:
-        if not self.api_key:
-            raise ImageGenerationError(self.missing_key_message)
+        if not self.api_base:
+            raise ImageGenerationError(self.missing_base_message)
 
         if reference_images:
             logger.warning(
@@ -1068,11 +1068,12 @@ class CustomImageGenerationClient(ImageGenerationProvider):
                 model,
             )
 
-        headers = {
-            "Authorization": f"Bearer {self.api_key}",
+        headers: dict[str, str] = {
             "Content-Type": "application/json",
-            **self.extra_headers,
         }
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        headers.update(self.extra_headers)
 
         body: dict[str, Any] = {
             "model": model,

--- a/tests/providers/test_image_generation.py
+++ b/tests/providers/test_image_generation.py
@@ -10,6 +10,7 @@ import pytest
 from nanobot.providers.image_generation import (
     AIHubMixImageGenerationClient,
     CodexImageGenerationClient,
+    CustomImageGenerationClient,
     GeminiImageGenerationClient,
     GeneratedImageResponse,
     ImageGenerationError,
@@ -804,6 +805,63 @@ async def test_openai_requires_api_key() -> None:
 
     with pytest.raises(ImageGenerationError, match="API key"):
         await client.generate(prompt="draw", model="dall-e-3")
+
+
+# ---------------------------------------------------------------------------
+# Custom OpenAI-compatible Images API
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_custom_generate_success() -> None:
+    fake = FakeClient(FakeResponse({"data": [{"b64_json": RAW_B64}]}))
+    client = CustomImageGenerationClient(
+        api_key="sk-custom-test",
+        api_base="https://custom.example/v1/",
+        extra_headers={"X-Test": "1"},
+        client=fake,  # type: ignore[arg-type]
+    )
+
+    response = await client.generate(
+        prompt="a cat on the moon",
+        model="custom-image-model",
+        aspect_ratio="16:9",
+    )
+
+    assert isinstance(response, GeneratedImageResponse)
+    assert response.images == [PNG_DATA_URL]
+    assert response.content == ""
+    call = fake.calls[0]
+    assert call["url"] == "https://custom.example/v1/images/generations"
+    assert call["headers"]["Authorization"] == "Bearer sk-custom-test"
+    assert call["headers"]["X-Test"] == "1"
+    body = call["json"]
+    assert body["model"] == "custom-image-model"
+    assert body["prompt"] == "a cat on the moon"
+    assert body["response_format"] == "b64_json"
+    assert body["n"] == 1
+    assert body["size"] == "1536x1024"
+
+
+@pytest.mark.asyncio
+async def test_custom_generate_no_api_key() -> None:
+    client = CustomImageGenerationClient(api_key=None)
+
+    with pytest.raises(ImageGenerationError, match="providers.custom.apiKey"):
+        await client.generate(prompt="draw", model="custom-image-model")
+
+
+@pytest.mark.asyncio
+async def test_custom_generate_http_error() -> None:
+    fake = FakeClient(FakeResponse({"error": "bad request"}, status_code=400))
+    client = CustomImageGenerationClient(
+        api_key="sk-custom-test",
+        api_base="https://custom.example/v1",
+        client=fake,  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(ImageGenerationError, match="HTTP 400"):
+        await client.generate(prompt="draw", model="custom-image-model")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/providers/test_image_generation.py
+++ b/tests/providers/test_image_generation.py
@@ -844,6 +844,67 @@ async def test_custom_generate_success() -> None:
 
 
 @pytest.mark.asyncio
+async def test_custom_generate_preserves_provider_size_hint() -> None:
+    fake = FakeClient(FakeResponse({"data": [{"b64_json": RAW_B64}]}))
+    client = CustomImageGenerationClient(
+        api_key="sk-custom-test",
+        api_base="https://custom.example/v1",
+        client=fake,  # type: ignore[arg-type]
+    )
+
+    await client.generate(
+        prompt="a cat on the moon",
+        model="custom-image-model",
+        image_size="2K",
+    )
+
+    assert fake.calls[0]["json"]["size"] == "2K"
+
+
+@pytest.mark.asyncio
+async def test_custom_generate_maps_one_k_to_openai_dimension() -> None:
+    fake = FakeClient(FakeResponse({"data": [{"b64_json": RAW_B64}]}))
+    client = CustomImageGenerationClient(
+        api_key="sk-custom-test",
+        api_base="https://custom.example/v1",
+        client=fake,  # type: ignore[arg-type]
+    )
+
+    await client.generate(
+        prompt="a cat on the moon",
+        model="custom-image-model",
+        image_size="1K",
+    )
+
+    assert fake.calls[0]["json"]["size"] == "1024x1024"
+
+
+@pytest.mark.asyncio
+async def test_custom_generate_extra_body_can_override_defaults() -> None:
+    fake = FakeClient(FakeResponse({"data": [{"url": "https://images.example/cat.png"}]}))
+    fake.get_response = FakeResponse({}, content=PNG_BYTES)
+    client = CustomImageGenerationClient(
+        api_key="sk-custom-test",
+        api_base="https://custom.example/v1",
+        extra_body={"response_format": "url", "size": "2K"},
+        client=fake,  # type: ignore[arg-type]
+    )
+
+    response = await client.generate(
+        prompt="a cat on the moon",
+        model="custom-image-model",
+        image_size="1K",
+    )
+
+    expected_data_url = f"data:image/png;base64,{base64.b64encode(PNG_BYTES).decode('ascii')}"
+    assert response.images == [expected_data_url]
+    assert fake.get_calls[0]["url"] == "https://images.example/cat.png"
+    body = fake.calls[0]["json"]
+    assert body["response_format"] == "url"
+    assert body["size"] == "2K"
+
+
+@pytest.mark.asyncio
 async def test_custom_generate_without_api_key_omits_authorization() -> None:
     fake = FakeClient(FakeResponse({"data": [{"b64_json": RAW_B64}]}))
     client = CustomImageGenerationClient(

--- a/tests/providers/test_image_generation.py
+++ b/tests/providers/test_image_generation.py
@@ -844,10 +844,25 @@ async def test_custom_generate_success() -> None:
 
 
 @pytest.mark.asyncio
-async def test_custom_generate_no_api_key() -> None:
-    client = CustomImageGenerationClient(api_key=None)
+async def test_custom_generate_without_api_key_omits_authorization() -> None:
+    fake = FakeClient(FakeResponse({"data": [{"b64_json": RAW_B64}]}))
+    client = CustomImageGenerationClient(
+        api_key=None,
+        api_base="http://localhost:7860/v1",
+        client=fake,  # type: ignore[arg-type]
+    )
 
-    with pytest.raises(ImageGenerationError, match="providers.custom.apiKey"):
+    response = await client.generate(prompt="draw", model="custom-image-model")
+
+    assert response.images == [PNG_DATA_URL]
+    assert "Authorization" not in fake.calls[0]["headers"]
+
+
+@pytest.mark.asyncio
+async def test_custom_generate_requires_api_base() -> None:
+    client = CustomImageGenerationClient(api_key="sk-custom-test")
+
+    with pytest.raises(ImageGenerationError, match="providers.custom.apiBase"):
         await client.generate(prompt="draw", model="custom-image-model")
 
 


### PR DESCRIPTION
Addresses #4132.

## Summary

Add a `custom` image generation provider for any OpenAI-compatible image generation API (local Stable Diffusion servers, Replicate, Agnes AI, etc.) that exposes the `/v1/images/generations` endpoint.

Uses the existing `providers.custom` config slot. No schema changes required.

## Changes

- `nanobot/providers/image_generation.py`: add `CustomImageGenerationClient` (OpenAI-compatible Images API)
- `tests/providers/test_image_generation.py`: add 3 tests (success, no api key, http error)
- `docs/image-generation.md`: add Custom provider section, update supported provider list

## Verification

- pytest tests/providers/test_image_generation.py (54 passed)
- ruff check (clean)
- ruff format --check (clean)