### PR TITLE
feat(subagent): allow spawn model override

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1865,6 +1865,11 @@ By default, nanobot only allows one spawned subagent at a time. When the limit i
 |--------|---------|-------------|
 | `agents.defaults.maxConcurrentSubagents` | `1` | Maximum number of spawned subagents that may run at the same time. Attempts to spawn beyond this limit return an error. |
 
+The `spawn` tool also accepts an optional `model` parameter for a single
+subagent run. When omitted, the subagent inherits the current agent model. When
+provided, only that subagent uses the requested model; the parent agent's active
+model is not changed.
+
 
 ## Auto Compact
 

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -157,12 +157,14 @@ class SubagentManager:
         session_key: str | None = None,
         origin_message_id: str | None = None,
         temperature: float | None = None,
+        model: str | None = None,
         workspace_scope: WorkspaceScope | None = None,
     ) -> str:
         """Spawn a subagent to execute a task in the background."""
         task_id = str(uuid.uuid4())[:8]
         display_label = label or task[:30] + ("..." if len(task) > 30 else "")
         origin = {"channel": origin_channel, "chat_id": origin_chat_id, "session_key": session_key}
+        run_model = model.strip() if isinstance(model, str) and model.strip() else None
 
         status = SubagentStatus(
             task_id=task_id,
@@ -181,6 +183,7 @@ class SubagentManager:
                 status,
                 origin_message_id,
                 temperature,
+                run_model,
                 workspace_scope,
             )
         )
@@ -210,6 +213,7 @@ class SubagentManager:
         status: SubagentStatus,
         origin_message_id: str | None = None,
         temperature: float | None = None,
+        model: str | None = None,
         workspace_scope: WorkspaceScope | None = None,
     ) -> None:
         """Execute the subagent task and announce the result."""
@@ -243,7 +247,7 @@ class SubagentManager:
                 result = await self.runner.run(AgentRunSpec(
                     initial_messages=messages,
                     tools=tools,
-                    model=self.model,
+                    model=model or self.model,
                     temperature=temperature,
                     max_iterations=self.max_iterations,
                     max_tool_result_chars=self.max_tool_result_chars,

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -18,6 +18,10 @@ if TYPE_CHECKING:
     tool_parameters_schema(
         task=StringSchema("The task for the subagent to complete"),
         label=StringSchema("Optional short label for the task (for display)"),
+        model=StringSchema(
+            "Optional model identifier for this subagent run. "
+            "When omitted, the subagent inherits the current agent model."
+        ),
         temperature=NumberSchema(
             description=(
                 "Optional sampling temperature for the subagent "
@@ -73,6 +77,7 @@ class SpawnTool(Tool, ContextAware):
         task: str,
         label: str | None = None,
         temperature: float | None = None,
+        model: str | None = None,
         **kwargs: Any,
     ) -> str:
         """Spawn a subagent to execute the given task."""
@@ -92,5 +97,6 @@ class SpawnTool(Tool, ContextAware):
             session_key=self._session_key.get(),
             origin_message_id=self._origin_message_id.get(),
             temperature=temperature,
+            model=model,
             workspace_scope=current_workspace_scope(),
         )

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -89,14 +89,17 @@ class SpawnTool(Tool, ContextAware):
                 f"({running}/{limit} running). Wait for a running subagent "
                 f"to complete before spawning a new one."
             )
-        return await self._manager.spawn(
-            task=task,
-            label=label,
-            origin_channel=self._origin_channel.get(),
-            origin_chat_id=self._origin_chat_id.get(),
-            session_key=self._session_key.get(),
-            origin_message_id=self._origin_message_id.get(),
-            temperature=temperature,
-            model=model,
-            workspace_scope=current_workspace_scope(),
-        )
+        spawn_kwargs: dict[str, Any] = {
+            "task": task,
+            "label": label,
+            "origin_channel": self._origin_channel.get(),
+            "origin_chat_id": self._origin_chat_id.get(),
+            "session_key": self._session_key.get(),
+            "origin_message_id": self._origin_message_id.get(),
+            "temperature": temperature,
+            "workspace_scope": current_workspace_scope(),
+        }
+        if isinstance(model, str) and model.strip():
+            spawn_kwargs["model"] = model
+
+        return await self._manager.spawn(**spawn_kwargs)

--- a/tests/agent/tools/test_subagent_tools.py
+++ b/tests/agent/tools/test_subagent_tools.py
@@ -128,6 +128,86 @@ async def test_spawn_forwards_temperature_to_run_spec(tmp_path):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("strong-model", "strong-model"),
+        ("  ", "test-model"),
+    ],
+)
+async def test_spawn_forwards_model_override_to_run_spec(tmp_path, model, expected):
+    """A model passed to spawn() should override only that subagent run."""
+    from nanobot.agent.subagent import SubagentManager
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    mgr = SubagentManager(
+        provider=provider,
+        workspace=tmp_path,
+        bus=bus,
+        model="test-model",
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    )
+    mgr._announce_result = AsyncMock()
+
+    seen = {}
+
+    async def fake_run(spec):
+        seen["model"] = spec.model
+        return SimpleNamespace(
+            stop_reason="done", final_content="done", error=None, tool_events=[],
+        )
+
+    mgr.runner.run = AsyncMock(side_effect=fake_run)
+
+    await mgr.spawn(task="do task", model=model)
+    await asyncio.gather(*mgr._running_tasks.values(), return_exceptions=True)
+
+    assert seen["model"] == expected
+    assert mgr.model == "test-model"
+
+
+def test_spawn_tool_parameters_include_optional_model():
+    """The spawn tool schema should expose model as an optional parameter."""
+    from nanobot.agent.tools.spawn import SpawnTool
+
+    tool = SpawnTool(MagicMock())
+
+    assert "model" in tool.parameters["properties"]
+    assert "current agent model" in tool.parameters["properties"]["model"]["description"]
+    assert "model" not in tool.parameters["required"]
+
+
+@pytest.mark.asyncio
+async def test_spawn_tool_forwards_model_to_manager():
+    """SpawnTool should pass the optional model override to SubagentManager."""
+    from nanobot.agent.tools.spawn import SpawnTool
+
+    class Manager:
+        max_concurrent_subagents = 4
+
+        def __init__(self) -> None:
+            self.seen = None
+
+        def get_running_count(self) -> int:
+            return 0
+
+        async def spawn(self, **kwargs):
+            self.seen = kwargs
+            return "spawned"
+
+    manager = Manager()
+    tool = SpawnTool(manager)  # type: ignore[arg-type]
+
+    result = await tool.execute(task="do task", model="strong-model")
+
+    assert result == "spawned"
+    assert manager.seen["model"] == "strong-model"
+
+
+@pytest.mark.asyncio
 async def test_spawn_tool_rejects_when_at_concurrency_limit(tmp_path):
     """SpawnTool should return an error string when the concurrency limit is reached."""
     from nanobot.agent.subagent import SubagentManager

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -656,11 +656,15 @@ async def test_connect_mcp_servers_streamable_http_uses_finite_timeout(
     async def _reachable(_url: str) -> bool:
         return True
 
+    def _validate(_url: str) -> tuple[bool, str]:
+        return True, ""
+
     @asynccontextmanager
     async def _capturing_streamable_http_client(_url: str, http_client=None):
         captured["timeout"] = http_client.timeout
         yield object(), object(), object()
 
+    monkeypatch.setattr(mcp_mod, "validate_url_target", _validate)
     monkeypatch.setattr(mcp_mod, "_probe_http_url", _reachable)
     monkeypatch.setattr(
         sys.modules["mcp.client.streamable_http"],
@@ -670,7 +674,7 @@ async def test_connect_mcp_servers_streamable_http_uses_finite_timeout(
 
     registry = ToolRegistry()
     stacks = await connect_mcp_servers(
-        {"test": MCPServerConfig(url="https://example.com/mcp")},
+        {"test": MCPServerConfig(url="https://mcp.example.com/mcp")},
         registry,
     )
     for stack in stacks.values():

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -670,7 +670,7 @@ async def test_connect_mcp_servers_streamable_http_uses_finite_timeout(
 
     registry = ToolRegistry()
     stacks = await connect_mcp_servers(
-        {"test": MCPServerConfig(url="https://mcp.example.com/mcp")},
+        {"test": MCPServerConfig(url="https://example.com/mcp")},
         registry,
     )
     for stack in stacks.values():


### PR DESCRIPTION
## Summary
- Add an optional `model` parameter to the `spawn` tool schema and execution path.
- Forward the override to `SubagentManager.spawn()` and then to the subagent `AgentRunSpec.model` for that run only.
- Keep blank model values and omitted values on the existing inherited model path, and document the behavior.

Fixes #4231

## Tests
- `uv run pytest tests/agent/tools/test_subagent_tools.py tests/agent/test_subagent_lifecycle.py tests/agent/test_task_cancel.py tests/tools/test_tool_loader.py tests/agent/test_workspace_scope.py`
- `uv run ruff check nanobot/agent/subagent.py nanobot/agent/tools/spawn.py tests/agent/tools/test_subagent_tools.py`
- `git diff --check`

## Notes
- This implements per-run model override for the current provider path. Preset or cross-provider routing can be layered separately without changing the basic spawn tool contract.