### PR TITLE
feat(bridge): send read receipts (blue ticks) for incoming WhatsApp messages

### DIFF
--- a/bridge/src/whatsapp.ts
+++ b/bridge/src/whatsapp.ts
@@ -181,6 +181,14 @@ export class WhatsAppClient {
         const msgTimestamp = msg.messageTimestamp as number;
         if (msgTimestamp && msgTimestamp < startupTimestamp) continue;
 
+        // Send read receipt (blue check) immediately
+        try {
+          await this.sock!.readMessages([msg.key]);
+        } catch (e) {
+          // Non-fatal: log but don't block message processing
+          console.error('Failed to send read receipt:', (e as Error).message);
+        }
+
         const unwrapped = baileysExtractMessageContent(msg.message);
         if (!unwrapped) continue;
 


### PR DESCRIPTION
## What
Mark each incoming WhatsApp message as read via `sock.readMessages()` right after the startup-timestamp filter, so senders see the blue double-check.

## Notes
- Wrapped in try/catch so a failed receipt never blocks message processing.
- 8-line, self-contained change in `bridge/src/whatsapp.ts`.