### PR TITLE
fix(tools): reject non-positive file pagination limits

### DIFF
--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -10,13 +10,13 @@ from typing import Any
 from nanobot.agent.tools.base import Tool, tool_parameters
 from nanobot.agent.tools.file_state import FileStates, _hash_file, current_file_states
 from nanobot.agent.tools.path_utils import resolve_workspace_path
-from nanobot.security.workspace_access import current_tool_workspace
 from nanobot.agent.tools.schema import (
     BooleanSchema,
     IntegerSchema,
     StringSchema,
     tool_parameters_schema,
 )
+from nanobot.security.workspace_access import current_tool_workspace
 from nanobot.utils.helpers import build_image_content_blocks, detect_image_mime
 
 
@@ -202,6 +202,8 @@ class ReadFileTool(_FsTool):
         try:
             if not path:
                 return "Error reading file: Unknown path"
+            if limit is not None and limit < 1:
+                return "Error: limit must be >= 1."
 
             # Device path blacklist
             if _is_blocked_device(path):
@@ -982,6 +984,8 @@ class ListDirTool(_FsTool):
         try:
             if path is None:
                 raise ValueError("Unknown path")
+            if max_entries is not None and max_entries < 1:
+                return "Error: max_entries must be >= 1."
             dp = self._resolve(path)
             if not dp.exists():
                 return f"Error: Directory not found: {path}"

--- a/tests/tools/test_filesystem_tools.py
+++ b/tests/tools/test_filesystem_tools.py
@@ -91,6 +91,12 @@ class TestReadFileTool:
         assert len(result) <= ReadFileTool._MAX_CHARS + 500  # small margin for footer
         assert "Use offset=" in result
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("limit", [0, -1])
+    async def test_rejects_non_positive_limit(self, tool, sample_file, limit):
+        result = await tool.execute(path=str(sample_file), limit=limit)
+        assert result == "Error: limit must be >= 1."
+
 
 # ---------------------------------------------------------------------------
 # _find_match  (unit tests for the helper)
@@ -262,6 +268,13 @@ class TestListDirTool:
         result = await tool.execute(path=str(tmp_path), max_entries=3)
         assert "truncated" in result
         assert "3 of 10" in result
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("max_entries", [0, -1])
+    async def test_rejects_non_positive_max_entries(self, tool, tmp_path, max_entries):
+        (tmp_path / "file.txt").write_text("x")
+        result = await tool.execute(path=str(tmp_path), max_entries=max_entries)
+        assert result == "Error: max_entries must be >= 1."
 
     @pytest.mark.asyncio
     async def test_empty_dir(self, tool, tmp_path):


### PR DESCRIPTION
## Summary

- Reject non-positive `read_file` limits before line-window calculation.
- Reject non-positive `list_dir` `max_entries` before directory traversal.
- Add regression coverage for direct tool calls that bypass schema validation.

## Root cause

The tool schemas already declare these parameters with `minimum=1`, but direct or internal tool execution can still call the implementations with invalid values. `read_file(limit=-1)` produced output like `Showing lines 1--1` and `offset=0`; `list_dir(max_entries=-1)` produced `showing first -1`.

## Validation

- `uv run pytest tests/tools/test_filesystem_tools.py`
- `uv run ruff check nanobot/agent/tools/filesystem.py tests/tools/test_filesystem_tools.py`
