### PR TITLE
fix(session): drop orphan tool results before trimming history

### DIFF
--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -16,6 +16,7 @@ from nanobot.config.paths import get_legacy_sessions_dir
 from nanobot.utils.helpers import (
     ensure_dir,
     estimate_message_tokens,
+    drop_orphan_tool_results,
     find_legal_message_start,
     image_placeholder_text,
     safe_filename,
@@ -164,7 +165,9 @@ class Session:
                 sliced = sliced[start:]
                 break
 
-        # Drop orphan tool results at the front.
+        # Drop orphan tool results before boundary trimming so a trailing
+        # orphan cannot advance the legal suffix past the latest user turn.
+        sliced = drop_orphan_tool_results(sliced)
         start = find_legal_message_start(sliced)
         if start:
             sliced = sliced[start:]
@@ -265,6 +268,7 @@ class Session:
                     kept = out[recovered_user:]
 
             # And keep a legal tool-call boundary at the front.
+            kept = drop_orphan_tool_results(kept)
             start = find_legal_message_start(kept)
             if start:
                 kept = kept[start:]
@@ -315,7 +319,9 @@ class Session:
             if latest_user is not None:
                 retained = list(self.messages[latest_user: latest_user + max_messages])
 
-        # Mirror get_history(): avoid persisting orphan tool results at the front.
+        # Mirror get_history(): avoid persisting orphan tool results before
+        # boundary trimming so a trailing orphan cannot empty the suffix.
+        retained = drop_orphan_tool_results(retained)
         start = find_legal_message_start(retained)
         if start:
             retained = retained[start:]
@@ -323,6 +329,7 @@ class Session:
         # Hard-cap guarantee: never keep more than max_messages.
         if len(retained) > max_messages:
             retained = retained[-max_messages:]
+            retained = drop_orphan_tool_results(retained)
             start = find_legal_message_start(retained)
             if start:
                 retained = retained[start:]

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -255,6 +255,27 @@ def find_legal_message_start(messages: list[dict[str, Any]]) -> int:
     return start
 
 
+def drop_orphan_tool_results(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return messages without tool results that lack assistant declarations."""
+    declared: set[str] = set()
+    legal: list[dict[str, Any]] = []
+
+    for msg in messages:
+        role = msg.get("role")
+        if role == "assistant":
+            for tc in msg.get("tool_calls") or []:
+                if isinstance(tc, dict) and tc.get("id"):
+                    declared.add(str(tc["id"]))
+            legal.append(msg)
+        elif role == "tool":
+            tid = msg.get("tool_call_id")
+            if tid and str(tid) in declared:
+                legal.append(msg)
+        else:
+            legal.append(msg)
+    return legal
+
+
 def stringify_text_blocks(content: list[dict[str, Any]]) -> str | None:
     parts: list[str] = []
     for block in content:

--- a/tests/agent/test_session_manager_history.py
+++ b/tests/agent/test_session_manager_history.py
@@ -142,6 +142,30 @@ def test_retain_recent_legal_suffix_keeps_recent_messages():
     assert session.messages[-1]["content"] == "msg9"
 
 
+def test_retain_recent_legal_suffix_drops_trailing_orphan_tool_result():
+    session = Session(key="test:trim-trailing-orphan")
+    session.messages.extend([
+        {"role": "user", "content": "question 1"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "A", "type": "function", "function": {"name": "x", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "A", "name": "x", "content": "ok"},
+        {"role": "user", "content": "question 2"},
+        {"role": "tool", "tool_call_id": "B", "name": "x", "content": "orphan"},
+    ])
+
+    session.retain_recent_legal_suffix(3)
+
+    assert session.messages == [
+        {"role": "user", "content": "question 2"},
+    ]
+
+    history = session.get_history(max_messages=500)
+    assert history == [{"role": "user", "content": "question 2"}]
+
+
 def test_retain_recent_legal_suffix_adjusts_last_consolidated():
     session = Session(key="test:trim-cons")
     for i in range(10):


### PR DESCRIPTION
Fixes #4203.

## Summary
- drop orphan tool results before legal-boundary trimming in session history
- keep the latest user turn when a trailing orphan tool result appears
- add a regression test for retain_recent_legal_suffix/get_history

## Tests
- `uv run --python 3.11 --with pytest --with loguru --with tiktoken --with pydantic --with pydantic-settings --with pyyaml python -m pytest tests/agent/test_session_manager_history.py -q`
  - 37 passed, 1 warning