### PR TITLE
feat: add file management features to the settings view

### DIFF
--- a/nanobot/webui/files_api.py
+++ b/nanobot/webui/files_api.py
@@ -1,0 +1,394 @@
+"""Workspace-scoped file listing for the WebUI."""
+
+from __future__ import annotations
+
+import base64 as _base64
+import mimetypes
+import os
+import secrets
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+MAX_FILE_PREVIEW_BYTES = 512 * 1024
+MAX_DIR_ENTRIES = 500
+MAX_CHUNK_B64_BYTES = 1024
+
+_upload_sessions: dict[str, "UploadSession"] = {}
+
+
+@dataclass
+class UploadSession:
+    upload_id: str
+    filename: str
+    target_path: Path
+    total_chunks: int
+    chunks: dict[int, bytes] = field(default_factory=dict)
+    created_at: float = field(default_factory=time.monotonic)
+
+
+def upload_init_payload(
+    workspace_path: Path,
+    raw_path: str,
+    filename: str,
+    total_chunks: int,
+) -> dict[str, Any]:
+    target_dir = (workspace_path / raw_path.lstrip("/")).resolve()
+    if not target_dir.is_relative_to(workspace_path):
+        return _error_payload(403, "Path is outside the workspace")
+
+    upload_id = secrets.token_urlsafe(16)
+    _upload_sessions[upload_id] = UploadSession(
+        upload_id=upload_id,
+        filename=filename,
+        target_path=target_dir,
+        total_chunks=total_chunks,
+    )
+    return {"ok": True, "upload_id": upload_id, "total_chunks": total_chunks}
+
+
+def upload_chunk_payload(
+    upload_id: str,
+    chunk_index: int,
+    chunk_b64: str,
+) -> dict[str, Any]:
+    session = _upload_sessions.get(upload_id)
+    if session is None:
+        return _error_payload(404, "Upload session not found")
+    if chunk_index < 0 or chunk_index >= session.total_chunks:
+        return _error_payload(400, "Invalid chunk index")
+    if len(chunk_b64) > MAX_CHUNK_B64_BYTES:
+        return _error_payload(413, f"Chunk too large. Maximum is {MAX_CHUNK_B64_BYTES} base64 bytes.")
+
+    try:
+        chunk_data = _base64.b64decode(chunk_b64, validate=True)
+    except Exception:
+        return _error_payload(400, "Invalid base64 chunk")
+
+    session.chunks[chunk_index] = chunk_data
+    received = len(session.chunks)
+    return {"ok": True, "upload_id": upload_id, "chunk_index": chunk_index, "received": received, "total": session.total_chunks}
+
+
+def upload_finalize_payload(upload_id: str) -> dict[str, Any]:
+    session = _upload_sessions.pop(upload_id, None)
+    if session is None:
+        return _error_payload(404, "Upload session not found")
+
+    if len(session.chunks) != session.total_chunks:
+        missing = set(range(session.total_chunks)) - set(session.chunks.keys())
+        return _error_payload(400, f"Missing chunks: {sorted(missing)}")
+
+    try:
+        full_content = b"".join(session.chunks[i] for i in range(session.total_chunks))
+        target = session.target_path / session.filename
+        if not target.is_relative_to(session.target_path):
+            return _error_payload(403, "Invalid filename")
+        session.target_path.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(full_content)
+    except OSError as e:
+        return _error_payload(500, f"Failed to write file: {e}")
+
+    return {"ok": True, "path": str(target), "size": len(full_content)}
+
+EXCLUDED_NAMES = {
+    "__pycache__",
+    ".git",
+    ".venv",
+    "node_modules",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".mypy_cache",
+    ".tox",
+    "dist",
+    "build",
+    ".egg-info",
+    ".DS_Store",
+    "Thumbs.db",
+}
+
+EXCLUDED_PREFIXES = (".",)
+
+
+def _is_hidden(name: str) -> bool:
+    if name in EXCLUDED_NAMES:
+        return True
+    for prefix in EXCLUDED_PREFIXES:
+        if name.startswith(prefix):
+            return True
+    return False
+
+
+def _sort_entries(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def key(entry: dict[str, Any]) -> tuple[int, str]:
+        if entry["is_dir"]:
+            return (0, entry["name"].lower())
+        return (1, entry["name"].lower())
+
+    return sorted(entries, key=key)
+
+
+def files_list_payload(
+    workspace_path: Path,
+    raw_path: str | None = None,
+) -> dict[str, Any]:
+    """Return directory entries for a path inside the workspace."""
+    if raw_path is None:
+        target = workspace_path
+    else:
+        target = (workspace_path / raw_path.lstrip("/")).resolve()
+
+    if not target.exists():
+        return _error_payload(404, "Directory not found")
+    if not target.is_dir():
+        return _error_payload(400, "Path is not a directory")
+    if not target.is_relative_to(workspace_path):
+        return _error_payload(403, "Path is outside the workspace")
+
+    try:
+        raw_entries = os.scandir(target)
+    except OSError:
+        return _error_payload(403, "Cannot read directory")
+
+    entries: list[dict[str, Any]] = []
+    count = 0
+    for entry in raw_entries:
+        if _is_hidden(entry.name):
+            continue
+        if count >= MAX_DIR_ENTRIES:
+            break
+        try:
+            stat = entry.stat()
+            rel = target / entry.name
+            entries.append(
+                {
+                    "name": entry.name,
+                    "is_dir": entry.is_dir(),
+                    "size": stat.st_size if not entry.is_dir() else 0,
+                    "mtime": stat.st_mtime,
+                }
+            )
+            count += 1
+        except OSError:
+            continue
+
+    display_path = _relative_path(target, workspace_path)
+    return {
+        "path": str(target),
+        "display_path": display_path,
+        "workspace_path": str(workspace_path),
+        "entries": _sort_entries(entries),
+        "has_more": count >= MAX_DIR_ENTRIES,
+    }
+
+
+def file_content_payload(
+    workspace_path: Path,
+    raw_path: str,
+) -> dict[str, Any]:
+    """Return the content of a file inside the workspace."""
+    target = (workspace_path / raw_path.lstrip("/")).resolve()
+
+    if not target.exists():
+        return _error_payload(404, "File not found")
+    if not target.is_file():
+        return _error_payload(400, "Path is not a file")
+    if not target.is_relative_to(workspace_path):
+        return _error_payload(403, "Path is outside the workspace")
+
+    size = target.stat().st_size
+    if size > MAX_FILE_PREVIEW_BYTES:
+        return _error_payload(413, f"File is too large ({size} bytes). Maximum is {MAX_FILE_PREVIEW_BYTES} bytes.")
+
+    try:
+        with open(target, "rb") as f:
+            raw = f.read(MAX_FILE_PREVIEW_BYTES + 1)
+    except OSError:
+        return _error_payload(500, "Failed to read file")
+
+    if b"\0" in raw[:4096]:
+        return _error_payload(415, "Binary files cannot be previewed as text")
+
+    truncated = len(raw) > MAX_FILE_PREVIEW_BYTES
+    preview_bytes = raw[:MAX_FILE_PREVIEW_BYTES]
+
+    try:
+        content = preview_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        content = preview_bytes.decode("utf-8", errors="replace")
+
+    mime = mimetypes.guess_type(str(target))[0]
+    return {
+        "path": str(target),
+        "display_path": _relative_path(target, workspace_path),
+        "language": _language_for_path(target),
+        "mime": mime,
+        "content": content,
+        "size": size,
+        "truncated": truncated,
+    }
+
+
+MAX_DOWNLOAD_SIZE_BYTES = 64 * 1024 * 1024
+MAX_UPLOAD_SIZE_BYTES = 10 * 1024 * 1024
+
+
+def file_download_info(
+    workspace_path: Path,
+    raw_path: str,
+) -> tuple[dict[str, Any], bytes | None]:
+    """Return file metadata and bytes for download. Bytes may be None on error."""
+    target = (workspace_path / raw_path.lstrip("/")).resolve()
+
+    if not target.exists():
+        return (_error_payload(404, "File not found"), None)
+    if not target.is_file():
+        return (_error_payload(400, "Path is not a file"), None)
+    if not target.is_relative_to(workspace_path):
+        return (_error_payload(403, "Path is outside the workspace"), None)
+
+    try:
+        raw = target.read_bytes()
+    except OSError:
+        return (_error_payload(500, "Failed to read file"), None)
+
+    size = len(raw)
+    if size > MAX_DOWNLOAD_SIZE_BYTES:
+        return (_error_payload(413, f"File too large ({size} bytes). Maximum is {MAX_DOWNLOAD_SIZE_BYTES} bytes."), None)
+
+    meta = {
+        "name": target.name,
+        "size": size,
+        "mime": mimetypes.guess_type(str(target))[0] or "application/octet-stream",
+    }
+    return (meta, raw)
+
+
+def file_delete_payload(
+    workspace_path: Path,
+    raw_path: str,
+) -> dict[str, Any]:
+    """Delete a file or empty directory inside the workspace."""
+    target = (workspace_path / raw_path.lstrip("/")).resolve()
+
+    if not target.exists():
+        return _error_payload(404, "Path not found")
+    if not target.is_relative_to(workspace_path):
+        return _error_payload(403, "Path is outside the workspace")
+
+    try:
+        if target.is_dir():
+            if any(target.iterdir()):
+                return _error_payload(409, "Directory is not empty")
+            target.rmdir()
+        else:
+            target.unlink()
+    except OSError as e:
+        return _error_payload(500, f"Failed to delete: {e}")
+
+    return {"ok": True, "deleted": str(target)}
+
+
+def file_upload_payload(
+    workspace_path: Path,
+    raw_path: str,
+    content_b64: str,
+    filename: str,
+) -> dict[str, Any]:
+    """Save a file (base64-encoded content) inside the workspace."""
+    if len(content_b64) > MAX_UPLOAD_SIZE_BYTES * 4 // 3:
+        return _error_payload(413, f"File too large. Maximum size is {MAX_UPLOAD_SIZE_BYTES} bytes.")
+
+    try:
+        content = _base64.b64decode(content_b64, validate=True)
+    except Exception:
+        return _error_payload(400, "Invalid base64 content")
+
+    target_dir = (workspace_path / raw_path.lstrip("/")).resolve()
+    if not target_dir.is_relative_to(workspace_path):
+        return _error_payload(403, "Path is outside the workspace")
+
+    try:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target = target_dir / filename
+        if not target.is_relative_to(target_dir):
+            return _error_payload(403, "Invalid filename")
+        target.write_bytes(content)
+    except OSError as e:
+        return _error_payload(500, f"Failed to write file: {e}")
+
+    return {"ok": True, "path": str(target), "size": len(content)}
+
+
+def file_save_payload(
+    workspace_path: Path,
+    raw_path: str,
+    content: str,
+) -> dict[str, Any]:
+    """Save text content to a file inside the workspace."""
+    target = (workspace_path / raw_path.lstrip("/")).resolve()
+
+    if not target.is_relative_to(workspace_path):
+        return _error_payload(403, "Path is outside the workspace")
+
+    try:
+        target.write_text(content, encoding="utf-8")
+    except OSError as e:
+        return _error_payload(500, f"Failed to save file: {e}")
+
+    return {"ok": True, "path": str(target), "size": len(content.encode("utf-8"))}
+
+
+def _error_payload(status: int, message: str) -> dict[str, Any]:
+    return {"error": message, "status": status}
+
+
+def _relative_path(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _language_for_path(path: Path) -> str:
+    name = path.name.lower()
+    ext = path.suffix.lower().lstrip(".")
+    if name == "dockerfile":
+        return "dockerfile"
+    return {
+        "cjs": "javascript",
+        "css": "css",
+        "cts": "typescript",
+        "html": "html",
+        "js": "javascript",
+        "json": "json",
+        "jsonl": "json",
+        "jsx": "jsx",
+        "md": "markdown",
+        "mdx": "markdown",
+        "mjs": "javascript",
+        "mts": "typescript",
+        "py": "python",
+        "pyi": "python",
+        "scss": "scss",
+        "sh": "bash",
+        "toml": "toml",
+        "ts": "typescript",
+        "tsx": "tsx",
+        "yaml": "yaml",
+        "yml": "yaml",
+        "txt": "text",
+        "rs": "rust",
+        "go": "go",
+        "java": "java",
+        "c": "c",
+        "cpp": "cpp",
+        "h": "c",
+        "hpp": "cpp",
+        "css": "css",
+        "less": "less",
+        "svg": "xml",
+        "xml": "xml",
+        "sql": "sql",
+    }.get(ext, ext or "text")

--- a/nanobot/webui/ws_http.py
+++ b/nanobot/webui/ws_http.py
@@ -19,10 +19,22 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 from websockets.http11 import Request as WsRequest
 from websockets.http11 import Response
+from websockets.datastructures import Headers
 
 from nanobot.command.builtin import builtin_command_palette
 from nanobot.utils.subagent_channel_display import scrub_subagent_messages_for_channel
 from nanobot.webui.file_preview import WebUIFilePreviewError, file_preview_payload
+from nanobot.webui.files_api import (
+    file_content_payload,
+    file_delete_payload,
+    file_download_info,
+    file_save_payload,
+    file_upload_payload,
+    files_list_payload,
+    upload_chunk_payload,
+    upload_finalize_payload,
+    upload_init_payload,
+)
 from nanobot.webui.gateway_tokens import GatewayTokenStore, token_response_payload
 from nanobot.webui.http_utils import (
     case_insensitive_header as _case_insensitive_header,
@@ -471,6 +483,32 @@ class GatewayHTTPHandler:
             return self._handle_webui_sidebar_state(request)
         if got == "/api/webui/sidebar-state/update":
             return self._handle_webui_sidebar_state_update(request)
+        if got == "/api/webui/files":
+            return self._handle_webui_files(request)
+        m = re.match(r"^/api/webui/files/read$", got)
+        if m:
+            return self._handle_webui_files_read(request)
+        m = re.match(r"^/api/webui/files/delete$", got)
+        if m:
+            return self._handle_webui_files_delete(request)
+        m = re.match(r"^/api/webui/files/download$", got)
+        if m:
+            return self._handle_webui_files_download(request)
+        m = re.match(r"^/api/webui/files/upload$", got)
+        if m:
+            return self._handle_webui_files_upload(request)
+        m = re.match(r"^/api/webui/files/upload/init$", got)
+        if m:
+            return self._handle_webui_files_upload_init(request)
+        m = re.match(r"^/api/webui/files/upload/chunk$", got)
+        if m:
+            return self._handle_webui_files_upload_chunk(request)
+        m = re.match(r"^/api/webui/files/upload/finalize$", got)
+        if m:
+            return self._handle_webui_files_upload_finalize(request)
+        m = re.match(r"^/api/webui/files/save$", got)
+        if m:
+            return self._handle_webui_files_save(request)
         return None
 
     def _handle_commands(self, request: WsRequest) -> Response:
@@ -540,6 +578,158 @@ class GatewayHTTPHandler:
             self._log.exception("failed to write webui sidebar state")
             return _http_error(500, "failed to write sidebar state")
         return _http_json_response(state)
+
+    def _handle_webui_files(self, request: WsRequest) -> Response:
+        if not self.check_api_token(request):
+            return _http_error(401, "Unauthorized")
+        query = _parse_query(request.path)
+        raw_path = _query_first(query, "path")
+        payload = files_list_payload(self.skills_workspace_path, raw_path)
+        status = payload.pop("status", 200) if "error" in payload else 200
+        return _http_json_response(payload, status=status)
+
+    def _handle_webui_files_read(self, request: WsRequest) -> Response:
+        if not self.check_api_token(request):
+            return _http_error(401, "Unauthorized")
+        query = _parse_query(request.path)
+        raw_path = _query_first(query, "path")
+        if not raw_path:
+            return _http_error(400, "missing path parameter")
+        payload = file_content_payload(self.skills_workspace_path, raw_path)
+        status = payload.pop("status", 200) if "error" in payload else 200
+        return _http_json_response(payload, status=status)
+
+    def _handle_webui_files_delete(self, request: WsRequest) -> Response:
+        if not self.check_api_token(request):
+            return _http_error(401, "Unauthorized")
+        query = _parse_query(request.path)
+        raw_path = _query_first(query, "path")
+        if not raw_path:
+            return _http_error(400, "missing path parameter")
+        payload = file_delete_payload(self.skills_workspace_path, raw_path)
+        status = payload.pop("status", 200) if "error" in payload else 200
+        return _http_json_response(payload, status=status)
+
+    def _handle_webui_files_download(self, request: WsRequest) -> Response:
+        if not self.check_api_token(request):
+            return _http_error(401, "Unauthorized")
+        query = _parse_query(request.path)
+        raw_path = _query_first(query, "path")
+        if not raw_path:
+            return _http_error(400, "missing path parameter")
+        meta, raw = file_download_info(self.skills_workspace_path, raw_path)
+        if raw is None:
+            status = meta.pop("status", 200)
+            return _http_json_response(meta, status=status)
+        name = meta["name"]
+        disposition = f'attachment; filename="{name}"'
+        import email.utils as _email_utils
+
+        headers = [
+            ("Date", _email_utils.formatdate(usegmt=True)),
+            ("Connection", "close"),
+            ("Content-Length", str(len(raw))),
+            ("Content-Type", meta["mime"]),
+            ("Content-Disposition", disposition),
+        ]
+        return Response(200, "OK", Headers(headers), raw)
+
+    def _handle_webui_files_upload(self, request: WsRequest) -> Response:
+        self._log.debug("[files] upload request path={}", request.path)
+        if not self.check_api_token(request):
+            return _http_error(401, "Unauthorized")
+        query = _parse_query(request.path)
+        raw_path = _query_first(query, "path")
+        filename = _query_first(query, "filename")
+        content_b64 = _query_first(query, "content")
+        self._log.debug("[files] upload params: path={} filename={} content_len={}", raw_path, filename, len(content_b64) if content_b64 else 0)
+        if not raw_path:
+            return _http_error(400, "missing path parameter")
+        if not filename:
+            return _http_error(400, "missing filename parameter")
+        if not content_b64:
+            return _http_error(400, "missing content parameter")
+        payload = file_upload_payload(self.skills_workspace_path, raw_path, content_b64, filename)
+        self._log.debug("[files] upload result: {}", payload)
+        status = payload.pop("status", 200) if "error" in payload else 200
+        return _http_json_response(payload, status=status)
+
+    def _handle_webui_files_upload_init(self, request: WsRequest) -> Response:
+        if not self.check_api_token(request):
+            return _http_error(401, "Unauthorized")
+        query = _parse_query(request.path)
+        raw_path = _query_first(query, "path")
+        filename = _query_first(query, "filename")
+        total_chunks = _query_first(query, "total_chunks")
+        if not raw_path:
+            return _http_error(400, "missing path parameter")
+        if not filename:
+            return _http_error(400, "missing filename parameter")
+        if not total_chunks:
+            return _http_error(400, "missing total_chunks parameter")
+        try:
+            total_chunks_int = int(total_chunks)
+        except ValueError:
+            return _http_error(400, "total_chunks must be an integer")
+        if total_chunks_int < 1:
+            return _http_error(400, "total_chunks must be >= 1")
+        payload = upload_init_payload(self.skills_workspace_path, raw_path, filename, total_chunks_int)
+        status = payload.pop("status", 200) if "error" in payload else 200
+        return _http_json_response(payload, status=status)
+
+    def _handle_webui_files_upload_chunk(self, request: WsRequest) -> Response:
+        if not self.check_api_token(request):
+            return _http_error(401, "Unauthorized")
+        query = _parse_query(request.path)
+        upload_id = _query_first(query, "upload_id")
+        chunk_index_str = _query_first(query, "chunk_index")
+        chunk_b64 = _query_first(query, "chunk")
+        if not upload_id:
+            return _http_error(400, "missing upload_id parameter")
+        if not chunk_index_str:
+            return _http_error(400, "missing chunk_index parameter")
+        if not chunk_b64:
+            return _http_error(400, "missing chunk parameter")
+        try:
+            chunk_index = int(chunk_index_str)
+        except ValueError:
+            return _http_error(400, "chunk_index must be an integer")
+        payload = upload_chunk_payload(upload_id, chunk_index, chunk_b64)
+        status = payload.pop("status", 200) if "error" in payload else 200
+        return _http_json_response(payload, status=status)
+
+    def _handle_webui_files_upload_finalize(self, request: WsRequest) -> Response:
+        if not self.check_api_token(request):
+            return _http_error(401, "Unauthorized")
+        query = _parse_query(request.path)
+        upload_id = _query_first(query, "upload_id")
+        if not upload_id:
+            return _http_error(400, "missing upload_id parameter")
+        payload = upload_finalize_payload(upload_id)
+        status = payload.pop("status", 200) if "error" in payload else 200
+        return _http_json_response(payload, status=status)
+
+    _FILE_SAVE_HEADER = "X-Nanobot-File-Content"
+
+    def _handle_webui_files_save(self, request: WsRequest) -> Response:
+        if not self.check_api_token(request):
+            return _http_error(401, "Unauthorized")
+        query = _parse_query(request.path)
+        raw_path = _query_first(query, "path")
+        if not raw_path:
+            return _http_error(400, "missing path parameter")
+        raw_content = request.headers.get(self._FILE_SAVE_HEADER)
+        if not raw_content:
+            return _http_error(400, "missing X-Nanobot-File-Content header")
+        import base64 as _base64
+
+        try:
+            content = _base64.b64decode(raw_content).decode("utf-8")
+        except Exception:
+            return _http_error(400, "X-Nanobot-File-Content must be base64-encoded UTF-8 text")
+        payload = file_save_payload(self.skills_workspace_path, raw_path, content)
+        status = payload.pop("status", 200) if "error" in payload else 200
+        return _http_json_response(payload, status=status)
 
     # -- Static file serving ------------------------------------------------
 

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -70,7 +70,7 @@ const SIDEBAR_WIDTH = 272;
 const SIDEBAR_RAIL_WIDTH = 56;
 const TOKEN_REFRESH_MARGIN_MS = 30_000;
 const TOKEN_REFRESH_MIN_DELAY_MS = 5_000;
-type ShellView = "chat" | "settings" | "apps" | "skills";
+type ShellView = "chat" | "settings" | "apps" | "skills" | "files";
 type ShellRoute = {
   view: ShellView;
   activeKey: string | null;
@@ -86,6 +86,7 @@ const SETTINGS_SECTION_KEYS: SettingsSectionKey[] = [
   "browser",
   "apps",
   "skills",
+  "files",
   "runtime",
   "advanced",
 ];
@@ -99,7 +100,7 @@ function defaultShellRoute(): ShellRoute {
 }
 
 function shellViewForSettingsSection(section: SettingsSectionKey): ShellView {
-  if (section === "apps" || section === "skills") return section;
+  if (section === "apps" || section === "skills" || section === "files") return section;
   return "settings";
 }
 
@@ -130,6 +131,9 @@ function readShellRoute(): ShellRoute {
   }
   if (path === "/skills") {
     return { view: "skills", activeKey, settingsSection: "skills" };
+  }
+  if (path === "/files") {
+    return { view: "files", activeKey, settingsSection: "files" };
   }
   if (path.startsWith("/chat/")) {
     const encoded = path.slice("/chat/".length);
@@ -1161,6 +1165,12 @@ function Shell({
     setMobileSidebarOpen(false);
   }, [activeKey, navigate]);
 
+  const onOpenFiles = useCallback(() => {
+    setSessionSearchOpen(false);
+    navigate({ view: "files", activeKey, settingsSection: "files" });
+    setMobileSidebarOpen(false);
+  }, [activeKey, navigate]);
+
   const onSettingsSectionChange = useCallback(
     (section: SettingsSectionKey) => {
       navigate({
@@ -1322,6 +1332,12 @@ function Shell({
       });
       return;
     }
+    if (view === "files") {
+      document.title = t("app.documentTitle.chat", {
+        title: t("settings.nav.files", { defaultValue: "Files" }),
+      });
+      return;
+    }
     document.title = activeSession
       ? t("app.documentTitle.chat", { title: headerTitle })
       : t("app.documentTitle.base");
@@ -1344,8 +1360,9 @@ function Shell({
     onOpenSettings,
     onOpenApps,
     onOpenSkills,
+    onOpenFiles,
     onOpenSearch: onOpenSessionSearch,
-    activeUtility: view === "apps" || view === "skills" ? view : null,
+    activeUtility: view === "apps" || view === "skills" || view === "files" ? view : null,
     onToggleArchived,
     pinnedKeys: sidebarState.pinned_keys,
     archivedKeys: sidebarState.archived_keys,

--- a/webui/src/components/Sidebar.tsx
+++ b/webui/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactNode } from "react";
 import {
   Archive,
   Brain,
+  FolderOpen,
   Menu,
   Search,
   Settings,
@@ -36,8 +37,9 @@ interface SidebarProps {
   onOpenSettings: () => void;
   onOpenApps: () => void;
   onOpenSkills: () => void;
+  onOpenFiles: () => void;
   onOpenSearch: () => void;
-  activeUtility?: "apps" | "skills" | null;
+  activeUtility?: "apps" | "skills" | "files" | null;
   onToggleArchived: () => void;
   onCollapse: () => void;
   onExpand?: () => void;
@@ -165,6 +167,13 @@ export function Sidebar(props: SidebarProps) {
           onClick={props.onOpenSkills}
           active={props.activeUtility === "skills"}
           icon={<Brain className="h-4 w-4" />}
+        />
+        <SidebarActionButton
+          collapsed={collapsed}
+          label={t("sidebar.files.title")}
+          onClick={props.onOpenFiles}
+          active={props.activeUtility === "files"}
+          icon={<FolderOpen className="h-4 w-4" />}
         />
         {props.archivedCount ? (
           <SidebarActionButton

--- a/webui/src/components/settings/FilesBrowserSettings.tsx
+++ b/webui/src/components/settings/FilesBrowserSettings.tsx
@@ -1,0 +1,640 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Download,
+  Edit3,
+  File,
+  FileArchive,
+  FileAudio,
+  FileCode,
+  FileImage,
+  FileJson,
+  FileText,
+  Folder,
+  Loader2,
+  Plus,
+  RefreshCw,
+  Save,
+  Trash2,
+  X,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  deleteFile,
+  downloadFile,
+  fetchFileContent,
+  fetchFilesList,
+  saveFile,
+  uploadFileChunked,
+} from "@/lib/api";
+import type { FileContentPayload, FileEntry } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { useClient } from "@/providers/ClientProvider";
+
+export function FilesBrowserSettings() {
+  const { t } = useTranslation();
+  const { token } = useClient();
+  const [currentPath, setCurrentPath] = useState<string | null>(null);
+  const [breadcrumbs, setBreadcrumbs] = useState<string[]>([]);
+  const [entries, setEntries] = useState<FileEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [previewFile, setPreviewFile] = useState<string | null>(null);
+  const uploadPathRef = useRef<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [actionTarget, setActionTarget] = useState<{ path: string; name: string; isDir: boolean } | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const loadDir = useCallback(
+    async (path: string | null) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const payload = await fetchFilesList(token, path);
+        if (payload.error) {
+          setError(payload.error);
+          return;
+        }
+        setEntries(payload.entries);
+        setHasMore(payload.has_more);
+        setCurrentPath(path);
+        if (path === null) {
+          setBreadcrumbs([]);
+        } else {
+          setBreadcrumbs(path.split("/").filter(Boolean));
+        }
+      } catch {
+        setError(t("settings.files.loadError", { defaultValue: "Failed to load directory." }));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [token, t],
+  );
+
+  useEffect(() => {
+    void loadDir(null);
+  }, [loadDir]);
+
+  const navigateTo = (index: number) => {
+    if (index < 0) {
+      void loadDir(null);
+    } else {
+      const parts = breadcrumbs.slice(0, index + 1);
+      void loadDir(parts.join("/"));
+    }
+  };
+
+  const handleEntryClick = (entry: FileEntry) => {
+    if (entry.is_dir) {
+      const newPath = currentPath ? `${currentPath}/${entry.name}` : entry.name;
+      void loadDir(newPath);
+    } else {
+      const filePath = currentPath ? `${currentPath}/${entry.name}` : entry.name;
+      setPreviewFile(filePath);
+    }
+  };
+
+  const handleUploadClick = (path: string | null) => {
+    const targetPath = path ?? "/";
+    uploadPathRef.current = targetPath;
+    setUploadError(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+      fileInputRef.current.click();
+    }
+  };
+
+  const handleFileInputChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    const targetPath = uploadPathRef.current ?? "/";
+    console.log("[FilesBrowser] handleFileInputChange", { targetPath, files: files?.length });
+    if (!files || files.length === 0) {
+      console.log("[FilesBrowser] No files selected");
+      return;
+    }
+    if (!targetPath) {
+      console.log("[FilesBrowser] targetPath is empty");
+      setUploadError("Upload path is empty");
+      return;
+    }
+
+    setUploading(true);
+    setUploadError(null);
+    try {
+      for (const file of Array.from(files)) {
+        console.log("[FilesBrowser] Uploading:", file.name, file.size, "bytes to", targetPath);
+        const buffer = await file.arrayBuffer();
+        console.log("[FilesBrowser] buffer size:", buffer.byteLength);
+        const result = await uploadFileChunked(token, targetPath, file.name, buffer);
+        console.log("[FilesBrowser] uploadFileChunked result:", result);
+        if (result.error) {
+          console.log("[FilesBrowser] uploadFileChunked error:", result.error);
+          setUploadError(result.error);
+          return;
+        }
+      }
+      void loadDir(targetPath === "/" ? null : targetPath);
+    } catch (err) {
+      console.error("[FilesBrowser] upload catch error:", err);
+      setUploadError(t("settings.files.uploadError", { defaultValue: "Failed to upload file." }));
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  };
+
+  const handleDownload = async (entry: FileEntry) => {
+    const filePath = currentPath ? `${currentPath}/${entry.name}` : entry.name;
+    try {
+      const buffer = await downloadFile(token, filePath);
+      const blob = new Blob([buffer]);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = entry.name;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch {
+      setError(t("settings.files.downloadError", { defaultValue: "Failed to download file." }));
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!actionTarget) return;
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      const result = await deleteFile(token, actionTarget.path);
+      if (result.error) {
+        setDeleteError(result.error);
+        return;
+      }
+      setActionTarget(null);
+      void loadDir(currentPath);
+    } catch {
+      setDeleteError(t("settings.files.deleteError", { defaultValue: "Failed to delete." }));
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const formatSize = (bytes: number) => {
+    if (bytes === 0) return "—";
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+  };
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center justify-between gap-3">
+        <p className="max-w-[680px] text-[13px] leading-5 text-muted-foreground">
+          {t("settings.files.description", {
+            defaultValue: "Browse files in the agent workspace directory.",
+          })}
+        </p>
+        <div className="flex items-center gap-1 shrink-0">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => void loadDir(currentPath)}
+            disabled={loading}
+            title={t("settings.files.refresh", { defaultValue: "Refresh" })}
+          >
+            <RefreshCw className={cn("h-4 w-4", loading && "animate-spin")} aria-hidden />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => handleUploadClick(currentPath)}
+            disabled={uploading}
+            title={t("settings.files.upload", { defaultValue: "Upload" })}
+          >
+            {uploading ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+            ) : (
+              <Plus className="h-4 w-4" aria-hidden />
+            )}
+          </Button>
+        </div>
+      </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        className="hidden"
+        onChange={handleFileInputChange}
+      />
+
+      {uploadError && (
+        <div className="rounded-[14px] bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          {uploadError}
+        </div>
+      )}
+
+      {deleteError && (
+        <div className="rounded-[14px] bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          {deleteError}
+        </div>
+      )}
+
+      {breadcrumbs.length > 0 && (
+        <div className="flex items-center gap-1 overflow-x-auto text-[13px]">
+          <button
+            type="button"
+            onClick={() => navigateTo(-1)}
+            className="shrink-0 rounded px-1.5 py-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            {t("settings.files.workspace", { defaultValue: "Workspace" })}
+          </button>
+          {breadcrumbs.map((part, i) => (
+            <span key={i} className="flex items-center gap-1">
+              <span className="text-muted-foreground/40">/</span>
+              <button
+                type="button"
+                onClick={() => navigateTo(i)}
+                className={cn(
+                  "shrink-0 rounded px-1.5 py-0.5 transition-colors",
+                  i === breadcrumbs.length - 1
+                    ? "font-medium text-foreground"
+                    : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                )}
+              >
+                {part}
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+
+      {loading && entries.length === 0 ? (
+        <div className="flex items-center gap-2 py-12 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+          {t("settings.files.loading", { defaultValue: "Loading..." })}
+        </div>
+      ) : error ? (
+        <div className="rounded-[14px] bg-destructive/10 px-4 py-4 text-sm text-destructive">
+          {error}
+        </div>
+      ) : entries.length === 0 ? (
+        <div className="py-12 text-center text-sm text-muted-foreground">
+          {t("settings.files.empty", { defaultValue: "This directory is empty." })}
+        </div>
+      ) : (
+        <div className="space-y-0.5">
+          {entries.map((entry) => (
+            <FileRow
+              key={entry.name}
+              entry={entry}
+              onClick={() => handleEntryClick(entry)}
+              onDelete={() => {
+                const path = currentPath ? `${currentPath}/${entry.name}` : entry.name;
+                setActionTarget({ path, name: entry.name, isDir: entry.is_dir });
+              }}
+              onDownload={() => handleDownload(entry)}
+              formatSize={formatSize}
+            />
+          ))}
+          {hasMore && (
+            <div className="py-2 text-center text-[12px] text-muted-foreground">
+              {t("settings.files.truncated", { defaultValue: "Directory listing truncated." })}
+            </div>
+          )}
+        </div>
+      )}
+
+      <FilePreviewSheet path={previewFile} onClose={() => setPreviewFile(null)} />
+
+      <DeleteConfirmDialog
+        target={actionTarget}
+        onClose={() => setActionTarget(null)}
+        onConfirm={handleDelete}
+        deleting={deleting}
+      />
+    </div>
+  );
+}
+
+function FileRow({
+  entry,
+  onClick,
+  onDelete,
+  onDownload,
+  formatSize,
+}: {
+  entry: FileEntry;
+  onClick: () => void;
+  onDelete: () => void;
+  onDownload: () => void;
+  formatSize: (bytes: number) => string;
+}) {
+  const [hovered, setHovered] = useState(false);
+
+  return (
+    <div
+      className="group flex w-full min-w-0 items-center gap-1 rounded-[14px] px-3 py-2 transition-colors hover:bg-muted/40"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <button
+        type="button"
+        onClick={onClick}
+        className="flex min-w-0 flex-1 items-center gap-3 text-left"
+      >
+        <FileEntryIcon name={entry.name} isDir={entry.is_dir} />
+        <span className="min-w-0 flex-1 truncate text-[14px] font-medium text-foreground/90">
+          {entry.name}
+        </span>
+        {!entry.is_dir && (
+          <span className="shrink-0 text-[12px] text-muted-foreground">
+            {formatSize(entry.size)}
+          </span>
+        )}
+      </button>
+
+      <div
+        className={cn(
+          "flex items-center gap-0.5 transition-opacity",
+          hovered ? "opacity-100" : "opacity-0 pointer-events-none",
+        )}
+      >
+        {!entry.is_dir && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={(e) => { e.stopPropagation(); onDownload(); }}
+            title="Download"
+          >
+            <Download className="h-3.5 w-3.5" aria-hidden />
+          </Button>
+        )}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 text-destructive/70 hover:text-destructive"
+          onClick={(e) => { e.stopPropagation(); onDelete(); }}
+          title="Delete"
+        >
+          <Trash2 className="h-3.5 w-3.5" aria-hidden />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function DeleteConfirmDialog({
+  target,
+  onClose,
+  onConfirm,
+  deleting,
+}: {
+  target: { path: string; name: string; isDir: boolean } | null;
+  onClose: () => void;
+  onConfirm: () => void;
+  deleting: boolean;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <Dialog open={!!target} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="max-w-sm gap-0 overflow-hidden p-0">
+        <div className="flex items-start gap-3 px-5 pt-5">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-destructive/10">
+            <Trash2 className="h-5 w-5 text-destructive" aria-hidden />
+          </div>
+          <div className="min-w-0 flex-1 pt-1">
+            <DialogTitle className="text-[16px] font-semibold text-foreground">
+              {t("settings.files.deleteTitle", { defaultValue: "Delete {{name}}?", name: target?.name ?? "" })}
+            </DialogTitle>
+            <DialogDescription className="mt-1 text-[13px] text-muted-foreground">
+              {target?.isDir
+                ? t("settings.files.deleteDirHint", { defaultValue: "The directory must be empty." })
+                : t("settings.files.deleteFileHint", { defaultValue: "This action cannot be undone." })}
+            </DialogDescription>
+          </div>
+        </div>
+        <div className="flex items-center justify-end gap-2 px-5 py-4">
+          <Button variant="ghost" onClick={onClose} disabled={deleting}>
+            {t("settings.files.cancel", { defaultValue: "Cancel" })}
+          </Button>
+          <Button variant="destructive" onClick={onConfirm} disabled={deleting}>
+            {deleting ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+            ) : (
+              t("settings.files.delete", { defaultValue: "Delete" })
+            )}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function FileEntryIcon({ name, isDir }: { name: string; isDir: boolean }) {
+  if (isDir) return <Folder className="h-4 w-4 shrink-0 text-amber-500" aria-hidden />;
+
+  const lower = name.toLowerCase();
+  if (/\.(png|jpg|jpeg|gif|svg|webp|bmp|ico)$/.test(lower))
+    return <FileImage className="h-4 w-4 shrink-0 text-green-500" aria-hidden />;
+  if (/\.(mp3|wav|ogg|m4a|flac|aac)$/.test(lower))
+    return <FileAudio className="h-4 w-4 shrink-0 text-purple-500" aria-hidden />;
+  if (/\.(zip|tar|gz|rar|7z)$/.test(lower))
+    return <FileArchive className="h-4 w-4 shrink-0 text-orange-500" aria-hidden />;
+  if (/\.(py|js|ts|tsx|jsx|go|rs|java|c|cpp|h|hpp|sh|rb)$/.test(lower))
+    return <FileCode className="h-4 w-4 shrink-0 text-blue-400" aria-hidden />;
+  if (/\.(json|jsonl)$/.test(lower))
+    return <FileJson className="h-4 w-4 shrink-0 text-yellow-500" aria-hidden />;
+  if (/\.(md|txt)$/.test(lower))
+    return <FileText className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />;
+
+  return <File className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />;
+}
+
+function FilePreviewSheet({
+  path,
+  onClose,
+}: {
+  path: string | null;
+  onClose: () => void;
+}) {
+  const { token } = useClient();
+  const { t } = useTranslation();
+  const [content, setContent] = useState<FileContentPayload | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [editValue, setEditValue] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!path) {
+      setContent(null);
+      setEditing(false);
+      setEditValue("");
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setContent(null);
+    setEditing(false);
+    setEditValue("");
+    setSaveError(null);
+    void fetchFileContent(token, path)
+      .then((payload) => {
+        if (cancelled) return;
+        if (payload.error) {
+          setError(payload.error);
+        } else {
+          setContent(payload);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setError(t("settings.files.previewError", { defaultValue: "Failed to load file." }));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [path, token, t]);
+
+  const handleEdit = () => {
+    if (!content) return;
+    setEditing(true);
+    setEditValue(content.content);
+  };
+
+  const handleSave = async () => {
+    if (!path || !content) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const result = await saveFile(token, path, editValue);
+      if (result.error) {
+        setSaveError(result.error);
+        return;
+      }
+      setEditing(false);
+      setContent({ ...content, content: editValue });
+    } catch {
+      setSaveError(t("settings.files.saveError", { defaultValue: "Failed to save file." }));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setEditing(false);
+    setEditValue("");
+    setSaveError(null);
+  };
+
+  return (
+    <Dialog open={!!path} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent
+        className="max-w-[min(80vw,80rem)] max-h-[85vh] flex flex-col overflow-hidden p-0 gap-0"
+        showCloseButton={false}
+      >
+        <DialogHeader className="flex-row items-center justify-between border-b border-border/45 px-5 py-3.5 shrink-0">
+          <div className="min-w-0 flex-1">
+            <DialogTitle className="truncate text-[14px] font-semibold text-foreground">
+              {path ?? ""}
+            </DialogTitle>
+            {content && (
+              <DialogDescription className="sr-only">
+                {content.language} · {content.size} bytes{content.truncated ? " · " + t("settings.files.truncated", { defaultValue: "Truncated" }) : ""}{editing ? " · " + t("settings.files.editing", { defaultValue: "Editing" }) : ""}
+              </DialogDescription>
+            )}
+          </div>
+          <div className="flex items-center gap-1 shrink-0 ml-2">
+            {editing ? (
+              <>
+                <Button variant="ghost" size="icon" onClick={handleCancel} disabled={saving}>
+                  <X className="h-4 w-4" aria-hidden />
+                </Button>
+                <Button variant="default" size="icon" onClick={handleSave} disabled={saving}>
+                  {saving ? (
+                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                  ) : (
+                    <Save className="h-4 w-4" aria-hidden />
+                  )}
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button variant="ghost" size="icon" onClick={handleEdit} disabled={loading || !!error}>
+                  <Edit3 className="h-4 w-4" aria-hidden />
+                </Button>
+                <Button variant="ghost" size="icon" onClick={onClose}>
+                  <X className="h-4 w-4" aria-hidden />
+                </Button>
+              </>
+            )}
+          </div>
+        </DialogHeader>
+
+        <div className="min-h-0 flex-1 overflow-auto p-5">
+          {loading ? (
+            <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              {t("settings.files.loading", { defaultValue: "Loading..." })}
+            </div>
+          ) : error ? (
+            <div className="rounded-[14px] bg-destructive/10 px-4 py-4 text-sm text-destructive">
+              {error}
+            </div>
+          ) : content ? (
+            editing ? (
+              <>
+                <textarea
+                  value={editValue}
+                  onChange={(e) => setEditValue(e.target.value)}
+                  className={cn(
+                    "w-full min-h-[60vh] rounded-[14px] border border-border/35 bg-muted/20 p-4",
+                    "font-mono text-[12.5px] leading-[1.75] text-foreground/80 resize-none",
+                    "focus:outline-none focus:ring-2 focus:ring-ring",
+                  )}
+                  spellCheck={false}
+                />
+                {saveError && (
+                  <div className="mt-3 rounded-[14px] bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                    {saveError}
+                  </div>
+                )}
+              </>
+            ) : (
+              <pre
+                className={cn(
+                  "whitespace-pre-wrap break-words rounded-[14px] border border-border/35 bg-muted/20 p-4",
+                  "font-mono text-[12.5px] leading-[1.75] text-foreground/80",
+                )}
+              >
+                {content.content}
+              </pre>
+            )
+          ) : null}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -56,6 +56,7 @@ import {
 import { useTranslation } from "react-i18next";
 
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import { FilesBrowserSettings } from "@/components/settings/FilesBrowserSettings";
 import { SkillsCatalogSettings } from "@/components/settings/SkillsCatalogSettings";
 import { TokenUsageHeatmap } from "@/components/settings/TokenUsageHeatmap";
 import { Button } from "@/components/ui/button";
@@ -134,6 +135,7 @@ export type SettingsSectionKey =
   | "browser"
   | "apps"
   | "skills"
+  | "files"
   | "runtime"
   | "advanced";
 
@@ -1500,6 +1502,8 @@ export function SettingsView({
         );
       case "skills":
         return <SkillsCatalogSettings skills={skills} />;
+      case "files":
+        return <FilesBrowserSettings />;
       case "runtime":
         return (
           <RuntimeSettings

--- a/webui/src/i18n/locales/en/common.json
+++ b/webui/src/i18n/locales/en/common.json
@@ -57,6 +57,9 @@
     "apps": "Apps",
     "skills": {
       "title": "Skills"
+    },
+    "files": {
+      "title": "Files"
     }
   },
   "settings": {
@@ -80,7 +83,8 @@
       "runtime": "System",
       "advanced": "Security",
       "apps": "Apps",
-      "skills": "Skills"
+      "skills": "Skills",
+      "files": "Files"
     },
     "sections": {
       "interface": "Interface",
@@ -500,6 +504,28 @@
       "rawInstructions": "Raw SKILL.md",
       "rawInstructionsEmpty": "No raw instructions.",
       "detailDescription": "Details for {{name}}."
+    },
+    "files": {
+      "description": "Browse files in the agent workspace directory.",
+      "workspace": "Workspace",
+      "loading": "Loading...",
+      "loadError": "Failed to load directory.",
+      "empty": "This directory is empty.",
+      "refresh": "Refresh",
+      "upload": "Upload file",
+      "previewTitle": "{{name}}",
+      "previewError": "Failed to load file.",
+      "truncated": "Directory listing truncated.",
+      "uploadError": "Failed to upload file.",
+      "downloadError": "Failed to download file.",
+      "deleteError": "Failed to delete.",
+      "deleteTitle": "Delete {{name}}?",
+      "deleteDirHint": "The directory must be empty.",
+      "deleteFileHint": "This action cannot be undone.",
+      "cancel": "Cancel",
+      "delete": "Delete",
+      "editing": "Editing",
+      "saveError": "Failed to save file."
     },
     "voice": {
       "selectProvider": "Select provider",

--- a/webui/src/i18n/locales/es/common.json
+++ b/webui/src/i18n/locales/es/common.json
@@ -57,6 +57,9 @@
     "apps": "Apps",
     "skills": {
       "title": "Habilidades"
+    },
+    "files": {
+      "title": "Archivos"
     }
   },
   "settings": {
@@ -80,7 +83,8 @@
       "cliApps": "Apps CLI",
       "mcp": "MCP",
       "apps": "Aplicaciones",
-      "skills": "Habilidades"
+      "skills": "Habilidades",
+      "files": "Archivos"
     },
     "sections": {
       "interface": "Interfaz",
@@ -500,6 +504,28 @@
       "rawInstructions": "SKILL.md original",
       "rawInstructionsEmpty": "No hay instrucciones originales.",
       "detailDescription": "Detalles de {{name}}."
+    },
+    "files": {
+      "description": "Explorar archivos en el directorio del espacio de trabajo del agente.",
+      "workspace": "Espacio de trabajo",
+      "loading": "Cargando...",
+      "loadError": "Error al cargar el directorio.",
+      "empty": "Este directorio está vacío.",
+      "refresh": "Actualizar",
+      "upload": "Subir archivo",
+      "previewTitle": "{{name}}",
+      "previewError": "Error al cargar el archivo.",
+      "truncated": "Lista de directorios truncada.",
+      "uploadError": "Error al subir el archivo.",
+      "downloadError": "Error al descargar el archivo.",
+      "deleteError": "Error al eliminar.",
+      "deleteTitle": "¿Eliminar {{name}}?",
+      "deleteDirHint": "El directorio debe estar vacío.",
+      "deleteFileHint": "Esta acción no se puede deshacer.",
+      "cancel": "Cancelar",
+      "delete": "Eliminar",
+      "editing": "Editando",
+      "saveError": "Error al guardar el archivo."
     },
     "voice": {
       "selectProvider": "Seleccionar proveedor",

--- a/webui/src/i18n/locales/fr/common.json
+++ b/webui/src/i18n/locales/fr/common.json
@@ -57,6 +57,9 @@
     "apps": "Apps",
     "skills": {
       "title": "Compétences"
+    },
+    "files": {
+      "title": "Fichiers"
     }
   },
   "settings": {
@@ -80,7 +83,8 @@
       "cliApps": "Apps CLI",
       "mcp": "MCP",
       "apps": "Applications",
-      "skills": "Compétences"
+      "skills": "Compétences",
+      "files": "Fichiers"
     },
     "sections": {
       "interface": "Interface utilisateur",
@@ -500,6 +504,28 @@
       "rawInstructions": "SKILL.md brut",
       "rawInstructionsEmpty": "Aucune instruction brute.",
       "detailDescription": "Détails de {{name}}."
+    },
+    "files": {
+      "description": "Parcourir les fichiers du répertoire de l'espace de travail de l'agent.",
+      "workspace": "Espace de travail",
+      "loading": "Chargement...",
+      "loadError": "Échec du chargement du répertoire.",
+      "empty": "Ce répertoire est vide.",
+      "refresh": "Actualiser",
+      "upload": "Téléverser un fichier",
+      "previewTitle": "{{name}}",
+      "previewError": "Échec du chargement du fichier.",
+      "truncated": "Liste de répertoires tronquée.",
+      "uploadError": "Échec du téléversement.",
+      "downloadError": "Échec du téléchargement.",
+      "deleteError": "Échec de la suppression.",
+      "deleteTitle": "Supprimer {{name}} ?",
+      "deleteDirHint": "Le répertoire doit être vide.",
+      "deleteFileHint": "Cette action est irréversible.",
+      "cancel": "Annuler",
+      "delete": "Supprimer",
+      "editing": "Modification",
+      "saveError": "Échec de l'enregistrement du fichier."
     },
     "voice": {
       "selectProvider": "Choisir un fournisseur",

--- a/webui/src/i18n/locales/id/common.json
+++ b/webui/src/i18n/locales/id/common.json
@@ -57,6 +57,9 @@
     "apps": "Aplikasi",
     "skills": {
       "title": "Skill"
+    },
+    "files": {
+      "title": "Berkas"
     }
   },
   "settings": {
@@ -80,7 +83,8 @@
       "cliApps": "Aplikasi CLI",
       "mcp": "MCP",
       "apps": "Aplikasi",
-      "skills": "Skill"
+      "skills": "Skill",
+      "files": "Berkas"
     },
     "sections": {
       "interface": "Antarmuka",
@@ -500,6 +504,28 @@
       "rawInstructions": "SKILL.md mentah",
       "rawInstructionsEmpty": "Tidak ada instruksi mentah.",
       "detailDescription": "Detail untuk {{name}}."
+    },
+    "files": {
+      "description": "Jelajahi file dalam direktori ruang kerja agent.",
+      "workspace": "Ruang kerja",
+      "loading": "Memuat...",
+      "loadError": "Gagal memuat direktori.",
+      "empty": "Direktori ini kosong.",
+      "refresh": "Segarkan",
+      "upload": "Unggah file",
+      "previewTitle": "{{name}}",
+      "previewError": "Gagal memuat file.",
+      "truncated": "Daftar direktori dipotong.",
+      "uploadError": "Gagal mengunggah file.",
+      "downloadError": "Gagal mengunduh file.",
+      "deleteError": "Gagal menghapus.",
+      "deleteTitle": "Hapus {{name}}?",
+      "deleteDirHint": "Direktori harus kosong.",
+      "deleteFileHint": "Tindakan ini tidak dapat dibatalkan.",
+      "cancel": "Batal",
+      "delete": "Hapus",
+      "editing": "Mengedit",
+      "saveError": "Gagal menyimpan file."
     },
     "voice": {
       "selectProvider": "Pilih penyedia",

--- a/webui/src/i18n/locales/ja/common.json
+++ b/webui/src/i18n/locales/ja/common.json
@@ -57,6 +57,9 @@
     "apps": "アプリ",
     "skills": {
       "title": "スキル"
+    },
+    "files": {
+      "title": "ファイル"
     }
   },
   "settings": {
@@ -80,7 +83,8 @@
       "cliApps": "CLI アプリ",
       "mcp": "MCP",
       "apps": "アプリ",
-      "skills": "スキル"
+      "skills": "スキル",
+      "files": "ファイル"
     },
     "sections": {
       "interface": "インターフェース",
@@ -500,6 +504,28 @@
       "rawInstructions": "元の SKILL.md",
       "rawInstructionsEmpty": "元の説明はありません。",
       "detailDescription": "{{name}} の詳細。"
+    },
+    "files": {
+      "description": "agent ワークスペースディレクトリ内のファイルを閲覧します。",
+      "workspace": "ワークスペース",
+      "loading": "読み込み中...",
+      "loadError": "ディレクトリの読み込みに失敗しました。",
+      "empty": "このディレクトリは空です。",
+      "refresh": "更新",
+      "upload": "ファイルをアップロード",
+      "previewTitle": "{{name}}",
+      "previewError": "ファイルの読み込みに失敗しました。",
+      "truncated": "ディレクトリリストは切り詰められました。",
+      "uploadError": "ファイルのアップロードに失敗しました。",
+      "downloadError": "ファイルのダウンロードに失敗しました。",
+      "deleteError": "削除に失敗しました。",
+      "deleteTitle": "{{name}} を削除しますか？",
+      "deleteDirHint": "ディレクトリは空である必要があります。",
+      "deleteFileHint": "この操作は元に戻せません。",
+      "cancel": "キャンセル",
+      "delete": "削除",
+      "editing": "編集中",
+      "saveError": "ファイルの保存に失敗しました。"
     },
     "voice": {
       "selectProvider": "プロバイダーを選択",

--- a/webui/src/i18n/locales/ko/common.json
+++ b/webui/src/i18n/locales/ko/common.json
@@ -57,6 +57,9 @@
     "apps": "앱",
     "skills": {
       "title": "스킬"
+    },
+    "files": {
+      "title": "파일"
     }
   },
   "settings": {
@@ -80,7 +83,8 @@
       "cliApps": "CLI 앱",
       "mcp": "MCP",
       "apps": "앱",
-      "skills": "스킬"
+      "skills": "스킬",
+      "files": "파일"
     },
     "sections": {
       "interface": "인터페이스",
@@ -500,6 +504,28 @@
       "rawInstructions": "원본 SKILL.md",
       "rawInstructionsEmpty": "원본 지침이 없습니다.",
       "detailDescription": "{{name}} 세부 정보."
+    },
+    "files": {
+      "description": "agent 작업 영역 디렉터리의 파일을 검색합니다.",
+      "workspace": "작업 영역",
+      "loading": "로딩 중...",
+      "loadError": "디렉터리를 불러오지 못했습니다.",
+      "empty": "이 디렉터리는 비어 있습니다.",
+      "refresh": "새로고침",
+      "upload": "파일 업로드",
+      "previewTitle": "{{name}}",
+      "previewError": "파일을 불러오지 못했습니다.",
+      "truncated": "디렉터리 목록이 잘렸습니다.",
+      "uploadError": "파일 업로드 실패.",
+      "downloadError": "파일 다운로드 실패.",
+      "deleteError": "삭제 실패.",
+      "deleteTitle": "{{name}}을(를) 삭제하시겠습니까?",
+      "deleteDirHint": "디렉터리가 비어 있어야 합니다.",
+      "deleteFileHint": "이 작업은 취소할 수 없습니다.",
+      "cancel": "취소",
+      "delete": "삭제",
+      "editing": "편집 중",
+      "saveError": "파일 저장 실패."
     },
     "voice": {
       "selectProvider": "제공자 선택",

--- a/webui/src/i18n/locales/vi/common.json
+++ b/webui/src/i18n/locales/vi/common.json
@@ -57,6 +57,9 @@
     "apps": "Ứng dụng",
     "skills": {
       "title": "Kỹ năng"
+    },
+    "files": {
+      "title": "Tệp"
     }
   },
   "settings": {
@@ -80,7 +83,8 @@
       "cliApps": "Ứng dụng CLI",
       "mcp": "MCP",
       "apps": "Ứng dụng",
-      "skills": "Kỹ năng"
+      "skills": "Kỹ năng",
+      "files": "Tệp"
     },
     "sections": {
       "interface": "Giao diện",
@@ -500,6 +504,28 @@
       "rawInstructions": "SKILL.md gốc",
       "rawInstructionsEmpty": "Không có hướng dẫn gốc.",
       "detailDescription": "Chi tiết cho {{name}}."
+    },
+    "files": {
+      "description": "Duyệt các tệp trong thư mục không gian làm việc của agent.",
+      "workspace": "Không gian làm việc",
+      "loading": "Đang tải...",
+      "loadError": "Không thể tải thư mục.",
+      "empty": "Thư mục này trống.",
+      "refresh": "Làm mới",
+      "upload": "Tải lên tệp",
+      "previewTitle": "{{name}}",
+      "previewError": "Không thể tải tệp.",
+      "truncated": "Danh sách thư mục đã bị cắt ngắn.",
+      "uploadError": "Không thể tải lên.",
+      "downloadError": "Không thể tải xuống.",
+      "deleteError": "Không thể xóa.",
+      "deleteTitle": "Xóa {{name}}?",
+      "deleteDirHint": "Thư mục phải trống.",
+      "deleteFileHint": "Hành động này không thể hoàn tác.",
+      "cancel": "Hủy",
+      "delete": "Xóa",
+      "editing": "Đang chỉnh sửa",
+      "saveError": "Không thể lưu tệp."
     },
     "voice": {
       "selectProvider": "Chon nha cung cap",

--- a/webui/src/i18n/locales/zh-CN/common.json
+++ b/webui/src/i18n/locales/zh-CN/common.json
@@ -57,6 +57,9 @@
     "apps": "应用",
     "skills": {
       "title": "技能"
+    },
+    "files": {
+      "title": "文件"
     }
   },
   "settings": {
@@ -80,7 +83,8 @@
       "runtime": "系统",
       "advanced": "安全",
       "apps": "应用",
-      "skills": "技能"
+      "skills": "技能",
+      "files": "文件"
     },
     "sections": {
       "interface": "界面",
@@ -500,6 +504,28 @@
       "rawInstructions": "原始 SKILL.md",
       "rawInstructionsEmpty": "没有原始说明。",
       "detailDescription": "{{name}} 的详情。"
+    },
+    "files": {
+      "description": "浏览 agent 工作区目录中的文件。",
+      "workspace": "工作区",
+      "loading": "加载中...",
+      "loadError": "加载目录失败。",
+      "empty": "此目录为空。",
+      "refresh": "刷新",
+      "upload": "上传文件",
+      "previewTitle": "{{name}}",
+      "previewError": "加载文件失败。",
+      "truncated": "目录列表已截断。",
+      "uploadError": "上传文件失败。",
+      "downloadError": "下载文件失败。",
+      "deleteError": "删除失败。",
+      "deleteTitle": "删除 {{name}}？",
+      "deleteDirHint": "目录必须为空。",
+      "deleteFileHint": "此操作无法撤销。",
+      "cancel": "取消",
+      "delete": "删除",
+      "editing": "编辑中",
+      "saveError": "保存文件失败。"
     },
     "voice": {
       "selectProvider": "选择提供商",

--- a/webui/src/i18n/locales/zh-TW/common.json
+++ b/webui/src/i18n/locales/zh-TW/common.json
@@ -57,6 +57,9 @@
     "apps": "應用",
     "skills": {
       "title": "技能"
+    },
+    "files": {
+      "title": "檔案"
     }
   },
   "settings": {
@@ -80,7 +83,8 @@
       "cliApps": "CLI 應用",
       "mcp": "MCP",
       "apps": "應用",
-      "skills": "技能"
+      "skills": "技能",
+      "files": "檔案"
     },
     "sections": {
       "interface": "介面",
@@ -500,6 +504,28 @@
       "rawInstructions": "原始 SKILL.md",
       "rawInstructionsEmpty": "沒有原始說明。",
       "detailDescription": "{{name}} 的詳細資訊。"
+    },
+    "files": {
+      "description": "瀏覽 agent 工作區目錄中的檔案。",
+      "workspace": "工作區",
+      "loading": "載入中...",
+      "loadError": "載入目錄失敗。",
+      "empty": "此目錄為空。",
+      "refresh": "重新整理",
+      "upload": "上傳檔案",
+      "previewTitle": "{{name}}",
+      "previewError": "載入檔案失敗。",
+      "truncated": "目錄列表已截斷。",
+      "uploadError": "上傳檔案失敗。",
+      "downloadError": "下載檔案失敗。",
+      "deleteError": "刪除失敗。",
+      "deleteTitle": "刪除 {{name}}？",
+      "deleteDirHint": "目錄必須為空。",
+      "deleteFileHint": "此操作無法撤銷。",
+      "cancel": "取消",
+      "delete": "刪除",
+      "editing": "編輯中",
+      "saveError": "儲存檔案失敗。"
     },
     "voice": {
       "selectProvider": "選擇提供商",

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -1,7 +1,12 @@
 import type {
   ChatSummary,
   CliAppsPayload,
+  FileContentPayload,
+  FileDeletePayload,
   FilePreviewPayload,
+  FileSavePayload,
+  FileUploadPayload,
+  FilesListPayload,
   ImageGenerationSettingsUpdate,
   McpPresetsPayload,
   ModelConfigurationCreate,
@@ -17,6 +22,9 @@ import type {
   SkillsPayload,
   SlashCommand,
   TranscriptionSettingsUpdate,
+  UploadChunkPayload,
+  UploadFinalizePayload,
+  UploadInitPayload,
   WebSearchSettingsUpdate,
   WorkspacesPayload,
   WebuiThreadPersistedPayload,
@@ -33,6 +41,17 @@ export class ApiError extends Error {
     this.status = status;
     this.name = "ApiError";
   }
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  const chunkSize = 8192;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
 }
 
 async function request<T>(
@@ -191,6 +210,132 @@ export async function fetchSkillDetail(
     undefined,
     API_READ_TIMEOUT_MS,
   );
+}
+
+export async function fetchFilesList(
+  token: string,
+  path: string | null = null,
+  base: string = "",
+): Promise<FilesListPayload> {
+  const url = path
+    ? `${base}/api/webui/files?path=${encodeURIComponent(path)}`
+    : `${base}/api/webui/files`;
+  return request<FilesListPayload>(url, token, undefined, API_READ_TIMEOUT_MS);
+}
+
+export async function fetchFileContent(
+  token: string,
+  path: string,
+  base: string = "",
+): Promise<FileContentPayload> {
+  return request<FileContentPayload>(
+    `${base}/api/webui/files/read?path=${encodeURIComponent(path)}`,
+    token,
+    undefined,
+    API_READ_TIMEOUT_MS,
+  );
+}
+
+export async function deleteFile(
+  token: string,
+  path: string,
+  base: string = "",
+): Promise<FileDeletePayload> {
+  return request<FileDeletePayload>(
+    `${base}/api/webui/files/delete?path=${encodeURIComponent(path)}`,
+    token,
+    undefined,
+    API_READ_TIMEOUT_MS,
+  );
+}
+
+const CHUNK_B64_SIZE = 768;
+
+export async function uploadFileChunked(
+  token: string,
+  path: string,
+  filename: string,
+  content: ArrayBuffer,
+  base: string = "",
+): Promise<FileUploadPayload> {
+  const b64 = arrayBufferToBase64(content);
+  const chunkSize = CHUNK_B64_SIZE;
+  const totalChunks = Math.ceil(b64.length / chunkSize);
+
+  const initPayload = await request<UploadInitPayload>(
+    `${base}/api/webui/files/upload/init?path=${encodeURIComponent(path)}&filename=${encodeURIComponent(filename)}&total_chunks=${totalChunks}`,
+    token,
+    undefined,
+    API_READ_TIMEOUT_MS,
+  );
+  if (!initPayload.ok || !initPayload.upload_id) {
+    return { ok: false, path: "", size: 0, error: initPayload.error };
+  }
+
+  for (let i = 0; i < totalChunks; i++) {
+    const chunkB64 = b64.slice(i * chunkSize, (i + 1) * chunkSize);
+    const chunkPayload = await request<UploadChunkPayload>(
+      `${base}/api/webui/files/upload/chunk?upload_id=${encodeURIComponent(initPayload.upload_id)}&chunk_index=${i}&chunk=${encodeURIComponent(chunkB64)}`,
+      token,
+      undefined,
+      API_READ_TIMEOUT_MS,
+    );
+    if (!chunkPayload.ok) {
+      return { ok: false, path: "", size: 0, error: chunkPayload.error };
+    }
+  }
+
+  const finalizePayload = await request<UploadFinalizePayload>(
+    `${base}/api/webui/files/upload/finalize?upload_id=${encodeURIComponent(initPayload.upload_id)}`,
+    token,
+    undefined,
+    API_READ_TIMEOUT_MS,
+  );
+  if (!finalizePayload.ok) {
+    return { ok: false, path: "", size: 0, error: finalizePayload.error };
+  }
+
+  return { ok: true, path: finalizePayload.path, size: finalizePayload.size };
+}
+
+export async function saveFile(
+  token: string,
+  path: string,
+  content: string,
+  base: string = "",
+): Promise<FileSavePayload> {
+  const b64 = arrayBufferToBase64(new TextEncoder().encode(content).buffer);
+  const url = `${base}/api/webui/files/save?path=${encodeURIComponent(path)}`;
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "X-Nanobot-File-Content": b64,
+    },
+    credentials: "same-origin",
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new ApiError(response.status, data.error || `HTTP ${response.status}`);
+  }
+  return data as FileSavePayload;
+}
+
+export async function downloadFile(
+  token: string,
+  path: string,
+  base: string = "",
+): Promise<ArrayBuffer> {
+  const url = `${base}/api/webui/files/download?path=${encodeURIComponent(path)}`;
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+    credentials: "same-origin",
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new ApiError(response.status, text || `HTTP ${response.status}`);
+  }
+  return response.arrayBuffer();
 }
 
 export async function deleteSession(

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -140,6 +140,84 @@ export interface SkillDetail extends SkillSummary {
 
 export interface SkillsPayload { skills: SkillSummary[]; }
 
+export interface FileEntry {
+  name: string;
+  is_dir: boolean;
+  size: number;
+  mtime: number;
+}
+
+export interface FilesListPayload {
+  path: string;
+  display_path: string;
+  workspace_path: string;
+  entries: FileEntry[];
+  has_more: boolean;
+  error?: string;
+  status?: number;
+}
+
+export interface FileDeletePayload {
+  ok: boolean;
+  deleted: string;
+  error?: string;
+  status?: number;
+}
+
+export interface FileSavePayload {
+  ok: boolean;
+  path: string;
+  size: number;
+  error?: string;
+  status?: number;
+}
+
+export interface FileUploadPayload {
+  ok: boolean;
+  path: string;
+  size: number;
+  error?: string;
+  status?: number;
+}
+
+export interface UploadInitPayload {
+  ok: boolean;
+  upload_id: string;
+  total_chunks: number;
+  error?: string;
+  status?: number;
+}
+
+export interface UploadChunkPayload {
+  ok: boolean;
+  upload_id: string;
+  chunk_index: number;
+  received: number;
+  total: number;
+  error?: string;
+  status?: number;
+}
+
+export interface UploadFinalizePayload {
+  ok: boolean;
+  path: string;
+  size: number;
+  error?: string;
+  status?: number;
+}
+
+export interface FileContentPayload {
+  path: string;
+  display_path: string;
+  language: string;
+  mime: string | null;
+  content: string;
+  size: number;
+  truncated: boolean;
+  error?: string;
+  status?: number;
+}
+
 /** Structured UI blob on ``progress`` WS frames; channels may add more ``kind`` values later. */
 export interface AgentUIBlob {
   kind: string;


### PR DESCRIPTION
When utilizing NanoBot, I observed that whenever the Agent generates files, I'm required to log in to the host machine to manually copy and paste them from the folder. To enhance convenience, I've introduced a folder-browsing feature, enabling users to swiftly grasp and modify the Agents/SOUL configurations. Moreover, users can now effortlessly manage files, including uploading, downloading, and deleting them. Additionally, users have the option to upload skills directly within the file system.

- Notably, I've seen that we've incorporated the workspace setting functionality on the conversation page. Should the pull request (PR) for the file management page be approved and merged, we might consider enabling the file management page's display content to dynamically adjust according to workspace changes in the future.
- The current system is constructed on ws, which appears to have limited support for HTTP requests beyond GET, making certain file operations, like uploading, less user-friendly. Given the opportunity, I'd like to explore the possibility of implementing a comprehensive HTTP framework in the system (such as leveraging fastapi to accommodate GET/POST/DELETE/PUT requests) instead of relying solely on GET requests.

## The Works
- Introduced a new Files section in the settings view, allowing users to browse and manage files. 
- Updated translations for the new Files section in English, Spanish, French, Indonesian, Japanese, Korean, Vietnamese, Simplified Chinese, and Traditional Chinese.
- Implemented API functions for file operations including listing, reading, deleting, uploading, saving, and downloading files.
- Added TypeScript interfaces for file-related payloads and entries to enhance type safety and clarity in the codebase.

<img width="1111" height="508" alt="image" src="https://github.com/user-attachments/assets/1dbc6955-cbd1-4c82-945a-8f053c258612" />
