### PR TITLE
fix(webui): resolve env-var templates in settings update paths

### DIFF
--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -1076,18 +1076,26 @@ def update_provider_settings(query: QueryParams) -> dict[str, Any]:
     if spec.is_oauth:
         raise WebUISettingsError("unknown provider")
 
+    # Resolve env-var templates for comparison so that e.g.
+    # "${OPENAI_API_KEY}" is compared against its resolved value,
+    # not the literal template string.  This prevents false "no change"
+    # detection and avoids overwriting template references with resolved
+    # values when the user submits the same key.
+    resolved_api_key = _resolve_env_placeholders(provider_config.api_key)
+    resolved_api_base = _resolve_env_placeholders(provider_config.api_base)
+
     changed = False
     if "api_key" in query or "apiKey" in query:
         api_key = _query_first_alias(query, "api_key", "apiKey")
         api_key = (api_key or "").strip() or None
-        if provider_config.api_key != api_key:
+        if resolved_api_key != api_key:
             provider_config.api_key = api_key
             changed = True
 
     if "api_base" in query or "apiBase" in query:
         api_base = _query_first_alias(query, "api_base", "apiBase")
         api_base = (api_base or "").strip() or None
-        if provider_config.api_base != api_base:
+        if resolved_api_base != api_base:
             provider_config.api_base = api_base
             changed = True
 
@@ -1235,9 +1243,20 @@ def update_web_search_settings(query: QueryParams) -> dict[str, Any]:
     changed = False
     restart_required = False
 
-    def set_search_value(attr: str, value: object) -> None:
+    # Resolve env-var templates for comparison so that e.g.
+    # "${TAVILY_API_KEY}" is compared against its resolved value,
+    # not the literal template string.  This prevents false "no change"
+    # detection and avoids overwriting template references with resolved
+    # values when the user submits the same key.
+    resolved_search_api_key = _resolve_env_placeholders(search_config.api_key)
+    resolved_search_base_url = _resolve_env_placeholders(search_config.base_url)
+
+    def set_search_value(attr: str, value: object, resolved_value: object = None) -> None:
         nonlocal changed
-        if getattr(search_config, attr) != value:
+        # Compare against the resolved value (if provided) instead of
+        # the raw config value which may contain ${VAR} templates.
+        compare_against = resolved_value if resolved_value is not None else getattr(search_config, attr)
+        if compare_against != value:
             setattr(search_config, attr, value)
             changed = True
 
@@ -1253,26 +1272,26 @@ def update_web_search_settings(query: QueryParams) -> dict[str, Any]:
 
     credential = provider_option["credential"]
     if credential == "none":
-        set_search_value("api_key", "")
-        set_search_value("base_url", "")
+        set_search_value("api_key", "", resolved_search_api_key)
+        set_search_value("base_url", "", resolved_search_base_url)
     elif credential == "base_url":
         base_url = _query_first_alias(query, "base_url", "baseUrl")
         base_url = base_url.strip() if base_url is not None else None
-        if not base_url and previous_provider == provider_name and search_config.base_url:
-            base_url = search_config.base_url
+        if not base_url and previous_provider == provider_name and resolved_search_base_url:
+            base_url = resolved_search_base_url
         if not base_url:
             raise WebUISettingsError("base_url is required")
-        set_search_value("base_url", base_url)
-        set_search_value("api_key", "")
+        set_search_value("base_url", base_url, resolved_search_base_url)
+        set_search_value("api_key", "", resolved_search_api_key)
     else:
         api_key = _query_first_alias(query, "api_key", "apiKey")
         api_key = api_key.strip() if api_key is not None else None
-        if not api_key and previous_provider == provider_name and search_config.api_key:
-            api_key = search_config.api_key
+        if not api_key and previous_provider == provider_name and resolved_search_api_key:
+            api_key = resolved_search_api_key
         if not api_key:
             raise WebUISettingsError("api_key is required")
-        set_search_value("api_key", api_key)
-        set_search_value("base_url", "")
+        set_search_value("api_key", api_key, resolved_search_api_key)
+        set_search_value("base_url", "", resolved_search_base_url)
 
     max_results = _query_first_alias(query, "max_results", "maxResults")
     if max_results is not None:


### PR DESCRIPTION
### Problem

`load_config()` returns raw `${VAR}` template strings for credentials like `api_key` and `api_base`. Two update code paths in `settings_api.py` compare these raw values against user-submitted values without resolving them first:

1. **`update_provider_settings()`** — compares `provider_config.api_key != api_key` where the left side is the raw template string (e.g., `"${OPENAI_API_KEY}"`). If the WebUI sends back the resolved key, the comparison detects a "change" and overwrites the template with the literal key in `config.json`. The env-var reference is permanently lost.

2. **`update_web_search_settings()`** — same pattern via `set_search_value()` which compares `getattr(search_config, attr) != value`. Additionally, the fallback path (`if not api_key and ... search_config.api_key`) returns the raw template string as the api_key value, which would then be written back as a literal.

### Fix

Resolve env-var templates before comparison and fallback logic, but continue to save the raw config object so that unchanged template references are preserved in `config.json`.

- `update_provider_settings()`: resolve `api_key` and `api_base` before comparison
- `update_web_search_settings()`: resolve `api_key` and `base_url` before comparison and fallback

### Open Questions

This fix addresses the immediate comparison bugs, but raises a broader design question:

**Should the WebUI allow editing a field that currently holds an env-var reference?**

Options:
- **Preserve templates**: Current approach — if the resolved value matches the submission, the template survives. If the user submits a different value, the template is replaced (intended behavior).
- **Lock env-var fields**: The WebUI could detect `${VAR}` references and make those fields read-only, requiring the user to edit the env var or config file directly.
- **Show env-var indicator**: The WebUI could display a badge like "Set via ${OPENAI_API_KEY}" next to the field, with an explicit "Override" action to replace the template.

This PR does not take a position on the UX question — it only fixes the data corruption bug. The design decision about env-var field handling should be a separate discussion.

### Testing

All 45 existing `test_settings_api.py` tests pass.
