### PR TITLE
feat(agent): skip LLM processing for read_only sessions

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -868,6 +868,16 @@ class AgentLoop:
             effective_key = self._effective_session_key(msg)
             if await agent_context.handle_runtime_control(self, msg, self.tools):
                 continue
+            # Read-only sessions: reply with a hint and skip all dispatch
+            # (priority commands, mid-turn injection, new tasks).
+            session = self.sessions.get_or_create(effective_key)
+            if session.metadata.get("read_only"):
+                await self.bus.publish_outbound(OutboundMessage(
+                    channel=msg.channel, chat_id=msg.chat_id,
+                    content="ℹ️ This session is read-only.",
+                    metadata=msg.metadata or {},
+                ))
+                continue
             if self.commands.is_priority(raw):
                 await self._dispatch_command_inline(
                     msg, effective_key, raw,
@@ -927,16 +937,6 @@ class AgentLoop:
         pending: asyncio.Queue | None = None
         try:
             async with lock, gate:
-                # Read-only sessions: reply with a hint and skip LLM.
-                session = self.sessions.get_or_create(session_key)
-                if session.metadata.get("read_only"):
-                    await self.bus.publish_outbound(OutboundMessage(
-                        channel=msg.channel, chat_id=msg.chat_id,
-                        content="ℹ️ This session is read-only.",
-                        metadata=msg.metadata or {},
-                    ))
-                    return
-
                 # Only the task that owns the session lock may publish the
                 # active mid-turn injection queue for this session.
                 pending = asyncio.Queue(maxsize=20)

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -927,6 +927,16 @@ class AgentLoop:
         pending: asyncio.Queue | None = None
         try:
             async with lock, gate:
+                # Read-only sessions: reply with a hint and skip LLM.
+                session = self.sessions.get_or_create(session_key)
+                if session.metadata.get("read_only"):
+                    await self.bus.publish_outbound(OutboundMessage(
+                        channel=msg.channel, chat_id=msg.chat_id,
+                        content="ℹ️ This session is read-only.",
+                        metadata=msg.metadata or {},
+                    ))
+                    return
+
                 # Only the task that owns the session lock may publish the
                 # active mid-turn injection queue for this session.
                 pending = asyncio.Queue(maxsize=20)

--- a/tests/agent/test_read_only_session.py
+++ b/tests/agent/test_read_only_session.py
@@ -1,0 +1,94 @@
+"""Tests for read_only session metadata flag in AgentLoop.run()."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nanobot.bus.events import InboundMessage, OutboundMessage
+from nanobot.session.manager import Session, SessionManager
+
+
+def _make_session(*, read_only: bool) -> Session:
+    return Session(
+        key="test:user1",
+        metadata={"read_only": True} if read_only else {},
+    )
+
+
+def _make_loop(workspace, session):
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+
+    sessions_mgr = MagicMock(spec=SessionManager)
+    sessions_mgr.get_or_create.return_value = session
+
+    with patch("nanobot.agent.loop.SessionManager", return_value=sessions_mgr), \
+         patch("nanobot.agent.loop.ContextBuilder"), \
+         patch("nanobot.agent.loop.SubagentManager") as MockSubMgr:
+        MockSubMgr.return_value.cancel_by_session = AsyncMock(return_value=0)
+        loop = AgentLoop(bus=bus, provider=provider, workspace=workspace)
+    return loop, bus
+
+
+@pytest.mark.asyncio
+async def test_read_only_session_returns_hint_and_skips_dispatch(tmp_path):
+    """An inbound message to a read-only session produces a hint and no dispatch."""
+    loop, bus = _make_loop(tmp_path, _make_session(read_only=True))
+    msg = InboundMessage(channel="test", sender_id="user1", chat_id="user1", content="hello")
+    await bus.publish_inbound(msg)
+
+    loop_task = asyncio.create_task(loop.run())
+    try:
+        outbound: OutboundMessage = await asyncio.wait_for(bus.consume_outbound(), timeout=2.0)
+        assert "read-only" in outbound.content.lower()
+    finally:
+        loop_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await loop_task
+
+
+@pytest.mark.asyncio
+async def test_read_only_session_blocks_priority_commands(tmp_path):
+    """A /-command sent to a read-only session is blocked."""
+    loop, bus = _make_loop(tmp_path, _make_session(read_only=True))
+    msg = InboundMessage(channel="test", sender_id="user1", chat_id="user1", content="/reset")
+    await bus.publish_inbound(msg)
+
+    loop_task = asyncio.create_task(loop.run())
+    try:
+        outbound = await asyncio.wait_for(bus.consume_outbound(), timeout=2.0)
+        assert "read-only" in outbound.content.lower()
+    finally:
+        loop_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await loop_task
+
+
+@pytest.mark.asyncio
+async def test_normal_session_proceeds_without_hint(tmp_path):
+    """A normal (non-read-only) session does not receive a read-only hint."""
+    loop, bus = _make_loop(tmp_path, _make_session(read_only=False))
+    msg = InboundMessage(channel="test", sender_id="user1", chat_id="user1", content="hello")
+    await bus.publish_inbound(msg)
+
+    loop_task = asyncio.create_task(loop.run())
+    try:
+        try:
+            outbound = await asyncio.wait_for(bus.consume_outbound(), timeout=0.5)
+        except asyncio.TimeoutError:
+            pass  # Normal — dispatch is async
+        else:
+            assert "read-only" not in outbound.content.lower(), (
+                f"Unexpected read-only hint: {outbound.content}"
+            )
+    finally:
+        loop_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await loop_task


### PR DESCRIPTION
## 需求

支持通过 session metadata 标记只读会话。平台构建者可通过设置 `metadata.read_only = true`，让指定的 pinned 会话（如系统配置页、项目指南、FAQ 等）禁止触发 LLM，仅返回静态提示。

## 方案

在消息循环入口 `run()` 中，`create_task(_dispatch)` 之前检查 session metadata 的 `read_only` 字段。若为 true，直接回复提示并 `continue`——不创建 task，不消耗并发槽位，不获取 session lock/gate。

```python
session = self.sessions.get_or_create(effective_key)
if session.metadata.get("read_only"):
    await self.bus.publish_outbound(OutboundMessage(...))
    continue
task = asyncio.create_task(self._dispatch(msg))
```

**与上一版的主要区别**：guard 从 `_dispatch` 内部（`async with lock, gate:` 之内）hoist 到 `run()` 中 `create_task` 之前——真正零开销，且覆盖所有消息路径（含 mid-turn injection）。

## 改动

`nanobot/agent/loop.py` `run()` 方法，+9 行。

## 影响

- pinned 会话的误触消息不再发起 LLM 调用
- metadata 纯扩展字段，不影响现有会话
