### PR TITLE
fix(sdk): pass per-run hooks to process_direct instead of mutating shared loop state

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -129,6 +129,10 @@ class TurnContext:
 
     ephemeral: bool = False
     tools: ToolRegistry | None = None
+    # Per-run hook override (e.g. SDK callers). When None, the loop's own
+    # ``self._extra_hooks`` apply. Passed explicitly (not via shared loop state)
+    # so concurrent runs on one AgentLoop cannot clobber each other's hooks.
+    extra_hooks: list[AgentHook] | None = None
 
     turn_wall_started_at: float = field(default_factory=time.time)
     visible_run_started_at: float | None = None
@@ -694,6 +698,7 @@ class AgentLoop:
         pending_queue: asyncio.Queue | None = None,
         ephemeral: bool = False,
         tools: ToolRegistry | None = None,
+        extra_hooks: list[AgentHook] | None = None,
     ) -> tuple[str | None, list[str], list[dict], str, bool]:
         """Run the agent iteration loop.
 
@@ -719,9 +724,12 @@ class AgentLoop:
             set_tool_context=self._set_tool_context,
             on_iteration=lambda iteration: setattr(self, "_current_iteration", iteration),
         )
+        # Per-run hooks (passed explicitly) override the loop's own configured
+        # hooks; this keeps concurrent SDK runs from sharing mutable loop state.
+        effective_extra_hooks = extra_hooks if extra_hooks is not None else self._extra_hooks
         hook: AgentHook = loop_hook
-        if not ephemeral and self._extra_hooks:
-            hook = CompositeHook([loop_hook] + self._extra_hooks)
+        if not ephemeral and effective_extra_hooks:
+            hook = CompositeHook([loop_hook] + effective_extra_hooks)
 
         async def _checkpoint(payload: dict[str, Any]) -> None:
             if session is None:
@@ -1240,6 +1248,7 @@ class AgentLoop:
         pending_queue: asyncio.Queue | None = None,
         ephemeral: bool = False,
         tools: ToolRegistry | None = None,
+        extra_hooks: list[AgentHook] | None = None,
     ) -> OutboundMessage | None:
         """Process a single inbound message and return the response."""
         self._refresh_provider_snapshot()
@@ -1272,6 +1281,7 @@ class AgentLoop:
             pending_queue=pending_queue,
             ephemeral=ephemeral,
             tools=tools,
+            extra_hooks=extra_hooks,
         )
 
         while ctx.state is not TurnState.DONE:
@@ -1498,6 +1508,7 @@ class AgentLoop:
             pending_queue=ctx.pending_queue,
             ephemeral=ctx.ephemeral,
             tools=ctx.tools,
+            extra_hooks=ctx.extra_hooks,
         )
         final_content, tools_used, all_msgs, stop_reason, had_injections = result
         ctx.final_content = final_content
@@ -1813,8 +1824,14 @@ class AgentLoop:
         ephemeral: bool = False,
         tools: ToolRegistry | None = None,
         persist_user_message: bool = True,
+        extra_hooks: list[AgentHook] | None = None,
     ) -> OutboundMessage | None:
-        """Process a message directly and return the outbound payload."""
+        """Process a message directly and return the outbound payload.
+
+        *extra_hooks*, when provided, are used for this call only (instead of the
+        loop's configured ``_extra_hooks``). Passing them per-call keeps concurrent
+        callers from clobbering each other's hooks via shared loop state.
+        """
         await self._connect_mcp()
         metadata: dict[str, Any] = {}
         if not persist_user_message:
@@ -1833,6 +1850,7 @@ class AgentLoop:
                     "on_stream": on_stream,
                     "on_stream_end": on_stream_end,
                     "ephemeral": ephemeral,
+                    "extra_hooks": extra_hooks,
                 }
                 if tools is not None:
                     kwargs["tools"] = tools

--- a/nanobot/nanobot.py
+++ b/nanobot/nanobot.py
@@ -84,15 +84,17 @@ class Nanobot:
             hooks: Optional lifecycle hooks for this run.
         """
         capture = SDKCaptureHook()
-        prev = self._loop._extra_hooks
-        base_hooks = list(hooks) if hooks is not None else list(prev or [])
-        self._loop._extra_hooks = [capture, *base_hooks]
-        try:
-            response = await self._loop.process_direct(
-                message, session_key=session_key,
-            )
-        finally:
-            self._loop._extra_hooks = prev
+        # Per-run hooks are passed explicitly to ``process_direct`` rather than
+        # mutating the shared ``self._loop._extra_hooks``; otherwise concurrent
+        # ``run()`` calls on one ``Nanobot`` would clobber each other's hooks and
+        # captured results. Fall back to the loop's configured hooks when the
+        # caller passes none.
+        base_hooks = list(hooks) if hooks is not None else list(self._loop._extra_hooks or [])
+        response = await self._loop.process_direct(
+            message,
+            session_key=session_key,
+            extra_hooks=[capture, *base_hooks],
+        )
 
         content = (response.content if response else None) or ""
         return RunResult(

--- a/tests/test_nanobot_facade.py
+++ b/tests/test_nanobot_facade.py
@@ -64,7 +64,14 @@ async def test_run_returns_result(tmp_path):
 
     assert isinstance(result, RunResult)
     assert result.content == "Hello back!"
-    bot._loop.process_direct.assert_awaited_once_with("hi", session_key="sdk:default")
+    # Hooks are passed per-call via extra_hooks (not by mutating shared loop state).
+    from nanobot.agent.hook import SDKCaptureHook
+
+    bot._loop.process_direct.assert_awaited_once()
+    call = bot._loop.process_direct.await_args
+    assert call.args == ("hi",)
+    assert call.kwargs["session_key"] == "sdk:default"
+    assert any(isinstance(h, SDKCaptureHook) for h in call.kwargs["extra_hooks"])
 
 
 @pytest.mark.asyncio
@@ -159,7 +166,9 @@ async def test_run_custom_session_key(tmp_path):
     bot._loop.process_direct = AsyncMock(return_value=mock_response)
 
     await bot.run("hi", session_key="user-alice")
-    bot._loop.process_direct.assert_awaited_once_with("hi", session_key="user-alice")
+    bot._loop.process_direct.assert_awaited_once()
+    assert bot._loop.process_direct.await_args.args == ("hi",)
+    assert bot._loop.process_direct.await_args.kwargs["session_key"] == "user-alice"
 
 
 def test_import_from_top_level():
@@ -183,9 +192,9 @@ async def test_run_populates_tools_used_across_iterations(tmp_path):
     config_path = _write_config(tmp_path)
     bot = Nanobot.from_config(config_path, workspace=tmp_path)
 
-    async def fake_process_direct(message, *, session_key):
-        # Whatever hooks the SDK installed are now on the loop.
-        extras = bot._loop._extra_hooks
+    async def fake_process_direct(message, *, session_key, extra_hooks):
+        # Hooks now arrive per-call via extra_hooks, not via shared loop state.
+        extras = extra_hooks
         messages = [{"role": "user", "content": message}]
         ctx1 = AgentHookContext(iteration=0, messages=messages)
         ctx1.tool_calls = [
@@ -216,8 +225,8 @@ async def test_run_populates_final_messages(tmp_path):
     config_path = _write_config(tmp_path)
     bot = Nanobot.from_config(config_path, workspace=tmp_path)
 
-    async def fake_process_direct(message, *, session_key):
-        extras = bot._loop._extra_hooks
+    async def fake_process_direct(message, *, session_key, extra_hooks):
+        extras = extra_hooks
         messages = [
             {"role": "user", "content": message},
             {"role": "assistant", "content": "hi there"},
@@ -265,8 +274,8 @@ async def test_run_user_hooks_still_fire_alongside_capture(tmp_path):
         async def after_iteration(self, context: AgentHookContext) -> None:
             seen_iterations.append(context.iteration)
 
-    async def fake_process_direct(message, *, session_key):
-        extras = bot._loop._extra_hooks
+    async def fake_process_direct(message, *, session_key, extra_hooks):
+        extras = extra_hooks
         assert len(extras) == 2, f"expected capture + user hook, got {len(extras)}"
         ctx = AgentHookContext(iteration=7, messages=[])
         for h in extras:
@@ -279,8 +288,9 @@ async def test_run_user_hooks_still_fire_alongside_capture(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_run_restores_extra_hooks_even_on_populated_iterations(tmp_path):
-    """Previously-installed _extra_hooks must be restored regardless of capture state."""
+async def test_run_uses_loop_configured_hooks_as_base_without_mutating(tmp_path):
+    """The loop's configured _extra_hooks are used as the base for a run and are
+    never mutated by run() (so they cannot leak/clobber across calls)."""
     from nanobot.agent.hook import AgentHook, AgentHookContext
     from nanobot.bus.events import OutboundMessage
 
@@ -290,15 +300,87 @@ async def test_run_restores_extra_hooks_even_on_populated_iterations(tmp_path):
     sentinel_hook = AgentHook()
     bot._loop._extra_hooks = [sentinel_hook]
 
-    async def fake_process_direct(message, *, session_key):
+    received: list[AgentHook] = []
+
+    async def fake_process_direct(message, *, session_key, extra_hooks):
+        received.extend(extra_hooks)
         ctx = AgentHookContext(iteration=0, messages=[])
-        for h in bot._loop._extra_hooks:
+        for h in extra_hooks:
             await h.after_iteration(ctx)
         return OutboundMessage(channel="cli", chat_id="direct", content="done")
 
     bot._loop.process_direct = fake_process_direct
     await bot.run("hello")
+
+    # Configured hook is carried into the run as the base (after the capture hook)...
+    assert sentinel_hook in received
+    # ...and the loop's own list is left untouched.
     assert bot._loop._extra_hooks == [sentinel_hook]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_runs_do_not_clobber_each_others_hooks(tmp_path):
+    """Regression for the per-run hook race: two concurrent run() calls on one
+    Nanobot must each use only their own hooks and capture only their own tools.
+
+    The fix passes hooks as a ``process_direct(extra_hooks=...)`` argument instead
+    of mutating the shared ``loop._extra_hooks``; this test interleaves two runs so
+    that the old shared-state approach would have clobbered one run's hooks.
+    """
+    import asyncio
+
+    from nanobot.agent.hook import AgentHook, AgentHookContext
+    from nanobot.bus.events import OutboundMessage
+    from nanobot.providers.base import ToolCallRequest
+
+    config_path = _write_config(tmp_path)
+    bot = Nanobot.from_config(config_path, workspace=tmp_path)
+
+    seen: dict[str, list[int]] = {}
+
+    class TaggedHook(AgentHook):
+        def __init__(self, tag: str) -> None:
+            super().__init__()
+            self.tag = tag
+
+        async def after_iteration(self, context: AgentHookContext) -> None:
+            seen.setdefault(self.tag, []).append(context.iteration)
+
+    a_inflight = asyncio.Event()
+    a_may_finish = asyncio.Event()
+
+    async def fake_process_direct(message, *, session_key, extra_hooks):
+        ctx = AgentHookContext(
+            iteration=0, messages=[{"role": "user", "content": message}]
+        )
+        ctx.tool_calls = [ToolCallRequest(id=message, name=f"tool_{message}", arguments={})]
+        if message == "A":
+            # Hold A open while B runs to completion, so any shared hook state
+            # would be overwritten by B before A fires its hooks.
+            a_inflight.set()
+            await a_may_finish.wait()
+        for h in extra_hooks:
+            await h.after_iteration(ctx)
+        return OutboundMessage(channel="cli", chat_id="direct", content=message)
+
+    bot._loop.process_direct = fake_process_direct
+
+    async def run_b():
+        await a_inflight.wait()
+        res = await bot.run("B", session_key="s-b", hooks=[TaggedHook("B")])
+        a_may_finish.set()
+        return res
+
+    res_a, res_b = await asyncio.gather(
+        bot.run("A", session_key="s-a", hooks=[TaggedHook("A")]),
+        run_b(),
+    )
+
+    # Each run captured only its own tool, and each tagged hook fired only once:
+    # no cross-run bleed despite the interleaving.
+    assert res_a.tools_used == ["tool_A"]
+    assert res_b.tools_used == ["tool_B"]
+    assert seen == {"A": [0], "B": [0]}
 
 
 @pytest.mark.asyncio

--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -467,7 +467,7 @@ async def test_process_direct_accepts_media() -> None:
 
     captured_msg = None
 
-    async def fake_process(msg, *, session_key="", on_progress=None, on_stream=None, on_stream_end=None, ephemeral=False):
+    async def fake_process(msg, *, session_key="", on_progress=None, on_stream=None, on_stream_end=None, ephemeral=False, extra_hooks=None):
         nonlocal captured_msg
         captured_msg = msg
         return None


### PR DESCRIPTION
# fix(sdk): pass per-run hooks to `process_direct` instead of mutating shared loop state

Closes https://github.com/HKUDS/nanobot/issues/4408

> Opening as a **draft** per `CONTRIBUTING.md`, since this touches a public method
> signature (`AgentLoop.process_direct`). Happy to switch to a context-scoped
> approach instead if maintainers prefer — see "Alternative considered" below.

## Summary

`Nanobot.run()` attached per-run hooks (the internal `SDKCaptureHook` plus any
caller-supplied `hooks=`) by **mutating the shared `self._loop._extra_hooks`** under a
`try/finally`. Because one `Nanobot` owns one `AgentLoop`, two `run()` calls executing
concurrently on the same instance raced on that single attribute — overwriting each
other's hook list, with the `finally` restoring the wrong snapshot. Lifecycle hooks and
the returned `RunResult.tools_used` / `messages` could bleed across concurrent runs.

This PR removes the shared mutable state from the SDK path: per-run hooks now travel as
an explicit `extra_hooks` argument, mirroring how `on_progress` / `on_stream` /
`pending_queue` / `tools` are already threaded.

## Root cause

`AgentLoop.process_direct()` had no per-call hook parameter, so the only way for
`Nanobot.run()` to inject hooks was to mutate `loop._extra_hooks` (read later in
`_run_agent_loop()` when building the `CompositeHook`). That field is shared by every
caller of the loop.

## Changes

- `AgentLoop.process_direct()`, `_process_message()`, `TurnContext`, and
  `_run_agent_loop()` gain an optional `extra_hooks: list[AgentHook] | None = None`.
- `_run_agent_loop()` uses `extra_hooks` when provided, else falls back to the loop's
  configured `self._extra_hooks`:
  ```python
  effective_extra_hooks = extra_hooks if extra_hooks is not None else self._extra_hooks
  ```
- `Nanobot.run()` passes `extra_hooks=[capture, *base_hooks]` and no longer touches
  `self._loop._extra_hooks` (the `try/finally` save/restore is gone).

## Compatibility

- **Backward compatible.** `extra_hooks` is optional and defaults to `None`, which
  preserves the existing behavior (the loop's configured hooks apply).
- The loop's constructor `hooks=` / `_extra_hooks` remain the fallback when no per-run
  hooks are passed.
- No behavior change for bus-dispatched turns or the CLI.

## Tests

- Added `test_concurrent_runs_do_not_clobber_each_others_hooks` — interleaves two
  `run()` calls (holds A open while B runs to completion) and asserts each captures only
  its own tool and fires only its own hooks.
- Updated existing facade tests to the new per-call contract (hooks asserted on the
  `process_direct(extra_hooks=...)` argument rather than on shared loop state).
- Updated one stub signature in `tests/test_openai_api.py` to accept the new kwarg.

```bash
python -m pytest tests/test_nanobot_facade.py -q          # incl. the new regression test
python -m pytest tests/test_nanobot_facade.py tests/test_openai_api.py tests/test_api_stream.py tests/agent -q
python -m ruff check nanobot/agent/loop.py nanobot/nanobot.py tests/test_nanobot_facade.py
```

All directly-affected suites pass; no formatting churn introduced.

## Alternative considered

A `ContextVar`-scoped per-run hooks holder (task-isolated, no signature change) would
also fix the race and matches the repo's existing ContextVar usage for per-turn state.
I chose explicit parameter threading because hooks are per-call *behavior* (siblings of
`on_progress` / `on_stream`, which are already threaded as params) and it keeps the data
flow visible at the call sites. Glad to switch if maintainers prefer the ContextVar
form.
