### PR TITLE
fix(webui): avoid slow settings route refreshes

### DIFF
--- a/nanobot/apps/cli/service.py
+++ b/nanobot/apps/cli/service.py
@@ -461,6 +461,48 @@ class CliAppManager:
         _write_json(cache_path, {"_cached_at": _now(), "data": fetched})
         return fetched
 
+    async def _fetch_registry_async(
+        self,
+        url: str,
+        cache_path: Path,
+        *,
+        force_refresh: bool = False,
+    ) -> dict[str, Any]:
+        data, cached_at = self._cached_registry(cache_path)
+        if (
+            not force_refresh
+            and data is not None
+            and _now() - cached_at < self.runtime.catalog_ttl_seconds
+        ):
+            return data
+
+        try:
+            async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
+                response = await client.get(url)
+            response.raise_for_status()
+            fetched = response.json()
+            if not isinstance(fetched, dict):
+                raise ValueError("registry response must be an object")
+        except Exception:
+            if data is not None:
+                return data
+            raise
+
+        _write_json(cache_path, {"_cached_at": _now(), "data": fetched})
+        return fetched
+
+    async def refresh_catalog_cache(self, *, force_refresh: bool = False) -> None:
+        for source, url, _raw_base, required in _CATALOG_SOURCES:
+            try:
+                await self._fetch_registry_async(
+                    url,
+                    self._cache_path(source),
+                    force_refresh=force_refresh,
+                )
+            except Exception:
+                if required:
+                    raise
+
     def catalog(
         self,
         *,

--- a/nanobot/apps/cli/service.py
+++ b/nanobot/apps/cli/service.py
@@ -407,6 +407,19 @@ class CliAppManager:
     def _cache_path(self, source: str) -> Path:
         return self.data_dir / f"{source}_registry_cache.json"
 
+    def _cached_registry(self, cache_path: Path) -> tuple[dict[str, Any] | None, float]:
+        cached = _read_json(cache_path)
+        if not cached:
+            return None, 0.0
+        data = cached.get("data")
+        if not isinstance(data, dict):
+            return None, 0.0
+        try:
+            cached_at = float(cached.get("_cached_at", 0))
+        except (TypeError, ValueError):
+            cached_at = 0.0
+        return data, cached_at
+
     def _load_installed(self) -> dict[str, Any]:
         data = _read_json(self.installed_path) or {}
         apps = data.get("apps") if isinstance(data.get("apps"), dict) else data
@@ -426,39 +439,48 @@ class CliAppManager:
         *,
         force_refresh: bool = False,
     ) -> dict[str, Any]:
-        cached = _read_json(cache_path)
+        data, cached_at = self._cached_registry(cache_path)
         if (
             not force_refresh
-            and cached
-            and _now() - float(cached.get("_cached_at", 0)) < self.runtime.catalog_ttl_seconds
+            and data is not None
+            and _now() - cached_at < self.runtime.catalog_ttl_seconds
         ):
-            data = cached.get("data")
-            if isinstance(data, dict):
-                return data
+            return data
 
         try:
             response = httpx.get(url, timeout=15.0, follow_redirects=True)
             response.raise_for_status()
-            data = response.json()
-            if not isinstance(data, dict):
+            fetched = response.json()
+            if not isinstance(fetched, dict):
                 raise ValueError("registry response must be an object")
         except Exception:
-            if cached and isinstance(cached.get("data"), dict):
-                return cached["data"]
+            if data is not None:
+                return data
             raise
 
-        _write_json(cache_path, {"_cached_at": _now(), "data": data})
-        return data
+        _write_json(cache_path, {"_cached_at": _now(), "data": fetched})
+        return fetched
 
-    def catalog(self, *, force_refresh: bool = False) -> tuple[list[dict[str, Any]], str | None]:
+    def catalog(
+        self,
+        *,
+        force_refresh: bool = False,
+        cache_only: bool = False,
+    ) -> tuple[list[dict[str, Any]], str | None]:
         registries: list[tuple[str, str, dict[str, Any]]] = []
         for source, url, raw_base, required in _CATALOG_SOURCES:
             try:
-                registry = self._fetch_registry(
-                    url,
-                    self._cache_path(source),
-                    force_refresh=force_refresh,
-                )
+                cache_path = self._cache_path(source)
+                if cache_only:
+                    registry, _ = self._cached_registry(cache_path)
+                    if registry is None:
+                        continue
+                else:
+                    registry = self._fetch_registry(
+                        url,
+                        cache_path,
+                        force_refresh=force_refresh,
+                    )
             except Exception:
                 if required:
                     raise
@@ -487,6 +509,15 @@ class CliAppManager:
                 else:
                     apps_by_name[key] = entry
         return list(apps_by_name.values()), max(updated_values) if updated_values else None
+
+    def catalog_cache_fresh(self) -> bool:
+        for source, _url, _raw_base, required in _CATALOG_SOURCES:
+            if not required:
+                continue
+            data, cached_at = self._cached_registry(self._cache_path(source))
+            if data is None or _now() - cached_at >= self.runtime.catalog_ttl_seconds:
+                return False
+        return True
 
     def _manifest_source(self, app: dict[str, Any]) -> str:
         source = str(app.get("_source") or "harness")
@@ -674,8 +705,8 @@ class CliAppManager:
             },
         )
 
-    def payload(self, *, force_refresh: bool = False) -> dict[str, Any]:
-        apps, updated = self.catalog(force_refresh=force_refresh)
+    def payload(self, *, force_refresh: bool = False, cache_only: bool = False) -> dict[str, Any]:
+        apps, updated = self.catalog(force_refresh=force_refresh, cache_only=cache_only)
         installed = self._load_installed()
         rows = [self._app_payload(app, installed) for app in apps]
         rows.sort(key=lambda item: (str(item["category"]), str(item["display_name"]).lower()))

--- a/nanobot/apps/cli/service.py
+++ b/nanobot/apps/cli/service.py
@@ -510,9 +510,9 @@ class CliAppManager:
                     apps_by_name[key] = entry
         return list(apps_by_name.values()), max(updated_values) if updated_values else None
 
-    def catalog_cache_fresh(self) -> bool:
+    def catalog_cache_fresh(self, *, include_optional: bool = False) -> bool:
         for source, _url, _raw_base, required in _CATALOG_SOURCES:
-            if not required:
+            if not required and not include_optional:
                 continue
             data, cached_at = self._cached_registry(self._cache_path(source))
             if data is None or _now() - cached_at >= self.runtime.catalog_ttl_seconds:

--- a/nanobot/webui/cli_apps_api.py
+++ b/nanobot/webui/cli_apps_api.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
-import threading
 import time
 from typing import Any
 
@@ -22,37 +22,26 @@ _CLI_APP_ATTACHMENT_KEYS = (
     "brand_color",
 )
 _CATALOG_REFRESH_RETRY_SECONDS = 60.0
-_catalog_refresh_lock = threading.Lock()
-_catalog_refresh_running = False
+_catalog_refresh_task: asyncio.Task[None] | None = None
 _catalog_refresh_last_started = 0.0
 
 
-def _start_catalog_refresh() -> bool:
-    global _catalog_refresh_last_started, _catalog_refresh_running
+async def _refresh_catalog(manager: CliAppManager) -> None:
+    try:
+        await manager.refresh_catalog_cache(force_refresh=True)
+    except Exception:
+        pass
+
+
+def _start_catalog_refresh(manager: CliAppManager) -> bool:
+    global _catalog_refresh_last_started, _catalog_refresh_task
     now = time.monotonic()
-    with _catalog_refresh_lock:
-        if _catalog_refresh_running:
-            return True
-        if now - _catalog_refresh_last_started < _CATALOG_REFRESH_RETRY_SECONDS:
-            return False
-        _catalog_refresh_running = True
-        _catalog_refresh_last_started = now
-
-    def refresh() -> None:
-        global _catalog_refresh_running
-        try:
-            _manager().catalog(force_refresh=True)
-        except Exception:
-            pass
-        finally:
-            with _catalog_refresh_lock:
-                _catalog_refresh_running = False
-
-    threading.Thread(
-        target=refresh,
-        name="nanobot-cli-app-catalog-refresh",
-        daemon=True,
-    ).start()
+    if _catalog_refresh_task is not None and not _catalog_refresh_task.done():
+        return True
+    if now - _catalog_refresh_last_started < _CATALOG_REFRESH_RETRY_SECONDS:
+        return False
+    _catalog_refresh_last_started = now
+    _catalog_refresh_task = asyncio.create_task(_refresh_catalog(manager))
     return True
 
 
@@ -108,14 +97,14 @@ def _manager() -> CliAppManager:
     )
 
 
-def cli_apps_payload(*, installed_only: bool = False) -> dict[str, Any]:
+async def cli_apps_payload(*, installed_only: bool = False) -> dict[str, Any]:
     manager = _manager()
     if installed_only:
         return manager.installed_payload()
     payload = manager.payload(cache_only=True)
     refresh_pending = False
     if not manager.catalog_cache_fresh(include_optional=True):
-        refresh_pending = _start_catalog_refresh()
+        refresh_pending = _start_catalog_refresh(manager)
     if not payload["apps"]:
         installed = manager.installed_payload()
         if installed["apps"]:

--- a/nanobot/webui/cli_apps_api.py
+++ b/nanobot/webui/cli_apps_api.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import re
+import threading
+import time
 from typing import Any
 
 from nanobot.apps.cli import CliAppError, CliAppManager, CliAppsRuntimeConfig
@@ -19,6 +21,39 @@ _CLI_APP_ATTACHMENT_KEYS = (
     "logo_url",
     "brand_color",
 )
+_CATALOG_REFRESH_RETRY_SECONDS = 60.0
+_catalog_refresh_lock = threading.Lock()
+_catalog_refresh_running = False
+_catalog_refresh_last_started = 0.0
+
+
+def _start_catalog_refresh() -> bool:
+    global _catalog_refresh_last_started, _catalog_refresh_running
+    now = time.monotonic()
+    with _catalog_refresh_lock:
+        if _catalog_refresh_running:
+            return True
+        if now - _catalog_refresh_last_started < _CATALOG_REFRESH_RETRY_SECONDS:
+            return True
+        _catalog_refresh_running = True
+        _catalog_refresh_last_started = now
+
+    def refresh() -> None:
+        global _catalog_refresh_running
+        try:
+            _manager().catalog(force_refresh=True)
+        except Exception:
+            pass
+        finally:
+            with _catalog_refresh_lock:
+                _catalog_refresh_running = False
+
+    threading.Thread(
+        target=refresh,
+        name="nanobot-cli-app-catalog-refresh",
+        daemon=True,
+    ).start()
+    return True
 
 
 def _clip_ws_string(value: Any, limit: int = 240) -> str | None:
@@ -77,7 +112,16 @@ def cli_apps_payload(*, installed_only: bool = False) -> dict[str, Any]:
     manager = _manager()
     if installed_only:
         return manager.installed_payload()
-    return manager.payload()
+    payload = manager.payload(cache_only=True)
+    refresh_pending = not manager.catalog_cache_fresh()
+    if refresh_pending:
+        _start_catalog_refresh()
+    if not payload["apps"]:
+        installed = manager.installed_payload()
+        if installed["apps"]:
+            payload = installed
+    payload["catalog_refresh_pending"] = refresh_pending
+    return payload
 
 
 def cli_apps_action(action: str, query: QueryParams) -> dict[str, Any]:

--- a/nanobot/webui/cli_apps_api.py
+++ b/nanobot/webui/cli_apps_api.py
@@ -34,7 +34,7 @@ def _start_catalog_refresh() -> bool:
         if _catalog_refresh_running:
             return True
         if now - _catalog_refresh_last_started < _CATALOG_REFRESH_RETRY_SECONDS:
-            return True
+            return False
         _catalog_refresh_running = True
         _catalog_refresh_last_started = now
 
@@ -113,9 +113,9 @@ def cli_apps_payload(*, installed_only: bool = False) -> dict[str, Any]:
     if installed_only:
         return manager.installed_payload()
     payload = manager.payload(cache_only=True)
-    refresh_pending = not manager.catalog_cache_fresh()
-    if refresh_pending:
-        _start_catalog_refresh()
+    refresh_pending = False
+    if not manager.catalog_cache_fresh(include_optional=True):
+        refresh_pending = _start_catalog_refresh()
     if not payload["apps"]:
         installed = manager.installed_payload()
         if installed["apps"]:

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -298,9 +298,12 @@ def _oauth_provider_status(spec: Any) -> dict[str, Any]:
                 token_filename=OPENAI_CODEX_PROVIDER.token_filename,
             ).load()
         expires_at = getattr(token, "expires", None) if token else None
+        now_ms = int(time.time() * 1000)
         return {
             "configured": bool(
-                token and token.access and expires_at and expires_at > int(time.time() * 1000)
+                token
+                and token.access
+                and (getattr(token, "refresh", None) or (expires_at and expires_at > now_ms))
             ),
             "account": getattr(token, "account_id", None) if token else None,
             "expires_at": expires_at,

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -283,7 +283,8 @@ def _oauth_provider_status(spec: Any) -> dict[str, Any]:
 
     if spec.name == "openai_codex":
         try:
-            from oauth_cli_kit import get_token as get_codex_token
+            from oauth_cli_kit.providers import OPENAI_CODEX_PROVIDER
+            from oauth_cli_kit.storage import FileTokenStorage
         except Exception:
             return {
                 "configured": False,
@@ -293,10 +294,14 @@ def _oauth_provider_status(spec: Any) -> dict[str, Any]:
             }
         token = None
         with suppress(Exception):
-            token = get_codex_token()
+            token = FileTokenStorage(
+                token_filename=OPENAI_CODEX_PROVIDER.token_filename,
+            ).load()
         expires_at = getattr(token, "expires", None) if token else None
         return {
-            "configured": bool(token and token.access),
+            "configured": bool(
+                token and token.access and expires_at and expires_at > int(time.time() * 1000)
+            ),
             "account": getattr(token, "account_id", None) if token else None,
             "expires_at": expires_at,
             "login_supported": True,

--- a/nanobot/webui/settings_routes.py
+++ b/nanobot/webui/settings_routes.py
@@ -8,6 +8,7 @@ request mapping and response shaping.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 from collections.abc import Callable
 from typing import Any
@@ -309,10 +310,12 @@ class WebUISettingsRouter:
             "yes",
         }
         try:
-            if installed_only:
-                payload = await asyncio.to_thread(cli_apps_payload, installed_only=True)
-            else:
-                payload = await asyncio.to_thread(cli_apps_payload)
+            payload_result = (
+                cli_apps_payload(installed_only=True)
+                if installed_only
+                else cli_apps_payload()
+            )
+            payload = await payload_result if inspect.isawaitable(payload_result) else payload_result
         except Exception:
             self.logger.exception("failed to load CLI Apps payload")
             return self._error_response(500, "failed to load CLI Apps")

--- a/nanobot/webui/settings_routes.py
+++ b/nanobot/webui/settings_routes.py
@@ -8,7 +8,6 @@ request mapping and response shaping.
 from __future__ import annotations
 
 import asyncio
-import inspect
 import json
 from collections.abc import Callable
 from typing import Any
@@ -310,12 +309,7 @@ class WebUISettingsRouter:
             "yes",
         }
         try:
-            payload_result = (
-                cli_apps_payload(installed_only=True)
-                if installed_only
-                else cli_apps_payload()
-            )
-            payload = await payload_result if inspect.isawaitable(payload_result) else payload_result
+            payload = await cli_apps_payload(installed_only=installed_only)
         except Exception:
             self.logger.exception("failed to load CLI Apps payload")
             return self._error_response(500, "failed to load CLI Apps")

--- a/tests/channels/test_websocket_http_routes.py
+++ b/tests/channels/test_websocket_http_routes.py
@@ -5,8 +5,8 @@ import functools
 import json
 import random
 import socket
-import threading
 import time
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -484,12 +484,13 @@ async def test_cli_apps_catalog_does_not_block_other_webui_http_routes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    entered = threading.Event()
-    release = threading.Event()
+    entered = asyncio.Event()
+    release = asyncio.Event()
 
-    def slow_payload() -> dict[str, Any]:
+    async def slow_payload() -> dict[str, Any]:
         entered.set()
-        release.wait(2.0)
+        with suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(release.wait(), 2.0)
         return {"apps": [], "installed_count": 0, "catalog_updated_at": None}
 
     monkeypatch.setattr("nanobot.webui.settings_routes.cli_apps_payload", slow_payload)
@@ -505,7 +506,7 @@ async def test_cli_apps_catalog_does_not_block_other_webui_http_routes(
         catalog_task = asyncio.create_task(
             _http_get("http://127.0.0.1:29935/api/settings/cli-apps", headers=auth)
         )
-        assert await asyncio.to_thread(entered.wait, 2.0)
+        assert await asyncio.wait_for(entered.wait(), 2.0)
         assert time.perf_counter() - started < 1.0
 
         workspaces_started = time.perf_counter()

--- a/tests/channels/test_websocket_http_routes.py
+++ b/tests/channels/test_websocket_http_routes.py
@@ -415,9 +415,8 @@ async def test_cli_apps_routes_require_token_and_return_payload(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(
-        "nanobot.webui.settings_routes.cli_apps_payload",
-        lambda: {
+    async def payload(*, installed_only: bool = False) -> dict[str, Any]:
+        return {
             "apps": [
                 {
                     "name": "gimp",
@@ -438,7 +437,11 @@ async def test_cli_apps_routes_require_token_and_return_payload(
             ],
             "installed_count": 0,
             "catalog_updated_at": "2026-04-18",
-        },
+        }
+
+    monkeypatch.setattr(
+        "nanobot.webui.settings_routes.cli_apps_payload",
+        payload,
     )
     monkeypatch.setattr(
         "nanobot.webui.settings_routes.cli_apps_action",
@@ -487,7 +490,8 @@ async def test_cli_apps_catalog_does_not_block_other_webui_http_routes(
     entered = asyncio.Event()
     release = asyncio.Event()
 
-    async def slow_payload() -> dict[str, Any]:
+    async def slow_payload(*, installed_only: bool = False) -> dict[str, Any]:
+        assert installed_only is False
         entered.set()
         with suppress(asyncio.TimeoutError):
             await asyncio.wait_for(release.wait(), 2.0)
@@ -532,7 +536,7 @@ async def test_cli_apps_route_supports_installed_only_payload(
 ) -> None:
     calls: list[bool] = []
 
-    def payload(*, installed_only: bool = False) -> dict[str, Any]:
+    async def payload(*, installed_only: bool = False) -> dict[str, Any]:
         calls.append(installed_only)
         return {"apps": [], "installed_count": 0, "catalog_updated_at": None}
 

--- a/tests/cli_apps/test_service.py
+++ b/tests/cli_apps/test_service.py
@@ -270,6 +270,36 @@ def test_optional_extension_registry_failure_does_not_break_payload(
     assert [app["name"] for app in payload["apps"]] == ["gimp"]
 
 
+def test_payload_cache_only_does_not_fetch_catalog(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manager = _manager(tmp_path)
+    _seed_catalog(manager)
+
+    def fail_get(*args, **kwargs):
+        raise AssertionError("network should not be used")
+
+    monkeypatch.setattr("nanobot.apps.cli.service.httpx.get", fail_get)
+
+    payload = manager.payload(cache_only=True)
+
+    assert payload["catalog_updated_at"] == "2026-04-18"
+    assert {app["name"] for app in payload["apps"]} >= {"gimp", "feishu"}
+    assert manager.catalog_cache_fresh() is True
+
+
+def test_payload_cache_only_without_cache_returns_empty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manager = _manager(tmp_path)
+
+    def fail_get(*args, **kwargs):
+        raise AssertionError("network should not be used")
+
+    monkeypatch.setattr("nanobot.apps.cli.service.httpx.get", fail_get)
+
+    payload = manager.payload(cache_only=True)
+
+    assert payload == {"apps": [], "installed_count": 0, "catalog_updated_at": None}
+    assert manager.catalog_cache_fresh() is False
+
+
 def test_install_dispatches_safe_pip_and_installs_skill(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/cli_apps/test_service.py
+++ b/tests/cli_apps/test_service.py
@@ -286,6 +286,21 @@ def test_payload_cache_only_does_not_fetch_catalog(tmp_path: Path, monkeypatch: 
     assert manager.catalog_cache_fresh() is True
 
 
+def test_catalog_cache_fresh_can_include_optional_sources(tmp_path: Path) -> None:
+    manager = _manager(tmp_path)
+    _write_cache(
+        manager._cache_path("harness"),
+        {"meta": {"updated": "2026-04-16"}, "clis": []},
+    )
+    _write_cache(
+        manager._cache_path("public"),
+        {"meta": {"updated": "2026-04-18"}, "clis": []},
+    )
+
+    assert manager.catalog_cache_fresh() is True
+    assert manager.catalog_cache_fresh(include_optional=True) is False
+
+
 def test_payload_cache_only_without_cache_returns_empty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     manager = _manager(tmp_path)
 

--- a/tests/webui/test_cli_apps_api.py
+++ b/tests/webui/test_cli_apps_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from nanobot.webui import cli_apps_api
@@ -60,9 +61,13 @@ def test_cli_apps_payload_uses_cache_and_marks_refresh_pending(monkeypatch) -> N
     manager = _FakeManager(fresh=False)
     refreshes = []
     monkeypatch.setattr(cli_apps_api, "_manager", lambda: manager)
-    monkeypatch.setattr(cli_apps_api, "_start_catalog_refresh", lambda: refreshes.append(True) or True)
+    monkeypatch.setattr(
+        cli_apps_api,
+        "_start_catalog_refresh",
+        lambda _manager: refreshes.append(True) or True,
+    )
 
-    payload = cli_apps_api.cli_apps_payload()
+    payload = asyncio.run(cli_apps_api.cli_apps_payload())
 
     assert manager.payload_calls == [True]
     assert manager.fresh_checks == [True]
@@ -95,9 +100,13 @@ def test_cli_apps_payload_skips_refresh_when_cache_is_fresh(monkeypatch) -> None
     )
     refreshes = []
     monkeypatch.setattr(cli_apps_api, "_manager", lambda: manager)
-    monkeypatch.setattr(cli_apps_api, "_start_catalog_refresh", lambda: refreshes.append(True) or True)
+    monkeypatch.setattr(
+        cli_apps_api,
+        "_start_catalog_refresh",
+        lambda _manager: refreshes.append(True) or True,
+    )
 
-    payload = cli_apps_api.cli_apps_payload()
+    payload = asyncio.run(cli_apps_api.cli_apps_payload())
 
     assert manager.payload_calls == [True]
     assert manager.fresh_checks == [True]
@@ -131,9 +140,13 @@ def test_cli_apps_payload_refreshes_when_optional_cache_is_stale(monkeypatch) ->
     )
     refreshes = []
     monkeypatch.setattr(cli_apps_api, "_manager", lambda: manager)
-    monkeypatch.setattr(cli_apps_api, "_start_catalog_refresh", lambda: refreshes.append(True) or True)
+    monkeypatch.setattr(
+        cli_apps_api,
+        "_start_catalog_refresh",
+        lambda _manager: refreshes.append(True) or True,
+    )
 
-    payload = cli_apps_api.cli_apps_payload()
+    payload = asyncio.run(cli_apps_api.cli_apps_payload())
 
     assert manager.payload_calls == [True]
     assert manager.fresh_checks == [True]
@@ -145,9 +158,9 @@ def test_cli_apps_payload_refreshes_when_optional_cache_is_stale(monkeypatch) ->
 def test_cli_apps_payload_reports_not_pending_when_refresh_is_throttled(monkeypatch) -> None:
     manager = _FakeManager(fresh=False)
     monkeypatch.setattr(cli_apps_api, "_manager", lambda: manager)
-    monkeypatch.setattr(cli_apps_api, "_start_catalog_refresh", lambda: False)
+    monkeypatch.setattr(cli_apps_api, "_start_catalog_refresh", lambda _manager: False)
 
-    payload = cli_apps_api.cli_apps_payload()
+    payload = asyncio.run(cli_apps_api.cli_apps_payload())
 
     assert manager.payload_calls == [True]
     assert manager.fresh_checks == [True]

--- a/tests/webui/test_cli_apps_api.py
+++ b/tests/webui/test_cli_apps_api.py
@@ -6,10 +6,18 @@ from nanobot.webui import cli_apps_api
 
 
 class _FakeManager:
-    def __init__(self, *, fresh: bool, apps: list[dict[str, Any]] | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        fresh: bool,
+        apps: list[dict[str, Any]] | None = None,
+        all_sources_fresh: bool | None = None,
+    ) -> None:
         self.fresh = fresh
+        self.all_sources_fresh = fresh if all_sources_fresh is None else all_sources_fresh
         self.apps = apps or []
         self.payload_calls: list[bool] = []
+        self.fresh_checks: list[bool] = []
 
     def payload(self, *, cache_only: bool = False) -> dict[str, Any]:
         self.payload_calls.append(cache_only)
@@ -19,8 +27,9 @@ class _FakeManager:
             "catalog_updated_at": "2026-04-18" if self.apps else None,
         }
 
-    def catalog_cache_fresh(self) -> bool:
-        return self.fresh
+    def catalog_cache_fresh(self, *, include_optional: bool = False) -> bool:
+        self.fresh_checks.append(include_optional)
+        return self.all_sources_fresh if include_optional else self.fresh
 
     def installed_payload(self) -> dict[str, Any]:
         return {
@@ -51,11 +60,12 @@ def test_cli_apps_payload_uses_cache_and_marks_refresh_pending(monkeypatch) -> N
     manager = _FakeManager(fresh=False)
     refreshes = []
     monkeypatch.setattr(cli_apps_api, "_manager", lambda: manager)
-    monkeypatch.setattr(cli_apps_api, "_start_catalog_refresh", lambda: refreshes.append(True))
+    monkeypatch.setattr(cli_apps_api, "_start_catalog_refresh", lambda: refreshes.append(True) or True)
 
     payload = cli_apps_api.cli_apps_payload()
 
     assert manager.payload_calls == [True]
+    assert manager.fresh_checks == [True]
     assert refreshes == [True]
     assert payload["catalog_refresh_pending"] is True
     assert payload["apps"][0]["name"] == "gimp"
@@ -85,11 +95,61 @@ def test_cli_apps_payload_skips_refresh_when_cache_is_fresh(monkeypatch) -> None
     )
     refreshes = []
     monkeypatch.setattr(cli_apps_api, "_manager", lambda: manager)
-    monkeypatch.setattr(cli_apps_api, "_start_catalog_refresh", lambda: refreshes.append(True))
+    monkeypatch.setattr(cli_apps_api, "_start_catalog_refresh", lambda: refreshes.append(True) or True)
 
     payload = cli_apps_api.cli_apps_payload()
 
     assert manager.payload_calls == [True]
+    assert manager.fresh_checks == [True]
     assert refreshes == []
     assert payload["catalog_refresh_pending"] is False
     assert payload["apps"][0]["source"] == "harness"
+
+
+def test_cli_apps_payload_refreshes_when_optional_cache_is_stale(monkeypatch) -> None:
+    manager = _FakeManager(
+        fresh=True,
+        all_sources_fresh=False,
+        apps=[
+            {
+                "name": "gimp",
+                "display_name": "GIMP",
+                "category": "image",
+                "description": "Image editing",
+                "requires": "Python",
+                "source": "harness",
+                "entry_point": "cli-anything-gimp",
+                "install_supported": True,
+                "installed": False,
+                "available": False,
+                "status": "not_installed",
+                "logo_url": None,
+                "brand_color": None,
+                "skill_installed": False,
+            }
+        ],
+    )
+    refreshes = []
+    monkeypatch.setattr(cli_apps_api, "_manager", lambda: manager)
+    monkeypatch.setattr(cli_apps_api, "_start_catalog_refresh", lambda: refreshes.append(True) or True)
+
+    payload = cli_apps_api.cli_apps_payload()
+
+    assert manager.payload_calls == [True]
+    assert manager.fresh_checks == [True]
+    assert refreshes == [True]
+    assert payload["catalog_refresh_pending"] is True
+    assert payload["apps"][0]["source"] == "harness"
+
+
+def test_cli_apps_payload_reports_not_pending_when_refresh_is_throttled(monkeypatch) -> None:
+    manager = _FakeManager(fresh=False)
+    monkeypatch.setattr(cli_apps_api, "_manager", lambda: manager)
+    monkeypatch.setattr(cli_apps_api, "_start_catalog_refresh", lambda: False)
+
+    payload = cli_apps_api.cli_apps_payload()
+
+    assert manager.payload_calls == [True]
+    assert manager.fresh_checks == [True]
+    assert payload["catalog_refresh_pending"] is False
+    assert payload["apps"][0]["name"] == "gimp"

--- a/tests/webui/test_cli_apps_api.py
+++ b/tests/webui/test_cli_apps_api.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import Any
+
+from nanobot.webui import cli_apps_api
+
+
+class _FakeManager:
+    def __init__(self, *, fresh: bool, apps: list[dict[str, Any]] | None = None) -> None:
+        self.fresh = fresh
+        self.apps = apps or []
+        self.payload_calls: list[bool] = []
+
+    def payload(self, *, cache_only: bool = False) -> dict[str, Any]:
+        self.payload_calls.append(cache_only)
+        return {
+            "apps": list(self.apps),
+            "installed_count": 0,
+            "catalog_updated_at": "2026-04-18" if self.apps else None,
+        }
+
+    def catalog_cache_fresh(self) -> bool:
+        return self.fresh
+
+    def installed_payload(self) -> dict[str, Any]:
+        return {
+            "apps": [
+                {
+                    "name": "gimp",
+                    "display_name": "GIMP",
+                    "category": "image",
+                    "description": "Image editing",
+                    "requires": "Python",
+                    "source": "local",
+                    "entry_point": "cli-anything-gimp",
+                    "install_supported": True,
+                    "installed": True,
+                    "available": True,
+                    "status": "installed",
+                    "logo_url": None,
+                    "brand_color": None,
+                    "skill_installed": True,
+                }
+            ],
+            "installed_count": 1,
+            "catalog_updated_at": None,
+        }
+
+
+def test_cli_apps_payload_uses_cache_and_marks_refresh_pending(monkeypatch) -> None:
+    manager = _FakeManager(fresh=False)
+    refreshes = []
+    monkeypatch.setattr(cli_apps_api, "_manager", lambda: manager)
+    monkeypatch.setattr(cli_apps_api, "_start_catalog_refresh", lambda: refreshes.append(True))
+
+    payload = cli_apps_api.cli_apps_payload()
+
+    assert manager.payload_calls == [True]
+    assert refreshes == [True]
+    assert payload["catalog_refresh_pending"] is True
+    assert payload["apps"][0]["name"] == "gimp"
+
+
+def test_cli_apps_payload_skips_refresh_when_cache_is_fresh(monkeypatch) -> None:
+    manager = _FakeManager(
+        fresh=True,
+        apps=[
+            {
+                "name": "gimp",
+                "display_name": "GIMP",
+                "category": "image",
+                "description": "Image editing",
+                "requires": "Python",
+                "source": "harness",
+                "entry_point": "cli-anything-gimp",
+                "install_supported": True,
+                "installed": False,
+                "available": False,
+                "status": "not_installed",
+                "logo_url": None,
+                "brand_color": None,
+                "skill_installed": False,
+            }
+        ],
+    )
+    refreshes = []
+    monkeypatch.setattr(cli_apps_api, "_manager", lambda: manager)
+    monkeypatch.setattr(cli_apps_api, "_start_catalog_refresh", lambda: refreshes.append(True))
+
+    payload = cli_apps_api.cli_apps_payload()
+
+    assert manager.payload_calls == [True]
+    assert refreshes == []
+    assert payload["catalog_refresh_pending"] is False
+    assert payload["apps"][0]["source"] == "harness"

--- a/tests/webui/test_settings_api.py
+++ b/tests/webui/test_settings_api.py
@@ -749,19 +749,17 @@ def test_update_network_safety_settings_default_access_is_webui_only(
 def test_openai_codex_oauth_status_uses_available_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def fake_get_token():
-        return type(
-            "Token",
-            (),
-            {
-                "access": "access-token",
-                "refresh": "refresh-token",
-                "expires": 2_000_000_000_000,
-                "account_id": "acct-codex",
-            },
-        )()
-
-    monkeypatch.setattr("oauth_cli_kit.get_token", fake_get_token)
+    token = type(
+        "Token",
+        (),
+        {
+            "access": "access-token",
+            "refresh": "refresh-token",
+            "expires": 2_000_000_000_000,
+            "account_id": "acct-codex",
+        },
+    )()
+    monkeypatch.setattr("oauth_cli_kit.storage.FileTokenStorage.load", lambda _self: token)
 
     status = _oauth_provider_status(find_by_name("openai_codex"))
 
@@ -772,10 +770,10 @@ def test_openai_codex_oauth_status_uses_available_token(
 def test_openai_codex_oauth_status_rejects_unavailable_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def fake_get_token():
+    def fake_load(_self):
         raise RuntimeError("refresh failed")
 
-    monkeypatch.setattr("oauth_cli_kit.get_token", fake_get_token)
+    monkeypatch.setattr("oauth_cli_kit.storage.FileTokenStorage.load", fake_load)
 
     status = _oauth_provider_status(find_by_name("openai_codex"))
 

--- a/tests/webui/test_settings_api.py
+++ b/tests/webui/test_settings_api.py
@@ -767,6 +767,27 @@ def test_openai_codex_oauth_status_uses_available_token(
     assert status["account"] == "acct-codex"
 
 
+def test_openai_codex_oauth_status_uses_refreshable_expired_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = type(
+        "Token",
+        (),
+        {
+            "access": "access-token",
+            "refresh": "refresh-token",
+            "expires": 1,
+            "account_id": "acct-codex",
+        },
+    )()
+    monkeypatch.setattr("oauth_cli_kit.storage.FileTokenStorage.load", lambda _self: token)
+
+    status = _oauth_provider_status(find_by_name("openai_codex"))
+
+    assert status["configured"] is True
+    assert status["expires_at"] == 1
+
+
 def test_openai_codex_oauth_status_rejects_unavailable_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -685,22 +685,31 @@ export function SettingsView({
   useEffect(() => {
     if (activeSection !== "apps") return;
     let cancelled = false;
-    setCliAppsLoading(true);
-    fetchCliApps(token)
-      .then((payload) => {
-        if (!cancelled) {
+    let retry: number | null = null;
+    const loadCliApps = (showLoading: boolean) => {
+      if (showLoading) setCliAppsLoading(true);
+      fetchCliApps(token)
+        .then((payload) => {
+          if (cancelled) return;
+          if (payload.catalog_refresh_pending) {
+            retry = window.setTimeout(() => loadCliApps(false), 2000);
+            if (payload.apps.length === 0) return;
+          }
           setCliApps(payload);
           setCliAppsError(null);
-        }
-      })
-      .catch((err) => {
-        if (!cancelled) setCliAppsError((err as Error).message);
-      })
-      .finally(() => {
-        if (!cancelled) setCliAppsLoading(false);
-      });
+          setCliAppsLoading(false);
+        })
+        .catch((err) => {
+          if (!cancelled) {
+            setCliAppsError((err as Error).message);
+            setCliAppsLoading(false);
+          }
+        });
+    };
+    loadCliApps(true);
     return () => {
       cancelled = true;
+      if (retry !== null) window.clearTimeout(retry);
     };
   }, [activeSection, token]);
 

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -213,6 +213,8 @@ const DEFERRED_MODEL_LIST_PROVIDERS = new Set([
   "volcengine_coding_plan",
 ]);
 const DEFERRED_MODEL_LIST_QUERY_MIN_LENGTH = 2;
+const CLI_APPS_REFRESH_RETRY_MS = 2_000;
+const CLI_APPS_REFRESH_MAX_RETRIES = 30;
 
 const FALLBACK_TIMEZONES = [
   "UTC",
@@ -686,13 +688,18 @@ export function SettingsView({
     if (activeSection !== "apps") return;
     let cancelled = false;
     let retry: number | null = null;
+    let retryCount = 0;
     const loadCliApps = (showLoading: boolean) => {
       if (showLoading) setCliAppsLoading(true);
       fetchCliApps(token)
         .then((payload) => {
           if (cancelled) return;
-          if (payload.catalog_refresh_pending) {
-            retry = window.setTimeout(() => loadCliApps(false), 2000);
+          if (payload.catalog_refresh_pending && retryCount < CLI_APPS_REFRESH_MAX_RETRIES) {
+            retryCount += 1;
+            retry = window.setTimeout(() => {
+              retry = null;
+              loadCliApps(false);
+            }, CLI_APPS_REFRESH_RETRY_MS);
           }
           setCliApps(payload);
           setCliAppsError(null);

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -693,7 +693,6 @@ export function SettingsView({
           if (cancelled) return;
           if (payload.catalog_refresh_pending) {
             retry = window.setTimeout(() => loadCliApps(false), 2000);
-            if (payload.apps.length === 0) return;
           }
           setCliApps(payload);
           setCliAppsError(null);

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -605,6 +605,7 @@ export interface CliAppsPayload {
   apps: CliAppInfo[];
   installed_count: number;
   catalog_updated_at?: string | null;
+  catalog_refresh_pending?: boolean;
   last_action?: {
     ok: boolean;
     message: string;

--- a/webui/src/tests/settings-view.test.tsx
+++ b/webui/src/tests/settings-view.test.tsx
@@ -286,6 +286,33 @@ describe("SettingsView Apps catalog", () => {
     await waitFor(() => expect(onSettingsChange).toHaveBeenCalledWith(payload));
   });
 
+  it("does not keep Apps loading while an empty CLI catalog refresh is pending", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "/api/settings") return jsonResponse(settingsPayload());
+        if (url === "/api/settings/cli-apps") {
+          return jsonResponse({
+            apps: [],
+            installed_count: 0,
+            catalog_updated_at: null,
+            catalog_refresh_pending: true,
+          });
+        }
+        if (url === "/api/settings/mcp-presets") {
+          return jsonResponse({ presets: [], installed_count: 0 });
+        }
+        return { ok: false, status: 404, json: async () => ({}) } as Response;
+      }),
+    );
+
+    renderSettingsView();
+
+    expect(await screen.findByText("No apps match this filter.")).toBeInTheDocument();
+    expect(screen.queryByText("Loading Apps...")).not.toBeInTheDocument();
+  });
+
   it("shows token activity on the overview", async () => {
     const payload: SettingsPayload = {
       ...settingsPayload(),


### PR DESCRIPTION
## Summary

- avoid refreshing Codex OAuth tokens while building `/api/settings`
- return cached or installed CLI Apps data immediately from `/api/settings/cli-apps`
- refresh remote CLI Apps catalogs in the background and let the WebUI refetch while refresh is pending

## Verification

- `python -m ruff check nanobot\webui\settings_api.py nanobot\webui\cli_apps_api.py nanobot\apps\cli\service.py tests\webui\test_settings_api.py tests\webui\test_cli_apps_api.py tests\cli_apps\test_service.py`
- `python -m pytest tests\webui\test_settings_api.py tests\webui\test_cli_apps_api.py tests\cli_apps\test_service.py -q --basetemp D:\tmp\pytest-fast-settings-oauth`
- `npm run test -- src/tests/settings-view.test.tsx`
- `npm run build`
- isolated gateway smoke test: `/api/settings` stayed under 30ms, cold `/api/settings/cli-apps` stayed under 10ms, refreshed catalog returned 97 apps, and no slow-route logs were emitted
