### PR TITLE
fix: advance dream cursor when Dream is disabled to prevent prompt bloat

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -304,6 +304,17 @@ class MemoryStore:
                 poisoned,
             )
 
+    def get_current_cursor(self) -> int:
+        """Return the most recently assigned history cursor, or 0 if none."""
+        if self._cursor_file.exists():
+            with suppress(ValueError, OSError):
+                return int(self._cursor_file.read_text(encoding="utf-8").strip())
+        last = self._read_last_entry() or {}
+        cursor = self._valid_cursor(last.get("cursor"))
+        if cursor is not None:
+            return cursor
+        return max((c for _, c in self._iter_valid_entries()), default=0)
+
     def _next_cursor(self) -> int:
         """Read the current cursor counter and return the next value."""
         if self._cursor_file.exists():

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1367,6 +1367,13 @@ def _run_gateway(
         ))
         console.print(f"[green]✓[/green] Dream: {dream_cfg.describe_schedule()}")
     else:
+        # Advance the dream cursor so the Recent History section in the system
+        # prompt does not inject every historical entry when Dream is disabled.
+        # Without this, read_unprocessed_history() returns all entries since the
+        # cursor was never advanced, bloating the prompt over time.
+        agent.context.memory.set_last_dream_cursor(
+            agent.context.memory.get_current_cursor()
+        )
         console.print("[yellow]○[/yellow] Dream: disabled")
 
     # Register Heartbeat system job (idempotent on restart)

--- a/tests/agent/test_memory_store.py
+++ b/tests/agent/test_memory_store.py
@@ -268,6 +268,57 @@ class TestDreamCursor:
         store2 = MemoryStore(store.workspace)
         assert store2.get_last_dream_cursor() == 3
 
+    def test_get_current_cursor_returns_zero_when_empty(self, store):
+        assert store.get_current_cursor() == 0
+
+    def test_get_current_cursor_returns_latest_history_cursor(self, store):
+        c1 = store.append_history("msg 1")
+        c2 = store.append_history("msg 2")
+        assert store.get_current_cursor() == c2
+        assert c2 > c1
+
+    def test_get_current_cursor_reflects_written_cursor_file(self, store):
+        # Simulate a cursor file written by append_history
+        store.append_history("msg 1")
+        store.append_history("msg 2")
+        assert store.get_current_cursor() == 2
+
+    def test_dream_disabled_advancing_cursor_prevents_history_injection(self, store):
+        """When Dream is disabled, advancing the dream cursor to the current
+        cursor prevents read_unprocessed_history from returning all entries."""
+        # Simulate some history entries
+        store.append_history("msg 1")
+        store.append_history("msg 2")
+        store.append_history("msg 3")
+
+        # Before advancing: all entries are unprocessed
+        unprocessed = store.read_unprocessed_history(
+            since_cursor=store.get_last_dream_cursor()
+        )
+        assert len(unprocessed) == 3
+
+        # Simulate the fix: advance dream cursor to current cursor
+        store.set_last_dream_cursor(store.get_current_cursor())
+
+        # After advancing: no entries are unprocessed
+        unprocessed = store.read_unprocessed_history(
+            since_cursor=store.get_last_dream_cursor()
+        )
+        assert len(unprocessed) == 0
+
+    def test_dream_disabled_new_entries_still_appear_after_cursor_advance(self, store):
+        """After advancing the dream cursor, new entries should still appear
+        as unprocessed."""
+        store.append_history("old msg")
+        store.set_last_dream_cursor(store.get_current_cursor())
+
+        store.append_history("new msg")
+        unprocessed = store.read_unprocessed_history(
+            since_cursor=store.get_last_dream_cursor()
+        )
+        assert len(unprocessed) == 1
+        assert unprocessed[0]["content"] == "new msg"
+
     def test_git_restore_rolls_back_dream_cursor(self, tmp_path):
         store = MemoryStore(tmp_path)
         store.write_memory("before")


### PR DESCRIPTION
## Problem

When `dream.enabled` is set to `false` in the config, the Dream cron job is correctly not registered. However, the dream cursor (`.dream_cursor`) is never advanced because `dream.run()` is never called. As a result, `read_unprocessed_history()` in `agent/context.py` returns **all** historical entries since the cursor was never advanced, injecting a growing amount of chat history summaries into every system prompt.

This means users who disable Dream to save tokens inadvertently cause the opposite effect — the prompt gets more bloated over time.

## Solution

Two changes:

1. **`MemoryStore.get_current_cursor()`** — new method that returns the most recently assigned history cursor value. This mirrors the existing `_next_cursor()` logic but returns the current value instead of current+1.

2. **Gateway startup** — when Dream is disabled, advance the dream cursor to the current history cursor so `read_unprocessed_history()` returns an empty list. New entries added after startup still appear as unprocessed, so the behavior is correct if Dream is later re-enabled.

## Verification

```
cd nanobot && python -m pytest tests/agent/test_memory_store.py -v -k "current_cursor or dream_disabled"
```

5 new tests:
- `test_get_current_cursor_returns_zero_when_empty`
- `test_get_current_cursor_returns_latest_history_cursor`
- `test_get_current_cursor_reflects_written_cursor_file`
- `test_dream_disabled_advancing_cursor_prevents_history_injection`
- `test_dream_disabled_new_entries_still_appear_after_cursor_advance`

All 42 non-dulwich tests pass (`ruff check` clean).

## Limitations

- The cursor advance happens once at gateway startup. If the gateway runs for a long time with Dream disabled, new history entries will accumulate in the Recent History section until restart. This is acceptable because the `_MAX_RECENT_HISTORY` cap (line 101 of `context.py`) already limits the blast radius.
- A `dulwich`-dependent test (`test_git_restore_rolls_back_dream_cursor`) fails due to a missing optional dependency — this is pre-existing and unrelated.

Fixes #4242