### PR TITLE
feat(audit): Add tools.audit for agent action observability

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -498,6 +498,18 @@ class AgentLoop:
 
         logger.info("Registered {} tools: {}", len(registered), registered)
 
+        # Audit tool — programmatic registration (not LLM-callable)
+        if self.tools_config.audit.enabled:
+            from nanobot.agent.tools.audit import AuditTool
+
+            audit_tool = AuditTool(cfg=self.tools_config.audit)
+            self.tools.register(audit_tool)
+            registered.append("audit")
+            logger.info("Audit tool enabled: transport={}, scope={}", self.tools_config.audit.transport, self.tools_config.audit.scope)
+            self._audit_tool = audit_tool
+        else:
+            self._audit_tool = None
+
     async def _connect_mcp(self) -> None:
         """Connect configured MCP servers."""
         await agent_context.connect_mcp(self, self.tools)
@@ -816,6 +828,7 @@ class AgentLoop:
                 ),
                 goal_active_predicate=lambda: sustained_goal_active(session.metadata) if session is not None else False,
                 goal_continue_message=_goal_continue,
+                audit_tool=getattr(self, "_audit_tool", None),
             ))
         finally:
             reset_workspace_scope(workspace_token)

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -13,6 +13,7 @@ from typing import Any, Callable
 from loguru import logger
 
 from nanobot.agent.hook import AgentHook, AgentHookContext
+from nanobot.agent.tools.audit import AuditTool, AuditToolConfig, AuditEvent
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 from nanobot.utils.file_edit_events import (
@@ -108,6 +109,7 @@ class AgentRunSpec:
     llm_timeout_s: float | None = None
     goal_active_predicate: Callable[[], bool] | None = None
     goal_continue_message: str | None = None
+    audit_tool: Any | None = None  # AuditTool instance, set by AgentLoop
 
 
 @dataclass(slots=True)
@@ -367,6 +369,21 @@ class AgentRunner:
                 tool_events.extend(new_events)
                 context.tool_results = list(results)
                 context.tool_events = list(new_events)
+
+                # --- Audit: emit events for each tool invocation ---
+                if spec.audit_tool is not None:
+                    for tc, (result, event, _err) in zip(response.tool_calls, tool_results):
+                        action = "call" if event.get("status") == "ok" else "error"
+                        result_summary = event.get("detail", "")
+                        duration_ms = None
+                        spec.audit_tool.record(
+                            tool=tc.name,
+                            action=action,
+                            params=tc.arguments if isinstance(tc.arguments, dict) else {},
+                            result_summary=result_summary,
+                            detail=result_summary,
+                            duration_ms=duration_ms,
+                        )
                 completed_tool_results: list[dict[str, Any]] = []
                 for tool_call, result in zip(response.tool_calls, results):
                     tool_message = {

--- a/nanobot/agent/tools/audit.py
+++ b/nanobot/agent/tools/audit.py
@@ -1,0 +1,309 @@
+"""Audit tool — records agent tool invocations for observability and attribution.
+
+Config schema (tools.audit):
+    enabled (bool):        Enable/disable audit recording. Default: False
+    scope (list[str]):     Tool names to audit. ["*"] means all. Default: ["*"]
+    transport (str):       Where to send audit events. One of:
+                              "logger"  — loguru info-level logging (default)
+                              "webhook" — HTTP POST to transport_url
+                              "file"    — append JSON lines to transport_path
+                              "custom"  — call transport_callback (programmatic only)
+    transport_url (str):   URL for "webhook" transport.
+    transport_path (str): File path for "file" transport.
+
+Audit events are emitted after each tool call (success or error) when the tool
+name matches the configured scope.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+from loguru import logger
+from pydantic import Field, model_validator
+from pydantic_settings import BaseSettings
+
+from nanobot.agent.tools.base import Tool
+
+
+# ---------------------------------------------------------------------------
+# Audit event model
+# ---------------------------------------------------------------------------
+
+@dataclass(slots=True)
+class AuditEvent:
+    """Single audit record for a tool invocation."""
+
+    tool: str
+    action: str  # "call" | "error" | "blocked"
+    params: dict[str, Any] = field(default_factory=dict)
+    result_summary: str = ""
+    detail: str = ""
+    timestamp: float = field(default_factory=time.time)
+    session: str = ""
+    agent_id: str = ""
+    duration_ms: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool": self.tool,
+            "action": self.action,
+            "params": self.params,
+            "result_summary": self.result_summary,
+            "detail": self.detail,
+            "timestamp": self.timestamp,
+            "session": self.session,
+            "agent_id": self.agent_id,
+            "duration_ms": self.duration_ms,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), default=str)
+
+
+# ---------------------------------------------------------------------------
+# Transport layer
+# ---------------------------------------------------------------------------
+
+class AuditTransport:
+    """Base class for audit event transports."""
+
+    def send(self, event: AuditEvent) -> None:
+        raise NotImplementedError
+
+
+class LoggerTransport(AuditTransport):
+    """Emit audit events via loguru at INFO level."""
+
+    def send(self, event: AuditEvent) -> None:
+        logger.info(
+            "audit.{} | {} | {} | session:{} | agent:{} | duration:{}ms",
+            event.action,
+            event.tool,
+            event.detail[:200] if event.detail else event.result_summary[:200],
+            event.session,
+            event.agent_id,
+            f"{event.duration_ms:.1f}" if event.duration_ms is not None else "N/A",
+        )
+
+
+class WebhookTransport(AuditTransport):
+    """POST audit events as JSON to a configurable URL."""
+
+    def __init__(self, url: str) -> None:
+        self._url = url
+
+    def send(self, event: AuditEvent) -> None:
+        import urllib.request
+
+        payload = event.to_json().encode("utf-8")
+        req = urllib.request.Request(
+            self._url,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                logger.debug("audit webhook response: {}", resp.status)
+        except Exception:
+            logger.warning("audit webhook delivery failed for {}", self._url)
+
+
+class FileTransport(AuditTransport):
+    """Append audit events as JSON lines to a file."""
+
+    def __init__(self, path: str) -> None:
+        self._path = Path(path)
+
+    def send(self, event: AuditEvent) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            with self._path.open("a", encoding="utf-8") as fh:
+                fh.write(event.to_json() + "\n")
+        except Exception:
+            logger.warning("audit file write failed for {}", self._path)
+
+
+class CallbackTransport(AuditTransport):
+    """Invoke a user-supplied async or sync callback for each event."""
+
+    def __init__(self, callback: Callable[[AuditEvent], None]) -> None:
+        self._callback = callback
+
+    def send(self, event: AuditEvent) -> None:
+        self._callback(event)
+
+
+# ---------------------------------------------------------------------------
+# Transport factory
+# ---------------------------------------------------------------------------
+
+_TRANSPORTS: dict[str, type[AuditTransport]] = {
+    "logger": LoggerTransport,
+    "webhook": WebhookTransport,
+    "file": FileTransport,
+}
+
+
+def build_transport(cfg: "AuditToolConfig") -> AuditTransport:
+    """Build the appropriate transport from config."""
+    kind = cfg.transport
+    if kind == "logger":
+        return LoggerTransport()
+    if kind == "webhook":
+        if not cfg.transport_url:
+            raise ValueError("tools.audit.transport_url is required when transport is 'webhook'")
+        return WebhookTransport(cfg.transport_url)
+    if kind == "file":
+        if not cfg.transport_path:
+            raise ValueError("tools.audit.transport_path is required when transport is 'file'")
+        return FileTransport(cfg.transport_path)
+    if kind == "custom":
+        # Custom transport must be set programmatically via set_custom_transport()
+        if _custom_transport is not None:
+            return _custom_transport
+        raise ValueError("tools.audit transport is 'custom' but no callback has been registered")
+    raise ValueError(f"Unknown tools.audit transport: {kind!r}")
+
+
+# Module-level custom transport (set programmatically for testing)
+_custom_transport: AuditTransport | None = None
+
+
+def set_custom_transport(transport: AuditTransport | None) -> None:
+    """Register a custom transport programmatically (e.g., for tests)."""
+    global _custom_transport
+    _custom_transport = transport
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+class AuditToolConfig(BaseSettings):
+    """Configuration for the audit tool."""
+
+    enabled: bool = False
+    scope: list[str] = Field(default_factory=lambda: ["*"])
+    transport: str = "logger"  # logger | webhook | file | custom
+    transport_url: str = ""  # URL for webhook transport
+    transport_path: str = ""  # File path for file transport
+
+    @model_validator(mode="after")
+    def _validate_transport_fields(self) -> "AuditToolConfig":
+        if self.transport == "webhook" and not self.transport_url:
+            # Don't raise at construction — allow empty config that's later filled.
+            # Validation happens at build_transport time.
+            pass
+        if self.transport == "file" and not self.transport_path:
+            pass
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Audit tool
+# ---------------------------------------------------------------------------
+
+class AuditTool(Tool):
+    """Audit tool — records agent tool invocations for observability.
+
+    This tool is not invoked by the agent LLM. It is called programmatically
+    by the agent runner after each tool call to emit audit events to the
+    configured transport.
+    """
+
+    config_key = "audit"
+    _scopes = {"core"}
+
+    @property
+    def name(self) -> str:  # noqa: D102
+        return "audit"
+
+    @property
+    def description(self) -> str:  # noqa: D102
+        return "Records agent tool invocations for observability and attribution."
+
+    @property
+    def parameters(self) -> dict[str, Any]:  # noqa: D102
+        return {}
+
+    def __init__(self, cfg: AuditToolConfig | None = None, **kwargs: Any) -> None:
+        super().__init__()
+        self._cfg = cfg or AuditToolConfig()
+        self._transport: AuditTransport | None = None
+        self._session: str = ""
+        self._agent_id: str = ""
+
+    # -- public API ---------------------------------------------------------
+
+    def configure(
+        self,
+        cfg: AuditToolConfig,
+        *,
+        session: str = "",
+        agent_id: str = "",
+    ) -> None:
+        """(Re)configure the audit tool at runtime."""
+        self._cfg = cfg
+        self._session = session
+        self._agent_id = agent_id
+        if cfg.enabled:
+            self._transport = build_transport(cfg)
+        else:
+            self._transport = None
+
+    def record(
+        self,
+        tool: str,
+        action: str,
+        *,
+        params: dict[str, Any] | None = None,
+        result_summary: str = "",
+        detail: str = "",
+        duration_ms: float | None = None,
+    ) -> None:
+        """Record an audit event if the tool is in scope and audit is enabled."""
+        if not self._cfg.enabled:
+            return
+        if not self._in_scope(tool):
+            return
+        if self._transport is None:
+            return
+        event = AuditEvent(
+            tool=tool,
+            action=action,
+            params=params or {},
+            result_summary=result_summary[:200] if result_summary else "",
+            detail=detail[:500] if detail else "",
+            session=self._session,
+            agent_id=self._agent_id,
+            duration_ms=duration_ms,
+        )
+        try:
+            self._transport.send(event)
+        except Exception:
+            logger.warning("audit transport failed for tool {}", tool)
+
+    def _in_scope(self, tool_name: str) -> bool:
+        scope = self._cfg.scope
+        if not scope:
+            return True  # empty scope means all
+        if "*" in scope:
+            return True
+        return tool_name in scope
+
+    # -- Tool interface (not LLM-callable) ----------------------------------
+
+    @classmethod
+    def definition(cls) -> dict[str, Any]:
+        """Audit tool has no LLM-callable definition."""
+        return {}
+
+    async def execute(self, **kwargs: Any) -> str:
+        """Not LLM-callable; use record() programmatically."""
+        return "audit tool: use record() API, not LLM invocation"

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -293,6 +293,7 @@ class ToolsConfig(Base):
     image_generation: ImageGenerationToolConfig = Field(
         default_factory=lambda: _lazy_default("nanobot.agent.tools.image_generation", "ImageGenerationToolConfig"),
     )
+    audit: "AuditToolConfig" = Field(default_factory=lambda: _lazy_default("nanobot.agent.tools.audit", "AuditToolConfig"))
     restrict_to_workspace: bool = False  # policy intent: keep tool access inside workspace when possible
     webui_allow_local_service_access: bool = Field(
         default=True,
@@ -493,6 +494,7 @@ def _resolve_tool_config_refs() -> None:
     from nanobot.agent.tools.image_generation import ImageGenerationToolConfig
     from nanobot.agent.tools.self import MyToolConfig
     from nanobot.agent.tools.shell import ExecToolConfig
+    from nanobot.agent.tools.audit import AuditToolConfig
     from nanobot.agent.tools.web import WebFetchConfig, WebSearchConfig, WebToolsConfig
 
     # Re-export into this module's namespace
@@ -504,6 +506,7 @@ def _resolve_tool_config_refs() -> None:
     mod.WebFetchConfig = WebFetchConfig  # type: ignore[attr-defined]
     mod.MyToolConfig = MyToolConfig  # type: ignore[attr-defined]
     mod.ImageGenerationToolConfig = ImageGenerationToolConfig  # type: ignore[attr-defined]
+    mod.AuditToolConfig = AuditToolConfig  # type: ignore[attr-defined]
 
     ToolsConfig.model_rebuild()
     Config.model_rebuild()

--- a/tests/tools/test_audit.py
+++ b/tests/tools/test_audit.py
@@ -1,0 +1,387 @@
+"""Tests for the audit tool module."""
+
+import json
+import os
+import tempfile
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nanobot.agent.tools.audit import (
+    AuditEvent,
+    AuditTool,
+    AuditToolConfig,
+    AuditTransport,
+    CallbackTransport,
+    FileTransport,
+    LoggerTransport,
+    WebhookTransport,
+    build_transport,
+    set_custom_transport,
+)
+
+
+# ---------------------------------------------------------------------------
+# AuditEvent
+# ---------------------------------------------------------------------------
+
+class TestAuditEvent:
+    def test_to_dict_defaults(self):
+        ev = AuditEvent(tool="exec", action="call")
+        d = ev.to_dict()
+        assert d["tool"] == "exec"
+        assert d["action"] == "call"
+        assert d["params"] == {}
+        assert d["result_summary"] == ""
+        assert d["session"] == ""
+        assert d["agent_id"] == ""
+        assert d["duration_ms"] is None
+        assert "timestamp" in d
+
+    def test_to_dict_full(self):
+        ev = AuditEvent(
+            tool="web_fetch",
+            action="error",
+            params={"url": "https://example.com"},
+            result_summary="404 not found",
+            detail="HTTP 404",
+            session="s1",
+            agent_id="a1",
+            duration_ms=123.4,
+        )
+        d = ev.to_dict()
+        assert d["tool"] == "web_fetch"
+        assert d["action"] == "error"
+        assert d["params"]["url"] == "https://example.com"
+        assert d["duration_ms"] == 123.4
+
+    def test_to_json_roundtrip(self):
+        ev = AuditEvent(tool="exec", action="call", params={"cmd": "ls"})
+        parsed = json.loads(ev.to_json())
+        assert parsed["tool"] == "exec"
+        assert parsed["params"]["cmd"] == "ls"
+
+
+# ---------------------------------------------------------------------------
+# AuditToolConfig
+# ---------------------------------------------------------------------------
+
+class TestAuditToolConfig:
+    def test_defaults(self):
+        cfg = AuditToolConfig()
+        assert cfg.enabled is False
+        assert cfg.scope == ["*"]
+        assert cfg.transport == "logger"
+        assert cfg.transport_url == ""
+        assert cfg.transport_path == ""
+
+    def test_custom_scope(self):
+        cfg = AuditToolConfig(enabled=True, scope=["exec", "web"])
+        assert cfg.scope == ["exec", "web"]
+
+    def test_webhook_config(self):
+        cfg = AuditToolConfig(enabled=True, transport="webhook", transport_url="https://hooks.example.com/audit")
+        assert cfg.transport == "webhook"
+        assert cfg.transport_url == "https://hooks.example.com/audit"
+
+    def test_file_config(self):
+        cfg = AuditToolConfig(enabled=True, transport="file", transport_path="/tmp/audit.jsonl")
+        assert cfg.transport == "file"
+        assert cfg.transport_path == "/tmp/audit.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Transports
+# ---------------------------------------------------------------------------
+
+class TestLoggerTransport:
+    def test_send_emits_info(self, capfd):
+        transport = LoggerTransport()
+        ev = AuditEvent(tool="exec", action="call", detail="ran ls")
+        transport.send(ev)
+        # LoggerTransport uses loguru; just verify no exception
+
+
+class TestFileTransport:
+    def test_send_writes_jsonl(self, tmp_path):
+        path = tmp_path / "audit.jsonl"
+        transport = FileTransport(str(path))
+        ev = AuditEvent(tool="exec", action="call", session="s1")
+        transport.send(ev)
+
+        lines = path.read_text().strip().split("\n")
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert parsed["tool"] == "exec"
+        assert parsed["action"] == "call"
+        assert parsed["session"] == "s1"
+
+    def test_send_appends(self, tmp_path):
+        path = tmp_path / "audit.jsonl"
+        transport = FileTransport(str(path))
+        transport.send(AuditEvent(tool="exec", action="call"))
+        transport.send(AuditEvent(tool="web", action="error"))
+
+        lines = path.read_text().strip().split("\n")
+        assert len(lines) == 2
+        assert json.loads(lines[0])["tool"] == "exec"
+        assert json.loads(lines[1])["tool"] == "web"
+
+    def test_creates_parent_dirs(self, tmp_path):
+        path = tmp_path / "nested" / "dir" / "audit.jsonl"
+        transport = FileTransport(str(path))
+        transport.send(AuditEvent(tool="exec", action="call"))
+        assert path.exists()
+
+
+class TestCallbackTransport:
+    def test_send_invokes_callback(self):
+        events = []
+        transport = CallbackTransport(callback=events.append)
+        ev = AuditEvent(tool="exec", action="call")
+        transport.send(ev)
+        assert len(events) == 1
+        assert events[0].tool == "exec"
+
+
+class TestWebhookTransport:
+    def test_send_posts_json(self):
+        transport = WebhookTransport("https://example.com/webhook")
+        ev = AuditEvent(tool="exec", action="call")
+        # WebhookTransport POSTs via urllib — just verify no crash on init
+        assert transport._url == "https://example.com/webhook"
+
+
+# ---------------------------------------------------------------------------
+# build_transport
+# ---------------------------------------------------------------------------
+
+class TestBuildTransport:
+    def test_logger(self):
+        cfg = AuditToolConfig(enabled=True, transport="logger")
+        t = build_transport(cfg)
+        assert isinstance(t, LoggerTransport)
+
+    def test_file(self, tmp_path):
+        cfg = AuditToolConfig(enabled=True, transport="file", transport_path=str(tmp_path / "audit.jsonl"))
+        t = build_transport(cfg)
+        assert isinstance(t, FileTransport)
+
+    def test_webhook(self):
+        cfg = AuditToolConfig(enabled=True, transport="webhook", transport_url="https://example.com")
+        t = build_transport(cfg)
+        assert isinstance(t, WebhookTransport)
+
+    def test_webhook_missing_url_raises(self):
+        cfg = AuditToolConfig(enabled=True, transport="webhook", transport_url="")
+        with pytest.raises(ValueError, match="transport_url"):
+            build_transport(cfg)
+
+    def test_file_missing_path_raises(self):
+        cfg = AuditToolConfig(enabled=True, transport="file", transport_path="")
+        with pytest.raises(ValueError, match="transport_path"):
+            build_transport(cfg)
+
+    def test_custom_with_registered_callback(self):
+        cb = CallbackTransport(callback=lambda e: None)
+        set_custom_transport(cb)
+        try:
+            cfg = AuditToolConfig(enabled=True, transport="custom")
+            t = build_transport(cfg)
+            assert isinstance(t, CallbackTransport)
+        finally:
+            set_custom_transport(None)
+
+    def test_custom_without_callback_raises(self):
+        set_custom_transport(None)
+        cfg = AuditToolConfig(enabled=True, transport="custom")
+        with pytest.raises(ValueError, match="custom"):
+            build_transport(cfg)
+
+    def test_unknown_transport_raises(self):
+        cfg = AuditToolConfig(enabled=True, transport="bogus")
+        with pytest.raises(ValueError, match="Unknown"):
+            build_transport(cfg)
+
+
+# ---------------------------------------------------------------------------
+# AuditTool
+# ---------------------------------------------------------------------------
+
+class TestAuditTool:
+    def test_record_disabled_no_event(self):
+        cfg = AuditToolConfig(enabled=False)
+        tool = AuditTool(cfg=cfg)
+        events = []
+        tool._transport = CallbackTransport(callback=events.append)
+        tool.record("exec", "call")
+        assert len(events) == 0
+
+    def test_record_enabled_sends_event(self):
+        cfg = AuditToolConfig(enabled=True, scope=["*"])
+        tool = AuditTool(cfg=cfg)
+        events = []
+        tool._transport = CallbackTransport(callback=events.append)
+        tool.record("exec", "call", params={"cmd": "ls"}, result_summary="success")
+        assert len(events) == 1
+        assert events[0].tool == "exec"
+        assert events[0].params == {"cmd": "ls"}
+
+    def test_record_scope_filtering(self):
+        cfg = AuditToolConfig(enabled=True, scope=["exec", "web"])
+        tool = AuditTool(cfg=cfg)
+        events = []
+        tool._transport = CallbackTransport(callback=events.append)
+
+        tool.record("exec", "call")  # in scope
+        tool.record("cron", "call")   # not in scope
+        tool.record("web", "call")    # in scope
+
+        assert len(events) == 2
+        assert events[0].tool == "exec"
+        assert events[1].tool == "web"
+
+    def test_record_wildcard_scope(self):
+        cfg = AuditToolConfig(enabled=True, scope=["*"])
+        tool = AuditTool(cfg=cfg)
+        events = []
+        tool._transport = CallbackTransport(callback=events.append)
+
+        tool.record("exec", "call")
+        tool.record("web", "call")
+        tool.record("cron", "call")
+
+        assert len(events) == 3
+
+    def test_record_empty_scope_means_all(self):
+        cfg = AuditToolConfig(enabled=True, scope=[])
+        tool = AuditTool(cfg=cfg)
+        events = []
+        tool._transport = CallbackTransport(callback=events.append)
+
+        tool.record("anything", "call")
+        assert len(events) == 1
+
+    def test_record_no_transport_no_crash(self):
+        cfg = AuditToolConfig(enabled=True, scope=["*"])
+        tool = AuditTool(cfg=cfg)
+        tool._transport = None
+        tool.record("exec", "call")  # should not raise
+
+    def test_configure_enables_transport(self, tmp_path):
+        cfg = AuditToolConfig(enabled=True, transport="file", transport_path=str(tmp_path / "audit.jsonl"))
+        tool = AuditTool()
+        tool.configure(cfg, session="s1", agent_id="a1")
+        assert tool._transport is not None
+        assert tool._session == "s1"
+        assert tool._agent_id == "a1"
+
+    def test_configure_disabled_clears_transport(self):
+        cfg = AuditToolConfig(enabled=False)
+        tool = AuditTool()
+        tool.configure(cfg)
+        assert tool._transport is None
+
+    def test_record_populates_event_fields(self):
+        cfg = AuditToolConfig(enabled=True, scope=["*"])
+        tool = AuditTool(cfg=cfg)
+        tool._session = "sess1"
+        tool._agent_id = "agent1"
+        events = []
+        tool._transport = CallbackTransport(callback=events.append)
+
+        tool.record("exec", "call", params={"cmd": "ls"}, duration_ms=50.3)
+
+        ev = events[0]
+        assert ev.session == "sess1"
+        assert ev.agent_id == "agent1"
+        assert ev.duration_ms == 50.3
+
+    def test_record_truncates_long_detail(self):
+        cfg = AuditToolConfig(enabled=True, scope=["*"])
+        tool = AuditTool(cfg=cfg)
+        events = []
+        tool._transport = CallbackTransport(callback=events.append)
+
+        tool.record("exec", "call", detail="x" * 1000)
+
+        assert len(events[0].detail) <= 500
+
+    async def test_execute_returns_message(self):
+        tool = AuditTool()
+        result = await tool.execute()
+        assert "record()" in result
+
+    def test_definition_empty(self):
+        assert AuditTool.definition() == {}
+
+
+# ---------------------------------------------------------------------------
+# Integration: config schema
+# ---------------------------------------------------------------------------
+
+class TestAuditConfigInSchema:
+    def test_tools_config_includes_audit(self):
+        from nanobot.config.schema import ToolsConfig
+
+        tc = ToolsConfig()
+        assert hasattr(tc, "audit")
+        assert isinstance(tc.audit, AuditToolConfig)
+        assert tc.audit.enabled is False
+
+    def test_tools_config_audit_enabled(self):
+        from nanobot.config.schema import ToolsConfig
+
+        tc = ToolsConfig(audit=AuditToolConfig(enabled=True, transport="file", transport_path="/tmp/audit.jsonl"))
+        assert tc.audit.enabled is True
+        assert tc.audit.transport == "file"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: file transport audit trail
+# ---------------------------------------------------------------------------
+
+class TestEndToEndFileAudit:
+    """Prove audit events are written to a file end-to-end."""
+
+    def test_file_audit_trail(self, tmp_path):
+        audit_path = tmp_path / "audit.jsonl"
+        cfg = AuditToolConfig(enabled=True, transport="file", transport_path=str(audit_path))
+        tool = AuditTool(cfg=cfg)
+        tool.configure(cfg, session="test-session", agent_id="test-agent")
+
+        # Simulate tool invocations
+        tool.record("exec", "call", params={"cmd": "ls -la"}, result_summary="file1.txt file2.txt", duration_ms=12.5)
+        tool.record("web_fetch", "call", params={"url": "https://example.com"}, result_summary="200 OK", duration_ms=340.2)
+        tool.record("cron", "error", detail="cron job failed: permission denied", duration_ms=0.1)
+
+        assert audit_path.exists()
+        lines = audit_path.read_text().strip().split("\n")
+        assert len(lines) == 3
+
+        events = [json.loads(line) for line in lines]
+        assert events[0]["tool"] == "exec"
+        assert events[0]["action"] == "call"
+        assert events[0]["session"] == "test-session"
+        assert events[0]["agent_id"] == "test-agent"
+        assert events[0]["duration_ms"] == 12.5
+
+        assert events[1]["tool"] == "web_fetch"
+        assert events[1]["action"] == "call"
+
+        assert events[2]["tool"] == "cron"
+        assert events[2]["action"] == "error"
+
+    def test_scope_filtering_end_to_end(self, tmp_path):
+        audit_path = tmp_path / "audit.jsonl"
+        cfg = AuditToolConfig(enabled=True, scope=["exec"], transport="file", transport_path=str(audit_path))
+        tool = AuditTool(cfg=cfg)
+        tool.configure(cfg)
+
+        tool.record("exec", "call")  # in scope
+        tool.record("web", "call")   # out of scope
+
+        lines = audit_path.read_text().strip().split("\n")
+        assert len(lines) == 1
+        assert json.loads(lines[0])["tool"] == "exec"


### PR DESCRIPTION
Audit module for nanobot agent tool invocations.

- `AuditTool` + `AuditEvent` — records tool invocations with scope filtering
- Config: `tools.audit.enabled`, `scope`, `transport`
- 4 transports: loguru, HTTP webhook, JSONL file, programmatic callback
- Integrated into `AgentLoop` and `AgentRunSpec` → `runner._execute_tools`
- 37 tests passing

Closes: MC-486