### PR TITLE
fix(webui): override wsUrl with local LAN IP when on dev server port 5173

### DIFF
--- a/webui/src/lib/bootstrap.ts
+++ b/webui/src/lib/bootstrap.ts
@@ -72,19 +72,19 @@ export function deriveWsUrl(
   wsUrl?: string | null,
 ): string {
   const query = `?token=${encodeURIComponent(token)}`;
-  if (wsUrl && /^(wss?|nanobot-host):\/\//i.test(wsUrl)) {
-    const join = wsUrl.includes("?") ? "&" : "?";
-    return `${wsUrl}${join}token=${encodeURIComponent(token)}`;
-  }
   const path = wsPath && wsPath.startsWith("/") ? wsPath : `/${wsPath || ""}`;
-  if (typeof window === "undefined") {
-    return `ws://127.0.0.1:8765${path}${query}`;
-  }
-  if (window.location.port === "5173") {
+  if (typeof window !== "undefined" && window.location.port === "5173") {
     const host = window.location.hostname.includes(":")
       ? `[${window.location.hostname}]`
       : window.location.hostname;
     return `ws://${host}:8765${path}${query}`;
+  }
+  if (wsUrl && /^(wss?|nanobot-host):\/\//i.test(wsUrl)) {
+    const join = wsUrl.includes("?") ? "&" : "?";
+    return `${wsUrl}${join}token=${encodeURIComponent(token)}`;
+  }
+  if (typeof window === "undefined") {
+    return `ws://127.0.0.1:8765${path}${query}`;
   }
   const scheme = window.location.protocol === "https:" ? "wss" : "ws";
   const host = window.location.host;

--- a/webui/src/tests/bootstrap.test.ts
+++ b/webui/src/tests/bootstrap.test.ts
@@ -14,6 +14,19 @@ describe("bootstrap helpers", () => {
     );
   });
 
+  it("overrides the server-provided websocket URL when on dev server port 5173", () => {
+    vi.stubGlobal("window", {
+      location: {
+        port: "5173",
+        hostname: "192.168.1.100",
+        protocol: "http:",
+      },
+    });
+    expect(deriveWsUrl("/", "tok", "ws://127.0.0.1:8765/")).toBe(
+      "ws://192.168.1.100:8765/?token=tok",
+    );
+  });
+
   it("preserves the host socket bridge URL", () => {
     expect(deriveWsUrl("/", "tok en", "nanobot-host://engine/")).toBe(
       "nanobot-host://engine/?token=tok%20en",


### PR DESCRIPTION
## Description

This PR fixes a bug where the WebUI gets stuck on "Opening new chat..." when accessed from a local network (LAN) device (e.g. `http://<lan-ip>:5173`).

### Root Cause
1. Vite dev server's proxy (`changeOrigin: true`) rewrites the `Host` header to `127.0.0.1:8765`.
2. When the frontend requests `/webui/bootstrap`, the backend sees the localhost header and returns `ws_url: "ws://127.0.0.1:8765"`.
3. In `bootstrap.ts`, `deriveWsUrl` checks if `wsUrl` is present *before* checking the port `5173`. Consequently, the browser on the LAN device attempts to establish a WebSocket connection with `127.0.0.1` (itself), which fails.

### Solution
Move the `window.location.port === "5173"` check to the top of `deriveWsUrl`. When the app is accessed on port `5173`, it will correctly derive the WebSocket URL using the current browser location host instead of the localhost-poisoned `wsUrl` from the backend.

## Test Plan
- Unit tests added in `bootstrap.test.ts` to verify the port 5173 override behavior.
- Clean build: `bun run build` compiles successfully.