### PR TITLE
fix(sandbox): set HOME inside bwrap

### DIFF
--- a/nanobot/agent/tools/sandbox.py
+++ b/nanobot/agent/tools/sandbox.py
@@ -26,13 +26,22 @@ def _bwrap(command: str, workspace: str, cwd: str) -> str:
     except ValueError:
         sandbox_cwd = str(ws)
 
-    required  = ["/usr"]
-    optional  = ["/bin", "/lib", "/lib64", "/etc/alternatives",
-                 "/etc/ssl/certs", "/etc/resolv.conf", "/etc/ld.so.cache"]
+    required = ["/usr"]
+    optional = [
+        "/bin",
+        "/lib",
+        "/lib64",
+        "/etc/alternatives",
+        "/etc/ssl/certs",
+        "/etc/resolv.conf",
+        "/etc/ld.so.cache",
+    ]
 
-    args = ["bwrap", "--new-session", "--die-with-parent"]
-    for p in required: args += ["--ro-bind",     p, p]
-    for p in optional: args += ["--ro-bind-try", p, p]
+    args = ["bwrap", "--new-session", "--die-with-parent", "--setenv", "HOME", str(ws)]
+    for p in required:
+        args += ["--ro-bind", p, p]
+    for p in optional:
+        args += ["--ro-bind-try", p, p]
     args += [
         "--proc", "/proc", "--dev", "/dev", "--tmpfs", "/tmp",
         "--tmpfs", str(ws.parent),        # mask config dir

--- a/tests/tools/test_sandbox.py
+++ b/tests/tools/test_sandbox.py
@@ -37,6 +37,17 @@ class TestBwrapBackend:
         bind_idx = [i for i, t in enumerate(tokens) if t == "--bind"]
         assert any(tokens[i + 1] == ws and tokens[i + 2] == ws for i in bind_idx)
 
+    def test_home_env_points_to_workspace(self, tmp_path):
+        ws = str(tmp_path / "project")
+        result = wrap_command("bwrap", "echo $HOME", ws, ws)
+        tokens = _parse(result)
+
+        setenv_idx = [i for i, t in enumerate(tokens) if t == "--setenv"]
+        assert any(
+            tokens[i + 1] == "HOME" and tokens[i + 2] == str(tmp_path / "project")
+            for i in setenv_idx
+        )
+
     def test_parent_dir_masked_with_tmpfs(self, tmp_path):
         ws = tmp_path / "project"
         result = wrap_command("bwrap", "ls", str(ws), str(ws))


### PR DESCRIPTION
## Summary

- Set `HOME` inside the `bwrap` sandbox to the resolved workspace path.
- Add a regression test that asserts the generated `bwrap` command includes `--setenv HOME <workspace>`.

## Why

When `tools.exec.sandbox` is set to `"bwrap"`, the sandbox only grants write access to the workspace. If `$HOME` still points to the host home directory, tools that resolve `~` or write caches/config under `$HOME` can fail inside the sandbox.

Fixes #4237.

## Tests

- `uv run --extra dev pytest tests/tools/test_sandbox.py tests/tools/test_exec_platform.py -q`
- `uv run --extra dev ruff check nanobot/agent/tools/sandbox.py tests/tools/test_sandbox.py`
