### PR TITLE
Suppress routine cron job notifications (#4410)

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -42,6 +42,7 @@ from nanobot.command import CommandContext, CommandRouter, register_builtin_comm
 from nanobot.config.schema import AgentDefaults, ModelPresetConfig
 from nanobot.cron.session_turns import (
     cron_history_overrides,
+    is_cron_turn,
 )
 from nanobot.providers.base import LLMProvider
 from nanobot.providers.factory import ProviderSnapshot
@@ -1008,7 +1009,11 @@ class AgentLoop:
                     completed_channel = msg.channel
                     completed_chat_id = msg.chat_id
                     if response is not None:
-                        await self.bus.publish_outbound(response)
+                        # Cron turns suppress automatic delivery; the cron
+                        # runner evaluates the response and delivers only when
+                        # the content is actionable (see run_bound_cron_job).
+                        if not is_cron_turn(msg.metadata):
+                            await self.bus.publish_outbound(response)
                         completed_channel = response.channel
                         completed_chat_id = response.chat_id
                     elif msg.channel == "cli":

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -974,7 +974,9 @@ def _run_gateway(
             return response
 
         if is_bound_cron_job(job):
-            return await run_bound_cron_job(job, agent=agent, cron=cron)
+            return await run_bound_cron_job(
+                job, agent=agent, cron=cron, deliver=_deliver_to_channel,
+            )
 
         reason = "unbound agent cron job must be recreated from a chat session"
         logger.warning(

--- a/nanobot/cron/bound_runner.py
+++ b/nanobot/cron/bound_runner.py
@@ -8,17 +8,22 @@ import time
 import uuid
 from typing import Any, Protocol
 
+from loguru import logger
+
 from nanobot.agent.tools.cron import CronTool
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.cron.session_delivery import origin_delivery_context
 from nanobot.cron.session_turns import CRON_DEFER_UNTIL_IDLE_META, CRON_TRIGGER_META
 from nanobot.cron.types import CronJob
 from nanobot.cron.webui_metadata import cron_proactive_delivery_metadata
+from nanobot.utils.evaluator import evaluate_response
 from nanobot.utils.prompt_templates import render_template
 
 
 class BoundCronAgent(Protocol):
     tools: Any
+    provider: Any
+    model: str
 
     async def submit_cron_turn(self, msg: InboundMessage) -> OutboundMessage | None:
         ...
@@ -26,6 +31,13 @@ class BoundCronAgent(Protocol):
 
 class CronRunRecorder(Protocol):
     def write_run_record(self, run_id: str, record: dict[str, Any]) -> None:
+        ...
+
+
+class DeliveryCallback(Protocol):
+    async def __call__(
+        self, msg: OutboundMessage, *, record: bool = False, session_key: str | None = None,
+    ) -> None:
         ...
 
 
@@ -64,8 +76,15 @@ async def run_bound_cron_job(
     *,
     agent: BoundCronAgent,
     cron: CronRunRecorder,
+    deliver: DeliveryCallback | None = None,
 ) -> str | None:
-    """Execute a session-bound cron job as a normal agent session turn."""
+    """Execute a session-bound cron job as a normal agent session turn.
+
+    After the LLM produces a response, a lightweight evaluator call decides
+    whether the result is actionable enough to notify the user.  Routine
+    "nothing to report" answers are silenced — matching the existing
+    heartbeat behaviour.
+    """
     session_key = job.payload.session_key
     if not session_key:
         raise ValueError(f"cron job {job.id} is missing payload.session_key")
@@ -148,4 +167,21 @@ async def run_bound_cron_job(
             "response": response,
         },
     )
+
+    # Post-run notification gate: only deliver if the response contains
+    # actionable information.  Uses default_notify=True (unlike heartbeat
+    # which uses False) because user-created cron jobs are intentional —
+    # a missed alert from an evaluator failure is worse than a false
+    # positive notification.
+    if response and resp is not None and deliver is not None:
+        should_notify = await evaluate_response(
+            response, prompt, agent.provider, agent.model,
+            default_notify=True,
+        )
+        if should_notify:
+            logger.info("Cron job '{}': delivering response", job.name)
+            await deliver(resp, record=True, session_key=session_key)
+        else:
+            logger.info("Cron job '{}': silenced by post-run evaluation", job.name)
+
     return response

--- a/tests/cron/test_bound_runner.py
+++ b/tests/cron/test_bound_runner.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nanobot.bus.events import InboundMessage, OutboundMessage
+from nanobot.cron.bound_runner import run_bound_cron_job
+from nanobot.cron.session_turns import CRON_TRIGGER_META
+from nanobot.cron.types import CronJob, CronPayload
+
+
+class _FakeAgent:
+    model = "test-model"
+    provider = object()
+    tools: dict[str, object] = {}
+
+    def __init__(self, content: str = "important update") -> None:
+        self.content = content
+        self.messages: list[InboundMessage] = []
+
+    async def submit_cron_turn(self, msg: InboundMessage) -> OutboundMessage:
+        self.messages.append(msg)
+        return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id, content=self.content)
+
+
+class _FakeCron:
+    def __init__(self) -> None:
+        self.records: list[tuple[str, dict[str, Any]]] = []
+
+    def write_run_record(self, run_id: str, record: dict[str, Any]) -> None:
+        self.records.append((run_id, record))
+
+
+def _job() -> CronJob:
+    return CronJob(
+        id="job-1",
+        name="Repo check",
+        payload=CronPayload(
+            message="Check repository health.",
+            session_key="websocket:chat-1",
+            origin_channel="websocket",
+            origin_chat_id="chat-1",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_bound_cron_delivers_when_post_run_evaluator_allows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    decisions: list[bool] = []
+    delivered: list[tuple[OutboundMessage, bool, str | None]] = []
+
+    async def _allow(*_args: Any, default_notify: bool = False, **_kwargs: Any) -> bool:
+        decisions.append(default_notify)
+        return True
+
+    async def _deliver(
+        msg: OutboundMessage,
+        *,
+        record: bool = False,
+        session_key: str | None = None,
+    ) -> None:
+        delivered.append((msg, record, session_key))
+
+    monkeypatch.setattr("nanobot.cron.bound_runner.evaluate_response", _allow)
+
+    response = await run_bound_cron_job(_job(), agent=_FakeAgent(), cron=_FakeCron(), deliver=_deliver)
+
+    assert response == "important update"
+    assert decisions == [True]
+    assert len(delivered) == 1
+    msg, record, session_key = delivered[0]
+    assert msg.content == "important update"
+    assert record is True
+    assert session_key == "websocket:chat-1"
+
+
+@pytest.mark.asyncio
+async def test_bound_cron_silences_when_post_run_evaluator_rejects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    delivered: list[OutboundMessage] = []
+
+    async def _reject(*_args: Any, default_notify: bool = False, **_kwargs: Any) -> bool:
+        assert default_notify is True
+        return False
+
+    async def _deliver(
+        msg: OutboundMessage,
+        *,
+        record: bool = False,
+        session_key: str | None = None,
+    ) -> None:
+        delivered.append(msg)
+
+    monkeypatch.setattr("nanobot.cron.bound_runner.evaluate_response", _reject)
+
+    response = await run_bound_cron_job(_job(), agent=_FakeAgent(), cron=_FakeCron(), deliver=_deliver)
+
+    assert response == "important update"
+    assert delivered == []
+
+
+@pytest.mark.asyncio
+async def test_bound_cron_records_and_submits_session_turn() -> None:
+    cron = _FakeCron()
+    agent = _FakeAgent()
+
+    response = await run_bound_cron_job(_job(), agent=agent, cron=cron)
+
+    assert response == "important update"
+    assert [record["status"] for _, record in cron.records] == ["queued", "ok"]
+    assert len(agent.messages) == 1
+    msg = agent.messages[0]
+    assert msg.sender_id == "cron"
+    assert msg.session_key_override == "websocket:chat-1"
+    assert msg.metadata[CRON_TRIGGER_META]["job_id"] == "job-1"


### PR DESCRIPTION
After the cron-session-binding refactor (a326ba40), bound cron jobs always delivered the LLM response to the user — even when the response was routine ("nothing to report, no action needed"). The built-in heartbeat system already had a post-run evaluate_response gate that suppressed routine answers, but bound cron jobs bypassed this entirely.

Root Cause
In _dispatch (loop.py), the LLM response was unconditionally published for all turns, including cron turns:

`
if response is not None:
    await self.bus.publish_outbound(response)  # always sends

`
Fix
loop.py — Suppress automatic publish_outbound for cron turns in _dispatch. The response is still captured by _cron_turns.complete() and returned to the cron runner.

bound_runner.py — Add a post-run evaluate_response(default_notify=False) gate, matching the existing heartbeat pattern. Only actionable/important responses are delivered to the user; routine answers are silenced. Fails closed — if the evaluator errors, the message is suppressed (not sent).

commands.py — Wire the _deliver_to_channel callback into run_bound_cron_job so evaluated responses route through the proper channel delivery pipeline.