### PR TITLE
fix(cli-apps): reject malformed argv payloads

### DIFF
--- a/nanobot/agent/tools/cli_apps.py
+++ b/nanobot/agent/tools/cli_apps.py
@@ -8,10 +8,16 @@ from typing import Any
 from pydantic import Field
 
 from nanobot.agent.tools.base import Tool, tool_parameters
-from nanobot.agent.tools.schema import ArraySchema, BooleanSchema, IntegerSchema, StringSchema, tool_parameters_schema
-from nanobot.security.workspace_access import current_tool_workspace
+from nanobot.agent.tools.schema import (
+    ArraySchema,
+    BooleanSchema,
+    IntegerSchema,
+    StringSchema,
+    tool_parameters_schema,
+)
 from nanobot.apps.cli import CliAppError, CliAppManager, CliAppsRuntimeConfig
 from nanobot.config_base import Base
+from nanobot.security.workspace_access import current_tool_workspace
 
 
 class CliAppsToolConfig(Base):
@@ -114,6 +120,10 @@ class CliAppsTool(Tool):
         working_dir: str | None = None,
         timeout: int | None = None,
     ) -> str:
+        if args is not None and (
+            not isinstance(args, list) or any(not isinstance(arg, str) for arg in args)
+        ):
+            return "Error: args must be a list of strings"
         access = current_tool_workspace(
             self.workspace,
             restrict_to_workspace=self.restrict_to_workspace,

--- a/tests/cli_apps/test_tool.py
+++ b/tests/cli_apps/test_tool.py
@@ -112,6 +112,18 @@ def test_run_cli_app_rejects_uninstalled_app(tmp_path: Path, monkeypatch) -> Non
     assert "not installed" in result
 
 
+def test_run_cli_app_rejects_malformed_args(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    tool = CliAppsTool(workspace=workspace, restrict_to_workspace=True)
+
+    string_args = asyncio.run(tool.execute(name="gimp", args="project list"))  # type: ignore[arg-type]
+    non_string_arg = asyncio.run(tool.execute(name="gimp", args=["project", 3]))  # type: ignore[list-item]
+
+    assert string_args == "Error: args must be a list of strings"
+    assert non_string_arg == "Error: args must be a list of strings"
+
+
 def test_run_cli_app_description_names_only_settings_installed_apps(tmp_path: Path, monkeypatch) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()


### PR DESCRIPTION
## Summary

- Validate `run_cli_app` `args` payloads at runtime.
- Reject string and non-string argument entries before constructing argv.
- Add regression coverage for direct tool calls that bypass schema validation.

## Root cause

The tool schema declares `args` as an array of strings, but direct/internal calls can still reach `CliAppsTool.execute` with malformed values. A plain string is iterable, so the service layer would turn `"project list"` into one CLI argument per character.

## Validation

- `uv run pytest tests/cli_apps/test_tool.py`
- `uv run ruff check nanobot/agent/tools/cli_apps.py tests/cli_apps/test_tool.py`
