### PR TITLE
feat(memory): gate archive facts with provenance context

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -22,6 +22,7 @@ from nanobot.utils.helpers import (
     estimate_message_tokens,
     estimate_prompt_tokens_chain,
     find_legal_message_start,
+    load_bundled_template,
     recent_message_start_index,
     strip_think,
     truncate_text,
@@ -618,6 +619,7 @@ class MemoryStore:
 # that catches any new caller that forgot to set its own cap.
 _RAW_ARCHIVE_MAX_CHARS = 16_000       # fallback dump (LLM failed)
 _ARCHIVE_SUMMARY_MAX_CHARS = 8_000    # LLM-produced consolidation summary
+_ARCHIVE_MEMORY_CONTEXT_MAX_CHARS = 4_000  # current MEMORY.md excerpt for archive dedup
 _HISTORY_ENTRY_HARD_CAP = 64_000      # emergency cap in append_history
 
 
@@ -815,6 +817,30 @@ class Consolidator:
             return truncate_text(text, _RAW_ARCHIVE_MAX_CHARS)
         return truncate_text_to_tokens(text, budget)
 
+    def _current_memory_context(self) -> str:
+        """Return a bounded MEMORY.md excerpt for duplicate/correction checks."""
+        memory = self.store.read_memory().strip()
+        if not memory:
+            return ""
+        template = load_bundled_template("memory/MEMORY.md")
+        if template is not None and memory == template.strip():
+            return ""
+        return truncate_text(memory, _ARCHIVE_MEMORY_CONTEXT_MAX_CHARS)
+
+    def _format_archive_input(self, formatted_messages: str) -> str:
+        memory_context = self._current_memory_context()
+        if not memory_context:
+            return formatted_messages
+        return "\n\n".join(
+            [
+                "Current long-term memory excerpt "
+                "(for duplicate and correction checks; do not rewrite it verbatim):",
+                memory_context,
+                "Conversation chunk to archive:",
+                formatted_messages,
+            ]
+        )
+
     async def archive(
         self,
         messages: list[dict],
@@ -835,7 +861,9 @@ class Consolidator:
             return None
         messages_to_summarize = summary_messages if summary_messages is not None else messages
         try:
-            formatted = MemoryStore._format_messages(messages_to_summarize)
+            formatted = self._format_archive_input(
+                MemoryStore._format_messages(messages_to_summarize)
+            )
             formatted = self._truncate_to_token_budget(formatted)
             response = await self.provider.chat_with_retry(
                 model=self.model,

--- a/nanobot/templates/agent/consolidator_archive.md
+++ b/nanobot/templates/agent/consolidator_archive.md
@@ -18,7 +18,12 @@ Marks (choose the best match):
 
 Priority: user corrections and preferences > solutions > decisions > events > environment facts. The most valuable memory prevents the user from having to repeat themselves.
 
-Do not mark something [skip] merely because it might already exist in long-term memory; Dream handles cross-file deduplication later.
+Source discipline:
+- Facts stated or explicitly confirmed by the user may receive [permanent], [durable], [ephemeral], or [correction].
+- Tool outputs and source-code observations may receive [durable] when they are concrete project facts, not agent speculation.
+- Agent-only guesses, inferred preferences, proposed options, and interpretations that the user did not confirm must be [skip], or [ephemeral] only when needed to resume the active task and marked "(agent-inferred)".
+- If a Current long-term memory excerpt is provided, mark facts already captured there as [skip] unless the conversation corrects, narrows, or supersedes them.
+- Preserve the narrowest true scope. Do not broaden a project-specific or task-specific observation into a global user preference.
 
 Output concise bullet points only. No preamble, no commentary.
 If nothing noteworthy happened, output: (nothing)

--- a/nanobot/templates/agent/dream.md
+++ b/nanobot/templates/agent/dream.md
@@ -39,6 +39,7 @@ Conversation History may contain Consolidator tags. Treat them as routing and re
 - [permanent]: keep unless explicitly corrected, especially user preferences and stable identity facts.
 - [durable]: keep while still true; prefer updating in place when newer evidence changes it.
 - [ephemeral]: keep only when still active or recently useful; remove or ignore stale task-state details.
+- Entries marked "(agent-inferred)" are not user-confirmed. Do not promote them to USER.md or SOUL.md, and do not broaden them into durable preferences or project facts unless a later user turn confirms them.
 
 Always strip these bracketed tags from saved memory content.
 

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -11,6 +11,7 @@ from nanobot.agent.memory import (
 )
 from nanobot.providers.base import LLMResponse
 from nanobot.session.manager import Session
+from nanobot.utils.helpers import load_bundled_template
 from nanobot.utils.prompt_templates import render_template
 
 
@@ -93,6 +94,46 @@ class TestConsolidatorSummarize:
         entries = store.read_unprocessed_history(since_cursor=0)
         assert entries[0]["session_key"] == "telegram:chat-1"
 
+    async def test_archive_includes_current_memory_for_duplicate_checks(
+        self,
+        consolidator,
+        mock_provider,
+        store,
+    ):
+        store.write_memory("# Memory\n- User already uses project Apollo.")
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="(nothing)",
+            finish_reason="stop",
+        )
+
+        await consolidator.archive([{"role": "user", "content": "Apollo is still active"}])
+
+        archive_input = mock_provider.chat_with_retry.await_args.kwargs["messages"][1]["content"]
+        assert "Current long-term memory excerpt" in archive_input
+        assert "User already uses project Apollo" in archive_input
+        assert "Conversation chunk to archive" in archive_input
+        assert "Apollo is still active" in archive_input
+
+    async def test_archive_omits_default_memory_template(
+        self,
+        consolidator,
+        mock_provider,
+        store,
+    ):
+        template = load_bundled_template("memory/MEMORY.md")
+        assert template is not None
+        store.write_memory(template)
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="(nothing)",
+            finish_reason="stop",
+        )
+
+        await consolidator.archive([{"role": "user", "content": "new fact"}])
+
+        archive_input = mock_provider.chat_with_retry.await_args.kwargs["messages"][1]["content"]
+        assert "Current long-term memory excerpt" not in archive_input
+        assert "new fact" in archive_input
+
     async def test_summarize_raw_dumps_on_llm_failure(self, consolidator, mock_provider, store):
         """On LLM failure, raw-dump messages to HISTORY.md."""
         mock_provider.chat_with_retry.side_effect = Exception("API error")
@@ -130,7 +171,9 @@ class TestConsolidatorPromptContract:
         for mark in ("[permanent]", "[durable]", "[ephemeral]", "[correction]", "[skip]"):
             assert mark in prompt
         assert "check context below" not in prompt.lower()
-        assert "Do not mark something [skip] merely because it might already exist" in prompt
+        assert "Current long-term memory excerpt" in prompt
+        assert "agent-inferred" in prompt
+        assert "Preserve the narrowest true scope" in prompt
 
 
 class TestConsolidatorArchiveErrorHandling:

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -117,6 +117,8 @@ class TestBuildDreamPrompt:
         assert "History attribute tags" in prompt
         assert "[skip]: audit-only" in prompt
         assert "[correction]: replace the older conflicting fact" in prompt
+        assert "agent-inferred" in prompt
+        assert "Do not promote them to USER.md or SOUL.md" in prompt
         assert "Always strip these bracketed tags from saved memory content" in prompt
 
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -656,11 +656,15 @@ async def test_connect_mcp_servers_streamable_http_uses_finite_timeout(
     async def _reachable(_url: str) -> bool:
         return True
 
+    def _validate(_url: str) -> tuple[bool, str]:
+        return True, ""
+
     @asynccontextmanager
     async def _capturing_streamable_http_client(_url: str, http_client=None):
         captured["timeout"] = http_client.timeout
         yield object(), object(), object()
 
+    monkeypatch.setattr(mcp_mod, "validate_url_target", _validate)
     monkeypatch.setattr(mcp_mod, "_probe_http_url", _reachable)
     monkeypatch.setattr(
         sys.modules["mcp.client.streamable_http"],
@@ -670,7 +674,7 @@ async def test_connect_mcp_servers_streamable_http_uses_finite_timeout(
 
     registry = ToolRegistry()
     stacks = await connect_mcp_servers(
-        {"test": MCPServerConfig(url="https://example.com/mcp")},
+        {"test": MCPServerConfig(url="https://mcp.example.com/mcp")},
         registry,
     )
     for stack in stacks.values():

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -670,7 +670,7 @@ async def test_connect_mcp_servers_streamable_http_uses_finite_timeout(
 
     registry = ToolRegistry()
     stacks = await connect_mcp_servers(
-        {"test": MCPServerConfig(url="https://mcp.example.com/mcp")},
+        {"test": MCPServerConfig(url="https://example.com/mcp")},
         registry,
     )
     for stack in stacks.values():


### PR DESCRIPTION
## Summary

- Include a bounded `MEMORY.md` excerpt in Consolidator archive prompts so duplicate facts can be skipped and corrections can be recognized earlier.
- Update the archive prompt with source-discipline rules for user-confirmed facts, concrete tool/source observations, and agent-only inferred facts.
- Update Dream guidance so `(agent-inferred)` entries are not promoted into durable USER/SOUL/MEMORY facts unless a later user turn confirms them.
- Add regression coverage for memory-context injection, bundled-template omission, and the prompt contracts.

## Why

Related to #4212. The current archive path can feed already-known facts and agent-only assumptions back into `history.jsonl`, where Recent History and Dream may treat them as established context. This PR adds a small provenance and duplicate-check layer without changing the stored history schema.

## Note

This branch also includes the one-line MCP timeout test URL baseline from #4417 (`mcp.example.com` -> `example.com`) so the current full CI matrix can reach the mocked streamable HTTP path while #4417 is still pending.

## Validation

- `uv run pytest tests/agent/test_consolidator.py tests/agent/test_dream.py -q`
- `uv run pytest tests/agent/test_consolidator.py tests/agent/test_dream.py tests/agent/test_memory_store.py tests/agent/test_context_prompt_cache.py -q`
- `uv run pytest tests/tools/test_mcp_tool.py::test_connect_mcp_servers_streamable_http_uses_finite_timeout tests/agent/test_consolidator.py tests/agent/test_dream.py tests/agent/test_memory_store.py tests/agent/test_context_prompt_cache.py -q`
- `uv run ruff check nanobot/agent/memory.py tests/agent/test_consolidator.py tests/agent/test_dream.py tests/tools/test_mcp_tool.py`
- `git diff --check`
