### PR TITLE
feat(skills): cache skills loader entries and metadata

### DIFF
--- a/nanobot/agent/skills.py
+++ b/nanobot/agent/skills.py
@@ -31,6 +31,15 @@ class SkillsLoader:
         self.workspace_skills = workspace / "skills"
         self.builtin_skills = builtin_skills_dir or BUILTIN_SKILLS_DIR
         self.disabled_skills = disabled_skills or set()
+        self._entries_cache: list[dict[str, str]] | None = None
+        self._entries_snapshot: tuple[tuple[str, str, int, int], ...] | None = None
+        self._metadata_cache: dict[str, tuple[tuple[str, int, int], dict | None]] = {}
+
+    def reload(self) -> None:
+        """Clear skill caches so the next lookup reloads from disk."""
+        self._entries_cache = None
+        self._entries_snapshot = None
+        self._metadata_cache.clear()
 
     def _skill_entries_from_dir(self, base: Path, source: str, *, skip_names: set[str] | None = None) -> list[dict[str, str]]:
         if not base.exists():
@@ -48,6 +57,69 @@ class SkillsLoader:
             entries.append({"name": name, "path": str(skill_file), "source": source})
         return entries
 
+    def _list_skill_entries_cached(self) -> list[dict[str, str]]:
+        snapshot = self._skill_entries_snapshot()
+        if self._entries_cache is not None and snapshot == self._entries_snapshot:
+            return [dict(entry) for entry in self._entries_cache]
+
+        skills = self._skill_entries_from_dir(self.workspace_skills, "workspace")
+        workspace_names = {entry["name"] for entry in skills}
+        if self.builtin_skills and self.builtin_skills.exists():
+            skills.extend(
+                self._skill_entries_from_dir(
+                    self.builtin_skills,
+                    "builtin",
+                    skip_names=workspace_names,
+                )
+            )
+
+        self._entries_snapshot = snapshot
+        self._entries_cache = [dict(entry) for entry in skills]
+        return [dict(entry) for entry in skills]
+
+    def _skill_entries_snapshot(self) -> tuple[tuple[str, str, int, int], ...]:
+        items: list[tuple[str, str, int, int]] = []
+        roots = [("workspace", self.workspace_skills)]
+        if self.builtin_skills:
+            roots.append(("builtin", self.builtin_skills))
+
+        for source, base in roots:
+            if not base.exists():
+                continue
+            try:
+                skill_dirs = sorted(base.iterdir(), key=lambda item: item.name)
+            except OSError:
+                continue
+            for skill_dir in skill_dirs:
+                if not skill_dir.is_dir():
+                    continue
+                skill_file = skill_dir / "SKILL.md"
+                signature = self._skill_file_signature(skill_file)
+                if signature is None:
+                    continue
+                resolved_path, mtime_ns, size = signature
+                items.append((source, resolved_path, mtime_ns, size))
+        return tuple(items)
+
+    def _skill_file_signature(self, path: Path) -> tuple[str, int, int] | None:
+        try:
+            stat = path.stat()
+        except OSError:
+            return None
+        if not path.is_file():
+            return None
+        return (str(path.resolve()), stat.st_mtime_ns, stat.st_size)
+
+    def _skill_file_for_name(self, name: str) -> Path | None:
+        roots = [self.workspace_skills]
+        if self.builtin_skills:
+            roots.append(self.builtin_skills)
+        for root in roots:
+            path = root / name / "SKILL.md"
+            if path.is_file():
+                return path
+        return None
+
     def list_skills(self, filter_unavailable: bool = True) -> list[dict[str, str]]:
         """
         List all available skills.
@@ -58,12 +130,7 @@ class SkillsLoader:
         Returns:
             List of skill info dicts with 'name', 'path', 'source'.
         """
-        skills = self._skill_entries_from_dir(self.workspace_skills, "workspace")
-        workspace_names = {entry["name"] for entry in skills}
-        if self.builtin_skills and self.builtin_skills.exists():
-            skills.extend(
-                self._skill_entries_from_dir(self.builtin_skills, "builtin", skip_names=workspace_names)
-            )
+        skills = self._list_skill_entries_cached()
 
         if self.disabled_skills:
             skills = [s for s in skills if s["name"] not in self.disabled_skills]
@@ -82,14 +149,10 @@ class SkillsLoader:
         Returns:
             Skill content or None if not found.
         """
-        roots = [self.workspace_skills]
-        if self.builtin_skills:
-            roots.append(self.builtin_skills)
-        for root in roots:
-            path = root / name / "SKILL.md"
-            if path.exists():
-                return path.read_text(encoding="utf-8")
-        return None
+        path = self._skill_file_for_name(name)
+        if path is None:
+            return None
+        return path.read_text(encoding="utf-8")
 
     def load_skills_for_context(self, skill_names: list[str]) -> str:
         """
@@ -240,7 +303,22 @@ class SkillsLoader:
         Returns:
             Metadata dict or None.
         """
-        content = self.load_skill(name)
+        path = self._skill_file_for_name(name)
+        if path is None:
+            return None
+        signature = self._skill_file_signature(path)
+        if signature is None:
+            return None
+        cached = self._metadata_cache.get(name)
+        if cached is not None and cached[0] == signature:
+            return cached[1]
+
+        content = path.read_text(encoding="utf-8")
+        metadata = self._parse_skill_frontmatter(content)
+        self._metadata_cache[name] = (signature, metadata)
+        return metadata
+
+    def _parse_skill_frontmatter(self, content: str) -> dict | None:
         if not content or not content.startswith("---"):
             return None
         match = _STRIP_SKILL_FRONTMATTER.match(content)

--- a/tests/agent/test_skills_loader.py
+++ b/tests/agent/test_skills_loader.py
@@ -397,3 +397,134 @@ def test_get_skill_metadata_handles_yaml_types(tmp_path: Path) -> None:
     assert meta.get("always") is True
     # metadata is a parsed dict, not a JSON string
     assert isinstance(meta.get("metadata"), dict)
+
+
+def test_list_skills_cache_reuses_scan_until_snapshot_changes_or_reload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "ws"
+    ws_skills = workspace / "skills"
+    ws_skills.mkdir(parents=True)
+    alpha_path = _write_skill(ws_skills, "alpha", body="# Alpha")
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+
+    loader = SkillsLoader(workspace, builtin_skills_dir=builtin)
+    original_scan = loader._skill_entries_from_dir
+    scan_calls = 0
+
+    def scan_with_count(*args: object, **kwargs: object) -> list[dict[str, str]]:
+        nonlocal scan_calls
+        scan_calls += 1
+        return original_scan(*args, **kwargs)
+
+    monkeypatch.setattr(loader, "_skill_entries_from_dir", scan_with_count)
+
+    assert loader.list_skills(filter_unavailable=False) == [
+        {"name": "alpha", "path": str(alpha_path), "source": "workspace"},
+    ]
+    calls_after_first_list = scan_calls
+    assert loader.list_skills(filter_unavailable=False) == [
+        {"name": "alpha", "path": str(alpha_path), "source": "workspace"},
+    ]
+    assert scan_calls == calls_after_first_list
+
+    beta_path = _write_skill(ws_skills, "beta", body="# Beta")
+    entries = sorted(loader.list_skills(filter_unavailable=False), key=lambda item: item["name"])
+    assert entries == [
+        {"name": "alpha", "path": str(alpha_path), "source": "workspace"},
+        {"name": "beta", "path": str(beta_path), "source": "workspace"},
+    ]
+    assert scan_calls > calls_after_first_list
+    calls_after_add = scan_calls
+
+    alpha_path.unlink()
+    assert loader.list_skills(filter_unavailable=False) == [
+        {"name": "beta", "path": str(beta_path), "source": "workspace"},
+    ]
+    assert scan_calls > calls_after_add
+    calls_after_delete = scan_calls
+
+    loader.reload()
+    assert loader.list_skills(filter_unavailable=False) == [
+        {"name": "beta", "path": str(beta_path), "source": "workspace"},
+    ]
+    assert scan_calls > calls_after_delete
+
+
+def test_skill_metadata_cache_reuses_parse_until_signature_changes_or_reload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "ws"
+    ws_skills = workspace / "skills"
+    ws_skills.mkdir(parents=True)
+    skill_path = _write_skill(ws_skills, "meta", metadata_json={"always": True}, body="# Meta")
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+
+    loader = SkillsLoader(workspace, builtin_skills_dir=builtin)
+    original_parse = loader._parse_skill_frontmatter
+    parse_calls = 0
+
+    def parse_with_count(content: str) -> dict | None:
+        nonlocal parse_calls
+        parse_calls += 1
+        return original_parse(content)
+
+    monkeypatch.setattr(loader, "_parse_skill_frontmatter", parse_with_count)
+
+    assert loader.get_skill_metadata("meta") is not None
+    assert loader.get_skill_metadata("meta") is not None
+    assert parse_calls == 1
+
+    skill_path.write_text(
+        "---\n"
+        "description: Updated description with a different size.\n"
+        "---\n\n# Meta\n",
+        encoding="utf-8",
+    )
+    assert (loader.get_skill_metadata("meta") or {}).get("description") == (
+        "Updated description with a different size."
+    )
+    assert parse_calls == 2
+
+    loader.reload()
+    assert (loader.get_skill_metadata("meta") or {}).get("description") == (
+        "Updated description with a different size."
+    )
+    assert parse_calls == 3
+
+
+def test_metadata_cache_does_not_survive_workspace_shadowing_builtin(tmp_path: Path) -> None:
+    workspace = tmp_path / "ws"
+    ws_skills = workspace / "skills"
+    ws_skills.mkdir(parents=True)
+    builtin = tmp_path / "builtin"
+    builtin_path = _write_skill(builtin, "dup", body="# Builtin")
+    builtin_path.write_text(
+        "---\n"
+        "description: Builtin description.\n"
+        "---\n\n# Builtin\n",
+        encoding="utf-8",
+    )
+
+    loader = SkillsLoader(workspace, builtin_skills_dir=builtin)
+    assert loader.list_skills(filter_unavailable=False) == [
+        {"name": "dup", "path": str(builtin_path), "source": "builtin"},
+    ]
+    assert (loader.get_skill_metadata("dup") or {}).get("description") == "Builtin description."
+
+    workspace_path = _write_skill(ws_skills, "dup", body="# Workspace")
+    workspace_path.write_text(
+        "---\n"
+        "description: Workspace description wins over builtin.\n"
+        "---\n\n# Workspace\n",
+        encoding="utf-8",
+    )
+
+    assert loader.list_skills(filter_unavailable=False) == [
+        {"name": "dup", "path": str(workspace_path), "source": "workspace"},
+    ]
+    assert (loader.get_skill_metadata("dup") or {}).get("description") == (
+        "Workspace description wins over builtin."
+    )


### PR DESCRIPTION
## Summary

Cache skill discovery and frontmatter metadata in `SkillsLoader` to avoid repeated directory scans and YAML parsing on every agent context build.

## Problem

`SkillsLoader` previously rescanned workspace/builtin skills and reparsed `SKILL.md` frontmatter whenever skills were listed or metadata was queried. In long-running gateway processes with multiple sessions, this caused unnecessary IO and parsing work even when skills had not changed.

## Changes

- Added cached skill entries with file-signature based invalidation.
- Added cached skill metadata with file-signature based invalidation.
- Added `reload()` to explicitly clear skill caches.
- Preserved workspace-overrides-builtin behavior.
- Added regression tests for cache reuse, automatic invalidation, explicit reload, and workspace shadowing.