### PR TITLE
[codex] Add bwrap Ubuntu 24.04 namespace diagnostics

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1483,6 +1483,31 @@ For API keys, tokens, and other secrets, see [Environment Variables for Secrets]
 
 **Docker security**: The official Docker image runs as a non-root user (`nanobot`, UID 1000) with bubblewrap pre-installed. When using `docker-compose.yml`, the container drops all Linux capabilities except `SYS_ADMIN` (required for bwrap's namespace isolation).
 
+### Bubblewrap on Ubuntu 24.04
+
+Ubuntu 23.10 and 24.04 added AppArmor restrictions for unprivileged user namespaces. On affected hosts, `tools.exec.sandbox: "bwrap"` can fail before the command starts with errors such as `Operation not permitted`, `clone3: Operation not permitted`, or `creating new namespace failed`.
+
+Nanobot detects these failures and adds a diagnostic hint to the exec output. A targeted AppArmor profile for `/usr/bin/bwrap` is preferred over globally disabling user namespace restrictions:
+
+```text
+abi <abi/4.0>,
+include <tunables/global>
+
+profile bwrap /usr/bin/bwrap flags=(unconfined) {
+  userns,
+}
+```
+
+Save this as `/etc/apparmor.d/bwrap-userns-restrict`, then load it:
+
+```bash
+sudo apparmor_parser -r /etc/apparmor.d/bwrap-userns-restrict
+```
+
+If you run Nanobot in Docker on an Ubuntu 24.04 host, the container still needs the security options shown in [Docker](deployment.md#docker): `--cap-add SYS_ADMIN`, `apparmor=unconfined`, and `seccomp=unconfined`.
+
+For background on the Ubuntu/AppArmor restriction model, see Canonical's [AppArmor user namespace restriction explanation](https://discourse.ubuntu.com/t/understanding-apparmor-user-namespace-restriction/58007).
+
 
 ## Pairing
 

--- a/nanobot/agent/tools/sandbox.py
+++ b/nanobot/agent/tools/sandbox.py
@@ -10,6 +10,54 @@ from pathlib import Path
 
 from nanobot.config.paths import get_media_dir
 
+_BWRAP_USERNS_ERROR_PATTERNS = (
+    "operation not permitted",
+    "permission denied",
+    "creating new namespace failed",
+    "namespace setup failed",
+    "clone3",
+    "clone",
+    "unshare",
+    "user namespace",
+)
+
+
+def _read_sysctl(name: str) -> str | None:
+    path = Path("/proc/sys") / Path(name.replace(".", "/"))
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+
+
+def bwrap_userns_failure_hint(stderr: str) -> str | None:
+    """Return an actionable hint for common bwrap user namespace failures."""
+    lower = stderr.lower()
+    if not any(pattern in lower for pattern in _BWRAP_USERNS_ERROR_PATTERNS):
+        return None
+
+    details: list[str] = []
+    unprivileged = _read_sysctl("kernel.unprivileged_userns_clone")
+    if unprivileged == "0":
+        details.append("kernel.unprivileged_userns_clone=0")
+
+    max_namespaces = _read_sysctl("user.max_user_namespaces")
+    if max_namespaces == "0":
+        details.append("user.max_user_namespaces=0")
+
+    apparmor_userns = _read_sysctl("kernel.apparmor_restrict_unprivileged_userns")
+    if apparmor_userns == "1":
+        details.append("kernel.apparmor_restrict_unprivileged_userns=1")
+
+    suffix = f" Detected: {', '.join(details)}." if details else ""
+    return (
+        "Bubblewrap sandbox failed while creating Linux namespaces. This is common on "
+        "Ubuntu 24.04+ when AppArmor restricts unprivileged user namespaces, or when "
+        "the host/container disables user namespaces."
+        f"{suffix} See docs/configuration.md#bubblewrap-on-ubuntu-2404 for the "
+        "AppArmor profile and container capability requirements."
+    )
+
 
 def _bwrap(command: str, workspace: str, cwd: str) -> str:
     """Wrap command in a bubblewrap sandbox (requires bwrap in container).
@@ -31,8 +79,10 @@ def _bwrap(command: str, workspace: str, cwd: str) -> str:
                  "/etc/ssl/certs", "/etc/resolv.conf", "/etc/ld.so.cache"]
 
     args = ["bwrap", "--new-session", "--die-with-parent"]
-    for p in required: args += ["--ro-bind",     p, p]
-    for p in optional: args += ["--ro-bind-try", p, p]
+    for p in required:
+        args += ["--ro-bind", p, p]
+    for p in optional:
+        args += ["--ro-bind-try", p, p]
     args += [
         "--proc", "/proc", "--dev", "/dev", "--tmpfs", "/tmp",
         "--tmpfs", str(ws.parent),        # mask config dir

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -26,7 +26,7 @@ from nanobot.agent.tools.exec_session import (
     clamp_session_int,
     format_session_poll,
 )
-from nanobot.agent.tools.sandbox import wrap_command
+from nanobot.agent.tools.sandbox import bwrap_userns_failure_hint, wrap_command
 from nanobot.agent.tools.schema import (
     BooleanSchema,
     IntegerSchema,
@@ -292,6 +292,10 @@ class ExecTool(Tool):
             if stderr:
                 stderr_text = stderr.decode("utf-8", errors="replace")
                 if stderr_text.strip():
+                    if self.sandbox == "bwrap":
+                        hint = bwrap_userns_failure_hint(stderr_text)
+                        if hint:
+                            stderr_text = f"{stderr_text.rstrip()}\n\n{hint}\n"
                     output_parts.append(f"STDERR:\n{stderr_text}")
 
             output_parts.append(f"\nExit code: {process.returncode}")

--- a/tests/tools/test_exec_platform.py
+++ b/tests/tools/test_exec_platform.py
@@ -272,6 +272,35 @@ class TestSandboxPlatform:
         spawned_cmd = mock_spawn.call_args[0][0]
         assert "bwrap" in spawned_cmd
 
+    @pytest.mark.asyncio
+    async def test_bwrap_userns_failure_adds_actionable_hint(self):
+        """Ubuntu/AppArmor namespace failures should explain the host fix."""
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (
+            b"",
+            b"bwrap: creating new namespace failed: Operation not permitted\n",
+        )
+        mock_proc.returncode = 1
+
+        with (
+            patch("nanobot.agent.tools.shell._IS_WINDOWS", False),
+            patch("nanobot.agent.tools.shell.wrap_command", return_value="bwrap -- sh -c ls"),
+            patch(
+                "nanobot.agent.tools.sandbox._read_sysctl",
+                side_effect=lambda name: {
+                    "kernel.apparmor_restrict_unprivileged_userns": "1",
+                }.get(name),
+            ),
+            patch.object(ExecTool, "_spawn", return_value=mock_proc),
+            patch.object(ExecTool, "_guard_command", return_value=None),
+        ):
+            tool = ExecTool(sandbox="bwrap", working_dir="/workspace")
+            result = await tool.execute(command="ls")
+
+        assert "Bubblewrap sandbox failed while creating Linux namespaces" in result
+        assert "Ubuntu 24.04" in result
+        assert "kernel.apparmor_restrict_unprivileged_userns=1" in result
+
 
 # ---------------------------------------------------------------------------
 # end-to-end (mocked subprocess, full execute path)

--- a/tests/tools/test_sandbox.py
+++ b/tests/tools/test_sandbox.py
@@ -4,7 +4,7 @@ import shlex
 
 import pytest
 
-from nanobot.agent.tools.sandbox import wrap_command
+from nanobot.agent.tools.sandbox import bwrap_userns_failure_hint, wrap_command
 
 
 def _parse(cmd: str) -> list[str]:
@@ -119,3 +119,28 @@ class TestUnknownBackend:
         ws = str(tmp_path / "project")
         with pytest.raises(ValueError):
             wrap_command("", "ls", ws, ws)
+
+
+class TestBwrapDiagnostics:
+    def test_userns_failure_hint_mentions_ubuntu_2404(self, monkeypatch):
+        values = {
+            "kernel.apparmor_restrict_unprivileged_userns": "1",
+            "kernel.unprivileged_userns_clone": "1",
+            "user.max_user_namespaces": "6191547",
+        }
+        monkeypatch.setattr(
+            "nanobot.agent.tools.sandbox._read_sysctl",
+            lambda name: values.get(name),
+        )
+
+        hint = bwrap_userns_failure_hint(
+            "bwrap: creating new namespace failed: Operation not permitted"
+        )
+
+        assert hint is not None
+        assert "Ubuntu 24.04" in hint
+        assert "kernel.apparmor_restrict_unprivileged_userns=1" in hint
+        assert "docs/configuration.md#bubblewrap-on-ubuntu-2404" in hint
+
+    def test_userns_failure_hint_ignores_unrelated_stderr(self):
+        assert bwrap_userns_failure_hint("command not found: python") is None


### PR DESCRIPTION
## Summary

Fixes #4236.

- Detect common Bubblewrap namespace setup failures and append an actionable diagnostic hint to `exec` stderr when `sandbox = "bwrap"` is enabled.
- Document the Ubuntu 24.04 AppArmor user-namespace workaround and the existing container flags needed for Docker-based runs.
- Add focused tests for the sandbox diagnostic helper and the `ExecTool` output path.

## Problem

On Ubuntu 24.04, Bubblewrap can fail before the target command starts because host policy blocks unprivileged user namespace creation. The raw stderr usually only reports low-level namespace errors such as `Operation not permitted`, which makes the failure look like a command/runtime problem instead of a host sandbox policy problem.

## Root Cause

`bwrap` depends on Linux namespace creation. Ubuntu 23.10+ / 24.04 AppArmor policy can restrict unprivileged user namespaces, and container runtimes can also block the same setup unless they grant the required capability/security options. Nanobot previously surfaced the raw `bwrap` stderr without classifying this failure mode.

## Fix

- Add `bwrap_userns_failure_hint()` in `nanobot.agent.tools.sandbox`.
- Read relevant sysctls when available:
  - `kernel.unprivileged_userns_clone`
  - `user.max_user_namespaces`
  - `kernel.apparmor_restrict_unprivileged_userns`
- Append a targeted hint from `ExecTool.execute()` only for `bwrap` sandbox failures.
- Add `docs/configuration.md#bubblewrap-on-ubuntu-2404` with the AppArmor profile and Docker notes.

## Validation

- `uv run pytest tests/tools/test_sandbox.py tests/tools/test_exec_platform.py::TestSandboxPlatform -q`
- `uv run ruff check nanobot/agent/tools/sandbox.py nanobot/agent/tools/shell.py tests/tools/test_sandbox.py tests/tools/test_exec_platform.py`
- `python3 -m compileall -q nanobot/agent/tools/sandbox.py nanobot/agent/tools/shell.py`
