### PR TITLE
feat(dingtalk): add group_allow_from for group chat allowlist

### DIFF
--- a/nanobot/channels/dingtalk.py
+++ b/nanobot/channels/dingtalk.py
@@ -158,6 +158,7 @@ class DingTalkConfig(Base):
     client_id: str = ""
     client_secret: str = ""
     allow_from: list[str] = Field(default_factory=list)
+    group_allow_from: list[str] = Field(default_factory=list)
     allow_remote_media_redirects: bool = False
     remote_media_redirect_allowed_hosts: list[str] = Field(default_factory=list)
     group_user_isolation: bool = False  # If True, each user in group chat gets their own session
@@ -694,6 +695,18 @@ class DingTalkChannel(BaseChannel):
             self.logger.info("inbound: {} from {}", content, sender_name)
             is_group = conversation_type == "2" and conversation_id
             chat_id = f"group:{conversation_id}" if is_group else sender_id
+
+            if is_group:
+                group_allow_list = getattr(self.config, "group_allow_from", None) or []
+                if "*" not in group_allow_list:
+                    if str(conversation_id) not in group_allow_list:
+                        self.logger.warning(
+                            "Access denied for group {}. "
+                            "Add it to groupAllowFrom list in config to grant access.",
+                            conversation_id,
+                        )
+                        return
+
             session_key = None
             if is_group and self.config.group_user_isolation:
                 session_key = f"{self.name}:group:{conversation_id}:{sender_id}"

--- a/nanobot/channels/dingtalk.py
+++ b/nanobot/channels/dingtalk.py
@@ -14,7 +14,7 @@ from urllib.parse import unquote, urljoin, urlparse
 import httpx
 from pydantic import Field
 
-from nanobot.bus.events import OutboundMessage
+from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
 from nanobot.config.schema import Base
@@ -696,20 +696,40 @@ class DingTalkChannel(BaseChannel):
             is_group = conversation_type == "2" and conversation_id
             chat_id = f"group:{conversation_id}" if is_group else sender_id
 
-            if is_group:
-                group_allow_list = getattr(self.config, "group_allow_from", None) or []
-                if "*" not in group_allow_list:
-                    if str(conversation_id) not in group_allow_list:
-                        self.logger.warning(
-                            "Access denied for group {}. "
-                            "Add it to groupAllowFrom list in config to grant access.",
-                            conversation_id,
-                        )
-                        return
-
             session_key = None
             if is_group and self.config.group_user_isolation:
                 session_key = f"{self.name}:group:{conversation_id}:{sender_id}"
+
+            if is_group:
+                group_allow_list = getattr(self.config, "group_allow_from", None) or []
+                if "*" in group_allow_list or str(conversation_id) in group_allow_list:
+                    # Group allowlisted; skip sender-level allow_from check
+                    meta: dict[str, Any] = {
+                        "sender_name": sender_name,
+                        "platform": "dingtalk",
+                        "conversation_type": conversation_type,
+                    }
+                    if self.supports_streaming:
+                        meta = {**meta, "_wants_stream": True}
+                    msg = InboundMessage(
+                        channel=self.name,
+                        sender_id=str(sender_id),
+                        chat_id=chat_id,
+                        content=str(content),
+                        media=[],
+                        metadata=meta,
+                        session_key_override=session_key,
+                    )
+                    await self.bus.publish_inbound(msg)
+                    return
+                self.logger.warning(
+                    "Access denied for group {}. "
+                    "Add it to groupAllowFrom list in config to grant access.",
+                    conversation_id,
+                )
+                return
+
+            # Single chat: use BaseChannel permission check
             await self._handle_message(
                 sender_id=sender_id,
                 chat_id=chat_id,

--- a/tests/channels/test_dingtalk_channel.py
+++ b/tests/channels/test_dingtalk_channel.py
@@ -148,6 +148,49 @@ async def test_group_user_isolation_true_separates_sessions() -> None:
 
 
 @pytest.mark.asyncio
+async def test_group_allow_from_skips_sender_check() -> None:
+    """Group allowlist bypasses sender-level allow_from check."""
+    config = DingTalkConfig(
+        client_id="app", client_secret="secret", allow_from=["other_user"], group_allow_from=["conv123"]
+    )
+    bus = MessageBus()
+    channel = DingTalkChannel(config, bus)
+
+    await channel._on_message(
+        "hello",
+        sender_id="unauthorized_user",
+        sender_name="Bob",
+        conversation_type="2",
+        conversation_id="conv123",
+    )
+
+    msg = await bus.consume_inbound()
+    assert msg.sender_id == "unauthorized_user"
+    assert msg.chat_id == "group:conv123"
+
+
+@pytest.mark.asyncio
+async def test_group_not_in_allow_list_rejects_even_sender_allowed() -> None:
+    """Group not in allowlist is rejected even if sender is in allow_from."""
+    config = DingTalkConfig(
+        client_id="app", client_secret="secret", allow_from=["user1"], group_allow_from=[]
+    )
+    bus = MessageBus()
+    channel = DingTalkChannel(config, bus)
+
+    await channel._on_message(
+        "hello",
+        sender_id="user1",
+        sender_name="Alice",
+        conversation_type="2",
+        conversation_id="conv999",
+    )
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(bus.consume_inbound(), timeout=0.1)
+
+
+@pytest.mark.asyncio
 async def test_group_send_uses_group_messages_api() -> None:
     config = DingTalkConfig(client_id="app", client_secret="secret", allow_from=["*"])
     channel = DingTalkChannel(config, MessageBus())

--- a/tests/channels/test_dingtalk_channel.py
+++ b/tests/channels/test_dingtalk_channel.py
@@ -80,7 +80,7 @@ class _NetworkErrorHttp:
 
 @pytest.mark.asyncio
 async def test_group_message_keeps_sender_id_and_routes_chat_id() -> None:
-    config = DingTalkConfig(client_id="app", client_secret="secret", allow_from=["user1"])
+    config = DingTalkConfig(client_id="app", client_secret="secret", allow_from=["user1"], group_allow_from=["conv123"])
     bus = MessageBus()
     channel = DingTalkChannel(config, bus)
 
@@ -102,7 +102,7 @@ async def test_group_message_keeps_sender_id_and_routes_chat_id() -> None:
 async def test_group_user_isolation_false_uses_shared_session() -> None:
     """By default group messages share the same session_key."""
     config = DingTalkConfig(
-        client_id="app", client_secret="secret", allow_from=["*"], group_user_isolation=False
+        client_id="app", client_secret="secret", allow_from=["*"], group_allow_from=["conv123"], group_user_isolation=False
     )
     bus = MessageBus()
     channel = DingTalkChannel(config, bus)
@@ -126,7 +126,7 @@ async def test_group_user_isolation_false_uses_shared_session() -> None:
 async def test_group_user_isolation_true_separates_sessions() -> None:
     """When group_user_isolation is True, each user gets their own session_key."""
     config = DingTalkConfig(
-        client_id="app", client_secret="secret", allow_from=["*"], group_user_isolation=True
+        client_id="app", client_secret="secret", allow_from=["*"], group_allow_from=["conv123"], group_user_isolation=True
     )
     bus = MessageBus()
     channel = DingTalkChannel(config, bus)
@@ -171,7 +171,7 @@ async def test_group_send_uses_group_messages_api() -> None:
 async def test_handler_uses_voice_recognition_text_when_text_is_empty(monkeypatch) -> None:
     bus = MessageBus()
     channel = DingTalkChannel(
-        DingTalkConfig(client_id="app", client_secret="secret", allow_from=["user1"]),
+        DingTalkConfig(client_id="app", client_secret="secret", allow_from=["user1"], group_allow_from=["conv123"]),
         bus,
     )
     handler = NanobotDingTalkHandler(channel)


### PR DESCRIPTION
- Add group_allow_from field to DingTalkConfig
- Reject group messages when group_allow_from is empty or doesn't match
- Support wildcard '*' to allow all groups
- Update tests to include group_allow_from for group chat scenarios