### PR TITLE
Clarify filesystem workspace write policy

### DIFF
--- a/.agent/security.md
+++ b/.agent/security.md
@@ -6,7 +6,7 @@ The agent operates with significant power (file system, shell, web). The followi
 
 Filesystem tools (`read_file`, `write_file`, `edit_file`, `list_dir`, `apply_patch`) resolve paths through the workspace path resolver (`agent/tools/filesystem.py` / `agent/tools/path_utils.py`), which enforces that the resolved path must lie under the active workspace when workspace restriction is enabled. The media upload directory is always an internal extra read root while restricted.
 
-Additional filesystem roots must be capability-specific. `extra_allowed_dirs` is a legacy read-only alias. Use `extra_read_allowed_dirs` for read-only roots and `extra_write_allowed_dirs` only when a write-capable tool is intentionally allowed to modify an extra root.
+Additional filesystem roots must be capability-specific. `extra_allowed_dirs` is a legacy read-only alias. Use `extra_read_allowed_dirs` for read-only roots, `extra_write_allowed_dirs` only when a write-capable tool is intentionally allowed to modify an extra directory, and exact file allowlists when a tool may modify only specific files.
 
 Shell execution (`ExecTool`, `agent/tools/shell.py`) also respects `restrict_to_workspace` as an application-level guard: if enabled and `working_dir` is outside the workspace, the command is rejected before execution, and command text is checked for obvious workspace escapes. This is not process-level isolation; use an exec sandbox backend for that.
 

--- a/.agent/security.md
+++ b/.agent/security.md
@@ -4,11 +4,13 @@ The agent operates with significant power (file system, shell, web). The followi
 
 ## Workspace Restriction
 
-Filesystem tools (`read_file`, `write_file`, `edit_file`, `list_dir`) resolve paths through `_resolve_path` (`agent/tools/filesystem.py`), which enforces that the resolved path must lie under `allowed_dir` (typically the configured workspace), plus the media upload directory (`get_media_dir()`) and any `extra_allowed_dirs`.
+Filesystem tools (`read_file`, `write_file`, `edit_file`, `list_dir`, `apply_patch`) resolve paths through the workspace path resolver (`agent/tools/filesystem.py` / `agent/tools/path_utils.py`), which enforces that the resolved path must lie under the active workspace when workspace restriction is enabled. The media upload directory is always an internal extra read root while restricted.
 
-Shell execution (`ExecTool`, `agent/tools/shell.py`) also respects `restrict_to_workspace`: if enabled and `working_dir` is outside the workspace, the command is rejected before execution.
+Additional filesystem roots must be capability-specific. `extra_allowed_dirs` is a legacy read-only alias. Use `extra_read_allowed_dirs` for read-only roots and `extra_write_allowed_dirs` only when a write-capable tool is intentionally allowed to modify an extra root.
 
-**Rule**: Any new path-handling logic must go through `_resolve_path` or perform an equivalent `allowed_dir` check.
+Shell execution (`ExecTool`, `agent/tools/shell.py`) also respects `restrict_to_workspace` as an application-level guard: if enabled and `working_dir` is outside the workspace, the command is rejected before execution, and command text is checked for obvious workspace escapes. This is not process-level isolation; use an exec sandbox backend for that.
+
+**Rule**: Any new path-handling logic must go through the workspace path resolver or perform an equivalent containment check with explicit read/write capability semantics.
 
 ## SSRF Protection
 
@@ -22,6 +24,6 @@ HTTP/SSE MCP transports are part of this boundary: validate configured MCP URLs 
 
 ## Shell Sandbox
 
-`tools/sandbox.py` provides optional command wrapping. The only backend currently shipped is `bwrap` (bubblewrap), intended for containerized deployments. On Windows and bare-metal Linux without `bwrap`, commands run in the native shell with workspace restriction as the only guard.
+`tools/sandbox.py` provides optional command wrapping. The only backend currently shipped is `bwrap` (bubblewrap), intended for containerized deployments. On Windows and bare-metal Linux without `bwrap`, commands run in the native shell with workspace restriction as an application-level guard only.
 
 **Rule**: If adding a new sandbox backend, implement `_wrap_<name>(command, workspace, cwd) -> str` and register it in `_BACKENDS`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1720,14 +1720,14 @@ MCP tools are automatically discovered and registered on startup. The LLM can us
 ## Security
 
 > [!TIP]
-> For production deployments, set `"restrictToWorkspace": true` and `"tools.exec.sandbox": "bwrap"` in your config to sandbox the agent.
+> For production deployments, set both `"restrictToWorkspace": true` and `"tools.exec.sandbox": "bwrap"` in your config. `restrictToWorkspace` enables nanobot's application-level workspace guards; `tools.exec.sandbox` provides process-level isolation for shell commands.
 
 For API keys, tokens, and other secrets, see [Environment Variables for Secrets](#environment-variables-for-secrets) — avoid storing them directly in `config.json`.
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `tools.restrictToWorkspace` | `false` | When `true`, restricts **all** agent tools (shell, file read/write/edit, list) to the workspace directory. Prevents path traversal and out-of-scope access. |
-| `tools.exec.sandbox` | `""` | Sandbox backend for shell commands. Set to `"bwrap"` to wrap exec calls in a [bubblewrap](https://github.com/containers/bubblewrap) sandbox — the process can only see the workspace (read-write) and media directory (read-only); config files and API keys are hidden. Automatically enables `restrictToWorkspace` for file tools. **Linux only** — requires `bwrap` installed (`apt install bubblewrap`; pre-installed in the Docker image). Not available on macOS or Windows (bwrap depends on Linux kernel namespaces). |
+| `tools.restrictToWorkspace` | `false` | When `true`, enables nanobot's application-level workspace guards for workspace-aware tools. File tools resolve paths under the active workspace; selected internal roots can be added as read-only or explicitly write-enabled roots, and media uploads are read-only by default. Shell execution rejects workspace-external `working_dir` values and applies best-effort command path checks, but this is not an OS sandbox. |
+| `tools.exec.sandbox` | `""` | Sandbox backend for shell commands. Set to `"bwrap"` to wrap exec calls in a [bubblewrap](https://github.com/containers/bubblewrap) sandbox — the process can only see the workspace (read-write) and media directory (read-only); config files and API keys are hidden. Automatically enables workspace restriction for file tools. **Linux only** — requires `bwrap` installed (`apt install bubblewrap`; pre-installed in the Docker image). Not available on macOS or Windows (bwrap depends on Linux kernel namespaces). |
 | `tools.exec.enable` | `true` | When `false`, the shell `exec` tool is not registered at all. Use this to completely disable shell command execution. |
 | `tools.exec.timeout` | `60` | Default hard timeout in seconds for shell commands. Config values may exceed the per-call tool cap; set `0` to disable the hard timeout for trusted long-running commands. |
 | `tools.exec.pathPrepend` | `""` | Extra directories to prepend to `PATH` when running shell commands. Use this when configured tools should win executable lookup precedence, such as a Python virtual environment's `bin` or `Scripts` directory. |

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -503,7 +503,7 @@ class MemoryStore:
         skills_dir.mkdir(parents=True, exist_ok=True)
 
         extra_read = [BUILTIN_SKILLS_DIR] if BUILTIN_SKILLS_DIR.exists() else None
-        editable_roots = [self.soul_file, self.user_file, skills_dir]
+        editable_files = [self.memory_file, self.soul_file, self.user_file]
 
         tools.register(ReadFileTool(
             workspace=workspace,
@@ -513,14 +513,14 @@ class MemoryStore:
         ))
         tools.register(EditFileTool(
             workspace=workspace,
-            allowed_dir=self.memory_file,
-            extra_write_allowed_dirs=editable_roots,
+            allowed_dir=skills_dir,
+            extra_write_allowed_files=editable_files,
             file_states=file_states,
         ))
         tools.register(ApplyPatchTool(
             workspace=workspace,
-            allowed_dir=self.memory_file,
-            extra_write_allowed_dirs=editable_roots,
+            allowed_dir=skills_dir,
+            extra_write_allowed_files=editable_files,
             file_states=file_states,
         ))
         tools.register(WriteFileTool(

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -508,19 +508,19 @@ class MemoryStore:
         tools.register(ReadFileTool(
             workspace=workspace,
             allowed_dir=workspace,
-            extra_allowed_dirs=extra_read,
+            extra_read_allowed_dirs=extra_read,
             file_states=file_states,
         ))
         tools.register(EditFileTool(
             workspace=workspace,
-            allowed_dir=self.memory_dir,
-            extra_allowed_dirs=editable_roots,
+            allowed_dir=self.memory_file,
+            extra_write_allowed_dirs=editable_roots,
             file_states=file_states,
         ))
         tools.register(ApplyPatchTool(
             workspace=workspace,
-            allowed_dir=self.memory_dir,
-            extra_allowed_dirs=editable_roots,
+            allowed_dir=self.memory_file,
+            extra_write_allowed_dirs=editable_roots,
             file_states=file_states,
         ))
         tools.register(WriteFileTool(

--- a/nanobot/agent/tools/apply_patch.py
+++ b/nanobot/agent/tools/apply_patch.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import difflib
-import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -31,19 +30,12 @@ class _PatchError(ValueError):
     pass
 
 
-_ABSOLUTE_WINDOWS_RE = re.compile(r"^[A-Za-z]:[\\/]")
-
-
-def _validate_relative_path(path: str) -> str:
+def _validate_patch_path(path: str) -> str:
     normalized = path.strip()
     if not normalized:
         raise _PatchError("patch path cannot be empty")
     if "\0" in normalized:
         raise _PatchError(f"patch path contains a null byte: {path!r}")
-    if normalized.startswith(("~", "/", "\\")) or _ABSOLUTE_WINDOWS_RE.match(normalized):
-        raise _PatchError(f"patch path must be relative: {path}")
-    if any(part == ".." for part in re.split(r"[\\/]+", normalized)):
-        raise _PatchError(f"patch path must not contain '..': {path}")
     return normalized
 
 
@@ -98,7 +90,10 @@ def _format_summary(summary: _PatchSummary) -> str:
     tool_parameters_schema(
         edits=ArraySchema(
             items=ObjectSchema(
-                path=StringSchema("Relative path to the file to edit."),
+                path=StringSchema(
+                    "Path to the file to edit. Relative paths resolve against the "
+                    "workspace; absolute paths and '..' obey the workspace access policy."
+                ),
                 action=StringSchema(
                     "Operation type: replace or add.",
                     enum=["replace", "add"],
@@ -138,7 +133,8 @@ class ApplyPatchTool(_FsTool):
             "Default tool for code edits. Supports multi-file changes in a single call. "
             "Provide a list of structured edits, each specifying a file path, action "
             "(replace/add), and the exact text to change. "
-            "Paths must be relative. Set dry_run=true to validate and preview without writing files. "
+            "Paths are resolved by the current workspace access policy. "
+            "Set dry_run=true to validate and preview without writing files. "
             "Use edit_file only for small exact replacements on a single file."
         )
 
@@ -161,11 +157,11 @@ class ApplyPatchTool(_FsTool):
                 raw_path = edit.get("path")
                 if not isinstance(raw_path, str):
                     raise _PatchError("path required for edit")
-                path = _validate_relative_path(raw_path)
+                path = _validate_patch_path(raw_path)
                 action = edit.get("action")
                 if not isinstance(action, str):
                     raise _PatchError(f"action required for edit: {path}")
-                source = self._resolve(path)
+                source = self._resolve_write(path)
 
                 if action == "add":
                     new_text = edit.get("new_text")

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -101,15 +101,13 @@ class _FsTool(Tool):
         return current_file_states(self._fallback_file_states)
 
     def _effective_allowed_root(self, access_allowed_root: Path | None) -> Path | None:
-        if access_allowed_root is None:
-            return None
         if self._allowed_dir is None or self._workspace is None:
             return access_allowed_root
         try:
             allowed_dir = Path(self._allowed_dir).expanduser().resolve(strict=False)
             workspace = Path(self._workspace).expanduser().resolve(strict=False)
         except (OSError, RuntimeError, TypeError, ValueError):
-            return access_allowed_root
+            return access_allowed_root if access_allowed_root is not None else self._allowed_dir
         if allowed_dir == workspace:
             return access_allowed_root
         return allowed_dir

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -47,7 +47,6 @@ class _FsTool(Tool):
         extra_allowed_dirs: list[Path] | None = None,
         extra_read_allowed_dirs: list[Path] | None = None,
         extra_write_allowed_dirs: list[Path] | None = None,
-        extra_read_allowed_files: list[Path] | None = None,
         extra_write_allowed_files: list[Path] | None = None,
         file_states: FileStates | None = None,
         restrict_to_workspace: bool | None = None,
@@ -62,9 +61,7 @@ class _FsTool(Tool):
             *(extra_read_allowed_dirs or []),
         ]
         self._extra_write_allowed_dirs = list(extra_write_allowed_dirs or [])
-        self._extra_read_allowed_files = list(extra_read_allowed_files or [])
         self._extra_write_allowed_files = list(extra_write_allowed_files or [])
-        self._extra_allowed_dirs = self._extra_read_allowed_dirs
         self._restrict_to_workspace = (
             bool(restrict_to_workspace)
             if restrict_to_workspace is not None
@@ -143,7 +140,7 @@ class _FsTool(Tool):
         return self._resolve_with_extra(
             path,
             self._extra_read_allowed_dirs,
-            self._extra_read_allowed_files,
+            None,
             include_media_dir=True,
         )
 

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -47,6 +47,8 @@ class _FsTool(Tool):
         extra_allowed_dirs: list[Path] | None = None,
         extra_read_allowed_dirs: list[Path] | None = None,
         extra_write_allowed_dirs: list[Path] | None = None,
+        extra_read_allowed_files: list[Path] | None = None,
+        extra_write_allowed_files: list[Path] | None = None,
         file_states: FileStates | None = None,
         restrict_to_workspace: bool | None = None,
         sandbox_restricts_workspace: bool = False,
@@ -60,6 +62,8 @@ class _FsTool(Tool):
             *(extra_read_allowed_dirs or []),
         ]
         self._extra_write_allowed_dirs = list(extra_write_allowed_dirs or [])
+        self._extra_read_allowed_files = list(extra_read_allowed_files or [])
+        self._extra_write_allowed_files = list(extra_write_allowed_files or [])
         self._extra_allowed_dirs = self._extra_read_allowed_dirs
         self._restrict_to_workspace = (
             bool(restrict_to_workspace)
@@ -117,6 +121,7 @@ class _FsTool(Tool):
         self,
         path: str,
         extra_allowed_dirs: list[Path] | None,
+        extra_allowed_files: list[Path] | None,
         *,
         include_media_dir: bool,
     ) -> Path:
@@ -130,6 +135,7 @@ class _FsTool(Tool):
             access.project_path,
             self._effective_allowed_root(access.allowed_root),
             extra_allowed_dirs,
+            extra_allowed_files,
             include_media_dir=include_media_dir,
         )
 
@@ -137,6 +143,7 @@ class _FsTool(Tool):
         return self._resolve_with_extra(
             path,
             self._extra_read_allowed_dirs,
+            self._extra_read_allowed_files,
             include_media_dir=True,
         )
 
@@ -144,6 +151,7 @@ class _FsTool(Tool):
         return self._resolve_with_extra(
             path,
             self._extra_write_allowed_dirs,
+            self._extra_write_allowed_files,
             include_media_dir=False,
         )
 

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -45,13 +45,22 @@ class _FsTool(Tool):
         workspace: Path | None = None,
         allowed_dir: Path | None = None,
         extra_allowed_dirs: list[Path] | None = None,
+        extra_read_allowed_dirs: list[Path] | None = None,
+        extra_write_allowed_dirs: list[Path] | None = None,
         file_states: FileStates | None = None,
         restrict_to_workspace: bool | None = None,
         sandbox_restricts_workspace: bool = False,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
-        self._extra_allowed_dirs = extra_allowed_dirs
+        # Legacy alias: extra_allowed_dirs is read-only. Write-capable tools
+        # must opt in via extra_write_allowed_dirs.
+        self._extra_read_allowed_dirs = [
+            *(extra_allowed_dirs or []),
+            *(extra_read_allowed_dirs or []),
+        ]
+        self._extra_write_allowed_dirs = list(extra_write_allowed_dirs or [])
+        self._extra_allowed_dirs = self._extra_read_allowed_dirs
         self._restrict_to_workspace = (
             bool(restrict_to_workspace)
             if restrict_to_workspace is not None
@@ -78,7 +87,7 @@ class _FsTool(Tool):
         return cls(
             workspace=Path(ctx.workspace),
             allowed_dir=allowed_dir,
-            extra_allowed_dirs=extra_read,
+            extra_read_allowed_dirs=extra_read,
             file_states=ctx.file_state_store,
             restrict_to_workspace=ctx.config.restrict_to_workspace,
             sandbox_restricts_workspace=sandbox_restricts,
@@ -90,7 +99,27 @@ class _FsTool(Tool):
             return self._explicit_file_states
         return current_file_states(self._fallback_file_states)
 
-    def _resolve(self, path: str) -> Path:
+    def _effective_allowed_root(self, access_allowed_root: Path | None) -> Path | None:
+        if access_allowed_root is None:
+            return None
+        if self._allowed_dir is None or self._workspace is None:
+            return access_allowed_root
+        try:
+            allowed_dir = Path(self._allowed_dir).expanduser().resolve(strict=False)
+            workspace = Path(self._workspace).expanduser().resolve(strict=False)
+        except (OSError, RuntimeError, TypeError, ValueError):
+            return access_allowed_root
+        if allowed_dir == workspace:
+            return access_allowed_root
+        return allowed_dir
+
+    def _resolve_with_extra(
+        self,
+        path: str,
+        extra_allowed_dirs: list[Path] | None,
+        *,
+        include_media_dir: bool,
+    ) -> Path:
         access = current_tool_workspace(
             self._workspace,
             restrict_to_workspace=self._restrict_to_workspace,
@@ -99,9 +128,27 @@ class _FsTool(Tool):
         return resolve_workspace_path(
             path,
             access.project_path,
-            access.allowed_root,
-            self._extra_allowed_dirs,
+            self._effective_allowed_root(access.allowed_root),
+            extra_allowed_dirs,
+            include_media_dir=include_media_dir,
         )
+
+    def _resolve_read(self, path: str) -> Path:
+        return self._resolve_with_extra(
+            path,
+            self._extra_read_allowed_dirs,
+            include_media_dir=True,
+        )
+
+    def _resolve_write(self, path: str) -> Path:
+        return self._resolve_with_extra(
+            path,
+            self._extra_write_allowed_dirs,
+            include_media_dir=False,
+        )
+
+    def _resolve(self, path: str) -> Path:
+        return self._resolve_read(path)
 
     def _display_workspace(self) -> Path | None:
         return current_tool_workspace(self._workspace).project_path
@@ -224,7 +271,7 @@ class ReadFileTool(_FsTool):
             if _is_blocked_device(path):
                 return f"Error: Reading {path} is blocked (device path that could hang or produce infinite output)."
 
-            fp = self._resolve(path)
+            fp = self._resolve_read(path)
             if _is_blocked_device(fp):
                 return f"Error: Reading {fp} is blocked (device path that could hang or produce infinite output)."
             if not fp.exists():
@@ -436,7 +483,7 @@ class WriteFileTool(_FsTool):
                 raise ValueError("Unknown path")
             if content is None:
                 raise ValueError("Unknown content")
-            fp = self._resolve(path)
+            fp = self._resolve_write(path)
             fp.parent.mkdir(parents=True, exist_ok=True)
             fp.write_text(content, encoding="utf-8")
             self._file_states.record_write(fp)
@@ -786,7 +833,7 @@ class EditFileTool(_FsTool):
             if expected_replacements is not None and expected_replacements < 1:
                 return "Error: expected_replacements must be >= 1."
 
-            fp = self._resolve(path)
+            fp = self._resolve_write(path)
 
             # Create-file semantics: old_text='' + file doesn't exist → create
             if not fp.exists():

--- a/nanobot/agent/tools/path_utils.py
+++ b/nanobot/agent/tools/path_utils.py
@@ -19,9 +19,11 @@ def resolve_workspace_path(
     workspace: Path | None = None,
     allowed_dir: Path | None = None,
     extra_allowed_dirs: list[Path] | None = None,
+    include_media_dir: bool = True,
 ) -> Path:
     """Resolve path against workspace and enforce allowed directory containment."""
-    extra_roots = [get_media_dir(), *(extra_allowed_dirs or [])] if allowed_dir else None
+    media_roots = [get_media_dir()] if include_media_dir else []
+    extra_roots = [*media_roots, *(extra_allowed_dirs or [])] if allowed_dir else None
     return resolve_allowed_path(
         path,
         workspace=workspace,

--- a/nanobot/agent/tools/path_utils.py
+++ b/nanobot/agent/tools/path_utils.py
@@ -19,6 +19,7 @@ def resolve_workspace_path(
     workspace: Path | None = None,
     allowed_dir: Path | None = None,
     extra_allowed_dirs: list[Path] | None = None,
+    extra_allowed_files: list[Path] | None = None,
     include_media_dir: bool = True,
 ) -> Path:
     """Resolve path against workspace and enforce allowed directory containment."""
@@ -29,4 +30,5 @@ def resolve_workspace_path(
         workspace=workspace,
         allowed_root=allowed_dir,
         extra_allowed_roots=extra_roots,
+        extra_allowed_files=extra_allowed_files,
     )

--- a/nanobot/security/workspace_policy.py
+++ b/nanobot/security/workspace_policy.py
@@ -6,6 +6,7 @@ consistent across tools, but they are not a replacement for an OS sandbox.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Iterable
 
@@ -28,6 +29,18 @@ def resolve_path(path: str | Path, workspace: str | Path | None = None, *, stric
     return candidate.resolve(strict=strict)
 
 
+def _resolve_logical_path(path: str | Path, workspace: str | Path | None = None) -> Path:
+    """Return an absolute normalized path without following symlinks."""
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute() and workspace is not None:
+        candidate = Path(workspace).expanduser() / candidate
+    return Path(os.path.abspath(candidate))
+
+
+def _same_logical_path(left: str | Path, right: str | Path) -> bool:
+    return os.path.normcase(os.fspath(left)) == os.path.normcase(os.fspath(right))
+
+
 def is_path_within(path: str | Path, root: str | Path) -> bool:
     """Return True when *path* resolves to *root* or a descendant of *root*."""
     try:
@@ -44,18 +57,20 @@ def is_path_allowed(path: str | Path, roots: Iterable[str | Path]) -> bool:
     return any(is_path_within(path, root) for root in roots)
 
 
-def _is_path_exactly_allowed(path: str | Path, files: Iterable[str | Path]) -> bool:
+def _is_path_exactly_allowed(
+    logical_path: Path,
+    resolved_path: Path,
+    files: Iterable[str | Path],
+) -> bool:
     """Return True when *path* resolves exactly to one of the allowed files."""
-    try:
-        resolved_path = Path(path).expanduser().resolve(strict=False)
-    except (OSError, RuntimeError, TypeError, ValueError):
-        return False
     for file in files:
         try:
-            resolved_file = Path(file).expanduser().resolve(strict=False)
+            allowed_file = _resolve_logical_path(file)
         except (OSError, RuntimeError, TypeError, ValueError):
             continue
-        if resolved_path == resolved_file:
+        if not _same_logical_path(logical_path, allowed_file):
+            continue
+        if _same_logical_path(resolved_path, allowed_file):
             return True
     return False
 
@@ -87,6 +102,7 @@ def resolve_allowed_path(
     strict: bool = False,
 ) -> Path:
     """Resolve a path and enforce containment in allowed roots when configured."""
+    logical = _resolve_logical_path(path, workspace)
     resolved = resolve_path(path, workspace, strict=False)
     files = list(extra_allowed_files or [])
     if allowed_root is None and not files:
@@ -96,7 +112,11 @@ def resolve_allowed_path(
     if allowed_root is not None:
         roots.append(allowed_root)
     roots.extend(extra_allowed_roots or [])
-    if not is_path_allowed(resolved, roots) and not _is_path_exactly_allowed(resolved, files):
+    if not is_path_allowed(resolved, roots) and not _is_path_exactly_allowed(
+        logical,
+        resolved,
+        files,
+    ):
         boundary = Path(allowed_root).expanduser() if allowed_root is not None else "allowed files"
         raise WorkspaceBoundaryError(
             f"Path {path} is outside allowed directory {boundary}"

--- a/nanobot/security/workspace_policy.py
+++ b/nanobot/security/workspace_policy.py
@@ -37,8 +37,8 @@ def _resolve_logical_path(path: str | Path, workspace: str | Path | None = None)
     return Path(os.path.abspath(candidate))
 
 
-def _same_logical_path(left: str | Path, right: str | Path) -> bool:
-    return os.path.normcase(os.fspath(left)) == os.path.normcase(os.fspath(right))
+def _path_key(path: str | Path) -> str:
+    return os.path.normcase(os.fspath(path))
 
 
 def is_path_within(path: str | Path, root: str | Path) -> bool:
@@ -63,14 +63,15 @@ def _is_path_exactly_allowed(
     files: Iterable[str | Path],
 ) -> bool:
     """Return True when *path* resolves exactly to one of the allowed files."""
+    logical_key = _path_key(logical_path)
+    if _path_key(resolved_path) != logical_key:
+        return False
     for file in files:
         try:
             allowed_file = _resolve_logical_path(file)
         except (OSError, RuntimeError, TypeError, ValueError):
             continue
-        if not _same_logical_path(logical_path, allowed_file):
-            continue
-        if _same_logical_path(resolved_path, allowed_file):
+        if _path_key(allowed_file) == logical_key:
             return True
     return False
 
@@ -102,7 +103,6 @@ def resolve_allowed_path(
     strict: bool = False,
 ) -> Path:
     """Resolve a path and enforce containment in allowed roots when configured."""
-    logical = _resolve_logical_path(path, workspace)
     resolved = resolve_path(path, workspace, strict=False)
     files = list(extra_allowed_files or [])
     if allowed_root is None and not files:
@@ -112,11 +112,12 @@ def resolve_allowed_path(
     if allowed_root is not None:
         roots.append(allowed_root)
     roots.extend(extra_allowed_roots or [])
-    if not is_path_allowed(resolved, roots) and not _is_path_exactly_allowed(
-        logical,
+    exact_allowed = bool(files) and _is_path_exactly_allowed(
+        _resolve_logical_path(path, workspace),
         resolved,
         files,
-    ):
+    )
+    if not is_path_allowed(resolved, roots) and not exact_allowed:
         boundary = Path(allowed_root).expanduser() if allowed_root is not None else "allowed files"
         raise WorkspaceBoundaryError(
             f"Path {path} is outside allowed directory {boundary}"

--- a/nanobot/security/workspace_policy.py
+++ b/nanobot/security/workspace_policy.py
@@ -44,7 +44,7 @@ def is_path_allowed(path: str | Path, roots: Iterable[str | Path]) -> bool:
     return any(is_path_within(path, root) for root in roots)
 
 
-def is_path_exactly_allowed(path: str | Path, files: Iterable[str | Path]) -> bool:
+def _is_path_exactly_allowed(path: str | Path, files: Iterable[str | Path]) -> bool:
     """Return True when *path* resolves exactly to one of the allowed files."""
     try:
         resolved_path = Path(path).expanduser().resolve(strict=False)
@@ -96,7 +96,7 @@ def resolve_allowed_path(
     if allowed_root is not None:
         roots.append(allowed_root)
     roots.extend(extra_allowed_roots or [])
-    if not is_path_allowed(resolved, roots) and not is_path_exactly_allowed(resolved, files):
+    if not is_path_allowed(resolved, roots) and not _is_path_exactly_allowed(resolved, files):
         boundary = Path(allowed_root).expanduser() if allowed_root is not None else "allowed files"
         raise WorkspaceBoundaryError(
             f"Path {path} is outside allowed directory {boundary}"

--- a/nanobot/security/workspace_policy.py
+++ b/nanobot/security/workspace_policy.py
@@ -44,6 +44,22 @@ def is_path_allowed(path: str | Path, roots: Iterable[str | Path]) -> bool:
     return any(is_path_within(path, root) for root in roots)
 
 
+def is_path_exactly_allowed(path: str | Path, files: Iterable[str | Path]) -> bool:
+    """Return True when *path* resolves exactly to one of the allowed files."""
+    try:
+        resolved_path = Path(path).expanduser().resolve(strict=False)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return False
+    for file in files:
+        try:
+            resolved_file = Path(file).expanduser().resolve(strict=False)
+        except (OSError, RuntimeError, TypeError, ValueError):
+            continue
+        if resolved_path == resolved_file:
+            return True
+    return False
+
+
 def require_path_within(
     path: str | Path,
     root: str | Path,
@@ -67,17 +83,23 @@ def resolve_allowed_path(
     workspace: str | Path | None = None,
     allowed_root: str | Path | None = None,
     extra_allowed_roots: Iterable[str | Path] | None = None,
+    extra_allowed_files: Iterable[str | Path] | None = None,
     strict: bool = False,
 ) -> Path:
     """Resolve a path and enforce containment in allowed roots when configured."""
     resolved = resolve_path(path, workspace, strict=False)
-    if allowed_root is None:
+    files = list(extra_allowed_files or [])
+    if allowed_root is None and not files:
         return resolve_path(path, workspace, strict=strict) if strict else resolved
 
-    roots = [allowed_root, *(extra_allowed_roots or [])]
-    if not is_path_allowed(resolved, roots):
+    roots = []
+    if allowed_root is not None:
+        roots.append(allowed_root)
+    roots.extend(extra_allowed_roots or [])
+    if not is_path_allowed(resolved, roots) and not is_path_exactly_allowed(resolved, files):
+        boundary = Path(allowed_root).expanduser() if allowed_root is not None else "allowed files"
         raise WorkspaceBoundaryError(
-            f"Path {path} is outside allowed directory {Path(allowed_root).expanduser()}"
+            f"Path {path} is outside allowed directory {boundary}"
             + WORKSPACE_BOUNDARY_NOTE
         )
     if strict:

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -126,6 +126,86 @@ class TestDreamTools:
             "write_file",
         }
 
+    @pytest.mark.asyncio
+    async def test_dream_can_edit_canonical_memory_files(self, store):
+        tools = store.build_dream_tools()
+
+        memory_result = await tools.execute(
+            "apply_patch",
+            {
+                "edits": [
+                    {
+                        "path": "memory/MEMORY.md",
+                        "action": "replace",
+                        "old_text": "Project X active",
+                        "new_text": "Project Y active",
+                    }
+                ]
+            },
+        )
+        soul_result = await tools.execute(
+            "edit_file",
+            {
+                "path": "SOUL.md",
+                "old_text": "Helpful",
+                "new_text": "Precise",
+            },
+        )
+
+        assert "Patch applied" in memory_result
+        assert "Successfully edited" in soul_result
+        assert "Project Y active" in store.memory_file.read_text(encoding="utf-8")
+        assert "Precise" in store.soul_file.read_text(encoding="utf-8")
+
+    @pytest.mark.asyncio
+    async def test_dream_can_write_workspace_skills(self, store):
+        tools = store.build_dream_tools()
+        target = store.workspace / "skills" / "demo" / "SKILL.md"
+
+        result = await tools.execute(
+            "write_file",
+            {
+                "path": "skills/demo/SKILL.md",
+                "content": "---\nname: demo\ndescription: Demo skill.\n---\n\nUse when needed.\n",
+            },
+        )
+
+        assert "Successfully wrote" in result
+        assert target.read_text(encoding="utf-8").startswith("---\nname: demo")
+
+    @pytest.mark.asyncio
+    async def test_dream_cannot_modify_memory_internal_files(self, store):
+        tools = store.build_dream_tools()
+        store.history_file.write_text("before\n", encoding="utf-8")
+        store._dream_cursor_file.write_text("1", encoding="utf-8")
+
+        history_result = await tools.execute(
+            "apply_patch",
+            {
+                "edits": [
+                    {
+                        "path": "memory/history.jsonl",
+                        "action": "replace",
+                        "old_text": "before",
+                        "new_text": "after",
+                    }
+                ]
+            },
+        )
+        cursor_result = await tools.execute(
+            "edit_file",
+            {
+                "path": "memory/.dream_cursor",
+                "old_text": "1",
+                "new_text": "2",
+            },
+        )
+
+        assert "outside allowed directory" in history_result
+        assert "outside allowed directory" in cursor_result
+        assert store.history_file.read_text(encoding="utf-8") == "before\n"
+        assert store._dream_cursor_file.read_text(encoding="utf-8") == "1"
+
 
 class TestEphemeralDirect:
     """Tests for the ephemeral flag that skips history.jsonl writes for Dream."""
@@ -149,7 +229,9 @@ class TestEphemeralDirect:
         provider.supports_tools = True
         provider.generation = MagicMock(max_tokens=4096)
         provider.chat_with_retry = AsyncMock(
-            return_value=LLMResponse(content="done", tool_calls=[], finish_reason="stop", usage={})
+            return_value=MagicMock(
+                content="done", finish_reason="stop", tool_calls=[], usage={},
+            )
         )
 
         with (
@@ -181,13 +263,9 @@ class TestEphemeralDirect:
             mock_archive.assert_not_called()
 
     async def test_non_ephemeral_runs_normally(self, tmp_path, _make_loop):
-        """Without ephemeral, the normal path returns the model response."""
+        """Without ephemeral, the normal path is untouched — no crash."""
         loop, store = _make_loop
-        response = await loop.process_direct("test", session_key="cli:normal")
-
-        assert response is not None
-        assert response.content == "done"
-        loop.provider.chat_with_retry.assert_awaited()
+        await loop.process_direct("test", session_key="cli:normal")
 
     async def test_ephemeral_sets_ctx_flag(self, tmp_path, _make_loop):
         """Verify that ephemeral=True is forwarded to TurnContext."""

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -206,6 +206,38 @@ class TestDreamTools:
         assert store.history_file.read_text(encoding="utf-8") == "before\n"
         assert store._dream_cursor_file.read_text(encoding="utf-8") == "1"
 
+    @pytest.mark.asyncio
+    async def test_dream_cannot_create_children_under_canonical_files(self, store):
+        tools = store.build_dream_tools()
+
+        memory_child = store.memory_file / "evil.txt"
+        user_child = store.user_file / "evil.txt"
+        memory_result = await tools.execute(
+            "apply_patch",
+            {
+                "edits": [
+                    {
+                        "path": "memory/MEMORY.md/evil.txt",
+                        "action": "add",
+                        "new_text": "owned",
+                    }
+                ]
+            },
+        )
+        user_result = await tools.execute(
+            "edit_file",
+            {
+                "path": "USER.md/evil.txt",
+                "old_text": "",
+                "new_text": "owned",
+            },
+        )
+
+        assert "outside allowed directory" in memory_result
+        assert "outside allowed directory" in user_result
+        assert not memory_child.exists()
+        assert not user_child.exists()
+
 
 class TestEphemeralDirect:
     """Tests for the ephemeral flag that skips history.jsonl writes for Dream."""
@@ -229,9 +261,7 @@ class TestEphemeralDirect:
         provider.supports_tools = True
         provider.generation = MagicMock(max_tokens=4096)
         provider.chat_with_retry = AsyncMock(
-            return_value=MagicMock(
-                content="done", finish_reason="stop", tool_calls=[], usage={},
-            )
+            return_value=LLMResponse(content="done", tool_calls=[], finish_reason="stop", usage={})
         )
 
         with (
@@ -263,9 +293,13 @@ class TestEphemeralDirect:
             mock_archive.assert_not_called()
 
     async def test_non_ephemeral_runs_normally(self, tmp_path, _make_loop):
-        """Without ephemeral, the normal path is untouched — no crash."""
+        """Without ephemeral, the normal path returns the model response."""
         loop, store = _make_loop
-        await loop.process_direct("test", session_key="cli:normal")
+        response = await loop.process_direct("test", session_key="cli:normal")
+
+        assert response is not None
+        assert response.content == "done"
+        loop.provider.chat_with_retry.assert_awaited()
 
     async def test_ephemeral_sets_ctx_flag(self, tmp_path, _make_loop):
         """Verify that ephemeral=True is forwarded to TurnContext."""

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -4,6 +4,11 @@ import pytest
 
 from nanobot.agent.memory import MemoryStore
 from nanobot.providers.base import LLMResponse
+from nanobot.security.workspace_access import (
+    bind_workspace_scope,
+    default_workspace_scope,
+    reset_workspace_scope,
+)
 from nanobot.utils.prompt_templates import render_template
 
 
@@ -172,6 +177,41 @@ class TestDreamTools:
 
         assert "Successfully wrote" in result
         assert target.read_text(encoding="utf-8").startswith("---\nname: demo")
+
+    @pytest.mark.asyncio
+    async def test_dream_tools_keep_internal_write_scope_under_full_access(self, store):
+        tools = store.build_dream_tools()
+        scope = default_workspace_scope(store.workspace, restrict_to_workspace=False)
+        outside = store.workspace.parent / f"{store.workspace.name}-outside"
+        outside.mkdir()
+        outside_target = outside / "escape.txt"
+        skill_target = store.workspace / "skills" / "scoped" / "SKILL.md"
+
+        token = bind_workspace_scope(scope)
+        try:
+            outside_result = await tools.execute(
+                "write_file",
+                {"path": str(outside_target), "content": "owned"},
+            )
+            skill_result = await tools.execute(
+                "apply_patch",
+                {
+                    "edits": [
+                        {
+                            "path": "skills/scoped/SKILL.md",
+                            "action": "add",
+                            "new_text": "---\nname: scoped\n---\n",
+                        }
+                    ]
+                },
+            )
+        finally:
+            reset_workspace_scope(token)
+
+        assert "outside allowed directory" in outside_result
+        assert not outside_target.exists()
+        assert "Patch applied" in skill_result
+        assert skill_target.read_text(encoding="utf-8").startswith("---\nname: scoped")
 
     @pytest.mark.asyncio
     async def test_dream_cannot_modify_memory_internal_files(self, store):

--- a/tests/agent/test_workspace_scope.py
+++ b/tests/agent/test_workspace_scope.py
@@ -6,11 +6,13 @@ from types import SimpleNamespace
 import pytest
 
 from nanobot.agent.tools.cli_apps import CliAppsTool
-from nanobot.agent.tools.filesystem import ReadFileTool
+from nanobot.agent.tools.filesystem import ReadFileTool, WriteFileTool
 from nanobot.agent.tools.image_generation import ImageGenerationError, ImageGenerationTool
 from nanobot.agent.tools.message import MessageTool
 from nanobot.agent.tools.shell import ExecTool
 from nanobot.agent.tools.spawn import SpawnTool
+from nanobot.apps.cli.service import CliAppManager, CliAppsRuntimeConfig
+from nanobot.config.schema import ImageGenerationToolConfig, ProviderConfig
 from nanobot.security.workspace_access import (
     WORKSPACE_SCOPE_METADATA_KEY,
     WorkspaceScopeError,
@@ -20,8 +22,6 @@ from nanobot.security.workspace_access import (
     validate_workspace_scope_payload,
     workspace_scope_from_metadata,
 )
-from nanobot.apps.cli.service import CliAppManager, CliAppsRuntimeConfig
-from nanobot.config.schema import ImageGenerationToolConfig, ProviderConfig
 
 PNG_BYTES = (
     b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
@@ -114,6 +114,28 @@ async def test_filesystem_tool_uses_current_restricted_workspace_scope(tmp_path:
         assert "outside allowed directory" in await tool.execute(path=str(outside))
     finally:
         reset_workspace_scope(token)
+
+
+@pytest.mark.asyncio
+async def test_filesystem_write_tool_full_scope_allows_outside_project(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    outside = tmp_path / "outside"
+    project.mkdir()
+    outside.mkdir()
+    tool = WriteFileTool(workspace=tmp_path, allowed_dir=tmp_path, restrict_to_workspace=True)
+    scope = validate_workspace_scope_payload(
+        {"project_path": str(project), "access_mode": "full"},
+        default_workspace=tmp_path,
+        default_restrict_to_workspace=True,
+    )
+    token = bind_workspace_scope(scope)
+    try:
+        result = await tool.execute(path=str(outside / "outside.txt"), content="ok")
+    finally:
+        reset_workspace_scope(token)
+
+    assert "Successfully wrote" in result
+    assert (outside / "outside.txt").read_text(encoding="utf-8") == "ok"
 
 
 @pytest.mark.asyncio

--- a/tests/security/test_workspace_policy.py
+++ b/tests/security/test_workspace_policy.py
@@ -67,3 +67,27 @@ def test_resolve_allowed_path_allows_extra_root(tmp_path: Path) -> None:
     )
 
     assert resolved == image.resolve()
+
+
+def test_resolve_allowed_path_allows_extra_file_only_exactly(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    allowed = outside / "allowed.txt"
+
+    resolved = resolve_allowed_path(
+        allowed,
+        workspace=workspace,
+        allowed_root=workspace,
+        extra_allowed_files=[allowed],
+    )
+
+    assert resolved == allowed.resolve()
+    with pytest.raises(WorkspaceBoundaryError, match="outside allowed directory"):
+        resolve_allowed_path(
+            allowed / "child.txt",
+            workspace=workspace,
+            allowed_root=workspace,
+            extra_allowed_files=[allowed],
+        )

--- a/tests/security/test_workspace_policy.py
+++ b/tests/security/test_workspace_policy.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -9,6 +11,24 @@ from nanobot.security.workspace_policy import (
     is_path_within,
     resolve_allowed_path,
 )
+
+
+def _make_directory_link(link: Path, target: Path) -> None:
+    if os.name == "nt":
+        completed = subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(link), str(target)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            pytest.skip(completed.stderr.strip() or completed.stdout.strip())
+        return
+
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
 
 
 def test_resolve_allowed_path_accepts_workspace_relative_path(tmp_path: Path) -> None:
@@ -90,4 +110,25 @@ def test_resolve_allowed_path_allows_extra_file_only_exactly(tmp_path: Path) -> 
             workspace=workspace,
             allowed_root=workspace,
             extra_allowed_files=[allowed],
+        )
+
+
+def test_resolve_allowed_path_extra_file_blocks_link_escape(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    outside_target = outside / "MEMORY.md"
+    outside_target.write_text("secret", encoding="utf-8")
+
+    memory_link = workspace / "memory"
+    _make_directory_link(memory_link, outside)
+    logical_allowed = memory_link / "MEMORY.md"
+
+    with pytest.raises(WorkspaceBoundaryError, match="outside allowed directory"):
+        resolve_allowed_path(
+            "memory/MEMORY.md",
+            workspace=workspace,
+            allowed_root=workspace / "skills",
+            extra_allowed_files=[logical_allowed],
         )

--- a/tests/tools/test_apply_patch_tool.py
+++ b/tests/tools/test_apply_patch_tool.py
@@ -256,14 +256,56 @@ def test_apply_patch_edits_dry_run_validates_without_writing(tmp_path):
     assert not (tmp_path / "added.txt").exists()
 
 
-def test_apply_patch_edits_rejects_absolute_and_parent_paths(tmp_path):
-    tool = ApplyPatchTool(workspace=tmp_path)
+def test_apply_patch_edits_allows_absolute_and_parent_paths_when_unrestricted(tmp_path):
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    absolute_target = outside / "absolute.txt"
+    parent_target = outside / "parent.txt"
+    tool = ApplyPatchTool(workspace=workspace, restrict_to_workspace=False)
 
     absolute = asyncio.run(
         tool.execute(
             edits=[
                 {
-                    "path": "/tmp/owned.txt",
+                    "path": str(absolute_target),
+                    "action": "add",
+                    "new_text": "absolute",
+                }
+            ]
+        )
+    )
+    parent = asyncio.run(
+        tool.execute(
+            edits=[
+                {
+                    "path": "../outside/parent.txt",
+                    "action": "add",
+                    "new_text": "parent",
+                }
+            ]
+        )
+    )
+
+    assert "Patch applied" in absolute
+    assert "Patch applied" in parent
+    assert absolute_target.read_text() == "absolute\n"
+    assert parent_target.read_text() == "parent\n"
+
+
+def test_apply_patch_edits_rejects_outside_paths_when_restricted(tmp_path):
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    tool = ApplyPatchTool(workspace=workspace, allowed_dir=workspace)
+
+    absolute = asyncio.run(
+        tool.execute(
+            edits=[
+                {
+                    "path": str(outside / "absolute.txt"),
                     "action": "add",
                     "new_text": "nope",
                 }
@@ -274,29 +316,7 @@ def test_apply_patch_edits_rejects_absolute_and_parent_paths(tmp_path):
         tool.execute(
             edits=[
                 {
-                    "path": "../owned.txt",
-                    "action": "add",
-                    "new_text": "nope",
-                }
-            ]
-        )
-    )
-    windows_absolute = asyncio.run(
-        tool.execute(
-            edits=[
-                {
-                    "path": r"C:\owned.txt",
-                    "action": "add",
-                    "new_text": "nope",
-                }
-            ]
-        )
-    )
-    windows_parent = asyncio.run(
-        tool.execute(
-            edits=[
-                {
-                    "path": r"..\owned.txt",
+                    "path": "../outside/parent.txt",
                     "action": "add",
                     "new_text": "nope",
                 }
@@ -304,11 +324,95 @@ def test_apply_patch_edits_rejects_absolute_and_parent_paths(tmp_path):
         )
     )
 
-    assert "must be relative" in absolute
-    assert "must not contain '..'" in parent
-    assert "must be relative" in windows_absolute
-    assert "must not contain '..'" in windows_parent
-    assert not (tmp_path.parent / "owned.txt").exists()
+    assert "outside allowed directory" in absolute
+    assert "outside allowed directory" in parent
+    assert not (outside / "absolute.txt").exists()
+    assert not (outside / "parent.txt").exists()
+
+
+def test_apply_patch_legacy_extra_allowed_dirs_are_read_only(tmp_path):
+    workspace = tmp_path / "workspace"
+    skills = tmp_path / "skills"
+    workspace.mkdir()
+    skills.mkdir()
+    target = skills / "demo.md"
+    target.write_text("before\n", encoding="utf-8")
+    tool = ApplyPatchTool(
+        workspace=workspace,
+        allowed_dir=workspace,
+        extra_allowed_dirs=[skills],
+    )
+
+    result = asyncio.run(
+        tool.execute(
+            edits=[
+                {
+                    "path": str(target),
+                    "action": "replace",
+                    "old_text": "before",
+                    "new_text": "after",
+                }
+            ]
+        )
+    )
+
+    assert "outside allowed directory" in result
+    assert target.read_text(encoding="utf-8") == "before\n"
+
+
+def test_apply_patch_media_dir_is_read_only_by_default(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    media = tmp_path / "media"
+    workspace.mkdir()
+    media.mkdir()
+    target = media / "demo.md"
+    target.write_text("before\n", encoding="utf-8")
+    monkeypatch.setattr("nanobot.agent.tools.path_utils.get_media_dir", lambda: media)
+    tool = ApplyPatchTool(workspace=workspace, allowed_dir=workspace)
+
+    result = asyncio.run(
+        tool.execute(
+            edits=[
+                {
+                    "path": str(target),
+                    "action": "replace",
+                    "old_text": "before",
+                    "new_text": "after",
+                }
+            ]
+        )
+    )
+
+    assert "outside allowed directory" in result
+    assert target.read_text(encoding="utf-8") == "before\n"
+
+
+def test_apply_patch_allows_explicit_extra_write_allowed_dirs_when_restricted(tmp_path):
+    workspace = tmp_path / "workspace"
+    writable = tmp_path / "writable"
+    workspace.mkdir()
+    writable.mkdir()
+    target = writable / "allowed.txt"
+    tool = ApplyPatchTool(
+        workspace=workspace,
+        allowed_dir=workspace,
+        extra_write_allowed_dirs=[writable],
+    )
+
+    result = asyncio.run(
+        tool.execute(
+            edits=[
+                {
+                    "path": str(target),
+                    "action": "add",
+                    "new_text": "allowed",
+                }
+            ]
+        )
+    )
+
+    assert "Patch applied" in result
+    assert target.read_text(encoding="utf-8") == "allowed\n"
 
 
 def test_apply_patch_edits_reports_invalid_edit_shapes(tmp_path):

--- a/tests/tools/test_filesystem_tools.py
+++ b/tests/tools/test_filesystem_tools.py
@@ -386,6 +386,30 @@ class TestWorkspaceRestriction:
         assert (writable / "ok.txt").read_text(encoding="utf-8") == "allowed"
 
     @pytest.mark.asyncio
+    async def test_extra_write_allowed_files_allow_only_exact_file(self, tmp_path):
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        allowed_file = outside / "allowed.txt"
+        child_path = allowed_file / "child.txt"
+
+        tool = WriteFileTool(
+            workspace=workspace,
+            allowed_dir=workspace,
+            extra_write_allowed_files=[allowed_file],
+        )
+
+        exact = await tool.execute(path=str(allowed_file), content="allowed")
+        child = await tool.execute(path=str(child_path), content="blocked")
+
+        assert "Successfully wrote" in exact
+        assert allowed_file.read_text(encoding="utf-8") == "allowed"
+        assert "Error" in child
+        assert "outside" in child.lower()
+        assert not child_path.exists()
+
+    @pytest.mark.asyncio
     async def test_read_still_blocked_for_unrelated_dir(self, tmp_path):
         workspace = tmp_path / "ws"
         workspace.mkdir()

--- a/tests/tools/test_filesystem_tools.py
+++ b/tests/tools/test_filesystem_tools.py
@@ -6,6 +6,7 @@ from nanobot.agent.tools.filesystem import (
     EditFileTool,
     ListDirTool,
     ReadFileTool,
+    WriteFileTool,
     _find_match,
 )
 
@@ -283,7 +284,7 @@ class TestListDirTool:
 
 
 # ---------------------------------------------------------------------------
-# Workspace restriction + extra_allowed_dirs
+# Workspace restriction + extra read/write allowed dirs
 # ---------------------------------------------------------------------------
 
 class TestWorkspaceRestriction:
@@ -314,7 +315,7 @@ class TestWorkspaceRestriction:
 
         tool = ReadFileTool(
             workspace=workspace, allowed_dir=workspace,
-            extra_allowed_dirs=[skills_dir],
+            extra_read_allowed_dirs=[skills_dir],
         )
         result = await tool.execute(path=str(skill_file))
         assert "Test Skill" in result
@@ -337,18 +338,52 @@ class TestWorkspaceRestriction:
         assert "Error" not in result
 
     @pytest.mark.asyncio
-    async def test_extra_dirs_does_not_widen_write(self, tmp_path):
-        from nanobot.agent.tools.filesystem import WriteFileTool
-
+    async def test_write_blocked_in_media_dir_by_default(self, tmp_path, monkeypatch):
         workspace = tmp_path / "ws"
         workspace.mkdir()
-        outside = tmp_path / "outside"
-        outside.mkdir()
+        media_dir = tmp_path / "media"
+        media_dir.mkdir()
+
+        monkeypatch.setattr("nanobot.agent.tools.path_utils.get_media_dir", lambda: media_dir)
 
         tool = WriteFileTool(workspace=workspace, allowed_dir=workspace)
-        result = await tool.execute(path=str(outside / "hack.txt"), content="pwned")
+        result = await tool.execute(path=str(media_dir / "hack.txt"), content="pwned")
         assert "Error" in result
         assert "outside" in result.lower()
+        assert not (media_dir / "hack.txt").exists()
+
+    @pytest.mark.asyncio
+    async def test_legacy_extra_allowed_dirs_does_not_widen_write(self, tmp_path):
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+
+        tool = WriteFileTool(
+            workspace=workspace,
+            allowed_dir=workspace,
+            extra_allowed_dirs=[skills_dir],
+        )
+        result = await tool.execute(path=str(skills_dir / "hack.txt"), content="pwned")
+        assert "Error" in result
+        assert "outside" in result.lower()
+        assert not (skills_dir / "hack.txt").exists()
+
+    @pytest.mark.asyncio
+    async def test_write_allowed_with_extra_write_dir(self, tmp_path):
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        writable = tmp_path / "writable"
+        writable.mkdir()
+
+        tool = WriteFileTool(
+            workspace=workspace,
+            allowed_dir=workspace,
+            extra_write_allowed_dirs=[writable],
+        )
+        result = await tool.execute(path=str(writable / "ok.txt"), content="allowed")
+        assert "Successfully wrote" in result
+        assert (writable / "ok.txt").read_text(encoding="utf-8") == "allowed"
 
     @pytest.mark.asyncio
     async def test_read_still_blocked_for_unrelated_dir(self, tmp_path):
@@ -398,7 +433,11 @@ class TestWorkspaceRestriction:
         skill_file.parent.mkdir()
         skill_file.write_text("# Weather\nOriginal content.")
 
-        tool = EditFileTool(workspace=workspace, allowed_dir=workspace)
+        tool = EditFileTool(
+            workspace=workspace,
+            allowed_dir=workspace,
+            extra_allowed_dirs=[skills_dir],
+        )
         result = await tool.execute(
             path=str(skill_file),
             old_text="Original content.",
@@ -407,3 +446,25 @@ class TestWorkspaceRestriction:
         assert "Error" in result
         assert "outside" in result.lower()
         assert skill_file.read_text() == "# Weather\nOriginal content."
+
+    @pytest.mark.asyncio
+    async def test_edit_allowed_with_extra_write_dir(self, tmp_path):
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        writable = tmp_path / "writable"
+        writable.mkdir()
+        target = writable / "note.txt"
+        target.write_text("before\n", encoding="utf-8")
+
+        tool = EditFileTool(
+            workspace=workspace,
+            allowed_dir=workspace,
+            extra_write_allowed_dirs=[writable],
+        )
+        result = await tool.execute(
+            path=str(target),
+            old_text="before",
+            new_text="after",
+        )
+        assert "Successfully edited" in result
+        assert target.read_text(encoding="utf-8") == "after\n"


### PR DESCRIPTION
## Summary
- align `apply_patch` path handling with the existing workspace access policy instead of hard-coding relative-only paths
- treat legacy `extra_allowed_dirs` as read-only, and add explicit internal `extra_read_allowed_dirs` / `extra_write_allowed_dirs`
- route write-capable filesystem tools through write allowlists only, with media uploads read-only by default
- tighten Dream filesystem writes to canonical memory files plus workspace `skills/`, even when the outer workspace scope is full access
- add exact-file write allowlists for Dream canonical memory files without allowing children or link/junction escapes
- clarify `restrictToWorkspace` docs as application-level guards rather than process sandboxing

## Review follow-up
- rebased onto latest `main`
- fixed exact-file allowlist handling so symlinks or Windows junctions cannot redirect canonical paths to an external write target
- simplified the exact-file check so the resolved target must still equal the requested logical path before it can match the allowlist

## Split from
Split out from draft PR #4190 so tool-call validation and filesystem workspace policy can be reviewed independently.

## Verification
- `ruff check nanobot/agent/tools/path_utils.py nanobot/agent/tools/filesystem.py nanobot/agent/tools/apply_patch.py nanobot/agent/memory.py nanobot/security/workspace_policy.py tests/tools/test_filesystem_tools.py tests/tools/test_apply_patch_tool.py tests/agent/test_dream.py tests/agent/test_workspace_scope.py tests/security/test_workspace_policy.py`
- `python -m pytest tests/agent/test_dream.py tests/agent/test_workspace_scope.py tests/security/test_workspace_policy.py tests/tools/test_filesystem_tools.py tests/tools/test_apply_patch_tool.py tests/tools/test_search_tools.py -q` (`117 passed, 1 skipped`)
- package/tool consumer smoke: editable install, then `ToolRegistry` + `write_file` verified normal exact-file writes, legacy read-only extra dirs, junction escape rejection, and Dream write scope behavior
- GitHub Actions: test matrix passes on Ubuntu and Windows for Python 3.13 / 3.14