### PR TITLE
Drop Python 3.11/3.12 support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -59,9 +59,8 @@ body:
       label: Python Version
       description: What Python version are you using?
       options:
-        - "3.11"
-        - "3.12"
         - "3.13"
+        - "3.14"
         - Other (specify below)
     validations:
       required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ fromJSON('["ubuntu-latest","windows-latest"]') }}
-        # CI concentrates on newer runtimes (3.11/3.12 still supported per pyproject requires-python).
         python-version: ${{ fromJSON('["3.13","3.14"]') }}
 
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the full two-branch model (`main`
 
 ## Code Style
 
-- Python 3.11+, asyncio throughout.
+- Python 3.13+, asyncio throughout.
 - Line length: 100.
 - Linting: `ruff` with rules E, F, I, N, W (E501 ignored).
 - pytest with `asyncio_mode = "auto"`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ When contributing, please aim for code that feels:
 In practice:
 
 - Line length: 100 characters (`ruff`)
-- Target: Python 3.11+
+- Target: Python 3.13+
 - Linting: `ruff` with rules E, F, I, N, W (E501 ignored)
 - Async: uses `asyncio` throughout; pytest with `asyncio_mode = "auto"`
 - Prefer readable code over magical code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
 
 # Install Node.js 20 for the WhatsApp bridge
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <p>
     <a href="https://pypi.org/project/nanobot-ai/"><img src="https://img.shields.io/pypi/v/nanobot-ai" alt="PyPI"></a>
     <a href="https://pepy.tech/project/nanobot-ai"><img src="https://static.pepy.tech/badge/nanobot-ai" alt="Downloads"></a>
-    <img src="https://img.shields.io/badge/python-≥3.11-blue" alt="Python">
+    <img src="https://img.shields.io/badge/python-≥3.13-blue" alt="Python">
     <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
     <a href="https://github.com/HKUDS/nanobot/graphs/commit-activity" target="_blank">
         <img alt="Commits last month" src="https://img.shields.io/github/commit-activity/m/HKUDS/nanobot?labelColor=%20%2332b583&color=%20%2312b76a"></a>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -147,7 +147,7 @@ For production use:
 1. **Isolate the Environment**
    ```bash
    # Run in a container or VM
-   docker run --rm -it python:3.11
+   docker run --rm -it python:3.13
    pip install nanobot-ai
    ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "nanobot-ai"
 version = "0.2.1"
 description = "A lightweight personal AI assistant framework"
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 license = {text = "MIT"}
 authors = [
     {name = "Xubin Ren"},
@@ -14,8 +14,8 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 license-files = [
     "LICENSE",
@@ -166,7 +166,7 @@ include = [
 
 [tool.ruff]
 line-length = 100
-target-version = "py311"
+target-version = "py313"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W"]


### PR DESCRIPTION
## Summary

Aligns the project's **declared** Python support with what CI **actually tests**. The CI matrix (`.github/workflows/ci.yml`) runs only `3.13` and `3.14`, so 3.11 and 3.12 have not been exercised in CI — yet `pyproject.toml` still advertises `>=3.11` and ships 3.11/3.12 classifiers. This drops 3.11/3.12 so the promise matches reality.

## Rationale

If we're not going to CI-test 3.11/3.12, we shouldn't advertise support for them — an untested runtime is an unsupported runtime in all but name, and silently shipping it invites bug reports we can't reproduce or guard against. This PR closes that gap by making `>=3.13` the real, tested floor.

**If dropping these versions isn't acceptable**, the alternative is the opposite fix: add 3.11 and 3.12 back into the CI matrix so the declared support is genuinely covered. I'm happy to swap this PR for that approach instead — just let me know which direction you'd prefer.

