### PR TITLE
fix(webui): localize update check copy

### DIFF
--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -1942,7 +1942,10 @@ function VersionCheckRow({ currentVersion }: { currentVersion?: string }) {
         {result?.type === "update" ? (
           <span className="inline-flex items-center gap-1.5 text-[12px] text-blue-600 dark:text-blue-300">
             <ArrowUpCircle className="h-3 w-3" aria-hidden />
-            {tx("settings.about.updateAvailable", "Update available")}{result.latestVersion && ` v${result.latestVersion}`}
+            {t("settings.about.updateAvailable", {
+              defaultValue: "Update available v{{version}}",
+              version: result.latestVersion,
+            })}
             {result.pypiUrl ? (
               <a
                 href={result.pypiUrl}

--- a/webui/src/i18n/locales/en/common.json
+++ b/webui/src/i18n/locales/en/common.json
@@ -86,6 +86,7 @@
       "interface": "Interface",
       "ai": "AI",
       "system": "System",
+      "about": "About",
       "status": "Status",
       "localPreferences": "Local preferences",
       "presets": "Presets",
@@ -250,6 +251,13 @@
       "unsupported": "Unsupported",
       "unavailable": "Unavailable",
       "noDescription": "No description available."
+    },
+    "about": {
+      "version": "Version",
+      "checking": "Checking...",
+      "checkForUpdates": "Check for updates",
+      "upToDate": "You're up to date",
+      "updateAvailable": "Update available v{{version}}"
     },
     "mcp": {
       "allCategories": "All categories",

--- a/webui/src/i18n/locales/es/common.json
+++ b/webui/src/i18n/locales/es/common.json
@@ -86,6 +86,7 @@
       "interface": "Interfaz",
       "ai": "AI",
       "system": "Sistema",
+      "about": "Acerca de",
       "status": "Estado",
       "localPreferences": "Preferencias locales",
       "presets": "Preajustes",
@@ -390,6 +391,13 @@
       "install": "Instalar CLI",
       "unavailable": "No disponible",
       "noDescription": "Sin descripción disponible."
+    },
+    "about": {
+      "version": "Versión",
+      "checking": "Buscando actualizaciones...",
+      "checkForUpdates": "Buscar actualizaciones",
+      "upToDate": "Estás al día",
+      "updateAvailable": "Actualización disponible v{{version}}"
     },
     "mcp": {
       "allCategories": "Todas las categorías",

--- a/webui/src/i18n/locales/fr/common.json
+++ b/webui/src/i18n/locales/fr/common.json
@@ -86,6 +86,7 @@
       "interface": "Interface utilisateur",
       "ai": "AI",
       "system": "Système",
+      "about": "À propos",
       "status": "État",
       "localPreferences": "Préférences locales",
       "presets": "Préréglages",
@@ -390,6 +391,13 @@
       "install": "Installer le CLI",
       "unavailable": "Indisponible",
       "noDescription": "Aucune description disponible."
+    },
+    "about": {
+      "version": "Version",
+      "checking": "Recherche de mises à jour...",
+      "checkForUpdates": "Rechercher les mises à jour",
+      "upToDate": "Vous êtes à jour",
+      "updateAvailable": "Mise à jour disponible v{{version}}"
     },
     "mcp": {
       "allCategories": "Toutes les catégories",

--- a/webui/src/i18n/locales/id/common.json
+++ b/webui/src/i18n/locales/id/common.json
@@ -86,6 +86,7 @@
       "interface": "Antarmuka",
       "ai": "AI",
       "system": "Sistem",
+      "about": "Tentang",
       "status": "Status",
       "localPreferences": "Preferensi lokal",
       "presets": "Preset",
@@ -390,6 +391,13 @@
       "install": "Pasang CLI",
       "unavailable": "Tidak tersedia",
       "noDescription": "Tidak ada deskripsi."
+    },
+    "about": {
+      "version": "Versi",
+      "checking": "Memeriksa pembaruan...",
+      "checkForUpdates": "Periksa pembaruan",
+      "upToDate": "Anda sudah menggunakan versi terbaru",
+      "updateAvailable": "Pembaruan tersedia v{{version}}"
     },
     "mcp": {
       "allCategories": "Semua kategori",

--- a/webui/src/i18n/locales/ja/common.json
+++ b/webui/src/i18n/locales/ja/common.json
@@ -86,6 +86,7 @@
       "interface": "インターフェース",
       "ai": "AI",
       "system": "システム",
+      "about": "情報",
       "status": "状態",
       "localPreferences": "ローカル設定",
       "presets": "プリセット",
@@ -390,6 +391,13 @@
       "install": "CLI をインストール",
       "unavailable": "利用不可",
       "noDescription": "説明はありません。"
+    },
+    "about": {
+      "version": "バージョン",
+      "checking": "確認中...",
+      "checkForUpdates": "アップデートを確認",
+      "upToDate": "最新の状態です",
+      "updateAvailable": "アップデートがあります v{{version}}"
     },
     "mcp": {
       "allCategories": "すべてのカテゴリ",

--- a/webui/src/i18n/locales/ko/common.json
+++ b/webui/src/i18n/locales/ko/common.json
@@ -86,6 +86,7 @@
       "interface": "인터페이스",
       "ai": "AI",
       "system": "시스템",
+      "about": "정보",
       "status": "상태",
       "localPreferences": "로컬 환경설정",
       "presets": "프리셋",
@@ -390,6 +391,13 @@
       "install": "CLI 설치",
       "unavailable": "사용 불가",
       "noDescription": "설명이 없습니다."
+    },
+    "about": {
+      "version": "버전",
+      "checking": "확인 중...",
+      "checkForUpdates": "업데이트 확인",
+      "upToDate": "최신 버전입니다",
+      "updateAvailable": "업데이트 사용 가능 v{{version}}"
     },
     "mcp": {
       "allCategories": "모든 카테고리",

--- a/webui/src/i18n/locales/vi/common.json
+++ b/webui/src/i18n/locales/vi/common.json
@@ -86,6 +86,7 @@
       "interface": "Giao diện",
       "ai": "AI",
       "system": "Hệ thống",
+      "about": "Giới thiệu",
       "status": "Trạng thái",
       "localPreferences": "Tùy chọn cục bộ",
       "presets": "Preset",
@@ -390,6 +391,13 @@
       "install": "Cài CLI",
       "unavailable": "Không khả dụng",
       "noDescription": "Không có mô tả."
+    },
+    "about": {
+      "version": "Phiên bản",
+      "checking": "Đang kiểm tra...",
+      "checkForUpdates": "Kiểm tra bản cập nhật",
+      "upToDate": "Bạn đang dùng phiên bản mới nhất",
+      "updateAvailable": "Có bản cập nhật v{{version}}"
     },
     "mcp": {
       "allCategories": "Tất cả danh mục",

--- a/webui/src/i18n/locales/zh-CN/common.json
+++ b/webui/src/i18n/locales/zh-CN/common.json
@@ -86,6 +86,7 @@
       "interface": "界面",
       "ai": "AI",
       "system": "系统",
+      "about": "关于",
       "status": "状态",
       "localPreferences": "本地偏好",
       "presets": "预设",
@@ -250,6 +251,13 @@
       "unsupported": "暂不支持",
       "unavailable": "不可用",
       "noDescription": "暂无描述。"
+    },
+    "about": {
+      "version": "版本",
+      "checking": "正在检查...",
+      "checkForUpdates": "检查更新",
+      "upToDate": "已是最新版本",
+      "updateAvailable": "有可用更新 v{{version}}"
     },
     "mcp": {
       "allCategories": "全部分类",

--- a/webui/src/i18n/locales/zh-TW/common.json
+++ b/webui/src/i18n/locales/zh-TW/common.json
@@ -86,6 +86,7 @@
       "interface": "介面",
       "ai": "AI",
       "system": "系統",
+      "about": "關於",
       "status": "狀態",
       "localPreferences": "本機偏好",
       "presets": "預設",
@@ -390,6 +391,13 @@
       "install": "安裝 CLI",
       "unavailable": "不可用",
       "noDescription": "暫無描述。"
+    },
+    "about": {
+      "version": "版本",
+      "checking": "正在檢查...",
+      "checkForUpdates": "檢查更新",
+      "upToDate": "已是最新版本",
+      "updateAvailable": "有可用更新 v{{version}}"
     },
     "mcp": {
       "allCategories": "全部分類",

--- a/webui/src/tests/i18n.test.tsx
+++ b/webui/src/tests/i18n.test.tsx
@@ -52,6 +52,7 @@ const LOCALIZED_SETTINGS_COPY_KEYS = [
   "settings.sections.webuiSafety",
   "settings.sections.capabilities",
   "settings.sections.apps",
+  "settings.sections.about",
   "settings.rows.theme",
   "settings.rows.language",
   "settings.rows.density",
@@ -87,6 +88,10 @@ const LOCALIZED_SETTINGS_COPY_KEYS = [
   "settings.status.upToDate",
   "settings.actions.save",
   "settings.actions.saving",
+  "settings.about.checking",
+  "settings.about.checkForUpdates",
+  "settings.about.upToDate",
+  "settings.about.updateAvailable",
 ];
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -230,6 +235,7 @@ describe("webui i18n", () => {
       for (const key of SETTINGS_NAV_KEYS) {
         expect(common.settings.nav[key as keyof typeof common.settings.nav]).toBeTruthy();
       }
+      expect(common.settings.sections.about).toBeTruthy();
       expect(common.settings.rows.theme).toBeTruthy();
       expect(common.settings.status.loading).toBeTruthy();
       expect(common.settings.actions.save).toBeTruthy();
@@ -241,6 +247,9 @@ describe("webui i18n", () => {
       expect(common.settings.byok.showApiKey).toBeTruthy();
       expect(common.settings.byok.hideApiKey).toBeTruthy();
       expect(common.settings.byok.configuredKeyHint).toBeTruthy();
+      expect(common.settings.about.version).toBeTruthy();
+      expect(common.settings.about.checkForUpdates).toBeTruthy();
+      expect(common.settings.about.updateAvailable).toContain("{{version}}");
     }
   });
 


### PR DESCRIPTION
## Summary
- add i18n resources for the settings About/update check copy across all WebUI locales
- localize the update-available message with a version interpolation
- extend i18n tests to cover the new About/update check keys

## Verification
- npm run test -- src/tests/i18n.test.tsx
- npm run test -- src/tests/settings-view.test.tsx
- npm run build
- temporary gateway + Playwright check: zh-CN settings overview shows 关于 / 检查更新 with no About / Check for updates fallback