### PR TITLE
feat(skills): Check skill type requirements

### DIFF
--- a/nanobot/agent/skills.py
+++ b/nanobot/agent/skills.py
@@ -70,7 +70,7 @@ class SkillsLoader:
 
         if filter_unavailable:
             return [s for s in skills if self._is_skill_fully_available(s["name"], skills)]
-        
+
         return skills
 
     def load_skill(self, name: str) -> str | None:
@@ -242,7 +242,7 @@ class SkillsLoader:
         return all(shutil.which(cmd) for cmd in required_bins) and all(
             os.environ.get(var) for var in required_env_vars
         )
-    
+
     def _is_skill_fully_available(
         self, name: str, all_skills: list[dict[str, str]], visited: set[str] | None = None,
     ) -> bool:

--- a/nanobot/agent/skills.py
+++ b/nanobot/agent/skills.py
@@ -69,7 +69,8 @@ class SkillsLoader:
             skills = [s for s in skills if s["name"] not in self.disabled_skills]
 
         if filter_unavailable:
-            return [skill for skill in skills if self._check_requirements(self._get_skill_meta(skill["name"]))]
+            return [s for s in skills if self._is_skill_fully_available(s["name"], skills)]
+        
         return skills
 
     def load_skill(self, name: str) -> str | None:
@@ -131,42 +132,71 @@ class SkillsLoader:
             if exclude and skill_name in exclude:
                 continue
             meta = self._get_skill_meta(skill_name)
-            available = self._check_requirements(meta)
+            available = self._is_skill_fully_available(skill_name, all_skills)
             desc = self._get_skill_description(skill_name)
             if available:
                 lines.append(f"- **{skill_name}** — {desc}  `{entry['path']}`")
             else:
-                missing = self._get_missing_requirements(meta)
+                missing = self._get_missing_requirements(meta, all_skills)
                 suffix = f" (unavailable: {missing})" if missing else " (unavailable)"
                 lines.append(f"- **{skill_name}** — {desc}{suffix}  `{entry['path']}`")
         return "\n".join(lines)
 
-    def _get_missing_requirements(self, skill_meta: dict) -> str:
-        """Get a description of missing requirements."""
+    def _get_missing_requirements(self, skill_meta: dict, all_skills: list[dict[str, str]] | None = None, visited: set[str] | None = None) -> str:
+        """Get a description of missing requirements, including recursive skill deps."""
         requires = skill_meta.get("requires", {})
         required_bins = requires.get("bins", [])
         required_env_vars = requires.get("env", [])
-        return ", ".join(
-            [f"CLI: {command_name}" for command_name in required_bins if not shutil.which(command_name)]
-            + [f"ENV: {env_name}" for env_name in required_env_vars if not os.environ.get(env_name)]
-        )
+        parts: list[str] = [
+            f"CLI: {cmd}" for cmd in required_bins if not shutil.which(cmd)
+        ]
+        parts += [f"ENV: {v}" for v in required_env_vars if not os.environ.get(v)]
+
+        # Recursively check skill-type dependencies
+        if all_skills is not None:
+            v = visited or set()
+            required_skills = requires.get("skills", [])
+            for dep_name in required_skills:
+                if dep_name in v:
+                    continue  # cycle detected, skip
+                v.add(dep_name)
+                dep_entry = next((s for s in all_skills if s["name"] == dep_name), None)
+                if dep_entry is None:
+                    parts.append("SKILL: " + dep_name + " (missing)")
+                else:
+                    dep_meta = self._get_skill_meta(dep_name)
+                    dep_missing = self._get_missing_requirements(dep_meta, all_skills, v)
+                    if dep_missing:
+                        parts.append("SKILL: " + dep_name + " (needs " + dep_missing + ")")
+
+        return ", ".join(parts)
 
     def get_skill_availability(self, name: str) -> tuple[bool, str]:
         """Return whether a skill can run and why not when it cannot."""
+        all_skills = self.list_skills(filter_unavailable=False)
+        available = self._is_skill_fully_available(name, all_skills)
+        if available:
+            return True, ""
         meta = self._get_skill_meta(name)
-        available = self._check_requirements(meta)
-        return available, "" if available else self._get_missing_requirements(meta)
+        return False, self._get_missing_requirements(meta, all_skills)
 
     def get_skill_requirements(self, name: str) -> dict[str, list[str]]:
-        """Return explicit command/env requirements and currently missing entries."""
+        """Return explicit command/env/skill requirements and currently missing entries."""
+        all_skills = self.list_skills(filter_unavailable=False)
         requires = self._get_skill_meta(name).get("requires", {})
         bins = [str(value) for value in requires.get("bins", [])]
         env = [str(value) for value in requires.get("env", [])]
+        skills_req = [str(value) for value in requires.get("skills", [])]
         return {
             "bins": bins,
             "env": env,
-            "missing_bins": [value for value in bins if not shutil.which(value)],
-            "missing_env": [value for value in env if not os.environ.get(value)],
+            "skills": skills_req,
+            "missing_bins": [v for v in bins if not shutil.which(v)],
+            "missing_env": [v for v in env if not os.environ.get(v)],
+            "missing_skills": [
+                v for v in skills_req
+                if not any(s["name"] == v for s in all_skills)
+            ],
         }
 
     def _get_skill_description(self, name: str) -> str:
@@ -212,6 +242,34 @@ class SkillsLoader:
         return all(shutil.which(cmd) for cmd in required_bins) and all(
             os.environ.get(var) for var in required_env_vars
         )
+    
+    def _is_skill_fully_available(
+        self, name: str, all_skills: list[dict[str, str]], visited: set[str] | None = None,
+    ) -> bool:
+        """Check bins, env, AND all transitive skill dependencies (cycle-safe)."""
+        if visited is None:
+            visited = set()
+        if name in visited:
+            return True  # already verified this dependency upstream
+        visited.add(name)
+
+        meta = self._get_skill_meta(name)
+        if not meta:
+            return True
+
+        # Bins and env vars must be satisfied first.
+        if not self._check_requirements(meta):
+            return False
+
+        required_skills = meta.get("requires", {}).get("skills", [])
+        for dep_name in required_skills:
+            dep_entry = next((s for s in all_skills if s["name"] == dep_name), None)
+            if dep_entry is None:
+                return False  # dependency doesn't exist at all
+            if not self._is_skill_fully_available(dep_name, all_skills, visited):
+                return False
+
+        return True
 
     def _get_skill_meta(self, name: str) -> dict:
         """Get nanobot metadata for a skill (cached in frontmatter)."""

--- a/tests/agent/test_skills_loader.py
+++ b/tests/agent/test_skills_loader.py
@@ -397,3 +397,111 @@ def test_get_skill_metadata_handles_yaml_types(tmp_path: Path) -> None:
     assert meta.get("always") is True
     # metadata is a parsed dict, not a JSON string
     assert isinstance(meta.get("metadata"), dict)
+
+
+# -- skill dependency tests -----------------------------------------------------
+
+
+def test_list_skills_filters_out_missing_skill_dep(tmp_path: Path) -> None:
+    """Skill A depends on B, but B doesn't exist — A should be unavailable."""
+    workspace = tmp_path / "ws"
+    skills_root = workspace / "skills"
+    skills_root.mkdir(parents=True)
+    _write_skill(skills_root, "A", metadata_json={"requires": {"skills": ["B"]}})
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+
+    loader = SkillsLoader(workspace, builtin_skills_dir=builtin)
+    entries = loader.list_skills(filter_unavailable=True)
+    assert entries == []
+
+
+def test_list_skills_includes_when_skill_dep_exists(tmp_path: Path) -> None:
+    """A depends on B, B exists with no requirements — both available."""
+    workspace = tmp_path / "ws"
+    skills_root = workspace / "skills"
+    skills_root.mkdir(parents=True)
+    _write_skill(skills_root, "A", metadata_json={"requires": {"skills": ["B"]}})
+    _write_skill(skills_root, "B")
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+
+    loader = SkillsLoader(workspace, builtin_skills_dir=builtin)
+    entries = loader.list_skills(filter_unavailable=True)
+    print(entries)
+    names = {e["name"] for e in entries}
+    assert names == {"A", "B"}
+
+
+def test_list_skills_recursive_skill_dep_unmet_deep(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A -> B -> C where C has unmet bin — A should be unavailable (transitive)."""
+    workspace = tmp_path / "ws"
+    skills_root = workspace / "skills"
+    skills_root.mkdir(parents=True)
+    _write_skill(skills_root, "A", metadata_json={"requires": {"skills": ["B"]}})
+    _write_skill(skills_root, "B", metadata_json={"requires": {"skills": ["C"]}})
+    _write_skill(skills_root, "C", metadata_json={"requires": {"bins": ["fake_bin"]}})
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+
+    monkeypatch.setattr("nanobot.agent.skills.shutil.which", lambda _cmd: None)
+
+    loader = SkillsLoader(workspace, builtin_skills_dir=builtin)
+    entries = loader.list_skills(filter_unavailable=True)
+    assert entries == []
+
+
+def test_get_skill_availability_reports_missing_skill_dep(tmp_path: Path) -> None:
+    """get_skill_availability reason should mention the missing dependency."""
+    workspace = tmp_path / "ws"
+    skills_root = workspace / "skills"
+    skills_root.mkdir(parents=True)
+    _write_skill(skills_root, "A", metadata_json={"requires": {"skills": ["B"]}})
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+
+    loader = SkillsLoader(workspace, builtin_skills_dir=builtin)
+    available, reason = loader.get_skill_availability("A")
+    assert not available
+    assert "B" in reason
+
+
+def test_get_skill_requirements_includes_skills_field(tmp_path: Path) -> None:
+    """get_skill_requirements should report skills and missing_skills."""
+    workspace = tmp_path / "ws"
+    skills_root = workspace / "skills"
+    skills_root.mkdir(parents=True)
+    _write_skill(skills_root, "A", metadata_json={"requires": {"skills": ["B", "Z"]}})
+    _write_skill(skills_root, "B")
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+
+    loader = SkillsLoader(workspace, builtin_skills_dir=builtin)
+    reqs = loader.get_skill_requirements("A")
+    assert reqs["skills"] == ["B", "Z"]
+    assert reqs["missing_skills"] == ["Z"]  # Z doesn't exist
+
+
+def test_cycle_dependency_does_not_recurse_infinitely(tmp_path: Path) -> None:
+    """A -> B -> C -> A cycle: should not hit RecursionError."""
+    workspace = tmp_path / "ws"
+    skills_root = workspace / "skills"
+    skills_root.mkdir(parents=True, exist_ok=True)
+    _write_skill(skills_root, "A", metadata_json={"requires": {"skills": ["B"]}})
+    _write_skill(skills_root, "B", metadata_json={"requires": {"skills": ["C"]}})
+    _write_skill(skills_root, "C", metadata_json={"requires": {"skills": ["A"]}})
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+
+    loader = SkillsLoader(workspace, builtin_skills_dir=builtin)
+    # _is_skill_fully_available: visited prevents inf loop
+    entries = loader.list_skills(filter_unavailable=True)
+    assert {e["name"] for e in entries} == {"A", "B", "C"}
+
+    # _get_missing_requirements: visited prevents inf loop in summary
+    summary = loader.build_skills_summary()
+    assert "A" in summary
+    assert "B" in summary
+    assert "C" in summary

--- a/tests/channels/test_websocket_http_routes.py
+++ b/tests/channels/test_websocket_http_routes.py
@@ -308,11 +308,14 @@ async def test_webui_skills_route_requires_token_and_hides_paths(
         assert detail.status_code == 200
         detail_body = detail.json()
         assert "path" not in detail_body
+        print(detail_body["requirements"] )
         assert detail_body["requirements"] == {
             "bins": ["definitely-missing-nanobot-skill-cli"],
             "env": ["DEFINITELY_MISSING_NANOBOT_SKILL_ENV"],
+            "skills": [],
             "missing_bins": ["definitely-missing-nanobot-skill-cli"],
             "missing_env": ["DEFINITELY_MISSING_NANOBOT_SKILL_ENV"],
+            "missing_skills": [],
         }
         assert "Use the missing CLI and env var." in detail_body["raw_markdown"]
     finally:


### PR DESCRIPTION
## Summary

- add `_is_skill_fully_available()` in nanobot/agent/skills.py to check skill type requirements


## Why

Recently,  I want to build a skill about fund management. I found some powerful existing skills about stock data and news,  and I intend to apply them to fund position analysis. Then I realised it's better to add them as the requirements instead of merge them. This phenomenon may become quite common in the future. Since nanobots already have skill-dependent checks, why not add checks for skill type requirements.

## Variation

The interface has barely changed. `_is_skill_fully_available()` recursively checked all skill dependencies, including `bin`, `env`, and `skill`. A set is used to avoid repeated checks and infinite recursion

## CI
- `test_list_skills_filters_out_missing_skill_dep`: Skill A depends on B, but B doesn't exist — A should be unavailable.
- `test_list_skills_includes_when_skill_dep_exists`: A depends on B, B exists with no requirements — both available.
- `test_list_skills_recursive_skill_dep_unmet_deep`: A -> B -> C where C has unmet bin — A should be unavailable (transitive).
- `test_get_skill_availability_reports_missing_skill_dep`: get_skill_availability reason should mention the missing dependency.
- `test_get_skill_requirements_includes_skills_field`: get_skill_requirements should report skills and missing_skills.
- `test_cycle_dependency_does_not_recurse_infinitely`: A -> B -> C -> A cycle: should not hit RecursionError.
- tests/channels/test_websocket_http_routes.py::test_webui_skills_route_requires_token_and_hides_paths is changed, because `skills` and `missing_skills` are appended to `get_skill_requirements`