### PR TITLE
fix(providers): use non-descriptive placeholder when stripping images

### DIFF
--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -15,8 +15,6 @@ from typing import Any
 import json_repair
 from loguru import logger
 
-from nanobot.utils.helpers import image_placeholder_text
-
 STREAM_IDLE_TIMEOUT_ENV = "NANOBOT_STREAM_IDLE_TIMEOUT_S"
 DEFAULT_STREAM_IDLE_TIMEOUT_S = 90.0
 MAX_STREAM_IDLE_TIMEOUT_S = 3600.0
@@ -564,8 +562,10 @@ class LLMProvider(ABC):
                 new_content = []
                 for b in content:
                     if isinstance(b, dict) and b.get("type") == "image_url":
-                        path = (b.get("_meta") or {}).get("path", "")
-                        placeholder = image_placeholder_text(path, empty="[image omitted]")
+                        placeholder = (
+                            "[Image not delivered to model — "
+                            "do not describe or reference it]"
+                        )
                         new_content.append({"type": "text", "text": placeholder})
                         found = True
                     else:
@@ -589,8 +589,10 @@ class LLMProvider(ABC):
             if isinstance(content, list):
                 for i, b in enumerate(content):
                     if isinstance(b, dict) and b.get("type") == "image_url":
-                        path = (b.get("_meta") or {}).get("path", "")
-                        placeholder = image_placeholder_text(path, empty="[image omitted]")
+                        placeholder = (
+                            "[Image not delivered to model — "
+                            "do not describe or reference it]"
+                        )
                         content[i] = {"type": "text", "text": placeholder}
                         found = True
         return found

--- a/tests/providers/test_provider_retry.py
+++ b/tests/providers/test_provider_retry.py
@@ -309,7 +309,7 @@ async def test_non_transient_error_with_images_retries_without_images() -> None:
         content = msg.get("content")
         if isinstance(content, list):
             assert all(b.get("type") != "image_url" for b in content)
-            assert any("[image: /media/test.png]" in (b.get("text") or "") for b in content)
+            assert any("not delivered" in (b.get("text") or "").lower() for b in content)
 
 
 @pytest.mark.asyncio
@@ -327,7 +327,7 @@ async def test_successful_image_retry_mutates_original_messages_in_place() -> No
     content = messages[0]["content"]
     assert isinstance(content, list)
     assert all(block.get("type") != "image_url" for block in content)
-    assert any("[image: /media/test.png]" in (block.get("text") or "") for block in content)
+    assert any("not delivered" in (block.get("text") or "").lower() for block in content)
 
 
 @pytest.mark.asyncio
@@ -362,7 +362,7 @@ async def test_image_fallback_returns_error_on_second_failure() -> None:
 
 @pytest.mark.asyncio
 async def test_image_fallback_without_meta_uses_default_placeholder() -> None:
-    """When _meta is absent, fallback placeholder is '[image omitted]'."""
+    """When _meta is absent, fallback placeholder is non-descriptive."""
     provider = ScriptedProvider([
         LLMResponse(content="error", finish_reason="error"),
         LLMResponse(content="ok"),
@@ -376,7 +376,7 @@ async def test_image_fallback_without_meta_uses_default_placeholder() -> None:
     for msg in msgs_on_retry:
         content = msg.get("content")
         if isinstance(content, list):
-            assert any("[image omitted]" in (b.get("text") or "") for b in content)
+            assert any("not delivered" in (b.get("text") or "").lower() for b in content)
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_strip_image_content.py
+++ b/tests/providers/test_strip_image_content.py
@@ -1,0 +1,173 @@
+"""Tests for LLMProvider._strip_image_content and _strip_image_content_inplace.
+
+Regression test for #4345: image-strip fallback should not leak file paths
+or produce text that makes the model hallucinate about unseen images.
+"""
+
+from __future__ import annotations
+
+from nanobot.providers.base import LLMProvider
+
+
+# ---------------------------------------------------------------------------
+# _strip_image_content (returns new list)
+# ---------------------------------------------------------------------------
+
+
+class TestStripImageContent:
+    """Tests for the non-mutating _strip_image_content method."""
+
+    def test_replaces_image_url_with_nondescriptive_placeholder(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What is this?"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,abc"},
+                        "_meta": {"path": "/tmp/screenshot.png"},
+                    },
+                ],
+            }
+        ]
+        result = LLMProvider._strip_image_content(messages)
+        assert result is not None
+        content = result[0]["content"]
+        assert len(content) == 2
+        assert content[0] == {"type": "text", "text": "What is this?"}
+        assert content[1]["type"] == "text"
+        placeholder = content[1]["text"]
+        # Must NOT leak the file path
+        assert "/tmp/screenshot.png" not in placeholder
+        assert "screenshot" not in placeholder
+        # Must clearly indicate the image was not delivered
+        assert "not delivered" in placeholder.lower() or "not describe" in placeholder.lower()
+
+    def test_returns_none_when_no_images(self):
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "hello"}]}
+        ]
+        assert LLMProvider._strip_image_content(messages) is None
+
+    def test_handles_multiple_images(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Look at these:"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,abc"},
+                        "_meta": {"path": "/a.png"},
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,def"},
+                        "_meta": {"path": "/b.png"},
+                    },
+                ],
+            }
+        ]
+        result = LLMProvider._strip_image_content(messages)
+        assert result is not None
+        content = result[0]["content"]
+        # text + 2 placeholders
+        assert len(content) == 3
+        for block in content[1:]:
+            assert block["type"] == "text"
+            assert "/a.png" not in block["text"]
+            assert "/b.png" not in block["text"]
+
+    def test_handles_image_without_meta(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,abc"},
+                    },
+                ],
+            }
+        ]
+        result = LLMProvider._strip_image_content(messages)
+        assert result is not None
+        placeholder = result[0]["content"][0]["text"]
+        assert "[image" not in placeholder.lower() or "not delivered" in placeholder.lower()
+
+    def test_preserves_non_image_content(self):
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Hello"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,abc"},
+                        "_meta": {"path": "/x.png"},
+                    },
+                ],
+            },
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+        result = LLMProvider._strip_image_content(messages)
+        assert result is not None
+        # system and assistant messages unchanged
+        assert result[0]["content"] == "You are helpful."
+        assert result[2]["content"] == "Hi there!"
+        # user message has image replaced
+        assert result[1]["content"][0]["type"] == "text"
+
+
+# ---------------------------------------------------------------------------
+# _strip_image_content_inplace (mutates in place)
+# ---------------------------------------------------------------------------
+
+
+class TestStripImageContentInplace:
+    """Tests for the mutating _strip_image_content_inplace method."""
+
+    def test_replaces_image_url_with_nondescriptive_placeholder(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What is this?"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,abc"},
+                        "_meta": {"path": "/tmp/photo.jpg"},
+                    },
+                ],
+            }
+        ]
+        found = LLMProvider._strip_image_content_inplace(messages)
+        assert found is True
+        content = messages[0]["content"]
+        assert len(content) == 2
+        placeholder = content[1]["text"]
+        assert "/tmp/photo.jpg" not in placeholder
+        assert "not delivered" in placeholder.lower() or "not describe" in placeholder.lower()
+
+    def test_returns_false_when_no_images(self):
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "hello"}]}
+        ]
+        assert LLMProvider._strip_image_content_inplace(messages) is False
+
+    def test_mutates_original_messages(self):
+        original_content = [
+            {"type": "text", "text": "see this"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,abc"},
+                "_meta": {"path": "/img.png"},
+            },
+        ]
+        messages = [{"role": "user", "content": original_content}]
+        LLMProvider._strip_image_content_inplace(messages)
+        # The original list was mutated
+        assert original_content[1]["type"] == "text"
+        assert "/img.png" not in original_content[1]["text"]

--- a/tests/providers/test_strip_image_content.py
+++ b/tests/providers/test_strip_image_content.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from nanobot.providers.base import LLMProvider
 
-
 # ---------------------------------------------------------------------------
 # _strip_image_content (returns new list)
 # ---------------------------------------------------------------------------

--- a/tests/providers/test_strip_image_content.py
+++ b/tests/providers/test_strip_image_content.py
@@ -41,7 +41,7 @@ class TestStripImageContent:
         assert "/tmp/screenshot.png" not in placeholder
         assert "screenshot" not in placeholder
         # Must clearly indicate the image was not delivered
-        assert "not delivered" in placeholder.lower() or "not describe" in placeholder.lower()
+        assert "not delivered" in placeholder.lower()
 
     def test_returns_none_when_no_images(self):
         messages = [
@@ -93,7 +93,7 @@ class TestStripImageContent:
         result = LLMProvider._strip_image_content(messages)
         assert result is not None
         placeholder = result[0]["content"][0]["text"]
-        assert "[image" not in placeholder.lower() or "not delivered" in placeholder.lower()
+        assert "not delivered" in placeholder.lower()
 
     def test_preserves_non_image_content(self):
         messages = [
@@ -148,7 +148,7 @@ class TestStripImageContentInplace:
         assert len(content) == 2
         placeholder = content[1]["text"]
         assert "/tmp/photo.jpg" not in placeholder
-        assert "not delivered" in placeholder.lower() or "not describe" in placeholder.lower()
+        assert "not delivered" in placeholder.lower()
 
     def test_returns_false_when_no_images(self):
         messages = [


### PR DESCRIPTION
## Summary

When a model returns a non-transient error on `image_url` input, the provider base strips image blocks and retries as text. The current fallback placeholder `[image: <path>]` (or `[image omitted]`) reads like a live, available image to the LLM, causing it to hallucinate about contents it never received, attempt `read_file` on the leaked server path, and expose internal file paths.

This PR replaces the placeholder with an explicit `[Image not delivered to model — do not describe or reference it]` message in both `_strip_image_content` and `_strip_image_content_inplace`.

## Linked Issue

Fixes #4345

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- `nanobot/providers/base.py`: Replace `image_placeholder_text(path, empty="[image omitted]")` with a fixed `[Image not delivered to model — do not describe or reference it]` placeholder in both `_strip_image_content` and `_strip_image_content_inplace`
- Remove unused `image_placeholder_text` import from `base.py`
- `tests/providers/test_strip_image_content.py`: 8 new tests covering both methods — verifies no path leakage, correct placeholder text, multi-image handling, no-image return, and in-place mutation

## How to Test

```bash
pytest tests/providers/test_strip_image_content.py -v
```

All 8 tests verify that:
1. The placeholder does NOT contain the file path
2. The placeholder clearly indicates the image was not delivered
3. Non-image content is preserved
4. Multiple images are all replaced
5. Images without `_meta` are handled
6. In-place mutation works correctly

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the project's coding style (ruff passes)
- [x] I have added tests that prove my fix is effective
