### PR TITLE
fix(agent): add pending_queue to process_direct for subagent result injection

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -975,6 +975,7 @@ class AgentLoop:
         self,
         session_key: str,
     ) -> AsyncIterator[asyncio.Queue]:
+        """Publish a session's active injection queue while the caller owns its lock."""
         pending: asyncio.Queue = asyncio.Queue(maxsize=20)
         self._pending_queues[session_key] = pending
         try:
@@ -1881,3 +1882,4 @@ class AgentLoop:
         finally:
             await self._runtime_events().run_status_changed(msg, session_key, "idle")
             self._runtime_events().clear_turn(session_key)
+            await self._cron_turns.publish_next_deferred(session_key)

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -6,12 +6,12 @@ import asyncio
 import dataclasses
 import os
 import time
-from contextlib import AsyncExitStack, nullcontext, suppress
+from contextlib import AsyncExitStack, asynccontextmanager, nullcontext, suppress
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, AsyncIterator, Awaitable, Callable
 
 from loguru import logger
 
@@ -970,6 +970,36 @@ class AgentLoop:
             # MCP stdio transports use AnyIO cancel scopes; close them from the task that opened them.
             await self.close_mcp()
 
+    @asynccontextmanager
+    async def _active_pending_queue(
+        self,
+        session_key: str,
+    ) -> AsyncIterator[asyncio.Queue]:
+        pending: asyncio.Queue = asyncio.Queue(maxsize=20)
+        self._pending_queues[session_key] = pending
+        try:
+            yield pending
+        finally:
+            queue = (
+                self._pending_queues.pop(session_key, None)
+                if self._pending_queues.get(session_key) is pending
+                else pending
+            )
+            leftover = 0
+            while True:
+                try:
+                    item = queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                await self.bus.publish_inbound(item)
+                leftover += 1
+            if leftover:
+                logger.info(
+                    "Re-published {} leftover message(s) to bus for session {}",
+                    leftover,
+                    session_key,
+                )
+
     async def _dispatch(self, msg: InboundMessage) -> None:
         """Process a message: per-session serial, cross-session concurrent."""
         session_key = self._effective_session_key(msg)
@@ -981,136 +1011,114 @@ class AgentLoop:
         pending: asyncio.Queue | None = None
         try:
             async with lock, gate:
-                # Only the task that owns the session lock may publish the
-                # active mid-turn injection queue for this session.
-                pending = asyncio.Queue(maxsize=20)
-                self._pending_queues[session_key] = pending
                 try:
-                    on_stream = on_stream_end = None
-                    if msg.metadata.get("_wants_stream"):
-                        # Split one answer into distinct stream segments.
-                        stream_base_id = f"{msg.session_key}:{time.time_ns()}"
-                        stream_segment = 0
+                    async with self._active_pending_queue(session_key) as pending:
+                        try:
+                            on_stream = on_stream_end = None
+                            if msg.metadata.get("_wants_stream"):
+                                # Split one answer into distinct stream segments.
+                                stream_base_id = f"{msg.session_key}:{time.time_ns()}"
+                                stream_segment = 0
 
-                        def _current_stream_id() -> str:
-                            return f"{stream_base_id}:{stream_segment}"
+                                def _current_stream_id() -> str:
+                                    return f"{stream_base_id}:{stream_segment}"
 
-                        async def on_stream(delta: str) -> None:
-                            meta = dict(msg.metadata or {})
-                            meta["_stream_delta"] = True
-                            meta["_stream_id"] = _current_stream_id()
-                            await self.bus.publish_outbound(OutboundMessage(
-                                channel=msg.channel, chat_id=msg.chat_id,
-                                content=delta,
-                                metadata=meta,
-                            ))
+                                async def on_stream(delta: str) -> None:
+                                    meta = dict(msg.metadata or {})
+                                    meta["_stream_delta"] = True
+                                    meta["_stream_id"] = _current_stream_id()
+                                    await self.bus.publish_outbound(OutboundMessage(
+                                        channel=msg.channel, chat_id=msg.chat_id,
+                                        content=delta,
+                                        metadata=meta,
+                                    ))
 
-                        async def on_stream_end(*, resuming: bool = False) -> None:
-                            nonlocal stream_segment
-                            meta = dict(msg.metadata or {})
-                            meta["_stream_end"] = True
-                            meta["_resuming"] = resuming
-                            meta["_stream_id"] = _current_stream_id()
-                            await self.bus.publish_outbound(OutboundMessage(
-                                channel=msg.channel, chat_id=msg.chat_id,
-                                content="",
-                                metadata=meta,
-                            ))
-                            stream_segment += 1
+                                async def on_stream_end(*, resuming: bool = False) -> None:
+                                    nonlocal stream_segment
+                                    meta = dict(msg.metadata or {})
+                                    meta["_stream_end"] = True
+                                    meta["_resuming"] = resuming
+                                    meta["_stream_id"] = _current_stream_id()
+                                    await self.bus.publish_outbound(OutboundMessage(
+                                        channel=msg.channel, chat_id=msg.chat_id,
+                                        content="",
+                                        metadata=meta,
+                                    ))
+                                    stream_segment += 1
 
-                    response = await self._process_message(
-                        msg, on_stream=on_stream, on_stream_end=on_stream_end,
-                        pending_queue=pending,
-                    )
-                    completed_channel = msg.channel
-                    completed_chat_id = msg.chat_id
-                    if response is not None:
-                        await self.bus.publish_outbound(response)
-                        completed_channel = response.channel
-                        completed_chat_id = response.chat_id
-                    elif msg.channel == "cli":
-                        await self.bus.publish_outbound(OutboundMessage(
-                            channel=msg.channel, chat_id=msg.chat_id,
-                            content="", metadata=msg.metadata or {},
-                        ))
-                    continuing = turn_continuation.internal_continuation_pending(msg.metadata)
-                    if not continuing:
-                        await self._runtime_events().turn_completed(
-                            channel=completed_channel,
-                            chat_id=completed_chat_id,
-                            session_key=session_key,
-                            metadata=msg.metadata,
-                        )
-                    self._cron_turns.complete(msg, response=response)
-                except asyncio.CancelledError:
-                    self._cron_turns.complete(
-                        msg,
-                        error=asyncio.CancelledError(),
-                    )
-                    logger.info("Task cancelled for session {}", session_key)
-                    # Preserve partial context from the interrupted turn so
-                    # the user does not lose tool results and assistant
-                    # messages accumulated before /stop.  The checkpoint was
-                    # already persisted to session metadata by
-                    # _emit_checkpoint during tool execution; materializing
-                    # it into session history now makes it visible in the
-                    # next conversation turn.
-                    try:
-                        key = self._effective_session_key(msg)
-                        session = self.sessions.get_or_create(key)
-                        if self._restore_runtime_checkpoint(session):
-                            self._clear_pending_user_turn(session)
-                            self.sessions.save(session)
-                            logger.info(
-                                "Restored partial context for cancelled session {}",
-                                key,
+                            response = await self._process_message(
+                                msg, on_stream=on_stream, on_stream_end=on_stream_end,
+                                pending_queue=pending,
                             )
-                    except Exception:
-                        logger.debug(
-                            "Could not restore checkpoint for cancelled session {}",
-                            session_key,
-                            exc_info=True,
-                        )
-                    raise
-                except Exception as exc:
-                    logger.exception("Error processing message for session {}", session_key)
-                    await self.bus.publish_outbound(OutboundMessage(
-                        channel=msg.channel, chat_id=msg.chat_id,
-                        content="Sorry, I encountered an error.",
-                    ))
-                    if not turn_continuation.internal_continuation_pending(msg.metadata):
-                        await self._runtime_events().turn_completed(
-                            channel=msg.channel,
-                            chat_id=msg.chat_id,
-                            session_key=session_key,
-                            metadata=msg.metadata,
-                        )
-                    self._cron_turns.complete(msg, error=exc)
-                finally:
-                    # Drain any messages still in the pending queue and re-publish
-                    # them to the bus so they are processed as fresh inbound messages
-                    # rather than silently lost.  Only remove our own queue; a
-                    # later task waiting on the lock must not be able to steal
-                    # cleanup ownership.
-                    queue = None
-                    if self._pending_queues.get(session_key) is pending:
-                        queue = self._pending_queues.pop(session_key, None)
-                    else:
-                        queue = pending
-                    if queue is not None:
-                        leftover = 0
-                        while True:
+                            completed_channel = msg.channel
+                            completed_chat_id = msg.chat_id
+                            if response is not None:
+                                await self.bus.publish_outbound(response)
+                                completed_channel = response.channel
+                                completed_chat_id = response.chat_id
+                            elif msg.channel == "cli":
+                                await self.bus.publish_outbound(OutboundMessage(
+                                    channel=msg.channel, chat_id=msg.chat_id,
+                                    content="", metadata=msg.metadata or {},
+                                ))
+                            continuing = turn_continuation.internal_continuation_pending(
+                                msg.metadata
+                            )
+                            if not continuing:
+                                await self._runtime_events().turn_completed(
+                                    channel=completed_channel,
+                                    chat_id=completed_chat_id,
+                                    session_key=session_key,
+                                    metadata=msg.metadata,
+                                )
+                            self._cron_turns.complete(msg, response=response)
+                        except asyncio.CancelledError:
+                            self._cron_turns.complete(
+                                msg,
+                                error=asyncio.CancelledError(),
+                            )
+                            logger.info("Task cancelled for session {}", session_key)
+                            # Preserve partial context from the interrupted turn so
+                            # the user does not lose tool results and assistant
+                            # messages accumulated before /stop.  The checkpoint was
+                            # already persisted to session metadata by
+                            # _emit_checkpoint during tool execution; materializing
+                            # it into session history now makes it visible in the
+                            # next conversation turn.
                             try:
-                                item = queue.get_nowait()
-                            except asyncio.QueueEmpty:
-                                break
-                            await self.bus.publish_inbound(item)
-                            leftover += 1
-                        if leftover:
-                            logger.info(
-                                "Re-published {} leftover message(s) to bus for session {}",
-                                leftover, session_key,
-                            )
+                                key = self._effective_session_key(msg)
+                                session = self.sessions.get_or_create(key)
+                                if self._restore_runtime_checkpoint(session):
+                                    self._clear_pending_user_turn(session)
+                                    self.sessions.save(session)
+                                    logger.info(
+                                        "Restored partial context for cancelled session {}",
+                                        key,
+                                    )
+                            except Exception:
+                                logger.debug(
+                                    "Could not restore checkpoint for cancelled session {}",
+                                    session_key,
+                                    exc_info=True,
+                                )
+                            raise
+                        except Exception as exc:
+                            logger.exception("Error processing message for session {}", session_key)
+                            await self.bus.publish_outbound(OutboundMessage(
+                                channel=msg.channel, chat_id=msg.chat_id,
+                                content="Sorry, I encountered an error.",
+                            ))
+                            if not turn_continuation.internal_continuation_pending(
+                                msg.metadata
+                            ):
+                                await self._runtime_events().turn_completed(
+                                    channel=msg.channel,
+                                    chat_id=msg.chat_id,
+                                    session_key=session_key,
+                                    metadata=msg.metadata,
+                                )
+                            self._cron_turns.complete(msg, error=exc)
+                finally:
                     if not turn_continuation.internal_continuation_pending(msg.metadata):
                         await self._runtime_events().run_status_changed(
                             msg, session_key, "idle"
@@ -1851,23 +1859,25 @@ class AgentLoop:
         lock = self._session_locks.setdefault(session_key, asyncio.Lock())
         try:
             async with lock:
-                kwargs: dict[str, Any] = {
-                    "session_key": session_key,
-                    "on_progress": on_progress,
-                    "on_stream": on_stream,
-                    "on_stream_end": on_stream_end,
-                    "ephemeral": ephemeral,
-                }
-                if _run_extra_hooks_for_ephemeral:
-                    kwargs["run_extra_hooks_for_ephemeral"] = True
-                if hooks is not None:
-                    kwargs["hooks"] = hooks
-                if tools is not None:
-                    kwargs["tools"] = tools
-                return await self._process_message(
-                    msg,
-                    **kwargs,
-                )
+                async with self._active_pending_queue(session_key) as pending:
+                    kwargs: dict[str, Any] = {
+                        "session_key": session_key,
+                        "on_progress": on_progress,
+                        "on_stream": on_stream,
+                        "on_stream_end": on_stream_end,
+                        "ephemeral": ephemeral,
+                        "pending_queue": pending,
+                    }
+                    if _run_extra_hooks_for_ephemeral:
+                        kwargs["run_extra_hooks_for_ephemeral"] = True
+                    if hooks is not None:
+                        kwargs["hooks"] = hooks
+                    if tools is not None:
+                        kwargs["tools"] = tools
+                    return await self._process_message(
+                        msg,
+                        **kwargs,
+                    )
         finally:
             await self._runtime_events().run_status_changed(msg, session_key, "idle")
             self._runtime_events().clear_turn(session_key)

--- a/tests/agent/test_loop_direct_websocket_status.py
+++ b/tests/agent/test_loop_direct_websocket_status.py
@@ -120,3 +120,66 @@ async def test_process_direct_applies_per_run_hooks(tmp_path) -> None:
     assert response is not None
     assert response.content == "done"
     assert events == [("before", None), ("after", "done")]
+
+
+@pytest.mark.asyncio
+async def test_process_direct_creates_and_cleans_up_pending_queue(tmp_path) -> None:
+    """process_direct should register a pending_queue during execution and remove it after."""
+    loop = _make_loop(tmp_path)
+    session_key = "cron:test-queue"
+
+    assert session_key not in loop._pending_queues
+
+    await loop.process_direct("hello", session_key=session_key)
+
+    assert session_key not in loop._pending_queues
+
+
+@pytest.mark.asyncio
+async def test_process_direct_passes_pending_queue_to_process_message(tmp_path) -> None:
+    """process_direct should pass a non-None pending_queue to _process_message."""
+    loop = _make_loop(tmp_path)
+    loop._connect_mcp = AsyncMock()
+    captured_kwargs = {}
+
+    async def _process_message(msg, **kwargs):
+        captured_kwargs.update(kwargs)
+        return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id, content=msg.content)
+
+    loop._process_message = _process_message
+
+    await loop.process_direct("hello", session_key="cron:test-pq")
+
+    assert "pending_queue" in captured_kwargs
+    assert captured_kwargs["pending_queue"] is not None
+
+
+@pytest.mark.asyncio
+async def test_process_direct_republishes_leftover_queue_messages(tmp_path) -> None:
+    """Messages left in the pending queue after process_direct should be re-published to the bus."""
+    loop = _make_loop(tmp_path)
+    loop._connect_mcp = AsyncMock()
+    session_key = "cron:test-leftover"
+
+    async def _process_message(msg, **kwargs):
+        # Simulate a subagent result arriving in the pending queue
+        # during execution but not consumed by the runner.
+        pq = kwargs.get("pending_queue")
+        if pq is not None:
+            from nanobot.bus.events import InboundMessage
+            pq.put_nowait(InboundMessage(
+                channel="system", sender_id="subagent", chat_id="cli:c",
+                content="subagent result",
+            ))
+        return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id, content=msg.content)
+
+    loop._process_message = _process_message
+
+    await loop.process_direct("hello", session_key=session_key)
+
+    # The leftover message should have been re-published to the bus
+    msgs = []
+    while loop.bus.inbound_size:
+        msgs.append(await asyncio.wait_for(loop.bus.consume_inbound(), timeout=0.5))
+    contents = [m.content for m in msgs]
+    assert "subagent result" in contents

--- a/tests/agent/test_loop_direct_websocket_status.py
+++ b/tests/agent/test_loop_direct_websocket_status.py
@@ -4,8 +4,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from nanobot.agent.loop import AgentLoop
-from nanobot.bus.events import OutboundMessage
+from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.queue import MessageBus
+from nanobot.cron.session_turns import CRON_DEFER_UNTIL_IDLE_META, CRON_TRIGGER_META
 from nanobot.providers.base import GenerationSettings, LLMResponse
 from nanobot.session.webui_turns import WebuiTurnCoordinator
 
@@ -183,3 +184,36 @@ async def test_process_direct_republishes_leftover_queue_messages(tmp_path) -> N
         msgs.append(await asyncio.wait_for(loop.bus.consume_inbound(), timeout=0.5))
     contents = [m.content for m in msgs]
     assert "subagent result" in contents
+
+
+@pytest.mark.asyncio
+async def test_process_direct_publishes_deferred_cron_turn_after_pending_queue(tmp_path) -> None:
+    loop = _make_loop(tmp_path)
+    loop._connect_mcp = AsyncMock()
+    session_key = "cron:test-deferred"
+
+    async def _process_message(msg, **_kwargs):
+        deferred = InboundMessage(
+            channel="websocket",
+            sender_id="cron",
+            chat_id="chat-1",
+            content="deferred cron turn",
+            metadata={
+                CRON_TRIGGER_META: {"job_id": "job-1", "run_id": "run-1"},
+                CRON_DEFER_UNTIL_IDLE_META: True,
+            },
+        )
+        assert loop._cron_turns.defer_if_active(
+            deferred,
+            session_key=session_key,
+            active_session_keys=loop._pending_queues.keys(),
+        )
+        return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id, content=msg.content)
+
+    loop._process_message = _process_message
+
+    await loop.process_direct("hello", session_key=session_key)
+
+    msg = await asyncio.wait_for(loop.bus.consume_inbound(), timeout=0.5)
+    assert msg.content == "deferred cron turn"
+    assert session_key not in loop._cron_turns.deferred_queues

--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -464,10 +464,12 @@ async def test_process_direct_accepts_media() -> None:
     loop = AgentLoop.__new__(AgentLoop)
     loop._connect_mcp = AsyncMock()
     loop._session_locks = {}
+    loop._pending_queues = {}
+    loop.bus = AsyncMock()
 
     captured_msg = None
 
-    async def fake_process(msg, *, session_key="", on_progress=None, on_stream=None, on_stream_end=None, ephemeral=False):
+    async def fake_process(msg, *, session_key="", on_progress=None, on_stream=None, on_stream_end=None, ephemeral=False, pending_queue=None):
         nonlocal captured_msg
         captured_msg = msg
         return None

--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -465,6 +465,8 @@ async def test_process_direct_accepts_media() -> None:
     loop._connect_mcp = AsyncMock()
     loop._session_locks = {}
     loop._pending_queues = {}
+    loop._cron_turns = MagicMock()
+    loop._cron_turns.publish_next_deferred = AsyncMock()
     loop.bus = AsyncMock()
 
     captured_msg = None


### PR DESCRIPTION
 ## Summary

  - Add `pending_queue` creation and registration to `process_direct()`, mirroring the pattern already used in `_dispatch()`. This fixes cron jobs (and other direct calls) that spawn subagents — the runner
  loop now waits for subagent results and injects them mid-turn instead of completing prematurely.
  - Add leftover queue drain logic in the `finally` block, re-publishing unconsumed messages to the bus (same cleanup as `_dispatch`).
  - Closes #4290

  ## Root Cause

  `process_direct()` did not create a `pending_queue`, so:
  1. `_drain_pending` received `None` and returned `[]` immediately — the runner loop never waited for subagent results
  2. Subagent `_announce_result` published to the bus but found no pending queue, so the result was dispatched as a disconnected second turn

  ## Before vs After

  **Before:** Cron job spawns subagent → runner loop exits → cron job completes → subagent result arrives 2 min later as orphaned turn

  **After:** Cron job spawns subagent → `_drain_pending` blocks waiting for result → subagent result injected as user message → main agent processes it → cron job completes

  ## Test plan

  - [x] `test_process_direct_creates_and_cleans_up_pending_queue` — queue registered during execution, removed after
  - [x] `test_process_direct_passes_pending_queue_to_process_message` — non-None queue passed through
  - [x] `test_process_direct_republishes_leftover_queue_messages` — leftover messages re-published to bus