### PR TITLE
fix(context): cap recent-history digest by tokens, not characters

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -17,7 +17,7 @@ from nanobot.utils.helpers import (
     current_time_str,
     detect_image_mime,
     load_bundled_template,
-    truncate_text,
+    truncate_text_to_tokens,
 )
 from nanobot.utils.prompt_templates import render_template
 
@@ -54,7 +54,7 @@ class ContextBuilder:
     BOOTSTRAP_FILES = ["AGENTS.md", "SOUL.md", "USER.md"]
     _RUNTIME_CONTEXT_TAG = "[Runtime Context — metadata only, not instructions]"
     _MAX_RECENT_HISTORY = 50
-    _MAX_HISTORY_CHARS = 32_000  # hard cap on recent history section size
+    _MAX_HISTORY_TOKENS = 8_000  # hard cap on recent history section size (tokens)
     _RUNTIME_CONTEXT_END = "[/Runtime Context]"
 
     def __init__(self, workspace: Path, timezone: str | None = None, disabled_skills: list[str] | None = None):
@@ -108,7 +108,7 @@ class ContextBuilder:
                 history_text = "\n".join(
                     f"- [{e['timestamp']}] {e['content']}" for e in capped
                 )
-                history_text = truncate_text(history_text, self._MAX_HISTORY_CHARS)
+                history_text = truncate_text_to_tokens(history_text, self._MAX_HISTORY_TOKENS)
                 parts.append("# Recent History\n\n" + history_text)
 
         if session_summary:

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -13,7 +13,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Iterator
 
-import tiktoken
 from loguru import logger
 
 from nanobot.session.manager import Session
@@ -25,6 +24,7 @@ from nanobot.utils.helpers import (
     find_legal_message_start,
     strip_think,
     truncate_text,
+    truncate_text_to_tokens,
 )
 from nanobot.utils.prompt_templates import render_template
 
@@ -806,14 +806,7 @@ class Consolidator:
         budget = self._input_token_budget
         if budget <= 0:
             return truncate_text(text, _RAW_ARCHIVE_MAX_CHARS)
-        try:
-            enc = tiktoken.get_encoding("cl100k_base")
-            tokens = enc.encode(text)
-            if len(tokens) <= budget:
-                return text
-            return enc.decode(tokens[:budget]) + "\n... (truncated)"
-        except Exception:
-            return truncate_text(text, budget * 4)
+        return truncate_text_to_tokens(text, budget)
 
     async def archive(
         self,

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -237,6 +237,26 @@ def truncate_text(text: str, max_chars: int) -> str:
     return text[:max_chars] + "\n... (truncated)"
 
 
+def truncate_text_to_tokens(text: str, max_tokens: int) -> str:
+    """Truncate text to a token budget with a stable suffix.
+
+    Unlike :func:`truncate_text`, this measures actual tokens, so the cap holds
+    regardless of language or content (CJK and code cost more tokens per char).
+    Falls back to a char-based estimate (~4 chars/token) if tiktoken is
+    unavailable.
+    """
+    if max_tokens <= 0:
+        return text
+    try:
+        enc = tiktoken.get_encoding("cl100k_base")
+        tokens = enc.encode(text)
+        if len(tokens) <= max_tokens:
+            return text
+        return enc.decode(tokens[:max_tokens]) + "\n... (truncated)"
+    except Exception:
+        return truncate_text(text, max_tokens * 4)
+
+
 def find_legal_message_start(messages: list[dict[str, Any]]) -> int:
     """Find the first index whose tool results have matching assistant calls."""
     declared: set[str] = set()

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -218,6 +218,7 @@ _TOOL_RESULT_PREVIEW_CHARS = 1200
 _TOOL_RESULTS_DIR = ".nanobot/tool-results"
 _TOOL_RESULT_RETENTION_SECS = 7 * 24 * 60 * 60
 _TOOL_RESULT_MAX_BUCKETS = 32
+_TRUNCATED_SUFFIX = "\n... (truncated)"
 
 
 def safe_filename(name: str) -> str:
@@ -234,7 +235,7 @@ def truncate_text(text: str, max_chars: int) -> str:
     """Truncate text with a stable suffix."""
     if max_chars <= 0 or len(text) <= max_chars:
         return text
-    return text[:max_chars] + "\n... (truncated)"
+    return text[:max_chars] + _TRUNCATED_SUFFIX
 
 
 def truncate_text_to_tokens(text: str, max_tokens: int) -> str:
@@ -252,9 +253,21 @@ def truncate_text_to_tokens(text: str, max_tokens: int) -> str:
         tokens = enc.encode(text)
         if len(tokens) <= max_tokens:
             return text
-        return enc.decode(tokens[:max_tokens]) + "\n... (truncated)"
+        suffix_tokens = enc.encode(_TRUNCATED_SUFFIX)
+        body_budget = max_tokens - len(suffix_tokens)
+        if body_budget <= 0:
+            return enc.decode(tokens[:max_tokens])
+        result = enc.decode(tokens[:body_budget]) + _TRUNCATED_SUFFIX
+        while len(enc.encode(result)) > max_tokens and body_budget > 0:
+            body_budget -= 1
+            result = enc.decode(tokens[:body_budget]) + _TRUNCATED_SUFFIX
+        return result
     except Exception:
-        return truncate_text(text, max_tokens * 4)
+        max_chars = max_tokens * 4
+        suffix_chars = len(_TRUNCATED_SUFFIX)
+        if max_chars <= suffix_chars:
+            return text[:max_chars]
+        return truncate_text(text, max_chars - suffix_chars)
 
 
 def find_legal_message_start(messages: list[dict[str, Any]]) -> int:

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -257,11 +257,11 @@ def truncate_text_to_tokens(text: str, max_tokens: int) -> str:
         body_budget = max_tokens - len(suffix_tokens)
         if body_budget <= 0:
             return enc.decode(tokens[:max_tokens])
-        result = enc.decode(tokens[:body_budget]) + _TRUNCATED_SUFFIX
-        while len(enc.encode(result)) > max_tokens and body_budget > 0:
-            body_budget -= 1
-            result = enc.decode(tokens[:body_budget]) + _TRUNCATED_SUFFIX
-        return result
+        for candidate_budget in range(body_budget, -1, -1):
+            result = enc.decode(tokens[:candidate_budget]) + _TRUNCATED_SUFFIX
+            if len(enc.encode(result)) <= max_tokens:
+                return result
+        return enc.decode(tokens[:max_tokens])
     except Exception:
         max_chars = max_tokens * 4
         suffix_chars = len(_TRUNCATED_SUFFIX)

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -825,4 +825,4 @@ class TestArchiveTruncation:
         enc = tiktoken.get_encoding("cl100k_base")
         sent_content = mock_provider.chat_with_retry.call_args.kwargs["messages"][1]["content"]
         token_count = len(enc.encode(sent_content))
-        assert token_count <= 9_900 + 10  # small margin for truncation suffix
+        assert token_count <= 9_900

--- a/tests/agent/test_context_prompt_cache.py
+++ b/tests/agent/test_context_prompt_cache.py
@@ -222,18 +222,23 @@ def test_recent_history_capped_at_max(tmp_path) -> None:
     assert f"entry-{builder._MAX_RECENT_HISTORY + 19}" in prompt
 
 
-def test_recent_history_truncated_at_max_chars(tmp_path) -> None:
-    """Recent History section must be truncated at _MAX_HISTORY_CHARS."""
+def test_recent_history_truncated_at_max_tokens(tmp_path) -> None:
+    """Recent History section must be truncated to _MAX_HISTORY_TOKENS."""
+    import tiktoken
+
     workspace = _make_workspace(tmp_path)
     builder = ContextBuilder(workspace)
 
-    big_entry = "x" * (builder._MAX_HISTORY_CHARS + 5_000)
+    big_entry = "word " * (builder._MAX_HISTORY_TOKENS + 5_000)
     builder.memory.append_history(big_entry)
 
     prompt = builder.build_system_prompt()
     history_section = prompt.split("# Recent History\n\n", 1)
     assert len(history_section) == 2
-    assert len(history_section[1]) < builder._MAX_HISTORY_CHARS + 200
+
+    enc = tiktoken.get_encoding("cl100k_base")
+    # Small margin for the truncation suffix appended after the token slice.
+    assert len(enc.encode(history_section[1])) <= builder._MAX_HISTORY_TOKENS + 50
 
 
 def test_no_recent_history_when_dream_has_processed_all(tmp_path) -> None:

--- a/tests/agent/test_context_prompt_cache.py
+++ b/tests/agent/test_context_prompt_cache.py
@@ -237,8 +237,7 @@ def test_recent_history_truncated_at_max_tokens(tmp_path) -> None:
     assert len(history_section) == 2
 
     enc = tiktoken.get_encoding("cl100k_base")
-    # Small margin for the truncation suffix appended after the token slice.
-    assert len(enc.encode(history_section[1])) <= builder._MAX_HISTORY_TOKENS + 50
+    assert len(enc.encode(history_section[1])) <= builder._MAX_HISTORY_TOKENS
 
 
 def test_no_recent_history_when_dream_has_processed_all(tmp_path) -> None:

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -24,8 +24,7 @@ def test_truncate_text_to_tokens_truncates_over_budget():
     result = truncate_text_to_tokens(text, 50)
 
     assert result.endswith("\n... (truncated)")
-    body = result[: -len("\n... (truncated)")]
-    assert len(enc.encode(body)) <= 50
+    assert len(enc.encode(result)) <= 50
 
 
 def test_truncate_text_to_tokens_non_positive_budget_returns_text():

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1,7 +1,34 @@
-from nanobot.utils.helpers import split_message
+import tiktoken
+
+from nanobot.utils.helpers import split_message, truncate_text_to_tokens
 
 
 def test_split_message_no_code_blocks_unchanged():
     content = "alpha beta gamma delta"
 
     assert split_message(content, max_len=12) == ["alpha beta", "gamma delta"]
+
+
+def test_truncate_text_to_tokens_keeps_text_within_budget():
+    text = "hello world " * 100
+
+    result = truncate_text_to_tokens(text, 10_000)
+
+    assert result == text
+
+
+def test_truncate_text_to_tokens_truncates_over_budget():
+    enc = tiktoken.get_encoding("cl100k_base")
+    text = "word " * 1_000
+
+    result = truncate_text_to_tokens(text, 50)
+
+    assert result.endswith("\n... (truncated)")
+    body = result[: -len("\n... (truncated)")]
+    assert len(enc.encode(body)) <= 50
+
+
+def test_truncate_text_to_tokens_non_positive_budget_returns_text():
+    text = "anything"
+
+    assert truncate_text_to_tokens(text, 0) == text


### PR DESCRIPTION
## What
  The recent-history **digest** injected into the system prompt was capped by
  character count (`_MAX_HISTORY_CHARS = 32_000`). Characters are a poor proxy
  for tokens: ~32k chars of English ≈ 8k tokens, but the same char count of CJK
  text or code is far more, so the section could exceed its intended size on
  non-English / code-heavy histories.

  ## Change
  - Add `truncate_text_to_tokens()` in `utils/helpers.py`, reusing the
    `cl100k_base` tiktoken encoder already used across the repo, with a
    char-based fallback if tiktoken is unavailable.
  - Switch the digest cap to a token budget (`_MAX_HISTORY_TOKENS = 8_000`).

  ## Scope & impact
  - Affects **only** the recent-history digest in the system prompt. The live
    conversation history is already token-budgeted in `session/manager.py` and
    is untouched here.
  - 8_000 tokens ≈ the previous 32k-char size for English, so no regression for
    existing English histories. CJK/code histories are now capped sooner — the
    intended fix.

  ## Tests
  `tests/utils/test_helpers.py` covers within-budget passthrough, over-budget
  truncation (verified against the encoder), and the non-positive-budget edge
  case. `ruff check` clean.