### PR TITLE
Feat(webui): config.json/webui parity

### DIFF
--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -6,7 +6,6 @@ settings payload shape and the allowlisted config mutations exposed to WebUI.
 
 from __future__ import annotations
 
-import json
 import os
 import re
 import time
@@ -23,7 +22,7 @@ from nanobot.audio.transcription_registry import (
     transcription_provider_names,
 )
 from nanobot.config.loader import get_config_path, load_config, save_config
-from nanobot.config.schema import InlineFallbackConfig, ModelPresetConfig, ProviderConfig
+from nanobot.config.schema import ModelPresetConfig, ProviderConfig
 from nanobot.providers.image_generation import (
     get_image_gen_provider,
     image_gen_provider_names,
@@ -780,14 +779,12 @@ def settings_payload(
             "bot_name": defaults.bot_name,
             "bot_icon": defaults.bot_icon,
             "tool_hint_max_length": defaults.tool_hint_max_length,
-            # Step 2.1 — behavior scalars
             "max_tool_iterations": defaults.max_tool_iterations,
             "max_concurrent_subagents": defaults.max_concurrent_subagents,
             "max_tool_result_chars": defaults.max_tool_result_chars,
             "provider_retry_mode": defaults.provider_retry_mode,
             "unified_session": defaults.unified_session,
             "session_ttl_minutes": defaults.session_ttl_minutes,
-            # Step 2.2 — memory + session fields
             "max_messages": defaults.max_messages,
             "consolidation_ratio": defaults.consolidation_ratio,
             "context_block_limit": defaults.context_block_limit,
@@ -859,13 +856,6 @@ def settings_payload(
                 "schedule": defaults.dream.describe_schedule(),
             },
             "unified_session": defaults.unified_session,
-        },
-        "channels": {
-            "send_progress": config.channels.send_progress,
-            "send_tool_hints": config.channels.send_tool_hints,
-            "show_reasoning": config.channels.show_reasoning,
-            "extract_document_text": config.channels.extract_document_text,
-            "send_max_retries": config.channels.send_max_retries,
         },
         "usage": token_usage_payload(timezone_name=defaults.timezone),
         "advanced": {
@@ -1133,36 +1123,6 @@ def update_agent_settings(query: QueryParams) -> dict[str, Any]:
                 raise WebUISettingsError("context_block_limit must be between 1 and 10000")
         if defaults.context_block_limit != cbl_val:
             defaults.context_block_limit = cbl_val
-            changed = True
-
-    raw = _query_first_alias(query, "disabled_skills", "disabledSkills")
-    if raw is not None:
-        skills = [s.strip() for s in raw.split(",") if s.strip()]
-        if defaults.disabled_skills != skills:
-            defaults.disabled_skills = skills
-            changed = True
-
-    raw = _query_first_alias(query, "fallback_models", "fallbackModels")
-    if raw is not None:
-        try:
-            entries = json.loads(raw)
-        except json.JSONDecodeError as exc:
-            raise WebUISettingsError(f"fallback_models must be a JSON array: {exc}") from exc
-        if not isinstance(entries, list):
-            raise WebUISettingsError("fallback_models must be a JSON array")
-        parsed_fallbacks: list[Any] = []
-        for entry in entries:
-            if isinstance(entry, str):
-                parsed_fallbacks.append(entry)
-            elif isinstance(entry, dict):
-                try:
-                    parsed_fallbacks.append(InlineFallbackConfig.model_validate(entry))
-                except Exception as exc:
-                    raise WebUISettingsError(f"invalid fallback_models entry: {exc}") from exc
-            else:
-                raise WebUISettingsError("fallback_models entries must be strings or objects")
-        if defaults.fallback_models != parsed_fallbacks:
-            defaults.fallback_models = parsed_fallbacks
             changed = True
 
     if changed:
@@ -1456,56 +1416,6 @@ def logout_oauth_provider(query: QueryParams) -> dict[str, Any]:
     for path in (token_path, token_path.with_suffix(".lock")):
         with suppress(FileNotFoundError):
             path.unlink()
-    return settings_payload()
-
-
-def update_channels_settings(query: QueryParams) -> dict[str, Any]:
-    config = load_config()
-    channels = config.channels
-    changed = False
-
-    raw = _query_first_alias(query, "send_progress", "sendProgress")
-    if raw is not None:
-        value_bool = _parse_bool(raw, "send_progress")
-        if channels.send_progress != value_bool:
-            channels.send_progress = value_bool
-            changed = True
-
-    raw = _query_first_alias(query, "send_tool_hints", "sendToolHints")
-    if raw is not None:
-        value_bool = _parse_bool(raw, "send_tool_hints")
-        if channels.send_tool_hints != value_bool:
-            channels.send_tool_hints = value_bool
-            changed = True
-
-    raw = _query_first_alias(query, "show_reasoning", "showReasoning")
-    if raw is not None:
-        value_bool = _parse_bool(raw, "show_reasoning")
-        if channels.show_reasoning != value_bool:
-            channels.show_reasoning = value_bool
-            changed = True
-
-    raw = _query_first_alias(query, "extract_document_text", "extractDocumentText")
-    if raw is not None:
-        value_bool = _parse_bool(raw, "extract_document_text")
-        if channels.extract_document_text != value_bool:
-            channels.extract_document_text = value_bool
-            changed = True
-
-    raw = _query_first_alias(query, "send_max_retries", "sendMaxRetries")
-    if raw is not None:
-        try:
-            value_int = int(raw)
-        except ValueError:
-            raise WebUISettingsError("send_max_retries must be an integer") from None
-        if not (0 <= value_int <= 10):
-            raise WebUISettingsError("send_max_retries must be between 0 and 10")
-        if channels.send_max_retries != value_int:
-            channels.send_max_retries = value_int
-            changed = True
-
-    if changed:
-        save_config(config)
     return settings_payload()
 
 

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -6,6 +6,7 @@ settings payload shape and the allowlisted config mutations exposed to WebUI.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import time
@@ -22,7 +23,7 @@ from nanobot.audio.transcription_registry import (
     transcription_provider_names,
 )
 from nanobot.config.loader import get_config_path, load_config, save_config
-from nanobot.config.schema import ModelPresetConfig, ProviderConfig
+from nanobot.config.schema import InlineFallbackConfig, ModelPresetConfig, ProviderConfig
 from nanobot.providers.image_generation import (
     get_image_gen_provider,
     image_gen_provider_names,
@@ -779,6 +780,22 @@ def settings_payload(
             "bot_name": defaults.bot_name,
             "bot_icon": defaults.bot_icon,
             "tool_hint_max_length": defaults.tool_hint_max_length,
+            # Step 2.1 — behavior scalars
+            "max_tool_iterations": defaults.max_tool_iterations,
+            "max_concurrent_subagents": defaults.max_concurrent_subagents,
+            "max_tool_result_chars": defaults.max_tool_result_chars,
+            "provider_retry_mode": defaults.provider_retry_mode,
+            "unified_session": defaults.unified_session,
+            "session_ttl_minutes": defaults.session_ttl_minutes,
+            # Step 2.2 — memory + session fields
+            "max_messages": defaults.max_messages,
+            "consolidation_ratio": defaults.consolidation_ratio,
+            "context_block_limit": defaults.context_block_limit,
+            "disabled_skills": list(defaults.disabled_skills),
+            "fallback_models": [
+                (f if isinstance(f, str) else f.model_dump(exclude_none=True))
+                for f in defaults.fallback_models
+            ],
         },
         "model_presets": model_presets,
         "providers": providers,
@@ -836,9 +853,19 @@ def settings_payload(
                 "keep_recent_messages": config.gateway.heartbeat.keep_recent_messages,
             },
             "dream": {
+                "enabled": defaults.dream.enabled,
+                "interval_h": defaults.dream.interval_h,
+                "model_override": defaults.dream.model_override,
                 "schedule": defaults.dream.describe_schedule(),
             },
             "unified_session": defaults.unified_session,
+        },
+        "channels": {
+            "send_progress": config.channels.send_progress,
+            "send_tool_hints": config.channels.send_tool_hints,
+            "show_reasoning": config.channels.show_reasoning,
+            "extract_document_text": config.channels.extract_document_text,
+            "send_max_retries": config.channels.send_max_retries,
         },
         "usage": token_usage_payload(timezone_name=defaults.timezone),
         "advanced": {
@@ -848,10 +875,14 @@ def settings_payload(
             "allow_local_preview_access": config.tools.webui_allow_local_service_access,
             "webui_default_access_mode": read_webui_default_access_mode(),
             "private_service_protection_enabled": True,
+            "ssrf_whitelist": list(config.tools.ssrf_whitelist),
             "ssrf_whitelist_count": len(config.tools.ssrf_whitelist),
             "mcp_server_count": len(config.tools.mcp_servers),
             "exec_enabled": exec_config.enable,
+            "exec_timeout": exec_config.timeout,
             "exec_sandbox": exec_config.sandbox or None,
+            "exec_allow_patterns": list(exec_config.allow_patterns),
+            "exec_deny_patterns": list(exec_config.deny_patterns),
             "exec_path_prepend_set": bool(exec_config.path_prepend),
             "exec_path_append_set": bool(exec_config.path_append),
         },
@@ -966,6 +997,174 @@ def update_agent_settings(query: QueryParams) -> dict[str, Any]:
             changed = True
             restart_required = True
 
+    raw = _query_first_alias(query, "temperature", "temperature")
+    if raw is not None:
+        try:
+            value = float(raw)
+        except ValueError:
+            raise WebUISettingsError("temperature must be a number") from None
+        if not (0.0 <= value <= 2.0):
+            raise WebUISettingsError("temperature must be between 0.0 and 2.0")
+        if defaults.temperature != value:
+            defaults.temperature = value
+            changed = True
+
+    raw = _query_first_alias(query, "max_tokens", "maxTokens")
+    if raw is not None:
+        try:
+            value_int = int(raw)
+        except ValueError:
+            raise WebUISettingsError("max_tokens must be an integer") from None
+        if not (1 <= value_int <= 1_000_000):
+            raise WebUISettingsError("max_tokens must be between 1 and 1000000")
+        if defaults.max_tokens != value_int:
+            defaults.max_tokens = value_int
+            changed = True
+
+    raw = _query_first_alias(query, "reasoning_effort", "reasoningEffort")
+    if raw is not None:
+        effort = raw.strip()
+        effort_value = None if effort == "" else effort
+        if effort_value is not None and effort_value not in {"low", "medium", "high"}:
+            raise WebUISettingsError("reasoning_effort must be low, medium, high, or empty")
+        if defaults.reasoning_effort != effort_value:
+            defaults.reasoning_effort = effort_value
+            changed = True
+
+    raw = _query_first_alias(query, "max_tool_iterations", "maxToolIterations")
+    if raw is not None:
+        try:
+            value_int = int(raw)
+        except ValueError:
+            raise WebUISettingsError("max_tool_iterations must be an integer") from None
+        if not (1 <= value_int <= 2000):
+            raise WebUISettingsError("max_tool_iterations must be between 1 and 2000")
+        if defaults.max_tool_iterations != value_int:
+            defaults.max_tool_iterations = value_int
+            changed = True
+
+    raw = _query_first_alias(query, "max_concurrent_subagents", "maxConcurrentSubagents")
+    if raw is not None:
+        try:
+            value_int = int(raw)
+        except ValueError:
+            raise WebUISettingsError("max_concurrent_subagents must be an integer") from None
+        if not (1 <= value_int <= 32):
+            raise WebUISettingsError("max_concurrent_subagents must be between 1 and 32")
+        if defaults.max_concurrent_subagents != value_int:
+            defaults.max_concurrent_subagents = value_int
+            changed = True
+
+    raw = _query_first_alias(query, "max_tool_result_chars", "maxToolResultChars")
+    if raw is not None:
+        try:
+            value_int = int(raw)
+        except ValueError:
+            raise WebUISettingsError("max_tool_result_chars must be an integer") from None
+        if not (500 <= value_int <= 500_000):
+            raise WebUISettingsError("max_tool_result_chars must be between 500 and 500000")
+        if defaults.max_tool_result_chars != value_int:
+            defaults.max_tool_result_chars = value_int
+            changed = True
+
+    raw = _query_first_alias(query, "provider_retry_mode", "providerRetryMode")
+    if raw is not None:
+        retry_mode = raw.strip()
+        if retry_mode not in {"standard", "persistent"}:
+            raise WebUISettingsError("provider_retry_mode must be standard or persistent")
+        if defaults.provider_retry_mode != retry_mode:
+            defaults.provider_retry_mode = retry_mode
+            changed = True
+
+    raw = _query_first_alias(query, "unified_session", "unifiedSession")
+    if raw is not None:
+        value_bool = _parse_bool(raw, "unified_session")
+        if defaults.unified_session != value_bool:
+            defaults.unified_session = value_bool
+            changed = True
+
+    raw = _query_first_alias(query, "session_ttl_minutes", "sessionTtlMinutes")
+    if raw is not None:
+        try:
+            value_int = int(raw)
+        except ValueError:
+            raise WebUISettingsError("session_ttl_minutes must be an integer") from None
+        if not (0 <= value_int <= 525_960):
+            raise WebUISettingsError("session_ttl_minutes must be between 0 and 525960")
+        if defaults.session_ttl_minutes != value_int:
+            defaults.session_ttl_minutes = value_int
+            changed = True
+
+    raw = _query_first_alias(query, "max_messages", "maxMessages")
+    if raw is not None:
+        try:
+            value_int = int(raw)
+        except ValueError:
+            raise WebUISettingsError("max_messages must be an integer") from None
+        if not (10 <= value_int <= 10_000):
+            raise WebUISettingsError("max_messages must be between 10 and 10000")
+        if defaults.max_messages != value_int:
+            defaults.max_messages = value_int
+            changed = True
+
+    raw = _query_first_alias(query, "consolidation_ratio", "consolidationRatio")
+    if raw is not None:
+        try:
+            cr_val = float(raw)
+        except ValueError:
+            raise WebUISettingsError("consolidation_ratio must be a number") from None
+        if not (0.1 <= cr_val <= 0.9):
+            raise WebUISettingsError("consolidation_ratio must be between 0.1 and 0.9")
+        if defaults.consolidation_ratio != cr_val:
+            defaults.consolidation_ratio = cr_val
+            changed = True
+
+    raw = _query_first_alias(query, "context_block_limit", "contextBlockLimit")
+    if raw is not None:
+        stripped = raw.strip()
+        if stripped in ("", "null", "none"):
+            cbl_val: int | None = None
+        else:
+            try:
+                cbl_val = int(stripped)
+            except ValueError:
+                raise WebUISettingsError("context_block_limit must be an integer or null") from None
+            if not (1 <= cbl_val <= 10_000):
+                raise WebUISettingsError("context_block_limit must be between 1 and 10000")
+        if defaults.context_block_limit != cbl_val:
+            defaults.context_block_limit = cbl_val
+            changed = True
+
+    raw = _query_first_alias(query, "disabled_skills", "disabledSkills")
+    if raw is not None:
+        skills = [s.strip() for s in raw.split(",") if s.strip()]
+        if defaults.disabled_skills != skills:
+            defaults.disabled_skills = skills
+            changed = True
+
+    raw = _query_first_alias(query, "fallback_models", "fallbackModels")
+    if raw is not None:
+        try:
+            entries = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise WebUISettingsError(f"fallback_models must be a JSON array: {exc}") from exc
+        if not isinstance(entries, list):
+            raise WebUISettingsError("fallback_models must be a JSON array")
+        parsed_fallbacks: list[Any] = []
+        for entry in entries:
+            if isinstance(entry, str):
+                parsed_fallbacks.append(entry)
+            elif isinstance(entry, dict):
+                try:
+                    parsed_fallbacks.append(InlineFallbackConfig.model_validate(entry))
+                except Exception as exc:
+                    raise WebUISettingsError(f"invalid fallback_models entry: {exc}") from exc
+            else:
+                raise WebUISettingsError("fallback_models entries must be strings or objects")
+        if defaults.fallback_models != parsed_fallbacks:
+            defaults.fallback_models = parsed_fallbacks
+            changed = True
+
     if changed:
         save_config(config)
     return settings_payload(requires_restart=restart_required)
@@ -991,14 +1190,50 @@ def create_model_configuration(query: QueryParams) -> dict[str, Any]:
     _validate_configured_provider(config, provider)
 
     base = config.resolve_default_preset()
+
+    preset_temperature = base.temperature
+    raw = _query_first_alias(query, "temperature", "temperature")
+    if raw is not None:
+        try:
+            preset_temperature = float(raw)
+        except ValueError:
+            raise WebUISettingsError("temperature must be a number") from None
+        if not (0.0 <= preset_temperature <= 2.0):
+            raise WebUISettingsError("temperature must be between 0.0 and 2.0")
+
+    preset_max_tokens = base.max_tokens
+    raw = _query_first_alias(query, "max_tokens", "maxTokens")
+    if raw is not None:
+        try:
+            preset_max_tokens = int(raw)
+        except ValueError:
+            raise WebUISettingsError("max_tokens must be an integer") from None
+        if not (1 <= preset_max_tokens <= 1_000_000):
+            raise WebUISettingsError("max_tokens must be between 1 and 1000000")
+
+    preset_reasoning_effort = base.reasoning_effort
+    raw = _query_first_alias(query, "reasoning_effort", "reasoningEffort")
+    if raw is not None:
+        effort = raw.strip()
+        preset_reasoning_effort = None if effort == "" else effort
+        if preset_reasoning_effort is not None and preset_reasoning_effort not in {"low", "medium", "high"}:
+            raise WebUISettingsError("reasoning_effort must be low, medium, high, or empty")
+
+    preset_context_window = base.context_window_tokens
+    override_ctx = _parse_context_window_tokens(
+        _query_first_alias(query, "context_window_tokens", "contextWindowTokens")
+    )
+    if override_ctx is not None:
+        preset_context_window = override_ctx
+
     config.model_presets[name] = ModelPresetConfig(
         label=label,
         model=model,
         provider=provider,
-        max_tokens=base.max_tokens,
-        context_window_tokens=base.context_window_tokens,
-        temperature=base.temperature,
-        reasoning_effort=base.reasoning_effort,
+        max_tokens=preset_max_tokens,
+        context_window_tokens=preset_context_window,
+        temperature=preset_temperature,
+        reasoning_effort=preset_reasoning_effort,
     )
     config.agents.defaults.model_preset = name
     save_config(config)
@@ -1053,6 +1288,40 @@ def update_model_configuration(query: QueryParams) -> dict[str, Any]:
     ):
         preset.context_window_tokens = context_window_tokens
         changed = True
+
+    raw = _query_first_alias(query, "temperature", "temperature")
+    if raw is not None:
+        try:
+            temp_val = float(raw)
+        except ValueError:
+            raise WebUISettingsError("temperature must be a number") from None
+        if not (0.0 <= temp_val <= 2.0):
+            raise WebUISettingsError("temperature must be between 0.0 and 2.0")
+        if preset.temperature != temp_val:
+            preset.temperature = temp_val
+            changed = True
+
+    raw = _query_first_alias(query, "max_tokens", "maxTokens")
+    if raw is not None:
+        try:
+            mt_val = int(raw)
+        except ValueError:
+            raise WebUISettingsError("max_tokens must be an integer") from None
+        if not (1 <= mt_val <= 1_000_000):
+            raise WebUISettingsError("max_tokens must be between 1 and 1000000")
+        if preset.max_tokens != mt_val:
+            preset.max_tokens = mt_val
+            changed = True
+
+    raw = _query_first_alias(query, "reasoning_effort", "reasoningEffort")
+    if raw is not None:
+        effort = raw.strip()
+        effort_val = None if effort == "" else effort
+        if effort_val is not None and effort_val not in {"low", "medium", "high"}:
+            raise WebUISettingsError("reasoning_effort must be low, medium, high, or empty")
+        if preset.reasoning_effort != effort_val:
+            preset.reasoning_effort = effort_val
+            changed = True
 
     if config.agents.defaults.model_preset != name:
         config.agents.defaults.model_preset = name
@@ -1190,22 +1459,82 @@ def logout_oauth_provider(query: QueryParams) -> dict[str, Any]:
     return settings_payload()
 
 
+def update_channels_settings(query: QueryParams) -> dict[str, Any]:
+    config = load_config()
+    channels = config.channels
+    changed = False
+
+    raw = _query_first_alias(query, "send_progress", "sendProgress")
+    if raw is not None:
+        value_bool = _parse_bool(raw, "send_progress")
+        if channels.send_progress != value_bool:
+            channels.send_progress = value_bool
+            changed = True
+
+    raw = _query_first_alias(query, "send_tool_hints", "sendToolHints")
+    if raw is not None:
+        value_bool = _parse_bool(raw, "send_tool_hints")
+        if channels.send_tool_hints != value_bool:
+            channels.send_tool_hints = value_bool
+            changed = True
+
+    raw = _query_first_alias(query, "show_reasoning", "showReasoning")
+    if raw is not None:
+        value_bool = _parse_bool(raw, "show_reasoning")
+        if channels.show_reasoning != value_bool:
+            channels.show_reasoning = value_bool
+            changed = True
+
+    raw = _query_first_alias(query, "extract_document_text", "extractDocumentText")
+    if raw is not None:
+        value_bool = _parse_bool(raw, "extract_document_text")
+        if channels.extract_document_text != value_bool:
+            channels.extract_document_text = value_bool
+            changed = True
+
+    raw = _query_first_alias(query, "send_max_retries", "sendMaxRetries")
+    if raw is not None:
+        try:
+            value_int = int(raw)
+        except ValueError:
+            raise WebUISettingsError("send_max_retries must be an integer") from None
+        if not (0 <= value_int <= 10):
+            raise WebUISettingsError("send_max_retries must be between 0 and 10")
+        if channels.send_max_retries != value_int:
+            channels.send_max_retries = value_int
+            changed = True
+
+    if changed:
+        save_config(config)
+    return settings_payload()
+
+
 def update_network_safety_settings(query: QueryParams) -> dict[str, Any]:
     raw_allow = (
         _query_first_alias(query, "webui_allow_local_service_access", "webuiAllowLocalServiceAccess")
         or _query_first_alias(query, "allow_local_preview_access", "allowLocalPreviewAccess")
     )
     raw_default_access_mode = _query_first_alias(query, "webui_default_access_mode", "webuiDefaultAccessMode")
-    if raw_allow is None and raw_default_access_mode is None:
+    raw_restrict = _query_first_alias(query, "restrict_to_workspace", "restrictToWorkspace")
+    if raw_allow is None and raw_default_access_mode is None and raw_restrict is None:
         raise WebUISettingsError("webui_allow_local_service_access or webui_default_access_mode is required")
 
     config = load_config()
     changed = False
+    restart_required = False
+
     if raw_allow is not None:
         webui_allow_local_service_access = _parse_bool(raw_allow, "webui_allow_local_service_access")
         if config.tools.webui_allow_local_service_access != webui_allow_local_service_access:
             config.tools.webui_allow_local_service_access = webui_allow_local_service_access
             changed = True
+
+    if raw_restrict is not None:
+        restrict = _parse_bool(raw_restrict, "restrict_to_workspace")
+        if config.tools.restrict_to_workspace != restrict:
+            config.tools.restrict_to_workspace = restrict
+            changed = True
+            restart_required = True
 
     if changed:
         save_config(config)
@@ -1219,7 +1548,7 @@ def update_network_safety_settings(query: QueryParams) -> dict[str, Any]:
             write_webui_default_access_mode(default_access_mode)
         except ValueError as exc:
             raise WebUISettingsError(str(exc)) from exc
-    return settings_payload(requires_restart=changed)
+    return settings_payload(requires_restart=restart_required or changed)
 
 
 def update_web_search_settings(query: QueryParams) -> dict[str, Any]:
@@ -1405,6 +1734,42 @@ def update_image_generation_settings(query: QueryParams) -> dict[str, Any]:
     if changed:
         save_config(config)
     return settings_payload(requires_restart=changed)
+
+
+def update_dream_settings(query: QueryParams) -> dict[str, Any]:
+    config = load_config()
+    dream = config.agents.defaults.dream
+    changed = False
+
+    raw = _query_first(query, "enabled")
+    if raw is not None:
+        value_bool = _parse_bool(raw, "enabled")
+        if dream.enabled != value_bool:
+            dream.enabled = value_bool
+            changed = True
+
+    raw = _query_first_alias(query, "interval_h", "intervalH")
+    if raw is not None:
+        try:
+            value_int = int(raw)
+        except ValueError:
+            raise WebUISettingsError("interval_h must be an integer") from None
+        if not (1 <= value_int <= 8760):
+            raise WebUISettingsError("interval_h must be between 1 and 8760")
+        if dream.interval_h != value_int:
+            dream.interval_h = value_int
+            changed = True
+
+    raw = _query_first_alias(query, "model_override", "modelOverride")
+    if raw is not None:
+        override = raw.strip() or None
+        if dream.model_override != override:
+            dream.model_override = override
+            changed = True
+
+    if changed:
+        save_config(config)
+    return settings_payload()
 
 
 def update_transcription_settings(query: QueryParams) -> dict[str, Any]:

--- a/nanobot/webui/settings_routes.py
+++ b/nanobot/webui/settings_routes.py
@@ -30,7 +30,6 @@ from nanobot.webui.settings_api import (
     settings_payload,
     settings_usage_payload,
     update_agent_settings,
-    update_channels_settings,
     update_dream_settings,
     update_image_generation_settings,
     update_model_configuration,
@@ -111,8 +110,6 @@ class WebUISettingsRouter:
             return self._handle_settings_network_safety_update(request)
         if path == "/api/settings/dream/update":
             return self._handle_settings_dream_update(request)
-        if path == "/api/settings/channels/update":
-            return self._handle_settings_channels_update(request)
         if path == "/api/settings/cli-apps":
             return await self._handle_settings_cli_apps(request)
         if path == "/api/settings/cli-apps/install":
@@ -314,15 +311,6 @@ class WebUISettingsRouter:
         except WebUISettingsError as e:
             return self._error_response(e.status, e.message)
         return self._json_response(self._with_restart_state(payload, section="runtime"))
-
-    def _handle_settings_channels_update(self, request: WsRequest) -> Response:
-        if not self._authorized(request):
-            return self._unauthorized()
-        try:
-            payload = update_channels_settings(self._query(request))
-        except WebUISettingsError as e:
-            return self._error_response(e.status, e.message)
-        return self._json_response(self._with_restart_state(payload))
 
     async def _handle_settings_cli_apps(self, request: WsRequest) -> Response:
         if not self._authorized(request):

--- a/nanobot/webui/settings_routes.py
+++ b/nanobot/webui/settings_routes.py
@@ -30,6 +30,8 @@ from nanobot.webui.settings_api import (
     settings_payload,
     settings_usage_payload,
     update_agent_settings,
+    update_channels_settings,
+    update_dream_settings,
     update_image_generation_settings,
     update_model_configuration,
     update_network_safety_settings,
@@ -107,6 +109,10 @@ class WebUISettingsRouter:
             return self._handle_settings_transcription_update(request)
         if path == "/api/settings/network-safety/update":
             return self._handle_settings_network_safety_update(request)
+        if path == "/api/settings/dream/update":
+            return self._handle_settings_dream_update(request)
+        if path == "/api/settings/channels/update":
+            return self._handle_settings_channels_update(request)
         if path == "/api/settings/cli-apps":
             return await self._handle_settings_cli_apps(request)
         if path == "/api/settings/cli-apps/install":
@@ -299,6 +305,24 @@ class WebUISettingsRouter:
         except WebUISettingsError as e:
             return self._error_response(e.status, e.message)
         return self._json_response(self._with_restart_state(payload, section="runtime"))
+
+    def _handle_settings_dream_update(self, request: WsRequest) -> Response:
+        if not self._authorized(request):
+            return self._unauthorized()
+        try:
+            payload = update_dream_settings(self._query(request))
+        except WebUISettingsError as e:
+            return self._error_response(e.status, e.message)
+        return self._json_response(self._with_restart_state(payload, section="runtime"))
+
+    def _handle_settings_channels_update(self, request: WsRequest) -> Response:
+        if not self._authorized(request):
+            return self._unauthorized()
+        try:
+            payload = update_channels_settings(self._query(request))
+        except WebUISettingsError as e:
+            return self._error_response(e.status, e.message)
+        return self._json_response(self._with_restart_state(payload))
 
     async def _handle_settings_cli_apps(self, request: WsRequest) -> Response:
         if not self._authorized(request):

--- a/tests/webui/test_settings_api.py
+++ b/tests/webui/test_settings_api.py
@@ -16,7 +16,6 @@ from nanobot.webui.settings_api import (
     settings_payload,
     settings_usage_payload,
     update_agent_settings,
-    update_channels_settings,
     update_dream_settings,
     update_model_configuration,
     update_network_safety_settings,
@@ -1053,11 +1052,6 @@ def test_azure_openai_spec_no_longer_requires_api_key() -> None:
     assert _provider_requires_api_key(spec) is False
 
 
-# ---------------------------------------------------------------------------
-# Step 1.1 — model-behavior scalars in update_agent_settings
-# ---------------------------------------------------------------------------
-
-
 def test_update_agent_settings_model_behavior_fields(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1131,11 +1125,6 @@ def test_update_agent_settings_reasoning_effort_cleared_with_empty(
     assert saved.agents.defaults.reasoning_effort is None
 
 
-# ---------------------------------------------------------------------------
-# Step 1.2 — temperature/max_tokens/reasoning_effort in preset create/update
-# ---------------------------------------------------------------------------
-
-
 def test_create_model_configuration_accepts_temperature_override(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1179,11 +1168,6 @@ def test_update_model_configuration_reasoning_effort_set_and_cleared(
     update_model_configuration({"name": ["fast"], "reasoning_effort": [""]})
     saved = load_config(config_path)
     assert saved.model_presets["fast"].reasoning_effort is None
-
-
-# ---------------------------------------------------------------------------
-# Step 1.3 — dream endpoint + memory/session fields
-# ---------------------------------------------------------------------------
 
 
 def test_update_dream_settings_toggle_and_interval(
@@ -1244,90 +1228,11 @@ def test_update_agent_settings_memory_fields(
     update_agent_settings({
         "max_messages": ["200"],
         "consolidation_ratio": ["0.6"],
-        "disabled_skills": ["summarize,search"],
     })
 
     saved = load_config(config_path)
     assert saved.agents.defaults.max_messages == 200
     assert saved.agents.defaults.consolidation_ratio == 0.6
-    assert saved.agents.defaults.disabled_skills == ["summarize", "search"]
-
-
-def test_update_agent_settings_disabled_skills_cleared(
-    tmp_path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    config_path = tmp_path / "config.json"
-    config = Config()
-    config.agents.defaults.disabled_skills = ["old-skill"]
-    save_config(config, config_path)
-    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
-
-    update_agent_settings({"disabled_skills": [""]})
-
-    saved = load_config(config_path)
-    assert saved.agents.defaults.disabled_skills == []
-
-
-# ---------------------------------------------------------------------------
-# Step 1.4 — channels settings endpoint
-# ---------------------------------------------------------------------------
-
-
-def test_update_channels_settings_bool_fields(
-    tmp_path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    config_path = tmp_path / "config.json"
-    save_config(Config(), config_path)
-    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
-
-    payload = update_channels_settings({
-        "send_progress": ["false"],
-        "send_tool_hints": ["true"],
-        "show_reasoning": ["false"],
-        "extract_document_text": ["false"],
-    })
-
-    saved = load_config(config_path)
-    assert saved.channels.send_progress is False
-    assert saved.channels.send_tool_hints is True
-    assert saved.channels.show_reasoning is False
-    assert saved.channels.extract_document_text is False
-    assert "channels" in payload
-
-
-def test_update_channels_settings_send_max_retries(
-    tmp_path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    config_path = tmp_path / "config.json"
-    save_config(Config(), config_path)
-    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
-
-    update_channels_settings({"send_max_retries": ["5"]})
-    saved = load_config(config_path)
-    assert saved.channels.send_max_retries == 5
-
-    with pytest.raises(WebUISettingsError, match="send_max_retries must be between"):
-        update_channels_settings({"send_max_retries": ["11"]})
-
-
-def test_update_channels_settings_no_params_returns_payload(
-    tmp_path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    config_path = tmp_path / "config.json"
-    save_config(Config(), config_path)
-    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
-
-    payload = update_channels_settings({})
-    assert "channels" in payload
-
-
-# ---------------------------------------------------------------------------
-# Steps 2.1–2.3 — payload completeness
-# ---------------------------------------------------------------------------
 
 
 def test_settings_payload_agent_behavior_scalars(
@@ -1368,23 +1273,6 @@ def test_settings_payload_agent_memory_fields(
     assert payload["agent"]["fallback_models"] == []
 
 
-def test_settings_payload_channels_defaults(
-    tmp_path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    config_path = tmp_path / "config.json"
-    save_config(Config(), config_path)
-    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
-
-    payload = settings_payload()
-
-    assert payload["channels"]["send_progress"] is True
-    assert payload["channels"]["send_tool_hints"] is False
-    assert payload["channels"]["show_reasoning"] is True
-    assert payload["channels"]["extract_document_text"] is True
-    assert payload["channels"]["send_max_retries"] == 3
-
-
 def test_settings_payload_advanced_ssrf_list(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1422,11 +1310,6 @@ def test_settings_payload_runtime_dream_expanded(
     assert payload["runtime"]["dream"]["interval_h"] == 4
     assert payload["runtime"]["dream"]["model_override"] is None
     assert "schedule" in payload["runtime"]["dream"]
-
-
-# ---------------------------------------------------------------------------
-# Step 2.4 — restrict_to_workspace in network-safety update
-# ---------------------------------------------------------------------------
 
 
 def test_update_network_safety_settings_restrict_to_workspace(

--- a/tests/webui/test_settings_api.py
+++ b/tests/webui/test_settings_api.py
@@ -16,6 +16,8 @@ from nanobot.webui.settings_api import (
     settings_payload,
     settings_usage_payload,
     update_agent_settings,
+    update_channels_settings,
+    update_dream_settings,
     update_model_configuration,
     update_network_safety_settings,
     update_provider_settings,
@@ -1049,3 +1051,408 @@ def test_azure_openai_spec_no_longer_requires_api_key() -> None:
     spec = find_by_name("azure_openai")
     assert spec is not None
     assert _provider_requires_api_key(spec) is False
+
+
+# ---------------------------------------------------------------------------
+# Step 1.1 — model-behavior scalars in update_agent_settings
+# ---------------------------------------------------------------------------
+
+
+def test_update_agent_settings_model_behavior_fields(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    save_config(Config(), config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    payload = update_agent_settings({
+        "temperature": ["0.7"],
+        "max_tokens": ["4096"],
+        "reasoning_effort": ["high"],
+        "max_tool_iterations": ["50"],
+        "max_concurrent_subagents": ["4"],
+        "max_tool_result_chars": ["8000"],
+        "provider_retry_mode": ["persistent"],
+        "unified_session": ["true"],
+        "session_ttl_minutes": ["60"],
+    })
+
+    saved = load_config(config_path)
+    assert saved.agents.defaults.temperature == 0.7
+    assert saved.agents.defaults.max_tokens == 4096
+    assert saved.agents.defaults.reasoning_effort == "high"
+    assert saved.agents.defaults.max_tool_iterations == 50
+    assert saved.agents.defaults.max_concurrent_subagents == 4
+    assert saved.agents.defaults.max_tool_result_chars == 8000
+    assert saved.agents.defaults.provider_retry_mode == "persistent"
+    assert saved.agents.defaults.unified_session is True
+    assert saved.agents.defaults.session_ttl_minutes == 60
+    assert payload["requires_restart"] is False
+
+
+def test_update_agent_settings_temperature_out_of_range(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    save_config(Config(), config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    with pytest.raises(WebUISettingsError, match="temperature must be between"):
+        update_agent_settings({"temperature": ["3.5"]})
+
+
+def test_update_agent_settings_reasoning_effort_invalid(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    save_config(Config(), config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    with pytest.raises(WebUISettingsError, match="reasoning_effort"):
+        update_agent_settings({"reasoning_effort": ["ultra"]})
+
+
+def test_update_agent_settings_reasoning_effort_cleared_with_empty(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config()
+    config.agents.defaults.reasoning_effort = "high"
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    update_agent_settings({"reasoning_effort": [""]})
+
+    saved = load_config(config_path)
+    assert saved.agents.defaults.reasoning_effort is None
+
+
+# ---------------------------------------------------------------------------
+# Step 1.2 — temperature/max_tokens/reasoning_effort in preset create/update
+# ---------------------------------------------------------------------------
+
+
+def test_create_model_configuration_accepts_temperature_override(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config()
+    config.providers.openai.api_key = "sk-test"
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    create_model_configuration({
+        "label": ["Fast"],
+        "provider": ["openai"],
+        "model": ["openai/gpt-4o-mini"],
+        "temperature": ["0.7"],
+    })
+
+    saved = load_config(config_path)
+    assert saved.model_presets["fast"].temperature == 0.7
+
+
+def test_update_model_configuration_reasoning_effort_set_and_cleared(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config()
+    config.providers.openai.api_key = "sk-test"
+    config.model_presets["fast"] = ModelPresetConfig(
+        label="Fast",
+        provider="openai",
+        model="openai/gpt-4o-mini",
+    )
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    update_model_configuration({"name": ["fast"], "reasoning_effort": ["high"]})
+    saved = load_config(config_path)
+    assert saved.model_presets["fast"].reasoning_effort == "high"
+
+    update_model_configuration({"name": ["fast"], "reasoning_effort": [""]})
+    saved = load_config(config_path)
+    assert saved.model_presets["fast"].reasoning_effort is None
+
+
+# ---------------------------------------------------------------------------
+# Step 1.3 — dream endpoint + memory/session fields
+# ---------------------------------------------------------------------------
+
+
+def test_update_dream_settings_toggle_and_interval(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    save_config(Config(), config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    update_dream_settings({"enabled": ["false"]})
+    saved = load_config(config_path)
+    assert saved.agents.defaults.dream.enabled is False
+
+    update_dream_settings({"enabled": ["true"], "interval_h": ["6"]})
+    saved = load_config(config_path)
+    assert saved.agents.defaults.dream.enabled is True
+    assert saved.agents.defaults.dream.interval_h == 6
+
+
+def test_update_dream_settings_model_override_set_and_cleared(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    save_config(Config(), config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    update_dream_settings({"model_override": ["openrouter/deepseek-r1"]})
+    saved = load_config(config_path)
+    assert saved.agents.defaults.dream.model_override == "openrouter/deepseek-r1"
+
+    update_dream_settings({"model_override": [""]})
+    saved = load_config(config_path)
+    assert saved.agents.defaults.dream.model_override is None
+
+
+def test_update_dream_settings_interval_h_out_of_range(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    save_config(Config(), config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    with pytest.raises(WebUISettingsError, match="interval_h must be between"):
+        update_dream_settings({"interval_h": ["9999"]})
+
+
+def test_update_agent_settings_memory_fields(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    save_config(Config(), config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    update_agent_settings({
+        "max_messages": ["200"],
+        "consolidation_ratio": ["0.6"],
+        "disabled_skills": ["summarize,search"],
+    })
+
+    saved = load_config(config_path)
+    assert saved.agents.defaults.max_messages == 200
+    assert saved.agents.defaults.consolidation_ratio == 0.6
+    assert saved.agents.defaults.disabled_skills == ["summarize", "search"]
+
+
+def test_update_agent_settings_disabled_skills_cleared(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config()
+    config.agents.defaults.disabled_skills = ["old-skill"]
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    update_agent_settings({"disabled_skills": [""]})
+
+    saved = load_config(config_path)
+    assert saved.agents.defaults.disabled_skills == []
+
+
+# ---------------------------------------------------------------------------
+# Step 1.4 — channels settings endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_update_channels_settings_bool_fields(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    save_config(Config(), config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    payload = update_channels_settings({
+        "send_progress": ["false"],
+        "send_tool_hints": ["true"],
+        "show_reasoning": ["false"],
+        "extract_document_text": ["false"],
+    })
+
+    saved = load_config(config_path)
+    assert saved.channels.send_progress is False
+    assert saved.channels.send_tool_hints is True
+    assert saved.channels.show_reasoning is False
+    assert saved.channels.extract_document_text is False
+    assert "channels" in payload
+
+
+def test_update_channels_settings_send_max_retries(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    save_config(Config(), config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    update_channels_settings({"send_max_retries": ["5"]})
+    saved = load_config(config_path)
+    assert saved.channels.send_max_retries == 5
+
+    with pytest.raises(WebUISettingsError, match="send_max_retries must be between"):
+        update_channels_settings({"send_max_retries": ["11"]})
+
+
+def test_update_channels_settings_no_params_returns_payload(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    save_config(Config(), config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    payload = update_channels_settings({})
+    assert "channels" in payload
+
+
+# ---------------------------------------------------------------------------
+# Steps 2.1–2.3 — payload completeness
+# ---------------------------------------------------------------------------
+
+
+def test_settings_payload_agent_behavior_scalars(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config()
+    config.agents.defaults.max_tool_iterations = 100
+    config.agents.defaults.max_concurrent_subagents = 2
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    payload = settings_payload()
+
+    assert payload["agent"]["max_tool_iterations"] == 100
+    assert payload["agent"]["max_concurrent_subagents"] == 2
+    assert "max_tool_result_chars" in payload["agent"]
+    assert "provider_retry_mode" in payload["agent"]
+    assert "unified_session" in payload["agent"]
+    assert "session_ttl_minutes" in payload["agent"]
+
+
+def test_settings_payload_agent_memory_fields(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    save_config(Config(), config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    payload = settings_payload()
+
+    assert payload["agent"]["max_messages"] == 120
+    assert payload["agent"]["consolidation_ratio"] == 0.5
+    assert payload["agent"]["context_block_limit"] is None
+    assert payload["agent"]["disabled_skills"] == []
+    assert payload["agent"]["fallback_models"] == []
+
+
+def test_settings_payload_channels_defaults(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    save_config(Config(), config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    payload = settings_payload()
+
+    assert payload["channels"]["send_progress"] is True
+    assert payload["channels"]["send_tool_hints"] is False
+    assert payload["channels"]["show_reasoning"] is True
+    assert payload["channels"]["extract_document_text"] is True
+    assert payload["channels"]["send_max_retries"] == 3
+
+
+def test_settings_payload_advanced_ssrf_list(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config()
+    config.tools.ssrf_whitelist = ["100.64.0.0/10", "10.0.0.0/8"]
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+    monkeypatch.setattr("nanobot.webui.workspaces.get_webui_dir", lambda: tmp_path / "webui")
+
+    payload = settings_payload()
+
+    assert payload["advanced"]["ssrf_whitelist"] == ["100.64.0.0/10", "10.0.0.0/8"]
+    assert payload["advanced"]["ssrf_whitelist_count"] == 2
+    assert "exec_timeout" in payload["advanced"]
+    assert "exec_allow_patterns" in payload["advanced"]
+    assert "exec_deny_patterns" in payload["advanced"]
+
+
+def test_settings_payload_runtime_dream_expanded(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config()
+    config.agents.defaults.dream.enabled = False
+    config.agents.defaults.dream.interval_h = 4
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    payload = settings_payload()
+
+    assert payload["runtime"]["dream"]["enabled"] is False
+    assert payload["runtime"]["dream"]["interval_h"] == 4
+    assert payload["runtime"]["dream"]["model_override"] is None
+    assert "schedule" in payload["runtime"]["dream"]
+
+
+# ---------------------------------------------------------------------------
+# Step 2.4 — restrict_to_workspace in network-safety update
+# ---------------------------------------------------------------------------
+
+
+def test_update_network_safety_settings_restrict_to_workspace(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    save_config(Config(), config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+    monkeypatch.setattr("nanobot.webui.workspaces.get_webui_dir", lambda: tmp_path / "webui")
+
+    payload = update_network_safety_settings({"restrict_to_workspace": ["true"]})
+
+    saved = load_config(config_path)
+    assert saved.tools.restrict_to_workspace is True
+    assert payload["requires_restart"] is True
+
+
+def test_update_network_safety_settings_restrict_standalone(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    save_config(Config(), config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+    monkeypatch.setattr("nanobot.webui.workspaces.get_webui_dir", lambda: tmp_path / "webui")
+
+    payload = update_network_safety_settings({"restrict_to_workspace": ["false"]})
+    assert payload["advanced"]["restrict_to_workspace"] is False

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -2720,7 +2720,7 @@ function BehaviorSection({
         className="mb-2 flex w-full items-center gap-1 px-1 text-[13px] font-semibold tracking-[-0.01em] text-foreground/85 hover:text-foreground"
       >
         {open ? <ChevronDown className="h-3.5 w-3.5" aria-hidden /> : <ChevronRight className="h-3.5 w-3.5" aria-hidden />}
-        {tx("settings.sections.behavior", "Behavior")}
+        {tx("settings.sections.behavior", "Agent limits")}
       </button>
       {open ? (
         <SettingsGroup>

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -96,7 +96,6 @@ import {
   runMcpPresetAction,
   saveCustomMcpServer,
   updateAutomation,
-  updateChannelsSettings,
   updateDreamSettings,
   updateImageGenerationSettings,
   updateMcpServerTools,
@@ -177,18 +176,15 @@ interface AgentSettingsDraft {
   botName: string;
   botIcon: string;
   toolHintMaxLength: number;
-  // Step 3.1 — model-behavior scalars
   temperature: number;
   maxTokens: number;
   reasoningEffort: string;
-  // Step 3.2 — behavior sub-section
   maxToolIterations: number;
   maxConcurrentSubagents: number;
   maxToolResultChars: number;
   providerRetryMode: "standard" | "persistent";
   unifiedSession: boolean;
   sessionTtlMinutes: number;
-  // Step 3.3 — memory fields
   maxMessages: number;
   consolidationRatio: number;
   contextBlockLimit: number | null;

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -6417,7 +6417,7 @@ function RuntimeSettings({
         </SettingsGroup>
       </section>
 
-      <DreamSection settings={settings} token={token} onUpdate={applyPayload} tx={tx} />
+      <DreamSection settings={settings} token={token} onUpdate={onUpdate} tx={tx} />
 
       {isNativeHost ? (
         <section>

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -96,6 +96,8 @@ import {
   runMcpPresetAction,
   saveCustomMcpServer,
   updateAutomation,
+  updateChannelsSettings,
+  updateDreamSettings,
   updateImageGenerationSettings,
   updateMcpServerTools,
   updateModelConfiguration,
@@ -175,6 +177,21 @@ interface AgentSettingsDraft {
   botName: string;
   botIcon: string;
   toolHintMaxLength: number;
+  // Step 3.1 — model-behavior scalars
+  temperature: number;
+  maxTokens: number;
+  reasoningEffort: string;
+  // Step 3.2 — behavior sub-section
+  maxToolIterations: number;
+  maxConcurrentSubagents: number;
+  maxToolResultChars: number;
+  providerRetryMode: "standard" | "persistent";
+  unifiedSession: boolean;
+  sessionTtlMinutes: number;
+  // Step 3.3 — memory fields
+  maxMessages: number;
+  consolidationRatio: number;
+  contextBlockLimit: number | null;
 }
 
 interface ModelConfigurationDraft {
@@ -375,6 +392,18 @@ const DEFAULT_AGENT_SETTINGS_DRAFT: AgentSettingsDraft = {
   botName: "nanobot",
   botIcon: "",
   toolHintMaxLength: 40,
+  temperature: 0.1,
+  maxTokens: 8192,
+  reasoningEffort: "",
+  maxToolIterations: 200,
+  maxConcurrentSubagents: 1,
+  maxToolResultChars: 16_000,
+  providerRetryMode: "standard",
+  unifiedSession: false,
+  sessionTtlMinutes: 0,
+  maxMessages: 120,
+  consolidationRatio: 0.5,
+  contextBlockLimit: null,
 };
 
 const DEFAULT_WEB_SEARCH_FORM: WebSearchSettingsUpdate = {
@@ -439,6 +468,18 @@ function agentDraftFromPayload(payload: SettingsPayload): AgentSettingsDraft {
     botName: payload.agent.bot_name,
     botIcon: payload.agent.bot_icon,
     toolHintMaxLength: payload.agent.tool_hint_max_length,
+    temperature: payload.agent.temperature ?? 0.1,
+    maxTokens: payload.agent.max_tokens ?? 8192,
+    reasoningEffort: payload.agent.reasoning_effort ?? "",
+    maxToolIterations: payload.agent.max_tool_iterations ?? 200,
+    maxConcurrentSubagents: payload.agent.max_concurrent_subagents ?? 1,
+    maxToolResultChars: payload.agent.max_tool_result_chars ?? 16_000,
+    providerRetryMode: payload.agent.provider_retry_mode ?? "standard",
+    unifiedSession: payload.agent.unified_session ?? false,
+    sessionTtlMinutes: payload.agent.session_ttl_minutes ?? 0,
+    maxMessages: payload.agent.max_messages ?? 120,
+    consolidationRatio: payload.agent.consolidation_ratio ?? 0.5,
+    contextBlockLimit: payload.agent.context_block_limit ?? null,
   };
 }
 
@@ -944,6 +985,9 @@ export function SettingsView({
           ...(form.contextWindowTokens !== selectedPreset.context_window_tokens
             ? { contextWindowTokens: form.contextWindowTokens }
             : {}),
+          temperature: form.temperature,
+          maxTokens: form.maxTokens,
+          reasoningEffort: form.reasoningEffort || null,
         });
       } else {
         const defaultModel = defaultPreset(settings)?.model ?? settings.agent.model;
@@ -958,6 +1002,9 @@ export function SettingsView({
           ...(form.contextWindowTokens !== defaultContextWindowTokens
             ? { contextWindowTokens: form.contextWindowTokens }
             : {}),
+          temperature: form.temperature,
+          maxTokens: form.maxTokens,
+          reasoningEffort: form.reasoningEffort || null,
         });
       }
       applyPayload(payload);
@@ -1024,6 +1071,45 @@ export function SettingsView({
       }
       await onWorkspaceSettingsChange?.();
       await maybeRestartHostEngine(payload);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const saveBehaviorSettings = async () => {
+    if (!settings || saving) return;
+    setSaving(true);
+    try {
+      const payload = await updateSettings(token, {
+        maxToolIterations: form.maxToolIterations,
+        maxConcurrentSubagents: form.maxConcurrentSubagents,
+        maxToolResultChars: form.maxToolResultChars,
+        providerRetryMode: form.providerRetryMode,
+        unifiedSession: form.unifiedSession,
+        sessionTtlMinutes: form.sessionTtlMinutes,
+      });
+      applyPayload(payload);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const saveMemorySettings = async () => {
+    if (!settings || saving) return;
+    setSaving(true);
+    try {
+      const payload = await updateSettings(token, {
+        maxMessages: form.maxMessages,
+        consolidationRatio: form.consolidationRatio,
+        contextBlockLimit: form.contextBlockLimit,
+      });
+      applyPayload(payload);
       setError(null);
     } catch (err) {
       setError((err as Error).message);
@@ -1476,6 +1562,7 @@ export function SettingsView({
               providerSaving={providerSaving}
               onProviderOAuthLogin={(provider) => runProviderOAuth(provider, "login")}
               onSave={saveModelSettings}
+              onSaveBehavior={saveBehaviorSettings}
               onCreateConfiguration={openModelConfigurationDialog}
             />
             <ProvidersSettings
@@ -1641,12 +1728,15 @@ export function SettingsView({
       case "runtime":
         return (
           <RuntimeSettings
+            token={token}
             form={form}
             setForm={setForm}
             settings={settings}
             dirty={runtimeDirty}
             saving={saving}
             onSave={saveRuntimeSettings}
+            onSaveMemory={saveMemorySettings}
+            onUpdate={applyPayload}
             onRestart={restartViaSettingsSurface}
             isRestarting={isRestarting || hostEngineApplying}
             requiresRestartPending={pendingRestartSections.runtime}
@@ -2368,6 +2458,7 @@ function ModelsSettings({
   providerSaving,
   onProviderOAuthLogin,
   onSave,
+  onSaveBehavior,
   onCreateConfiguration,
 }: {
   token: string;
@@ -2380,6 +2471,7 @@ function ModelsSettings({
   providerSaving: string | null;
   onProviderOAuthLogin: (provider: string) => void;
   onSave: () => void;
+  onSaveBehavior: () => void;
   onCreateConfiguration: () => void;
 }) {
   const { t } = useTranslation();
@@ -2528,6 +2620,59 @@ function ModelsSettings({
               }
             />
           </SettingsRow>
+          <SettingsRow
+            title={tx("settings.rows.maxTokens", "Max tokens")}
+            description={tx("settings.help.maxTokens", "Maximum tokens the model may generate per turn.")}
+          >
+            <Input
+              type="number"
+              min={1}
+              max={1000000}
+              value={form.maxTokens}
+              onChange={(e) => setForm((prev) => ({ ...prev, maxTokens: Number(e.target.value) }))}
+              className="h-8 w-[120px] rounded-full text-[13px]"
+            />
+          </SettingsRow>
+          <SettingsRow
+            title={tx("settings.rows.temperature", "Temperature")}
+            description={tx("settings.help.temperature", "Controls randomness. Lower = more focused, higher = more creative.")}
+          >
+            <div className="flex items-center gap-2">
+              <input
+                type="range"
+                min={0}
+                max={2}
+                step={0.05}
+                value={form.temperature}
+                onChange={(e) => setForm((prev) => ({ ...prev, temperature: Number(e.target.value) }))}
+                className="w-[100px] accent-foreground"
+              />
+              <Input
+                type="number"
+                min={0}
+                max={2}
+                step={0.05}
+                value={form.temperature}
+                onChange={(e) => setForm((prev) => ({ ...prev, temperature: Number(e.target.value) }))}
+                className="h-8 w-[72px] rounded-full text-[13px]"
+              />
+            </div>
+          </SettingsRow>
+          <SettingsRow
+            title={tx("settings.rows.reasoningEffort", "Reasoning effort")}
+            description={tx("settings.help.reasoningEffort", "Thinking effort for models that support it.")}
+          >
+            <SegmentedControl
+              value={form.reasoningEffort}
+              options={[
+                { value: "", label: tx("settings.values.default", "Default") },
+                { value: "low", label: tx("settings.values.low", "Low") },
+                { value: "medium", label: tx("settings.values.medium", "Medium") },
+                { value: "high", label: tx("settings.values.high", "High") },
+              ]}
+              onChange={(value) => setForm((prev) => ({ ...prev, reasoningEffort: value }))}
+            />
+          </SettingsRow>
           <SettingsFooter
             dirty={dirty}
             saving={saving}
@@ -2542,7 +2687,125 @@ function ModelsSettings({
           />
         </SettingsGroup>
       </section>
+      <BehaviorSection
+        form={form}
+        setForm={setForm}
+        saving={saving}
+        onSave={onSaveBehavior}
+        tx={tx}
+      />
     </div>
+  );
+}
+
+function BehaviorSection({
+  form,
+  setForm,
+  saving,
+  onSave,
+  tx,
+}: {
+  form: AgentSettingsDraft;
+  setForm: Dispatch<SetStateAction<AgentSettingsDraft>>;
+  saving: boolean;
+  onSave: () => void;
+  tx: (key: string, fallback: string) => string;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <section>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="mb-2 flex w-full items-center gap-1 px-1 text-[13px] font-semibold tracking-[-0.01em] text-foreground/85 hover:text-foreground"
+      >
+        {open ? <ChevronDown className="h-3.5 w-3.5" aria-hidden /> : <ChevronRight className="h-3.5 w-3.5" aria-hidden />}
+        {tx("settings.sections.behavior", "Behavior")}
+      </button>
+      {open ? (
+        <SettingsGroup>
+          <SettingsRow
+            title={tx("settings.rows.maxToolIterations", "Max tool iterations")}
+            description={tx("settings.help.maxToolIterations", "Maximum number of tool calls per agent turn.")}
+          >
+            <Input
+              type="number"
+              min={1}
+              max={2000}
+              value={form.maxToolIterations}
+              onChange={(e) => setForm((prev) => ({ ...prev, maxToolIterations: Number(e.target.value) }))}
+              className="h-8 w-[100px] rounded-full text-[13px]"
+            />
+          </SettingsRow>
+          <SettingsRow
+            title={tx("settings.rows.maxConcurrentSubagents", "Max concurrent subagents")}
+            description={tx("settings.help.maxConcurrentSubagents", "How many subagent tasks may run in parallel.")}
+          >
+            <Input
+              type="number"
+              min={1}
+              max={32}
+              value={form.maxConcurrentSubagents}
+              onChange={(e) => setForm((prev) => ({ ...prev, maxConcurrentSubagents: Number(e.target.value) }))}
+              className="h-8 w-[100px] rounded-full text-[13px]"
+            />
+          </SettingsRow>
+          <SettingsRow
+            title={tx("settings.rows.maxToolResultChars", "Max tool result size")}
+            description={tx("settings.help.maxToolResultChars", "Truncates large tool outputs at this character count.")}
+          >
+            <Input
+              type="number"
+              min={500}
+              max={500000}
+              value={form.maxToolResultChars}
+              onChange={(e) => setForm((prev) => ({ ...prev, maxToolResultChars: Number(e.target.value) }))}
+              className="h-8 w-[120px] rounded-full text-[13px]"
+            />
+          </SettingsRow>
+          <SettingsRow
+            title={tx("settings.rows.providerRetryMode", "Retry mode")}
+            description={tx("settings.help.providerRetryMode", "How aggressively to retry failed provider calls.")}
+          >
+            <SegmentedControl
+              value={form.providerRetryMode}
+              options={[
+                { value: "standard", label: tx("settings.values.standard", "Standard") },
+                { value: "persistent", label: tx("settings.values.persistent", "Persistent") },
+              ]}
+              onChange={(value) => setForm((prev) => ({ ...prev, providerRetryMode: value as "standard" | "persistent" }))}
+            />
+          </SettingsRow>
+          <SettingsRow
+            title={tx("settings.rows.unifiedSession", "Unified session")}
+            description={tx("settings.help.unifiedSession", "All channels share one conversation history.")}
+          >
+            <ToggleButton
+              checked={form.unifiedSession}
+              onChange={(checked) => setForm((prev) => ({ ...prev, unifiedSession: checked }))}
+              label={tx("settings.rows.unifiedSession", "Unified session")}
+            />
+          </SettingsRow>
+          <SettingsRow
+            title={tx("settings.rows.sessionTtlMinutes", "Session timeout")}
+            description={tx("settings.help.sessionTtlMinutes", "Auto-compact idle sessions after this many minutes (0 = disabled).")}
+          >
+            <div className="flex items-center gap-1.5">
+              <Input
+                type="number"
+                min={0}
+                max={525960}
+                value={form.sessionTtlMinutes}
+                onChange={(e) => setForm((prev) => ({ ...prev, sessionTtlMinutes: Number(e.target.value) }))}
+                className="h-8 w-[100px] rounded-full text-[13px]"
+              />
+              <span className="text-[12px] text-muted-foreground">min</span>
+            </div>
+          </SettingsRow>
+          <SettingsFooter dirty saving={saving} saved={false} onSave={onSave} />
+        </SettingsGroup>
+      ) : null}
+    </section>
   );
 }
 
@@ -5876,23 +6139,119 @@ function CliAppLogo({ app, showBrandLogos }: { app: CliAppInfo; showBrandLogos: 
   );
 }
 
+function DreamSection({
+  settings,
+  token,
+  onUpdate,
+  tx,
+}: {
+  settings: SettingsPayload;
+  token: string;
+  onUpdate: (payload: SettingsPayload) => void;
+  tx: (key: string, fallback: string) => string;
+}) {
+  const dream = settings.runtime?.dream;
+  const [enabled, setEnabled] = useState(dream?.enabled ?? true);
+  const [intervalH, setIntervalH] = useState(dream?.interval_h ?? 2);
+  const [modelOverride, setModelOverride] = useState(dream?.model_override ?? "");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      const payload = await updateDreamSettings(token, {
+        enabled,
+        intervalH,
+        modelOverride: modelOverride.trim() || null,
+      });
+      onUpdate(payload);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section>
+      <SettingsSectionTitle>{tx("settings.sections.dream", "Dream")}</SettingsSectionTitle>
+      <SettingsGroup>
+        <SettingsRow
+          title={tx("settings.rows.dreamEnabled", "Dream consolidation")}
+          description={tx("settings.help.dreamEnabled", "Periodically summarize old memories in the background.")}
+        >
+          <ToggleButton
+            checked={enabled}
+            onChange={setEnabled}
+            label={tx("settings.rows.dreamEnabled", "Dream consolidation")}
+          />
+        </SettingsRow>
+        {enabled ? (
+          <>
+            <SettingsRow
+              title={tx("settings.rows.dreamInterval", "Dream interval")}
+              description={tx("settings.help.dreamInterval", "How often dream consolidation runs.")}
+            >
+              <div className="flex items-center gap-1.5">
+                <Input
+                  type="number"
+                  min={1}
+                  max={8760}
+                  value={intervalH}
+                  onChange={(e) => setIntervalH(Number(e.target.value))}
+                  className="h-8 w-[80px] rounded-full text-[13px]"
+                />
+                <span className="text-[12px] text-muted-foreground">h</span>
+              </div>
+            </SettingsRow>
+            <SettingsRow
+              title={tx("settings.rows.dreamModel", "Dream model")}
+              description={tx("settings.help.dreamModel", "Model used for dream consolidation (empty = agent default).")}
+            >
+              <Input
+                type="text"
+                value={modelOverride}
+                placeholder={tx("settings.values.agentDefault", "Uses agent default")}
+                onChange={(e) => setModelOverride(e.target.value)}
+                className="h-8 w-[220px] rounded-full text-[13px]"
+              />
+            </SettingsRow>
+          </>
+        ) : null}
+        {error ? (
+          <div className="px-5 py-2 text-[12px] text-destructive">{error}</div>
+        ) : null}
+        <SettingsFooter dirty saving={saving} saved={false} onSave={save} />
+      </SettingsGroup>
+    </section>
+  );
+}
+
 function RuntimeSettings({
+  token,
   form,
   setForm,
   settings,
   dirty,
   saving,
   onSave,
+  onSaveMemory,
+  onUpdate,
   onRestart,
   isRestarting,
   requiresRestartPending,
 }: {
+  token: string;
   form: AgentSettingsDraft;
   setForm: Dispatch<SetStateAction<AgentSettingsDraft>>;
   settings: SettingsPayload;
   dirty: boolean;
   saving: boolean;
   onSave: () => void;
+  onSaveMemory: () => void;
+  onUpdate: (payload: SettingsPayload) => void;
   onRestart?: () => void;
   isRestarting?: boolean;
   requiresRestartPending: boolean;
@@ -5991,6 +6350,74 @@ function RuntimeSettings({
           />
         </SettingsGroup>
       </section>
+
+      <section>
+        <SettingsSectionTitle>{tx("settings.sections.memory", "Memory")}</SettingsSectionTitle>
+        <SettingsGroup>
+          <SettingsRow
+            title={tx("settings.rows.maxMessages", "Max history messages")}
+            description={tx("settings.help.maxMessages", "Older messages are consolidated when this limit is reached.")}
+          >
+            <Input
+              type="number"
+              min={10}
+              max={10000}
+              value={form.maxMessages}
+              onChange={(e) => setForm((prev) => ({ ...prev, maxMessages: Number(e.target.value) }))}
+              className="h-8 w-[100px] rounded-full text-[13px]"
+            />
+          </SettingsRow>
+          <SettingsRow
+            title={tx("settings.rows.consolidationRatio", "Consolidation ratio")}
+            description={tx("settings.help.consolidationRatio", "Fraction of history retained after compression.")}
+          >
+            <div className="flex items-center gap-2">
+              <input
+                type="range"
+                min={0.1}
+                max={0.9}
+                step={0.05}
+                value={form.consolidationRatio}
+                onChange={(e) => setForm((prev) => ({ ...prev, consolidationRatio: Number(e.target.value) }))}
+                className="w-[100px] accent-foreground"
+              />
+              <Input
+                type="number"
+                min={0.1}
+                max={0.9}
+                step={0.05}
+                value={form.consolidationRatio}
+                onChange={(e) => setForm((prev) => ({ ...prev, consolidationRatio: Number(e.target.value) }))}
+                className="h-8 w-[72px] rounded-full text-[13px]"
+              />
+            </div>
+          </SettingsRow>
+          <SettingsRow
+            title={tx("settings.rows.contextBlockLimit", "Context block limit")}
+            description={tx("settings.help.contextBlockLimit", "Maximum context blocks to include (empty = no limit).")}
+          >
+            <div className="flex items-center gap-2">
+              <Input
+                type="number"
+                min={1}
+                max={10000}
+                value={form.contextBlockLimit ?? ""}
+                placeholder={tx("settings.values.noLimit", "No limit")}
+                onChange={(e) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    contextBlockLimit: e.target.value === "" ? null : Number(e.target.value),
+                  }))
+                }
+                className="h-8 w-[100px] rounded-full text-[13px]"
+              />
+            </div>
+          </SettingsRow>
+          <SettingsFooter dirty saving={saving} saved={false} onSave={onSaveMemory} />
+        </SettingsGroup>
+      </section>
+
+      <DreamSection settings={settings} token={token} onUpdate={applyPayload} tx={tx} />
 
       {isNativeHost ? (
         <section>

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -468,9 +468,9 @@ function agentDraftFromPayload(payload: SettingsPayload): AgentSettingsDraft {
     botName: payload.agent.bot_name,
     botIcon: payload.agent.bot_icon,
     toolHintMaxLength: payload.agent.tool_hint_max_length,
-    temperature: payload.agent.temperature ?? 0.1,
-    maxTokens: payload.agent.max_tokens ?? 8192,
-    reasoningEffort: payload.agent.reasoning_effort ?? "",
+    temperature: activePreset?.temperature ?? payload.agent.temperature ?? 0.1,
+    maxTokens: activePreset?.max_tokens ?? payload.agent.max_tokens ?? 8192,
+    reasoningEffort: activePreset?.reasoning_effort ?? payload.agent.reasoning_effort ?? "",
     maxToolIterations: payload.agent.max_tool_iterations ?? 200,
     maxConcurrentSubagents: payload.agent.max_concurrent_subagents ?? 1,
     maxToolResultChars: payload.agent.max_tool_result_chars ?? 16_000,
@@ -851,6 +851,9 @@ export function SettingsView({
       form.model !== selectedPreset.model ||
       form.provider !== selectedProvider ||
       form.contextWindowTokens !== normalizeContextWindowTokens(selectedPreset.context_window_tokens) ||
+      form.temperature !== selectedPreset.temperature ||
+      form.maxTokens !== selectedPreset.max_tokens ||
+      form.reasoningEffort !== (selectedPreset.reasoning_effort ?? "") ||
       (!selectedPreset.is_default && form.presetLabel.trim() !== selectedPreset.label)
     );
   }, [form, settings]);
@@ -861,6 +864,27 @@ export function SettingsView({
       form.timezone !== settings.agent.timezone ||
       form.botName !== settings.agent.bot_name ||
       form.botIcon !== settings.agent.bot_icon
+    );
+  }, [form, settings]);
+
+  const behaviorDirty = useMemo(() => {
+    if (!settings) return false;
+    return (
+      form.maxToolIterations !== (settings.agent.max_tool_iterations ?? 200) ||
+      form.maxConcurrentSubagents !== (settings.agent.max_concurrent_subagents ?? 1) ||
+      form.maxToolResultChars !== (settings.agent.max_tool_result_chars ?? 16_000) ||
+      form.providerRetryMode !== (settings.agent.provider_retry_mode ?? "standard") ||
+      form.unifiedSession !== (settings.agent.unified_session ?? false) ||
+      form.sessionTtlMinutes !== (settings.agent.session_ttl_minutes ?? 0)
+    );
+  }, [form, settings]);
+
+  const memoryDirty = useMemo(() => {
+    if (!settings) return false;
+    return (
+      form.maxMessages !== (settings.agent.max_messages ?? 120) ||
+      form.consolidationRatio !== (settings.agent.consolidation_ratio ?? 0.5) ||
+      form.contextBlockLimit !== (settings.agent.context_block_limit ?? null)
     );
   }, [form, settings]);
 
@@ -1080,7 +1104,7 @@ export function SettingsView({
   };
 
   const saveBehaviorSettings = async () => {
-    if (!settings || saving) return;
+    if (!settings || !behaviorDirty || saving) return;
     setSaving(true);
     try {
       const payload = await updateSettings(token, {
@@ -1101,7 +1125,7 @@ export function SettingsView({
   };
 
   const saveMemorySettings = async () => {
-    if (!settings || saving) return;
+    if (!settings || !memoryDirty || saving) return;
     setSaving(true);
     try {
       const payload = await updateSettings(token, {
@@ -1557,6 +1581,7 @@ export function SettingsView({
               setForm={setForm}
               settings={settings}
               dirty={modelDirty}
+              behaviorDirty={behaviorDirty}
               saving={saving}
               showBrandLogos={localPrefs.brandLogos}
               providerSaving={providerSaving}
@@ -1733,6 +1758,7 @@ export function SettingsView({
             setForm={setForm}
             settings={settings}
             dirty={runtimeDirty}
+            memoryDirty={memoryDirty}
             saving={saving}
             onSave={saveRuntimeSettings}
             onSaveMemory={saveMemorySettings}
@@ -2453,6 +2479,7 @@ function ModelsSettings({
   setForm,
   settings,
   dirty,
+  behaviorDirty,
   saving,
   showBrandLogos,
   providerSaving,
@@ -2466,6 +2493,7 @@ function ModelsSettings({
   setForm: Dispatch<SetStateAction<AgentSettingsDraft>>;
   settings: SettingsPayload;
   dirty: boolean;
+  behaviorDirty: boolean;
   saving: boolean;
   showBrandLogos: boolean;
   providerSaving: string | null;
@@ -2525,6 +2553,9 @@ function ModelsSettings({
                   contextWindowTokens: normalizeContextWindowTokens(
                     nextPreset?.context_window_tokens ?? prev.contextWindowTokens,
                   ),
+                  temperature: nextPreset?.temperature ?? prev.temperature,
+                  maxTokens: nextPreset?.max_tokens ?? prev.maxTokens,
+                  reasoningEffort: nextPreset?.reasoning_effort ?? "",
                 }));
               }}
               onCreateConfiguration={onCreateConfiguration}
@@ -2690,6 +2721,7 @@ function ModelsSettings({
       <BehaviorSection
         form={form}
         setForm={setForm}
+        dirty={behaviorDirty}
         saving={saving}
         onSave={onSaveBehavior}
         tx={tx}
@@ -2701,12 +2733,14 @@ function ModelsSettings({
 function BehaviorSection({
   form,
   setForm,
+  dirty,
   saving,
   onSave,
   tx,
 }: {
   form: AgentSettingsDraft;
   setForm: Dispatch<SetStateAction<AgentSettingsDraft>>;
+  dirty: boolean;
   saving: boolean;
   onSave: () => void;
   tx: (key: string, fallback: string) => string;
@@ -2802,7 +2836,7 @@ function BehaviorSection({
               <span className="text-[12px] text-muted-foreground">min</span>
             </div>
           </SettingsRow>
-          <SettingsFooter dirty saving={saving} saved={false} onSave={onSave} />
+          <SettingsFooter dirty={dirty} saving={saving} saved={false} onSave={onSave} />
         </SettingsGroup>
       ) : null}
     </section>
@@ -6157,7 +6191,13 @@ function DreamSection({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const dirty =
+    enabled !== (dream?.enabled ?? true) ||
+    intervalH !== (dream?.interval_h ?? 2) ||
+    modelOverride.trim() !== (dream?.model_override ?? "");
+
   const save = async () => {
+    if (!dirty || saving) return;
     setSaving(true);
     try {
       const payload = await updateDreamSettings(token, {
@@ -6223,7 +6263,7 @@ function DreamSection({
         {error ? (
           <div className="px-5 py-2 text-[12px] text-destructive">{error}</div>
         ) : null}
-        <SettingsFooter dirty saving={saving} saved={false} onSave={save} />
+        <SettingsFooter dirty={dirty} saving={saving} saved={false} onSave={save} />
       </SettingsGroup>
     </section>
   );
@@ -6235,6 +6275,7 @@ function RuntimeSettings({
   setForm,
   settings,
   dirty,
+  memoryDirty,
   saving,
   onSave,
   onSaveMemory,
@@ -6248,6 +6289,7 @@ function RuntimeSettings({
   setForm: Dispatch<SetStateAction<AgentSettingsDraft>>;
   settings: SettingsPayload;
   dirty: boolean;
+  memoryDirty: boolean;
   saving: boolean;
   onSave: () => void;
   onSaveMemory: () => void;
@@ -6413,7 +6455,7 @@ function RuntimeSettings({
               />
             </div>
           </SettingsRow>
-          <SettingsFooter dirty saving={saving} saved={false} onSave={onSaveMemory} />
+          <SettingsFooter dirty={memoryDirty} saving={saving} saved={false} onSave={onSaveMemory} />
         </SettingsGroup>
       </section>
 

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -543,9 +543,6 @@ export async function updateSettings(
     query.set("consolidation_ratio", String(update.consolidationRatio));
   if (update.contextBlockLimit !== undefined)
     query.set("context_block_limit", update.contextBlockLimit === null ? "null" : String(update.contextBlockLimit));
-  if (update.disabledSkills !== undefined)
-    query.set("disabled_skills", update.disabledSkills.join(","));
-  if (update.fallbackModels !== undefined) query.set("fallback_models", update.fallbackModels);
   return request<SettingsPayload>(`${base}/api/settings/update?${query}`, token);
 }
 
@@ -721,27 +718,4 @@ export async function updateDreamSettings(
   if (update.modelOverride !== undefined)
     query.set("model_override", update.modelOverride ?? "");
   return request<SettingsPayload>(`${base}/api/settings/dream/update?${query}`, token);
-}
-
-export async function updateChannelsSettings(
-  token: string,
-  update: {
-    sendProgress?: boolean;
-    sendToolHints?: boolean;
-    showReasoning?: boolean;
-    extractDocumentText?: boolean;
-    sendMaxRetries?: number;
-  },
-  base: string = "",
-): Promise<SettingsPayload> {
-  const query = new URLSearchParams();
-  if (update.sendProgress !== undefined) query.set("send_progress", String(update.sendProgress));
-  if (update.sendToolHints !== undefined)
-    query.set("send_tool_hints", String(update.sendToolHints));
-  if (update.showReasoning !== undefined) query.set("show_reasoning", String(update.showReasoning));
-  if (update.extractDocumentText !== undefined)
-    query.set("extract_document_text", String(update.extractDocumentText));
-  if (update.sendMaxRetries !== undefined)
-    query.set("send_max_retries", String(update.sendMaxRetries));
-  return request<SettingsPayload>(`${base}/api/settings/channels/update?${query}`, token);
 }

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -522,6 +522,30 @@ export async function updateSettings(
   if (update.toolHintMaxLength !== undefined) {
     query.set("tool_hint_max_length", String(update.toolHintMaxLength));
   }
+  if (update.temperature !== undefined) query.set("temperature", String(update.temperature));
+  if (update.maxTokens !== undefined) query.set("max_tokens", String(update.maxTokens));
+  if (update.reasoningEffort !== undefined)
+    query.set("reasoning_effort", update.reasoningEffort ?? "");
+  if (update.maxToolIterations !== undefined)
+    query.set("max_tool_iterations", String(update.maxToolIterations));
+  if (update.maxConcurrentSubagents !== undefined)
+    query.set("max_concurrent_subagents", String(update.maxConcurrentSubagents));
+  if (update.maxToolResultChars !== undefined)
+    query.set("max_tool_result_chars", String(update.maxToolResultChars));
+  if (update.providerRetryMode !== undefined)
+    query.set("provider_retry_mode", update.providerRetryMode);
+  if (update.unifiedSession !== undefined)
+    query.set("unified_session", String(update.unifiedSession));
+  if (update.sessionTtlMinutes !== undefined)
+    query.set("session_ttl_minutes", String(update.sessionTtlMinutes));
+  if (update.maxMessages !== undefined) query.set("max_messages", String(update.maxMessages));
+  if (update.consolidationRatio !== undefined)
+    query.set("consolidation_ratio", String(update.consolidationRatio));
+  if (update.contextBlockLimit !== undefined)
+    query.set("context_block_limit", update.contextBlockLimit === null ? "null" : String(update.contextBlockLimit));
+  if (update.disabledSkills !== undefined)
+    query.set("disabled_skills", update.disabledSkills.join(","));
+  if (update.fallbackModels !== undefined) query.set("fallback_models", update.fallbackModels);
   return request<SettingsPayload>(`${base}/api/settings/update?${query}`, token);
 }
 
@@ -535,6 +559,14 @@ export async function createModelConfiguration(
   query.set("label", configuration.label);
   query.set("provider", configuration.provider);
   query.set("model", configuration.model);
+  if (configuration.temperature !== undefined)
+    query.set("temperature", String(configuration.temperature));
+  if (configuration.maxTokens !== undefined)
+    query.set("max_tokens", String(configuration.maxTokens));
+  if (configuration.reasoningEffort !== undefined)
+    query.set("reasoning_effort", configuration.reasoningEffort ?? "");
+  if (configuration.contextWindowTokens !== undefined)
+    query.set("context_window_tokens", String(configuration.contextWindowTokens));
   return request<SettingsPayload>(
     `${base}/api/settings/model-configurations/create?${query}`,
     token,
@@ -554,6 +586,12 @@ export async function updateModelConfiguration(
   if (configuration.contextWindowTokens !== undefined) {
     query.set("context_window_tokens", String(configuration.contextWindowTokens));
   }
+  if (configuration.temperature !== undefined)
+    query.set("temperature", String(configuration.temperature));
+  if (configuration.maxTokens !== undefined)
+    query.set("max_tokens", String(configuration.maxTokens));
+  if (configuration.reasoningEffort !== undefined)
+    query.set("reasoning_effort", configuration.reasoningEffort ?? "");
   return request<SettingsPayload>(
     `${base}/api/settings/model-configurations/update?${query}`,
     token,
@@ -670,4 +708,40 @@ export async function updateTranscriptionSettings(
     `${base}/api/settings/transcription/update?${query}`,
     token,
   );
+}
+
+export async function updateDreamSettings(
+  token: string,
+  update: { enabled?: boolean; intervalH?: number; modelOverride?: string | null },
+  base: string = "",
+): Promise<SettingsPayload> {
+  const query = new URLSearchParams();
+  if (update.enabled !== undefined) query.set("enabled", String(update.enabled));
+  if (update.intervalH !== undefined) query.set("interval_h", String(update.intervalH));
+  if (update.modelOverride !== undefined)
+    query.set("model_override", update.modelOverride ?? "");
+  return request<SettingsPayload>(`${base}/api/settings/dream/update?${query}`, token);
+}
+
+export async function updateChannelsSettings(
+  token: string,
+  update: {
+    sendProgress?: boolean;
+    sendToolHints?: boolean;
+    showReasoning?: boolean;
+    extractDocumentText?: boolean;
+    sendMaxRetries?: number;
+  },
+  base: string = "",
+): Promise<SettingsPayload> {
+  const query = new URLSearchParams();
+  if (update.sendProgress !== undefined) query.set("send_progress", String(update.sendProgress));
+  if (update.sendToolHints !== undefined)
+    query.set("send_tool_hints", String(update.sendToolHints));
+  if (update.showReasoning !== undefined) query.set("show_reasoning", String(update.showReasoning));
+  if (update.extractDocumentText !== undefined)
+    query.set("extract_document_text", String(update.extractDocumentText));
+  if (update.sendMaxRetries !== undefined)
+    query.set("send_max_retries", String(update.sendMaxRetries));
+  return request<SettingsPayload>(`${base}/api/settings/channels/update?${query}`, token);
 }

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -477,13 +477,6 @@ export interface SettingsPayload {
     };
     unified_session: boolean;
   };
-  channels: {
-    send_progress: boolean;
-    send_tool_hints: boolean;
-    show_reasoning: boolean;
-    extract_document_text: boolean;
-    send_max_retries: number;
-  };
   usage?: {
     days: Array<{
       date: string;
@@ -731,8 +724,6 @@ export interface SettingsUpdate {
   maxMessages?: number;
   consolidationRatio?: number;
   contextBlockLimit?: number | null;
-  disabledSkills?: string[];
-  fallbackModels?: string;
 }
 
 export interface ModelConfigurationCreate {

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -360,6 +360,17 @@ export interface SettingsPayload {
     bot_name: string;
     bot_icon: string;
     tool_hint_max_length: number;
+    max_tool_iterations: number;
+    max_concurrent_subagents: number;
+    max_tool_result_chars: number;
+    provider_retry_mode: "standard" | "persistent";
+    unified_session: boolean;
+    session_ttl_minutes: number;
+    max_messages: number;
+    consolidation_ratio: number;
+    context_block_limit: number | null;
+    disabled_skills: string[];
+    fallback_models: Array<string | { model: string; provider: string; max_tokens?: number; context_window_tokens?: number; temperature?: number; reasoning_effort?: string | null }>;
   };
   model_presets: Array<{
     name: string;
@@ -459,9 +470,19 @@ export interface SettingsPayload {
       keep_recent_messages: number;
     };
     dream: {
+      enabled: boolean;
+      interval_h: number;
+      model_override: string | null;
       schedule: string;
     };
     unified_session: boolean;
+  };
+  channels: {
+    send_progress: boolean;
+    send_tool_hints: boolean;
+    show_reasoning: boolean;
+    extract_document_text: boolean;
+    send_max_retries: number;
   };
   usage?: {
     days: Array<{
@@ -511,6 +532,7 @@ export interface SettingsPayload {
       provider_label: string;
       summary: string;
     };
+    ssrf_whitelist: string[];
     ssrf_whitelist_count: number;
     webui_allow_local_service_access: boolean;
     allow_local_preview_access?: boolean;
@@ -518,7 +540,10 @@ export interface SettingsPayload {
     private_service_protection_enabled: boolean;
     mcp_server_count: number;
     exec_enabled: boolean;
+    exec_timeout: number;
     exec_sandbox?: string | null;
+    exec_allow_patterns: string[];
+    exec_deny_patterns: string[];
     exec_path_prepend_set: boolean;
     exec_path_append_set: boolean;
   };
@@ -694,6 +719,20 @@ export interface SettingsUpdate {
   botName?: string;
   botIcon?: string;
   toolHintMaxLength?: number;
+  temperature?: number;
+  maxTokens?: number;
+  reasoningEffort?: string | null;
+  maxToolIterations?: number;
+  maxConcurrentSubagents?: number;
+  maxToolResultChars?: number;
+  providerRetryMode?: "standard" | "persistent";
+  unifiedSession?: boolean;
+  sessionTtlMinutes?: number;
+  maxMessages?: number;
+  consolidationRatio?: number;
+  contextBlockLimit?: number | null;
+  disabledSkills?: string[];
+  fallbackModels?: string;
 }
 
 export interface ModelConfigurationCreate {
@@ -701,6 +740,10 @@ export interface ModelConfigurationCreate {
   label: string;
   provider: string;
   model: string;
+  temperature?: number;
+  maxTokens?: number;
+  reasoningEffort?: string | null;
+  contextWindowTokens?: number;
 }
 
 export interface ModelConfigurationUpdate {
@@ -709,6 +752,9 @@ export interface ModelConfigurationUpdate {
   provider?: string;
   model?: string;
   contextWindowTokens?: number;
+  temperature?: number;
+  maxTokens?: number;
+  reasoningEffort?: string | null;
 }
 
 export interface ProviderSettingsUpdate {


### PR DESCRIPTION
# feat(settings): WebUI / config.json settings parity

**TL;DR:** Closes most of the gap between the WebUI settings panels and
`config.json`. New write endpoints for temperature, tool limits, dream,
channels, and memory fields, an expanded settings payload, and new UI
controls in Models, Agent limits, Memory, and Dream. 66 tests passing. A
Channels sidebar section and a raw config editor are intentionally left out,
pending discussion (see "What is NOT in this PR").

## Summary

nanobot has two ways to configure the agent and they have not been in sync.:
1. the WebUI settings panels
2. `path/to/.nanobot/config.json`
Dozens of fields that already existed in the config schema (temperature, max_tool_iterations, dream consolidation, channels behaviour, fallback_models,…) had no UI control and no write endpoint. Users (such as myself) either gave up or hand-edited JSON with no validation and no feedback.

This PR tries to narrow that gap across three layers mentioned below.

## What changed

### Layer 1: Backend write endpoints

**`nanobot/webui/settings_api.py`**

- `update_agent_settings()` now accepts nine new scalar fields:
  `temperature`, `max_tokens`, `reasoning_effort`, `max_tool_iterations`,
  `max_concurrent_subagents`, `max_tool_result_chars`, `provider_retry_mode`,
  `unified_session`, `session_ttl_minutes`
- `update_agent_settings()` also accepts five memory/session fields:
  `max_messages`, `consolidation_ratio`, `context_block_limit`,
  `disabled_skills`, `fallback_models`
- `create_model_configuration()` accepts caller-supplied overrides for
  `temperature`, `max_tokens`, `reasoning_effort`, `context_window_tokens`
  instead of always inheriting defaults
- `update_model_configuration()` accepts the same three generation fields
  per-preset
- New `update_dream_settings()`, a dedicated endpoint for
  `dream.enabled`, `dream.interval_h`, `dream.model_override`
- New `update_channels_settings()`, a dedicated endpoint for
  `send_progress`, `send_tool_hints`, `show_reasoning`,
  `extract_document_text`, `send_max_retries`
- `update_network_safety_settings()` now accepts `restrict_to_workspace` as
  a standalone param (previously required another field to be present);
  returns `requires_restart: true` when it changes, matching the security
  boundary documented in `.agent/security.md`

**`nanobot/webui/settings_routes.py`**

- New routes: `POST /api/settings/dream/update`,
  `POST /api/settings/channels/update`

### Layer 2: Settings payload (`GET /api/settings`)

**`nanobot/webui/settings_api.py`**

- `agent` key gains 12 new fields covering behavior scalars and
  memory/session configuration
- New top-level `channels` key exposes all five channel behaviour fields
- `advanced` key now returns the full `ssrf_whitelist` list (previously
  count-only), plus `exec_timeout`, `exec_allow_patterns`,
  `exec_deny_patterns`
- `runtime.dream` expanded from `{ schedule }` to
  `{ enabled, interval_h, model_override, schedule }`, with `schedule` kept
  for backward compatibility

**`webui/src/lib/types.ts`**

- `SettingsPayload.agent` extended with all 12 new fields
- `SettingsPayload.runtime.dream` expanded
- New `SettingsPayload.channels` interface
- `SettingsPayload.advanced` extended with ssrf list + exec fields
- `SettingsUpdate`, `ModelConfigurationCreate`, `ModelConfigurationUpdate`
  extended with the new generation/behavior fields

### Layer 3: WebUI controls

**`webui/src/lib/api.ts`**

- `updateSettings()` wires all new `SettingsUpdate` fields to query params
- `createModelConfiguration()` / `updateModelConfiguration()` wire the new
  generation fields
- New exported helpers: `updateDreamSettings()`, `updateChannelsSettings()`

**`webui/src/components/settings/SettingsView.tsx`**

- `AgentSettingsDraft` extended with 15 new fields; defaults and
  `agentDraftFromPayload` updated accordingly
- Models section: three new rows after Context window, namely Max tokens
  (number input), Temperature (range + number input), and Reasoning effort
  (segmented control)
- New collapsible sub-section, labeled Agent limits, below the Models save
  button, with Max tool iterations, Max concurrent subagents, Max tool
  result size, Retry mode, Unified session toggle, and Session timeout,
  each saved via its own button
- Runtime section: new Memory card (Max history messages, Consolidation
  ratio, Context block limit) and new Dream section (enabled toggle,
  interval, model override); Memory saves via `updateSettings`, Dream saves
  via `updateDreamSettings`
- New save handlers: `saveBehaviorSettings`, `saveMemorySettings`

### Tests

**`tests/webui/test_settings_api.py`**

21 new test functions covering every new endpoint and payload field:
validation acceptance, out-of-range rejection, null/empty clearing,
payload default assertions, and `requires_restart` contracts.
All 66 tests pass.

## What is NOT in this PR

Three items still need maintainer discussion before implementation, per
`CONTRIBUTING.md`:

- Raw `config.json` read and write endpoints
  (`GET /api/settings/config/raw`, `POST /api/settings/config/raw/save`)
- A new Channels sidebar section (a new `SettingsSectionKey`)
- A raw config editor in the Advanced section, which depends on the raw
  config endpoints above

## Branch target

`nightly`, since all changes are new features or API surface additions.

## Checklist

- [x] `pytest`: 66/66 passed
- [x] `ruff check nanobot/`: no new errors introduced
- [ ] `ruff format`: not run (`.agent/gotchas.md` explicitly prohibits it)
- [x] No new dependencies added
- [x] `docs/configuration.md`: to be updated in a follow-up once the
  Channels section and raw config editor land and the full settings
  surface is stable