### PR TITLE
fix(websocket): Fix bug in webui where session content is dropped

### DIFF
--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -1059,7 +1059,7 @@ class WebSocketChannel(BaseChannel):
                 buffered.append(delta)
             full_text = "".join(buffered)
             rewritten = self._media.rewrite_local_markdown_images(full_text)
-            if rewritten != full_text:
+            if full_text:
                 body["text"] = rewritten
         else:
             body = {

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -1059,7 +1059,7 @@ class WebSocketChannel(BaseChannel):
                 buffered.append(delta)
             full_text = "".join(buffered)
             rewritten = self._media.rewrite_local_markdown_images(full_text)
-            if full_text:
+            if delta or rewritten != full_text:
                 body["text"] = rewritten
         else:
             body = {

--- a/tests/channels/test_websocket_channel.py
+++ b/tests/channels/test_websocket_channel.py
@@ -1015,6 +1015,28 @@ async def test_send_delta_emits_delta_and_stream_end() -> None:
     assert second["event"] == "stream_end"
     assert second["chat_id"] == "chat-1"
     assert second["stream_id"] == "sid"
+    assert "text" not in second
+
+
+@pytest.mark.asyncio
+async def test_send_delta_stream_end_includes_inline_final_text() -> None:
+    bus = MagicMock()
+    channel = WebSocketChannel({"enabled": True, "allowFrom": ["*"], "streaming": True}, bus, gateway=_basic_handler(bus))
+    mock_ws = AsyncMock()
+    channel._attach(mock_ws, "chat-1")
+
+    await channel.send_delta(
+        "chat-1",
+        "merged plain text",
+        {"_stream_delta": True, "_stream_end": True, "_stream_id": "sid"},
+    )
+
+    mock_ws.send.assert_awaited_once()
+    final = json.loads(mock_ws.send.await_args.args[0])
+    assert final["event"] == "stream_end"
+    assert final["chat_id"] == "chat-1"
+    assert final["stream_id"] == "sid"
+    assert final["text"] == "merged plain text"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes a WebUI streaming edge case where an assistant reply could be saved in session history but never appear in the rendered conversation.

## Root Cause

`ChannelManager._coalesce_stream_deltas()` can merge queued `_stream_delta` messages into a single `_stream_end` message when the model streams faster than the WebSocket channel drains the queue.

In that coalesced path, the final text is carried by the `delta` argument passed to `WebSocketChannel.send_delta()`. Previously, the WebSocket channel only attached `text` to the `stream_end` payload when local markdown media rewriting changed the content. Plain-text replies therefore produced a bare `stream_end` event with no text for the WebUI to render.

## Fix

Send `text` on `stream_end` when either:

- the `stream_end` call itself carries inline final text from a coalesced delta, or
- local markdown media rewriting changed the final text.

Normal streams that already emitted delta frames still avoid sending duplicate full-text payloads at `stream_end`.

## Tests

- Added a regression test for coalesced inline final text.
- Kept coverage for normal stream endings without duplicate final text.
- Verified local markdown media rewrite behavior still sends final rewritten text.
