### PR TITLE
Fail fast on invalid config files

### DIFF
--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Any
 
 import pydantic
-from loguru import logger
 from pydantic import BaseModel
 
 from nanobot.config.schema import Config, _resolve_tool_config_refs
@@ -55,8 +54,7 @@ def load_config(config_path: Path | None = None) -> Config:
             data = _migrate_config(data)
             config = Config.model_validate(data)
         except (json.JSONDecodeError, ValueError, pydantic.ValidationError) as e:
-            logger.warning("Failed to load config from {}: {}", path, e)
-            logger.warning("Using default configuration.")
+            raise ValueError(f"Failed to load config from {path}: {e}") from e
 
     _apply_ssrf_whitelist(config)
     return config

--- a/tests/config/test_config_load_errors.py
+++ b/tests/config/test_config_load_errors.py
@@ -1,0 +1,30 @@
+import json
+
+import pytest
+
+from nanobot.config.loader import load_config
+
+
+def test_load_config_missing_file_uses_defaults(tmp_path) -> None:
+    config = load_config(tmp_path / "missing.json")
+
+    assert config.agents.defaults.model
+
+
+def test_load_config_invalid_json_fails_fast(tmp_path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{broken json", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Failed to load config"):
+        load_config(config_path)
+
+
+def test_load_config_invalid_schema_fails_fast(tmp_path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"tools": {"exec": {"timeout": -1}}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Failed to load config"):
+        load_config(config_path)


### PR DESCRIPTION
## Summary
- Fail fast when an existing config file cannot be parsed, migrated, or validated.
- Preserve default config behavior when no config file exists.
- Add focused config load error tests.

## Verification
- PASS: `python -m nanobot agent --config .verify\work\bad-config.json --workspace .verify\work\workspace -m verify` exited 1 and printed `Error: Failed to load config from ...`; no `Using default configuration` fallback appeared.
- PASS: `python -m nanobot agent --config .verify\work\bad-schema-config.json --workspace .verify\work\workspace -m verify` exited 1 and printed Pydantic validation error under `Failed to load config from ...`.
- PASS: isolated first-run `python -m nanobot status` with temporary `USERPROFILE` exited 0 and reported missing default config/workspace paths without crashing.
- PASS: `python -m ruff check nanobot/config/loader.py tests/config/test_config_load_errors.py`
- PASS: `python -m pytest tests/config/test_config_load_errors.py tests/config/test_config_migration.py tests/config/test_env_interpolation.py -v` (25 passed; existing third-party deprecation warnings only)

## Limitations
- Did not call real model providers or start gateway; the changed behavior is local config loading before provider startup.
