### PR TITLE
[codex] fix MCP malformed progress notifications

### DIFF
--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -46,6 +46,58 @@ _RELOAD_LOCKS: WeakKeyDictionary[Any, asyncio.Lock] = WeakKeyDictionary()
 _ReconnectCallback = Callable[[str, str, Tool], Awaitable[Tool | None]]
 
 
+def _is_malformed_mcp_progress_notification(message: Any) -> bool:
+    root = getattr(getattr(message, "message", None), "root", None)
+    if getattr(root, "method", None) != "notifications/progress":
+        return False
+
+    params = getattr(root, "params", None)
+    return not isinstance(params, Mapping) or "progressToken" not in params
+
+
+class _MalformedProgressNotificationFilter:
+    def __init__(self, read_stream: Any, server_name: str) -> None:
+        self._read_stream = read_stream
+        self._server_name = server_name
+        self._iterator: Any | None = None
+
+    async def __aenter__(self) -> "_MalformedProgressNotificationFilter":
+        await self._read_stream.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> Any:
+        return await self._read_stream.__aexit__(exc_type, exc, tb)
+
+    def __aiter__(self) -> "_MalformedProgressNotificationFilter":
+        self._iterator = self._read_stream.__aiter__()
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._iterator is None:
+            self._iterator = self._read_stream.__aiter__()
+
+        while True:
+            message = await self._iterator.__anext__()
+            if _is_malformed_mcp_progress_notification(message):
+                logger.debug(
+                    "MCP server '{}': dropped progress notification without progressToken",
+                    self._server_name,
+                )
+                continue
+            return message
+
+    async def aclose(self) -> None:
+        close = getattr(self._read_stream, "aclose", None)
+        if close is not None:
+            await close()
+
+
+def _filter_malformed_mcp_progress_notifications(read_stream: Any, server_name: str) -> Any:
+    if not all(hasattr(read_stream, name) for name in ("__aenter__", "__aexit__", "__aiter__")):
+        return read_stream
+    return _MalformedProgressNotificationFilter(read_stream, server_name)
+
+
 def _sanitize_name(name: str) -> str:
     """Sanitize an MCP-derived name for model API compatibility."""
     return _SANITIZE_RE.sub("_", re.sub(r"[^a-zA-Z0-9_-]", "_", name))
@@ -681,6 +733,7 @@ async def connect_mcp_servers(
                 await server_stack.aclose()
                 return name, None
 
+            read = _filter_malformed_mcp_progress_notifications(read, name)
             session = await server_stack.enter_async_context(ClientSession(read, write))
             await session.initialize()
 

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -47,12 +47,30 @@ _ReconnectCallback = Callable[[str, str, Tool], Awaitable[Tool | None]]
 
 
 def _is_malformed_mcp_progress_notification(message: Any) -> bool:
-    root = getattr(getattr(message, "message", None), "root", None)
-    if getattr(root, "method", None) != "notifications/progress":
+    payload = _mcp_jsonrpc_payload(message)
+    if _payload_value(payload, "method") != "notifications/progress":
         return False
 
-    params = getattr(root, "params", None)
-    return not isinstance(params, Mapping) or "progressToken" not in params
+    params = _payload_value(payload, "params")
+    return not _progress_params_have_token(params)
+
+
+def _mcp_jsonrpc_payload(message: Any) -> Any:
+    """Return the JSON-RPC payload across current and future MCP SDK shapes."""
+    envelope = getattr(message, "message", message)
+    return getattr(envelope, "root", None) or envelope
+
+
+def _payload_value(payload: Any, key: str) -> Any:
+    if isinstance(payload, Mapping):
+        return payload.get(key)
+    return getattr(payload, key, None)
+
+
+def _progress_params_have_token(params: Any) -> bool:
+    if isinstance(params, Mapping):
+        return "progressToken" in params
+    return hasattr(params, "progressToken") or hasattr(params, "progress_token")
 
 
 class _MalformedProgressNotificationFilter:

--- a/tests/agent/test_mcp_connection.py
+++ b/tests/agent/test_mcp_connection.py
@@ -8,9 +8,11 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
+import anyio
 import pytest
 from mcp import types as mcp_types
 from mcp.shared.exceptions import McpError
+from mcp.shared.message import SessionMessage
 from mcp.types import ErrorData
 
 from nanobot.agent.loop import AgentLoop
@@ -20,6 +22,18 @@ from nanobot.agent.tools.mcp import MCPResourceWrapper, MCPToolWrapper
 from nanobot.bus.queue import MessageBus
 from nanobot.config.loader import load_config, save_config
 from nanobot.config.schema import MCPServerConfig
+
+
+def _mcp_notification(method: str, params: dict[str, Any] | None = None) -> SessionMessage:
+    return SessionMessage(
+        message=mcp_types.JSONRPCMessage(
+            mcp_types.JSONRPCNotification(
+                jsonrpc="2.0",
+                method=method,
+                params=params,
+            )
+        )
+    )
 
 
 class _FakeMcpTool(Tool):
@@ -54,6 +68,33 @@ def _make_loop(tmp_path, *, mcp_servers: dict | None = None) -> AgentLoop:
         model="test-model",
         mcp_servers=mcp_servers or {"test": object()},
     )
+
+
+@pytest.mark.asyncio
+async def test_mcp_read_filter_drops_progress_notifications_without_progress_token():
+    send, receive = anyio.create_memory_object_stream(4)
+    malformed_progress = _mcp_notification(
+        "notifications/progress",
+        {"progress": 20, "total": 600, "message": "Polling"},
+    )
+    tool_change = _mcp_notification("notifications/tools/list_changed")
+    valid_progress = _mcp_notification(
+        "notifications/progress",
+        {"progressToken": "req-1", "progress": 25, "total": 600, "message": "Polling"},
+    )
+
+    await send.send(malformed_progress)
+    await send.send(tool_change)
+    await send.send(valid_progress)
+    await send.aclose()
+
+    wrapped = mcp_runtime._filter_malformed_mcp_progress_notifications(receive, "brightdata")
+    forwarded = []
+    async with wrapped:
+        async for message in wrapped:
+            forwarded.append(message)
+
+    assert forwarded == [tool_change, valid_progress]
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_mcp_connection.py
+++ b/tests/agent/test_mcp_connection.py
@@ -36,6 +36,24 @@ def _mcp_notification(method: str, params: dict[str, Any] | None = None) -> Sess
     )
 
 
+def test_mcp_progress_detection_accepts_flattened_sdk_message_shape():
+    malformed = SimpleNamespace(
+        message=SimpleNamespace(
+            method="notifications/progress",
+            params={"progress": 20, "total": 600},
+        )
+    )
+    valid = SimpleNamespace(
+        message=SimpleNamespace(
+            method="notifications/progress",
+            params={"progressToken": "req-1", "progress": 25},
+        )
+    )
+
+    assert mcp_runtime._is_malformed_mcp_progress_notification(malformed) is True
+    assert mcp_runtime._is_malformed_mcp_progress_notification(valid) is False
+
+
 class _FakeMcpTool(Tool):
     def __init__(self, name: str) -> None:
         self._name = name


### PR DESCRIPTION
## Summary

- filter MCP `notifications/progress` messages that are missing `params.progressToken` before they enter `ClientSession`
- keep valid progress notifications and all other MCP messages flowing through unchanged
- add a stream-level regression test using the malformed progress payload shape from #4052

## Why

The current MCP SDK recognizes `notifications/progress`, but validates server notifications strictly. Progress notifications without a `progressToken` cannot be associated with a request, so they only produce validation warnings when forwarded to the SDK session loop.

Dropping those unattributable progress updates at the nanobot MCP read boundary avoids repeated validation noise from MCP servers that emit this payload while preserving normal progress callbacks for well-formed notifications.

Fixes #4052.

## Tests

- `python -m ruff check nanobot/agent/tools/mcp.py tests/agent/test_mcp_connection.py`
- `python -m pytest tests/agent/test_mcp_connection.py tests/tools/test_mcp_tool.py tests/agent/test_mcp_transient_retry.py -q`
- verified the issue payload raises `ValidationError` with `mcp.types.ServerNotification` and matches the nanobot filter predicate
