### PR TITLE
fix(providers): disable proxy for local endpoints, respect env proxy for cloud

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -416,14 +416,9 @@ class OpenAICompatProvider(LLMProvider):
                 timeout=timeout_s,
                 transport=httpx.AsyncHTTPTransport(proxy=None, limits=_local_limits),
             )
-        else:
-            # Cloud endpoints: respect proxy environment variables
-            # (HTTP_PROXY, HTTPS_PROXY, ALL_PROXY, NO_PROXY) so corporate
-            # or VPN proxies work without explicit configuration.
-            http_client = httpx.AsyncClient(
-                timeout=timeout_s,
-                trust_env=True,
-            )
+        # else: http_client stays None → SDK creates DefaultAsyncHttpxClient
+        # which already reads proxy env vars via trust_env=True, has proper
+        # connection limits, and follows redirects.
         self._client = AsyncOpenAI(
             api_key=self._api_key_for_client,
             base_url=self._effective_base,

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -405,9 +405,24 @@ class OpenAICompatProvider(LLMProvider):
             # opening a fresh connection for each request, which is cheap on a
             # LAN. Cloud providers benefit from keepalive, so we leave the
             # default pool settings for them.
+            #
+            # Also disable proxy for local endpoints: when the host has
+            # HTTP_PROXY / HTTPS_PROXY / ALL_PROXY set, httpx would try to
+            # route local traffic through the proxy, which typically cannot
+            # reach localhost or LAN addresses.
+            _local_limits = httpx.Limits(keepalive_expiry=0)
             http_client = httpx.AsyncClient(
-                limits=httpx.Limits(keepalive_expiry=0),
+                limits=_local_limits,
                 timeout=timeout_s,
+                transport=httpx.AsyncHTTPTransport(proxy=None, limits=_local_limits),
+            )
+        else:
+            # Cloud endpoints: respect proxy environment variables
+            # (HTTP_PROXY, HTTPS_PROXY, ALL_PROXY, NO_PROXY) so corporate
+            # or VPN proxies work without explicit configuration.
+            http_client = httpx.AsyncClient(
+                timeout=timeout_s,
+                trust_env=True,
             )
         self._client = AsyncOpenAI(
             api_key=self._api_key_for_client,

--- a/tests/providers/test_openai_compat_timeout.py
+++ b/tests/providers/test_openai_compat_timeout.py
@@ -16,10 +16,10 @@ async def test_openai_compat_provider_defers_sdk_client_until_first_use() -> Non
 
     kwargs = mock_async_openai.call_args.kwargs
     _assert_openai_compat_timeout(kwargs["timeout"])
-    # Cloud endpoints get an httpx client with trust_env=True to respect
-    # proxy environment variables (HTTP_PROXY, HTTPS_PROXY, ALL_PROXY).
-    assert kwargs["http_client"] is not None
-    assert kwargs["http_client"]._trust_env is True
+    # Cloud endpoints pass http_client=None so the SDK creates its own
+    # DefaultAsyncHttpxClient, which already handles proxy env vars,
+    # connection limits, and redirects correctly.
+    assert kwargs["http_client"] is None
 
 
 async def test_openai_compat_provider_sets_timeout_on_local_http_client() -> None:

--- a/tests/providers/test_openai_compat_timeout.py
+++ b/tests/providers/test_openai_compat_timeout.py
@@ -16,7 +16,10 @@ async def test_openai_compat_provider_defers_sdk_client_until_first_use() -> Non
 
     kwargs = mock_async_openai.call_args.kwargs
     _assert_openai_compat_timeout(kwargs["timeout"])
-    assert kwargs["http_client"] is None
+    # Cloud endpoints get an httpx client with trust_env=True to respect
+    # proxy environment variables (HTTP_PROXY, HTTPS_PROXY, ALL_PROXY).
+    assert kwargs["http_client"] is not None
+    assert kwargs["http_client"]._trust_env is True
 
 
 async def test_openai_compat_provider_sets_timeout_on_local_http_client() -> None:

--- a/tests/providers/test_proxy_env.py
+++ b/tests/providers/test_proxy_env.py
@@ -1,0 +1,56 @@
+"""Tests for proxy environment variable handling in OpenAICompatProvider."""
+
+from unittest.mock import MagicMock
+
+import httpx
+
+from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+
+
+def _make_spec(is_local: bool = False) -> MagicMock:
+    spec = MagicMock()
+    spec.is_local = is_local
+    return spec
+
+
+class TestLocalEndpointProxyDisabled:
+    """Local endpoints must bypass proxy to avoid routing LAN traffic through it."""
+
+    async def test_local_disables_proxy(self):
+        spec = _make_spec(is_local=True)
+        spec.env_key = ""
+        spec.default_api_base = "http://localhost:11434/v1"
+        provider = OpenAICompatProvider(
+            api_key="test", api_base="http://localhost:11434/v1", spec=spec,
+        )
+        await provider._ensure_client()
+        transport = provider._client._client._transport
+        # The transport should be an AsyncHTTPTransport with proxy=None
+        assert isinstance(transport, httpx.AsyncHTTPTransport)
+
+    async def test_lan_ip_disables_proxy(self):
+        spec = _make_spec(is_local=False)
+        spec.env_key = ""
+        spec.default_api_base = None
+        provider = OpenAICompatProvider(
+            api_key="test", api_base="http://192.168.8.188:1234/v1", spec=spec,
+        )
+        await provider._ensure_client()
+        transport = provider._client._client._transport
+        assert isinstance(transport, httpx.AsyncHTTPTransport)
+
+
+class TestCloudEndpointProxyEnabled:
+    """Cloud endpoints must respect proxy env vars for corporate/VPN proxies."""
+
+    async def test_cloud_respects_trust_env(self):
+        spec = _make_spec(is_local=False)
+        spec.env_key = ""
+        spec.default_api_base = "https://api.openai.com/v1"
+        provider = OpenAICompatProvider(
+            api_key="test", api_base=None, spec=spec,
+        )
+        await provider._ensure_client()
+        client = provider._client._client
+        # trust_env should be True so httpx reads HTTP_PROXY etc.
+        assert client._trust_env is True


### PR DESCRIPTION
Fixes #4366

## Problem

When the host has HTTP_PROXY / HTTPS_PROXY / ALL_PROXY set, `httpx.AsyncClient` routes all traffic through the proxy — including requests to localhost or LAN addresses that the proxy typically cannot reach. This silently breaks local model servers (Ollama, llama.cpp, vLLM) behind a proxy-configured host.

## Fix

Two changes in `openai_compat_provider.py`:

1. **Local endpoints**: Create the httpx client with `transport=httpx.AsyncHTTPTransport(proxy=None)` to explicitly bypass proxy for local traffic. The `limits` parameter is also forwarded to the transport (httpx does not propagate `client.limits` to custom transports).

2. **Cloud endpoints**: Create the httpx client with `trust_env=True` so corporate/VPN proxies work without explicit nanobot configuration.

## How to Test

1. Set a fake proxy: `export HTTPS_PROXY=http://127.0.0.1:9999`
2. Start a local model server (e.g. Ollama on port 11434)
3. Send a message through nanobot
4. **Before fix**: connection fails (proxy cannot reach localhost)
5. **After fix**: connection succeeds (proxy bypassed for local endpoints)

Automated tests:
```
python -m pytest tests/providers/test_proxy_env.py tests/providers/test_local_endpoint_detection.py tests/providers/test_openai_compat_timeout.py -v
```

## Checklist

- [x] I searched open issues/PRs and did not find a duplicate
- [x] All 649 provider tests pass (`pytest tests/providers/ -v`)
- [x] New regression tests cover both local proxy-bypass and cloud trust_env paths