### PR TITLE
Refactor capture state to use run-level hook snapshots

### DIFF
--- a/nanobot/agent/hook.py
+++ b/nanobot/agent/hook.py
@@ -164,22 +164,14 @@ class CompositeHook(AgentHook):
 class SDKCaptureHook(AgentHook):
     """Record tool names and the final message list for ``RunResult``.
 
-    The runner mutates ``context.messages`` in place across iterations, so the
-    snapshot is refreshed on every ``after_iteration`` call; the last call
-    reflects the end-of-turn state the SDK caller cares about.  The run-level
-    snapshot is authoritative when available and covers paths without a final
-    per-iteration callback.
+    The run-level snapshot is authoritative and reflects the end-of-turn state
+    the SDK caller cares about.
     """
 
     def __init__(self) -> None:
         super().__init__()
         self.tools_used: list[str] = []
         self.messages: list[dict[str, Any]] = []
-
-    async def after_iteration(self, context: AgentHookContext) -> None:
-        for call in context.tool_calls:
-            self.tools_used.append(call.name)
-        self.messages = list(context.messages)
 
     async def after_run(self, context: AgentRunHookContext) -> None:
         self.tools_used = list(context.tools_used)

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -10,22 +10,22 @@ from typing import Any, Callable
 
 from loguru import logger
 
-from nanobot.agent.hook import AgentHook, AgentHookContext
+from nanobot.agent.hook import AgentHook, AgentHookContext, AgentRunHookContext
 from nanobot.agent.runner import AgentRunner, AgentRunSpec
 from nanobot.agent.tools.context import ToolContext
 from nanobot.agent.tools.file_state import FileStates
 from nanobot.agent.tools.loader import ToolLoader
 from nanobot.agent.tools.registry import ToolRegistry
+from nanobot.bus.events import InboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.config.schema import AgentDefaults, ToolsConfig
+from nanobot.providers.base import LLMProvider
 from nanobot.security.workspace_access import (
     WorkspaceScope,
     bind_workspace_scope,
     reset_workspace_scope,
     workspace_sandbox_status,
 )
-from nanobot.bus.events import InboundMessage
-from nanobot.bus.queue import MessageBus
-from nanobot.config.schema import AgentDefaults, ToolsConfig
-from nanobot.providers.base import LLMProvider
 from nanobot.utils.prompt_templates import render_template
 
 
@@ -69,6 +69,21 @@ class _SubagentHook(AgentHook):
         self._status.usage = dict(context.usage)
         if context.error:
             self._status.error = str(context.error)
+
+    def _apply_run_context(self, context: AgentRunHookContext) -> None:
+        if self._status is None:
+            return
+        self._status.tool_events = list(context.tool_events)
+        self._status.usage = dict(context.usage)
+        self._status.stop_reason = context.stop_reason
+        if context.error:
+            self._status.error = str(context.error)
+
+    async def after_run(self, context: AgentRunHookContext) -> None:
+        self._apply_run_context(context)
+
+    async def on_error(self, context: AgentRunHookContext) -> None:
+        self._apply_run_context(context)
 
 
 class SubagentManager:
@@ -259,10 +274,8 @@ class SubagentManager:
                 if token is not None:
                     reset_workspace_scope(token)
             status.phase = "done"
-            status.stop_reason = result.stop_reason
 
             if result.stop_reason == "tool_error":
-                status.tool_events = list(result.tool_events)
                 await self._announce_result(
                     task_id, label, task,
                     self._format_partial_progress(result),

--- a/tests/agent/test_subagent_lifecycle.py
+++ b/tests/agent/test_subagent_lifecycle.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from nanobot.agent.hook import AgentHookContext
+from nanobot.agent.hook import AgentHookContext, AgentRunHookContext
 from nanobot.agent.runner import AgentRunResult
 from nanobot.agent.subagent import (
     SubagentManager,
@@ -16,7 +16,6 @@ from nanobot.agent.subagent import (
 )
 from nanobot.bus.queue import MessageBus
 from nanobot.providers.base import LLMProvider
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -49,6 +48,21 @@ def _make_hook_context(**overrides) -> AgentHookContext:
     )
     defaults.update(overrides)
     return AgentHookContext(**defaults)
+
+
+def _make_run_hook_context(**overrides) -> AgentRunHookContext:
+    defaults = dict(
+        messages=[],
+        final_content="ok",
+        tools_used=[],
+        usage={},
+        stop_reason="completed",
+        error=None,
+        tool_events=[],
+        had_injections=False,
+    )
+    defaults.update(overrides)
+    return AgentRunHookContext(**defaults)
 
 
 # ---------------------------------------------------------------------------
@@ -259,9 +273,12 @@ class TestRunSubagent:
     @pytest.mark.asyncio
     async def test_status_updated_on_success(self, tmp_path):
         sm = _manager(tmp_path)
-        sm.runner.run = AsyncMock(return_value=AgentRunResult(
-            final_content="ok", messages=[], stop_reason="completed",
-        ))
+
+        async def _run(spec):
+            await spec.hook.after_run(_make_run_hook_context(stop_reason="completed"))
+            return AgentRunResult(final_content="ok", messages=[], stop_reason="completed")
+
+        sm.runner.run = _run
         status = SubagentStatus(task_id="t1", label="label", task_description="do task", started_at=time.monotonic())
         with patch.object(sm, "_announce_result", new_callable=AsyncMock):
             await sm._run_subagent(
@@ -556,3 +573,32 @@ class TestSubagentHook:
         ctx = _make_hook_context(error="something broke")
         await hook.after_iteration(ctx)
         assert status.error == "something broke"
+
+    @pytest.mark.asyncio
+    async def test_after_run_updates_final_status(self):
+        status = SubagentStatus(
+            task_id="t1", label="test", task_description="do", started_at=time.monotonic(),
+        )
+        hook = _SubagentHook("t1", status)
+        ctx = _make_run_hook_context(
+            stop_reason="tool_error",
+            tool_events=[{"name": "read_file", "status": "error", "detail": "not found"}],
+            usage={"prompt_tokens": 100, "completion_tokens": 20},
+            error="tool failed",
+        )
+        await hook.after_run(ctx)
+        assert status.stop_reason == "tool_error"
+        assert status.tool_events == ctx.tool_events
+        assert status.usage == {"prompt_tokens": 100, "completion_tokens": 20}
+        assert status.error == "tool failed"
+
+    @pytest.mark.asyncio
+    async def test_on_error_updates_final_status(self):
+        status = SubagentStatus(
+            task_id="t1", label="test", task_description="do", started_at=time.monotonic(),
+        )
+        hook = _SubagentHook("t1", status)
+        ctx = _make_run_hook_context(stop_reason="error", error="LLM down")
+        await hook.on_error(ctx)
+        assert status.stop_reason == "error"
+        assert status.error == "LLM down"

--- a/tests/test_nanobot_facade.py
+++ b/tests/test_nanobot_facade.py
@@ -170,35 +170,29 @@ def test_import_from_top_level():
 
 
 # ---------------------------------------------------------------------------
-# RunResult.tools_used / messages — populated from the agent iterations
+# RunResult.tools_used / messages — populated from the final run snapshot
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_run_populates_tools_used_across_iterations(tmp_path):
-    """tools_used collects every tool name fired across all iterations, in order."""
-    from nanobot.agent.hook import AgentHookContext
+async def test_run_populates_tools_used_from_run_snapshot(tmp_path):
+    """tools_used comes from the authoritative run-level snapshot."""
+    from nanobot.agent.hook import AgentRunHookContext
     from nanobot.bus.events import OutboundMessage
-    from nanobot.providers.base import ToolCallRequest
 
     config_path = _write_config(tmp_path)
     bot = Nanobot.from_config(config_path, workspace=tmp_path)
 
     async def fake_process_direct(message, *, session_key):
-        # Whatever hooks the SDK installed are now on the loop.
         extras = bot._loop._extra_hooks
         messages = [{"role": "user", "content": message}]
-        ctx1 = AgentHookContext(iteration=0, messages=messages)
-        ctx1.tool_calls = [
-            ToolCallRequest(id="c1", name="read_file", arguments={}),
-            ToolCallRequest(id="c2", name="grep", arguments={}),
-        ]
+        messages.append({"role": "assistant", "content": "final"})
+        ctx = AgentRunHookContext(
+            messages=messages,
+            tools_used=["read_file", "grep", "web_fetch"],
+            stop_reason="completed",
+        )
         for h in extras:
-            await h.after_iteration(ctx1)
-        messages.append({"role": "assistant", "content": "ok"})
-        ctx2 = AgentHookContext(iteration=1, messages=messages)
-        ctx2.tool_calls = [ToolCallRequest(id="c3", name="web_fetch", arguments={})]
-        for h in extras:
-            await h.after_iteration(ctx2)
+            await h.after_run(ctx)
         return OutboundMessage(channel="cli", chat_id="direct", content="final")
 
     bot._loop.process_direct = fake_process_direct
@@ -209,8 +203,8 @@ async def test_run_populates_tools_used_across_iterations(tmp_path):
 
 @pytest.mark.asyncio
 async def test_run_populates_final_messages(tmp_path):
-    """messages reflects the agent's message list at the last iteration."""
-    from nanobot.agent.hook import AgentHookContext
+    """messages reflects the final run-level message list."""
+    from nanobot.agent.hook import AgentRunHookContext
     from nanobot.bus.events import OutboundMessage
 
     config_path = _write_config(tmp_path)
@@ -222,9 +216,9 @@ async def test_run_populates_final_messages(tmp_path):
             {"role": "user", "content": message},
             {"role": "assistant", "content": "hi there"},
         ]
-        ctx = AgentHookContext(iteration=0, messages=messages)
+        ctx = AgentRunHookContext(messages=messages, stop_reason="completed")
         for h in extras:
-            await h.after_iteration(ctx)
+            await h.after_run(ctx)
         return OutboundMessage(channel="cli", chat_id="direct", content="hi there")
 
     bot._loop.process_direct = fake_process_direct
@@ -237,7 +231,7 @@ async def test_run_populates_final_messages(tmp_path):
 
 @pytest.mark.asyncio
 async def test_run_no_iterations_leaves_defaults_empty(tmp_path):
-    """If process_direct never triggers after_iteration, tools_used/messages stay []."""
+    """If process_direct never reaches the runner, tools_used/messages stay []."""
     from nanobot.bus.events import OutboundMessage
 
     config_path = _write_config(tmp_path)
@@ -302,19 +296,10 @@ async def test_run_restores_extra_hooks_even_on_populated_iterations(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_sdk_capture_prefers_run_level_snapshot():
-    from nanobot.agent.hook import AgentHookContext, AgentRunHookContext, SDKCaptureHook
-    from nanobot.providers.base import ToolCallRequest
+async def test_sdk_capture_uses_run_level_snapshot():
+    from nanobot.agent.hook import AgentRunHookContext, SDKCaptureHook
 
     hook = SDKCaptureHook()
-    iter_messages = [{"role": "user", "content": "work"}]
-    iter_context = AgentHookContext(iteration=0, messages=iter_messages)
-    iter_context.tool_calls = [
-        ToolCallRequest(id="call_1", name="read_file", arguments={}),
-        ToolCallRequest(id="call_2", name="grep", arguments={}),
-    ]
-    await hook.after_iteration(iter_context)
-
     final_messages = [
         {"role": "user", "content": "work"},
         {"role": "assistant", "content": "done"},


### PR DESCRIPTION
## Summary
- make `SDKCaptureHook` rely on the authoritative `after_run` snapshot instead of accumulating per-iteration state
- move subagent final status synchronization (`tool_events`, `usage`, `stop_reason`, `error`) into run-level hook callbacks
- keep `AgentLoop` bookkeeping unchanged to keep this PR focused

## Dependency
Stacked on #4176 (`codex/hook-lifecycle`). This PR depends on the run-level hook lifecycle added there and should be merged after #4176 lands, or merged into `codex/hook-lifecycle` before #4176 is merged to `main`.

## Verification
- `python -m pytest tests/test_nanobot_facade.py tests/agent/test_subagent_lifecycle.py tests/agent/test_hook_composite.py -q`
- `ruff check nanobot/agent/hook.py nanobot/agent/subagent.py tests/test_nanobot_facade.py tests/agent/test_subagent_lifecycle.py`
- `git diff --check`
- `python -m pytest tests/agent -q`