### PR TITLE
fix(providers): allow dropping default OpenAI image params via null extraBody

### DIFF
--- a/nanobot/providers/image_generation.py
+++ b/nanobot/providers/image_generation.py
@@ -996,6 +996,8 @@ class OpenAIImageGenerationClient(ImageGenerationProvider):
             body["size"] = size
 
         body.update(self.extra_body)
+        # Drop null-valued params so extraBody can opt out of defaults like response_format.
+        body = {key: value for key, value in body.items() if value is not None}
 
         logger.info("OpenAI Images API request: POST {}/images/generations body={}", self.api_base, body)
 

--- a/tests/providers/test_image_generation.py
+++ b/tests/providers/test_image_generation.py
@@ -632,6 +632,28 @@ async def test_openai_payload_and_response() -> None:
 
 
 @pytest.mark.asyncio
+async def test_openai_extra_body_null_drops_default_params_only() -> None:
+    fake = FakeClient(FakeResponse({"data": [{"b64_json": RAW_B64}]}))
+    client = OpenAIImageGenerationClient(
+        api_key="sk-openai-test",
+        extra_body={
+            "response_format": None,
+            "seed": 0,
+            "safety_checker": False,
+        },
+        client=fake,  # type: ignore[arg-type]
+    )
+
+    await client.generate(prompt="draw", model="dall-e-3")
+
+    body = fake.calls[0]["json"]
+    assert "response_format" not in body
+    assert body["n"] == 1
+    assert body["seed"] == 0
+    assert body["safety_checker"] is False
+
+
+@pytest.mark.asyncio
 async def test_openai_b64_json_response_uses_detected_mime() -> None:
     raw_b64 = base64.b64encode(JPEG_BYTES).decode("ascii")
     fake = FakeClient(FakeResponse({"data": [{"b64_json": raw_b64}]}))


### PR DESCRIPTION
Closes #4167

The OpenAI Images path always sends `response_format`, which some OpenAI-compatible image APIs reject. Drop null-valued keys after merging `extraBody` so users can opt out with `{"response_format": null}`. 