### PR TITLE
fix(webui): auto-compact transcript when file exceeds size limit

### DIFF
--- a/nanobot/webui/transcript.py
+++ b/nanobot/webui/transcript.py
@@ -113,14 +113,7 @@ def webui_transcript_path(session_key: str) -> Path:
     return get_webui_dir() / f"{stem}.jsonl"
 
 
-def read_transcript_lines(session_key: str) -> list[dict[str, Any]]:
-    path = webui_transcript_path(session_key)
-    if not path.is_file():
-        return []
-    size = path.stat().st_size
-    if size > _MAX_TRANSCRIPT_FILE_BYTES:
-        logger.warning("webui transcript too large, skipping: {}", path)
-        return []
+def _read_all_transcript_lines(path: Path) -> list[dict[str, Any]]:
     lines_out: list[dict[str, Any]] = []
     try:
         with open(path, encoding="utf-8") as f:
@@ -141,6 +134,76 @@ def read_transcript_lines(session_key: str) -> list[dict[str, Any]]:
     return lines_out
 
 
+def _compact_transcript_lines(lines: list[dict[str, Any]], target_bytes: int) -> list[dict[str, Any]]:
+    """Compact transcript lines by discarding oldest turns until total encoded size <= target_bytes."""
+    turns = _split_transcript_turns(lines)
+    if not turns:
+        return []
+    kept_turns: list[list[dict[str, Any]]] = []
+    current_bytes = 0
+    for turn in reversed(turns):
+        turn_bytes = 0
+        for rec in turn:
+            raw = json.dumps(rec, ensure_ascii=False, separators=(",", ":"))
+            turn_bytes += len(raw.encode("utf-8")) + 1  # +1 for newline
+        if not kept_turns or current_bytes + turn_bytes <= target_bytes:
+            kept_turns.append(turn)
+            current_bytes += turn_bytes
+        else:
+            break
+    kept_turns.reverse()
+    compacted_lines: list[dict[str, Any]] = []
+    for turn in kept_turns:
+        compacted_lines.extend(turn)
+    return compacted_lines
+
+
+def _write_transcript_lines(path: Path, lines: list[dict[str, Any]]) -> None:
+    """Overwrite transcript file with specified lines atomically."""
+    tmp_path = path.with_suffix(".tmp")
+    tmp_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            for rec in lines:
+                raw = json.dumps(rec, ensure_ascii=False, separators=(",", ":"))
+                f.write(raw + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+        if path.is_file():
+            try:
+                path.unlink()
+            except OSError:
+                pass
+        tmp_path.rename(path)
+    except Exception as e:
+        if tmp_path.is_file():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+        raise e
+
+
+def read_transcript_lines(session_key: str) -> list[dict[str, Any]]:
+    path = webui_transcript_path(session_key)
+    if not path.is_file():
+        return []
+    size = path.stat().st_size
+    if size > _MAX_TRANSCRIPT_FILE_BYTES:
+        logger.warning("webui transcript too large ({}), compacting: {}", size, path)
+        lines = _read_all_transcript_lines(path)
+        if not lines:
+            return []
+        try:
+            compacted = _compact_transcript_lines(lines, _MAX_TRANSCRIPT_FILE_BYTES // 2)
+            _write_transcript_lines(path, compacted)
+            return compacted
+        except Exception as e:
+            logger.warning("Failed to compact transcript {}: {}", path, e)
+            return lines
+    return _read_all_transcript_lines(path)
+
+
 def append_transcript_object(session_key: str, obj: dict[str, Any]) -> None:
     raw = json.dumps(obj, ensure_ascii=False, separators=(",", ":"))
     if len(raw.encode("utf-8")) > _MAX_TRANSCRIPT_FILE_BYTES:
@@ -153,6 +216,18 @@ def append_transcript_object(session_key: str, obj: dict[str, Any]) -> None:
         f.write(line)
         f.flush()
         os.fsync(f.fileno())
+
+    if obj.get("event") == "turn_end":
+        try:
+            size = path.stat().st_size
+            if size > _MAX_TRANSCRIPT_FILE_BYTES:
+                logger.info("webui transcript too large ({}), compacting: {}", size, path)
+                lines = _read_all_transcript_lines(path)
+                if lines:
+                    compacted = _compact_transcript_lines(lines, _MAX_TRANSCRIPT_FILE_BYTES // 2)
+                    _write_transcript_lines(path, compacted)
+        except Exception as e:
+            logger.warning("Failed to compact transcript {} after turn_end: {}", path, e)
 
 
 def normalize_webui_turn_id(value: Any) -> str:

--- a/nanobot/webui/transcript.py
+++ b/nanobot/webui/transcript.py
@@ -158,9 +158,9 @@ def _compact_transcript_lines(lines: list[dict[str, Any]], target_bytes: int) ->
     return compacted_lines
 
 
-def _write_transcript_lines(path: Path, lines: list[dict[str, Any]]) -> None:
+def _write_transcript_path_lines(path: Path, lines: list[dict[str, Any]]) -> None:
     """Overwrite transcript file with specified lines atomically."""
-    tmp_path = path.with_suffix(".tmp")
+    tmp_path = path.with_suffix(f"{path.suffix}.tmp")
     tmp_path.parent.mkdir(parents=True, exist_ok=True)
     try:
         with open(tmp_path, "w", encoding="utf-8") as f:
@@ -169,19 +169,10 @@ def _write_transcript_lines(path: Path, lines: list[dict[str, Any]]) -> None:
                 f.write(raw + "\n")
             f.flush()
             os.fsync(f.fileno())
-        if path.is_file():
-            try:
-                path.unlink()
-            except OSError:
-                pass
-        tmp_path.rename(path)
-    except Exception as e:
-        if tmp_path.is_file():
-            try:
-                tmp_path.unlink()
-            except OSError:
-                pass
-        raise e
+        os.replace(tmp_path, path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
 
 
 def read_transcript_lines(session_key: str) -> list[dict[str, Any]]:
@@ -196,7 +187,7 @@ def read_transcript_lines(session_key: str) -> list[dict[str, Any]]:
             return []
         try:
             compacted = _compact_transcript_lines(lines, _MAX_TRANSCRIPT_FILE_BYTES // 2)
-            _write_transcript_lines(path, compacted)
+            _write_transcript_path_lines(path, compacted)
             return compacted
         except Exception as e:
             logger.warning("Failed to compact transcript {}: {}", path, e)
@@ -225,7 +216,7 @@ def append_transcript_object(session_key: str, obj: dict[str, Any]) -> None:
                 lines = _read_all_transcript_lines(path)
                 if lines:
                     compacted = _compact_transcript_lines(lines, _MAX_TRANSCRIPT_FILE_BYTES // 2)
-                    _write_transcript_lines(path, compacted)
+                    _write_transcript_path_lines(path, compacted)
         except Exception as e:
             logger.warning("Failed to compact transcript {} after turn_end: {}", path, e)
 

--- a/tests/utils/test_webui_transcript_compaction.py
+++ b/tests/utils/test_webui_transcript_compaction.py
@@ -1,0 +1,131 @@
+"""Tests for WebUI transcript automatic rolling compaction."""
+
+from __future__ import annotations
+
+import json
+
+from nanobot.webui.transcript import (
+    append_transcript_object,
+    read_transcript_lines,
+    webui_transcript_path,
+)
+
+
+def test_read_transcript_compaction_on_large_file(tmp_path, monkeypatch) -> None:
+    # Set data dir to tmp path
+    monkeypatch.setattr("nanobot.config.paths.get_data_dir", lambda: tmp_path)
+
+    # Set small transcript limit for easy testing
+    limit = 300
+    monkeypatch.setattr("nanobot.webui.transcript._MAX_TRANSCRIPT_FILE_BYTES", limit)
+
+    session_key = "websocket:test_session_1"
+
+    # Construct multiple turns
+    # Turn 1: 3 messages, end with turn_end
+    turn_1 = [
+        {"event": "user", "chat_id": "test_session_1", "text": "hello 1"},
+        {"event": "delta", "content": "reply 1"},
+        {"event": "turn_end"},
+    ]
+    # Turn 2: 3 messages, end with turn_end
+    turn_2 = [
+        {
+            "event": "user",
+            "chat_id": "test_session_1",
+            "text": "hello 2 hello 2 hello 2 hello 2 hello 2",
+        },
+        {
+            "event": "delta",
+            "content": "reply 2 reply 2 reply 2 reply 2 reply 2 reply 2 reply 2",
+        },
+        {"event": "turn_end"},
+    ]
+    # Turn 3: 3 messages, end with turn_end
+    turn_3 = [
+        {"event": "user", "chat_id": "test_session_1", "text": "hello 3"},
+        {"event": "delta", "content": "reply 3"},
+        {"event": "turn_end"},
+    ]
+
+    path = webui_transcript_path(session_key)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    all_events = turn_1 + turn_2 + turn_3
+
+    with open(path, "w", encoding="utf-8") as f:
+        for ev in all_events:
+            f.write(json.dumps(ev, ensure_ascii=False) + "\n")
+
+    # Verify file is larger than the limit
+    assert path.stat().st_size > limit
+
+    # Read transcript. This should trigger automatic compaction
+    lines = read_transcript_lines(session_key)
+
+    # Check that it read successfully and file size is now compacted (<= limit // 2)
+    assert len(lines) > 0
+    assert len(lines) < len(all_events)
+    assert path.stat().st_size <= limit // 2
+
+    # Check that the remaining events are the most recent complete turns.
+    assert lines[-1]["event"] == "turn_end"
+
+    # Ensure all remaining events belong to complete turns
+    assert lines[0]["event"] == "user"
+
+
+def test_append_transcript_compaction_on_turn_end(tmp_path, monkeypatch) -> None:
+    # Set data dir to tmp path
+    monkeypatch.setattr("nanobot.config.paths.get_data_dir", lambda: tmp_path)
+
+    # Set small transcript limit
+    limit = 400
+    monkeypatch.setattr("nanobot.webui.transcript._MAX_TRANSCRIPT_FILE_BYTES", limit)
+
+    session_key = "websocket:test_session_2"
+    path = webui_transcript_path(session_key)
+
+    # 1. Append event by event
+    # We will write 4 turns. Each turn is about 150 bytes.
+    # Total size for 3 turns is about 450 bytes (< limit 500).
+    # Total size for 4 turns is about 600 bytes (> limit 500).
+
+    # Turn 1
+    append_transcript_object(session_key, {"event": "user", "chat_id": "test_session_2", "text": "hello 1"})
+    append_transcript_object(session_key, {"event": "delta", "content": "reply 1"})
+    append_transcript_object(session_key, {"event": "turn_end"})
+
+    # Turn 2
+    append_transcript_object(session_key, {"event": "user", "chat_id": "test_session_2", "text": "hello 2"})
+    append_transcript_object(session_key, {"event": "delta", "content": "reply 2"})
+    append_transcript_object(session_key, {"event": "turn_end"})
+
+    # Turn 3
+    append_transcript_object(session_key, {"event": "user", "chat_id": "test_session_2", "text": "hello 3"})
+    append_transcript_object(session_key, {"event": "delta", "content": "reply 3"})
+    append_transcript_object(session_key, {"event": "turn_end"})
+
+    # File size should be small, no compaction yet
+    assert path.stat().st_size < limit
+
+    # Turn 4
+    append_transcript_object(session_key, {"event": "user", "chat_id": "test_session_2", "text": "hello 4"})
+    append_transcript_object(session_key, {"event": "delta", "content": "reply 4"})
+
+    # Currently, file size may exceed the limit, but because event is "delta" (not "turn_end"),
+    # no compaction should trigger yet.
+    assert path.stat().st_size > limit
+
+    # Now append "turn_end" for the 4th turn.
+    # This should trigger compaction.
+    append_transcript_object(session_key, {"event": "turn_end"})
+
+    # After turn_end, the file should be compacted to <= limit // 2 (250 bytes)
+    assert path.stat().st_size <= limit // 2
+
+    # Read back and verify
+    lines = read_transcript_lines(session_key)
+    assert len(lines) > 0
+    # The remaining events should end with "turn_end"
+    assert lines[-1]["event"] == "turn_end"
+    assert lines[0]["event"] == "user"


### PR DESCRIPTION
## Problem

When a WebUI transcript JSONL file exceeds the 8 MB hard limit, read_transcript_lines logs a warning and returns []:

  WARNING: webui transcript too large, skipping: ...websocket_f63c59ba-....jsonl

This causes the chat history to disappear entirely in the WebUI for any session whose transcript has grown large.

## Solution

Implement rolling compaction using complete conversation turns as the retention unit, instead of silently skipping the file.

### Changes in nanobot/webui/transcript.py

- _read_all_transcript_lines(path): extracted shared JSONL reader used by both compaction and normal read paths.
- _compact_transcript_lines(lines, target_bytes): retains the most-recent turns whose cumulative size fits within target_bytes (limit // 2 = 4 MB), preserving complete turn boundaries.
- _write_transcript_lines(path, lines): atomic overwrite via .tmp + rename, safe on Windows and Unix.
- read_transcript_lines: when the file exceeds the limit, compact and rewrite in-place before returning, immediately unblocking any chat that was previously unreadable.
- append_transcript_object: after a turn_end event, check file size and compact proactively so the file never grows unbounded.

### Tests: tests/utils/test_webui_transcript_compaction.py

- test_read_transcript_compaction_on_large_file: an over-limit file is compacted in-place and correct (most-recent) records are returned.
- test_append_transcript_compaction_on_turn_end: compaction is triggered only on turn_end, not on delta events.

## Notes

- gateway.heartbeat.keepRecentMessages is unrelated to this issue; it only trims the heartbeat agent session, not WebUI display transcripts.
- Backward-compatible: existing transcripts under 8 MB are read with no change in behavior.