### PR TITLE
fix: set httpx timeout for streamableHttp transport

### DIFF
--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -644,7 +644,7 @@ async def connect_mcp_servers(
                     httpx.AsyncClient(
                         headers=cfg.headers or None,
                         follow_redirects=True,
-                        timeout=None,
+                        timeout=httpx.Timeout(30.0, connect=10.0),
                     )
                 )
                 read, write, _ = await server_stack.enter_async_context(

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -551,7 +551,7 @@ async def test_connect_mcp_servers_streamable_http_uses_finite_timeout(
 
     registry = ToolRegistry()
     stacks = await connect_mcp_servers(
-        {"test": MCPServerConfig(url="http://127.0.0.1:4001/mcp")},
+        {"test": MCPServerConfig(url="https://mcp.example.com/mcp")},
         registry,
     )
     for stack in stacks.values():

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -527,6 +527,44 @@ async def test_connect_mcp_servers_one_failure_does_not_block_others(
 
 
 @pytest.mark.asyncio
+async def test_connect_mcp_servers_streamable_http_uses_finite_timeout(
+    fake_mcp_runtime: dict[str, object | None],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_mcp_runtime["session"] = _make_fake_session(["demo"])
+    captured: dict[str, object] = {}
+
+    async def _reachable(_url: str) -> bool:
+        return True
+
+    @asynccontextmanager
+    async def _capturing_streamable_http_client(_url: str, http_client=None):
+        captured["timeout"] = http_client.timeout
+        yield object(), object(), object()
+
+    monkeypatch.setattr(mcp_mod, "_probe_http_url", _reachable)
+    monkeypatch.setattr(
+        sys.modules["mcp.client.streamable_http"],
+        "streamable_http_client",
+        _capturing_streamable_http_client,
+    )
+
+    registry = ToolRegistry()
+    stacks = await connect_mcp_servers(
+        {"test": MCPServerConfig(url="http://127.0.0.1:4001/mcp")},
+        registry,
+    )
+    for stack in stacks.values():
+        await stack.aclose()
+
+    timeout = captured["timeout"]
+    assert timeout.connect == 10.0
+    assert timeout.read == 30.0
+    assert timeout.write == 30.0
+    assert timeout.pool == 30.0
+
+
+@pytest.mark.asyncio
 async def test_connect_mcp_servers_wraps_windows_stdio_launchers(
     fake_mcp_runtime: dict[str, object | None],
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Problem

`streamableHttp` MCP connections currently create a custom `httpx.AsyncClient` with `timeout=None`. That disables httpx/MCP default timeout protection. If the TCP port is reachable but the streamable HTTP handshake or initialization never responds, MCP startup can wait indefinitely and the agent may never reach normal message processing.

## Fix

Use a finite timeout for streamable HTTP MCP clients: `httpx.Timeout(30.0, connect=10.0)`. This matches the intended MCP default behavior while keeping custom headers and redirects.

## Test plan

- `python -m pytest tests/tools/test_mcp_tool.py::test_connect_mcp_servers_streamable_http_uses_finite_timeout -q`
- `python -m pytest tests/tools/test_mcp_tool.py -q`
- `python -m ruff check nanobot/agent/tools/mcp.py tests/tools/test_mcp_tool.py`
