### PR TITLE
docs(readme): link Kimi partner banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,7 @@
 ## Open Source Partners
 
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://kimi-file.moonshot.cn/prod-chat-kimi/kfs/4/1/2026-06-05/1d8h69mt3v89kkekg24gg">
-    <img alt="Kimi Open Source Friends" height="44" src="https://kimi-file.moonshot.cn/prod-chat-kimi/kfs/4/1/2026-06-05/1d8h69fudcmosb3pipls0">
-  </picture>
+  <a href="https://platform.kimi.com?aff=nanobot"><picture><source media="(prefers-color-scheme: dark)" srcset="https://kimi-file.moonshot.cn/prod-chat-kimi/kfs/4/1/2026-06-05/1d8h69mt3v89kkekg24gg"><img alt="Kimi Open Source Friends" height="44" src="https://kimi-file.moonshot.cn/prod-chat-kimi/kfs/4/1/2026-06-05/1d8h69fudcmosb3pipls0"></picture></a>
   <a href="https://platform.minimaxi.com/subscribe/token-plan?code=GILTJpMTqZ&source=link"><img alt="MiniMax" height="40" src="https://mintcdn.com/minimax-zh/1UjvBcdoC6r0UeyA/logo/light.svg?fit=max&auto=format&n=1UjvBcdoC6r0UeyA&q=85&s=672d724b639b2d88d0702fae329ea4f8"></a>
 </p>
 


### PR DESCRIPTION
## Summary
- Make the Kimi Open Source Friends banner in README's Open Source Partners strip clickable.
- Link it to the same Kimi provider setup URL used in `docs/configuration.md`: `https://platform.kimi.com?aff=nanobot`.
- Keep the existing dark/light Kimi image behavior and MiniMax discount link unchanged.

## Validation
- `git diff --check origin/main...HEAD`
- Rendered the GitHub Markdown API output locally with Chrome headless and verified the partner strip has one Kimi image, one MiniMax image, and no visual artifacts.
- Verified `https://platform.kimi.com?aff=nanobot` returns `200 OK`.
