### PR TITLE
fix(sdk): close MCP connections from Nanobot facade

### DIFF
--- a/docs/python-sdk.md
+++ b/docs/python-sdk.md
@@ -11,8 +11,8 @@ from nanobot import Nanobot
 
 
 async def main() -> None:
-    bot = Nanobot.from_config()
-    result = await bot.run("What time is it in Tokyo?")
+    async with Nanobot.from_config() as bot:
+        result = await bot.run("What time is it in Tokyo?")
     print(result.content)
 
 
@@ -20,6 +20,8 @@ asyncio.run(main())
 ```
 
 `Nanobot.from_config()` reuses your normal `~/.nanobot/config.json`, so the SDK follows the same provider, model, tools, and workspace defaults as the CLI unless you override them.
+
+Use `async with` when possible so MCP connections and background cleanup work are closed before the event loop exits. If you manage the instance manually, call `await bot.aclose()` in a `finally` block.
 
 ## Common Patterns
 
@@ -82,6 +84,15 @@ Run the agent once and return a `RunResult`.
 | `message` | `str` | *(required)* | The user message to process. |
 | `session_key` | `str` | `"sdk:default"` | Session identifier for conversation isolation. Different keys get independent history. |
 | `hooks` | `list[AgentHook] \| None` | `None` | Lifecycle hooks for this run only. |
+
+### `await bot.aclose()`
+
+Release resources held by the SDK instance, including MCP connections. The async context manager calls this automatically:
+
+```python
+async with Nanobot.from_config() as bot:
+    result = await bot.run("Summarize this repo")
+```
 
 ### `RunResult`
 

--- a/nanobot/nanobot.py
+++ b/nanobot/nanobot.py
@@ -101,4 +101,13 @@ class Nanobot:
             messages=capture.messages,
         )
 
+    async def aclose(self) -> None:
+        """Release resources held by this instance (MCP connections, etc.)."""
+        await self._loop.close_mcp()
+
+    async def __aenter__(self) -> Nanobot:
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self.aclose()
 

--- a/tests/test_nanobot_facade.py
+++ b/tests/test_nanobot_facade.py
@@ -326,3 +326,40 @@ async def test_sdk_capture_prefers_run_level_snapshot():
 
     assert hook.tools_used == ["read_file"]
     assert hook.messages == final_messages
+
+
+@pytest.mark.asyncio
+async def test_aclose_delegates_to_loop_close_mcp(tmp_path):
+    config_path = _write_config(tmp_path)
+    bot = Nanobot.from_config(config_path, workspace=tmp_path)
+    bot._loop.close_mcp = AsyncMock()
+
+    await bot.aclose()
+
+    bot._loop.close_mcp.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_context_manager_calls_aclose_on_exit(tmp_path):
+    config_path = _write_config(tmp_path)
+    bot = Nanobot.from_config(config_path, workspace=tmp_path)
+    bot._loop.close_mcp = AsyncMock()
+
+    async with bot as b:
+        assert b is bot
+
+    bot._loop.close_mcp.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_context_manager_does_not_swallow_exceptions(tmp_path):
+    config_path = _write_config(tmp_path)
+    bot = Nanobot.from_config(config_path, workspace=tmp_path)
+    bot._loop.close_mcp = AsyncMock()
+
+    with pytest.raises(ValueError):
+        async with bot as b:
+            assert b is bot
+            raise ValueError("boom")
+
+    bot._loop.close_mcp.assert_awaited_once()


### PR DESCRIPTION
Fixes #4211

## Summary

The `Nanobot` SDK facade opens MCP connections through `AgentLoop.process_direct` (which calls `_connect_mcp`), but exposes no teardown. When users run a one-shot `await bot.run(...)` via `asyncio.run()`, the event loop shuts down and `shutdown_asyncgens` finalizes the `stdio_client` async generator from a different task than entered its cancel scope, producing:

```
RuntimeError: Attempted to exit cancel scope in a different task than it was entered in
```

`AgentLoop.close_mcp()` already handles this correctly (drains background tasks, closes each MCP `AsyncExitStack`). The fix adds a public `aclose()` method on `Nanobot` that delegates to it, plus `__aenter__`/`__aexit__` so the SDK works as an async context manager.

After this fix, users can either call `await bot.aclose()` explicitly or use:

```python
async with Nanobot.from_config() as bot:
    result = await bot.run("...")
```

## Testing

### Verified locally

- `pytest tests/test_nanobot_facade.py -v`: 20/20 passed (3 new tests)
- `pytest tests/test_nanobot_facade.py tests/agent/test_consolidate_offset.py tests/agent/test_mcp_connection.py -v`: 66/66 passed
- `ruff check nanobot/nanobot.py tests/test_nanobot_facade.py`: all checks passed
- `git diff --check`: clean

### Added or updated tests

Three new tests in `tests/test_nanobot_facade.py`:
- `test_aclose_delegates_to_loop_close_mcp` -- verifies `aclose()` calls `close_mcp` once
- `test_context_manager_calls_aclose_on_exit` -- verifies `async with` teardown
- `test_context_manager_does_not_swallow_exceptions` -- verifies exceptions propagate and teardown still runs

### QA follow-up

- Test with a real stdio MCP server to confirm the RuntimeError no longer appears at shutdown
- Confirm `aclose()` is safe to call multiple times (idempotent)

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] Tests pass locally
- [x] Linting passes locally (ruff)
