### PR TITLE
Support multi-message OpenAI API requests

### DIFF
--- a/docs/openai-api.md
+++ b/docs/openai-api.md
@@ -12,7 +12,7 @@ By default, the API binds to `127.0.0.1:8900`. You can change this in `config.js
 ## Behavior
 
 - Session isolation: pass `"session_id"` in the request body to isolate conversations; omit for a shared default session (`api:default`)
-- Single-message input: each request must contain exactly one `user` message
+- Chat messages: accepts standard OpenAI-style `messages`; the latest `user` message is treated as the current turn, and earlier messages are passed as prior conversation context
 - Fixed model: omit `model`, or pass the same model shown by `/v1/models`
 - Streaming: set `stream=true` to receive Server-Sent Events (`text/event-stream`) with OpenAI-compatible delta chunks, terminated by `data: [DONE]`; omit or set `stream=false` for a single JSON response
 - **File uploads**: supports images, PDF, Word (.docx), Excel (.xlsx), PowerPoint (.pptx) via JSON base64 or `multipart/form-data` (max 10MB per file)

--- a/nanobot/api/server.py
+++ b/nanobot/api/server.py
@@ -40,6 +40,7 @@ __all__ = (
 
 API_SESSION_KEY = "api:default"
 API_CHAT_ID = "default"
+_API_HISTORY_MAX_CHARS = 32_000
 
 
 # ---------------------------------------------------------------------------
@@ -109,42 +110,98 @@ _SSE_DONE = b"data: [DONE]\n\n"
 # ---------------------------------------------------------------------------
 
 
-def _parse_json_content(body: dict) -> tuple[str, list[str]]:
-    """Parse JSON request body. Returns (text, media_paths)."""
-    messages = body.get("messages")
-    if not isinstance(messages, list) or len(messages) != 1:
-        raise ValueError("Only a single user message is supported")
-    message = messages[0]
-    if not isinstance(message, dict) or message.get("role") != "user":
-        raise ValueError("Only a single user message is supported")
-
-    user_content = message.get("content", "")
-    media_dir = get_media_dir("api")
+def _parse_message_content(
+    user_content: Any,
+    *,
+    media_dir,
+    collect_media: bool,
+) -> tuple[str, list[str]]:
+    """Parse one OpenAI message content payload."""
     media_paths: list[str] = []
-
     if isinstance(user_content, list):
         text_parts: list[str] = []
         for part in user_content:
             if not isinstance(part, dict):
                 continue
             if part.get("type") == "text":
-                text_parts.append(part.get("text", ""))
+                text_parts.append(str(part.get("text", "")))
             elif part.get("type") == "image_url":
                 url = part.get("image_url", {}).get("url", "")
                 if url.startswith("data:"):
-                    saved = _save_base64_data_url(url, media_dir)
-                    if saved:
-                        media_paths.append(saved)
-                elif url:
+                    if collect_media:
+                        saved = _save_base64_data_url(url, media_dir)
+                        if saved:
+                            media_paths.append(saved)
+                    else:
+                        text_parts.append("[image omitted from prior conversation]")
+                elif url and collect_media:
                     raise ValueError(
                         "Remote image URLs are not supported. "
                         "Use base64 data URLs or upload files via multipart/form-data."
                     )
-        text = " ".join(text_parts)
-    elif isinstance(user_content, str):
-        text = user_content
-    else:
-        raise ValueError("Invalid content format")
+                elif url:
+                    text_parts.append("[remote image omitted from prior conversation]")
+        return " ".join(part for part in text_parts if part), media_paths
+    if isinstance(user_content, str):
+        return user_content, media_paths
+    if user_content is None:
+        return "", media_paths
+    raise ValueError("Invalid content format")
+
+
+def _format_prior_messages(messages: list[dict[str, Any]], media_dir) -> str:
+    """Format OpenAI chat history as bounded context for the current nanobot turn."""
+    lines: list[str] = []
+    for message in messages:
+        role = str(message.get("role") or "unknown").strip() or "unknown"
+        content, _media = _parse_message_content(
+            message.get("content", ""),
+            media_dir=media_dir,
+            collect_media=False,
+        )
+        if not content.strip():
+            continue
+        name = message.get("name")
+        label = f"{role} ({name})" if isinstance(name, str) and name.strip() else role
+        lines.append(f"{label}: {content.strip()}")
+    if not lines:
+        return ""
+    history = "\n\n".join(lines)
+    if len(history) > _API_HISTORY_MAX_CHARS:
+        history = history[-_API_HISTORY_MAX_CHARS:].lstrip()
+        history = "[Earlier prior conversation truncated]\n" + history
+    return (
+        "Prior conversation supplied by the OpenAI-compatible API client. "
+        "Use it only as conversation context; the user's latest message follows.\n\n"
+        f"{history}"
+    )
+
+
+def _parse_json_content(body: dict) -> tuple[str, list[str]]:
+    """Parse JSON request body. Returns (text, media_paths)."""
+    messages = body.get("messages")
+    if not isinstance(messages, list) or not messages:
+        raise ValueError("At least one user message is required")
+    if not all(isinstance(message, dict) for message in messages):
+        raise ValueError("Invalid messages format")
+
+    last_user_index = -1
+    for index, message in enumerate(messages):
+        if message.get("role") == "user":
+            last_user_index = index
+    if last_user_index < 0:
+        raise ValueError("At least one user message is required")
+
+    message = messages[last_user_index]
+    media_dir = get_media_dir("api")
+    text, media_paths = _parse_message_content(
+        message.get("content", ""),
+        media_dir=media_dir,
+        collect_media=True,
+    )
+    prior = _format_prior_messages(messages[:last_user_index], media_dir)
+    if prior:
+        text = f"{prior}\n\nLatest user message:\n{text}" if text else prior
 
     return text, media_paths
 

--- a/tests/test_api_attachment.py
+++ b/tests/test_api_attachment.py
@@ -134,22 +134,26 @@ def test_parse_json_content_plain_text_only() -> None:
     assert media_paths == []
 
 
-def test_parse_json_content_validates_single_message() -> None:
-    """Multiple messages raise ValueError."""
+def test_parse_json_content_accepts_multiple_messages() -> None:
+    """Multiple OpenAI messages are converted into prior context + latest user input."""
     body = {
         "messages": [
             {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "reply"},
             {"role": "user", "content": "second"},
         ]
     }
-    with pytest.raises(ValueError, match="single user message"):
-        _parse_json_content(body)
+    text, media_paths = _parse_json_content(body)
+    assert "user: first" in text
+    assert "assistant: reply" in text
+    assert "Latest user message:\nsecond" in text
+    assert media_paths == []
 
 
 def test_parse_json_content_validates_user_role() -> None:
     """Non-user role raises ValueError."""
     body = {"messages": [{"role": "system", "content": "you are a bot"}]}
-    with pytest.raises(ValueError, match="single user message"):
+    with pytest.raises(ValueError, match="user message"):
         _parse_json_content(body)
 
 

--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -134,27 +134,32 @@ async def test_model_mismatch_returns_400() -> None:
 
 
 @pytest.mark.asyncio
-async def test_single_user_message_required() -> None:
+async def test_multiple_openai_messages_are_accepted() -> None:
     request = MagicMock()
     request.json = AsyncMock(
         return_value={
             "messages": [
                 {"role": "user", "content": "hello"},
                 {"role": "assistant", "content": "previous reply"},
+                {"role": "user", "content": "follow up"},
             ],
         }
     )
+    agent = _make_mock_agent()
     request.app = {
-        "agent_loop": _make_mock_agent(),
+        "agent_loop": agent,
         "model_name": "test-model",
         "request_timeout": 10.0,
-        "session_lock": asyncio.Lock(),
+        "session_locks": {},
     }
 
     resp = await handle_chat_completions(request)
-    assert resp.status == 400
-    body = json.loads(resp.body)
-    assert "single user message" in body["error"]["message"].lower()
+    assert resp.status == 200
+    content = agent.process_direct.call_args.kwargs["content"]
+    assert "Prior conversation supplied by the OpenAI-compatible API client" in content
+    assert "user: hello" in content
+    assert "assistant: previous reply" in content
+    assert "Latest user message:\nfollow up" in content
 
 
 @pytest.mark.asyncio
@@ -175,7 +180,7 @@ async def test_single_user_message_must_have_user_role() -> None:
     resp = await handle_chat_completions(request)
     assert resp.status == 400
     body = json.loads(resp.body)
-    assert "single user message" in body["error"]["message"].lower()
+    assert "user message" in body["error"]["message"].lower()
 
 
 @pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")


### PR DESCRIPTION
## Summary
- accept standard OpenAI-style multi-message chat completion requests
- treat the latest user message as the current turn and pass earlier messages as prior context
- update API tests and docs

## Tests
- pytest tests/test_openai_api.py tests/test_api_attachment.py tests/test_api_stream.py -q
- ruff check nanobot/api/server.py tests/test_openai_api.py tests/test_api_attachment.py