### PR TITLE
fix(feishu): support reading WebSocket rendered card content

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -103,6 +103,18 @@ def _extract_interactive_content(content: dict) -> list[str]:
     if not isinstance(content, dict):
         return parts
 
+    # user_dsl: original card definition (richest source for rendered cards)
+    user_dsl = content.get("user_dsl")
+    if isinstance(user_dsl, str) and user_dsl.strip():
+        try:
+            dsl = json.loads(user_dsl)
+            if isinstance(dsl, dict):
+                parts.extend(_extract_interactive_content(dsl))
+                if parts:
+                    return parts
+        except (json.JSONDecodeError, TypeError):
+            pass
+
     if "title" in content:
         title = content["title"]
         if isinstance(title, dict):
@@ -112,11 +124,27 @@ def _extract_interactive_content(content: dict) -> list[str]:
         elif isinstance(title, str):
             parts.append(f"title: {title}")
 
-    for elements in (
-        content.get("elements", []) if isinstance(content.get("elements"), list) else []
-    ):
-        for element in elements:
-            parts.extend(_extract_element_content(element))
+    # Top-level elements: flat list or nested list format
+    elements = content.get("elements")
+    if isinstance(elements, list):
+        if elements and isinstance(elements[0], list):
+            # Nested list: [[{tag:"text",text:"..."}], ...]
+            for row in elements:
+                if isinstance(row, list):
+                    for element in row:
+                        parts.extend(_extract_element_content(element))
+        else:
+            # Flat list: [{tag:"markdown",content:"..."}, ...]
+            for element in elements:
+                parts.extend(_extract_element_content(element))
+
+    # Body elements (schema 2.0)
+    body = content.get("body", {})
+    if isinstance(body, dict):
+        body_elements = body.get("elements")
+        if isinstance(body_elements, list):
+            for element in body_elements:
+                parts.extend(_extract_element_content(element))
 
     card = content.get("card", {})
     if card:
@@ -146,6 +174,11 @@ def _extract_element_content(element: dict) -> list[str]:
         content = element.get("content", "")
         if content:
             parts.append(content)
+
+    elif tag == "text":
+        text = element.get("text", "")
+        if isinstance(text, str) and text.strip():
+            parts.append(text)
 
     elif tag == "div":
         text = element.get("text", {})

--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -161,6 +161,28 @@ def _extract_interactive_content(content: dict) -> list[str]:
     return parts
 
 
+def _stringify_table_cell(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, int | float | bool):
+        return str(value)
+    if isinstance(value, list):
+        return " ".join(filter(None, (_stringify_table_cell(item) for item in value)))
+    if isinstance(value, dict):
+        nested = _extract_element_content(value)
+        if nested:
+            return " ".join(nested)
+        for key in ("content", "text", "value", "name"):
+            text = value.get(key)
+            if isinstance(text, str):
+                return text.strip()
+            if isinstance(text, int | float | bool):
+                return str(text)
+    return ""
+
+
 def _extract_element_content(element: dict) -> list[str]:
     """Extract content from a single card element."""
     parts = []
@@ -231,6 +253,28 @@ def _extract_element_content(element: dict) -> list[str]:
         content = element.get("content", "")
         if content:
             parts.append(content)
+
+    elif tag == "table":
+        columns = element.get("columns", [])
+        rows = element.get("rows", [])
+        if isinstance(columns, list):
+            column_names = []
+            headers = []
+            for column in columns:
+                if not isinstance(column, dict) or not column.get("name"):
+                    continue
+                column_names.append(column["name"])
+                headers.append(str(column.get("display_name") or column["name"]))
+            if headers:
+                parts.append(" | ".join(headers))
+            if isinstance(rows, list):
+                for row in rows:
+                    if not isinstance(row, dict):
+                        continue
+                    values = [_stringify_table_cell(row.get(name)) for name in column_names]
+                    row_text = " | ".join(values).strip()
+                    if row_text:
+                        parts.append(row_text)
 
     else:
         for ne in element.get("elements", []):

--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -161,28 +161,6 @@ def _extract_interactive_content(content: dict) -> list[str]:
     return parts
 
 
-def _stringify_table_cell(value: Any) -> str:
-    if value is None:
-        return ""
-    if isinstance(value, str):
-        return value.strip()
-    if isinstance(value, int | float | bool):
-        return str(value)
-    if isinstance(value, list):
-        return " ".join(filter(None, (_stringify_table_cell(item) for item in value)))
-    if isinstance(value, dict):
-        nested = _extract_element_content(value)
-        if nested:
-            return " ".join(nested)
-        for key in ("content", "text", "value", "name"):
-            text = value.get(key)
-            if isinstance(text, str):
-                return text.strip()
-            if isinstance(text, int | float | bool):
-                return str(text)
-    return ""
-
-
 def _extract_element_content(element: dict) -> list[str]:
     """Extract content from a single card element."""
     parts = []
@@ -255,26 +233,27 @@ def _extract_element_content(element: dict) -> list[str]:
             parts.append(content)
 
     elif tag == "table":
-        columns = element.get("columns", [])
+        columns = [
+            (column["name"], str(column.get("display_name") or column["name"]))
+            for column in (element.get("columns") or [])
+            if isinstance(column, dict) and column.get("name")
+        ]
         rows = element.get("rows", [])
-        if isinstance(columns, list):
-            column_names = []
-            headers = []
-            for column in columns:
-                if not isinstance(column, dict) or not column.get("name"):
+        if columns:
+            parts.append(" | ".join(header for _, header in columns))
+        if isinstance(rows, list):
+            for row in rows:
+                if not isinstance(row, dict):
                     continue
-                column_names.append(column["name"])
-                headers.append(str(column.get("display_name") or column["name"]))
-            if headers:
-                parts.append(" | ".join(headers))
-            if isinstance(rows, list):
-                for row in rows:
-                    if not isinstance(row, dict):
-                        continue
-                    values = [_stringify_table_cell(row.get(name)) for name in column_names]
-                    row_text = " | ".join(values).strip()
-                    if row_text:
-                        parts.append(row_text)
+                values = []
+                for name, _ in columns:
+                    value = row.get(name)
+                    if isinstance(value, list):
+                        value = " ".join(str(item).strip() for item in value if item is not None)
+                    values.append("" if value is None else str(value).strip())
+                row_text = " | ".join(values).strip()
+                if row_text:
+                    parts.append(row_text)
 
     else:
         for ne in element.get("elements", []):

--- a/tests/channels/test_feishu_card_extraction.py
+++ b/tests/channels/test_feishu_card_extraction.py
@@ -1,0 +1,39 @@
+import json
+
+from nanobot.channels.feishu import _extract_share_card_content
+
+
+def test_extract_interactive_card_reads_user_dsl_body_elements() -> None:
+    content = {
+        "user_dsl": json.dumps(
+            {
+                "schema": "2.0",
+                "body": {"elements": [{"tag": "markdown", "content": "**hello**"}]},
+            }
+        )
+    }
+
+    assert _extract_share_card_content(content, "interactive") == "**hello**"
+
+
+def test_extract_interactive_card_reads_nested_text_elements() -> None:
+    content = {"elements": [[{"tag": "text", "text": "hello"}]]}
+
+    assert _extract_share_card_content(content, "interactive") == "hello"
+
+
+def test_extract_interactive_card_reads_table_rows() -> None:
+    content = {
+        "elements": [
+            {
+                "tag": "table",
+                "columns": [
+                    {"name": "c0", "display_name": "Name"},
+                    {"name": "c1", "display_name": "Score"},
+                ],
+                "rows": [{"c0": "Alice", "c1": 98}],
+            }
+        ]
+    }
+
+    assert _extract_share_card_content(content, "interactive") == "Name | Score\nAlice | 98"


### PR DESCRIPTION
## Problem
Feishu cards arriving via WebSocket have a different structure than expected. The  function returned empty results, causing cards to be displayed as  placeholder.

## Root Cause
Three structural mismatches between actual WebSocket card format and code expectations:

1. **Nested list elements**:  is  (list of lists), not  (flat list)
2. **Text element format**: Rendered cards use  with  field, not  with  field  
3. **Missing user_dsl**: Original card definition is in  JSON string field, not used by extraction code

## Fix
Three minimal changes to :

1. Extract  first (richest source for original card data)
2. Handle nested list  format (detect  is list)
3. Add  handler in 
4. Support  (schema 2.0 format)

## Testing
Verified with actual Feishu card messages - bot now correctly reads card content including markdown, tables, and structured data.