### PR TITLE
fix: advance dream cursor when dream is disabled

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -403,6 +403,22 @@ class MemoryStore:
     def set_last_dream_cursor(self, cursor: int) -> None:
         self._dream_cursor_file.write_text(str(cursor), encoding="utf-8")
 
+    def advance_dream_cursor_to_history_tail(self) -> int:
+        """Advance the dream cursor to the current history tail.
+
+        Useful when Dream is disabled: without this, the cursor stays
+        frozen and every history entry appears "unprocessed", bloating
+        the system prompt's Recent History section.
+
+        Returns the cursor value that was written, or 0 if no history
+        exists (preserving get_last_dream_cursor()==0 semantics).
+        """
+        tail = self._next_cursor() - 1
+        if tail <= 0:
+            return self.get_last_dream_cursor()
+        self.set_last_dream_cursor(tail)
+        return tail
+
     def build_dream_prompt(self, *, max_entries: int = 20) -> tuple[str, int] | None:
         """Build the Dream prompt with unprocessed history context.
 

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1367,7 +1367,8 @@ def _run_gateway(
         ))
         console.print(f"[green]✓[/green] Dream: {dream_cfg.describe_schedule()}")
     else:
-        console.print("[yellow]○[/yellow] Dream: disabled")
+        agent.context.memory.advance_dream_cursor_to_history_tail()
+        console.print("[yellow]○[/yellow] Dream: disabled (cursor advanced)")
 
     # Register Heartbeat system job (idempotent on restart)
     if hb_cfg.enabled:

--- a/tests/agent/test_memory_store.py
+++ b/tests/agent/test_memory_store.py
@@ -446,3 +446,47 @@ class TestLegacyHistoryMigration:
         assert entries[0]["timestamp"] == "2026-04-01 10:00"
         assert "Broken" in entries[0]["content"]
         assert "migration." in entries[0]["content"]
+
+
+class TestAdvanceDreamCursorToHistoryTail:
+    @pytest.fixture
+    def store(self, tmp_path):
+        return MemoryStore(tmp_path)
+
+    def test_no_history_returns_current_cursor(self, store):
+        """When no history exists, should return current dream cursor (0)."""
+        result = store.advance_dream_cursor_to_history_tail()
+        assert result == 0
+        assert store.get_last_dream_cursor() == 0
+
+    def test_advances_to_history_tail(self, store):
+        """With multiple entries, cursor should advance to the last entry's cursor."""
+        store.append_history("first")
+        store.append_history("second")
+        c3 = store.append_history("third")
+
+        result = store.advance_dream_cursor_to_history_tail()
+        assert result == c3
+        assert store.get_last_dream_cursor() == c3
+
+        # After advancing, read_unprocessed_history should return nothing
+        entries = store.read_unprocessed_history(since_cursor=store.get_last_dream_cursor())
+        assert entries == []
+
+    def test_advances_past_existing_dream_cursor(self, store):
+        """When dream cursor is older than history tail, should advance to tail."""
+        store.append_history("first")
+        store.append_history("second")
+        store.set_last_dream_cursor(0)  # Simulate stale cursor
+
+        result = store.advance_dream_cursor_to_history_tail()
+        assert result > 0
+        assert store.get_last_dream_cursor() == result
+
+    def test_idempotent_when_already_at_tail(self, store):
+        """Calling twice should be idempotent."""
+        store.append_history("entry")
+        first = store.advance_dream_cursor_to_history_tail()
+        second = store.advance_dream_cursor_to_history_tail()
+        assert first == second
+        assert store.get_last_dream_cursor() == first


### PR DESCRIPTION
Fixes #4242

## Summary

When `dream.enabled` is set to `false`, the Dream cron job is correctly not registered. However, the dream cursor (stored in `.dream_cursor`) never advances because `dream.run()` is never called. As a result, `read_unprocessed_history()` returns all accumulated history entries, and the system prompt's Recent History section grows unboundedly.

This adds a public `MemoryStore.advance_dream_cursor_to_history_tail()` method and calls it during gateway startup when Dream is disabled, so the cursor starts at the correct position.

## Changes

- `nanobot/agent/memory.py`: Add `advance_dream_cursor_to_history_tail()` public method (16 lines). Computes the current history tail and sets the dream cursor to that value. Returns 0 if no history exists (preserving existing semantics).
- `nanobot/cli/commands.py`: Call `agent.context.memory.advance_dream_cursor_to_history_tail()` in the `else` branch when `dream.enabled` is false (2 lines changed).
- `tests/agent/test_memory_store.py`: 4 new tests covering empty history, tail advancement, stale cursor advancement, and idempotency (44 lines).

## Testing

- tests/agent/test_memory_store.py: 42/42 passed (4 new)
- tests/agent/test_dream.py: 18/18 passed
- tests/config/test_dream_config.py: 5/5 passed
- tests/command/test_builtin_dream.py: 5/5 passed
- ruff check: clean
- git diff --check: clean

## Conflict note

PRs #4088 and #4025 also touch `nanobot/agent/memory.py` (compaction cursor safety). This change is additive only (new method after `set_last_dream_cursor`) and does not overlap with their `compact_history()` or `read_unprocessed_history()` changes. Both PRs are currently OPEN and CONFLICTING with each other; neither has merged.

## Backward compatible

- No existing behavior changes when `dream.enabled=true` (default).
- When `dream.enabled=false`, the cursor now starts at the history tail instead of 0. This prevents unbounded Recent History accumulation.
- No new config fields, no new dependencies.