### PR TITLE
fix(providers): widen omit_temperature to cover opus-4-8 and fable

### DIFF
--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -452,9 +452,10 @@ class AnthropicProvider(LLMProvider):
         max_tokens = max(1, max_tokens)
         thinking_enabled = bool(reasoning_effort) and reasoning_effort.lower() != "none"
 
-        # claude-opus-4-7 deprecated the `temperature` parameter entirely — the
-        # API returns 400 if it is present, on any code path.
-        omit_temperature = "opus-4-7" in model_name
+        # Several Anthropic models (opus-4-7, opus-4-8, fable) deprecated the
+        # `temperature` parameter — the API returns 400 if it is present.
+        _model_lower = model_name.lower()
+        omit_temperature = any(m in _model_lower for m in ("opus-4-7", "opus-4-8", "fable"))
 
         kwargs: dict[str, Any] = {
             "model": model_name,

--- a/tests/providers/test_anthropic_thinking.py
+++ b/tests/providers/test_anthropic_thinking.py
@@ -101,17 +101,17 @@ def test_opus_4_8_omits_temperature_none() -> None:
 
 
 def test_fable_omits_temperature_adaptive() -> None:
-    kw = _build(_make_provider("claude-fable-1"), "adaptive")
+    kw = _build(_make_provider("claude-fable-5"), "adaptive")
     assert "temperature" not in kw
 
 
 def test_fable_omits_temperature_enabled() -> None:
-    kw = _build(_make_provider("claude-fable-1"), "high", max_tokens=4096)
+    kw = _build(_make_provider("claude-fable-5"), "high", max_tokens=4096)
     assert "temperature" not in kw
 
 
 def test_fable_omits_temperature_none() -> None:
-    kw = _build(_make_provider("claude-fable-1"), None)
+    kw = _build(_make_provider("claude-fable-5"), None)
     assert "temperature" not in kw
 
 

--- a/tests/providers/test_anthropic_thinking.py
+++ b/tests/providers/test_anthropic_thinking.py
@@ -85,6 +85,41 @@ def test_opus_4_7_omits_temperature_none() -> None:
     assert "thinking" not in kw
 
 
+def test_opus_4_8_omits_temperature_adaptive() -> None:
+    kw = _build(_make_provider("claude-opus-4-8"), "adaptive")
+    assert "temperature" not in kw
+
+
+def test_opus_4_8_omits_temperature_enabled() -> None:
+    kw = _build(_make_provider("claude-opus-4-8"), "high", max_tokens=4096)
+    assert "temperature" not in kw
+
+
+def test_opus_4_8_omits_temperature_none() -> None:
+    kw = _build(_make_provider("claude-opus-4-8"), None)
+    assert "temperature" not in kw
+
+
+def test_fable_omits_temperature_adaptive() -> None:
+    kw = _build(_make_provider("claude-fable-1"), "adaptive")
+    assert "temperature" not in kw
+
+
+def test_fable_omits_temperature_enabled() -> None:
+    kw = _build(_make_provider("claude-fable-1"), "high", max_tokens=4096)
+    assert "temperature" not in kw
+
+
+def test_fable_omits_temperature_none() -> None:
+    kw = _build(_make_provider("claude-fable-1"), None)
+    assert "temperature" not in kw
+
+
+def test_ordinary_model_sends_temperature() -> None:
+    kw = _build(_make_provider("claude-sonnet-4-6"), None)
+    assert kw["temperature"] == 0.7
+
+
 def test_reasoning_effort_string_none_does_not_enable_thinking() -> None:
     """reasoning_effort='none' must not enable thinking — treated same as disabled."""
     kw = _build(_make_provider(), "none")


### PR DESCRIPTION
## Problem

The `omit_temperature` check in `_build_kwargs` is hardcoded to `"opus-4-7" in model_name`. Newer Anthropic models that also reject the `temperature` parameter (opus-4-8, Fable) fall through and get the parameter sent, causing a 400 on every request.

Reported in #4333.

## Fix

- Widen the check to match any of `opus-4-7`, `opus-4-8`, or `fable` via `any(...)`.
- Normalize `model_name` to lowercase before matching so mixed-case configs do not fall through.
- Update the comment to cover the broader set of affected models.

## Testing

Added 7 new tests in `test_anthropic_thinking.py`:
- `test_opus_4_8_omits_temperature_adaptive` / `_enabled` / `_none`
- `test_fable_omits_temperature_adaptive` / `_enabled` / `_none`
- `test_ordinary_model_sends_temperature` (negative test confirming unaffected models still send temperature)

All 18 tests in the file pass. Ruff clean.

## Scope

2 files changed, +39/-3. No capability registry, no new abstractions.