### PR TITLE
fix: archive full session history in idle compact

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -990,7 +990,7 @@ class Consolidator:
             last_active = session.updated_at
             summary: str | None = ""
             if archive_msgs:
-                summary = await self.archive(archive_msgs, session_key=session_key)
+                summary = await self.archive(tail, session_key=session_key)
 
             if summary and summary != "(nothing)":
                 session.metadata["_last_summary"] = {

--- a/tests/agent/test_auto_compact.py
+++ b/tests/agent/test_auto_compact.py
@@ -89,10 +89,10 @@ def _make_fake_compact(
         s = summary
         if archive_msgs:
             if on_archive:
-                result = on_archive(archive_msgs)
+                result = on_archive(tail)
                 s = result if isinstance(result, str) else summary
             if track_archived is not None:
-                track_archived.extend(archive_msgs)
+                track_archived.extend(tail)
 
         if s and s != "(nothing)":
             session.metadata["_last_summary"] = {
@@ -284,8 +284,8 @@ class TestAutoCompact:
         await loop.close_mcp()
 
     @pytest.mark.asyncio
-    async def test_auto_compact_archives_prefix_and_keeps_recent_suffix(self, tmp_path):
-        """_archive should summarize the old prefix and keep a recent legal suffix."""
+    async def test_auto_compact_archives_full_tail_and_keeps_recent_suffix(self, tmp_path):
+        """_archive should summarize the full unconsolidated tail and keep a suffix."""
         loop = _make_loop(tmp_path, session_ttl_minutes=15)
         session = loop.sessions.get_or_create("cli:test")
         _add_turns(session, 6)
@@ -298,11 +298,34 @@ class TestAutoCompact:
 
         await loop.auto_compact._archive("cli:test")
 
-        assert len(archived_messages) == 4
+        assert len(archived_messages) == 12
         session_after = loop.sessions.get_or_create("cli:test")
         assert len(session_after.messages) == loop.auto_compact._RECENT_SUFFIX_MESSAGES
         assert session_after.messages[0]["content"] == "msg user 2"
         assert session_after.messages[-1]["content"] == "msg assistant 5"
+        await loop.close_mcp()
+
+    @pytest.mark.asyncio
+    async def test_compact_idle_session_archives_full_unconsolidated_tail(self, tmp_path):
+        """compact_idle_session should archive kept messages as part of the summary input."""
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)
+        session = loop.sessions.get_or_create("cli:test")
+        for i in range(12):
+            session.add_message("user", f"msg {i}")
+        loop.sessions.save(session)
+
+        loop.consolidator.archive = AsyncMock(return_value="Summary.")
+
+        await loop.consolidator.compact_idle_session("cli:test", max_suffix=8)
+
+        loop.consolidator.archive.assert_awaited_once()
+        archived = loop.consolidator.archive.await_args.args[0]
+        assert [m["content"] for m in archived] == [f"msg {i}" for i in range(12)]
+        session_after = loop.sessions.get_or_create("cli:test")
+        assert len(session_after.messages) == 8
+        assert [m["content"] for m in session_after.messages] == [
+            f"msg {i}" for i in range(4, 12)
+        ]
         await loop.close_mcp()
 
     @pytest.mark.asyncio
@@ -356,7 +379,7 @@ class TestAutoCompact:
 
         await loop.auto_compact._archive("cli:test")
 
-        assert len(archived_messages) == 2
+        assert len(archived_messages) == 10
         await loop.close_mcp()
 
 
@@ -400,7 +423,7 @@ class TestAutoCompactIdleDetection:
         await loop._process_message(msg)
 
         session_after = loop.sessions.get_or_create("cli:test")
-        assert len(archived_messages) == 4
+        assert len(archived_messages) == 12
         assert not any(m["content"] == "old user 0" for m in session_after.messages)
         assert any(m["content"] == "new msg" for m in session_after.messages)
         await loop.close_mcp()
@@ -752,7 +775,7 @@ class TestProactiveAutoCompact:
 
         session_after = loop.sessions.get_or_create("cli:test")
         assert len(session_after.messages) == loop.auto_compact._RECENT_SUFFIX_MESSAGES
-        assert len(archived_messages) == 2
+        assert len(archived_messages) == 10
         entry = loop.auto_compact._summaries.get("cli:test")
         assert entry is not None
         assert entry[0] == "User chatted about old things."

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -511,8 +511,7 @@ class TestCompactIdleSession:
         real_consolidator,
         mock_provider,
     ):
-        """Assistant-only tails retain a non-contiguous slice, so archive the
-        actual dropped messages rather than a computed prefix."""
+        """Archive receives the full tail for richer summary context."""
         mock_provider.chat_with_retry.return_value = MagicMock(
             content="Tail summary.", finish_reason="stop"
         )
@@ -539,8 +538,8 @@ class TestCompactIdleSession:
 
         archived_call = mock_provider.chat_with_retry.call_args
         user_content = archived_call.kwargs["messages"][1]["content"]
-        assert "user-14" not in user_content
-        assert "assistant-00" not in user_content
+        assert "user-14" in user_content
+        assert "assistant-00" in user_content
         assert "assistant-09" in user_content
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`compact_idle_session` only passes the old prefix (messages before the kept suffix) to `archive()` for summarization. If a user corrects the model in the last few messages, those corrections are excluded from the summary. The summary then reflects stale/incorrect information.

Example scenario:
1. User asks a question
2. Model gives wrong answer
3. User points out the error
4. Model gives correct answer
5. Session goes idle, idleCompact triggers

The summary only covers messages from step 1-2. Steps 3-4 (the correction and correct answer) are in the kept suffix and excluded from the summary.

## Fix

Pass the full unconsolidated tail to `archive()` instead of just the dropped prefix. The session still retains only the last N messages for context continuity.

One-line change in `nanobot/agent/memory.py`, plus updated and new tests.

## Tests

- `pytest tests/agent/test_auto_compact.py -v`: 52/52 passed
- `ruff check nanobot/agent/memory.py tests/agent/test_auto_compact.py`: all checks passed
- New test: `test_compact_idle_session_archives_full_unconsolidated_tail` verifies all 12 messages are passed to archive (not just the 4 old ones), while the session still keeps only the last 8.
