### PR TITLE
feat(cron): add 'silent' jobs that run without auto-delivering a response

### DIFF
--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -9,6 +9,7 @@ from typing import Any
 from nanobot.agent.tools.base import Tool, tool_parameters
 from nanobot.agent.tools.context import ContextAware, RequestContext
 from nanobot.agent.tools.schema import (
+    BooleanSchema,
     IntegerSchema,
     StringSchema,
     tool_parameters_schema,
@@ -39,6 +40,13 @@ _CRON_PARAMETERS = tool_parameters_schema(
         "Naive values use the tool's default timezone."
     ),
     job_id=StringSchema("REQUIRED when action='remove'. Job ID to remove (obtain via action='list')."),
+    silent=BooleanSchema(
+        "If true, the job runs the agent turn but its response is NOT auto-delivered "
+        "to the session. The agent must notify explicitly via the message tool. "
+        "Use for background monitoring jobs that only report when there is something "
+        "worth reporting. Default false.",
+        default=False,
+    ),
     required=["action"],
     description=(
         "Action-specific parameters: add requires a non-empty message plus one schedule "
@@ -144,12 +152,13 @@ class CronTool(Tool, ContextAware):
         at: str | None = None,
         job_id: str | None = None,
         deliver: bool = True,
+        silent: bool = False,
         **kwargs: Any,
     ) -> str:
         if action == "add":
             if self._in_cron_context.get():
                 return "Error: cannot schedule new jobs from within a cron job execution"
-            return self._add_job(name, message, every_seconds, cron_expr, tz, at)
+            return self._add_job(name, message, every_seconds, cron_expr, tz, at, silent)
         elif action == "list":
             return self._list_jobs()
         elif action == "remove":
@@ -164,6 +173,7 @@ class CronTool(Tool, ContextAware):
         cron_expr: str | None,
         tz: str | None,
         at: str | None,
+        silent: bool = False,
     ) -> str:
         if not message:
             return (
@@ -219,6 +229,7 @@ class CronTool(Tool, ContextAware):
             origin_channel=origin_channel,
             origin_chat_id=origin_chat_id,
             origin_metadata=dict(self._origin_metadata.get() or {}),
+            silent=silent,
         )
         return f"Created job '{job.name}' (id: {job.id})"
 

--- a/nanobot/cron/bound_runner.py
+++ b/nanobot/cron/bound_runner.py
@@ -91,7 +91,10 @@ async def run_bound_cron_job(
             f"Scheduled cron job triggered: {job.name}\n\n{job.payload.message}"
         ),
     }
-    metadata[CRON_DEFER_UNTIL_IDLE_META] = True
+    # Silent jobs run the agent turn but their response is not auto-delivered
+    # to the origin session; the agent can still notify via the message tool.
+    if not job.payload.silent:
+        metadata[CRON_DEFER_UNTIL_IDLE_META] = True
     run_record_base: dict[str, Any] = {
         "job_id": job.id,
         "job_name": job.name,

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -190,6 +190,7 @@ class CronService:
                             kind=j["payload"].get("kind", "agent_turn"),
                             message=j["payload"].get("message", ""),
                             deliver=j["payload"].get("deliver", False),
+                            silent=j["payload"].get("silent", False),
                             channel=j["payload"].get("channel"),
                             to=j["payload"].get("to"),
                             channel_meta=(
@@ -347,6 +348,7 @@ class CronService:
                         "originChannel": j.payload.origin_channel,
                         "originChatId": j.payload.origin_chat_id,
                         "originMetadata": j.payload.origin_metadata,
+                        "silent": j.payload.silent,
                     },
                     "state": {
                         "nextRunAtMs": j.state.next_run_at_ms,
@@ -610,6 +612,7 @@ class CronService:
         origin_channel: str | None = None,
         origin_chat_id: str | None = None,
         origin_metadata: dict | None = None,
+        silent: bool = False,
     ) -> CronJob:
         """Add a new job."""
         _validate_schedule_for_add(schedule)
@@ -631,6 +634,7 @@ class CronService:
                 origin_channel=origin_channel,
                 origin_chat_id=origin_chat_id,
                 origin_metadata=origin_metadata or {},
+                silent=silent,
             ),
             state=CronJobState(next_run_at_ms=_compute_next_run(schedule, now)),
             created_at_ms=now,

--- a/nanobot/cron/types.py
+++ b/nanobot/cron/types.py
@@ -32,6 +32,11 @@ class CronPayload:
     origin_channel: str | None = None
     origin_chat_id: str | None = None
     origin_metadata: dict[str, Any] = field(default_factory=dict)
+    # When True the job runs the agent turn but its response is NOT
+    # auto-delivered to the origin session. The agent can still notify
+    # explicitly via the message tool. Useful for background monitoring
+    # jobs that only act when there is something worth reporting.
+    silent: bool = False
 
 
 @dataclass


### PR DESCRIPTION
## Motivation
Some scheduled jobs only need to act when there is something worth reporting (e.g. monitoring checks) and should stay quiet otherwise. Today every bound cron job auto-delivers its turn response to the origin session.

## What
Add a `silent` flag to the cron tool and `CronPayload`. When set, the bound cron runner skips the defer-until-idle delivery marker: the agent turn still runs (and can notify explicitly via the `message` tool) but its turn response is not auto-delivered to the origin session.

## Notes
- Defaults to `false`, preserving current behaviour.
- Persisted in the cron store payload (`silent`).