### PR TITLE
fix(runner): insert user-attention hint before mid-turn user messages

### DIFF
--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -205,6 +205,21 @@ class AgentRunner:
             return False, injection_cycles
         if real_injection:
             injection_cycles += 1
+            # Prepend a user-attention hint as the first injection.
+            # _append_injected_messages will merge consecutive user
+            # messages via _merge_message_content, producing a single
+            # user message with the hint as prefix — avoiding provider
+            # compatibility issues with consecutive user roles.
+            hint_msg = {
+                "role": "user",
+                "content": (
+                    "⚠️ The user has sent new messages while you were working. "
+                    "Read them carefully — the user may want to correct or "
+                    "redirect your task. You MUST acknowledge the user's "
+                    "message and respond BEFORE resuming any tool calls."
+                ),
+            }
+            injections.insert(0, hint_msg)
         if assistant_message is not None:
             messages.append(assistant_message)
             if iteration is not None:


### PR DESCRIPTION
## 问题

用户在 LLM 执行工具链期间发送消息时，LLM 可能忽略新消息继续调用工具。需要中断工具链让 LLM 优先响应用户。

## 核心目的
hint 和用户输入合并后作为一条独立的 user 消息发给 LLM，夹在 assistant(tool_calls) 和接下来的工具结果之间。LLM 看到这条 user 消息——没有其他 role 混在一起——它必须处理，不能跳过继续调工具。和之前内容前缀方案的区别是，这次不是拼在已有消息里，而是让它占据一个完整的 user 轮次。

## 方案
hint 作为第一条 injection 交给 `_append_injected_messages`，由其内部的 `_merge_message_content` 自动合并连续 user 消息，产生**一条独立 user 消息**（hint 为前缀），夹在 assistant(tool_calls) 和工具结果之间：

```
messages = [
  assistant_tool_calls,
  user: "⚠️ 用户打断了你...\n\n我想改个方向",  ← 合并后的单条 user 消息
  tool_result_1,                                  ← 工具结果完整保留
  tool_result_2,
]
```

**实现**：

```python
hint_msg = {"role": "user", "content": hint}
injections.insert(0, hint_msg)
# _append_injected_messages 检测连续 user → merge 为单条
self._append_injected_messages(messages, injections)
```

**优点**：
- 复用项目已有的 `_append_injected_messages` 角色交替保证，不绕过现有逻辑
- 单条 user 消息，对主流 provider 无连续 user 兼容性问题
- 避免 multimodal content（list）时 str + list crash
- 工具结果完整保留，LLM 回应用户后可继续

## 改动

`nanobot/agent/runner.py` `_try_drain_injections()` 中，`real_injection` 时在前插入 hint_msg。

## 影响

- 仅影响 mid-turn 注入的消息格式，不影响正常对话流
- 全 provider 兼容（user role，单条消息）
- 效果待实测定性：需确认 LLM 在 hint 后确实优先回应用户而非继续调工具
