### PR TITLE
ci: skip docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: Test Suite
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - docs/**
   pull_request:
     branches: [main]
+    paths-ignore:
+      - docs/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- skip CI when a push or pull request only changes files under docs/

## Verification
- git diff --check