### PR TITLE
feat(webui): add configurable hidden_settings_sections to strip UI noise

### DIFF
--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -80,6 +80,12 @@ def save_config(config: Config, config_path: Path | None = None) -> None:
 
     data = config.model_dump(mode="json", by_alias=True)
 
+    # Strip webui section when at defaults to avoid config noise for users
+    # who never opt into hidden settings sections.
+    webui_data = data.get("webui")
+    if isinstance(webui_data, dict) and not webui_data.get("hiddenSettingsSections"):
+        data.pop("webui", None)
+
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -341,6 +341,16 @@ class ToolsConfig(Base):
     ssrf_whitelist: list[str] = Field(default_factory=list)  # CIDR ranges to exempt from SSRF blocking (e.g. ["100.64.0.0/10"] for Tailscale)
 
 
+class WebUIConfig(Base):
+    """WebUI display configuration."""
+
+    hidden_settings_sections: list[str] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("hiddenSettingsSections", "hidden_settings_sections"),
+        serialization_alias="hiddenSettingsSections",
+    )  # Settings section keys to hide from the UI (e.g. ["advanced", "runtime", "models"])
+
+
 class Config(BaseSettings):
     """Root configuration for nanobot."""
 
@@ -355,6 +365,7 @@ class Config(BaseSettings):
         default_factory=dict,
         validation_alias=AliasChoices("modelPresets", "model_presets"),
     )
+    webui: WebUIConfig = Field(default_factory=WebUIConfig)
 
     def __init__(self, **values: Any) -> None:
         if not type(self).__pydantic_complete__:

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -896,6 +896,9 @@ def settings_payload(
             "exec_path_prepend_set": bool(exec_config.path_prepend),
             "exec_path_append_set": bool(exec_config.path_append),
         },
+        "webui": {
+            "hidden_settings_sections": list(config.webui.hidden_settings_sections),
+        },
         "requires_restart": requires_restart,
         "version": _version_payload(),
     }

--- a/tests/webui/test_settings_hidden_sections.py
+++ b/tests/webui/test_settings_hidden_sections.py
@@ -99,3 +99,28 @@ def test_hidden_sections_snake_case_alias_works(
         }
     })
     assert config.webui.hidden_settings_sections == ["models", "image"]
+
+
+def test_save_config_omits_webui_key_when_at_defaults(
+    tmp_path,
+) -> None:
+    """Default config should not serialize the webui key to avoid config noise."""
+    config_path = tmp_path / "config.json"
+    save_config(Config(), config_path)
+
+    raw = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "webui" not in raw
+
+
+def test_save_config_preserves_webui_key_when_configured(
+    tmp_path,
+) -> None:
+    """Non-default hidden sections should be serialized."""
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate({
+        "webui": {"hiddenSettingsSections": ["advanced"]},
+    })
+    save_config(config, config_path)
+
+    raw = json.loads(config_path.read_text(encoding="utf-8"))
+    assert raw["webui"]["hiddenSettingsSections"] == ["advanced"]

--- a/tests/webui/test_settings_hidden_sections.py
+++ b/tests/webui/test_settings_hidden_sections.py
@@ -1,0 +1,101 @@
+"""Tests for WebUI hidden_settings_sections feature."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from nanobot.config.loader import load_config, save_config
+from nanobot.config.schema import Config
+from nanobot.webui.settings_api import settings_payload
+
+
+def test_settings_payload_includes_empty_hidden_sections_by_default(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    save_config(Config(), config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    payload = settings_payload()
+
+    assert "webui" in payload
+    assert payload["webui"]["hidden_settings_sections"] == []
+
+
+def test_settings_payload_includes_configured_hidden_sections(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate({
+        "webui": {
+            "hiddenSettingsSections": ["advanced", "runtime", "models"],
+        }
+    })
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    payload = settings_payload()
+
+    hidden = payload["webui"]["hidden_settings_sections"]
+    assert "advanced" in hidden
+    assert "runtime" in hidden
+    assert "models" in hidden
+    assert len(hidden) == 3
+
+
+def test_hidden_sections_config_accepts_unknown_keys_without_crash(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown section keys should be silently accepted — no validation error."""
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate({
+        "webui": {
+            "hiddenSettingsSections": ["nonexistent_section", "models"],
+        }
+    })
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    payload = settings_payload()
+
+    hidden = payload["webui"]["hidden_settings_sections"]
+    assert "nonexistent_section" in hidden
+    assert "models" in hidden
+
+
+def test_hidden_sections_round_trips_through_save_and_load(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure the hidden_settings_sections value survives save/load cycle."""
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate({
+        "webui": {
+            "hiddenSettingsSections": ["advanced", "runtime"],
+        }
+    })
+    save_config(config, config_path)
+
+    loaded = load_config(config_path)
+    assert loaded.webui.hidden_settings_sections == ["advanced", "runtime"]
+
+    # Verify the serialized JSON uses camelCase alias
+    raw = json.loads(config_path.read_text(encoding="utf-8"))
+    assert raw["webui"]["hiddenSettingsSections"] == ["advanced", "runtime"]
+
+
+def test_hidden_sections_snake_case_alias_works(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """snake_case alias should work as input in config.json."""
+    config = Config.model_validate({
+        "webui": {
+            "hidden_settings_sections": ["models", "image"],
+        }
+    })
+    assert config.webui.hidden_settings_sections == ["models", "image"]

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -594,6 +594,15 @@ export function SettingsView({
     setActiveSection(initialSection);
   }, [initialSection]);
 
+  // Redirect to overview if the active section is hidden by config.
+  useEffect(() => {
+    const hidden = settings?.webui?.hidden_settings_sections;
+    if (hidden?.includes(activeSection) && activeSection !== "overview") {
+      setActiveSection("overview");
+      onSectionChange?.("overview");
+    }
+  }, [activeSection, settings?.webui?.hidden_settings_sections, onSectionChange]);
+
   const selectSection = useCallback(
     (section: SettingsSectionKey) => {
       setActiveSection(section);
@@ -1451,6 +1460,7 @@ export function SettingsView({
             requiresRestart={hasPendingRestart}
             showBrandLogos={localPrefs.brandLogos}
             onSelectSection={selectSection}
+            hiddenSections={settings.webui?.hidden_settings_sections}
           />
         );
       case "appearance":
@@ -1687,6 +1697,7 @@ export function SettingsView({
           onBackToChat={onBackToChat}
           onLogout={onLogout}
           hostChromeInset={hostChromeInset}
+          hiddenSections={settings?.webui?.hidden_settings_sections}
         />
       ) : null}
 
@@ -1799,12 +1810,14 @@ function SettingsSidebar({
   onBackToChat,
   onLogout,
   hostChromeInset,
+  hiddenSections,
 }: {
   activeSection: SettingsSectionKey;
   onSelectSection: (section: SettingsSectionKey) => void;
   onBackToChat: () => void;
   onLogout?: () => void;
   hostChromeInset?: boolean;
+  hiddenSections?: string[];
 }) {
   const { t } = useTranslation();
   return (
@@ -1832,7 +1845,9 @@ function SettingsSidebar({
         aria-label={t("settings.sidebar.ariaLabel")}
         className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden md:mx-0 md:block md:space-y-1 md:overflow-visible md:px-0 md:pb-0"
       >
-        {SETTINGS_NAV_ITEMS.map(({ key, icon: Icon, fallback }) => {
+        {SETTINGS_NAV_ITEMS.filter(
+          ({ key }) => key === "overview" || !hiddenSections?.includes(key),
+        ).map(({ key, icon: Icon, fallback }) => {
           const active = key === activeSection;
           return (
             <button
@@ -1876,12 +1891,16 @@ function OverviewSettings({
   requiresRestart,
   onSelectSection,
   showBrandLogos,
+  hiddenSections,
 }: {
   settings: SettingsPayload;
   requiresRestart: boolean;
   onSelectSection: (section: SettingsSectionKey) => void;
   showBrandLogos: boolean;
+  hiddenSections?: string[];
 }) {
+  const isSectionVisible = (key: SettingsSectionKey) =>
+    !hiddenSections?.includes(key);
   const { t } = useTranslation();
   const tx = (key: string, fallback: string) => t(key, { defaultValue: fallback });
   const activePreset = settings.agent.model_preset || "default";
@@ -1953,6 +1972,7 @@ function OverviewSettings({
         <TokenUsageHeatmap usage={settings.usage} timeZone={settings.agent.timezone} />
       </section>
 
+      {isSectionVisible("models") ? (
       <section>
         <SettingsSectionTitle>{tx("settings.sections.ai", "AI")}</SettingsSectionTitle>
         <SettingsGroup>
@@ -1967,10 +1987,13 @@ function OverviewSettings({
           />
         </SettingsGroup>
       </section>
+      ) : null}
 
+      {(isSectionVisible("browser") || isSectionVisible("image") || isSectionVisible("voice")) ? (
       <section>
         <SettingsSectionTitle>{tx("settings.sections.capabilities", "Capabilities")}</SettingsSectionTitle>
         <SettingsGroup>
+          {isSectionVisible("browser") ? (
           <OverviewListRow
             icon={Globe2}
             valueLogoProvider={settings.web_search.provider}
@@ -1980,6 +2003,8 @@ function OverviewSettings({
             showBrandLogos={showBrandLogos}
             onClick={() => onSelectSection("browser")}
           />
+          ) : null}
+          {isSectionVisible("image") ? (
           <OverviewListRow
             icon={ImageIcon}
             valueLogoProvider={settings.image_generation.provider}
@@ -1989,6 +2014,8 @@ function OverviewSettings({
             showBrandLogos={showBrandLogos}
             onClick={() => onSelectSection("image")}
           />
+          ) : null}
+          {isSectionVisible("voice") ? (
           <OverviewListRow
             icon={Mic}
             valueLogoProvider={transcription.provider}
@@ -1998,9 +2025,12 @@ function OverviewSettings({
             showBrandLogos={showBrandLogos}
             onClick={() => onSelectSection("voice")}
           />
+          ) : null}
         </SettingsGroup>
       </section>
+      ) : null}
 
+      {isSectionVisible("runtime") ? (
       <section>
         <SettingsSectionTitle>{tx("settings.sections.system", "System")}</SettingsSectionTitle>
         <SettingsGroup>
@@ -2020,6 +2050,7 @@ function OverviewSettings({
           />
         </SettingsGroup>
       </section>
+      ) : null}
 
       <section>
         <SettingsSectionTitle>{tx("settings.sections.about", "About")}</SettingsSectionTitle>

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -523,6 +523,9 @@ export interface SettingsPayload {
     exec_path_prepend_set: boolean;
     exec_path_append_set: boolean;
   };
+  webui?: {
+    hidden_settings_sections?: string[];
+  };
   requires_restart: boolean;
   restart_required_sections?: Array<"runtime" | "browser" | "image">;
   version?: {


### PR DESCRIPTION
Add webui.hiddenSettingsSections config option that allows administrators to hide specific settings sections from the WebUI. This enables a simplified 'normie-friendly' UI for non-technical users in multi-instance deployments.

Changes:
- Add WebUIConfig class with hidden_settings_sections field to schema
- Include hidden list in the settings API payload
- Filter sidebar navigation items in SettingsView
- Redirect to overview if active section is hidden
- Filter overview cards for hidden sections
- Add TypeScript type for the new webui payload field
- Add 5 backend tests covering payload, round-trip, and aliases