### PR TITLE
fix(weixin): reload session state after pause expiry

### DIFF
--- a/nanobot/channels/weixin.py
+++ b/nanobot/channels/weixin.py
@@ -539,6 +539,7 @@ class WeixinChannel(BaseChannel):
         remaining = self._session_pause_remaining_s()
         if remaining > 0:
             await asyncio.sleep(remaining)
+            self._load_state()
             return
 
         body: dict[str, Any] = {


### PR DESCRIPTION
## 问题

`_poll_once()` 检测到 session 过期（errcode -14）后会设置 60 分钟暂停并 sleep。但醒来后直接 `return`，没有调用 `_load_state()` 重新读取 `account.json`。后续轮询继续使用内存中的过期 token，反复命中 errcode -14，形成永久静默的死循环。

## 复现

1. `nanobot channels login weixin` 扫码登录
2. 等待 session token 自然过期（约 2 小时）
3. 微信频道永久静默 — 不重新扫码就无法恢复

## 修复

在 pause sleep 之后调用 `self._load_state()`，从 `account.json` 重新加载 token。这样通过 channel rebinding 等方式刷新的 token 能被立即拾取。

## 变更

`nanobot/channels/weixin.py`：+1 行

```
  if remaining > 0:
      await asyncio.sleep(remaining)
+     self._load_state()
      return
```

影响范围：所有长期运行的 weixin 频道实例。
