### PR TITLE
fix(transcription): resolve env vars before transcription config lookup

### DIFF
--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -52,9 +52,11 @@ class BaseChannel(ABC):
                 resolve_transcription_config,
                 transcribe_audio_file,
             )
-            from nanobot.config.loader import load_config
+            from nanobot.config.loader import load_config, resolve_config_env_vars
 
-            return await transcribe_audio_file(file_path, resolve_transcription_config(load_config()))
+            return await transcribe_audio_file(
+                file_path, resolve_transcription_config(resolve_config_env_vars(load_config()))
+            )
         except Exception:
             self.logger.exception("Audio transcription failed")
             return ""

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -21,7 +21,7 @@ from nanobot.audio.transcription_registry import (
     resolve_transcription_provider,
     transcription_provider_names,
 )
-from nanobot.config.loader import get_config_path, load_config, save_config
+from nanobot.config.loader import get_config_path, load_config, resolve_config_env_vars, save_config
 from nanobot.config.schema import ModelPresetConfig, ProviderConfig
 from nanobot.providers.image_generation import (
     get_image_gen_provider,
@@ -678,7 +678,7 @@ def settings_payload(
     restart_required_sections: list[str] | None = None,
     apply_state: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    config = load_config()
+    config = resolve_config_env_vars(load_config())
     defaults = config.agents.defaults
     active_preset_name = defaults.model_preset or "default"
     try:
@@ -869,12 +869,12 @@ def settings_payload(
 
 def settings_usage_payload() -> dict[str, Any]:
     """Return the lightweight token usage slice for Overview refreshes."""
-    config = load_config()
+    config = resolve_config_env_vars(load_config())
     return token_usage_payload(timezone_name=config.agents.defaults.timezone)
 
 
 def update_agent_settings(query: QueryParams) -> dict[str, Any]:
-    config = load_config()
+    config = resolve_config_env_vars(load_config())
     defaults = config.agents.defaults
     changed = False
     restart_required = False

--- a/nanobot/webui/transcription_ws.py
+++ b/nanobot/webui/transcription_ws.py
@@ -13,7 +13,7 @@ from nanobot.audio.transcription import (
     resolve_transcription_config,
     transcribe_audio_data_url,
 )
-from nanobot.config.loader import load_config
+from nanobot.config.loader import load_config, resolve_config_env_vars
 
 _MAX_REQUEST_ID_LENGTH = 80
 
@@ -38,7 +38,7 @@ async def webui_transcription_event(envelope: dict[str, Any]) -> tuple[str, dict
     try:
         text = await transcribe_audio_data_url(
             envelope.get("data_url"),
-            resolve_transcription_config(load_config()),
+            resolve_transcription_config(resolve_config_env_vars(load_config())),
             duration_ms=envelope.get("duration_ms"),
         )
     except TranscriptionIngressError as exc:


### PR DESCRIPTION
## Problem

`load_config()` returns raw config with `${VAR}` env-var templates still unresolved. All transcription code paths passed this unresolved config directly to `resolve_transcription_config()`, which then couldn't find provider API keys (e.g. `GROQ_API_KEY`). Transcription would fail silently and fall back to returning the raw audio file path.

This is the same root cause as the ElevenLabs API key bug — `resolve_config_env_vars()` must be called between `load_config()` and any code that reads provider credentials.

## Fix

Wrap `load_config()` with `resolve_config_env_vars()` in all transcription and settings code paths:

- `nanobot/channels/base.py` — `transcribe_audio()` (main Telegram transcription path)
- `nanobot/webui/transcription_ws.py` — WebSocket transcription
- `nanobot/webui/settings_api.py` — `settings_payload()`, `settings_usage_payload()`, `update_agent_settings()`

## Testing

All existing tests pass.