### PR TITLE
fix(message): reject malformed media attachments

### DIFF
--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -10,9 +10,9 @@ from nanobot.agent.tools.base import Tool, tool_parameters
 from nanobot.agent.tools.context import ContextAware, RequestContext
 from nanobot.agent.tools.path_utils import resolve_workspace_path
 from nanobot.agent.tools.schema import ArraySchema, StringSchema, tool_parameters_schema
-from nanobot.security.workspace_access import current_tool_workspace
 from nanobot.bus.events import OutboundMessage
 from nanobot.config.paths import get_workspace_path
+from nanobot.security.workspace_access import current_tool_workspace
 
 
 @tool_parameters(
@@ -199,6 +199,12 @@ class MessageTool(Tool, ContextAware):
                 for row in buttons
             ):
                 return "Error: buttons must be a list of list of strings"
+        if media is not None:
+            if (
+                not isinstance(media, list)
+                or any(not isinstance(path, str) or not path.strip() for path in media)
+            ):
+                return "Error: media must be a list of non-empty strings"
         default_channel = self._default_channel.get()
         default_chat_id = self._default_chat_id.get()
         channel = channel or default_channel

--- a/tests/tools/test_message_tool.py
+++ b/tests/tools/test_message_tool.py
@@ -39,6 +39,34 @@ async def test_message_tool_rejects_malformed_buttons(bad) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "output/image.png",
+        [123],
+        [""],
+        ["   "],
+    ],
+)
+async def test_message_tool_rejects_malformed_media(bad) -> None:
+    sent: list[OutboundMessage] = []
+
+    async def _send(msg: OutboundMessage) -> None:
+        sent.append(msg)
+
+    tool = MessageTool(send_callback=_send)
+    result = await tool.execute(
+        content="see attached",
+        channel="telegram",
+        chat_id="1",
+        media=bad,
+    )
+
+    assert result == "Error: media must be a list of non-empty strings"
+    assert sent == []
+
+
+@pytest.mark.asyncio
 async def test_message_tool_suppresses_delivery_when_active() -> None:
     sent: list[OutboundMessage] = []
 


### PR DESCRIPTION
## Summary

- Validate `message` tool `media` payloads at runtime.
- Reject string, non-string, and empty attachment entries before resolving paths.
- Add regression coverage so a single media string is not split into one attachment per character.

## Root cause

The schema declares `media` as an array of strings, but direct/internal calls can still reach `MessageTool.execute` with malformed values. Passing `media="output/image.png"` was iterable, so `_resolve_media` treated each character as a separate path and sent many bogus attachments.

## Validation

- `uv run pytest tests/tools/test_message_tool.py tests/tools/test_message_tool_suppress.py`
- `uv run ruff check nanobot/agent/tools/message.py tests/tools/test_message_tool.py`
