### PR TITLE
fix(session): preserve user turns in replay-window history

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1170,6 +1170,7 @@ class AgentLoop:
             "max_messages": self._max_messages,
             "max_tokens": self._replay_token_budget(),
             "include_timestamps": True,
+            "extend_to_user": True,
         }
         history = session.get_history(**_hist_kwargs)
         current_role = "assistant" if is_subagent else "user"
@@ -1445,6 +1446,7 @@ class AgentLoop:
             "max_messages": self._max_messages,
             "max_tokens": self._replay_token_budget(),
             "include_timestamps": True,
+            "extend_to_user": True,
         }
         ctx.history = ctx.session.get_history(**_hist_kwargs)
         self._runtime_events().record_turn_runtime(

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1166,14 +1166,14 @@ class AgentLoop:
             channel, chat_id, msg.metadata.get("message_id"),
             msg.metadata, session_key=key,
         )
+        current_role = "assistant" if is_subagent else "user"
         _hist_kwargs: dict[str, Any] = {
             "max_messages": self._max_messages,
             "max_tokens": self._replay_token_budget(),
             "include_timestamps": True,
-            "extend_to_user": True,
+            "extend_to_user": is_subagent,
         }
         history = session.get_history(**_hist_kwargs)
-        current_role = "assistant" if is_subagent else "user"
         workspace_scope = self.workspace_scopes.for_message(msg, session.metadata)
 
         messages = self.context.build_messages(
@@ -1446,7 +1446,7 @@ class AgentLoop:
             "max_messages": self._max_messages,
             "max_tokens": self._replay_token_budget(),
             "include_timestamps": True,
-            "extend_to_user": True,
+            "extend_to_user": False,
         }
         ctx.history = ctx.session.get_history(**_hist_kwargs)
         self._runtime_events().record_turn_runtime(

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -23,6 +23,7 @@ from nanobot.utils.helpers import (
     estimate_message_tokens,
     estimate_prompt_tokens_chain,
     find_legal_message_start,
+    recent_message_start_index,
     strip_think,
     truncate_text,
 )
@@ -717,7 +718,13 @@ class Consolidator:
         if len(tail) <= replay_max_messages:
             return None
 
-        sliced = tail[-replay_max_messages:]
+        tail_messages = [message for _idx, message in tail]
+        start_idx = recent_message_start_index(
+            tail_messages,
+            replay_max_messages,
+            extend_to_user=True,
+        )
+        sliced = tail[start_idx:]
         for i, (_idx, message) in enumerate(sliced):
             if message.get("role") == "user":
                 start = i

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -19,6 +19,7 @@ from nanobot.utils.helpers import (
     estimate_message_tokens,
     find_legal_message_start,
     image_placeholder_text,
+    recent_message_start_index,
     safe_filename,
     strip_think,
 )
@@ -153,6 +154,7 @@ class Session:
         *,
         max_tokens: int = 0,
         include_timestamps: bool = False,
+        extend_to_user: bool = False,
     ) -> list[dict[str, Any]]:
         """Return unconsolidated messages for LLM input.
 
@@ -161,7 +163,12 @@ class Session:
         """
         unconsolidated = self.messages[self.last_consolidated:]
         max_messages = max_messages if max_messages > 0 else 120
-        sliced = unconsolidated[-max_messages:]
+        start_idx = recent_message_start_index(
+            unconsolidated,
+            max_messages,
+            extend_to_user=extend_to_user,
+        )
+        sliced = unconsolidated[start_idx:]
 
         # Avoid starting mid-turn when possible, except for proactive
         # assistant deliveries that the user may be replying to.

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -237,6 +237,30 @@ def truncate_text(text: str, max_chars: int) -> str:
     return text[:max_chars] + "\n... (truncated)"
 
 
+def recent_message_start_index(
+    messages: list[dict[str, Any]],
+    max_messages: int,
+    *,
+    extend_to_user: bool = False,
+) -> int:
+    """Return the start index for a recent replay window."""
+    if max_messages <= 0:
+        return len(messages)
+    start_idx = max(0, len(messages) - max_messages)
+    if not extend_to_user or len(messages) <= max_messages:
+        return start_idx
+
+    recovered_user = next(
+        (i for i in range(start_idx, -1, -1) if messages[i].get("role") == "user"),
+        None,
+    )
+    if recovered_user is None:
+        return start_idx
+    if recovered_user > 0 and messages[recovered_user - 1].get("_channel_delivery"):
+        return recovered_user - 1
+    return recovered_user
+
+
 def find_legal_message_start(messages: list[dict[str, Any]]) -> int:
     """Find the first index whose tool results have matching assistant calls."""
     declared: set[str] = set()

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -249,9 +249,11 @@ def recent_message_start_index(
     start_idx = max(0, len(messages) - max_messages)
     if not extend_to_user or len(messages) <= max_messages:
         return start_idx
+    if any(messages[i].get("role") == "user" for i in range(start_idx, len(messages))):
+        return start_idx
 
     recovered_user = next(
-        (i for i in range(start_idx, -1, -1) if messages[i].get("role") == "user"),
+        (i for i in range(start_idx - 1, -1, -1) if messages[i].get("role") == "user"),
         None,
     )
     if recovered_user is None:

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -263,6 +263,38 @@ class TestConsolidatorTokenBudget:
         assert history[0]["content"] == "record this"
         assert history[-1]["content"] == "final answer"
 
+    async def test_replay_window_overflow_uses_newer_user_inside_window(
+        self,
+        consolidator,
+    ):
+        """Do not extend to an older long turn when the hard window has a newer user."""
+        session = Session(key="test:replay-newer-user")
+        session.add_message("user", "old")
+        session.add_message("assistant", "old answer")
+        session.add_message("user", "long older turn")
+        for i in range(8):
+            session.messages.extend(_tool_round(f"older-{i}"))
+        session.add_message("assistant", "older final")
+        session.add_message("user", "new question")
+        session.add_message("assistant", "new answer")
+
+        consolidator.sessions._session_cache[session.key] = session
+        consolidator.estimate_session_prompt_tokens = MagicMock(return_value=(100, "tiktoken"))
+        consolidator.archive = AsyncMock(return_value="older turn summary")
+
+        await consolidator.maybe_consolidate_by_tokens(
+            session,
+            replay_max_messages=6,
+        )
+
+        archived_chunk = consolidator.archive.await_args.args[0]
+        assert archived_chunk[2]["content"] == "long older turn"
+        assert archived_chunk[-1]["content"] == "older final"
+        assert session.last_consolidated == len(session.messages) - 2
+
+        history = session.get_history(max_messages=6, extend_to_user=True)
+        assert [m["content"] for m in history] == ["new question", "new answer"]
+
     async def test_large_chunk_archived_without_cap(self, consolidator):
         """Without chunk cap, the full range from pick_consolidation_boundary is archived."""
         consolidator._SAFETY_BUFFER = 0

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -48,6 +48,19 @@ def consolidator(store, mock_provider):
     )
 
 
+def _tool_round(call_id: str) -> list[dict]:
+    return [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": call_id, "type": "function", "function": {"name": "x", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": call_id, "name": "x", "content": "ok"},
+    ]
+
+
 class TestConsolidatorSummarize:
     async def test_summarize_appends_to_history(self, consolidator, mock_provider, store):
         """Consolidator should call LLM to summarize, then append to HISTORY.md."""
@@ -219,21 +232,17 @@ class TestConsolidatorTokenBudget:
         assert session.metadata["_last_summary"]["text"] == "old conversation summary"
         consolidator.sessions.save.assert_called()
 
-    async def test_replay_window_overflow_matches_history_tool_boundary(
+    async def test_replay_window_overflow_extends_to_long_recent_user_turn(
         self,
         consolidator,
     ):
-        """Archive the exact prefix hidden by get_history's legal-start trimming."""
+        """Replay-window consolidation must not cut into the latest user turn."""
         session = Session(key="test:replay-tool-boundary")
-        session.add_message("user", "run the tool")
-        session.add_message(
-            "assistant",
-            "",
-            tool_calls=[
-                {"id": "call-1", "type": "function", "function": {"name": "x", "arguments": "{}"}}
-            ],
-        )
-        session.add_message("tool", "tool result", tool_call_id="call-1", name="x")
+        session.add_message("user", "old")
+        session.add_message("assistant", "old answer")
+        session.add_message("user", "record this")
+        for i in range(4):
+            session.messages.extend(_tool_round(f"call-{i}"))
         session.add_message("assistant", "final answer")
 
         consolidator.sessions._session_cache[session.key] = session
@@ -242,13 +251,17 @@ class TestConsolidatorTokenBudget:
 
         await consolidator.maybe_consolidate_by_tokens(
             session,
-            replay_max_messages=2,
+            replay_max_messages=4,
         )
 
         archived_chunk = consolidator.archive.await_args.args[0]
-        assert [m["role"] for m in archived_chunk] == ["user", "assistant", "tool"]
-        assert session.last_consolidated == 3
-        assert session.get_history(max_messages=2) == [{"role": "assistant", "content": "final answer"}]
+        assert [m["content"] for m in archived_chunk] == ["old", "old answer"]
+        assert session.last_consolidated == 2
+
+        history = session.get_history(max_messages=4, extend_to_user=True)
+        assert len(history) > 4
+        assert history[0]["content"] == "record this"
+        assert history[-1]["content"] == "final answer"
 
     async def test_large_chunk_archived_without_cap(self, consolidator):
         """Without chunk cap, the full range from pick_consolidation_boundary is archived."""

--- a/tests/agent/test_max_messages_config.py
+++ b/tests/agent/test_max_messages_config.py
@@ -111,6 +111,7 @@ class TestMaxMessagesIntegration:
         assert result is not None
         assert mock_hist.call_count == 1
         assert mock_hist.call_args.kwargs["max_messages"] == 25
+        assert mock_hist.call_args.kwargs["extend_to_user"] is True
 
     @pytest.mark.asyncio
     async def test_zero_config_passes_builtin_limit_to_history_call(self, tmp_path: Path) -> None:
@@ -129,6 +130,7 @@ class TestMaxMessagesIntegration:
 
         assert result is not None
         assert mock_hist.call_args.kwargs["max_messages"] == DEFAULT_MAX_MESSAGES
+        assert mock_hist.call_args.kwargs["extend_to_user"] is True
 
 
 class TestSchemaConfig:

--- a/tests/agent/test_max_messages_config.py
+++ b/tests/agent/test_max_messages_config.py
@@ -37,6 +37,19 @@ def _populated_session(n: int) -> Session:
     return session
 
 
+def _tool_round(call_id: str) -> list[dict]:
+    return [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": call_id, "type": "function", "function": {"name": "x", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": call_id, "name": "x", "content": "ok"},
+    ]
+
+
 class TestMaxMessagesInit:
     """Verify AgentLoop stores the config value correctly."""
 
@@ -111,7 +124,7 @@ class TestMaxMessagesIntegration:
         assert result is not None
         assert mock_hist.call_count == 1
         assert mock_hist.call_args.kwargs["max_messages"] == 25
-        assert mock_hist.call_args.kwargs["extend_to_user"] is True
+        assert mock_hist.call_args.kwargs["extend_to_user"] is False
 
     @pytest.mark.asyncio
     async def test_zero_config_passes_builtin_limit_to_history_call(self, tmp_path: Path) -> None:
@@ -130,7 +143,45 @@ class TestMaxMessagesIntegration:
 
         assert result is not None
         assert mock_hist.call_args.kwargs["max_messages"] == DEFAULT_MAX_MESSAGES
-        assert mock_hist.call_args.kwargs["extend_to_user"] is True
+        assert mock_hist.call_args.kwargs["extend_to_user"] is False
+
+    @pytest.mark.asyncio
+    async def test_process_message_uses_current_user_as_replay_boundary(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A live user turn should not extend history to an older long tool turn."""
+        loop = _make_loop(tmp_path, max_messages=6)
+        loop.provider.chat_with_retry = AsyncMock(
+            return_value=LLMResponse(content="ok", tool_calls=[], usage={})
+        )
+        loop.tools.get_definitions = MagicMock(return_value=[])
+        loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+        session = loop.sessions.get_or_create("cli:test")
+        session.add_message("user", "old")
+        session.add_message("assistant", "old answer")
+        session.add_message("user", "long older turn")
+        for i in range(8):
+            session.messages.extend(_tool_round(f"older-{i}"))
+        session.add_message("assistant", "older final")
+
+        with patch.object(session, "get_history", wraps=session.get_history) as mock_hist:
+            result = await loop._process_message(
+                InboundMessage(
+                    channel="cli",
+                    sender_id="user",
+                    chat_id="test",
+                    content="new question",
+                )
+            )
+
+        assert result is not None
+        assert mock_hist.call_args.kwargs["extend_to_user"] is False
+        sent_messages = loop.provider.chat_with_retry.await_args.kwargs["messages"]
+        sent_text = "\n".join(str(message.get("content")) for message in sent_messages)
+        assert "new question" in sent_text
+        assert "long older turn" not in sent_text
 
 
 class TestSchemaConfig:

--- a/tests/agent/test_session_manager_history.py
+++ b/tests/agent/test_session_manager_history.py
@@ -660,6 +660,23 @@ def test_get_history_can_extend_to_user_for_long_recent_turn():
     _assert_no_orphans(extended)
 
 
+def test_get_history_extend_to_user_keeps_newer_user_inside_window():
+    session = Session(key="test:history-extend-newer-user")
+    session.messages.append({"role": "user", "content": "old"})
+    session.messages.append({"role": "assistant", "content": "old answer"})
+    session.messages.append({"role": "user", "content": "long older turn"})
+    for i in range(8):
+        session.messages.extend(_tool_turn("older", i))
+    session.messages.append({"role": "assistant", "content": "older final"})
+    session.messages.append({"role": "user", "content": "new question"})
+    session.messages.append({"role": "assistant", "content": "new answer"})
+
+    history = session.get_history(max_messages=6, extend_to_user=True)
+
+    assert [m["content"] for m in history] == ["new question", "new answer"]
+    _assert_no_orphans(history)
+
+
 # --- enforce_file_cap archive correctness (issue #4128) ---
 
 

--- a/tests/agent/test_session_manager_history.py
+++ b/tests/agent/test_session_manager_history.py
@@ -641,6 +641,25 @@ def test_retain_recent_legal_suffix_can_extend_to_user_for_long_recent_turn():
     _assert_no_orphans(history)
 
 
+def test_get_history_can_extend_to_user_for_long_recent_turn():
+    session = Session(key="test:history-extend-to-user")
+    session.messages.append({"role": "user", "content": "old"})
+    session.messages.append({"role": "assistant", "content": "old answer"})
+    session.messages.append({"role": "user", "content": "record this"})
+    for i in range(4):
+        session.messages.extend(_tool_turn("recent", i))
+    session.messages.append({"role": "assistant", "content": "done"})
+
+    hard_capped = session.get_history(max_messages=8)
+    extended = session.get_history(max_messages=8, extend_to_user=True)
+
+    assert len(hard_capped) <= 8
+    assert len(extended) > 8
+    assert extended[0]["content"] == "record this"
+    assert extended[-1]["content"] == "done"
+    _assert_no_orphans(extended)
+
+
 # --- enforce_file_cap archive correctness (issue #4128) ---
 
 


### PR DESCRIPTION
## Summary

Fix replay-window history trimming so LLM replay does not start in the middle of a long recent user turn.

When a recent turn contains many assistant/tool messages, the existing replay window could keep only the tail of that turn. Token consolidation then treated the hidden prefix as safe to archive, leaving live replay history that began with an assistant tool call instead of the user request that caused it.

## Changes

- Add an explicit `extend_to_user` mode for `Session.get_history()`.
- Enable that mode only for AgentLoop LLM replay, preserving the existing hard-cap default for other callers.
- Reuse the same recent-window boundary helper in replay-window consolidation so archived prefixes stop before the current user turn.
- Add regression coverage for long tool-heavy recent turns and wiring tests that ensure AgentLoop uses the safer replay mode.

## Validation

- `python -m ruff check nanobot/utils/helpers.py nanobot/session/manager.py nanobot/agent/memory.py nanobot/agent/loop.py tests/agent/test_session_manager_history.py tests/agent/test_consolidator.py tests/agent/test_max_messages_config.py`
- `python -m pytest tests/agent/test_session_manager_history.py tests/agent/test_consolidator.py tests/agent/test_max_messages_config.py tests/agent/test_loop_consolidation_tokens.py tests/agent/test_runner_governance.py tests/providers/test_enforce_role_alternation.py tests/providers/test_anthropic_merge_consecutive.py tests/session -q`
