### PR TITLE
fix: preserve empty-string reasoning_content instead of coercing to None

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -999,7 +999,7 @@ class OpenAICompatProvider(LLMProvider):
             if not content and msg0.get("reasoning") and self._spec and self._spec.reasoning_as_content:
                 content = self._extract_text_content(msg0.get("reasoning"))
             reasoning_content = msg0.get("reasoning_content")
-            if not reasoning_content and msg0.get("reasoning"):
+            if reasoning_content is None and msg0.get("reasoning"):
                 reasoning_content = self._extract_text_content(msg0.get("reasoning"))
             for ch in choices:
                 ch_map = self._maybe_mapping(ch) or {}
@@ -1011,7 +1011,7 @@ class OpenAICompatProvider(LLMProvider):
                         finish_reason = str(ch_map["finish_reason"])
                 if not content:
                     content = self._extract_text_content(m.get("content"))
-                if not reasoning_content:
+                if reasoning_content is None:
                     reasoning_content = m.get("reasoning_content")
 
             parsed_tool_calls = []
@@ -1074,8 +1074,8 @@ class OpenAICompatProvider(LLMProvider):
                 function_provider_specific_fields=fn_prov,
             ))
 
-        reasoning_content = getattr(msg, "reasoning_content", None) or None
-        if not reasoning_content and getattr(msg, "reasoning", None):
+        reasoning_content = getattr(msg, "reasoning_content", None)
+        if reasoning_content is None and getattr(msg, "reasoning", None):
             reasoning_content = msg.reasoning
 
         return LLMResponse(

--- a/tests/providers/test_reasoning_content.py
+++ b/tests/providers/test_reasoning_content.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+from nanobot.utils.helpers import build_assistant_message
 
 # ── _parse: non-streaming ─────────────────────────────────────────────────
 
@@ -75,6 +76,56 @@ def test_parse_dict_reasoning_content_empty_string_preserved() -> None:
     result = provider._parse(response)
 
     assert result.reasoning_content == ""
+
+
+def test_parse_sdk_reasoning_content_empty_string_preserved() -> None:
+    """SDK response objects preserve reasoning_content=\"\"."""
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        provider = OpenAICompatProvider()
+
+    message = SimpleNamespace(content="answer", reasoning_content="", tool_calls=None)
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    response = SimpleNamespace(choices=[choice], usage=None)
+
+    result = provider._parse(response)
+
+    assert result.content == "answer"
+    assert result.reasoning_content == ""
+
+
+def test_tool_call_history_preserves_empty_reasoning_content_after_sanitize() -> None:
+    """Empty reasoning_content survives the tool-call history round trip."""
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        provider = OpenAICompatProvider()
+
+    response = {
+        "choices": [{
+            "message": {
+                "content": "",
+                "reasoning_content": "",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }],
+            },
+            "finish_reason": "tool_calls",
+        }],
+    }
+
+    result = provider._parse(response)
+    assistant_message = build_assistant_message(
+        result.content or "",
+        tool_calls=[tc.to_openai_tool_call() for tc in result.tool_calls],
+        reasoning_content=result.reasoning_content,
+    )
+    sanitized = provider._sanitize_messages([
+        {"role": "user", "content": "look something up"},
+        assistant_message,
+        {"role": "tool", "tool_call_id": "call_1", "content": "done"},
+    ])
+
+    assert sanitized[1]["reasoning_content"] == ""
 
 
 # ── _parse_chunks: streaming dict branch ─────────────────────────────────

--- a/tests/providers/test_reasoning_content.py
+++ b/tests/providers/test_reasoning_content.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 
 from nanobot.providers.openai_compat_provider import OpenAICompatProvider
 
-
 # ── _parse: non-streaming ─────────────────────────────────────────────────
 
 
@@ -50,6 +49,32 @@ def test_parse_dict_reasoning_content_none_when_absent() -> None:
     result = provider._parse(response)
 
     assert result.reasoning_content is None
+
+
+def test_parse_dict_reasoning_content_empty_string_preserved() -> None:
+    """reasoning_content=\"\" is preserved, not coerced to None.
+
+    Some providers (e.g. DeepSeek) require the reasoning_content key to
+    be present in subsequent requests even when empty.  Coercing \"\" to
+    None drops the key downstream and causes API errors.
+    """
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        provider = OpenAICompatProvider()
+
+    response = {
+        "choices": [{
+            "message": {
+                "content": "answer",
+                "reasoning_content": "",
+            },
+            "finish_reason": "stop",
+        }],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+    }
+
+    result = provider._parse(response)
+
+    assert result.reasoning_content == ""
 
 
 # ── _parse_chunks: streaming dict branch ─────────────────────────────────


### PR DESCRIPTION
## Problem

Custom providers (e.g. DeepSeek, Kimi K2.5/K2.6) may return `reasoning_content` as an empty string `""` to explicitly indicate no reasoning occurred in a given turn. The previous truthiness checks (`or None`, `not x`) treated `""` as falsy and converted it to `None`, which caused the field to be dropped from the message history entirely. Providers that require `reasoning_content` on all assistant messages then rejected subsequent requests with HTTP 400.

This is the same root cause as #4105.

## Fix

Replace truthiness checks with identity checks (`is None`) so that empty-string `reasoning_content` is preserved as-is. The semantic distinction matters:

- `""` = the model explicitly had no reasoning this turn (field should be present)
- `None` = this field is not applicable / was not returned

### Changes (1 file, 4 lines)

`nanobot/providers/openai_compat_provider.py`:

| Line | Before | After |
|------|--------|-------|
| 1002 | `if not reasoning_content and msg0.get("reasoning"):` | `if reasoning_content is None and msg0.get("reasoning"):` |
| 1014 | `if not reasoning_content:` | `if reasoning_content is None:` |
| 1077 | `getattr(msg, "reasoning_content", None) or None` | `getattr(msg, "reasoning_content", None)` |
| 1078 | `if not reasoning_content and getattr(msg, "reasoning", None):` | `if reasoning_content is None and getattr(msg, "reasoning", None):` |

The streaming path (`"".join(reasoning_parts) or None`) is intentionally left unchanged — if no reasoning chunks were received during streaming, there genuinely was no reasoning.

## Testing

- `ruff check nanobot/providers/openai_compat_provider.py` — all checks passed
- `pytest tests/providers/ -x -q` — 142 passed, 1 pre-existing failure (missing `oauth_cli_kit` dependency, unrelated)

## Related

Fixes #4105