### PR TITLE
fix(context): fall back to default memory bootstrap

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -52,6 +52,7 @@ class ContextBuilder:
     """Builds the context (system prompt + messages) for the agent."""
 
     BOOTSTRAP_FILES = ["AGENTS.md", "SOUL.md", "USER.md"]
+    _DEFAULT_FALLBACK_BOOTSTRAP_FILES = {"SOUL.md", "USER.md"}
     _RUNTIME_CONTEXT_TAG = "[Runtime Context — metadata only, not instructions]"
     _MAX_RECENT_HISTORY = 50
     _MAX_HISTORY_TOKENS = 8_000  # hard cap on recent history section size (tokens)
@@ -164,17 +165,31 @@ class ContextBuilder:
         return _to_blocks(left) + _to_blocks(right)
 
     def _load_bootstrap_files(self, workspace: Path | None = None) -> str:
-        """Load all bootstrap files from workspace."""
+        """Load bootstrap files from workspace with default memory fallbacks."""
         parts = []
         root = workspace or self.workspace
 
         for filename in self.BOOTSTRAP_FILES:
-            file_path = root / filename
-            if file_path.exists():
-                content = file_path.read_text(encoding="utf-8")
-                parts.append(f"## {filename}\n\n{content}")
+            file_path = self._resolve_bootstrap_file(root, filename)
+            if file_path is None:
+                continue
+            content = file_path.read_text(encoding="utf-8")
+            parts.append(f"## {filename}\n\n{content}")
 
         return "\n\n".join(parts) if parts else ""
+
+    def _resolve_bootstrap_file(self, root: Path, filename: str) -> Path | None:
+        file_path = root / filename
+        if file_path.exists():
+            return file_path
+        if filename not in self._DEFAULT_FALLBACK_BOOTSTRAP_FILES:
+            return None
+        if root.expanduser().resolve(strict=False) == self.workspace.expanduser().resolve(strict=False):
+            return None
+        fallback_path = self.workspace / filename
+        if fallback_path.exists():
+            return fallback_path
+        return None
 
     @staticmethod
     def _is_template_content(content: str, template_path: str) -> bool:

--- a/tests/agent/test_context_builder.py
+++ b/tests/agent/test_context_builder.py
@@ -183,6 +183,22 @@ class TestLoadBootstrapFiles:
         assert "Default soul." not in result
         assert "Default user." in result
 
+    def test_default_workspace_load_does_not_use_project_fallback(self, tmp_path):
+        project = tmp_path / "project"
+        project.mkdir()
+        (tmp_path / "SOUL.md").write_text("Default soul.", encoding="utf-8")
+        (tmp_path / "USER.md").write_text("Default user.", encoding="utf-8")
+        (project / "SOUL.md").write_text("Project soul.", encoding="utf-8")
+        (project / "USER.md").write_text("Project user.", encoding="utf-8")
+
+        builder = _builder(tmp_path)
+        result = builder._load_bootstrap_files()
+
+        assert "Default soul." in result
+        assert "Default user." in result
+        assert "Project soul." not in result
+        assert "Project user." not in result
+
 
 # ---------------------------------------------------------------------------
 # _is_template_content (static)

--- a/tests/agent/test_context_builder.py
+++ b/tests/agent/test_context_builder.py
@@ -152,6 +152,37 @@ class TestLoadBootstrapFiles:
         result = builder._load_bootstrap_files()
         assert "用中文回复" in result
 
+    def test_project_workspace_falls_back_to_default_memory_bootstrap(self, tmp_path):
+        project = tmp_path / "project"
+        project.mkdir()
+        (tmp_path / "SOUL.md").write_text("Default soul.", encoding="utf-8")
+        (tmp_path / "USER.md").write_text("Default user.", encoding="utf-8")
+        (project / "AGENTS.md").write_text("Project rules.", encoding="utf-8")
+
+        builder = _builder(tmp_path)
+        result = builder._load_bootstrap_files(project)
+
+        assert "## AGENTS.md" in result
+        assert "Project rules." in result
+        assert "## SOUL.md" in result
+        assert "Default soul." in result
+        assert "## USER.md" in result
+        assert "Default user." in result
+
+    def test_project_workspace_memory_bootstrap_overrides_default_fallback(self, tmp_path):
+        project = tmp_path / "project"
+        project.mkdir()
+        (tmp_path / "SOUL.md").write_text("Default soul.", encoding="utf-8")
+        (tmp_path / "USER.md").write_text("Default user.", encoding="utf-8")
+        (project / "SOUL.md").write_text("Project soul.", encoding="utf-8")
+
+        builder = _builder(tmp_path)
+        result = builder._load_bootstrap_files(project)
+
+        assert "Project soul." in result
+        assert "Default soul." not in result
+        assert "Default user." in result
+
 
 # ---------------------------------------------------------------------------
 # _is_template_content (static)


### PR DESCRIPTION
## Summary

- load project-local `AGENTS.md` as before while falling back to the default workspace for missing `SOUL.md` and `USER.md`
- keep project-local `SOUL.md` / `USER.md` files preferred when they exist
- add regression coverage for bare project workspaces and project-local overrides

This addresses the fallback/no-persona facet described in #4374 without changing Dream's shared memory/history write root.

## Tests

- `uv run pytest tests/agent/test_context_builder.py -q`
- `uv run ruff check nanobot/agent/context.py tests/agent/test_context_builder.py`
- `git diff --check`
- `uv run pytest tests/agent/test_context_builder.py tests/agent/test_workspace_scope.py tests/channels/test_websocket_channel.py -q`
- `uv run pytest tests/agent/test_context_builder.py tests/agent/test_dream.py -q`