### PR TITLE
chore: ignore bridge/node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ temp/
 *.tmp
 exp/
 .playwright-mcp/
+bridge/node_modules/


### PR DESCRIPTION
`.gitignore` already excludes `desktop/` and `webui/` node_modules but not the bridge's. Add `bridge/node_modules/` so the compiled bridge deps are never accidentally committed.