### PR TITLE
test(exec): cover git commands in workspace subdirectories

### DIFF
--- a/tests/tools/test_exec_security.py
+++ b/tests/tools/test_exec_security.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
-import socket
 import shutil
+import socket
 import sys
 from unittest.mock import patch
 
 import pytest
 
 from nanobot.agent.tools.shell import ExecTool
-from nanobot.security.workspace_access import bind_workspace_scope, build_workspace_scope, reset_workspace_scope
+from nanobot.security.workspace_access import (
+    bind_workspace_scope,
+    build_workspace_scope,
+    reset_workspace_scope,
+)
 
 
 def _fake_resolve_private(hostname, port, family=0, type_=0):

--- a/tests/tools/test_exec_security.py
+++ b/tests/tools/test_exec_security.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import socket
+import shutil
 import sys
 from unittest.mock import patch
 
@@ -224,6 +225,34 @@ async def test_exec_allows_working_dir_within_workspace(tmp_path):
     result = await tool.execute(command="echo ok", working_dir=str(subdir))
     assert "ok" in result
     assert "outside the configured workspace" not in result
+
+
+@pytest.mark.asyncio
+async def test_exec_allows_git_commands_from_workspace_subdirectory(tmp_path):
+    """Regression for #4375: git commands in workspace subdirectories are allowed."""
+    if shutil.which("git") is None:
+        pytest.skip("git is required for the workspace git regression test")
+
+    workspace = tmp_path / "workspace"
+    repo = workspace / "obsidian_notes"
+    repo.mkdir(parents=True)
+    (repo / "note.md").write_text("hello\n", encoding="utf-8")
+
+    tool = ExecTool(working_dir=str(workspace), restrict_to_workspace=True, timeout=20)
+
+    commands = [
+        "git init",
+        "git config user.email test@example.com",
+        'git config user.name "Nanobot Test"',
+        "git add note.md",
+        'git commit -m "initial note"',
+        "git status --short",
+    ]
+    for command in commands:
+        result = await tool.execute(command=command, working_dir=str(repo))
+        assert "Command blocked by safety guard" not in result
+        assert "outside the configured workspace" not in result
+        assert "Exit code: 0" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add an end-to-end regression test for git commands run from a workspace subdirectory under restrictToWorkspace
- cover the #4375 flow with git init, local config, add, commit, and status through ExecTool
- keep the production behavior unchanged because #4380 already merged the guard fix

## Validation
- uv run pytest tests/tools/test_exec_security.py -q
- uv run ruff check nanobot tests/tools/test_exec_security.py --select F
- git diff --check

Refs #4375