### PR TITLE
fix: silence unroutable cli progress noise

### DIFF
--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -171,7 +171,7 @@ class ChannelManager:
         """Return whether progress (or tool-hints) may be sent to *channel_name*."""
         ch = self.channels.get(channel_name)
         if ch is None:
-            logger.warning("Progress check for unknown channel: {}", channel_name)
+            logger.debug("Progress check for unknown channel: {}", channel_name)
             return False
         return ch.send_tool_hints if tool_hint else ch.send_progress
 

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -311,6 +311,9 @@ async def cmd_dream(ctx: CommandContext) -> OutboundMessage:
     msg = ctx.msg
 
     async def _run_dream():
+        async def _silent(*_args, **_kwargs):
+            pass
+
         from nanobot.agent.memory import MemoryStore
 
         dream_session_key = MemoryStore.dream_session_key
@@ -337,6 +340,7 @@ async def cmd_dream(ctx: CommandContext) -> OutboundMessage:
                 session_key=key,
                 ephemeral=True,
                 tools=store.build_dream_tools(),
+                on_progress=_silent,
             )
             elapsed = time.monotonic() - t0
             if MemoryStore.dream_run_completed(resp):

--- a/tests/command/test_builtin_dream.py
+++ b/tests/command/test_builtin_dream.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from nanobot.bus.events import InboundMessage
+from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.command.builtin import cmd_dream, cmd_dream_log, cmd_dream_restore
 from nanobot.command.router import CommandContext
 from nanobot.utils.gitstore import CommitInfo
@@ -23,6 +23,12 @@ class _FakeStore:
 
     def build_dream_prompt(self):
         return self._dream_prompt_result
+
+    def build_dream_tools(self):
+        return None
+
+    def set_last_dream_cursor(self, value: int) -> None:
+        self._last_dream_cursor = value
 
     def compact_history(self) -> None:
         self.compact_history_called = True
@@ -103,6 +109,39 @@ async def test_dream_no_history_explains_how_to_create_input(tmp_path) -> None:
     assert "idle auto-compact" in content
     assert "Dream cursor" in content
     assert "agents.defaults.idleCompactAfterMinutes" in content
+
+
+@pytest.mark.asyncio
+async def test_dream_internal_run_silences_progress(tmp_path) -> None:
+    msg = InboundMessage(channel="feishu", sender_id="u1", chat_id="chat1", content="/dream")
+    store = _FakeStore(_FakeGit(initialized=False), dream_prompt_result=("dream prompt", 123))
+    bus = _FakeBus()
+    calls = []
+
+    async def process_direct(*args, **kwargs):
+        calls.append((args, kwargs))
+        return OutboundMessage(
+            channel="cli",
+            chat_id="direct",
+            content="done",
+            metadata={"_stop_reason": "completed"},
+        )
+
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    loop = SimpleNamespace(
+        bus=bus,
+        context=SimpleNamespace(memory=store, timezone="UTC"),
+        sessions=SimpleNamespace(sessions_dir=sessions_dir),
+        process_direct=process_direct,
+    )
+    ctx = CommandContext(msg=msg, session=None, key=msg.session_key, raw="/dream", args="", loop=loop)
+
+    await cmd_dream(ctx)
+    await asyncio.sleep(0)
+
+    assert len(calls) == 1
+    assert callable(calls[0][1]["on_progress"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- silence unroutable progress checks for unknown channels at debug level
- make manual `/dream` internal runs use a silent progress callback instead of defaulting to CLI progress routing
- add regression coverage for manual Dream progress silencing

## Tests
- python -m pytest tests/command/test_builtin_dream.py -q
- python -m pytest tests/channels/test_channel_manager_delta_coalescing.py::TestProgressFiltering -q
- python -m ruff check nanobot/channels/manager.py nanobot/command/builtin.py tests/command/test_builtin_dream.py