### PR TITLE
fix(cron): reject invalid schedule parameters at creation time

### DIFF
--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -206,17 +206,20 @@ class CronTool(Tool, ContextAware):
         else:
             return "Error: either every_seconds, cron_expr, or at is required"
 
-        job = self._cron.add_job(
-            name=name or message[:30],
-            schedule=schedule,
-            message=message,
-            deliver=deliver,
-            channel=channel,
-            to=chat_id,
-            delete_after_run=delete_after,
-            channel_meta=self._metadata.get(),
-            session_key=self._session_key.get() or None,
-        )
+        try:
+            job = self._cron.add_job(
+                name=name or message[:30],
+                schedule=schedule,
+                message=message,
+                deliver=deliver,
+                channel=channel,
+                to=chat_id,
+                delete_after_run=delete_after,
+                channel_meta=self._metadata.get(),
+                session_key=self._session_key.get() or None,
+            )
+        except ValueError as exc:
+            return f"Error: {exc}"
         return f"Created job '{job.name}' (id: {job.id})"
 
     def _format_timing(self, schedule: CronSchedule) -> str:

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -59,16 +59,42 @@ def _compute_next_run(schedule: CronSchedule, now_ms: int) -> int | None:
 
 def _validate_schedule_for_add(schedule: CronSchedule) -> None:
     """Validate schedule fields that would otherwise create non-runnable jobs."""
-    if schedule.tz and schedule.kind != "cron":
-        raise ValueError("tz can only be used with cron schedules")
+    if schedule.kind == "every":
+        if not schedule.every_ms or schedule.every_ms <= 0:
+            raise ValueError("every_ms must be a positive integer")
+        if schedule.tz:
+            raise ValueError("tz can only be used with cron schedules")
+        return
 
-    if schedule.kind == "cron" and schedule.tz:
+    if schedule.kind == "at":
+        if not schedule.at_ms:
+            raise ValueError("at_ms is required for one-time jobs")
+        if schedule.tz:
+            raise ValueError("tz can only be used with cron schedules")
+        return
+
+    if schedule.kind == "cron":
+        if not schedule.expr:
+            raise ValueError("cron_expr is required for cron jobs")
         try:
-            from zoneinfo import ZoneInfo
+            from croniter import croniter
 
-            ZoneInfo(schedule.tz)
-        except Exception:
-            raise ValueError(f"unknown timezone '{schedule.tz}'") from None
+            if not croniter.is_valid(schedule.expr):
+                raise ValueError(f"invalid cron expression: {schedule.expr!r}")
+        except ValueError:
+            raise
+        except Exception as exc:
+            raise ValueError(f"invalid cron expression: {schedule.expr!r}") from exc
+        if schedule.tz:
+            try:
+                from zoneinfo import ZoneInfo
+
+                ZoneInfo(schedule.tz)
+            except Exception:
+                raise ValueError(f"unknown timezone '{schedule.tz}'") from None
+        return
+
+    raise ValueError(f"unsupported schedule kind: {schedule.kind}")
 
 
 class CronService:

--- a/tests/cron/test_cron_service.py
+++ b/tests/cron/test_cron_service.py
@@ -17,6 +17,85 @@ async def _wait_until(predicate, *, timeout: float = 1.0, interval: float = 0.01
     assert predicate()
 
 
+def test_add_job_rejects_invalid_cron_expression(tmp_path) -> None:
+    service = CronService(tmp_path / "cron" / "jobs.json")
+
+    with pytest.raises(ValueError, match="invalid cron expression"):
+        service.add_job(
+            name="bad expr",
+            schedule=CronSchedule(kind="cron", expr="not a cron", tz="UTC"),
+            message="hello",
+        )
+
+    assert service.list_jobs(include_disabled=True) == []
+
+
+def test_add_job_rejects_empty_cron_expression(tmp_path) -> None:
+    service = CronService(tmp_path / "cron" / "jobs.json")
+
+    with pytest.raises(ValueError, match="cron_expr is required"):
+        service.add_job(
+            name="no expr",
+            schedule=CronSchedule(kind="cron", expr=None, tz="UTC"),
+            message="hello",
+        )
+
+
+def test_add_job_rejects_invalid_every_ms(tmp_path) -> None:
+    service = CronService(tmp_path / "cron" / "jobs.json")
+
+    with pytest.raises(ValueError, match="every_ms must be a positive integer"):
+        service.add_job(
+            name="zero every",
+            schedule=CronSchedule(kind="every", every_ms=0),
+            message="hello",
+        )
+
+
+def test_add_job_rejects_negative_every_ms(tmp_path) -> None:
+    service = CronService(tmp_path / "cron" / "jobs.json")
+
+    with pytest.raises(ValueError, match="every_ms must be a positive integer"):
+        service.add_job(
+            name="neg every",
+            schedule=CronSchedule(kind="every", every_ms=-1000),
+            message="hello",
+        )
+
+
+def test_add_job_rejects_missing_at_ms(tmp_path) -> None:
+    service = CronService(tmp_path / "cron" / "jobs.json")
+
+    with pytest.raises(ValueError, match="at_ms is required"):
+        service.add_job(
+            name="no at",
+            schedule=CronSchedule(kind="at", at_ms=None),
+            message="hello",
+        )
+
+
+def test_add_job_rejects_tz_with_every_schedule(tmp_path) -> None:
+    service = CronService(tmp_path / "cron" / "jobs.json")
+
+    with pytest.raises(ValueError, match="tz can only be used with cron schedules"):
+        service.add_job(
+            name="tz on every",
+            schedule=CronSchedule(kind="every", every_ms=60_000, tz="UTC"),
+            message="hello",
+        )
+
+
+def test_add_job_rejects_tz_with_at_schedule(tmp_path) -> None:
+    service = CronService(tmp_path / "cron" / "jobs.json")
+
+    with pytest.raises(ValueError, match="tz can only be used with cron schedules"):
+        service.add_job(
+            name="tz on at",
+            schedule=CronSchedule(kind="at", at_ms=9999999999999, tz="UTC"),
+            message="hello",
+        )
+
+
 def test_add_job_rejects_unknown_timezone(tmp_path) -> None:
     service = CronService(tmp_path / "cron" / "jobs.json")
 

--- a/tests/cron/test_cron_tool_list.py
+++ b/tests/cron/test_cron_tool_list.py
@@ -400,6 +400,27 @@ def test_add_job_captures_metadata_and_session_key(tmp_path) -> None:
     assert jobs[0].payload.session_key == "slack:C99:111.222"
 
 
+def test_add_job_invalid_cron_expr_returns_error(tmp_path) -> None:
+    tool = _make_tool(tmp_path)
+    tool.set_context(RequestContext(channel="telegram", chat_id="chat-1"))
+
+    result = tool._add_job(None, "test", None, "not a cron", None, None)
+
+    assert result.startswith("Error:")
+    assert "invalid cron expression" in result
+    assert tool._cron.list_jobs() == []
+
+
+def test_add_job_empty_cron_expr_returns_error(tmp_path) -> None:
+    tool = _make_tool(tmp_path)
+    tool.set_context(RequestContext(channel="telegram", chat_id="chat-1"))
+
+    # Pass cron_expr=None falls through to "either every_seconds, cron_expr, or at is required"
+    result = tool._add_job(None, "test", None, None, None, None)
+
+    assert "Error:" in result
+
+
 def test_list_excludes_disabled_jobs(tmp_path) -> None:
     tool = _make_tool(tmp_path)
     job = tool._cron.add_job(


### PR DESCRIPTION
## Summary

  - Extend `_validate_schedule_for_add` to validate all schedule kinds upfront: reject invalid/empty cron expressions (`croniter.is_valid`), non-positive `every_ms`, missing `at_ms`, and `tz` used with non-
  cron schedules
  - Catch `ValueError` in `CronTool._add_job` and return a user-facing error string instead of letting the exception propagate into the tool execution flow
  - Previously, an invalid cron expression like `"not a cron"` would silently create a job with `next_run_at_ms=None` that would never execute — the user/agent would see "Created job" with no indication of failure

  ## Test plan

  - [x] 7 new service-layer tests: invalid cron expr, empty cron expr, `every_ms <= 0`, negative `every_ms`, missing `at_ms`, `tz` with `every`, `tz` with `at`
  - [x] 2 new tool-layer tests: invalid cron expr returns `Error:`, empty cron expr returns `Error:`
  - [x] All 88 cron tests pass