### PR TITLE
fix(webui): resolve env-var templates in settings read paths

### DIFF
--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -328,12 +328,12 @@ def _provider_configured_for_settings(spec: Any, provider_config: Any) -> bool:
     if spec.is_oauth:
         return bool(_oauth_provider_status(spec)["configured"])
     if _provider_requires_api_base(spec):
-        return bool(provider_config.api_base)
+        return bool(_resolve_env_placeholders(provider_config.api_base))
     if _provider_requires_api_key(spec):
-        return bool(provider_config.api_key)
+        return bool(_resolve_env_placeholders(provider_config.api_key))
     return bool(
-        provider_config.api_key
-        or provider_config.api_base
+        _resolve_env_placeholders(provider_config.api_key)
+        or _resolve_env_placeholders(provider_config.api_base)
         or getattr(provider_config, "region", None)
         or getattr(provider_config, "profile", None)
     )
@@ -381,8 +381,8 @@ def _provider_settings_row(
         ),
         "auth_type": "oauth" if spec.is_oauth else "api_key",
         "api_key_required": _provider_requires_api_key(spec),
-        "api_key_hint": _mask_secret_hint(provider_config.api_key),
-        "api_base": provider_config.api_base,
+        "api_key_hint": _mask_secret_hint(_resolve_env_placeholders(provider_config.api_key)),
+        "api_base": _resolve_env_placeholders(provider_config.api_base),
         "default_api_base": spec.default_api_base or None,
         "model_selectable": not spec.is_transcription_only,
     }


### PR DESCRIPTION
### Problem

`load_config()` returns raw `${VAR}` template strings for credentials like `api_key` and `api_base`. Two read-only code paths in `settings_api.py` use these raw values without resolving them first:

1. **`_provider_configured_for_settings()`** — checks `bool(provider_config.api_key)` to determine if a provider is "configured". When the value is a template like `"${OPENAI_API_KEY}"`, it's truthy even if the env var is unset, so the WebUI incorrectly shows providers as configured.

2. **`_provider_settings_row()`** — passes raw `api_key` to `_mask_secret_hint()` and raw `api_base` to the settings payload. This produces confusing output like `${OP••••KEY}` for the key hint and shows template syntax instead of resolved URLs.

### Fix

Use the existing `_resolve_env_placeholders()` helper before truthiness checks and display formatting, consistent with `provider_models_payload()` which already resolves before use.

### Changes

- `_provider_configured_for_settings()`: resolve `api_key` and `api_base` before `bool()` checks
- `_provider_settings_row()`: resolve `api_key` before `_mask_secret_hint()`, resolve `api_base` before returning to UI

### Testing

All 45 existing `test_settings_api.py` tests pass.
