### PR TITLE
fix(session): drop orphan tool results individually instead of cutting the prefix

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -19,10 +19,10 @@ from loguru import logger
 from nanobot.session.manager import Session
 from nanobot.utils.gitstore import GitStore
 from nanobot.utils.helpers import (
+    drop_orphan_tool_results,
     ensure_dir,
     estimate_message_tokens,
     estimate_prompt_tokens_chain,
-    find_legal_message_start,
     strip_think,
     truncate_text,
 )
@@ -656,9 +656,9 @@ class Consolidator:
                 sliced = sliced[start:]
                 break
 
-        legal_start = find_legal_message_start([message for _idx, message in sliced])
-        if legal_start:
-            sliced = sliced[legal_start:]
+        kept_messages = drop_orphan_tool_results([message for _idx, message in sliced])
+        kept_ids = {id(message) for message in kept_messages}
+        sliced = [pair for pair in sliced if id(pair[1]) in kept_ids]
         if not sliced:
             return len(session.messages)
 

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -29,10 +29,10 @@ from nanobot.utils.file_edit_events import (
 from nanobot.utils.helpers import (
     IncrementalThinkExtractor,
     build_assistant_message,
+    drop_orphan_tool_results,
     estimate_message_tokens,
     estimate_prompt_tokens_chain,
     extract_reasoning,
-    find_legal_message_start,
     maybe_persist_tool_result,
     strip_think,
     truncate_text,
@@ -1369,14 +1369,10 @@ class AgentRunner:
                         break
                 # If no user exists at all, _enforce_role_alternation
                 # will insert a synthetic one as a safety net.
-            start = find_legal_message_start(kept)
-            if start:
-                kept = kept[start:]
+            kept = drop_orphan_tool_results(kept)
         if not kept:
             kept = non_system[-min(len(non_system), 4) :]
-            start = find_legal_message_start(kept)
-            if start:
-                kept = kept[start:]
+            kept = drop_orphan_tool_results(kept)
         return system_messages + kept
 
     def _partition_tool_batches(

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -14,9 +14,9 @@ from loguru import logger
 
 from nanobot.config.paths import get_legacy_sessions_dir
 from nanobot.utils.helpers import (
+    drop_orphan_tool_results,
     ensure_dir,
     estimate_message_tokens,
-    find_legal_message_start,
     image_placeholder_text,
     safe_filename,
     strip_think,
@@ -164,10 +164,8 @@ class Session:
                 sliced = sliced[start:]
                 break
 
-        # Drop orphan tool results at the front.
-        start = find_legal_message_start(sliced)
-        if start:
-            sliced = sliced[start:]
+        # Drop orphan tool results.
+        sliced = drop_orphan_tool_results(sliced)
 
         out: list[dict[str, Any]] = []
         for message in sliced:
@@ -264,10 +262,8 @@ class Session:
                 if recovered_user is not None:
                     kept = out[recovered_user:]
 
-            # And keep a legal tool-call boundary at the front.
-            start = find_legal_message_start(kept)
-            if start:
-                kept = kept[start:]
+            # And drop any orphan tool results.
+            kept = drop_orphan_tool_results(kept)
             out = kept
         return out
 
@@ -315,17 +311,13 @@ class Session:
             if latest_user is not None:
                 retained = list(self.messages[latest_user: latest_user + max_messages])
 
-        # Mirror get_history(): avoid persisting orphan tool results at the front.
-        start = find_legal_message_start(retained)
-        if start:
-            retained = retained[start:]
+        # Mirror get_history(): avoid persisting orphan tool results.
+        retained = drop_orphan_tool_results(retained)
 
         # Hard-cap guarantee: never keep more than max_messages.
         if len(retained) > max_messages:
             retained = retained[-max_messages:]
-            start = find_legal_message_start(retained)
-            if start:
-                retained = retained[start:]
+            retained = drop_orphan_tool_results(retained)
 
         # Compute actually-dropped messages using identity comparison so that
         # even when retained is a non-contiguous slice of original (the else

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -237,22 +237,32 @@ def truncate_text(text: str, max_chars: int) -> str:
     return text[:max_chars] + "\n... (truncated)"
 
 
-def find_legal_message_start(messages: list[dict[str, Any]]) -> int:
-    """Find the first index whose tool results have matching assistant calls."""
+def drop_orphan_tool_results(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop tool results that have no matching preceding assistant tool_call.
+
+    Window slicing and interrupted turns can leave ``tool`` messages whose
+    assistant ``tool_call`` is missing; chat APIs reject such histories. Only
+    those orphan tool messages are removed -- every other (legal) message is
+    preserved. Unlike a prefix cut, this does not discard legitimate messages
+    that happen to precede a trailing or mid-list orphan.
+    """
     declared: set[str] = set()
-    start = 0
-    for i, msg in enumerate(messages):
+    kept: list[dict[str, Any]] = []
+    for msg in messages:
         role = msg.get("role")
         if role == "assistant":
             for tc in msg.get("tool_calls") or []:
                 if isinstance(tc, dict) and tc.get("id"):
                     declared.add(str(tc["id"]))
+            kept.append(msg)
         elif role == "tool":
             tid = msg.get("tool_call_id")
             if tid and str(tid) not in declared:
-                start = i + 1
-                declared.clear()
-    return start
+                continue  # orphan tool result: drop only this message
+            kept.append(msg)
+        else:
+            kept.append(msg)
+    return kept
 
 
 def stringify_text_blocks(content: list[dict[str, Any]]) -> str | None:

--- a/tests/agent/test_session_manager_history.py
+++ b/tests/agent/test_session_manager_history.py
@@ -694,3 +694,32 @@ def test_retain_recent_legal_suffix_last_consolidated_correct_in_else_branch():
     assert session.last_consolidated == 3
     # already_cons should count dropped messages with original index < 12
     assert already_cons == 9
+
+
+def test_retain_recent_legal_suffix_keeps_user_before_trailing_orphan():
+    """Regression for #4203: a trailing orphan tool result must not discard legal messages.
+
+    A ``tool`` message whose ``tool_call_id`` has no matching assistant ``tool_call``
+    (an orphan) previously made the trim wipe every retained message -- including the
+    user's question -- instead of dropping just the orphan.
+    """
+    session = Session(key="test:trailing-orphan")
+    session.messages.append({"role": "user", "content": "q1"})
+    session.messages.append(
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "A", "type": "function", "function": {"name": "x", "arguments": "{}"}}],
+        }
+    )
+    session.messages.append({"role": "tool", "tool_call_id": "A", "name": "x", "content": "ok"})
+    session.messages.append({"role": "user", "content": "q2"})
+    session.messages.append({"role": "tool", "tool_call_id": "B", "name": "y", "content": "orphan"})
+
+    session.retain_recent_legal_suffix(3)
+
+    history = session.get_history(max_messages=500)
+    # The legal user turn must survive the trailing orphan.
+    assert any(m.get("role") == "user" and m.get("content") == "q2" for m in history)
+    # And no orphan tool result is left behind.
+    _assert_no_orphans(history)


### PR DESCRIPTION
Fixes #4203.

## Problem

`find_legal_message_start` returned the index *after* an orphan tool result:

```python
elif role == "tool":
    tid = msg.get("tool_call_id")
    if tid and str(tid) not in declared:
        start = i + 1          # jumps past everything before & including the orphan
        declared.clear()
```

Callers then did `messages = messages[start:]`. When a `tool` message has no matching preceding assistant `tool_call` (an orphan) and it sits **after** legal content, `start` becomes the list length, so `messages[start:]` is **empty** — every retained message, including the user's question, is discarded and the model is sent empty context.

Repro (from #4203):
```python
[user "q1", assistant(tool_call A), tool A, user "q2", tool B(orphan)]
# retain_recent_legal_suffix(3)  ->  expected: keep "q2";  actual: []
```

A prefix-cut index fundamentally cannot drop a trailing/mid-list orphan without discarding the legal messages before it.

## Fix

Replace `find_legal_message_start` (returns a cut index) with `drop_orphan_tool_results`, which **filters out only the orphan tool messages** and preserves every other message. Updated the seven call sites in `session/manager.py`, `agent/memory.py`, and `agent/runner.py` (all of which previously did `start = …; if start: x = x[start:]`). The call sites get simpler, and the existing "drop orphan tool results at the front" behavior is preserved (a leading orphan is still removed) while the trailing/mid case no longer wipes legal content.

## Verification

Added `test_retain_recent_legal_suffix_keeps_user_before_trailing_orphan` (the #4203 repro): asserts the legal user turn survives a trailing orphan and `_assert_no_orphans` holds. Verified it fails before the fix (the user turn is wiped) and passes after. The full `tests/agent/test_session_manager_history.py` invariant suite stays green (37 passed), and `tests/agent/` + `tests/session/` together are **1122 passed**. `ruff check` clean.