### PR TITLE
fix(memory): summarize full session tail during idle compaction (#4264)

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -799,15 +799,23 @@ class Consolidator:
         messages: list[dict],
         *,
         session_key: str | None = None,
+        summary_context: list[dict] | None = None,
     ) -> str | None:
         """Summarize messages via LLM and append to history.jsonl.
+
+        ``messages`` are the messages being archived (removed from the live
+        session); they are what gets raw-dumped if the LLM call fails.
+        ``summary_context``, when given, is fed to the summarizer in place of
+        ``messages`` so a caller can summarize over a wider window (e.g. the
+        full conversation tail) while still only archiving ``messages``.
 
         Returns the summary text on success, None if nothing to archive.
         """
         if not messages:
             return None
+        context = summary_context if summary_context is not None else messages
         try:
-            formatted = MemoryStore._format_messages(messages)
+            formatted = MemoryStore._format_messages(context)
             formatted = self._truncate_to_token_budget(formatted)
             response = await self.provider.chat_with_retry(
                 model=self.model,
@@ -990,7 +998,17 @@ class Consolidator:
             last_active = session.updated_at
             summary: str | None = ""
             if archive_msgs:
-                summary = await self.archive(archive_msgs, session_key=session_key)
+                # Summarize over the full unconsolidated tail — including the
+                # recent suffix we retain — not just the dropped prefix. Idle
+                # compaction usually runs on a finished conversation, so a late
+                # user correction or final result that landed in the kept suffix
+                # must still reach the persisted summary; otherwise history keeps
+                # the stale pre-correction conclusion that never gets fixed
+                # (#4264). Only archive_msgs are removed/raw-dumped; kept stays
+                # in the session.
+                summary = await self.archive(
+                    archive_msgs, session_key=session_key, summary_context=tail
+                )
 
             if summary and summary != "(nothing)":
                 session.metadata["_last_summary"] = {

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -799,23 +799,22 @@ class Consolidator:
         messages: list[dict],
         *,
         session_key: str | None = None,
-        summary_context: list[dict] | None = None,
+        summary_messages: list[dict] | None = None,
     ) -> str | None:
         """Summarize messages via LLM and append to history.jsonl.
 
         ``messages`` are the messages being archived (removed from the live
         session); they are what gets raw-dumped if the LLM call fails.
-        ``summary_context``, when given, is fed to the summarizer in place of
-        ``messages`` so a caller can summarize over a wider window (e.g. the
-        full conversation tail) while still only archiving ``messages``.
+        ``summary_messages``, when given, lets callers include retained
+        messages in the summary without archiving them.
 
         Returns the summary text on success, None if nothing to archive.
         """
         if not messages:
             return None
-        context = summary_context if summary_context is not None else messages
+        messages_to_summarize = summary_messages if summary_messages is not None else messages
         try:
-            formatted = MemoryStore._format_messages(context)
+            formatted = MemoryStore._format_messages(messages_to_summarize)
             formatted = self._truncate_to_token_budget(formatted)
             response = await self.provider.chat_with_retry(
                 model=self.model,
@@ -972,42 +971,38 @@ class Consolidator:
             self.sessions.invalidate(session_key)
             session = self.sessions.get_or_create(session_key)
 
-            tail = list(session.messages[session.last_consolidated:])
-            if not tail:
+            messages_to_summarize = list(session.messages[session.last_consolidated:])
+            if not messages_to_summarize:
                 session.updated_at = datetime.now()
                 self.sessions.save(session)
                 return ""
 
             probe = Session(
                 key=session.key,
-                messages=tail.copy(),
+                messages=messages_to_summarize.copy(),
                 created_at=session.created_at,
                 updated_at=session.updated_at,
                 metadata={},
                 last_consolidated=0,
             )
             dropped, already_consolidated = probe.retain_recent_legal_suffix(max_suffix)
-            kept = probe.messages
-            archive_msgs = dropped[already_consolidated:]
+            messages_to_keep = probe.messages
+            messages_to_remove = dropped[already_consolidated:]
 
-            if not archive_msgs and not kept:
+            if not messages_to_remove and not messages_to_keep:
                 session.updated_at = datetime.now()
                 self.sessions.save(session)
                 return ""
 
             last_active = session.updated_at
             summary: str | None = ""
-            if archive_msgs:
-                # Summarize over the full unconsolidated tail — including the
-                # recent suffix we retain — not just the dropped prefix. Idle
-                # compaction usually runs on a finished conversation, so a late
-                # user correction or final result that landed in the kept suffix
-                # must still reach the persisted summary; otherwise history keeps
-                # the stale pre-correction conclusion that never gets fixed
-                # (#4264). Only archive_msgs are removed/raw-dumped; kept stays
-                # in the session.
+            if messages_to_remove:
+                # Summarize the retained suffix too, but only remove/raw-dump
+                # the messages that are no longer kept in the live session.
                 summary = await self.archive(
-                    archive_msgs, session_key=session_key, summary_context=tail
+                    messages_to_remove,
+                    session_key=session_key,
+                    summary_messages=messages_to_summarize,
                 )
 
             if summary and summary != "(nothing)":
@@ -1016,17 +1011,17 @@ class Consolidator:
                     "last_active": last_active.isoformat(),
                 }
 
-            session.messages = kept
+            session.messages = messages_to_keep
             session.last_consolidated = 0
             session.updated_at = datetime.now()
             self.sessions.save(session)
 
-            if archive_msgs:
+            if messages_to_remove:
                 logger.info(
                     "Idle-session compact for {}: archived={}, kept={}, summary={}",
                     session_key,
-                    len(archive_msgs),
-                    len(kept),
+                    len(messages_to_remove),
+                    len(messages_to_keep),
                     bool(summary),
                 )
 

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -402,6 +402,56 @@ class TestCompactIdleSession:
         assert "last_active" in meta
 
     @pytest.mark.asyncio
+    async def test_summarizes_retained_suffix_not_just_dropped_prefix(
+        self, real_consolidator, mock_provider
+    ):
+        """idleCompact must summarize over the full unconsolidated tail, including
+        the recent suffix it retains. Otherwise a late user correction / final
+        result that lands in the kept suffix is excluded from the persisted
+        summary, leaving a stale wrong conclusion in history. Regression for #4264."""
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="Summary.", finish_reason="stop"
+        )
+        sessions = real_consolidator.sessions
+        session = sessions.get_or_create("cli:correction")
+        for i in range(18):
+            session.add_message("user", f"user msg {i}")
+            session.add_message("assistant", f"assistant msg {i}")
+        # Final correction exchange lands inside the retained max_suffix window.
+        session.add_message("user", "no, that's wrong, use approach B")
+        session.add_message("assistant", "CORRECTED_FINAL_RESULT_alpha")
+        sessions.save(session)
+
+        await real_consolidator.compact_idle_session("cli:correction", max_suffix=8)
+
+        summarized = mock_provider.chat_with_retry.call_args.kwargs["messages"][1]["content"]
+        assert "CORRECTED_FINAL_RESULT_alpha" in summarized
+
+    @pytest.mark.asyncio
+    async def test_raw_dumps_only_dropped_messages_on_llm_failure(
+        self, real_consolidator, mock_provider, store
+    ):
+        """Summarizing over the full tail must not widen what gets raw-dumped on
+        LLM failure: the breadcrumb should contain only the removed prefix, not
+        the retained suffix that stays live in the session. Regression for #4264."""
+        mock_provider.chat_with_retry.side_effect = RuntimeError("LLM unavailable")
+        sessions = real_consolidator.sessions
+        session = sessions.get_or_create("cli:rawdrop")
+        for i in range(18):
+            session.add_message("user", f"user msg {i}")
+            session.add_message("assistant", f"assistant msg {i}")
+        session.add_message("user", "final user follow-up")
+        session.add_message("assistant", "RETAINED_SUFFIX_marker")
+        sessions.save(session)
+
+        await real_consolidator.compact_idle_session("cli:rawdrop", max_suffix=8)
+
+        raw = "\n".join(e["content"] for e in store.read_unprocessed_history(since_cursor=0))
+        assert "[RAW]" in raw
+        assert "user msg 0" in raw  # removed prefix is the breadcrumb
+        assert "RETAINED_SUFFIX_marker" not in raw  # retained suffix not dumped
+
+    @pytest.mark.asyncio
     async def test_idle_compact_writes_session_key_to_history(
         self,
         real_consolidator,
@@ -537,11 +587,15 @@ class TestCompactIdleSession:
             "assistant-04",
         ]
 
+        # #4264: idle compaction now summarizes the full unconsolidated tail, so
+        # the dropped head (user-00), the non-contiguous dropped tail
+        # (assistant-09), and the retained suffix (user-14) are all summarized.
+        # Retention above still proves the non-contiguous suffix is handled.
         archived_call = mock_provider.chat_with_retry.call_args
         user_content = archived_call.kwargs["messages"][1]["content"]
-        assert "user-14" not in user_content
-        assert "assistant-00" not in user_content
+        assert "user-00" in user_content
         assert "assistant-09" in user_content
+        assert "user-14" in user_content
 
     @pytest.mark.asyncio
     async def test_acquires_consolidation_lock(self, real_consolidator, mock_provider):


### PR DESCRIPTION
## Summary
- Fixes #4264: `idleCompact` now summarizes over the **full unconsolidated session tail**, including the recent suffix it retains, instead of only the dropped prefix.
- Adds an opt-in `summary_context` argument to `Consolidator.archive` so the summarization window and the set of archived (removed) messages can differ, without affecting other callers.

## The bug
`compact_idle_session()` splits the tail into `archive_msgs` (older messages, removed) and `kept` (the recent `max_suffix` messages, retained), then summarized **only `archive_msgs`**:

```python
summary = await self.archive(archive_msgs, session_key=session_key)
```

Idle compaction almost always runs *after* a conversation is finished. In the common "model errs → user corrects → model delivers the correct result" flow, that final correction lands in the `kept` suffix — so it was excluded from the summary written to `history.jsonl`. The persisted memory then records the stale pre-correction conclusion, and because idle sessions are rarely resumed (especially in the WebUI, where new sessions start freely), the wrong record is never corrected.

This is specific to idle compaction. The token-budget path (`maybe_consolidate_by_tokens`) runs mid-conversation, where the record is still being updated, so it is intentionally left unchanged.

## The fix
Summarize over the full tail, while still only **removing** (and, on LLM failure, raw-dumping) the dropped messages:

```python
summary = await self.archive(archive_msgs, session_key=session_key, summary_context=tail)
```

`archive()` gains a `summary_context` parameter: when provided, it is fed to the summarizer in place of `messages`, but `messages` is still what gets raw-dumped if the LLM call fails. This keeps the failure breadcrumb honest (only the removed messages, not the retained suffix that stays live in the session) and leaves the other two `archive()` callers untouched.

The cost is the small, bounded redundancy the issue explicitly accepts: the retained suffix appears both in the summary and (verbatim) in the live session — far preferable to a permanently wrong memory.

## Test Plan
- `pytest tests/agent/test_consolidator.py -q` — 36 passed, including two new regression tests:
  - `test_summarizes_retained_suffix_not_just_dropped_prefix` — a correction in the kept suffix now reaches the summary input.
  - `test_raw_dumps_only_dropped_messages_on_llm_failure` — the LLM-failure breadcrumb contains only the removed prefix, never the retained suffix.
- Updated `test_non_contiguous_suffix_archives_actual_dropped_messages` to the new contract (full tail is summarized; retention of the non-contiguous suffix is unchanged).
- `pytest tests/agent/test_auto_compact.py tests/agent/test_autocompact_unit.py tests/agent/test_consolidate_offset.py tests/agent/test_consolidation_ratio.py tests/agent/test_loop_consolidation_tokens.py tests/agent/test_memory_store.py tests/session/ -q` — 214 passed.
- `ruff check nanobot/agent/memory.py tests/agent/test_consolidator.py` — clean.
