### PR TITLE
fix(session): prevent orphaned tool results from being persisted to history (#4006)

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1593,9 +1593,7 @@ class AgentLoop:
             if role == "tool":
                 tool_call_id = entry.get("tool_call_id")
                 if not tool_call_id or str(tool_call_id) not in declared_tool_call_ids:
-                    # A tool result without a declared call violates the
-                    # OpenAI/Anthropic pairing contract and would poison
-                    # every future request built from this session (#4006).
+                    # Undeclared tool results corrupt future provider requests.
                     logger.warning(
                         "Dropping orphaned tool result {} from session {} during persistence",
                         tool_call_id or "(missing id)",
@@ -1607,8 +1605,7 @@ class AgentLoop:
                 elif isinstance(content, list):
                     filtered = self._sanitize_persisted_blocks(content, should_truncate_text=True)
                     if not filtered:
-                        # Dropping the message would leave its assistant
-                        # tool_call without a result; keep a placeholder.
+                        # Preserve the tool_call/result pair after block filtering.
                         filtered = [
                             {"type": "text", "text": "[tool result omitted during persistence]"}
                         ]

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1589,7 +1589,11 @@ class AgentLoop:
                 elif isinstance(content, list):
                     filtered = self._sanitize_persisted_blocks(content, should_truncate_text=True)
                     if not filtered:
-                        continue
+                        # Dropping the message would leave its assistant
+                        # tool_call without a result; keep a placeholder.
+                        filtered = [
+                            {"type": "text", "text": "[tool result omitted during persistence]"}
+                        ]
                     entry["content"] = filtered
             elif role == "user":
                 if isinstance(content, str) and ContextBuilder._RUNTIME_CONTEXT_TAG in content:

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1592,13 +1592,13 @@ class AgentLoop:
                 continue  # skip empty assistant messages — they poison session context
             if role == "tool":
                 tool_call_id = entry.get("tool_call_id")
-                if tool_call_id and str(tool_call_id) not in declared_tool_call_ids:
+                if not tool_call_id or str(tool_call_id) not in declared_tool_call_ids:
                     # A tool result without a declared call violates the
                     # OpenAI/Anthropic pairing contract and would poison
                     # every future request built from this session (#4006).
                     logger.warning(
                         "Dropping orphaned tool result {} from session {} during persistence",
-                        tool_call_id,
+                        tool_call_id or "(missing id)",
                         session.key,
                     )
                     continue

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1577,6 +1577,13 @@ class AgentLoop:
         """Save new-turn messages into session, truncating large tool results."""
         from datetime import datetime
 
+        declared_tool_call_ids = {
+            str(tc["id"])
+            for m in session.messages
+            if m.get("role") == "assistant"
+            for tc in m.get("tool_calls") or []
+            if isinstance(tc, dict) and tc.get("id")
+        }
         last_assistant_idx: int | None = None
         for m in messages[skip:]:
             entry = dict(m)
@@ -1584,6 +1591,17 @@ class AgentLoop:
             if role == "assistant" and not content and not entry.get("tool_calls"):
                 continue  # skip empty assistant messages — they poison session context
             if role == "tool":
+                tool_call_id = entry.get("tool_call_id")
+                if tool_call_id and str(tool_call_id) not in declared_tool_call_ids:
+                    # A tool result without a declared call violates the
+                    # OpenAI/Anthropic pairing contract and would poison
+                    # every future request built from this session (#4006).
+                    logger.warning(
+                        "Dropping orphaned tool result {} from session {} during persistence",
+                        tool_call_id,
+                        session.key,
+                    )
+                    continue
                 if isinstance(content, str) and len(content) > self.max_tool_result_chars:
                     entry["content"] = truncate_text_fn(content, self.max_tool_result_chars)
                 elif isinstance(content, list):
@@ -1613,6 +1631,11 @@ class AgentLoop:
             session.messages.append(entry)
             if role == "assistant":
                 last_assistant_idx = len(session.messages) - 1
+                declared_tool_call_ids.update(
+                    str(tc["id"])
+                    for tc in entry.get("tool_calls") or []
+                    if isinstance(tc, dict) and tc.get("id")
+                )
         if turn_latency_ms is not None and last_assistant_idx is not None:
             session.messages[last_assistant_idx]["latency_ms"] = int(turn_latency_ms)
         session.updated_at = datetime.now()

--- a/nanobot/session/turn_continuation.py
+++ b/nanobot/session/turn_continuation.py
@@ -182,7 +182,15 @@ def _save_skip_for_turn(
     """Return the persisted-message append boundary for this turn."""
     if internal_continuation_inbound(message_metadata):
         return initial_message_count
-    return 1 + history_count + (1 if user_persisted_early else 0)
+    # ``build_messages`` merges the current message into the last history
+    # entry when both share a role, so the prompt prefix is not always
+    # ``2 + history_count``. Runner-appended messages always start at
+    # ``initial_message_count``; only step back when the current message
+    # exists as a standalone entry that was not persisted early.
+    has_standalone_current = initial_message_count > 1 + history_count
+    if has_standalone_current and not user_persisted_early:
+        return initial_message_count - 1
+    return initial_message_count
 
 
 def _goal_continuation_available(

--- a/nanobot/session/turn_continuation.py
+++ b/nanobot/session/turn_continuation.py
@@ -182,11 +182,8 @@ def _save_skip_for_turn(
     """Return the persisted-message append boundary for this turn."""
     if internal_continuation_inbound(message_metadata):
         return initial_message_count
-    # ``build_messages`` merges the current message into the last history
-    # entry when both share a role, so the prompt prefix is not always
-    # ``2 + history_count``. Runner-appended messages always start at
-    # ``initial_message_count``; only step back when the current message
-    # exists as a standalone entry that was not persisted early.
+    # build_messages may merge the current message into a same-role history tail.
+    # Runner-appended messages start at initial_message_count in either shape.
     has_standalone_current = initial_message_count > 1 + history_count
     if has_standalone_current and not user_persisted_early:
         return initial_message_count - 1

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -1293,11 +1293,6 @@ async def test_system_subagent_followup_uses_thread_session_and_slack_metadata(t
 
 @pytest.mark.asyncio
 async def test_turn_after_unanswered_user_keeps_tool_call_pairing(tmp_path: Path) -> None:
-    """Regression for #4006: when history ends with a user message,
-    ``build_messages`` merges the new user message into it, shrinking the
-    prompt prefix by one. The save boundary must follow, or the first
-    new-turn assistant message (carrying tool_calls) is cut from
-    persistence and its tool results are orphaned."""
     loop = _make_full_loop(tmp_path)
     loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=False)  # type: ignore[method-assign]
 
@@ -1306,8 +1301,6 @@ async def test_turn_after_unanswered_user_keeps_tool_call_pairing(tmp_path: Path
     loop.sessions.save(session)
 
     async def fake_run_agent_loop(initial_messages, **_kwargs):
-        # The merge branch collapsed the current user message into the
-        # history tail: the prompt prefix is [system, merged-user].
         assert [m["role"] for m in initial_messages] == ["system", "user"]
         return (
             "done",
@@ -1359,8 +1352,6 @@ async def test_turn_after_unanswered_user_keeps_tool_call_pairing(tmp_path: Path
 
 
 def test_save_turn_keeps_placeholder_for_empty_tool_result_blocks() -> None:
-    # Dropping the whole tool message would leave the assistant tool_call
-    # without a result, which strict APIs reject as firmly as orphans.
     loop = _mk_loop()
     session = Session(key="test:empty-tool-blocks")
 
@@ -1388,8 +1379,6 @@ def test_save_turn_keeps_placeholder_for_empty_tool_result_blocks() -> None:
 
 
 def test_save_turn_drops_orphaned_tool_results() -> None:
-    # Defense in depth for #4006: whatever upstream bug produces a tool
-    # result whose call was never declared, it must not reach history.
     loop = _mk_loop()
     session = Session(key="test:orphan-guard")
     session.add_message("user", "hi")
@@ -1424,8 +1413,6 @@ def test_save_turn_drops_tool_results_without_tool_call_id() -> None:
 
 
 def test_save_turn_keeps_tool_results_declared_in_prior_history() -> None:
-    # Declarations may live in already-persisted history (e.g. a restored
-    # runtime checkpoint), not only in the new-turn slice.
     loop = _mk_loop()
     session = Session(key="test:prior-declared")
     session.add_message(

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -1406,6 +1406,23 @@ def test_save_turn_drops_orphaned_tool_results() -> None:
     assert [m["role"] for m in session.messages] == ["user", "assistant"]
 
 
+def test_save_turn_drops_tool_results_without_tool_call_id() -> None:
+    loop = _mk_loop()
+    session = Session(key="test:missing-tool-call-id")
+    session.add_message("user", "hi")
+
+    loop._save_turn(
+        session,
+        [
+            {"role": "tool", "name": "exec", "content": "missing id"},
+            {"role": "assistant", "content": "done"},
+        ],
+        skip=0,
+    )
+
+    assert [m["role"] for m in session.messages] == ["user", "assistant"]
+
+
 def test_save_turn_keeps_tool_results_declared_in_prior_history() -> None:
     # Declarations may live in already-persisted history (e.g. a restored
     # runtime checkpoint), not only in the new-turn slice.

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -1345,3 +1345,32 @@ async def test_turn_after_unanswered_user_keeps_tool_call_pairing(tmp_path: Path
     assert [m["role"] for m in persisted.messages] == [
         "user", "user", "assistant", "tool", "assistant",
     ]
+
+
+def test_save_turn_keeps_placeholder_for_empty_tool_result_blocks() -> None:
+    # Dropping the whole tool message would leave the assistant tool_call
+    # without a result, which strict APIs reject as firmly as orphans.
+    loop = _mk_loop()
+    session = Session(key="test:empty-tool-blocks")
+
+    loop._save_turn(
+        session,
+        [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{
+                    "id": "call_empty",
+                    "type": "function",
+                    "function": {"name": "exec", "arguments": "{}"},
+                }],
+            },
+            {"role": "tool", "tool_call_id": "call_empty", "name": "exec", "content": []},
+        ],
+        skip=0,
+    )
+
+    assert [m["role"] for m in session.messages] == ["assistant", "tool"]
+    assert session.messages[1]["content"] == [
+        {"type": "text", "text": "[tool result omitted during persistence]"}
+    ]

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -1278,3 +1278,70 @@ async def test_system_subagent_followup_uses_thread_session_and_slack_metadata(t
     loop.sessions.invalidate("slack:C123:1700.42")
     persisted = loop.sessions.get_or_create("slack:C123:1700.42")
     assert any(m.get("subagent_task_id") == "sub-1" for m in persisted.messages)
+
+
+@pytest.mark.asyncio
+async def test_turn_after_unanswered_user_keeps_tool_call_pairing(tmp_path: Path) -> None:
+    """Regression for #4006: when history ends with a user message,
+    ``build_messages`` merges the new user message into it, shrinking the
+    prompt prefix by one. The save boundary must follow, or the first
+    new-turn assistant message (carrying tool_calls) is cut from
+    persistence and its tool results are orphaned."""
+    loop = _make_full_loop(tmp_path)
+    loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+    session = loop.sessions.get_or_create("feishu:c-merge")
+    session.add_message("user", "earlier question that never got an answer")
+    loop.sessions.save(session)
+
+    async def fake_run_agent_loop(initial_messages, **_kwargs):
+        # The merge branch collapsed the current user message into the
+        # history tail: the prompt prefix is [system, merged-user].
+        assert [m["role"] for m in initial_messages] == ["system", "user"]
+        return (
+            "done",
+            [],
+            [
+                *initial_messages,
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{
+                        "id": "call_ls",
+                        "type": "function",
+                        "function": {"name": "exec", "arguments": '{"command": "ls"}'},
+                    }],
+                },
+                {"role": "tool", "tool_call_id": "call_ls", "name": "exec", "content": "file.txt"},
+                {"role": "assistant", "content": "done"},
+            ],
+            "stop",
+            False,
+        )
+
+    loop._run_agent_loop = fake_run_agent_loop  # type: ignore[method-assign]
+
+    result = await loop._process_message(
+        InboundMessage(
+            channel="feishu", sender_id="u1", chat_id="c-merge", content="and another thing"
+        )
+    )
+
+    assert result is not None
+    loop.sessions.invalidate("feishu:c-merge")
+    persisted = loop.sessions.get_or_create("feishu:c-merge")
+
+    declared: set[str] = set()
+    for message in persisted.messages:
+        if message.get("role") == "assistant":
+            declared.update(
+                str(tc["id"]) for tc in message.get("tool_calls") or [] if tc.get("id")
+            )
+        if message.get("role") == "tool":
+            assert str(message.get("tool_call_id")) in declared, (
+                f"orphaned tool result {message.get('tool_call_id')!r}: "
+                f"{[m.get('role') for m in persisted.messages]}"
+            )
+    assert [m["role"] for m in persisted.messages] == [
+        "user", "user", "assistant", "tool", "assistant",
+    ]

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -286,11 +286,22 @@ def test_save_turn_keeps_tool_results_under_16k() -> None:
 
     loop._save_turn(
         session,
-        [{"role": "tool", "tool_call_id": "call_1", "name": "read_file", "content": content}],
+        [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": "{}"},
+                }],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "name": "read_file", "content": content},
+        ],
         skip=0,
     )
 
-    assert session.messages[0]["content"] == content
+    assert session.messages[1]["content"] == content
 
 
 def test_save_turn_stamps_latency_on_last_assistant() -> None:
@@ -1374,3 +1385,46 @@ def test_save_turn_keeps_placeholder_for_empty_tool_result_blocks() -> None:
     assert session.messages[1]["content"] == [
         {"type": "text", "text": "[tool result omitted during persistence]"}
     ]
+
+
+def test_save_turn_drops_orphaned_tool_results() -> None:
+    # Defense in depth for #4006: whatever upstream bug produces a tool
+    # result whose call was never declared, it must not reach history.
+    loop = _mk_loop()
+    session = Session(key="test:orphan-guard")
+    session.add_message("user", "hi")
+
+    loop._save_turn(
+        session,
+        [
+            {"role": "tool", "tool_call_id": "call_ghost", "name": "exec", "content": "boo"},
+            {"role": "assistant", "content": "done"},
+        ],
+        skip=0,
+    )
+
+    assert [m["role"] for m in session.messages] == ["user", "assistant"]
+
+
+def test_save_turn_keeps_tool_results_declared_in_prior_history() -> None:
+    # Declarations may live in already-persisted history (e.g. a restored
+    # runtime checkpoint), not only in the new-turn slice.
+    loop = _mk_loop()
+    session = Session(key="test:prior-declared")
+    session.add_message(
+        "assistant",
+        "working",
+        tool_calls=[{
+            "id": "call_prior",
+            "type": "function",
+            "function": {"name": "exec", "arguments": "{}"},
+        }],
+    )
+
+    loop._save_turn(
+        session,
+        [{"role": "tool", "tool_call_id": "call_prior", "name": "exec", "content": "ok"}],
+        skip=0,
+    )
+
+    assert [m["role"] for m in session.messages] == ["assistant", "tool"]

--- a/tests/session/test_turn_continuation.py
+++ b/tests/session/test_turn_continuation.py
@@ -142,11 +142,6 @@ def test_internal_continuation_requires_budget_boundary_and_queue():
 
 
 def test_save_skip_matches_prefix_when_current_message_merged():
-    # ``build_messages`` merges the current user message into a same-role
-    # history tail, so the prompt prefix is ``1 + history_count`` instead of
-    # ``2 + history_count``. The old boundary then cut the first new-turn
-    # assistant message (carrying tool_calls) from persistence, leaving its
-    # tool results orphaned in session history (#4006).
     skip = _save_skip_for_turn(
         message_metadata=None,
         initial_message_count=2,  # [system, merged user]
@@ -157,14 +152,13 @@ def test_save_skip_matches_prefix_when_current_message_merged():
 
 
 def test_save_skip_unchanged_for_standalone_current_message():
-    # [system, history user, current user] — early-persisted current message.
+    # [system, history user, current user] with the current user already saved.
     assert _save_skip_for_turn(
         message_metadata=None,
         initial_message_count=3,
         history_count=1,
         user_persisted_early=True,
     ) == 3
-    # Same prefix, current message not persisted early: re-save it.
     assert _save_skip_for_turn(
         message_metadata=None,
         initial_message_count=3,

--- a/tests/session/test_turn_continuation.py
+++ b/tests/session/test_turn_continuation.py
@@ -14,6 +14,7 @@ from nanobot.session.turn_continuation import (
     INTERNAL_CONTINUATION_META,
     INTERNAL_CONTINUATION_PENDING_META,
     INTERNAL_CONTINUATION_RUN_STARTED_AT_META,
+    _save_skip_for_turn,
     internal_continuation_pending,
     internal_continuation_run_started_at,
     maybe_continue_turn,
@@ -138,3 +139,35 @@ def test_internal_continuation_requires_budget_boundary_and_queue():
         pending_queue_available=True,
         session_metadata={},
     )
+
+
+def test_save_skip_matches_prefix_when_current_message_merged():
+    # ``build_messages`` merges the current user message into a same-role
+    # history tail, so the prompt prefix is ``1 + history_count`` instead of
+    # ``2 + history_count``. The old boundary then cut the first new-turn
+    # assistant message (carrying tool_calls) from persistence, leaving its
+    # tool results orphaned in session history (#4006).
+    skip = _save_skip_for_turn(
+        message_metadata=None,
+        initial_message_count=2,  # [system, merged user]
+        history_count=1,
+        user_persisted_early=True,
+    )
+    assert skip == 2
+
+
+def test_save_skip_unchanged_for_standalone_current_message():
+    # [system, history user, current user] — early-persisted current message.
+    assert _save_skip_for_turn(
+        message_metadata=None,
+        initial_message_count=3,
+        history_count=1,
+        user_persisted_early=True,
+    ) == 3
+    # Same prefix, current message not persisted early: re-save it.
+    assert _save_skip_for_turn(
+        message_metadata=None,
+        initial_message_count=3,
+        history_count=1,
+        user_persisted_early=False,
+    ) == 2


### PR DESCRIPTION
Fixes #4006

## Summary

Session history could end up with `role:"tool"` messages whose `tool_call_id` matches no prior assistant `tool_calls[].id`. Strict OpenAI/Anthropic-compatible APIs reject such histories, and trajectory renderers report "Orphaned Tool Results". A maintainer noted no reproduction path had been found — this PR includes a deterministic repro.

## Root cause

`ContextBuilder.build_messages` merges the current message into the last history entry when both share a role, shrinking the prompt prefix to `1 + history_count`. `_save_skip_for_turn` assumed a standalone current message (`2 + history_count`), so the persisted slice started one message late: the first new-turn assistant message — the one carrying `tool_calls` — was cut from history while its tool results were kept.

`test_turn_after_unanswered_user_keeps_tool_call_pairing` reproduces the exact orphan shape from the issue: persisting `['user', 'user', 'tool', 'assistant']` with the tool result referencing a call no assistant message ever declared.

## Changes

- `session/turn_continuation.py`: anchor the save boundary to the actual prompt prefix size instead of re-deriving it from `history_count`. Behavior is unchanged in all non-merged cases:
  - standalone current + persisted early: `2 + h` → `2 + h`
  - standalone current + not persisted early: `1 + h` → `1 + h`
  - merged current + persisted early: `2 + h` → `1 + h` (**the bug**)
  - merged current + not persisted early: `1 + h` → `1 + h`
- `agent/loop.py` `_save_turn`:
  - tool results whose sanitized content is empty now persist a placeholder instead of being dropped, preventing the mirror violation (assistant `tool_calls` without a result);
  - tool results whose call was never declared are not persisted (warning logged) — defense in depth so no upstream bug can permanently corrupt stored sessions again.
- Tests: unit tests for the boundary arithmetic, an end-to-end regression reproducing #4006, guard tests. One existing fixture (`test_save_turn_keeps_tool_results_under_16k`) updated to declare its tool call — the old fixture itself violated the pairing contract.

## Impact

Bug fix; no behavior change for well-formed histories.

## Verification

- `ruff check` clean on all touched files
- `pytest tests/agent/test_loop_save_turn.py tests/session/test_turn_continuation.py`: 43 passed
- Full suite: no regressions vs. the base commit (the only failures in my environment are 72 pre-existing websocket-channel test failures, identical on the base commit)

