### PR TITLE
fix(memory): preserve context continuity under context pressure

### DIFF
--- a/nanobot/agent/context_governance.py
+++ b/nanobot/agent/context_governance.py
@@ -26,6 +26,12 @@ if TYPE_CHECKING:
     from nanobot.providers.base import LLMProvider
 
 SNIP_SAFETY_BUFFER = 1024
+SNIP_CONTEXT_MIN_REMAINING_BUDGET = 512
+SNIP_CONTEXT_MIN_TOKENS = 96
+SNIP_CONTEXT_MAX_TOKENS = 768
+SNIP_CONTEXT_MAX_CHARS = 3_200
+SNIP_CONTEXT_MAX_MESSAGES = 10
+SNIP_PREVIEW_MAX_CHARS = 280
 MICROCOMPACT_KEEP_RECENT = 10
 MICROCOMPACT_MIN_CHARS = 500
 INFLIGHT_COMPACT_TARGET_RATIO = 0.85
@@ -412,22 +418,190 @@ class ContextGovernor:
             tools,
         )
         remaining_budget = max(0, budget - max(system_tokens, fixed_tokens))
-        kept: list[dict[str, Any]] = []
-        kept_tokens = 0
-        for message in reversed(non_system):
-            msg_tokens = estimate_message_tokens(message)
-            if kept and kept_tokens + msg_tokens > remaining_budget:
-                break
-            kept.append(message)
-            kept_tokens += msg_tokens
-        kept.reverse()
+        compact_budget = 0
+        tail_budget = remaining_budget
+        if remaining_budget >= SNIP_CONTEXT_MIN_REMAINING_BUDGET:
+            compact_budget = min(
+                SNIP_CONTEXT_MAX_TOKENS,
+                max(SNIP_CONTEXT_MIN_TOKENS, remaining_budget // 6),
+            )
+            tail_budget = max(0, remaining_budget - compact_budget)
 
-        return system_messages + self._legal_history_tail(kept, non_system)
+        kept, kept_start = self._select_history_tail(non_system, tail_budget)
+        kept_tokens = sum(estimate_message_tokens(message) for message in kept)
+        anchor = self._build_snipped_context_message(
+            non_system[:kept_start],
+            token_budget=compact_budget,
+            remaining_budget=remaining_budget,
+            kept_tokens=kept_tokens,
+        )
+
+        if anchor is None and tail_budget != remaining_budget:
+            kept, _kept_start = self._select_history_tail(non_system, remaining_budget)
+            return system_messages + kept
+        if anchor is not None:
+            return system_messages + [anchor] + kept
+        return system_messages + kept
 
     @staticmethod
     def _summary_for(message: dict[str, Any]) -> str:
         name = message.get("name", "tool")
         return f"[Prior {name} result compacted to fit context; the tool call already completed.]"
+
+    @staticmethod
+    def message_preview_for_snip(
+        message: dict[str, Any],
+        limit: int = SNIP_PREVIEW_MAX_CHARS,
+    ) -> str:
+        role = str(message.get("role") or "message").upper()
+        if message.get("role") == "tool":
+            name = str(message.get("name") or "tool")
+            role = f"TOOL {name}"
+
+        content = message.get("content")
+        omitted_blocks = 0
+        if isinstance(content, str):
+            text = content
+        elif isinstance(content, list):
+            parts: list[str] = []
+            for item in content:
+                if isinstance(item, dict) and item.get("type") == "text":
+                    part = item.get("text")
+                    if isinstance(part, str):
+                        parts.append(part)
+                    continue
+                if isinstance(item, str):
+                    parts.append(item)
+                    continue
+                omitted_blocks += 1
+            text = "\n".join(parts)
+            if omitted_blocks:
+                suffix = f"[{omitted_blocks} non-text block(s) omitted]"
+                text = f"{text}\n{suffix}" if text else suffix
+        elif content is None:
+            text = ""
+        else:
+            text = str(content)
+
+        if not text.strip() and message.get("role") == "assistant":
+            tool_names: list[str] = []
+            for call in message.get("tool_calls") or []:
+                if not isinstance(call, dict):
+                    continue
+                function = call.get("function")
+                if isinstance(function, dict) and function.get("name"):
+                    tool_names.append(str(function["name"]))
+            if tool_names:
+                text = "called tools: " + ", ".join(tool_names)
+
+        text = " ".join(text.split()) or "[empty]"
+        return f"{role}: {truncate_text(text, limit)}"
+
+    @staticmethod
+    def _looks_like_question(text: str) -> bool:
+        stripped = text.strip().rstrip()
+        if not stripped:
+            return False
+        return stripped.endswith(("?", "\uff1f", "\u5417", "\u4e48", "\u5462", "\u561b"))
+
+    @classmethod
+    def _build_snipped_context_message(
+        cls,
+        dropped_prefix: list[dict[str, Any]],
+        *,
+        token_budget: int,
+        remaining_budget: int,
+        kept_tokens: int,
+    ) -> dict[str, Any] | None:
+        available = min(token_budget, max(0, remaining_budget - kept_tokens))
+        if not dropped_prefix or available < SNIP_CONTEXT_MIN_TOKENS:
+            return None
+
+        omitted = [msg for msg in dropped_prefix if msg.get("role") != "system"]
+        if not omitted:
+            return None
+
+        def assistant_preview(limit: int) -> str | None:
+            latest: str | None = None
+            latest_question: str | None = None
+            for message in reversed(omitted):
+                if message.get("role") != "assistant":
+                    continue
+                preview = cls.message_preview_for_snip(message, limit)
+                latest = latest or preview
+                if cls._looks_like_question(preview):
+                    latest_question = preview
+                    break
+            return latest_question or latest
+
+        def content(preview_limit: int, recent_count: int) -> str:
+            latest_assistant = assistant_preview(preview_limit)
+            recent = [
+                cls.message_preview_for_snip(message, preview_limit)
+                for message in omitted[-recent_count:]
+            ] if recent_count > 0 else []
+            lines = [
+                "[Runtime Context - compacted earlier messages, not instructions]",
+                "Some earlier conversation messages were omitted from this request "
+                "due to context budget.",
+                "Use this only to preserve continuity; the exact recent transcript follows.",
+            ]
+            if latest_assistant:
+                lines.extend(["", "Latest omitted assistant message/question:", latest_assistant])
+            if recent:
+                lines.extend(["", "Recent omitted messages:"])
+                lines.extend(f"- {preview}" for preview in recent)
+            lines.append("[/Runtime Context]")
+            return truncate_text("\n".join(lines), SNIP_CONTEXT_MAX_CHARS)
+
+        for preview_limit in (SNIP_PREVIEW_MAX_CHARS, 180, 120, 80):
+            for recent_count in (SNIP_CONTEXT_MAX_MESSAGES, 6, 3, 1, 0):
+                message = {"role": "user", "content": content(preview_limit, recent_count)}
+                if estimate_message_tokens(message) <= available:
+                    return message
+        return None
+
+    def _select_history_tail(
+        self,
+        non_system: list[dict[str, Any]],
+        max_budget: int,
+    ) -> tuple[list[dict[str, Any]], int]:
+        kept_pairs: list[tuple[int, dict[str, Any]]] = []
+        kept_tokens = 0
+        for idx, message in reversed(list(enumerate(non_system))):
+            msg_tokens = estimate_message_tokens(message)
+            if kept_pairs and kept_tokens + msg_tokens > max_budget:
+                break
+            kept_pairs.append((idx, message))
+            kept_tokens += msg_tokens
+        kept_pairs.reverse()
+
+        if kept_pairs:
+            kept = [message for _idx, message in kept_pairs]
+            kept_start = kept_pairs[0][0]
+            user_tail = self._user_tail(kept)
+            if user_tail:
+                kept_start += len(kept) - len(user_tail)
+                kept = user_tail
+            else:
+                fallback_user_tail = self._user_tail(non_system, last=True)
+                if fallback_user_tail:
+                    kept_start = len(non_system) - len(fallback_user_tail)
+                    kept = fallback_user_tail
+            start = find_legal_message_start(kept)
+            if start:
+                kept_start += start
+                kept = kept[start:]
+            return kept, kept_start
+
+        fallback_len = min(len(non_system), 4)
+        kept_start = len(non_system) - fallback_len
+        kept = non_system[kept_start:]
+        start = find_legal_message_start(kept)
+        if start:
+            kept_start += start
+            kept = kept[start:]
+        return kept, kept_start
 
     def _legal_history_tail(
         self,

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -794,6 +794,8 @@ class Consolidator:
         self,
         session: Session,
         replay_max_messages: int | None,
+        *,
+        prior_summary: str | None = None,
     ) -> str | None:
         """Archive messages that would be hidden by the replay message window."""
         end_idx = self._replay_overflow_boundary(session, replay_max_messages)
@@ -808,10 +810,22 @@ class Consolidator:
             len(chunk),
             replay_max_messages,
         )
-        summary = await self.archive(chunk, session_key=session.key)
+        summary = await self.archive(
+            chunk,
+            session_key=session.key,
+            prior_summary=prior_summary,
+        )
         session.last_consolidated = end_idx
         self.sessions.save(session)
         return summary
+
+    @staticmethod
+    def _last_summary_text(session: Session) -> str | None:
+        meta = session.metadata.get("_last_summary")
+        if isinstance(meta, dict):
+            text = meta.get("text")
+            return text if isinstance(text, str) and text.strip() else None
+        return meta if isinstance(meta, str) and meta.strip() else None
 
     def _persist_last_summary(self, session: Session, summary: str | None) -> None:
         if summary and summary != "(nothing)":
@@ -829,8 +843,7 @@ class Consolidator:
         history = self._full_unconsolidated_history(session)
         channel, chat_id = (session.key.split(":", 1) if ":" in session.key else (None, None))
         # Include archived summary in estimation so the budget accounts for it.
-        meta = session.metadata.get("_last_summary")
-        summary = meta.get("text") if isinstance(meta, dict) else (meta if isinstance(meta, str) else None)
+        summary = self._last_summary_text(session)
         probe_messages = self._build_messages(
             history=history,
             current_message="[token-probe]",
@@ -867,6 +880,7 @@ class Consolidator:
         *,
         session_key: str | None = None,
         summary_messages: list[dict] | None = None,
+        prior_summary: str | None = None,
     ) -> str | None:
         """Summarize messages via LLM and append to history.jsonl.
 
@@ -882,6 +896,13 @@ class Consolidator:
         messages_to_summarize = summary_messages if summary_messages is not None else messages
         try:
             formatted = MemoryStore._format_messages(messages_to_summarize)
+            if prior_summary and prior_summary.strip():
+                formatted = (
+                    "[Previously archived summary]\n"
+                    f"{prior_summary.strip()}\n\n"
+                    "[New conversation messages]\n"
+                    f"{formatted}"
+                )
             formatted = self._truncate_to_token_budget(formatted)
             response = await self.provider.chat_with_retry(
                 model=self.model,
@@ -937,10 +958,14 @@ class Consolidator:
 
             budget = self._input_token_budget
             target = int(budget * self.consolidation_ratio)
+            rolling_summary = self._last_summary_text(session)
             last_summary = await self._consolidate_replay_overflow(
                 session,
                 replay_max_messages,
+                prior_summary=rolling_summary,
             )
+            if last_summary and last_summary != "(nothing)":
+                rolling_summary = last_summary
             try:
                 estimated, source = self.estimate_session_prompt_tokens(
                     session,
@@ -992,13 +1017,19 @@ class Consolidator:
                     source,
                     len(chunk),
                 )
-                summary = await self.archive(chunk, session_key=session.key)
+                summary = await self.archive(
+                    chunk,
+                    session_key=session.key,
+                    prior_summary=rolling_summary,
+                )
                 # Advance the cursor either way: on success the chunk was
                 # summarized; on failure archive() already raw-archived it as
                 # a breadcrumb. Re-archiving the same chunk on the next call
                 # would just emit duplicate [RAW] entries.
                 if summary:
                     last_summary = summary
+                    if summary != "(nothing)":
+                        rolling_summary = summary
                 session.last_consolidated = end_idx
                 self.sessions.save(session)
                 if not summary:
@@ -1068,6 +1099,7 @@ class Consolidator:
                     messages_to_remove,
                     session_key=session_key,
                     summary_messages=messages_to_summarize,
+                    prior_summary=self._last_summary_text(session),
                 )
 
             if summary and summary != "(nothing)":

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -93,6 +93,29 @@ class TestConsolidatorSummarize:
         entries = store.read_unprocessed_history(since_cursor=0)
         assert entries[0]["session_key"] == "telegram:chat-1"
 
+    async def test_archive_includes_prior_summary_in_prompt(
+        self,
+        consolidator,
+        mock_provider,
+    ):
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="Earlier auth work plus the new deployment decision.",
+            finish_reason="stop",
+        )
+        messages = [{"role": "user", "content": "deploy the auth fix"}]
+
+        await consolidator.archive(
+            messages,
+            prior_summary="Earlier summary: user fixed auth race condition.",
+        )
+
+        sent_messages = mock_provider.chat_with_retry.call_args.kwargs["messages"]
+        user_content = sent_messages[1]["content"]
+        assert "[Previously archived summary]" in user_content
+        assert "Earlier summary: user fixed auth race condition." in user_content
+        assert "[New conversation messages]" in user_content
+        assert "deploy the auth fix" in user_content
+
     async def test_summarize_raw_dumps_on_llm_failure(self, consolidator, mock_provider, store):
         """On LLM failure, raw-dump messages to HISTORY.md."""
         mock_provider.chat_with_retry.side_effect = Exception("API error")
@@ -231,6 +254,41 @@ class TestConsolidatorTokenBudget:
         assert session.last_consolidated == 14
         assert session.metadata["_last_summary"]["text"] == "old conversation summary"
         consolidator.sessions.save.assert_called()
+
+    async def test_token_consolidation_rolls_existing_metadata_summary(
+        self,
+        consolidator,
+    ):
+        consolidator._SAFETY_BUFFER = 0
+        session = Session(
+            key="test:rolling-summary",
+            metadata={
+                "_last_summary": {
+                    "text": "Earlier summary: user fixed auth race condition.",
+                    "last_active": "2026-06-01T10:00:00",
+                }
+            },
+        )
+        session.add_message("user", "deploy the auth fix")
+        session.add_message("assistant", "Deployed.")
+        session.add_message("user", "write release notes")
+
+        consolidator.sessions._session_cache[session.key] = session
+        consolidator.estimate_session_prompt_tokens = MagicMock(
+            side_effect=[(1000, "tiktoken"), (100, "tiktoken")]
+        )
+        consolidator.archive = AsyncMock(
+            return_value="Earlier auth work plus the new deployment decision."
+        )
+
+        await consolidator.maybe_consolidate_by_tokens(session)
+
+        assert consolidator.archive.await_args.kwargs["prior_summary"] == (
+            "Earlier summary: user fixed auth race condition."
+        )
+        assert session.metadata["_last_summary"]["text"] == (
+            "Earlier auth work plus the new deployment decision."
+        )
 
     async def test_replay_window_overflow_extends_to_long_recent_user_turn(
         self,

--- a/tests/agent/test_loop_consolidation_tokens.py
+++ b/tests/agent/test_loop_consolidation_tokens.py
@@ -221,7 +221,7 @@ async def test_preflight_consolidation_before_llm_call(tmp_path, monkeypatch) ->
 
     archived_session_keys: list[str | None] = []
 
-    async def track_consolidate(messages, *, session_key=None):
+    async def track_consolidate(messages, *, session_key=None, prior_summary=None):
         order.append("consolidate")
         archived_session_keys.append(session_key)
         return True

--- a/tests/agent/test_runner_governance.py
+++ b/tests/agent/test_runner_governance.py
@@ -190,6 +190,170 @@ def test_snip_history_reserves_budget_for_tool_definitions(monkeypatch):
     assert contents == ["system", "recent two"]
 
 
+def test_snip_history_injects_compacted_anchor_for_dropped_prefix(monkeypatch):
+    provider = MagicMock()
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "older setup"},
+        {
+            "role": "assistant",
+            "content": "I found three task groups. Should I create these tasks now?",
+        },
+        {"role": "user", "content": "yes, please do it"},
+    ]
+    spec = AgentRunSpec(
+        initial_messages=messages,
+        tools=tools,
+        model="test-model",
+        max_iterations=1,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        context_window_tokens=2000,
+        context_block_limit=820,
+    )
+
+    def _estimate(_provider, _model, estimate_messages, _tools):
+        if estimate_messages == [{"role": "system", "content": "system"}]:
+            return 100, None
+        return 2000, None
+
+    def _tokens(message):
+        content = str(message.get("content"))
+        if "Runtime Context - compacted earlier messages" in content:
+            return 100
+        return {
+            "system": 50,
+            "older setup": 300,
+            "I found three task groups. Should I create these tasks now?": 240,
+            "yes, please do it": 80,
+        }.get(content, 80)
+
+    monkeypatch.setattr("nanobot.agent.context_governance.estimate_prompt_tokens_chain", _estimate)
+    monkeypatch.setattr("nanobot.agent.context_governance.estimate_message_tokens", _tokens)
+
+    trimmed = ContextGovernor().snip_history(_governance_config(provider, tools, spec), messages)
+
+    assert trimmed[0]["role"] == "system"
+    anchor = trimmed[1]
+    assert anchor["role"] == "user"
+    assert "Runtime Context - compacted earlier messages" in anchor["content"]
+    assert "Should I create these tasks now?" in anchor["content"]
+    assert trimmed[-1]["content"] == "yes, please do it"
+
+
+async def test_snip_anchor_is_request_only_not_persisted(monkeypatch):
+    from nanobot.agent.runner import AgentRunner
+
+    provider = MagicMock()
+    captured_messages: list[dict] = []
+
+    async def chat_with_retry(*, messages, **kwargs):
+        captured_messages[:] = messages
+        return LLMResponse(content="done", tool_calls=[], usage={})
+
+    provider.chat_with_retry = chat_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    initial_messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "older setup"},
+        {
+            "role": "assistant",
+            "content": "I found three task groups. Should I create these tasks now?",
+        },
+        {"role": "user", "content": "yes, please do it"},
+    ]
+
+    def _estimate(_provider, _model, estimate_messages, _tools):
+        if estimate_messages == [{"role": "system", "content": "system"}]:
+            return 100, None
+        return 2000, None
+
+    def _tokens(message):
+        content = str(message.get("content"))
+        if "Runtime Context - compacted earlier messages" in content:
+            return 100
+        return {
+            "system": 50,
+            "older setup": 300,
+            "I found three task groups. Should I create these tasks now?": 240,
+            "yes, please do it": 80,
+            "done": 20,
+        }.get(content, 80)
+
+    monkeypatch.setattr("nanobot.agent.context_governance.estimate_prompt_tokens_chain", _estimate)
+    monkeypatch.setattr("nanobot.agent.context_governance.estimate_message_tokens", _tokens)
+
+    result = await AgentRunner(provider).run(AgentRunSpec(
+        initial_messages=initial_messages,
+        tools=tools,
+        model="test-model",
+        max_iterations=1,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        context_window_tokens=2000,
+        context_block_limit=820,
+    ))
+
+    assert any(
+        "Runtime Context - compacted earlier messages" in str(message.get("content"))
+        for message in captured_messages
+    )
+    assert not any(
+        "Runtime Context - compacted earlier messages" in str(message.get("content"))
+        for message in result.messages
+    )
+
+
+def test_snip_history_omits_anchor_when_budget_is_too_small(monkeypatch):
+    provider = MagicMock()
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "older setup"},
+        {"role": "assistant", "content": "Should I create these tasks now?"},
+        {"role": "user", "content": "yes"},
+    ]
+    spec = AgentRunSpec(
+        initial_messages=messages,
+        tools=tools,
+        model="test-model",
+        max_iterations=1,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        context_window_tokens=2000,
+        context_block_limit=200,
+    )
+
+    def _estimate(_provider, _model, estimate_messages, _tools):
+        if estimate_messages == [{"role": "system", "content": "system"}]:
+            return 100, None
+        return 2000, None
+
+    monkeypatch.setattr("nanobot.agent.context_governance.estimate_prompt_tokens_chain", _estimate)
+    monkeypatch.setattr("nanobot.agent.context_governance.estimate_message_tokens", lambda _msg: 80)
+
+    trimmed = ContextGovernor().snip_history(_governance_config(provider, tools, spec), messages)
+
+    assert not any(
+        "Runtime Context - compacted earlier messages" in str(message.get("content"))
+        for message in trimmed
+    )
+
+
+def test_snip_preview_handles_multimodal_content():
+    preview = ContextGovernor.message_preview_for_snip({
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "look at this"},
+            {"type": "image_url", "image_url": {"url": "file://image.png"}},
+        ],
+    })
+
+    assert "look at this" in preview
+    assert "non-text block(s) omitted" in preview
+
+
 async def test_backfill_missing_tool_results_inserts_error():
     """Orphaned tool_use (no matching tool_result) should get a synthetic error."""
 


### PR DESCRIPTION
- Related to HKUDS/nanobot#4044
I went through the short-term memory loss issue as follows:

1. When building context, in the persisted `session.messages` message list, the message history after the `consolidate` pointer but before the range covered by the configured `max_messages` may not enter the current context in its original form. The current code handles this by compressing that part into `history.jsonl` and `metadata`'s `_last_summary`.

   There is a timing difference here: the newly generated `_last_summary` usually cannot enter the current `prompt` in the same turn as `[Archived Context Summary]`, because `pending_summary` has already been generated from `auto_compact.prepare_session()` before context construction; the new `_last_summary` written after `consolidate` is too late to be backfilled into that `pending_summary`. However, if this `consolidate` happens in the `BUILD` stage and before `build_system_prompt()`, the summary written to `history.jsonl` will still be read into the current context as `# Recent History`.

   The drawback in the current code is that generating a dedicated summary for this interval may instead overwrite an earlier and more valuable `_last_summary` in `metadata`. This can be addressed by the rolling summary mechanism described in point 2. In addition, reasonably increasing `max_messages` in the config file (the default of 120 messages may not always be enough) may help; however, `max_messages` cannot be increased indefinitely. Otherwise, the `BUILD` stage may already fill the history too much, and after `_snip_history()` is triggered inside the `React` loop, the current request may still lose context continuity again (as described in point 3).

2. The current `_last_summary` in `metadata` is a single overwrite slot, which can cause earlier archived summaries to be lost directly after a new round of `consolidation`. A better approach is to change summary overwriting into a rolling summary: whenever a new summary is generated, do not summarize only the newly archived message `chunk`; instead, include the existing `_last_summary` from `metadata` as the `prior summary` in the archival `prompt`, and let the `LLM` produce the merged result of "old summary + new `chunk`". This way, `metadata` still stores only one `_last_summary`, but it represents the continuously rolled-up summary rather than an isolated summary of the latest `chunk`.

3. After entering the `React` loop, before each real model request, the model context from `get_history()` is slimmed again according to the `token` budget. If `_snip_history()` truncates messages at this step, then even with the change from point 2, summaries are still not immediately injected back under the current code logic: neither `metadata["_last_summary"]` nor `history.jsonl` has a new runtime injection path inside the `React loop`; they are only read again in the next `BUILD` turn. This means the model may not see the context removed by `runtime snip` in the current request. For example, it may only see the user's "yes, please do it", but not see what the `assistant` had just asked.

The main changes are as follows:

1. Change hard summary overwrites into rolling summaries (necessary).

   In `memory.py`, add `_last_summary_text()` to consistently read the available summary text from `session.metadata["_last_summary"]`. Add a `prior_summary` parameter to `archive()`: when an old summary exists, it is placed into the current `consolidation prompt` as `[Previously archived summary]`, and the newly archived messages are provided together as `[New conversation messages]` for the `LLM` to summarize.

   This change wires in all three paths that write `_last_summary`:

   - `replay-window consolidation`
   - `token-budget consolidation`
   - `idle-session compaction`

   As a result, the new `_last_summary` is no longer only a summary of "the latest archived messages"; it is the rolling result of "existing archived summary + newly archived messages". If the `LLM` returns `(nothing)` or archival fails, the existing summary will not be wiped by an empty result.

2. When conversation history exceeds the context-window budget, `_snip_history` silently drops older messages. This can lose key information such as an `assistant` question in the truncated prefix, causing the tail messages received by the model (such as an isolated "yes, please do it") to lose conversational continuity. This change adds a compact context anchor mechanism in `runner.py`: between the dropped prefix and the kept tail, it injects a synthetic `user` message marked with `[Runtime Context]`, containing a preview summary of omitted messages (prioritizing the latest `assistant` question), and this anchor is only sent to the model without being persisted.

   A progressive degradation strategy is also added: preview length and message count are reduced step by step; if the budget is still insufficient, the anchor is skipped automatically and the behavior falls back to keeping the full-budget tail. `test_runner_governance.py` adds tests covering anchor injection, non-persistence, skipping under insufficient budget, multimodal preview, and other key paths.

3. This change deliberately keeps the following boundaries unchanged:

   - No new config option
   - No change to `public API`
   - No change to `session schema`, `metadata schema`, or the `history.jsonl` format
   - No reading or writing of `history.jsonl` or `_last_summary` inside the `React loop`
   - The `runtime snip anchor` only affects the current model request and does not enter persisted `session.messages`

Verification:

```powershell
ruff check nanobot/agent/runner.py nanobot/agent/memory.py tests/agent/test_runner_governance.py tests/agent/test_consolidator.py tests/agent/test_loop_consolidation_tokens.py
python -m pytest tests/agent/test_consolidator.py tests/agent/test_loop_consolidation_tokens.py tests/agent/test_auto_compact.py -q
python -m pytest tests/agent/test_runner_governance.py tests/agent/test_runner_core.py tests/agent/test_runner_injections.py -q
git diff --check
```

All verification above has passed. 