### PR TITLE
feat: allow subagents to inherit MCP tools

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1396,8 +1396,17 @@ Use `enabledTools` to register only a subset of tools from an MCP server:
 
 MCP tools are automatically discovered and registered on startup. The LLM can use them alongside built-in tools — no extra configuration needed.
 
+Spawned subagents do not receive MCP tools by default. To let new subagents inherit the
+currently connected MCP tools, resources, and prompts from the main agent, opt in with
+`subagentMcpAccess`:
 
-
+```json
+{
+  "tools": {
+    "subagentMcpAccess": true
+  }
+}
+```
 
 ## Security
 

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -278,6 +278,7 @@ class AgentLoop:
             bus=bus,
             model=self.model,
             tools_config=_tc,
+            parent_tools=self.tools,
             max_tool_result_chars=self.max_tool_result_chars,
             restrict_to_workspace=restrict_to_workspace,
             disabled_skills=disabled_skills,

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -16,16 +16,16 @@ from nanobot.agent.tools.context import ToolContext
 from nanobot.agent.tools.file_state import FileStates
 from nanobot.agent.tools.loader import ToolLoader
 from nanobot.agent.tools.registry import ToolRegistry
+from nanobot.bus.events import InboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.config.schema import AgentDefaults, ToolsConfig
+from nanobot.providers.base import LLMProvider
 from nanobot.security.workspace_access import (
     WorkspaceScope,
     bind_workspace_scope,
     reset_workspace_scope,
     workspace_sandbox_status,
 )
-from nanobot.bus.events import InboundMessage
-from nanobot.bus.queue import MessageBus
-from nanobot.config.schema import AgentDefaults, ToolsConfig
-from nanobot.providers.base import LLMProvider
 from nanobot.utils.prompt_templates import render_template
 
 
@@ -82,6 +82,7 @@ class SubagentManager:
         max_tool_result_chars: int,
         model: str | None = None,
         tools_config: ToolsConfig | None = None,
+        parent_tools: ToolRegistry | None = None,
         restrict_to_workspace: bool = False,
         disabled_skills: list[str] | None = None,
         max_iterations: int | None = None,
@@ -94,6 +95,7 @@ class SubagentManager:
         self.bus = bus
         self.model = model or provider.get_default_model()
         self.tools_config = tools_config or ToolsConfig()
+        self.parent_tools = parent_tools
         self.max_tool_result_chars = max_tool_result_chars
         self.restrict_to_workspace = restrict_to_workspace
         self.disabled_skills = set(disabled_skills or [])
@@ -118,8 +120,20 @@ class SubagentManager:
         return ToolsConfig(
             exec=self.tools_config.exec,
             web=self.tools_config.web,
+            subagent_mcp_access=self.tools_config.subagent_mcp_access,
             restrict_to_workspace=self.restrict_to_workspace,
         )
+
+    def _register_parent_mcp_tools(self, registry: ToolRegistry, cfg: ToolsConfig) -> None:
+        """Share already-connected MCP wrappers with an isolated subagent registry."""
+        if not cfg.subagent_mcp_access or self.parent_tools is None:
+            return
+        for name in self.parent_tools.tool_names:
+            if not name.startswith("mcp_"):
+                continue
+            tool = self.parent_tools.get(name)
+            if tool is not None:
+                registry.register(tool)
 
     def _build_tools(
         self,
@@ -140,6 +154,7 @@ class SubagentManager:
             ),
         )
         ToolLoader().load(ctx, registry, scope="subagent")
+        self._register_parent_mcp_tools(registry, cfg)
         return registry
 
     def set_provider(self, provider: LLMProvider, model: str) -> None:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -303,6 +303,7 @@ class ToolsConfig(Base):
             "allow_local_preview_access",
         ),
     )  # allow WebUI Full Access shell checks against localhost services; legacy allowLocalPreviewAccess still reads
+    subagent_mcp_access: bool = False  # opt-in: let spawned subagents inherit live MCP tools
     mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
     ssrf_whitelist: list[str] = Field(default_factory=list)  # CIDR ranges to exempt from SSRF blocking (e.g. ["100.64.0.0/10"] for Tailscale)
 

--- a/tests/agent/test_subagent.py
+++ b/tests/agent/test_subagent.py
@@ -1,13 +1,37 @@
 """Tests for SubagentManager."""
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
 from nanobot.agent.subagent import SubagentManager
+from nanobot.agent.tools.base import Tool
+from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.bus.queue import MessageBus
+from nanobot.config.schema import ToolsConfig
 from nanobot.providers.base import LLMProvider
+
+
+class _FakeTool(Tool):
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return "fake tool"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {}}
+
+    async def execute(self, **_kwargs: Any) -> str:
+        return "ok"
 
 
 @pytest.mark.asyncio
@@ -51,3 +75,47 @@ async def test_subagent_build_tools_isolates_file_read_state(tmp_path):
     second_result = await second_read.execute(path="note.txt")
     assert second_result.startswith("1| hello")
     assert "File unchanged" not in second_result
+
+
+def test_subagent_does_not_inherit_parent_mcp_tools_by_default(tmp_path):
+    """Subagents keep MCP access disabled unless explicitly configured."""
+    provider = MagicMock(spec=LLMProvider)
+    provider.get_default_model.return_value = "test"
+    parent_tools = ToolRegistry()
+    parent_tools.register(_FakeTool("mcp_test_demo"))
+    sm = SubagentManager(
+        provider=provider,
+        workspace=tmp_path,
+        bus=MessageBus(),
+        model="test",
+        max_tool_result_chars=16_000,
+        parent_tools=parent_tools,
+    )
+
+    tools = sm._build_tools()
+
+    assert not tools.has("mcp_test_demo")
+
+
+def test_subagent_inherits_only_parent_mcp_tools_when_enabled(tmp_path):
+    """The opt-in shares connected MCP wrappers without copying non-MCP parent tools."""
+    provider = MagicMock(spec=LLMProvider)
+    provider.get_default_model.return_value = "test"
+    parent_tools = ToolRegistry()
+    mcp_tool = _FakeTool("mcp_test_demo")
+    parent_tools.register(mcp_tool)
+    parent_tools.register(_FakeTool("parent_only"))
+    sm = SubagentManager(
+        provider=provider,
+        workspace=tmp_path,
+        bus=MessageBus(),
+        model="test",
+        max_tool_result_chars=16_000,
+        tools_config=ToolsConfig(subagent_mcp_access=True),
+        parent_tools=parent_tools,
+    )
+
+    tools = sm._build_tools()
+
+    assert tools.get("mcp_test_demo") is mcp_tool
+    assert not tools.has("parent_only")

--- a/tests/agent/tools/test_subagent_tools.py
+++ b/tests/agent/tools/test_subagent_tools.py
@@ -3,21 +3,43 @@
 import asyncio
 import time
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from nanobot.agent.tools.base import Tool
 from nanobot.config.schema import AgentDefaults
 
 _MAX_TOOL_RESULT_CHARS = AgentDefaults().max_tool_result_chars
+
+
+class _FakeTool(Tool):
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return "fake tool"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {}}
+
+    async def execute(self, **_kwargs: Any) -> str:
+        return "ok"
 
 
 @pytest.mark.asyncio
 async def test_subagent_exec_tool_receives_allowed_env_keys(tmp_path):
     """allowed_env_keys from ExecToolConfig must be forwarded to the subagent's ExecTool."""
     from nanobot.agent.subagent import SubagentManager, SubagentStatus
-    from nanobot.bus.queue import MessageBus
     from nanobot.agent.tools.shell import ExecToolConfig
+    from nanobot.bus.queue import MessageBus
     from nanobot.config.schema import ToolsConfig
 
     bus = MessageBus()
@@ -235,6 +257,33 @@ def test_agent_loop_passes_max_iterations_to_subagents(tmp_path):
     )
 
     assert loop.subagents.max_iterations == 42
+
+
+def test_agent_loop_wires_parent_tools_for_subagent_mcp_access(tmp_path):
+    """AgentLoop should let subagents inherit only live MCP tools when configured."""
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+    from nanobot.config.schema import ToolsConfig
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    mcp_tool = _FakeTool("mcp_test_demo")
+
+    loop = AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+        tools_config=ToolsConfig(subagent_mcp_access=True),
+    )
+    loop.tools.register(mcp_tool)
+    loop.tools.register(_FakeTool("parent_only"))
+
+    tools = loop.subagents._build_tools()
+
+    assert tools.get("mcp_test_demo") is mcp_tool
+    assert not tools.has("parent_only")
 
 
 @pytest.mark.asyncio

--- a/tests/config/test_config_migration.py
+++ b/tests/config/test_config_migration.py
@@ -85,6 +85,7 @@ def test_onboard_does_not_crash_with_legacy_memory_window(tmp_path, monkeypatch)
     monkeypatch.setattr("nanobot.cli.commands.get_workspace_path", lambda _workspace=None: workspace)
 
     from typer.testing import CliRunner
+
     from nanobot.cli.commands import app
     runner = CliRunner()
     result = runner.invoke(app, ["onboard"], input="n\n")
@@ -131,6 +132,7 @@ def test_onboard_refresh_backfills_missing_channel_fields(tmp_path, monkeypatch)
     )
 
     from typer.testing import CliRunner
+
     from nanobot.cli.commands import app
     runner = CliRunner()
     result = runner.invoke(app, ["onboard"], input="n\n")
@@ -244,3 +246,24 @@ def test_load_config_accepts_legacy_local_preview_access(tmp_path) -> None:
     config = load_config(config_path)
 
     assert config.tools.webui_allow_local_service_access is False
+
+
+def test_load_config_defaults_subagent_mcp_access_to_disabled(tmp_path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"tools": {}}), encoding="utf-8")
+
+    config = load_config(config_path)
+
+    assert config.tools.subagent_mcp_access is False
+
+
+def test_load_config_accepts_subagent_mcp_access_flag(tmp_path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"tools": {"subagentMcpAccess": True}}),
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path)
+
+    assert config.tools.subagent_mcp_access is True


### PR DESCRIPTION
## Summary
- Add `tools.subagentMcpAccess`, defaulting to false.
- Allow spawned subagents to inherit live `mcp_*` tools from the main agent when enabled.
- Document the opt-in config and add regression tests.

Fixes #4166

## Test Plan
- `python -m pytest tests/agent/test_subagent.py tests/agent/tools/test_subagent_tools.py tests/config/test_config_migration.py -q`
- `python -m ruff check nanobot/agent/subagent.py nanobot/agent/loop.py nanobot/config/schema.py tests/agent/test_subagent.py tests/agent/tools/test_subagent_tools.py tests/config/test_config_migration.py`