### PR TITLE
fix(api): remove empty-response retry that duplicates user turns

### DIFF
--- a/nanobot/api/server.py
+++ b/nanobot/api/server.py
@@ -321,21 +321,10 @@ async def handle_chat_completions(request: web.Request) -> web.Response:
                 response_text = _response_text(response)
 
                 if not response_text or not response_text.strip():
-                    logger.warning("Empty response for session {}, retrying", session_key)
-                    retry_response = await asyncio.wait_for(
-                        agent_loop.process_direct(
-                            content=text,
-                            media=media_paths if media_paths else None,
-                            session_key=session_key,
-                            channel="api",
-                            chat_id=API_CHAT_ID,
-                        ),
-                        timeout=timeout_s,
+                    logger.warning(
+                        "Empty response for session {}, using fallback", session_key
                     )
-                    response_text = _response_text(retry_response)
-                    if not response_text or not response_text.strip():
-                        logger.warning("Empty response after retry, using fallback")
-                        response_text = fallback
+                    response_text = fallback
 
             except asyncio.TimeoutError:
                 return _error_json(504, f"Request timed out after {timeout_s}s")

--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -350,36 +350,8 @@ async def test_multimodal_remote_image_url_returns_400(aiohttp_client, mock_agen
 
 @pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")
 @pytest.mark.asyncio
-async def test_empty_response_retry_then_success(aiohttp_client) -> None:
-    call_count = 0
-
-    async def sometimes_empty(content, session_key="", channel="", chat_id="", **kwargs):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            return ""
-        return "recovered response"
-
-    agent = MagicMock()
-    agent.process_direct = sometimes_empty
-    agent._connect_mcp = AsyncMock()
-    agent.close_mcp = AsyncMock()
-
-    app = create_app(agent, model_name="m")
-    client = await aiohttp_client(app)
-    resp = await client.post(
-        "/v1/chat/completions",
-        json={"messages": [{"role": "user", "content": "hello"}]},
-    )
-    assert resp.status == 200
-    body = await resp.json()
-    assert body["choices"][0]["message"]["content"] == "recovered response"
-    assert call_count == 2
-
-
-@pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")
-@pytest.mark.asyncio
-async def test_empty_response_falls_back(aiohttp_client) -> None:
+async def test_empty_response_returns_fallback(aiohttp_client) -> None:
+    """Empty process_direct response returns fallback without retrying."""
     from nanobot.utils.runtime import EMPTY_FINAL_RESPONSE_MESSAGE
 
     call_count = 0
@@ -403,7 +375,45 @@ async def test_empty_response_falls_back(aiohttp_client) -> None:
     assert resp.status == 200
     body = await resp.json()
     assert body["choices"][0]["message"]["content"] == EMPTY_FINAL_RESPONSE_MESSAGE
-    assert call_count == 2
+    assert call_count == 1
+
+
+@pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")
+@pytest.mark.asyncio
+async def test_empty_response_does_not_duplicate_user_turn(aiohttp_client) -> None:
+    """A single API request must call process_direct exactly once.
+
+    The old retry-on-empty path called process_direct twice, which persisted
+    the user message twice in the session history.  See nanobot#4079.
+    """
+    from nanobot.utils.runtime import EMPTY_FINAL_RESPONSE_MESSAGE
+
+    call_count = 0
+
+    async def always_empty(content, session_key="", channel="", chat_id="", **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return ""
+
+    agent = MagicMock()
+    agent.process_direct = always_empty
+    agent._connect_mcp = AsyncMock()
+    agent.close_mcp = AsyncMock()
+
+    app = create_app(agent, model_name="m")
+    client = await aiohttp_client(app)
+
+    # Send one request with empty response
+    resp = await client.post(
+        "/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": "hello"}]},
+    )
+    assert resp.status == 200
+    body = await resp.json()
+    assert body["choices"][0]["message"]["content"] == EMPTY_FINAL_RESPONSE_MESSAGE
+
+    # process_direct must be called exactly once — no retry
+    assert call_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The OpenAI-compatible API handler (`/v1/chat/completions`) retries `process_direct()` when the response is empty. Since `process_direct` persists the user message to session history before generating output, retrying duplicates the user turn.

**Reproduction:** Send one API request → session history contains two identical user messages.

## Fix

Remove the retry from the non-streaming path. When `process_direct` returns empty, fall back to `EMPTY_FINAL_RESPONSE_MESSAGE` immediately instead of calling `process_direct` a second time.

A single API request now calls `process_direct` exactly once.

## Verification

```bash
pytest tests/test_openai_api.py -v
```

All 18 tests pass, including:
- `test_empty_response_returns_fallback` — empty response returns fallback (call count = 1)
- `test_empty_response_does_not_duplicate_user_turn` — confirms process_direct is called exactly once per request

## Changes

- `nanobot/api/server.py`: Removed retry-on-empty path, replaced with direct fallback
- `tests/test_openai_api.py`: Consolidated two retry tests into one fallback test, added regression test for the duplicate-turn bug

Closes #4079
