### PR TITLE
feat(webui): make Firecrawl a keyless Web Data app

### DIFF
--- a/docs/webui.md
+++ b/docs/webui.md
@@ -88,6 +88,12 @@ nanobot can call from a chat. CLI Apps install local adapters that nanobot runs
 on your machine; they do not modify the native apps themselves. MCP presets add
 predefined MCP server configurations.
 
+Some MCP presets connect to hosted keyless endpoints. For example, the Firecrawl
+preset uses Firecrawl's hosted MCP endpoint for search, scrape, crawl, and
+extraction tools without requiring an API key. This does not replace nanobot's
+built-in web search provider; mention the Firecrawl MCP preset with `@` when a
+turn needs Firecrawl's richer web data tools.
+
 After an App or MCP preset is available, mention it from the composer with `@`
 to attach that capability to the next message.
 

--- a/nanobot/webui/mcp_presets_api.py
+++ b/nanobot/webui/mcp_presets_api.py
@@ -173,25 +173,19 @@ MCP_PRESETS: tuple[McpPreset, ...] = (
         category="web",
         description="Scrape, crawl, search, and extract web pages through Firecrawl's MCP server.",
         docs_url="https://docs.firecrawl.dev/use-cases/developers-mcp",
-        transport="stdio",
+        transport="streamableHttp",
         install_supported=True,
         brand_domain="firecrawl.dev",
         brand_color="#EB5E28",
-        requires="Node.js, npx, and Firecrawl API key",
+        requires="Network access",
         server=MCPServerConfig(
-            type="stdio",
-            command="npx",
-            args=["-y", "firecrawl-mcp"],
+            type="streamableHttp",
+            url="https://mcp.firecrawl.dev/v2/mcp",
             tool_timeout=60,
         ),
-        fields=(
-            McpPresetField(
-                name="firecrawl_api_key",
-                label="Firecrawl API key",
-                target=("env", "FIRECRAWL_API_KEY"),
-                env_var="FIRECRAWL_API_KEY",
-                placeholder="fc-...",
-            ),
+        note=(
+            "Uses Firecrawl Keyless through the hosted MCP endpoint. No API key is required for "
+            "the built-in preset; use a custom MCP server URL if you want account-specific limits."
         ),
     ),
     McpPreset(

--- a/tests/webui/test_mcp_presets_api.py
+++ b/tests/webui/test_mcp_presets_api.py
@@ -135,26 +135,29 @@ def test_enable_no_auth_remote_presets_write_url(tmp_path, monkeypatch: pytest.M
 
     mcp_presets_action("enable", {"name": ["microsoft-learn"]})
     mcp_presets_action("enable", {"name": ["exa"]})
+    mcp_presets_action("enable", {"name": ["firecrawl"]})
 
     config = load_config()
     assert config.tools.mcp_servers["microsoft-learn"].url == "https://learn.microsoft.com/api/mcp"
     assert config.tools.mcp_servers["exa"].url == "https://mcp.exa.ai/mcp"
+    assert config.tools.mcp_servers["firecrawl"].url == "https://mcp.firecrawl.dev/v2/mcp"
 
 
-def test_enable_firecrawl_writes_scrubbed_env(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_firecrawl_preset_is_keyless(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     _use_config(tmp_path, monkeypatch)
 
-    payload = mcp_presets_action(
-        "enable",
-        {
-            "name": ["firecrawl"],
-            "firecrawl_api_key": ["fc-secret"],
-        },
-    )
+    payload = mcp_presets_action("enable", {"name": ["firecrawl"]})
 
-    assert "fc-secret" not in str(payload)
+    row = next(item for item in payload["presets"] if item["name"] == "firecrawl")
+    assert row["transport"] == "streamableHttp"
+    assert row["requires"] == "Network access"
+    assert row["required_fields"] == []
+    assert row["configured"] is True
+    assert "Keyless" in row["note"]
     config = load_config()
-    assert config.tools.mcp_servers["firecrawl"].env["FIRECRAWL_API_KEY"] == "fc-secret"
+    assert config.tools.mcp_servers["firecrawl"].type == "streamableHttp"
+    assert config.tools.mcp_servers["firecrawl"].url == "https://mcp.firecrawl.dev/v2/mcp"
+    assert config.tools.mcp_servers["firecrawl"].env == {}
 
 
 def test_remove_mcp_preset_updates_config(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- turn the built-in Firecrawl App preset into a keyless hosted Web Data integration
- switch Firecrawl from the old local `npx firecrawl-mcp` + `FIRECRAWL_API_KEY` setup to Firecrawl's hosted MCP endpoint
- update the WebUI docs and MCP preset tests so Firecrawl installs without an API key, Node.js, or npx

## Why

Firecrawl now provides a hosted keyless MCP endpoint:

```text
https://mcp.firecrawl.dev/v2/mcp
```

That endpoint can initialize without an API key and exposes Firecrawl's broader web data tools: search, scrape, crawl, and extract. This is a better default for nanobot's Apps surface than the previous local MCP package flow, which required users to install through `npx` and provide `FIRECRAWL_API_KEY` before trying the integration.

## Product behavior

Firecrawl remains an opt-in App / MCP preset:

- it is visible in Apps as a built-in Firecrawl integration
- it is not enabled by default
- it does not register tools until the user enables it
- it does not replace nanobot's built-in web search provider
- users can mention `@Firecrawl` when they want Firecrawl's richer web data tools for a turn

If a user needs account-specific Firecrawl limits or credentials, they can still add a custom MCP server URL/config manually. The built-in preset chooses the simplest keyless path.

## Validation

- `python -m pytest tests/webui/test_mcp_presets_api.py -q`
- `python -m ruff check nanobot/webui/mcp_presets_api.py tests/webui/test_mcp_presets_api.py`
- manually initialized `https://mcp.firecrawl.dev/v2/mcp` without an API key and received a successful `firecrawl-fastmcp` MCP response
