### PR TITLE
feat(feishu): add QR scan-to-create bot CLI login feishu command

### DIFF
--- a/docs/chat-apps.md
+++ b/docs/chat-apps.md
@@ -44,7 +44,7 @@ If `nanobot channels status` does not show the channel as enabled, the config sn
 | **Discord** | Bot token + Message Content intent |
 | **WhatsApp** | QR code scan (`nanobot channels login whatsapp`) |
 | **WeChat (Weixin)** | QR code scan (`nanobot channels login weixin`) |
-| **Feishu** | App ID + App Secret |
+| **Feishu** | QR code scan (`nanobot channels login feishu`) or App ID + App Secret |
 | **DingTalk** | App Key + App Secret |
 | **Slack** | Bot token + App-Level token |
 | **Matrix** | Homeserver URL + Access token |
@@ -342,6 +342,19 @@ nanobot gateway
 <summary><b>Feishu</b></summary>
 
 Uses **WebSocket** long connection — no public IP required.
+
+**Quick setup: QR login**
+
+```bash
+nanobot channels login feishu
+# Use --force to create/sign in with a new bot
+```
+
+Open the printed URL or scan the QR code with Feishu/Lark on your phone. nanobot writes `appId`, `appSecret`, `domain`, and `enabled` under `channels.feishu` in the active config file. Use `--config <path>` to update a non-default config.
+
+If QR login is unavailable for your account, use manual setup below.
+
+**Manual setup**
 
 **1. Create a Feishu bot**
 - Visit [Feishu Open Platform](https://open.feishu.cn/app)

--- a/docs/chat-apps.md
+++ b/docs/chat-apps.md
@@ -350,7 +350,7 @@ nanobot channels login feishu
 # Use --force to create/sign in with a new bot
 ```
 
-Open the printed URL or scan the QR code with Feishu/Lark on your phone. nanobot writes `appId`, `appSecret`, `domain`, and `enabled` under `channels.feishu` in the active config file. Use `--config <path>` to update a non-default config.
+Open the printed URL or scan the QR code with Feishu/Lark on your phone. If the optional `qrcode` package is installed, nanobot shows a terminal QR code; otherwise it prints the login URL. nanobot writes `appId`, `appSecret`, `domain`, and `enabled` under `channels.feishu` in the active config file. Use `--config <path>` to update a non-default config.
 
 If QR login is unavailable for your account, use manual setup below.
 

--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -296,6 +296,324 @@ class FeishuConfig(Base):
     topic_isolation: bool = True  # If True, each topic in group chat gets its own session (isolation)
 
 
+# =============================================================================
+# QR scan-to-create onboarding
+#
+# Device-code flow: user scans a QR code with the Feishu/Lark mobile app and
+# the platform creates a fully configured bot application automatically.
+# Called by the CLI onboard wizard during `nanobot --wizard`.
+# =============================================================================
+
+_ONBOARD_ACCOUNTS_URLS = {
+    "feishu": "https://accounts.feishu.cn",
+    "lark": "https://accounts.larksuite.com",
+}
+_ONBOARD_OPEN_URLS = {
+    "feishu": "https://open.feishu.cn",
+    "lark": "https://open.larksuite.com",
+}
+_REGISTRATION_PATH = "/oauth/v1/app/registration"
+_ONBOARD_REQUEST_TIMEOUT_S = 10
+
+
+def _accounts_base_url(domain: str) -> str:
+    return _ONBOARD_ACCOUNTS_URLS.get(domain, _ONBOARD_ACCOUNTS_URLS["feishu"])
+
+
+def _onboard_open_base_url(domain: str) -> str:
+    return _ONBOARD_OPEN_URLS.get(domain, _ONBOARD_OPEN_URLS["feishu"])
+
+
+def _post_registration(base_url: str, body: dict[str, str]) -> dict:
+    """POST form-encoded data to the registration endpoint, return parsed JSON.
+
+    The registration endpoint returns JSON even on HTTP errors (e.g. poll
+    returns authorization_pending as a 400). We always parse the body.
+    """
+    import httpx
+
+    url = f"{base_url}{_REGISTRATION_PATH}"
+    resp = httpx.post(
+        url,
+        data=body,
+        timeout=_ONBOARD_REQUEST_TIMEOUT_S,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    try:
+        return resp.json()
+    except json.JSONDecodeError:
+        resp.raise_for_status()
+        return {}
+
+
+def _init_registration(domain: str = "feishu") -> None:
+    """Verify the environment supports client_secret auth. Raises RuntimeError if not."""
+    base_url = _accounts_base_url(domain)
+    res = _post_registration(base_url, {"action": "init"})
+    methods = res.get("supported_auth_methods") or []
+    if "client_secret" not in methods:
+        raise RuntimeError(
+            f"Feishu / Lark registration does not support client_secret auth. "
+            f"Supported: {methods}"
+        )
+
+
+def _begin_registration(domain: str = "feishu") -> dict:
+    """Start the device-code flow. Returns device_code, qr_url, user_code, interval, expire_in."""
+    base_url = _accounts_base_url(domain)
+    res = _post_registration(base_url, {
+        "action": "begin",
+        "archetype": "PersonalAgent",
+        "auth_method": "client_secret",
+        "request_user_info": "open_id",
+    })
+    device_code = res.get("device_code")
+    if not device_code:
+        raise RuntimeError("Feishu / Lark registration did not return a device_code")
+    qr_url = res.get("verification_uri_complete", "")
+    if "?" in qr_url:
+        qr_url += "&from=nanobot&tp=nanobot"
+    else:
+        qr_url += "?from=nanobot&tp=nanobot"
+    return {
+        "device_code": device_code,
+        "qr_url": qr_url,
+        "user_code": res.get("user_code", ""),
+        "interval": res.get("interval") or 5,
+        "expire_in": res.get("expire_in") or 600,
+    }
+
+
+def _poll_registration(
+    *,
+    device_code: str,
+    interval: int,
+    expire_in: int,
+    domain: str = "feishu",
+) -> dict | None:
+    """Poll until the user scans the QR code, or timeout/denial.
+
+    Returns dict with app_id, app_secret, domain, open_id on success, None on failure.
+    """
+    deadline = time.monotonic() + expire_in
+    current_domain = domain
+    domain_switched = False
+    poll_count = 0
+
+    while time.monotonic() < deadline:
+        base_url = _accounts_base_url(current_domain)
+        try:
+            res = _post_registration(base_url, {
+                "action": "poll",
+                "device_code": device_code,
+                "tp": "ob_app",
+            })
+        except Exception:
+            time.sleep(interval)
+            continue
+
+        poll_count += 1
+        if poll_count == 1:
+            print("Fetching configuration results...", end="", flush=True)
+        elif poll_count % 6 == 0:
+            print(".", end="", flush=True)
+
+        # Domain auto-detection: if the user's tenant is on Lark, switch automatically
+        user_info = res.get("user_info") or {}
+        tenant_brand = user_info.get("tenant_brand")
+        if tenant_brand == "lark" and not domain_switched:
+            current_domain = "lark"
+            domain_switched = True
+
+        # Success
+        if res.get("client_id") and res.get("client_secret"):
+            if poll_count > 0:
+                print()
+            return {
+                "app_id": res["client_id"],
+                "app_secret": res["client_secret"],
+                "domain": current_domain,
+                "open_id": user_info.get("open_id"),
+            }
+
+        # Terminal errors
+        error = res.get("error", "")
+        if error in ("access_denied", "expired_token"):
+            if poll_count > 0:
+                print()
+            from loguru import logger
+
+            logger.warning("[Feishu onboard] Registration {}", error)
+            return None
+
+        # authorization_pending or unknown — keep polling
+        time.sleep(interval)
+
+    if poll_count > 0:
+        print()
+    print(f"[Warning] Poll timed out after {expire_in}s")
+    return None
+
+
+def _build_onboard_client(app_id: str, app_secret: str, domain: str) -> Any:
+    """Build a lark Client for the given credentials and domain."""
+    lark, feishu_domain, lark_domain = _load_lark_runtime()
+    sdk_domain = lark_domain if domain == "lark" else feishu_domain
+    return (
+        lark.Client.builder()
+        .app_id(app_id)
+        .app_secret(app_secret)
+        .domain(sdk_domain)
+        .log_level(lark.LogLevel.WARNING)
+        .build()
+    )
+
+
+def _parse_bot_response(data: dict) -> dict | None:
+    """Parse /bot/v3/info response. Returns dict with bot_name, bot_open_id or None."""
+    if data.get("code") != 0:
+        return None
+    bot = data.get("bot") or data.get("data", {}).get("bot") or {}
+    return {
+        "bot_name": bot.get("app_name") or bot.get("bot_name"),
+        "bot_open_id": bot.get("open_id"),
+    }
+
+
+def _probe_bot_sdk(app_id: str, app_secret: str, domain: str) -> dict | None:
+    """Probe bot info using lark_oapi SDK."""
+    try:
+        lark, _feishu_domain, _lark_domain = _load_lark_runtime()
+        client = _build_onboard_client(app_id, app_secret, domain)
+        req = (
+            lark.BaseRequest.builder()
+            .http_method(lark.HttpMethod.GET)
+            .uri("/open-apis/bot/v3/info")
+            .token_types({lark.AccessTokenType.TENANT})
+            .build()
+        )
+        resp = client.request(req)
+        raw = getattr(getattr(resp, "raw", None), "content", None)
+        if raw is None:
+            return None
+        return _parse_bot_response(json.loads(raw))
+    except Exception:
+        return None
+
+
+def _probe_bot_http(app_id: str, app_secret: str, domain: str) -> dict | None:
+    """Fallback probe using raw HTTP (when lark_oapi is not installed or fails)."""
+    import httpx
+
+    base_url = _onboard_open_base_url(domain)
+    try:
+        token_resp = httpx.post(
+            f"{base_url}/open-apis/auth/v3/tenant_access_token/internal",
+            json={"app_id": app_id, "app_secret": app_secret},
+            timeout=_ONBOARD_REQUEST_TIMEOUT_S,
+        )
+        token_data = token_resp.json()
+        access_token = token_data.get("tenant_access_token")
+        if not access_token:
+            return None
+
+        bot_resp = httpx.get(
+            f"{base_url}/open-apis/bot/v3/info",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=_ONBOARD_REQUEST_TIMEOUT_S,
+        )
+        return _parse_bot_response(bot_resp.json())
+    except Exception:
+        return None
+
+
+def probe_bot(app_id: str, app_secret: str, domain: str) -> dict | None:
+    """Verify bot connectivity via /open-apis/bot/v3/info.
+
+    Returns {"bot_name": ..., "bot_open_id": ...} on success, None on failure.
+    """
+    if FEISHU_AVAILABLE:
+        return _probe_bot_sdk(app_id, app_secret, domain)
+    return _probe_bot_http(app_id, app_secret, domain)
+
+
+def qr_register(
+    *,
+    initial_domain: str = "feishu",
+    timeout_seconds: int = 600,
+) -> dict | None:
+    """Run the Feishu / Lark scan-to-create QR registration flow.
+
+    Returns on success:
+        {
+            "app_id": str,
+            "app_secret": str,
+            "domain": "feishu" | "lark",
+            "open_id": str | None,
+            "bot_name": str | None,
+            "bot_open_id": str | None,
+        }
+
+    Returns None on expected failures (network, auth denied, timeout).
+    Unexpected errors (bugs, protocol regressions) propagate to the caller.
+    """
+    try:
+        return _qr_register_inner(
+            initial_domain=initial_domain, timeout_seconds=timeout_seconds
+        )
+    except (RuntimeError, OSError, json.JSONDecodeError) as exc:
+        print(f"[Warning] Registration failed: {exc}")
+        return None
+
+
+def _print_qr_code(url: str) -> None:
+    """Print QR code as ASCII art if qrcode package is available, otherwise print URL."""
+    try:
+        import qrcode as qr_lib
+
+        qr = qr_lib.QRCode(border=1)
+        qr.add_data(url)
+        qr.make(fit=True)
+        qr.print_ascii(invert=True)
+        print("Scan the QR code with Feishu / Lark on your phone to authorize.\n")
+    except ImportError:
+        print(f"\nLogin URL: {url}\n")
+
+
+def _qr_register_inner(
+    *,
+    initial_domain: str,
+    timeout_seconds: int,
+) -> dict | None:
+    """Run init → begin → poll → probe. Raises on network/protocol errors."""
+    print("Connecting to Feishu / Lark...", end="", flush=True)
+    _init_registration(initial_domain)
+    begin = _begin_registration(initial_domain)
+    print(" done.")
+
+    _print_qr_code(begin["qr_url"])
+
+    result = _poll_registration(
+        device_code=begin["device_code"],
+        interval=begin["interval"],
+        expire_in=min(begin["expire_in"], timeout_seconds),
+        domain=initial_domain,
+    )
+    if not result:
+        return None
+
+    # Probe bot — best-effort, don't fail the registration
+    bot_info = probe_bot(result["app_id"], result["app_secret"], result["domain"])
+    if bot_info:
+        result["bot_name"] = bot_info.get("bot_name")
+        result["bot_open_id"] = bot_info.get("bot_open_id")
+    else:
+        result["bot_name"] = None
+        result["bot_open_id"] = None
+
+    return result
+
+
 _STREAM_ELEMENT_ID = "streaming_md"
 
 
@@ -345,6 +663,74 @@ class FeishuChannel(BaseChannel):
         self._background_tasks: set[asyncio.Task] = set()
         self._reaction_ids: dict[str, str] = {}  # message_id → reaction_id
 
+    # ------------------------------------------------------------------
+    # QR login — writes credentials directly to config.json
+    # ------------------------------------------------------------------
+
+    async def login(self, force: bool = False) -> bool:
+        """Perform QR code scan-to-create login for Feishu/Lark.
+
+        Uses the Feishu device-code registration flow to create a new bot
+        application automatically.  Opens a URL for the user to authorize
+        with the Feishu or Lark mobile app.
+
+        On success, writes ``appId``, ``appSecret``, and ``domain`` to
+        ``channels.feishu`` in ``config.json`` and sets ``enabled: true``.
+
+        Args:
+            force: If True, clear existing credentials and force re-authentication.
+
+        Returns True on success.
+        """
+        if force:
+            self.config.app_id = ""
+            self.config.app_secret = ""
+
+        if self.config.app_id and self.config.app_secret:
+            print("Feishu / Lark is already authenticated.")
+            print("Use --force to re-authenticate with a new bot.")
+            print()
+            return True
+
+        print("--- Feishu / Lark QR Login ---")
+        print("Open the URL below in Feishu / Lark on your phone to authorize.")
+        print("The platform will create a new bot application automatically.")
+
+        result = qr_register(initial_domain=self.config.domain or "feishu")
+        if not result:
+            self.logger.error(
+                "QR registration failed. "
+                "Run 'nanobot channels login feishu --force' to retry."
+            )
+            return False
+
+        self.config.app_id = result["app_id"]
+        self.config.app_secret = result["app_secret"]
+        self.config.domain = result.get("domain", "feishu")
+
+        bot_name = result.get("bot_name")
+        if bot_name:
+            print(f"\nBot created: {bot_name}")
+        print(f"App ID: {result['app_id']}")
+        print(f"Domain: {self.config.domain}")
+
+        # Write credentials back to config.json
+        from nanobot.config.loader import load_config, save_config
+
+        full_config = load_config()
+        feishu_cfg = getattr(full_config.channels, "feishu", None) or {}
+        if isinstance(feishu_cfg, dict):
+            feishu_cfg["appId"] = result["app_id"]
+            feishu_cfg["appSecret"] = result["app_secret"]
+            feishu_cfg["domain"] = result.get("domain", "feishu")
+            feishu_cfg["enabled"] = True
+            setattr(full_config.channels, "feishu", feishu_cfg)
+        save_config(full_config)
+
+        print(f"\nCredentials saved to ~/.nanobot/config.json (feishu enabled)")
+        print("Login successful!")
+        return True
+
     @staticmethod
     def _register_optional_event(builder: Any, method_name: str, handler: Any) -> Any:
         """Register an event handler only when the SDK supports it."""
@@ -358,7 +744,10 @@ class FeishuChannel(BaseChannel):
             return
 
         if not self.config.app_id or not self.config.app_secret:
-            self.logger.error("app_id and app_secret not configured")
+            self.logger.error(
+                "app_id and app_secret not configured. "
+                "Run 'nanobot channels login feishu' to set up via QR code."
+            )
             return
 
         lark, feishu_domain, lark_domain = await asyncio.to_thread(_load_lark_runtime)

--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -460,9 +460,11 @@ def qr_register(
     Returns None on expected failures (network, auth denied, timeout).
     Unexpected errors (bugs, protocol regressions) propagate to the caller.
     """
+    import httpx
+
     try:
         return _qr_register_inner(initial_domain=initial_domain)
-    except (RuntimeError, OSError, json.JSONDecodeError) as exc:
+    except (RuntimeError, OSError, json.JSONDecodeError, httpx.HTTPError) as exc:
         print(f"[Warning] Registration failed: {exc}")
         return None
 

--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -301,16 +301,11 @@ class FeishuConfig(Base):
 #
 # Device-code flow: user scans a QR code with the Feishu/Lark mobile app and
 # the platform creates a fully configured bot application automatically.
-# Called by the CLI onboard wizard during `nanobot --wizard`.
 # =============================================================================
 
 _ONBOARD_ACCOUNTS_URLS = {
     "feishu": "https://accounts.feishu.cn",
     "lark": "https://accounts.larksuite.com",
-}
-_ONBOARD_OPEN_URLS = {
-    "feishu": "https://open.feishu.cn",
-    "lark": "https://open.larksuite.com",
 }
 _REGISTRATION_PATH = "/oauth/v1/app/registration"
 _ONBOARD_REQUEST_TIMEOUT_S = 10
@@ -318,10 +313,6 @@ _ONBOARD_REQUEST_TIMEOUT_S = 10
 
 def _accounts_base_url(domain: str) -> str:
     return _ONBOARD_ACCOUNTS_URLS.get(domain, _ONBOARD_ACCOUNTS_URLS["feishu"])
-
-
-def _onboard_open_base_url(domain: str) -> str:
-    return _ONBOARD_OPEN_URLS.get(domain, _ONBOARD_OPEN_URLS["feishu"])
 
 
 def _post_registration(base_url: str, body: dict[str, str]) -> dict:
@@ -359,7 +350,7 @@ def _init_registration(domain: str = "feishu") -> None:
 
 
 def _begin_registration(domain: str = "feishu") -> dict:
-    """Start the device-code flow. Returns device_code, qr_url, user_code, interval, expire_in."""
+    """Start the device-code flow. Returns device_code, qr_url, interval, expire_in."""
     base_url = _accounts_base_url(domain)
     res = _post_registration(base_url, {
         "action": "begin",
@@ -380,7 +371,6 @@ def _begin_registration(domain: str = "feishu") -> dict:
     return {
         "device_code": device_code,
         "qr_url": qr_url,
-        "user_code": res.get("user_code", ""),
         "interval": res.get("interval") or 5,
         "expire_in": res.get("expire_in") or 600,
     }
@@ -395,11 +385,10 @@ def _poll_registration(
 ) -> dict | None:
     """Poll until the user scans the QR code, or timeout/denial.
 
-    Returns dict with app_id, app_secret, domain, open_id on success, None on failure.
+    Returns dict with app_id, app_secret, domain on success, None on failure.
     """
     deadline = time.monotonic() + expire_in
     current_domain = domain
-    domain_switched = False
     poll_count = 0
 
     while time.monotonic() < deadline:
@@ -423,9 +412,8 @@ def _poll_registration(
         # Domain auto-detection: if the user's tenant is on Lark, switch automatically
         user_info = res.get("user_info") or {}
         tenant_brand = user_info.get("tenant_brand")
-        if tenant_brand == "lark" and not domain_switched:
+        if tenant_brand == "lark":
             current_domain = "lark"
-            domain_switched = True
 
         # Success
         if res.get("client_id") and res.get("client_secret"):
@@ -435,7 +423,6 @@ def _poll_registration(
                 "app_id": res["client_id"],
                 "app_secret": res["client_secret"],
                 "domain": current_domain,
-                "open_id": user_info.get("open_id"),
             }
 
         # Terminal errors
@@ -457,92 +444,9 @@ def _poll_registration(
     return None
 
 
-def _build_onboard_client(app_id: str, app_secret: str, domain: str) -> Any:
-    """Build a lark Client for the given credentials and domain."""
-    lark, feishu_domain, lark_domain = _load_lark_runtime()
-    sdk_domain = lark_domain if domain == "lark" else feishu_domain
-    return (
-        lark.Client.builder()
-        .app_id(app_id)
-        .app_secret(app_secret)
-        .domain(sdk_domain)
-        .log_level(lark.LogLevel.WARNING)
-        .build()
-    )
-
-
-def _parse_bot_response(data: dict) -> dict | None:
-    """Parse /bot/v3/info response. Returns dict with bot_name, bot_open_id or None."""
-    if data.get("code") != 0:
-        return None
-    bot = data.get("bot") or data.get("data", {}).get("bot") or {}
-    return {
-        "bot_name": bot.get("app_name") or bot.get("bot_name"),
-        "bot_open_id": bot.get("open_id"),
-    }
-
-
-def _probe_bot_sdk(app_id: str, app_secret: str, domain: str) -> dict | None:
-    """Probe bot info using lark_oapi SDK."""
-    try:
-        lark, _feishu_domain, _lark_domain = _load_lark_runtime()
-        client = _build_onboard_client(app_id, app_secret, domain)
-        req = (
-            lark.BaseRequest.builder()
-            .http_method(lark.HttpMethod.GET)
-            .uri("/open-apis/bot/v3/info")
-            .token_types({lark.AccessTokenType.TENANT})
-            .build()
-        )
-        resp = client.request(req)
-        raw = getattr(getattr(resp, "raw", None), "content", None)
-        if raw is None:
-            return None
-        return _parse_bot_response(json.loads(raw))
-    except Exception:
-        return None
-
-
-def _probe_bot_http(app_id: str, app_secret: str, domain: str) -> dict | None:
-    """Fallback probe using raw HTTP (when lark_oapi is not installed or fails)."""
-    import httpx
-
-    base_url = _onboard_open_base_url(domain)
-    try:
-        token_resp = httpx.post(
-            f"{base_url}/open-apis/auth/v3/tenant_access_token/internal",
-            json={"app_id": app_id, "app_secret": app_secret},
-            timeout=_ONBOARD_REQUEST_TIMEOUT_S,
-        )
-        token_data = token_resp.json()
-        access_token = token_data.get("tenant_access_token")
-        if not access_token:
-            return None
-
-        bot_resp = httpx.get(
-            f"{base_url}/open-apis/bot/v3/info",
-            headers={"Authorization": f"Bearer {access_token}"},
-            timeout=_ONBOARD_REQUEST_TIMEOUT_S,
-        )
-        return _parse_bot_response(bot_resp.json())
-    except Exception:
-        return None
-
-
-def probe_bot(app_id: str, app_secret: str, domain: str) -> dict | None:
-    """Verify bot connectivity via /open-apis/bot/v3/info.
-
-    Returns {"bot_name": ..., "bot_open_id": ...} on success, None on failure.
-    """
-    if FEISHU_AVAILABLE:
-        return _probe_bot_sdk(app_id, app_secret, domain)
-    return _probe_bot_http(app_id, app_secret, domain)
-
-
 def qr_register(
     *,
     initial_domain: str = "feishu",
-    timeout_seconds: int = 600,
 ) -> dict | None:
     """Run the Feishu / Lark scan-to-create QR registration flow.
 
@@ -551,18 +455,13 @@ def qr_register(
             "app_id": str,
             "app_secret": str,
             "domain": "feishu" | "lark",
-            "open_id": str | None,
-            "bot_name": str | None,
-            "bot_open_id": str | None,
         }
 
     Returns None on expected failures (network, auth denied, timeout).
     Unexpected errors (bugs, protocol regressions) propagate to the caller.
     """
     try:
-        return _qr_register_inner(
-            initial_domain=initial_domain, timeout_seconds=timeout_seconds
-        )
+        return _qr_register_inner(initial_domain=initial_domain)
     except (RuntimeError, OSError, json.JSONDecodeError) as exc:
         print(f"[Warning] Registration failed: {exc}")
         return None
@@ -585,9 +484,8 @@ def _print_qr_code(url: str) -> None:
 def _qr_register_inner(
     *,
     initial_domain: str,
-    timeout_seconds: int,
 ) -> dict | None:
-    """Run init → begin → poll → probe. Raises on network/protocol errors."""
+    """Run init → begin → poll. Raises on network/protocol errors."""
     print("Connecting to Feishu / Lark...", end="", flush=True)
     _init_registration(initial_domain)
     begin = _begin_registration(initial_domain)
@@ -598,21 +496,9 @@ def _qr_register_inner(
     result = _poll_registration(
         device_code=begin["device_code"],
         interval=begin["interval"],
-        expire_in=min(begin["expire_in"], timeout_seconds),
+        expire_in=begin["expire_in"],
         domain=initial_domain,
     )
-    if not result:
-        return None
-
-    # Probe bot — best-effort, don't fail the registration
-    bot_info = probe_bot(result["app_id"], result["app_secret"], result["domain"])
-    if bot_info:
-        result["bot_name"] = bot_info.get("bot_name")
-        result["bot_open_id"] = bot_info.get("bot_open_id")
-    else:
-        result["bot_name"] = None
-        result["bot_open_id"] = None
-
     return result
 
 
@@ -710,9 +596,6 @@ class FeishuChannel(BaseChannel):
         self.config.app_secret = result["app_secret"]
         self.config.domain = result.get("domain", "feishu")
 
-        bot_name = result.get("bot_name")
-        if bot_name:
-            print(f"\nBot created: {bot_name}")
         print(f"App ID: {result['app_id']}")
         print(f"Domain: {self.config.domain}")
 

--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -401,7 +401,7 @@ def _poll_registration(
 
         poll_count += 1
         if poll_count == 1:
-            print("Fetching configuration results...", end="", flush=True)
+            print("Waiting for authorization", end="", flush=True)
         elif poll_count % 6 == 0:
             print(".", end="", flush=True)
 
@@ -414,7 +414,7 @@ def _poll_registration(
         # Success
         if res.get("client_id") and res.get("client_secret"):
             if poll_count > 0:
-                print()
+                print(" done.")
             return {
                 "app_id": res["client_id"],
                 "app_secret": res["client_secret"],
@@ -435,8 +435,9 @@ def _poll_registration(
         time.sleep(interval)
 
     if poll_count > 0:
-        print()
-    print(f"[Warning] Poll timed out after {expire_in}s")
+        print(" timed out.")
+    else:
+        print("Login timed out.")
     return None
 
 
@@ -470,13 +471,15 @@ def _print_qr_code(url: str) -> None:
     try:
         import qrcode as qr_lib
 
+        print("\nScan this QR code with Feishu or Lark on your phone:\n")
         qr = qr_lib.QRCode(border=1)
         qr.add_data(url)
         qr.make(fit=True)
         qr.print_ascii(invert=True)
-        print("Scan the QR code with Feishu / Lark on your phone to authorize.\n")
+        print()
     except ImportError:
-        print(f"\nLogin URL: {url}\n")
+        print("\nOpen this link with Feishu or Lark on your phone:")
+        print(f"{url}\n")
 
 
 def _qr_register_inner(
@@ -484,10 +487,9 @@ def _qr_register_inner(
     initial_domain: str,
 ) -> dict | None:
     """Run init → begin → poll. Raises on network/protocol errors."""
-    print("Connecting to Feishu / Lark...", end="", flush=True)
+    print("Preparing Feishu/Lark login...")
     _init_registration(initial_domain)
     begin = _begin_registration(initial_domain)
-    print(" done.")
 
     _print_qr_code(begin["qr_url"])
 
@@ -578,24 +580,17 @@ class FeishuChannel(BaseChannel):
             print()
             return True
 
-        print("--- Feishu / Lark QR Login ---")
-        print("Open the URL below in Feishu / Lark on your phone to authorize.")
-        print("The platform will create a new bot application automatically.")
+        print("Authorize with the mobile app. nanobot will save the new bot credentials.")
+        print()
 
         result = qr_register(initial_domain=self.config.domain or "feishu")
         if not result:
-            self.logger.error(
-                "QR registration failed. "
-                "Run 'nanobot channels login feishu --force' to retry."
-            )
+            print("Login was not completed. Run 'nanobot channels login feishu --force' to retry.")
             return False
 
         self.config.app_id = result["app_id"]
         self.config.app_secret = result["app_secret"]
         self.config.domain = result.get("domain", "feishu")
-
-        print(f"App ID: {result['app_id']}")
-        print(f"Domain: {self.config.domain}")
 
         # Write credentials back to config.json
         from nanobot.config.loader import load_config, save_config
@@ -610,7 +605,9 @@ class FeishuChannel(BaseChannel):
             setattr(full_config.channels, "feishu", feishu_cfg)
         save_config(full_config)
 
-        print("Login successful!")
+        print("\nFeishu/Lark login complete.")
+        print(f"App ID: {result['app_id']}")
+        print(f"Domain: {self.config.domain}")
         return True
 
     @staticmethod

--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -717,7 +717,7 @@ class FeishuChannel(BaseChannel):
         print(f"Domain: {self.config.domain}")
 
         # Write credentials back to config.json
-        from nanobot.config.loader import get_config_path, load_config, save_config
+        from nanobot.config.loader import load_config, save_config
 
         full_config = load_config()
         feishu_cfg = getattr(full_config.channels, "feishu", None) or {}
@@ -729,7 +729,6 @@ class FeishuChannel(BaseChannel):
             setattr(full_config.channels, "feishu", feishu_cfg)
         save_config(full_config)
 
-        print(f"\nCredentials saved to {get_config_path()} (feishu enabled)")
         print("Login successful!")
         return True
 

--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -371,6 +371,8 @@ def _begin_registration(domain: str = "feishu") -> dict:
     if not device_code:
         raise RuntimeError("Feishu / Lark registration did not return a device_code")
     qr_url = res.get("verification_uri_complete", "")
+    if not qr_url:
+        raise RuntimeError("Feishu / Lark registration did not return a login URL")
     if "?" in qr_url:
         qr_url += "&from=nanobot&tp=nanobot"
     else:
@@ -715,7 +717,7 @@ class FeishuChannel(BaseChannel):
         print(f"Domain: {self.config.domain}")
 
         # Write credentials back to config.json
-        from nanobot.config.loader import load_config, save_config
+        from nanobot.config.loader import get_config_path, load_config, save_config
 
         full_config = load_config()
         feishu_cfg = getattr(full_config.channels, "feishu", None) or {}
@@ -727,7 +729,7 @@ class FeishuChannel(BaseChannel):
             setattr(full_config.channels, "feishu", feishu_cfg)
         save_config(full_config)
 
-        print(f"\nCredentials saved to ~/.nanobot/config.json (feishu enabled)")
+        print(f"\nCredentials saved to {get_config_path()} (feishu enabled)")
         print("Login successful!")
         return True
 

--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -364,10 +364,6 @@ def _begin_registration(domain: str = "feishu") -> dict:
     qr_url = res.get("verification_uri_complete", "")
     if not qr_url:
         raise RuntimeError("Feishu / Lark registration did not return a login URL")
-    if "?" in qr_url:
-        qr_url += "&from=nanobot&tp=nanobot"
-    else:
-        qr_url += "?from=nanobot&tp=nanobot"
     return {
         "device_code": device_code,
         "qr_url": qr_url,

--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -16,6 +16,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import Field
+from rich.console import Console
+from rich.markup import escape
+from rich.panel import Panel
+from rich.text import Text
 
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
@@ -29,6 +33,7 @@ if TYPE_CHECKING:
     from lark_oapi.api.im.v1.model import MentionEvent, P2ImMessageReceiveV1
 
 FEISHU_AVAILABLE = importlib.util.find_spec("lark_oapi") is not None
+_LOGIN_CONSOLE = Console()
 
 
 def _load_lark_runtime() -> tuple[Any, str, str]:
@@ -400,10 +405,6 @@ def _poll_registration(
             continue
 
         poll_count += 1
-        if poll_count == 1:
-            print("Waiting for authorization", end="", flush=True)
-        elif poll_count % 6 == 0:
-            print(".", end="", flush=True)
 
         # Domain auto-detection: if the user's tenant is on Lark, switch automatically
         user_info = res.get("user_info") or {}
@@ -413,8 +414,6 @@ def _poll_registration(
 
         # Success
         if res.get("client_id") and res.get("client_secret"):
-            if poll_count > 0:
-                print(" done.")
             return {
                 "app_id": res["client_id"],
                 "app_secret": res["client_secret"],
@@ -424,20 +423,13 @@ def _poll_registration(
         # Terminal errors
         error = res.get("error", "")
         if error in ("access_denied", "expired_token"):
-            if poll_count > 0:
-                print()
-            from loguru import logger
-
-            logger.warning("[Feishu onboard] Registration {}", error)
+            _LOGIN_CONSOLE.print("[yellow]Authorization was cancelled or expired.[/yellow]")
             return None
 
         # authorization_pending or unknown — keep polling
         time.sleep(interval)
 
-    if poll_count > 0:
-        print(" timed out.")
-    else:
-        print("Login timed out.")
+    _LOGIN_CONSOLE.print("[yellow]Authorization timed out.[/yellow]")
     return None
 
 
@@ -462,7 +454,9 @@ def qr_register(
     try:
         return _qr_register_inner(initial_domain=initial_domain)
     except (RuntimeError, OSError, json.JSONDecodeError, httpx.HTTPError) as exc:
-        print(f"[Warning] Registration failed: {exc}")
+        _LOGIN_CONSOLE.print(
+            f"[yellow]Unable to start Feishu/Lark login:[/yellow] {escape(str(exc))}"
+        )
         return None
 
 
@@ -471,15 +465,16 @@ def _print_qr_code(url: str) -> None:
     try:
         import qrcode as qr_lib
 
-        print("\nScan this QR code with Feishu or Lark on your phone:\n")
+        _LOGIN_CONSOLE.print("\n[bold]Scan with Feishu or Lark[/bold]\n")
         qr = qr_lib.QRCode(border=1)
         qr.add_data(url)
         qr.make(fit=True)
         qr.print_ascii(invert=True)
-        print()
+        _LOGIN_CONSOLE.print()
     except ImportError:
-        print("\nOpen this link with Feishu or Lark on your phone:")
-        print(f"{url}\n")
+        _LOGIN_CONSOLE.print()
+        _LOGIN_CONSOLE.print(Panel.fit(Text(url), title="Open with Feishu or Lark", border_style="cyan"))
+        _LOGIN_CONSOLE.print()
 
 
 def _qr_register_inner(
@@ -487,19 +482,19 @@ def _qr_register_inner(
     initial_domain: str,
 ) -> dict | None:
     """Run init → begin → poll. Raises on network/protocol errors."""
-    print("Preparing Feishu/Lark login...")
+    _LOGIN_CONSOLE.print("[cyan]Preparing Feishu/Lark login...[/cyan]")
     _init_registration(initial_domain)
     begin = _begin_registration(initial_domain)
 
     _print_qr_code(begin["qr_url"])
 
-    result = _poll_registration(
-        device_code=begin["device_code"],
-        interval=begin["interval"],
-        expire_in=begin["expire_in"],
-        domain=initial_domain,
-    )
-    return result
+    with _LOGIN_CONSOLE.status("Waiting for authorization in Feishu/Lark...", spinner="dots"):
+        return _poll_registration(
+            device_code=begin["device_code"],
+            interval=begin["interval"],
+            expire_in=begin["expire_in"],
+            domain=initial_domain,
+        )
 
 
 _STREAM_ELEMENT_ID = "streaming_md"
@@ -575,17 +570,18 @@ class FeishuChannel(BaseChannel):
             self.config.app_secret = ""
 
         if self.config.app_id and self.config.app_secret:
-            print("Feishu / Lark is already authenticated.")
-            print("Use --force to re-authenticate with a new bot.")
-            print()
+            _LOGIN_CONSOLE.print("[green]Feishu/Lark is already authenticated.[/green]")
+            _LOGIN_CONSOLE.print("Use --force to re-authenticate with a new bot.\n")
             return True
 
-        print("Authorize with the mobile app. nanobot will save the new bot credentials.")
-        print()
+        _LOGIN_CONSOLE.print("Authorize with the mobile app. nanobot will save the new bot credentials.\n")
 
         result = qr_register(initial_domain=self.config.domain or "feishu")
         if not result:
-            print("Login was not completed. Run 'nanobot channels login feishu --force' to retry.")
+            _LOGIN_CONSOLE.print(
+                "[yellow]Login was not completed.[/yellow] "
+                "Run 'nanobot channels login feishu --force' to retry."
+            )
             return False
 
         self.config.app_id = result["app_id"]
@@ -605,9 +601,9 @@ class FeishuChannel(BaseChannel):
             setattr(full_config.channels, "feishu", feishu_cfg)
         save_config(full_config)
 
-        print("\nFeishu/Lark login complete.")
-        print(f"App ID: {result['app_id']}")
-        print(f"Domain: {self.config.domain}")
+        _LOGIN_CONSOLE.print("\n[green]Feishu/Lark login complete.[/green]")
+        _LOGIN_CONSOLE.print(f"App ID: {escape(result['app_id'])}")
+        _LOGIN_CONSOLE.print(f"Domain: {escape(self.config.domain)}")
         return True
 
     @staticmethod

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1480,11 +1480,21 @@ def channels_login(
 ):
     """Authenticate with a channel via QR code or other interactive login."""
     from nanobot.channels.registry import discover_all
-    from nanobot.config.loader import load_config, set_config_path
+    from nanobot.config.loader import get_config_path, load_config, set_config_path
 
     resolved_config_path = Path(config_path).expanduser().resolve() if config_path else None
     if resolved_config_path is not None:
         set_config_path(resolved_config_path)
+
+    default_config_path = get_config_path()
+    # Feishu requires a configuration file to be present
+    if channel_name == "feishu" and not config_path and not default_config_path.exists():
+        console.print(
+            "[yellow]No configuration file found.[/yellow] "
+            "Please run [bold]nanobot onboard[/bold] to initialize nanobot first, "
+            "then retry this command."
+        )
+        raise typer.Exit(1)
 
     config = load_config(resolved_config_path)
     channel_cfg = getattr(config.channels, channel_name, None) or {}

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1480,21 +1480,11 @@ def channels_login(
 ):
     """Authenticate with a channel via QR code or other interactive login."""
     from nanobot.channels.registry import discover_all
-    from nanobot.config.loader import get_config_path, load_config, set_config_path
+    from nanobot.config.loader import load_config, set_config_path
 
     resolved_config_path = Path(config_path).expanduser().resolve() if config_path else None
     if resolved_config_path is not None:
         set_config_path(resolved_config_path)
-
-    default_config_path = get_config_path()
-    # Feishu requires a configuration file to be present
-    if channel_name == "feishu" and not config_path and not default_config_path.exists():
-        console.print(
-            "[yellow]No configuration file found.[/yellow] "
-            "Please run [bold]nanobot onboard[/bold] to initialize nanobot first, "
-            "then retry this command."
-        )
-        raise typer.Exit(1)
 
     config = load_config(resolved_config_path)
     channel_cfg = getattr(config.channels, channel_name, None) or {}

--- a/tests/channels/test_feishu_login.py
+++ b/tests/channels/test_feishu_login.py
@@ -1,11 +1,9 @@
 import json
 
 import pytest
-from typer.testing import CliRunner
 
 from nanobot.channels import feishu as feishu_module
 from nanobot.channels.feishu import FeishuChannel
-from nanobot.cli.commands import app
 from nanobot.config import loader
 from nanobot.config.schema import Config
 
@@ -24,8 +22,6 @@ async def test_feishu_login_writes_credentials_to_active_config(monkeypatch, tmp
             "app_id": "cli_app",
             "app_secret": "secret",
             "domain": "lark",
-            "bot_name": None,
-            "bot_open_id": None,
         },
     )
 
@@ -61,8 +57,6 @@ async def test_feishu_login_creates_missing_active_config(monkeypatch, tmp_path)
             "app_id": "cli_app",
             "app_secret": "secret",
             "domain": "feishu",
-            "bot_name": None,
-            "bot_open_id": None,
         },
     )
 
@@ -72,30 +66,3 @@ async def test_feishu_login_creates_missing_active_config(monkeypatch, tmp_path)
     assert missing_config.exists()
     data = json.loads(missing_config.read_text(encoding="utf-8"))
     assert data["channels"]["feishu"]["appId"] == "cli_app"
-
-
-def test_channels_login_feishu_uses_generic_channel_login(monkeypatch, tmp_path):
-    missing_config = tmp_path / "missing.json"
-    seen: dict[str, object] = {}
-
-    class _LoginChannel:
-        display_name = "Feishu"
-
-        def __init__(self, config, bus):
-            seen["config"] = config
-            seen["bus"] = bus
-
-        async def login(self, force: bool = False) -> bool:
-            seen["force"] = force
-            return True
-
-    monkeypatch.setattr(loader, "_current_config_path", missing_config)
-    monkeypatch.setattr(
-        "nanobot.channels.registry.discover_all",
-        lambda: {"feishu": _LoginChannel},
-    )
-
-    result = CliRunner().invoke(app, ["channels", "login", "feishu", "--force"])
-
-    assert result.exit_code == 0
-    assert seen["force"] is True

--- a/tests/channels/test_feishu_login.py
+++ b/tests/channels/test_feishu_login.py
@@ -1,5 +1,6 @@
 import json
 
+import httpx
 import pytest
 
 from nanobot.channels import feishu as feishu_module
@@ -44,6 +45,15 @@ def test_begin_registration_requires_login_url(monkeypatch):
 
     with pytest.raises(RuntimeError, match="login URL"):
         feishu_module._begin_registration()
+
+
+def test_qr_register_returns_none_on_network_error(monkeypatch):
+    def raise_connect_error(_base_url, _body):
+        raise httpx.ConnectError("network down")
+
+    monkeypatch.setattr(feishu_module, "_post_registration", raise_connect_error)
+
+    assert feishu_module.qr_register() is None
 
 
 @pytest.mark.asyncio

--- a/tests/channels/test_feishu_login.py
+++ b/tests/channels/test_feishu_login.py
@@ -50,11 +50,52 @@ def test_begin_registration_requires_login_url(monkeypatch):
         feishu_module._begin_registration()
 
 
-def test_channels_login_feishu_requires_default_config_file(monkeypatch, tmp_path):
+@pytest.mark.asyncio
+async def test_feishu_login_creates_missing_active_config(monkeypatch, tmp_path):
     missing_config = tmp_path / "missing.json"
-    monkeypatch.setattr(loader, "get_config_path", lambda: missing_config)
+    monkeypatch.setattr(loader, "_current_config_path", missing_config)
+    monkeypatch.setattr(
+        feishu_module,
+        "qr_register",
+        lambda initial_domain="feishu": {
+            "app_id": "cli_app",
+            "app_secret": "secret",
+            "domain": "feishu",
+            "bot_name": None,
+            "bot_open_id": None,
+        },
+    )
 
-    result = CliRunner().invoke(app, ["channels", "login", "feishu"])
+    channel = FeishuChannel({}, None)
 
-    assert result.exit_code == 1
-    assert "No configuration file found" in result.output
+    assert await channel.login() is True
+    assert missing_config.exists()
+    data = json.loads(missing_config.read_text(encoding="utf-8"))
+    assert data["channels"]["feishu"]["appId"] == "cli_app"
+
+
+def test_channels_login_feishu_uses_generic_channel_login(monkeypatch, tmp_path):
+    missing_config = tmp_path / "missing.json"
+    seen: dict[str, object] = {}
+
+    class _LoginChannel:
+        display_name = "Feishu"
+
+        def __init__(self, config, bus):
+            seen["config"] = config
+            seen["bus"] = bus
+
+        async def login(self, force: bool = False) -> bool:
+            seen["force"] = force
+            return True
+
+    monkeypatch.setattr(loader, "_current_config_path", missing_config)
+    monkeypatch.setattr(
+        "nanobot.channels.registry.discover_all",
+        lambda: {"feishu": _LoginChannel},
+    )
+
+    result = CliRunner().invoke(app, ["channels", "login", "feishu", "--force"])
+
+    assert result.exit_code == 0
+    assert seen["force"] is True

--- a/tests/channels/test_feishu_login.py
+++ b/tests/channels/test_feishu_login.py
@@ -1,0 +1,60 @@
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from nanobot.channels import feishu as feishu_module
+from nanobot.channels.feishu import FeishuChannel
+from nanobot.cli.commands import app
+from nanobot.config import loader
+from nanobot.config.schema import Config
+
+
+@pytest.mark.asyncio
+async def test_feishu_login_writes_credentials_to_active_config(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.json"
+    config = Config()
+    config.channels.feishu = {"enabled": False, "domain": "feishu"}
+    loader.save_config(config, config_path)
+    monkeypatch.setattr(loader, "_current_config_path", config_path)
+    monkeypatch.setattr(
+        feishu_module,
+        "qr_register",
+        lambda initial_domain="feishu": {
+            "app_id": "cli_app",
+            "app_secret": "secret",
+            "domain": "lark",
+            "bot_name": None,
+            "bot_open_id": None,
+        },
+    )
+
+    channel = FeishuChannel({"enabled": False, "domain": "feishu"}, None)
+
+    assert await channel.login() is True
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert data["channels"]["feishu"]["appId"] == "cli_app"
+    assert data["channels"]["feishu"]["appSecret"] == "secret"
+    assert data["channels"]["feishu"]["domain"] == "lark"
+    assert data["channels"]["feishu"]["enabled"] is True
+
+
+def test_begin_registration_requires_login_url(monkeypatch):
+    monkeypatch.setattr(
+        feishu_module,
+        "_post_registration",
+        lambda _base_url, _body: {"device_code": "device"},
+    )
+
+    with pytest.raises(RuntimeError, match="login URL"):
+        feishu_module._begin_registration()
+
+
+def test_channels_login_feishu_requires_default_config_file(monkeypatch, tmp_path):
+    missing_config = tmp_path / "missing.json"
+    monkeypatch.setattr(loader, "get_config_path", lambda: missing_config)
+
+    result = CliRunner().invoke(app, ["channels", "login", "feishu"])
+
+    assert result.exit_code == 1
+    assert "No configuration file found" in result.output

--- a/tests/channels/test_feishu_login.py
+++ b/tests/channels/test_feishu_login.py
@@ -47,6 +47,20 @@ def test_begin_registration_requires_login_url(monkeypatch):
         feishu_module._begin_registration()
 
 
+def test_begin_registration_preserves_login_url(monkeypatch):
+    login_url = "https://accounts.feishu.cn/login?device_code=device"
+    monkeypatch.setattr(
+        feishu_module,
+        "_post_registration",
+        lambda _base_url, _body: {
+            "device_code": "device",
+            "verification_uri_complete": login_url,
+        },
+    )
+
+    assert feishu_module._begin_registration()["qr_url"] == login_url
+
+
 def test_qr_register_returns_none_on_network_error(monkeypatch):
     def raise_connect_error(_base_url, _body):
         raise httpx.ConnectError("network down")


### PR DESCRIPTION
**Feishu channel (nanobot/channels/feishu.py)**

QR scan-to-create registration — implements the Feishu/Lark device-code flow (init → begin → poll → probe) that lets users scan a QR code with their mobile app to automatically create a new bot application. No manual app creation or credential hunting required.

<img width="1152" height="858" alt="d2135328d89f87f91f23cf2551334425" src="https://github.com/user-attachments/assets/219f9b2e-8f0a-4c5d-9477-c7687187f354" />
<img width="1080" height="2400" alt="738a8cefaaf247050dabfee5a3233332" src="https://github.com/user-attachments/assets/3c52b1b6-8adb-4a23-9cff-1358666dae7e" />



Graceful QR fallback — when the optional qrcode Python package is installed, the login URL is displayed as an ASCII QR art in the terminal for convenient mobile scanning. When the package is absent, it falls back to printing the plain URL. Tested both scenarios.

<img width="1314" height="351" alt="77128cabf7b52c763f2a6eda8ffd4a88" src="https://github.com/user-attachments/assets/f5fa6443-a8b6-4ea3-8806-7f596fe464bb" />


login() method — a new async login() method on FeishuChannel that runs the full QR flow and writes appId, appSecret, domain, and enabled: true back to config.json. Supports --force to re-authenticate.

<img width="891" height="69" alt="image" src="https://github.com/user-attachments/assets/3c3b35c1-8299-4126-9d34-02349e0d1951" />


Guard for missing config — before attempting Feishu login, verifies that a config file exists. If not, prompts the user to run nanobot onboard first, with a clear error message.

<img width="1557" height="63" alt="image" src="https://github.com/user-attachments/assets/3c5fdb0e-5482-456f-b425-1838d010a2d4" />



**Test Plan**
1. Run nanobot channels login feishu with qrcode installed — verify QR art is printed, scan with Feishu mobile app, confirm credentials are written to config.json and the channel connects on restart.
2. Run nanobot channels login feishu without qrcode — verify the plain URL fallback is shown and the flow still completes successfully.
3. Run nanobot channels login feishu --force — verify it clears existing credentials and re-runs the flow.
4. Run nanobot channels login feishu without a config file — verify the helpful error message is shown.
5. Run nanobot channels login feishu with an empty/invalid domain config — verify the flow uses the default feishu domain.