### PR TITLE
fix(session): delete_session also removes legacy path files to prevent history revival

### DIFF
--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -613,20 +613,22 @@ class SessionManager:
         self._cache.pop(key, None)
 
     def delete_session(self, key: str) -> bool:
-        """Remove a session from disk and the in-memory cache.
+        """Remove a session from disk (both workspace and legacy locations) and cache.
 
-        Returns True if a JSONL file was found and unlinked.
+        Returns True if at least one JSONL file was found and unlinked.
         """
-        path = self._get_session_path(key)
+        paths = [self._get_session_path(key), self._get_legacy_session_path(key)]
         self.invalidate(key)
-        if not path.exists():
-            return False
-        try:
-            path.unlink()
-            return True
-        except OSError as e:
-            logger.warning("Failed to delete session file {}: {}", path, e)
-            return False
+        deleted = False
+        for path in paths:
+            if not path.exists():
+                continue
+            try:
+                path.unlink()
+                deleted = True
+            except OSError as e:
+                logger.warning("Failed to delete session file {}: {}", path, e)
+        return deleted
 
     def read_session_file(self, key: str) -> dict[str, Any] | None:
         """Load a session from disk without caching; intended for read-only HTTP endpoints.

--- a/tests/agent/test_session_delete.py
+++ b/tests/agent/test_session_delete.py
@@ -63,3 +63,83 @@ def test_safe_key_matches_internal_path(tmp_path: Path) -> None:
     key = "telegram:abc/def"
     expected = sm._get_session_path(key).name
     assert SessionManager.safe_key(key) + ".jsonl" == expected
+
+
+def _write_legacy_session(legacy_dir: Path, key: str, roles: list[str]) -> Path:
+    legacy_dir.mkdir(parents=True, exist_ok=True)
+    safe = SessionManager.safe_key(key)
+    path = legacy_dir / f"{safe}.jsonl"
+    metadata_line = (
+        '{"_type":"metadata","key":"' + key + '",'
+        '"created_at":"2025-01-01T00:00:00",'
+        '"updated_at":"2025-01-01T00:00:00",'
+        '"metadata":{}}'
+    )
+    lines = [metadata_line]
+    for role in roles:
+        lines.append('{"role":"' + role + '","content":"msg"}')
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def test_delete_session_cleans_legacy_file(tmp_path: Path, monkeypatch) -> None:
+    """A session that only exists at the legacy location must also be deleted."""
+    legacy = tmp_path / "legacy_sessions"
+    monkeypatch.setattr(
+        "nanobot.session.manager.get_legacy_sessions_dir",
+        lambda: legacy,
+    )
+    key = "telegram:only-legacy"
+    legacy_path = _write_legacy_session(legacy, key, ["user", "assistant"])
+    assert legacy_path.exists()
+
+    sm = SessionManager(tmp_path / "workspace")
+    new_path = sm._get_session_path(key)
+    assert not new_path.exists()
+
+    assert sm.delete_session(key) is True
+    assert not legacy_path.exists(), "legacy session file should have been removed"
+
+
+def test_delete_session_cleans_both_locations(tmp_path: Path, monkeypatch) -> None:
+    """When files exist at both the new and legacy paths, both must be removed."""
+    legacy = tmp_path / "legacy_sessions"
+    monkeypatch.setattr(
+        "nanobot.session.manager.get_legacy_sessions_dir",
+        lambda: legacy,
+    )
+    workspace = tmp_path / "workspace"
+    key = "telegram:both-paths"
+    _write_legacy_session(legacy, key, ["user", "assistant"])
+
+    sm = SessionManager(workspace)
+    session = Session(key=key)
+    session.add_message("user", "recent")
+    sm.save(session)
+
+    assert sm._get_session_path(key).exists()
+    assert (legacy / f"{SessionManager.safe_key(key)}.jsonl").exists()
+
+    assert sm.delete_session(key) is True
+
+    assert not sm._get_session_path(key).exists()
+    assert not (legacy / f"{SessionManager.safe_key(key)}.jsonl").exists()
+
+
+def test_delete_session_prevents_legacy_revival(tmp_path: Path, monkeypatch) -> None:
+    """After delete_session, a subsequent get_or_create must not resurrect history."""
+    legacy = tmp_path / "legacy_sessions"
+    monkeypatch.setattr(
+        "nanobot.session.manager.get_legacy_sessions_dir",
+        lambda: legacy,
+    )
+    workspace = tmp_path / "workspace"
+    key = "telegram:no-revival"
+    _write_legacy_session(legacy, key, ["user", "assistant"])
+
+    sm = SessionManager(workspace)
+    assert sm.delete_session(key) is True
+    assert not (legacy / f"{SessionManager.safe_key(key)}.jsonl").exists()
+
+    fresh = sm.get_or_create(key)
+    assert fresh.messages == []


### PR DESCRIPTION
## Problem
SessionManager._load() reads sessions from both the workspace path and the legacy global directory ( ~/.nanobot/sessions/ ), migrating legacy files to the workspace when found. However, delete_session() only looked at the workspace path.

This asymmetry caused a real bug:

1. A user upgrades and has old sessions still sitting in ~/.nanobot/sessions/ (or there are leftover files there from any prior run).
2. They delete a session via the WebUI / CLI / HTTP API — delete_session() removes only the workspace copy.
3. On the next get_or_create() for the same key, _load() finds the legacy copy, migrates it back, and the history resurrects .
4. When the session had already been migrated to the workspace and a stale file remained under ~/.nanobot/sessions/ (e.g., after a move failure or manual restore), delete_session() returned True (workspace file removed), but the legacy file survived and was migrated back on next access.
Reproduced with a unit test (see test_delete_session_prevents_legacy_revival ) that planted a legacy session JSONL, called delete_session , then get_or_create() — on main the old messages came back; with this fix they do not.

## Fix
Make delete_session symmetric with _load by attempting to unlink both paths:

- SessionManager._get_session_path(key) — workspace location (primary)
- SessionManager._get_legacy_session_path(key) — ~/.nanobot/sessions/ (migration fallback)
Returns True if at least one file was removed, otherwise False (same external contract for "nothing was there"). The existing invalidate() cache-clear and individual OSError /logging are preserved.

## Changes
- nanobot/session/manager.py — delete_session now iterates over both paths
- tests/agent/test_session_delete.py — 3 new regression tests covering:
  1. legacy-only session file is removed
  2. files present at both paths are both removed
  3. after deletion, get_or_create() returns a fresh empty session (no history revival)