### PR TITLE
feat(slack): add groupRequireMention to scope allowlist channels to @mentions

### DIFF
--- a/docs/chat-apps.md
+++ b/docs/chat-apps.md
@@ -572,7 +572,9 @@ nanobot gateway
 DM the bot directly or @mention it in a channel — it should respond!
 
 > [!TIP]
-> - `groupPolicy`: `"mention"` (default — respond only when @mentioned), `"open"` (respond to all channel messages), or `"allowlist"` (restrict to specific channels).
+> - `groupPolicy`: `"mention"` (default — respond only when @mentioned), `"open"` (respond to all channel messages), or `"allowlist"` (restrict to specific channels via `groupAllowFrom`).
+> - `groupAllowFrom`: channel IDs the bot may respond in when `groupPolicy` is `"allowlist"`.
+> - `groupRequireMention`: when `true` and `groupPolicy` is `"allowlist"`, the bot only replies to channels in `groupAllowFrom` **and** only when @mentioned (instead of every message). No effect for `"mention"`/`"open"`. Use this to scope the bot to approved channels while keeping mention-only behavior.
 > - DM policy defaults to open. Set `"dm": {"enabled": false}` to disable DMs.
 
 </details>

--- a/nanobot/channels/slack.py
+++ b/nanobot/channels/slack.py
@@ -47,6 +47,10 @@ class SlackConfig(Base):
     allow_from: list[str] = Field(default_factory=list)
     group_policy: str = "mention"
     group_allow_from: list[str] = Field(default_factory=list)
+    # When group_policy is "allowlist", also require the bot to be @mentioned
+    # before responding (so it only replies to mentions in approved channels,
+    # instead of every message). No effect for "mention"/"open" policies.
+    group_require_mention: bool = False
     dm: SlackDMConfig = Field(default_factory=SlackDMConfig)
 
 
@@ -648,15 +652,22 @@ class SlackChannel(BaseChannel):
             return chat_id in self.config.group_allow_from
         return True
 
+    def _is_mention(self, event_type: str, text: str) -> bool:
+        if event_type == "app_mention":
+            return True
+        return self._bot_user_id is not None and f"<@{self._bot_user_id}>" in text
+
     def _should_respond_in_channel(self, event_type: str, text: str, chat_id: str) -> bool:
         if self.config.group_policy == "open":
             return True
         if self.config.group_policy == "mention":
-            if event_type == "app_mention":
-                return True
-            return self._bot_user_id is not None and f"<@{self._bot_user_id}>" in text
+            return self._is_mention(event_type, text)
         if self.config.group_policy == "allowlist":
-            return chat_id in self.config.group_allow_from
+            if chat_id not in self.config.group_allow_from:
+                return False
+            if self.config.group_require_mention:
+                return self._is_mention(event_type, text)
+            return True
         return False
 
     def is_allowed(self, sender_id: str) -> bool:

--- a/tests/channels/test_slack_channel.py
+++ b/tests/channels/test_slack_channel.py
@@ -655,3 +655,62 @@ def test_slack_channel_uses_channel_aware_allow_policy() -> None:
     channel = SlackChannel(SlackConfig(enabled=True, allow_from=[]), MessageBus())
     assert channel.is_allowed("U1") is True
     assert channel._is_allowed("U1", "C123", "channel") is True
+
+
+def test_mention_policy_responds_to_mentions_in_any_channel() -> None:
+    channel = SlackChannel(SlackConfig(enabled=True, group_policy="mention"), MessageBus())
+    channel._bot_user_id = "UBOT"
+
+    assert channel._should_respond_in_channel("app_mention", "<@UBOT> hi", "C123") is True
+    assert channel._should_respond_in_channel("message", "<@UBOT> hi", "C999") is True
+    assert channel._should_respond_in_channel("message", "no mention here", "C123") is False
+
+
+def test_allowlist_policy_restricts_to_approved_channels() -> None:
+    channel = SlackChannel(
+        SlackConfig(enabled=True, group_policy="allowlist", group_allow_from=["C_OK"]),
+        MessageBus(),
+    )
+    channel._bot_user_id = "UBOT"
+
+    # In an approved channel without require_mention, respond to anything.
+    assert channel._should_respond_in_channel("message", "anything", "C_OK") is True
+    # An unapproved channel is always rejected.
+    assert channel._should_respond_in_channel("app_mention", "<@UBOT> hi", "C_NOPE") is False
+    # _is_allowed also gates on the channel allowlist.
+    assert channel._is_allowed("U1", "C_OK", "channel") is True
+    assert channel._is_allowed("U1", "C_NOPE", "channel") is False
+
+
+def test_allowlist_with_require_mention_needs_both_channel_and_mention() -> None:
+    channel = SlackChannel(
+        SlackConfig(
+            enabled=True,
+            group_policy="allowlist",
+            group_allow_from=["C_OK"],
+            group_require_mention=True,
+        ),
+        MessageBus(),
+    )
+    channel._bot_user_id = "UBOT"
+
+    # Approved channel + mention -> respond.
+    assert channel._should_respond_in_channel("app_mention", "<@UBOT> hi", "C_OK") is True
+    assert channel._should_respond_in_channel("message", "<@UBOT> hi", "C_OK") is True
+    # Approved channel but no mention -> stay quiet.
+    assert channel._should_respond_in_channel("message", "just chatting", "C_OK") is False
+    # Mention in an unapproved channel -> stay quiet.
+    assert channel._should_respond_in_channel("app_mention", "<@UBOT> hi", "C_NOPE") is False
+
+
+def test_group_require_mention_accepts_camel_case_alias() -> None:
+    config = SlackConfig.model_validate(
+        {
+            "enabled": True,
+            "groupPolicy": "allowlist",
+            "groupAllowFrom": ["C_OK"],
+            "groupRequireMention": True,
+        }
+    )
+    assert config.group_require_mention is True
+    assert config.group_allow_from == ["C_OK"]


### PR DESCRIPTION
## What

Adds a `groupRequireMention` option to the Slack channel. When `groupPolicy` is `"allowlist"` and `groupRequireMention` is `true`, the bot responds **only** in channels listed in `groupAllowFrom` **and** only when @mentioned.

## Why

Today Slack's `groupPolicy` forces a choice:

- `"allowlist"` restricts *which* channels the bot serves, but then it replies to *every* message in those channels.
- `"mention"` requires an @mention, but applies to *any* channel the bot is invited to.

There's no way to express "only these channels, and only when mentioned." This mirrors the Signal channel, which already supports `group.policy: "allowlist"` together with `group.requireMention`.

## Behavior

- Defaults to `false`, and is a no-op for `groupPolicy: "mention"` / `"open"`, so existing configs are unchanged.
- In `"allowlist"` mode: the channel must be in `groupAllowFrom` **and** (when `groupRequireMention` is set) the message must mention the bot.
- Extracts the mention check into a shared `_is_mention` helper reused by both the `mention` and `allowlist` branches.

```json
{
  "channels": {
    "slack": {
      "enabled": true,
      "groupPolicy": "allowlist",
      "groupAllowFrom": ["C01234ABCDE"],
      "groupRequireMention": true
    }
  }
}
```

## Tests

Adds coverage for the mention policy, the allowlist policy, allowlist + requireMention (needs both channel and mention), and the camelCase alias. Full Slack suite passes locally; `ruff check` is clean.

## Docs

Updates the Slack tip block in `docs/chat-apps.md` to document `groupAllowFrom` and `groupRequireMention`.

Made with [Cursor](https://cursor.com)