### PR TITLE
Ignore local nanobot runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ desktop/resources/nanobot-engine/
 # Claude / AI assistant artifacts
 docs/superpowers/
 docs/plans/
+.nanobot/
 
 # webui (monorepo frontend)
 webui/node_modules/


### PR DESCRIPTION
## Summary
- Add `.nanobot/` to `.gitignore` alongside other local AI assistant artifacts

## Test plan
- Not run; ignore-only change

## Notes
- Created as a smoke test of the freecode web workflow.