### PR TITLE
fix(exec): block relative symlink workspace escapes

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import re
+import shlex
 import shutil
 import sys
 from contextlib import suppress
@@ -630,6 +631,17 @@ class ExecTool(Tool):
                         + _WORKSPACE_BOUNDARY_NOTE
                     )
 
+            for raw in self._extract_existing_relative_paths(cmd, cwd_path):
+                try:
+                    p = (cwd_path / os.path.expandvars(raw)).expanduser().resolve()
+                except Exception:
+                    continue
+                if not is_path_within(p, cwd_path):
+                    return (
+                        "Error: Command blocked by safety guard (path outside working dir)"
+                        + _WORKSPACE_BOUNDARY_NOTE
+                    )
+
         return None
 
     @classmethod
@@ -650,3 +662,29 @@ class ExecTool(Tool):
         posix_paths = re.findall(r"(?:^|[\s|>'\"])(/[^\s\"'>;|<]+)", command) # POSIX: /absolute only
         home_paths = re.findall(r"(?:^|[\s>'\"])(~[^\s\"'>;|<]*)", command) # POSIX/Windows home shortcut: ~
         return win_paths + posix_paths + home_paths
+
+    @staticmethod
+    def _extract_existing_relative_paths(command: str, cwd: Path) -> list[str]:
+        """Return relative shell words that already exist in the current cwd.
+
+        This catches symlink escapes such as ``cat link.txt`` without treating
+        ordinary command arguments like ``echo ok`` as filesystem paths.
+        """
+        try:
+            words = shlex.split(command, posix=not _IS_WINDOWS)
+        except ValueError:
+            return []
+        out: list[str] = []
+        for word in words:
+            if not word or word.startswith("-") or "=" in word:
+                continue
+            if any(ch in word for ch in "*?[{"):
+                continue
+            path = Path(os.path.expandvars(word)).expanduser()
+            if path.is_absolute():
+                continue
+            with suppress(OSError, RuntimeError, ValueError):
+                candidate = cwd / path
+                if candidate.exists() or candidate.is_symlink():
+                    out.append(word)
+        return out

--- a/tests/tools/test_tool_validation.py
+++ b/tests/tools/test_tool_validation.py
@@ -374,6 +374,24 @@ def test_exec_guard_blocks_non_benign_dev_path(tmp_path) -> None:
     assert "path outside working dir" in error
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink behavior differs on Windows")
+def test_exec_restricted_workspace_blocks_relative_symlink_escape(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    secret = outside / "secret.txt"
+    secret.write_text("sentinel", encoding="utf-8")
+    (workspace / "link.txt").symlink_to(secret)
+
+    tool = ExecTool(restrict_to_workspace=True, working_dir=str(workspace))
+    prepared = tool._prepare_command("cat link.txt")
+
+    assert isinstance(prepared, str)
+    assert "path outside working dir" in prepared
+    assert "hard policy boundary" in prepared
+
+
 def test_exec_extract_absolute_paths_ignores_pipe_tilde() -> None:
     cmd = "python query.py --query '{job=\"app\"} |~ \"error\"'"
     paths = ExecTool._extract_absolute_paths(cmd)


### PR DESCRIPTION
Fixes #4072.

## Summary
- resolve existing relative path operands in restricted `ExecTool` commands and block them when symlinks escape the working directory
- keep existing restricted workspace behavior for normal commands and workspace-internal paths
- add a regression test for `cat link.txt` where `link.txt` points outside the workspace

## Tests
- `python3 -m compileall nanobot/agent/tools/shell.py tests/tools/test_tool_validation.py`
- `uv run --python 3.11 --with pytest --with pytest-asyncio --with loguru --with pydantic --with pydantic-settings --with pyyaml --with dulwich --with tiktoken python -m pytest tests/agent/test_workspace_scope.py::test_exec_tool_uses_scope_project_as_default_cwd tests/agent/test_workspace_scope.py::test_exec_full_scope_allows_explicit_cwd_outside_project tests/tools/test_exec_security.py::test_exec_allows_working_dir_within_workspace tests/tools/test_exec_security.py::test_exec_allows_working_dir_equal_to_workspace tests/tools/test_exec_security.py::test_exec_3599_regression_rm_with_dev_null_redirect tests/tools/test_tool_validation.py::test_exec_restricted_workspace_blocks_relative_symlink_escape -q`
- `uv run --python 3.11 --with pytest --with pytest-asyncio --with loguru --with pydantic --with pydantic-settings --with pyyaml --with dulwich --with tiktoken python -m pytest tests/tools/test_tool_validation.py -q`
- `uv run --python 3.11 --with pytest --with pytest-asyncio --with loguru --with pydantic --with pydantic-settings --with pyyaml --with dulwich --with tiktoken python -m pytest tests/tools/test_exec_security.py tests/agent/test_workspace_scope.py -q`
- `uv run --python 3.11 --with pytest --with pytest-asyncio --with loguru --with pydantic --with pydantic-settings --with pyyaml --with dulwich --with tiktoken python -m pytest tests/tools/test_exec_platform.py tests/security/test_workspace_sandbox.py tests/tools/test_sandbox.py -q`