### PR TITLE
[codex] test(mcp): use resolvable timeout regression URL

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -670,7 +670,7 @@ async def test_connect_mcp_servers_streamable_http_uses_finite_timeout(
 
     registry = ToolRegistry()
     stacks = await connect_mcp_servers(
-        {"test": MCPServerConfig(url="https://mcp.example.com/mcp")},
+        {"test": MCPServerConfig(url="https://example.com/mcp")},
         registry,
     )
     for stack in stacks.values():


### PR DESCRIPTION
## Summary
- use `https://example.com/mcp` in the streamable HTTP timeout regression test
- keep the test focused on the fake transport timeout path instead of depending on an unresolvable hostname passing URL safety validation

## Why
The test monkeypatches the reachability probe and streamable HTTP client, but `connect_mcp_servers` validates the configured URL before either fake is used. In CI, `mcp.example.com` does not resolve, so the safety gate skips the fake client and the test fails with `KeyError: timeout`.

## Tests
- `uv run pytest tests/tools/test_mcp_tool.py::test_connect_mcp_servers_streamable_http_uses_finite_timeout`
- `uv run ruff check tests/tools/test_mcp_tool.py`
- `git diff --check origin/main...HEAD`
