### PR TITLE
feat(webui): render ANSI output in code blocks

### DIFF
--- a/webui/src/components/CodeBlock.tsx
+++ b/webui/src/components/CodeBlock.tsx
@@ -1,8 +1,9 @@
-import { Suspense, lazy, useCallback, useState } from "react";
+import { Suspense, lazy, useCallback, useState, type ReactNode } from "react";
 import { Check, Copy } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { useThemeValue } from "@/hooks/useTheme";
+import { hasAnsi, parseAnsiSegments, stripAnsi } from "@/lib/ansi";
 import { cn } from "@/lib/utils";
 
 interface CodeBlockProps {
@@ -35,6 +36,10 @@ const CODE_FONT_STACK = [
   "Consolas",
   "monospace",
 ].join(", ");
+
+const ANSI_LANGUAGES = new Set(["ansi", "ansi-output"]);
+const CODE_SURFACE_LIGHT = "#f4f4f5";
+const CODE_SURFACE_DARK = "#27272a";
 
 const LazyHighlightedCode = lazy(async () => {
   const [
@@ -74,7 +79,11 @@ const LazyHighlightedCode = lazy(async () => {
           language={language || "text"}
           style={transparentTheme}
           customStyle={{
-            background: chrome === "none" ? "transparent" : undefined,
+            background: chrome === "none"
+              ? "transparent"
+              : isDark
+                ? CODE_SURFACE_DARK
+                : CODE_SURFACE_LIGHT,
             margin: 0,
             padding: chrome === "none" ? "0.75rem 1rem" : "1rem",
             fontFamily: CODE_FONT_STACK,
@@ -83,10 +92,10 @@ const LazyHighlightedCode = lazy(async () => {
             tabSize: 2,
           }}
           codeTagProps={{
-            style: chrome === "none" ? {
+            style: {
               background: "transparent",
               fontFamily: CODE_FONT_STACK,
-            } : undefined,
+            },
           }}
           lineNumberStyle={{
             minWidth: "2.6em",
@@ -106,14 +115,32 @@ const LazyHighlightedCode = lazy(async () => {
   };
 });
 
-function PlainCodeFallback({
+function renderPlainText(value: string): ReactNode {
+  return value;
+}
+
+function renderAnsiText(value: string): ReactNode {
+  return parseAnsiSegments(value).map((segment, index) => (
+    <span key={index} style={segment.style}>
+      {segment.text}
+    </span>
+  ));
+}
+
+function CodeTextBlock({
   code,
   chrome,
   showLineNumbers,
+  testId,
+  className,
+  renderText = renderPlainText,
 }: {
   code: string;
   chrome: "default" | "none";
   showLineNumbers: boolean;
+  testId: string;
+  className?: string;
+  renderText?: (value: string) => ReactNode;
 }) {
   const lines = code.split("\n");
   return (
@@ -121,10 +148,11 @@ function PlainCodeFallback({
       className={cn(
         "m-0 overflow-x-auto p-4 font-mono text-sm leading-[1.6] text-foreground/90",
         showLineNumbers ? "whitespace-pre" : "whitespace-pre-wrap",
-        chrome === "default" ? "bg-background" : "bg-transparent",
+        chrome === "default" ? "bg-zinc-100 dark:bg-zinc-800" : "bg-transparent",
         chrome === "none" && "p-3 text-[13px] leading-[1.55]",
+        className,
       )}
-      data-testid="plain-code-fallback"
+      data-testid={testId}
     >
       <code className="text-inherit">
         {showLineNumbers ? (
@@ -133,14 +161,19 @@ function PlainCodeFallback({
               <span className="w-10 shrink-0 select-none pr-4 text-right text-muted-foreground/60">
                 {index + 1}
               </span>
-              <span className="whitespace-pre">{line || " "}</span>
+              <span className="whitespace-pre">{renderText(line || " ")}</span>
               {index < lines.length - 1 ? "\n" : null}
             </span>
           ))
-        ) : code}
+        ) : renderText(code)}
       </code>
     </pre>
   );
+}
+
+function shouldRenderAnsi(language: string | undefined, code: string): boolean {
+  const normalized = language?.trim().toLowerCase();
+  return Boolean((normalized && ANSI_LANGUAGES.has(normalized)) || hasAnsi(code));
 }
 
 export function CodeBlock({
@@ -156,19 +189,20 @@ export function CodeBlock({
   const [copied, setCopied] = useState(false);
   const isDark = useThemeValue() === "dark";
   const hasChrome = chrome === "default";
+  const renderAnsi = shouldRenderAnsi(language, code);
 
   const onCopy = useCallback(() => {
     if (!navigator.clipboard) return;
-    navigator.clipboard.writeText(code).then(() => {
+    navigator.clipboard.writeText(renderAnsi ? stripAnsi(code) : code).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 1_500);
     });
-  }, [code]);
+  }, [code, renderAnsi]);
 
   return (
     <div
       className={cn(
-        "overflow-hidden",
+        "not-prose overflow-hidden",
         hasChrome && "rounded-lg border",
         hasChrome && (isDark ? "border-white/10" : "border-black/10"),
         className,
@@ -177,7 +211,7 @@ export function CodeBlock({
       {hasChrome ? (
         <div
           className={cn(
-            "flex items-center justify-between px-4 py-1.5 text-xs font-medium",
+            "flex items-center justify-between px-4 pb-1.5 pt-2 text-xs font-medium",
             isDark
               ? "bg-zinc-800 text-zinc-300"
               : "bg-zinc-100 text-zinc-600",
@@ -206,13 +240,22 @@ export function CodeBlock({
           </button>
         </div>
       ) : null}
-      {highlight ? (
+      {renderAnsi ? (
+        <CodeTextBlock
+          code={code}
+          chrome={chrome}
+          showLineNumbers={showLineNumbers}
+          testId="ansi-code"
+          renderText={renderAnsiText}
+        />
+      ) : highlight ? (
         <Suspense
           fallback={
-            <PlainCodeFallback
+            <CodeTextBlock
               code={code}
               chrome={chrome}
               showLineNumbers={showLineNumbers}
+              testId="plain-code-fallback"
             />
           }
         >
@@ -226,10 +269,11 @@ export function CodeBlock({
           />
         </Suspense>
       ) : (
-        <PlainCodeFallback
+        <CodeTextBlock
           code={code}
           chrome={chrome}
           showLineNumbers={showLineNumbers}
+          testId="plain-code-fallback"
         />
       )}
     </div>

--- a/webui/src/lib/ansi.ts
+++ b/webui/src/lib/ansi.ts
@@ -1,0 +1,210 @@
+export type AnsiSegment = {
+  text: string;
+  style?: AnsiStyle;
+};
+
+export type AnsiStyle = {
+  backgroundColor?: string;
+  color?: string;
+  fontStyle?: "italic";
+  fontWeight?: number;
+  opacity?: number;
+  textDecorationLine?: "underline";
+};
+
+type AnsiState = {
+  backgroundColor?: string;
+  bold: boolean;
+  color?: string;
+  dim: boolean;
+  inverse: boolean;
+  italic: boolean;
+  underline: boolean;
+};
+
+const ESC = String.fromCharCode(27);
+const ANSI_PATTERN = new RegExp(`${ESC}\\[[0-?]*[ -/]*[@-~]`, "g");
+
+const ANSI_COLORS = [
+  "#000000",
+  "#cd3131",
+  "#0dbc79",
+  "#e5e510",
+  "#2472c8",
+  "#bc3fbc",
+  "#11a8cd",
+  "#e5e5e5",
+];
+
+const ANSI_BRIGHT_COLORS = [
+  "#666666",
+  "#f14c4c",
+  "#23d18b",
+  "#f5f543",
+  "#3b8eea",
+  "#d670d6",
+  "#29b8db",
+  "#ffffff",
+];
+
+const RGB_STEPS = [0, 95, 135, 175, 215, 255];
+
+export function hasAnsi(value: string): boolean {
+  ANSI_PATTERN.lastIndex = 0;
+  return ANSI_PATTERN.test(value);
+}
+
+export function stripAnsi(value: string): string {
+  ANSI_PATTERN.lastIndex = 0;
+  return value.replace(ANSI_PATTERN, "");
+}
+
+function initialState(): AnsiState {
+  return {
+    bold: false,
+    dim: false,
+    inverse: false,
+    italic: false,
+    underline: false,
+  };
+}
+
+function colorFrom256(value: number): string | undefined {
+  if (value < 0 || value > 255) return undefined;
+  if (value < 8) return ANSI_COLORS[value];
+  if (value < 16) return ANSI_BRIGHT_COLORS[value - 8];
+  if (value < 232) {
+    const offset = value - 16;
+    const red = RGB_STEPS[Math.floor(offset / 36)];
+    const green = RGB_STEPS[Math.floor((offset % 36) / 6)];
+    const blue = RGB_STEPS[offset % 6];
+    return `rgb(${red}, ${green}, ${blue})`;
+  }
+  const gray = 8 + ((value - 232) * 10);
+  return `rgb(${gray}, ${gray}, ${gray})`;
+}
+
+function colorFromRgb(red: number, green: number, blue: number): string | undefined {
+  if ([red, green, blue].some((value) => !Number.isFinite(value) || value < 0 || value > 255)) {
+    return undefined;
+  }
+  return `rgb(${red}, ${green}, ${blue})`;
+}
+
+function normalizedSgrParams(sequence: string): number[] | null {
+  if (!sequence.endsWith("m")) return null;
+  const body = sequence.slice(2, -1).trim();
+  if (!body) return [0];
+  return body.split(/[;:]/).map((part) => {
+    const value = Number.parseInt(part || "0", 10);
+    return Number.isFinite(value) ? value : 0;
+  });
+}
+
+function applyExtendedColor(
+  state: AnsiState,
+  params: number[],
+  index: number,
+  key: "color" | "backgroundColor",
+): number {
+  const mode = params[index + 1];
+  if (mode === 5) {
+    const color = colorFrom256(params[index + 2]);
+    if (color) state[key] = color;
+    return index + 2;
+  }
+  if (mode === 2) {
+    const color = colorFromRgb(params[index + 2], params[index + 3], params[index + 4]);
+    if (color) state[key] = color;
+    return index + 4;
+  }
+  return index;
+}
+
+function applySgrParams(state: AnsiState, params: number[]): void {
+  for (let index = 0; index < params.length; index += 1) {
+    const code = params[index];
+    if (code === 0) {
+      Object.assign(state, initialState());
+    } else if (code === 1) {
+      state.bold = true;
+      state.dim = false;
+    } else if (code === 2) {
+      state.dim = true;
+      state.bold = false;
+    } else if (code === 3) {
+      state.italic = true;
+    } else if (code === 4) {
+      state.underline = true;
+    } else if (code === 7) {
+      state.inverse = true;
+    } else if (code === 22) {
+      state.bold = false;
+      state.dim = false;
+    } else if (code === 23) {
+      state.italic = false;
+    } else if (code === 24) {
+      state.underline = false;
+    } else if (code === 27) {
+      state.inverse = false;
+    } else if (code === 39) {
+      delete state.color;
+    } else if (code === 49) {
+      delete state.backgroundColor;
+    } else if (code >= 30 && code <= 37) {
+      state.color = ANSI_COLORS[code - 30];
+    } else if (code >= 40 && code <= 47) {
+      state.backgroundColor = ANSI_COLORS[code - 40];
+    } else if (code >= 90 && code <= 97) {
+      state.color = ANSI_BRIGHT_COLORS[code - 90];
+    } else if (code >= 100 && code <= 107) {
+      state.backgroundColor = ANSI_BRIGHT_COLORS[code - 100];
+    } else if (code === 38) {
+      index = applyExtendedColor(state, params, index, "color");
+    } else if (code === 48) {
+      index = applyExtendedColor(state, params, index, "backgroundColor");
+    }
+  }
+}
+
+function styleFromState(state: AnsiState): AnsiStyle | undefined {
+  const foreground = state.inverse ? state.backgroundColor : state.color;
+  const background = state.inverse ? state.color : state.backgroundColor;
+  const style: AnsiStyle = {};
+  if (foreground) style.color = foreground;
+  if (background) style.backgroundColor = background;
+  if (state.bold) style.fontWeight = 700;
+  if (state.dim) style.opacity = 0.72;
+  if (state.italic) style.fontStyle = "italic";
+  if (state.underline) style.textDecorationLine = "underline";
+  return Object.keys(style).length ? style : undefined;
+}
+
+export function parseAnsiSegments(value: string): AnsiSegment[] {
+  const segments: AnsiSegment[] = [];
+  const state = initialState();
+  let cursor = 0;
+  ANSI_PATTERN.lastIndex = 0;
+
+  for (const match of value.matchAll(ANSI_PATTERN)) {
+    const index = match.index ?? 0;
+    if (index > cursor) {
+      segments.push({
+        text: value.slice(cursor, index),
+        style: styleFromState(state),
+      });
+    }
+    const params = normalizedSgrParams(match[0]);
+    if (params) applySgrParams(state, params);
+    cursor = index + match[0].length;
+  }
+
+  if (cursor < value.length) {
+    segments.push({
+      text: value.slice(cursor),
+      style: styleFromState(state),
+    });
+  }
+
+  return segments.filter((segment) => segment.text.length > 0);
+}

--- a/webui/src/tests/code-block.test.tsx
+++ b/webui/src/tests/code-block.test.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { CodeBlock } from "@/components/CodeBlock";
@@ -85,6 +86,64 @@ describe("CodeBlock", () => {
     expect(screen.getByTestId("highlighted-code")).toBeInTheDocument();
     expect(screen.getByTestId("highlighted-code")).toHaveAttribute("data-language", "text");
     expect(screen.getByText("const value = 1;")).toBeInTheDocument();
+  });
+
+  it("renders ANSI output without mounting the syntax highlighter", () => {
+    render(
+      <ThemeProvider theme="dark">
+        <CodeBlock
+          language="ansi"
+          code={"\x1b[32mPASS\x1b[0m <script>alert(1)</script>"}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.queryByTestId("highlighted-code")).not.toBeInTheDocument();
+    expect(screen.getByTestId("ansi-code")).toBeInTheDocument();
+    expect(screen.getByTestId("ansi-code").closest(".not-prose")).toBeTruthy();
+    expect(screen.getByText("ansi")).toBeInTheDocument();
+    expect(screen.getByText("PASS")).toHaveStyle({ color: "#0dbc79" });
+    expect(screen.getByText("<script>alert(1)</script>")).toBeInTheDocument();
+    expect(document.querySelector("script")).toBeNull();
+  });
+
+  it("detects ANSI sequences in regular code blocks", () => {
+    render(
+      <ThemeProvider theme="light">
+        <CodeBlock
+          language="text"
+          code={"\x1b[38;2;35;209;139mtruecolor\x1b[0m"}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.queryByTestId("highlighted-code")).not.toBeInTheDocument();
+    expect(screen.getByText("truecolor")).toHaveStyle({
+      color: "rgb(35, 209, 139)",
+    });
+  });
+
+  it("copies ANSI output as clean text", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    try {
+      render(
+        <ThemeProvider theme="dark">
+          <CodeBlock language="ansi" code={"\x1b[32mPASS\x1b[0m"} />
+        </ThemeProvider>,
+      );
+
+      await user.click(screen.getByRole("button", { name: /copy/i }));
+
+      expect(writeText).toHaveBeenCalledWith("PASS");
+    } finally {
+      Reflect.deleteProperty(navigator, "clipboard");
+    }
   });
 
   it("reads theme from context without creating per-block observers", async () => {


### PR DESCRIPTION
## Summary
- Render ANSI-colored output inside the existing WebUI code block shell.
- Add a small ANSI SGR parser that supports standard colors, bright colors, 256-color, RGB, bold, dim, italic, underline, and inverse styles.
- Copy ANSI output as clean text by stripping control sequences.

## Why
Agent/tool output can include terminal color sequences. The WebUI should preserve those visual cues without introducing a separate block style or leaking raw control characters into copy/paste.

## Notes
- The ANSI renderer reuses the normal CodeBlock chrome, spacing, copy affordance, and theme surface.
- Code blocks are isolated with `not-prose` so Markdown typography does not strip padding from custom rendered blocks.
- ANSI content is rendered as React text spans, not raw HTML.

## Validation
- `cd webui && bun run test src/tests/code-block.test.tsx`
- `cd webui && bun run lint`
- `cd webui && bun run build`