### PR TITLE
webui: serve correctly under a path prefix (reverse proxy / sub-path)

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -11,9 +11,9 @@
     />
     <meta name="theme-color" content="#fafaf9" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#161618" media="(prefers-color-scheme: dark)" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/brand/nanobot_favicon_32.png" />
-    <link rel="icon" type="image/png" sizes="73x75" href="/brand/nanobot_icon.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/brand/nanobot_apple_touch.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="./brand/nanobot_favicon_32.png" />
+    <link rel="icon" type="image/png" sizes="73x75" href="./brand/nanobot_icon.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="./brand/nanobot_apple_touch.png" />
     <style>
       html,
       body,

--- a/webui/src/components/Sidebar.tsx
+++ b/webui/src/components/Sidebar.tsx
@@ -19,6 +19,7 @@ import type {
   SidebarViewState,
 } from "@/lib/types";
 import { cn } from "@/lib/utils";
+import { getBasePath } from "@/lib/base-path";
 
 interface SidebarProps {
   sessions: ChatSummary[];
@@ -113,7 +114,7 @@ export function Sidebar(props: SidebarProps) {
           )}
         >
           <img
-            src="/brand/nanobot_icon.png"
+            src={`${getBasePath()}/brand/nanobot_icon.png`}
             alt=""
             className="h-8 w-8 select-none object-contain"
             draggable={false}

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -24,6 +24,7 @@ import type {
   WorkspaceScopePayload,
 } from "./types";
 import { fetchWithTimeout } from "./http";
+import { getBasePath } from "./base-path";
 
 const API_READ_TIMEOUT_MS = 20_000;
 
@@ -95,7 +96,7 @@ function splitKey(key: string): { channel: string; chatId: string } {
 
 export async function listSessions(
   token: string,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<ChatSummary[]> {
   type Row = {
     key: string;
@@ -135,7 +136,7 @@ export async function fetchWebuiThread(
   token: string,
   key: string,
   optionsOrBase?: FetchWebuiThreadOptions | string,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<WebuiThreadPersistedPayload | null> {
   const options = typeof optionsOrBase === "string" ? undefined : optionsOrBase;
   const resolvedBase = typeof optionsOrBase === "string" ? optionsOrBase : base;
@@ -159,7 +160,7 @@ export async function fetchFilePreview(
   token: string,
   key: string,
   path: string,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<FilePreviewPayload> {
   const query = new URLSearchParams();
   query.set("path", path);
@@ -174,7 +175,7 @@ export async function fetchFilePreview(
 export async function fetchSessionAutomations(
   token: string,
   key: string,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<SessionAutomationsPayload> {
   return request<SessionAutomationsPayload>(
     `${base}/api/sessions/${encodeURIComponent(key)}/automations`,
@@ -186,7 +187,7 @@ export async function fetchSessionAutomations(
 
 export async function fetchSkills(
   token: string,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<SkillsPayload> {
   return request<SkillsPayload>(
     `${base}/api/webui/skills`,
@@ -199,7 +200,7 @@ export async function fetchSkills(
 export async function fetchSkillDetail(
   token: string,
   name: string,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<SkillDetail> {
   return request<SkillDetail>(
     `${base}/api/webui/skills/${encodeURIComponent(name)}`,
@@ -213,7 +214,7 @@ export async function deleteSession(
   token: string,
   key: string,
   optionsOrBase?: { deleteAutomations?: boolean } | string,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<SessionDeleteResult> {
   const options = typeof optionsOrBase === "string" ? undefined : optionsOrBase;
   const resolvedBase = typeof optionsOrBase === "string" ? optionsOrBase : base;
@@ -228,7 +229,7 @@ export async function deleteSession(
 
 export async function fetchSettings(
   token: string,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<SettingsPayload> {
   return request<SettingsPayload>(
     `${base}/api/settings`,
@@ -240,7 +241,7 @@ export async function fetchSettings(
 
 export async function fetchSettingsUsage(
   token: string,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<NonNullable<SettingsPayload["usage"]>> {
   return request<NonNullable<SettingsPayload["usage"]>>(
     `${base}/api/settings/usage`,
@@ -260,7 +261,7 @@ export interface VersionCheckResult {
 
 export async function checkVersion(
   token: string,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<VersionCheckResult> {
   return request<VersionCheckResult>(
     `${base}/api/settings/version-check`,
@@ -272,7 +273,7 @@ export async function checkVersion(
 
 export async function fetchWorkspaces(
   token: string,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<WorkspacesPayload> {
   return request<WorkspacesPayload>(
     `${base}/api/workspaces`,
@@ -284,7 +285,7 @@ export async function fetchWorkspaces(
 
 export async function fetchCliApps(
   token: string,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<CliAppsPayload> {
   return request<CliAppsPayload>(
     `${base}/api/settings/cli-apps`,
@@ -298,7 +299,7 @@ export async function runCliAppAction(
   token: string,
   action: "install" | "update" | "uninstall" | "test",
   name: string,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<CliAppsPayload> {
   const query = new URLSearchParams();
   query.set("name", name);
@@ -307,7 +308,7 @@ export async function runCliAppAction(
 
 export async function fetchMcpPresets(
   token: string,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<McpPresetsPayload> {
   return request<McpPresetsPayload>(
     `${base}/api/settings/mcp-presets`,
@@ -320,7 +321,7 @@ export async function fetchMcpPresets(
 export async function fetchProviderModels(
   token: string,
   provider: string,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<ProviderModelsPayload> {
   const query = new URLSearchParams();
   query.set("provider", provider);
@@ -337,7 +338,7 @@ export async function runMcpPresetAction(
   action: "enable" | "remove" | "test",
   name: string,
   values: Record<string, string> = {},
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<McpPresetsPayload> {
   const query = new URLSearchParams();
   query.set("name", name);
@@ -351,7 +352,7 @@ export async function runMcpPresetAction(
 export async function saveCustomMcpServer(
   token: string,
   values: Record<string, string>,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<McpPresetsPayload> {
   return request<McpPresetsPayload>(
     `${base}/api/settings/mcp-presets/custom`,
@@ -363,7 +364,7 @@ export async function saveCustomMcpServer(
 export async function importMcpConfig(
   token: string,
   config: string,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<McpPresetsPayload> {
   return request<McpPresetsPayload>(
     `${base}/api/settings/mcp-presets/import`,
@@ -376,7 +377,7 @@ export async function updateMcpServerTools(
   token: string,
   name: string,
   enabledTools: string[],
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<McpPresetsPayload> {
   return request<McpPresetsPayload>(
     `${base}/api/settings/mcp-presets/tools`,
@@ -387,7 +388,7 @@ export async function updateMcpServerTools(
 
 export async function listSlashCommands(
   token: string,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<SlashCommand[]> {
   type Row = {
     command: string;
@@ -415,7 +416,7 @@ export async function listSlashCommands(
 
 export async function fetchSidebarState(
   token: string,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<SidebarStatePayload> {
   return request<SidebarStatePayload>(
     `${base}/api/webui/sidebar-state`,
@@ -428,7 +429,7 @@ export async function fetchSidebarState(
 export async function updateSidebarState(
   token: string,
   state: SidebarStatePayload,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<SidebarStatePayload> {
   const query = new URLSearchParams();
   query.set("state", JSON.stringify(state));
@@ -441,7 +442,7 @@ export async function updateSidebarState(
 export async function updateSettings(
   token: string,
   update: SettingsUpdate,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<SettingsPayload> {
   const query = new URLSearchParams();
   if (update.modelPreset !== undefined) {
@@ -464,7 +465,7 @@ export async function updateSettings(
 export async function createModelConfiguration(
   token: string,
   configuration: ModelConfigurationCreate,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<SettingsPayload> {
   const query = new URLSearchParams();
   if (configuration.name !== undefined) query.set("name", configuration.name);
@@ -480,7 +481,7 @@ export async function createModelConfiguration(
 export async function updateModelConfiguration(
   token: string,
   configuration: ModelConfigurationUpdate,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<SettingsPayload> {
   const query = new URLSearchParams();
   query.set("name", configuration.name);
@@ -499,7 +500,7 @@ export async function updateModelConfiguration(
 export async function updateProviderSettings(
   token: string,
   update: ProviderSettingsUpdate,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<SettingsPayload> {
   const query = new URLSearchParams();
   query.set("provider", update.provider);
@@ -515,7 +516,7 @@ export async function updateProviderSettings(
 export async function loginProviderOAuth(
   token: string,
   provider: string,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<SettingsPayload> {
   const query = new URLSearchParams();
   query.set("provider", provider);
@@ -528,7 +529,7 @@ export async function loginProviderOAuth(
 export async function logoutProviderOAuth(
   token: string,
   provider: string,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<SettingsPayload> {
   const query = new URLSearchParams();
   query.set("provider", provider);
@@ -541,7 +542,7 @@ export async function logoutProviderOAuth(
 export async function updateWebSearchSettings(
   token: string,
   update: WebSearchSettingsUpdate,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<SettingsPayload> {
   const query = new URLSearchParams();
   query.set("provider", update.provider);
@@ -561,7 +562,7 @@ export async function updateWebSearchSettings(
 export async function updateNetworkSafetySettings(
   token: string,
   update: NetworkSafetySettingsUpdate,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<SettingsPayload> {
   const query = new URLSearchParams();
   query.set("webui_allow_local_service_access", String(update.webuiAllowLocalServiceAccess));
@@ -575,7 +576,7 @@ export async function updateNetworkSafetySettings(
 export async function updateImageGenerationSettings(
   token: string,
   update: ImageGenerationSettingsUpdate,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<SettingsPayload> {
   const query = new URLSearchParams();
   query.set("enabled", String(update.enabled));
@@ -593,7 +594,7 @@ export async function updateImageGenerationSettings(
 export async function updateTranscriptionSettings(
   token: string,
   update: TranscriptionSettingsUpdate,
-  base: string = "",
+  base: string = getBasePath(),
 ): Promise<SettingsPayload> {
   const query = new URLSearchParams();
   query.set("enabled", String(update.enabled));

--- a/webui/src/lib/base-path.ts
+++ b/webui/src/lib/base-path.ts
@@ -1,0 +1,8 @@
+export function getBasePath(): string {
+  if (typeof window === "undefined") return "";
+  const pathname = window.location.pathname || "/";
+  const dir = pathname.endsWith("/")
+    ? pathname
+    : pathname.slice(0, pathname.lastIndexOf("/") + 1);
+  return dir.replace(/\/+$/, "");
+}

--- a/webui/src/lib/bootstrap.ts
+++ b/webui/src/lib/bootstrap.ts
@@ -1,5 +1,6 @@
 import type { BootstrapResponse } from "./types";
 import { fetchWithTimeout } from "./http";
+import { getBasePath } from "./base-path";
 
 const SECRET_STORAGE_KEY = "nanobot-webui.bootstrap-secret";
 
@@ -44,7 +45,8 @@ export async function fetchBootstrap(
   if (secret) {
     headers["X-Nanobot-Auth"] = secret;
   }
-  const res = await fetchWithTimeout(`${baseUrl}/webui/bootstrap`, {
+  const root = baseUrl || getBasePath();
+  const res = await fetchWithTimeout(`${root}/webui/bootstrap`, {
     method: "GET",
     credentials: "same-origin",
     headers,
@@ -72,7 +74,8 @@ export function deriveWsUrl(
   wsUrl?: string | null,
 ): string {
   const query = `?token=${encodeURIComponent(token)}`;
-  if (wsUrl && /^(wss?|nanobot-host):\/\//i.test(wsUrl)) {
+  const base = getBasePath();
+  if (!base && wsUrl && /^(wss?|nanobot-host):\/\//i.test(wsUrl)) {
     const join = wsUrl.includes("?") ? "&" : "?";
     return `${wsUrl}${join}token=${encodeURIComponent(token)}`;
   }
@@ -88,5 +91,5 @@ export function deriveWsUrl(
   }
   const scheme = window.location.protocol === "https:" ? "wss" : "ws";
   const host = window.location.host;
-  return `${scheme}://${host}${path}${query}`;
+  return `${scheme}://${host}${base}${path}${query}`;
 }

--- a/webui/src/tests/base-path.test.ts
+++ b/webui/src/tests/base-path.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getBasePath } from "@/lib/base-path";
+import { deriveWsUrl } from "@/lib/bootstrap";
+
+function stubLocation(loc: Partial<Location>): void {
+  vi.stubGlobal("window", { location: loc });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("getBasePath", () => {
+  it("returns '' at the web root (direct / native access)", () => {
+    stubLocation({ pathname: "/" });
+    expect(getBasePath()).toBe("");
+  });
+
+  it("derives a sub-path mount served with a trailing slash", () => {
+    stubLocation({ pathname: "/nanobot/" });
+    expect(getBasePath()).toBe("/nanobot");
+  });
+
+  it("derives the parent directory when served as a document path", () => {
+    stubLocation({ pathname: "/nanobot/index.html" });
+    expect(getBasePath()).toBe("/nanobot");
+  });
+
+  it("derives a deep sub-path mount (e.g. behind a reverse proxy)", () => {
+    stubLocation({ pathname: "/apps/nanobot/" });
+    expect(getBasePath()).toBe("/apps/nanobot");
+  });
+
+  it("derives the Home Assistant Ingress prefix", () => {
+    stubLocation({ pathname: "/api/hassio_ingress/AbC-123/" });
+    expect(getBasePath()).toBe("/api/hassio_ingress/AbC-123");
+  });
+});
+
+describe("deriveWsUrl under a sub-path", () => {
+  it("prefixes the WebSocket URL with the served base path (wss)", () => {
+    stubLocation({
+      protocol: "https:",
+      host: "example.com",
+      port: "",
+      pathname: "/api/hassio_ingress/AbC-123/",
+    } as Partial<Location>);
+    expect(deriveWsUrl("/", "tok")).toBe(
+      "wss://example.com/api/hassio_ingress/AbC-123/?token=tok",
+    );
+  });
+
+  it("leaves the WebSocket URL unprefixed at the web root", () => {
+    stubLocation({
+      protocol: "https:",
+      host: "example.com",
+      port: "",
+      pathname: "/",
+    } as Partial<Location>);
+    expect(deriveWsUrl("/ws", "tok")).toBe(
+      "wss://example.com/ws?token=tok",
+    );
+  });
+
+  it("ignores the server ws_url under a sub-path and uses the location prefix", () => {
+    stubLocation({
+      protocol: "https:",
+      host: "example.com",
+      port: "",
+      pathname: "/nanobot/",
+    } as Partial<Location>);
+    expect(deriveWsUrl("/", "tok", "wss://example.com/")).toBe(
+      "wss://example.com/nanobot/?token=tok",
+    );
+  });
+
+  it("honors the server ws_url at the web root", () => {
+    stubLocation({
+      protocol: "https:",
+      host: "example.com",
+      port: "",
+      pathname: "/",
+    } as Partial<Location>);
+    expect(deriveWsUrl("/", "tok", "wss://other.example/")).toBe(
+      "wss://other.example/?token=tok",
+    );
+  });
+});

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig(({ mode }) => {
   const hmrPath = "/__nanobot_vite_hmr";
 
   return {
+    base: "./",
     plugins: [react()],
     resolve: {
       alias: {


### PR DESCRIPTION
## Problem

The WebUI assumes it is served at the web root (`/`). Built asset URLs, the
REST calls, the bootstrap fetch, and the WebSocket URL are all constructed as
absolute root paths. When the WebUI is served **behind a reverse proxy or under
a sub-path** — e.g. `https://host/nanobot/` or, concretely, **Home Assistant
Ingress** which mounts add-ons at `/api/hassio_ingress/<token>/` — those
absolute paths point above the mount, so:

- `index.html` requests `/assets/...` instead of `<prefix>/assets/...` → blank page,
- REST requests hit `/api/...` instead of `<prefix>/api/...` → 404 / wrong host,
- the WebSocket connects to `wss://host/<ws_path>` instead of
  `wss://host<prefix>/<ws_path>` → the proxy can't route the upgrade.

## Fix

Make the WebUI prefix-aware while keeping root behavior identical:

- **`vite.config.ts`**: set `base: "./"` so the built bundle references assets
  with relative URLs, which resolve correctly under any mount.
- **`index.html`**: make the `/brand/*` favicon hrefs relative (`./brand/...`).
- **`src/lib/base-path.ts`** (new): `getBasePath()` derives the mount prefix
  from `window.location.pathname`. The WebUI is a single-page app with no
  client-side router and the gateway serves the SPA shell at `<prefix>/`, so the
  directory portion of the current pathname *is* the mount prefix. Returns the
  prefix with no trailing slash, `""` at the web root, and `""` during SSR /
  when `window` is undefined.
- **`src/lib/api.ts`**: every endpoint helper now defaults its `base` argument
  to `getBasePath()` instead of `""`.
- **`src/lib/bootstrap.ts`**: `fetchBootstrap` uses `baseUrl || getBasePath()`;
  `deriveWsUrl` prefixes the production same-host WS URL with `getBasePath()`
  (the dev-server and SSR branches, which connect directly to the gateway, are
  left untouched).

## Backward compatibility

At the web root `getBasePath()` returns `""`, so REST, bootstrap, and WebSocket
URLs are byte-for-byte identical to today. Relative asset URLs resolve to the
same files at the root. Direct/native deployments and the Vite dev server are
unchanged.

## Testing

- `npm run build` passes (`tsc` + `vite build`); the built
  `nanobot/web/dist/index.html` now references `./assets/...` and `./brand/...`.
- Added `src/tests/base-path.test.ts` covering the web root, a trailing-slash
  sub-path, a document-path mount, a deep sub-path, the HA Ingress prefix, and
  WebSocket prefixing (prefixed under a sub-path, unprefixed at the root).