### PR TITLE
fix(memory): keep history cursor monotonic

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -61,7 +61,7 @@ class MemoryStore:
         self.user_file = workspace / "USER.md"
         self._cursor_file = self.memory_dir / ".cursor"
         self._dream_cursor_file = self.memory_dir / ".dream_cursor"
-        self._corruption_logged = False  # rate-limit non-int cursor warning
+        self._corruption_logged = False  # rate-limit invalid cursor warning
         self._malformed_entry_logged = False  # rate-limit bad history shape warning
         self._oversize_logged = False  # rate-limit oversized-entry warning
         self._append_lock = threading.Lock()  # serialize cursor allocation + append
@@ -291,8 +291,8 @@ class MemoryStore:
 
     @staticmethod
     def _valid_cursor(value: Any) -> int | None:
-        """Int cursors only — reject bool (``isinstance(True, int)`` is True)."""
-        if isinstance(value, bool) or not isinstance(value, int):
+        """Non-negative int cursors only; reject bool (``isinstance(True, int)`` is True)."""
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
             return None
         return value
 
@@ -315,7 +315,7 @@ class MemoryStore:
         if poisoned is not None and not self._corruption_logged:
             self._corruption_logged = True
             logger.warning(
-                "history.jsonl contains a non-int cursor ({!r}); dropping it. "
+                "history.jsonl contains an invalid cursor ({!r}); dropping it. "
                 "Usually caused by an external writer; further occurrences suppressed.",
                 poisoned,
             )

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -336,18 +336,32 @@ class MemoryStore:
         session_key = entry.get("session_key")
         return session_key is None or isinstance(session_key, str)
 
+    def _read_cursor_counter(self) -> int | None:
+        """Return the persisted cursor counter when it is usable."""
+        if not self._cursor_file.exists():
+            return None
+        with suppress(ValueError, OSError):
+            cursor = int(self._cursor_file.read_text(encoding="utf-8").strip())
+            if cursor >= 0:
+                return cursor
+        return None
+
     def _next_cursor(self) -> int:
         """Read the current cursor counter and return the next value."""
-        if self._cursor_file.exists():
-            with suppress(ValueError, OSError):
-                return int(self._cursor_file.read_text(encoding="utf-8").strip()) + 1
+        cursor_counter = self._read_cursor_counter()
+        last = self._read_last_entry() or {}
+        last_cursor = self._valid_cursor(last.get("cursor"))
+        if cursor_counter is not None:
+            if last_cursor is not None:
+                return max(cursor_counter, last_cursor) + 1
+            max_history_cursor = max((c for _, c in self._iter_valid_entries()), default=0)
+            return max(cursor_counter, max_history_cursor) + 1
+
         # Fast path: trust the tail when intact.  Otherwise scan the whole
         # file and take ``max`` — that stays correct even if the monotonic
         # invariant was broken by external writes.
-        last = self._read_last_entry() or {}
-        cursor = self._valid_cursor(last.get("cursor"))
-        if cursor is not None:
-            return cursor + 1
+        if last_cursor is not None:
+            return last_cursor + 1
         return max((c for _, c in self._iter_valid_entries()), default=0) + 1
 
     def read_unprocessed_history(self, since_cursor: int) -> list[dict[str, Any]]:

--- a/tests/agent/test_cursor_recovery.py
+++ b/tests/agent/test_cursor_recovery.py
@@ -6,8 +6,6 @@ history.jsonl (e.g. ``"cursor": "abc"``).  The original ``_next_cursor`` and
 ``TypeError`` / ``ValueError``, blocking all subsequent history appends.
 """
 
-import json
-
 import pytest
 
 from nanobot.agent.memory import MemoryStore
@@ -69,6 +67,40 @@ class TestNextCursorRecovery:
         )
         cursor = store.append_history("after bad cursor file")
         assert cursor == 11
+
+    def test_stale_cursor_file_does_not_reuse_history_cursor(self, store):
+        """A stale .cursor file must not allocate a duplicate cursor."""
+        store.history_file.write_text(
+            '{"cursor": 10, "timestamp": "2026-04-01 10:00", "content": "valid"}\n',
+            encoding="utf-8",
+        )
+        store._cursor_file.write_text("2", encoding="utf-8")
+
+        cursor = store.append_history("after stale cursor file")
+
+        assert cursor == 11
+        entries = store.read_unprocessed_history(since_cursor=0)
+        assert [e["cursor"] for e in entries] == [10, 11]
+
+    def test_cursor_file_stays_ahead_after_history_compaction(self, store):
+        """A cursor counter ahead of the tail preserves monotonic allocation."""
+        store.history_file.write_text(
+            '{"cursor": 10, "timestamp": "2026-04-01 10:00", "content": "valid"}\n',
+            encoding="utf-8",
+        )
+        store._cursor_file.write_text("100", encoding="utf-8")
+
+        cursor = store.append_history("after compacted history")
+
+        assert cursor == 101
+
+    def test_negative_cursor_file_content_falls_back(self, store):
+        """A negative .cursor value is corrupt and should not produce negative IDs."""
+        store._cursor_file.write_text("-5", encoding="utf-8")
+
+        cursor = store.append_history("after negative cursor file")
+
+        assert cursor == 1
 
 
 class TestReadUnprocessedWithCorruption:
@@ -159,6 +191,7 @@ class TestCursorValidationInvariant:
         warning, subsequent reads on the same store stay quiet.  Without
         this, a poisoned file produces one warning per agent turn."""
         import logging
+
         from loguru import logger as loguru_logger
 
         store.history_file.write_text(

--- a/tests/agent/test_cursor_recovery.py
+++ b/tests/agent/test_cursor_recovery.py
@@ -104,7 +104,7 @@ class TestNextCursorRecovery:
 
 
 class TestReadUnprocessedWithCorruption:
-    """``read_unprocessed_history`` must skip entries with non-int cursors
+    """``read_unprocessed_history`` must skip entries with invalid cursors
     instead of crashing on comparison."""
 
     def test_skips_string_cursor_entries(self, store):
@@ -153,6 +153,7 @@ class TestCursorValidationInvariant:
         """
         assert MemoryStore._valid_cursor(True) is None
         assert MemoryStore._valid_cursor(False) is None
+        assert MemoryStore._valid_cursor(-1) is None
         assert MemoryStore._valid_cursor(5) == 5
         assert MemoryStore._valid_cursor(0) == 0
 
@@ -166,6 +167,18 @@ class TestCursorValidationInvariant:
 
         entries = store.read_unprocessed_history(since_cursor=0)
         assert [e["cursor"] for e in entries] == [4, 5]
+
+    def test_negative_history_cursor_rejected(self, store):
+        """A negative history cursor is corrupt and must not seed new writes."""
+        store.history_file.write_text(
+            '{"cursor": -5, "timestamp": "2026-04-01 10:00", "content": "negative"}\n',
+            encoding="utf-8",
+        )
+        store._cursor_file.unlink(missing_ok=True)
+
+        assert store.append_history("next") == 1
+        entries = store.read_unprocessed_history(since_cursor=0)
+        assert [e["cursor"] for e in entries] == [1]
 
     def test_next_cursor_returns_max_not_just_last_int(self, store):
         """Under adversarial corruption, file order ≠ numeric order.  The
@@ -187,7 +200,7 @@ class TestCursorValidationInvariant:
         assert store.append_history("safe next") == 101
 
     def test_corruption_is_logged_exactly_once_per_store(self, store, caplog):
-        """Observability without spam: the first non-int cursor emits one
+        """Observability without spam: the first invalid cursor emits one
         warning, subsequent reads on the same store stay quiet.  Without
         this, a poisoned file produces one warning per agent turn."""
         import logging
@@ -213,7 +226,7 @@ class TestCursorValidationInvariant:
             loguru_logger.remove(handler_id)
 
         corruption_warnings = [
-            r for r in caplog.records if "non-int cursor" in r.getMessage()
+            r for r in caplog.records if "invalid cursor" in r.getMessage()
         ]
         assert len(corruption_warnings) == 1, (
             "Expected exactly one corruption warning per store instance; "


### PR DESCRIPTION
## Summary
- Keep `MemoryStore` cursor allocation monotonic when `.cursor` is stale, compacted ahead of history, or contains a negative value.
- Compare the persisted cursor counter with the current history tail / max valid history cursor before allocating the next ID.
- Add regression coverage for stale, ahead-of-history, and negative cursor counter states.

## Tests
- `uv run --extra dev pytest tests/agent/test_cursor_recovery.py tests/agent/test_memory_store.py -q`
- `uv run --extra dev pytest tests/agent/test_cursor_recovery.py tests/agent/test_memory_store.py tests/agent/test_dream_session.py tests/agent/test_dream_tools.py tests/command/test_builtin_dream.py -q`
- `uv run --extra dev ruff check nanobot/agent/memory.py tests/agent/test_cursor_recovery.py`
- `git diff --check`