### PR TITLE
feat(channels): add iMessage channel via Photon Spectrum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,4 +103,3 @@ bridge/node_modules/
 bridge/imessage-sidecar/node_modules/
 bridge/imessage-sidecar/dist/
 bridge/imessage-sidecar/package-lock.json
-bridge/imessage-sidecar/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,7 @@ temp/
 exp/
 .playwright-mcp/
 bridge/node_modules/
+bridge/imessage-sidecar/node_modules/
+bridge/imessage-sidecar/dist/
+bridge/imessage-sidecar/package-lock.json
+bridge/imessage-sidecar/package-lock.json

--- a/bridge/imessage-sidecar/package.json
+++ b/bridge/imessage-sidecar/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "nanobot-imessage-sidecar",
+  "version": "0.1.0",
+  "description": "iMessage sidecar for nanobot using Photon Spectrum",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsc && node dist/index.js"
+  },
+  "dependencies": {
+    "spectrum-ts": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "typescript": "^5.4.0"
+  },
+  "engines": {
+    "node": ">=18.17.0"
+  }
+}

--- a/bridge/imessage-sidecar/package.json
+++ b/bridge/imessage-sidecar/package.json
@@ -10,7 +10,7 @@
     "dev": "tsc && node dist/index.js"
   },
   "dependencies": {
-    "spectrum-ts": "^1.0.0"
+    "spectrum-ts": "1.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.0",

--- a/bridge/imessage-sidecar/src/index.ts
+++ b/bridge/imessage-sidecar/src/index.ts
@@ -52,13 +52,22 @@ export function resolveSpace(
   const cached = spaceCache.get(spaceId);
   if (cached) return Promise.resolve(cached);
 
-  return im.space(spaceId).then(
-    (resolved: Space) => {
-      spaceCache.set(resolved.id, resolved);
-      return resolved;
-    },
-    () => null
-  );
+  // Cold start: try to reconstruct the space from the chat_id.
+  // Spectrum space IDs for DMs take the form "any;-;+15551234567" where
+  // the phone number is the last segment.  Group chat IDs are opaque
+  // and cannot be resolved this way.
+  const phone = spaceId.split(";-;").pop();
+  if (phone && phone.startsWith("+")) {
+    return im.space(phone).then(
+      (resolved: Space) => {
+        spaceCache.set(resolved.id, resolved);
+        return resolved;
+      },
+      () => null
+    );
+  }
+
+  return Promise.resolve(null);
 }
 
 // ── Entry point ────────────────────────────────────────────────────────
@@ -221,7 +230,8 @@ async function main() {
 // Only run main() when executed directly, not when imported for testing.
 const isMain =
   process.argv[1] &&
-  (process.argv[1].endsWith("/dist/index.js") ||
+  (process.argv[1].endsWith("dist/index.js") ||
+    process.argv[1].endsWith("/dist/index.js") ||
     process.argv[1].endsWith("/src/index.ts") ||
     process.argv[1].endsWith("/src/index.js"));
 

--- a/bridge/imessage-sidecar/src/index.ts
+++ b/bridge/imessage-sidecar/src/index.ts
@@ -1,0 +1,233 @@
+import { createServer, IncomingMessage, ServerResponse } from "node:http";
+import { Spectrum, attachment } from "spectrum-ts";
+import { imessage } from "spectrum-ts/providers/imessage";
+import type { Space, Message } from "spectrum-ts";
+
+interface InboundMessage {
+  type: "message";
+  sender: string;
+  chat_id: string;
+  content: string;
+  message_id: string;
+  is_group: boolean;
+  was_mentioned: boolean;
+  media: { fileName: string; mimetype: string }[];
+}
+
+function extractMedia(content: Message["content"]): { fileName: string; mimetype: string }[] {
+  if (content.type === "attachment") {
+    return [{ fileName: content.name, mimetype: content.mimeType }];
+  }
+  // TODO: content.read() bytes — for voice and other binary types
+  return [];
+}
+
+function extractText(content: Message["content"]): string {
+  if (content.type === "text") {
+    return content.text;
+  }
+  if (content.type === "attachment") {
+    return `[attachment: ${content.name}]`;
+  }
+  if (content.type === "voice") {
+    return `[Voice Message]`;
+  }
+  return `[${content.type}]`;
+}
+
+// ── Exported for testing ──────────────────────────────────────────────
+
+/**
+ * Resolve a space by ID: cache first, then SDK, then null.
+ *
+ * Extracted so tests can verify the three branches without needing
+ * a real Photon connection.  The `im` parameter is typed as `any` to
+ * avoid the complex generic PlatformInstance signature.
+ */
+export function resolveSpace(
+  im: any,
+  spaceCache: Map<string, Space>,
+  spaceId: string
+): Promise<Space | null> {
+  const cached = spaceCache.get(spaceId);
+  if (cached) return Promise.resolve(cached);
+
+  return im.space(spaceId).then(
+    (resolved: Space) => {
+      spaceCache.set(resolved.id, resolved);
+      return resolved;
+    },
+    () => null
+  );
+}
+
+// ── Entry point ────────────────────────────────────────────────────────
+
+async function main() {
+  const PROJECT_ID = process.env.PROJECT_ID || "";
+  const PROJECT_SECRET = process.env.PROJECT_SECRET || "";
+  const PORT = parseInt(process.env.PORT || "8789", 10);
+
+  if (!PROJECT_ID || !PROJECT_SECRET) {
+    console.error(
+      "Missing PROJECT_ID or PROJECT_SECRET. Set them in environment variables."
+    );
+    process.exit(1);
+  }
+
+  const app = await Spectrum({
+    projectId: PROJECT_ID,
+    projectSecret: PROJECT_SECRET,
+    providers: [imessage.config()],
+  });
+
+  console.log("Spectrum SDK initialized");
+
+  const im = imessage(app);
+
+  // Cache resolved spaces by ID for outbound sends
+  const spaceCache = new Map<string, Space>();
+
+  // #2: Track the active inbound consumer via a generation counter.
+  // When a new /inbound connection arrives, increment the generation. The old
+  // loop sees the mismatch and exits immediately — before consuming another
+  // message from app.messages — avoiding the race where `res.end()` hasn't
+  // closed the socket yet.
+  let inboundGeneration = 0;
+
+  const server = createServer(
+    async (req: IncomingMessage, res: ServerResponse) => {
+      if (req.method === "GET" && req.url === "/inbound") {
+        // #2: single-consumer guard — generation counter ensures the old
+        // loop exits immediately (before consuming another message) when a
+        // new connection arrives.
+        const myGeneration = ++inboundGeneration;
+
+        res.writeHead(200, {
+          "Content-Type": "application/x-ndjson",
+          "Transfer-Encoding": "chunked",
+          "X-Accel-Buffering": "no",
+          "Cache-Control": "no-cache",
+        });
+
+        try {
+          for await (const [space, message] of app.messages) {
+            if (myGeneration !== inboundGeneration) {
+              // Kicked by a newer connection — exit before consuming.
+              break;
+            }
+            if (res.destroyed) break;
+
+            // Cache space for outbound sends
+            spaceCache.set(space.id, space);
+
+            const spaceType = (space as any).type as string | undefined;
+
+            const msg: InboundMessage = {
+              type: "message",
+              sender: message.sender?.id || "",
+              chat_id: space.id,
+              content: extractText(message.content),
+              message_id: message.id || "",
+              is_group: spaceType === "group",
+              was_mentioned: (message as any).wasMentioned === true,
+              media: extractMedia(message.content),
+            };
+
+            res.write(JSON.stringify(msg) + "\n");
+          }
+        } catch (err) {
+          if (!res.destroyed) {
+            console.error("Inbound stream error:", err);
+          }
+        }
+        if (!res.destroyed) {
+          res.end();
+        }
+        return;
+      }
+
+      if (req.method === "POST" && req.url === "/send") {
+        let body = "";
+        req.on("data", (chunk) => (body += chunk));
+        req.on("end", async () => {
+          try {
+            const { space: spaceId, text } = JSON.parse(body);
+            const target = await resolveSpace(im, spaceCache, spaceId);
+            if (!target) {
+              res.writeHead(404, { "Content-Type": "application/json" });
+              res.end(JSON.stringify({ error: `Space not found: ${spaceId}` }));
+              return;
+            }
+            await target.send(text);
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ ok: true }));
+          } catch (err: any) {
+            console.error("Send error:", err);
+            res.writeHead(500, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: err.message }));
+          }
+        });
+        return;
+      }
+
+      if (req.method === "POST" && req.url === "/send-attachment") {
+        let body = "";
+        req.on("data", (chunk) => (body += chunk));
+        req.on("end", async () => {
+          try {
+            const { space: spaceId, filePath, mimetype, fileName } =
+              JSON.parse(body);
+            const target = await resolveSpace(im, spaceCache, spaceId);
+            if (!target) {
+              res.writeHead(404, { "Content-Type": "application/json" });
+              res.end(JSON.stringify({ error: `Space not found: ${spaceId}` }));
+              return;
+            }
+
+            const att = attachment(filePath, { mimeType: mimetype });
+            await target.send(att);
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ ok: true }));
+          } catch (err: any) {
+            console.error("Send attachment error:", err);
+            res.writeHead(500, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: err.message }));
+          }
+        });
+        return;
+      }
+
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Not found" }));
+    }
+  );
+
+  server.listen(PORT, "127.0.0.1", () => {
+    console.log(`iMessage sidecar listening on http://127.0.0.1:${PORT}`);
+  });
+
+  const shutdown = async () => {
+    console.log("Shutting down...");
+    server.close();
+    await app.stop();
+    process.exit(0);
+  };
+
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+}
+
+// Only run main() when executed directly, not when imported for testing.
+const isMain =
+  process.argv[1] &&
+  (process.argv[1].endsWith("/dist/index.js") ||
+    process.argv[1].endsWith("/src/index.ts") ||
+    process.argv[1].endsWith("/src/index.js"));
+
+if (isMain) {
+  main().catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  });
+}

--- a/bridge/imessage-sidecar/tests/sidecar.test.ts
+++ b/bridge/imessage-sidecar/tests/sidecar.test.ts
@@ -32,31 +32,38 @@ function makeFakeIm(known: Record<string, any>) {
 
 describe("resolveSpace", () => {
   it("cache hit: returns cached space without SDK call", async () => {
-    const known = makeFakeSpace("dm-123");
+    const known = makeFakeSpace("any;-;+15551234567");
     const cache = new Map<string, any>();
-    cache.set("dm-123", known);
+    cache.set("any;-;+15551234567", known);
     const im = makeFakeIm({}); // empty — should never be called
 
-    const result = await resolveSpace(im, cache, "dm-123");
+    const result = await resolveSpace(im, cache, "any;-;+15551234567");
     assert.equal(result, known);
   });
 
-  it("cache miss + SDK success: resolves and caches", async () => {
-    const known = makeFakeSpace("dm-123");
+  it("cache miss + SDK resolve by phone: resolves and caches", async () => {
+    const known = makeFakeSpace("any;-;+15551234567");
     const cache = new Map<string, any>();
-    const im = makeFakeIm({ "user-1": known });
+    const im = makeFakeIm({ "+15551234567": known });
 
-    const result = await resolveSpace(im, cache, "user-1");
+    const result = await resolveSpace(im, cache, "any;-;+15551234567");
     assert.equal(result, known);
-    // Should be cached for next call
-    assert.equal(cache.get("dm-123"), known);
+    assert.equal(cache.get("any;-;+15551234567"), known);
   });
 
-  it("cache miss + SDK failure: returns null", async () => {
+  it("cache miss + non-phone spaceId: returns null immediately", async () => {
     const cache = new Map<string, any>();
-    const im = makeFakeIm({});
+    const im = makeFakeIm({}); // never called — spaceId has no phone
 
-    const result = await resolveSpace(im, cache, "unknown");
+    const result = await resolveSpace(im, cache, "opaque-group-id");
+    assert.equal(result, null);
+  });
+
+  it("cache miss + phone extraction + SDK fails: returns null", async () => {
+    const cache = new Map<string, any>();
+    const im = makeFakeIm({}); // phone not in known set
+
+    const result = await resolveSpace(im, cache, "any;-;+19999999999");
     assert.equal(result, null);
   });
 });

--- a/bridge/imessage-sidecar/tests/sidecar.test.ts
+++ b/bridge/imessage-sidecar/tests/sidecar.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for sidecar core logic (no Photon connection needed).
+ *
+ * Tests the exported resolveSpace() function with fake objects.
+ * Run with:  npx tsx --test tests/sidecar.test.ts
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolveSpace } from "../src/index.ts";
+
+// -------------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------------
+
+function makeFakeSpace(id: string) {
+  return { id, __platform: "imessage" };
+}
+
+function makeFakeIm(known: Record<string, any>) {
+  return {
+    space: (userId: string) =>
+      known[userId]
+        ? Promise.resolve(known[userId])
+        : Promise.reject(new Error(`not found: ${userId}`)),
+  };
+}
+
+// -------------------------------------------------------------------------
+// resolveSpace tests
+// -------------------------------------------------------------------------
+
+describe("resolveSpace", () => {
+  it("cache hit: returns cached space without SDK call", async () => {
+    const known = makeFakeSpace("dm-123");
+    const cache = new Map<string, any>();
+    cache.set("dm-123", known);
+    const im = makeFakeIm({}); // empty — should never be called
+
+    const result = await resolveSpace(im, cache, "dm-123");
+    assert.equal(result, known);
+  });
+
+  it("cache miss + SDK success: resolves and caches", async () => {
+    const known = makeFakeSpace("dm-123");
+    const cache = new Map<string, any>();
+    const im = makeFakeIm({ "user-1": known });
+
+    const result = await resolveSpace(im, cache, "user-1");
+    assert.equal(result, known);
+    // Should be cached for next call
+    assert.equal(cache.get("dm-123"), known);
+  });
+
+  it("cache miss + SDK failure: returns null", async () => {
+    const cache = new Map<string, any>();
+    const im = makeFakeIm({});
+
+    const result = await resolveSpace(im, cache, "unknown");
+    assert.equal(result, null);
+  });
+});
+
+// -------------------------------------------------------------------------
+// Single-consumer guard (static check — confirmed by behaviour test above)
+// -------------------------------------------------------------------------
+
+describe("single consumer", () => {
+  it("generation counter guard is present in source", async () => {
+    const fs = await import("node:fs/promises");
+    const src = await fs.readFile(
+      new URL("../src/index.ts", import.meta.url),
+      "utf-8"
+    );
+    assert.ok(src.includes("inboundGeneration"));
+    assert.ok(src.includes("myGeneration !== inboundGeneration"));
+  });
+});

--- a/bridge/imessage-sidecar/tsconfig.json
+++ b/bridge/imessage-sidecar/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/nanobot/channels/imessage.py
+++ b/nanobot/channels/imessage.py
@@ -1,0 +1,379 @@
+"""iMessage channel implementation using Photon Spectrum sidecar."""
+
+import asyncio
+import hashlib
+import json
+import mimetypes
+import os
+import shutil
+import socket
+import subprocess
+from collections import OrderedDict
+from contextlib import suppress
+from pathlib import Path
+from typing import Any, Literal
+
+import httpx
+from loguru import logger
+from pydantic import Field
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.schema import Base
+
+
+class IMessageConfig(Base):
+    """iMessage channel configuration via Photon Spectrum."""
+
+    enabled: bool = False
+    project_id: str = ""
+    project_secret: str = ""
+    sidecar_url: str = "http://127.0.0.1:8789"
+    sidecar_port: int = 8789
+    sidecar_autostart: bool = True
+    node_bin: str = ""
+    allow_from: list[str] = Field(default_factory=list)
+    group_policy: Literal["open", "mention"] = "open"
+    mention_patterns: list[str] = Field(default_factory=list)
+
+
+class IMessageChannel(BaseChannel):
+    """
+    iMessage channel that connects to a Photon Spectrum Node.js sidecar.
+
+    The sidecar uses spectrum-ts SDK to handle the iMessage protocol.
+    Communication between Python and Node.js is via HTTP loopback.
+    """
+
+    name = "imessage"
+    display_name = "iMessage"
+
+    @classmethod
+    def default_config(cls) -> dict[str, Any]:
+        return IMessageConfig().model_dump(by_alias=True)
+
+    def __init__(self, config: Any, bus: MessageBus):
+        if isinstance(config, dict):
+            config = IMessageConfig.model_validate(config)
+        super().__init__(config, bus)
+        self._proc: subprocess.Popen | None = None
+        self._client: httpx.AsyncClient | None = None
+        self._inbound_client: httpx.AsyncClient | None = None
+        self._processed_message_ids: OrderedDict[str, None] = OrderedDict()
+
+    async def login(self, force: bool = False) -> bool:
+        """
+        Check that project credentials are configured.
+
+        Returns True if project_id and project_secret are set,
+        otherwise prints instructions and returns False.
+        """
+        # TODO: device-code login
+        if self.config.project_id and self.config.project_secret:
+            return True
+        self.logger.warning(
+            "iMessage channel requires project_id and project_secret. "
+            "Get them from https://app.photon.codes → Settings."
+        )
+        return False
+
+    async def start(self) -> None:
+        """Start the iMessage channel: setup sidecar, spawn it, and stream inbound messages."""
+        try:
+            sidecar_dir = _ensure_sidecar_setup()
+        except RuntimeError:
+            self.logger.exception("Sidecar setup failed")
+            return
+
+        if self.config.sidecar_autostart:
+            self._spawn_sidecar(sidecar_dir)
+
+        self._running = True
+        # #1: separate clients for unbounded inbound stream vs normal outbound requests
+        self._client = httpx.AsyncClient(timeout=httpx.Timeout(30.0))
+        self._inbound_client = httpx.AsyncClient(timeout=None)
+
+        sidecar_url = self.config.sidecar_url
+        inbound_url = f"{sidecar_url}/inbound"
+
+        self.logger.info("Connecting to iMessage sidecar at {}...", sidecar_url)
+
+        while self._running:
+            try:
+                async with self._inbound_client.stream("GET", inbound_url) as resp:
+                    if resp.status_code != 200:
+                        body = await resp.aread()
+                        self.logger.warning(
+                            "Sidecar /inbound returned {}: {}; retrying in 5s...",
+                            resp.status_code,
+                            body[:200],
+                        )
+                        await asyncio.sleep(5)
+                        continue
+
+                    async for line in resp.aiter_lines():
+                        if not line or not self._running:
+                            continue
+                        try:
+                            data = json.loads(line)
+                            await self._handle_inbound(data)
+                        except json.JSONDecodeError:
+                            self.logger.warning("Invalid JSON from sidecar: {}", line[:100])
+                        except Exception:
+                            self.logger.exception("Error handling inbound message")
+
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                self.logger.warning("iMessage sidecar connection error: {}", e)
+                if self._running:
+                    self.logger.info("Reconnecting in 5 seconds...")
+                    await asyncio.sleep(5)
+
+    async def stop(self) -> None:
+        """Stop the iMessage channel."""
+        self._running = False
+
+        if self._client:
+            with suppress(Exception):
+                await self._client.aclose()
+            self._client = None
+
+        if self._inbound_client:
+            with suppress(Exception):
+                await self._inbound_client.aclose()
+            self._inbound_client = None
+
+        if self._proc:
+            self._proc.terminate()
+            try:
+                self._proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+                self._proc.wait()
+            self._proc = None
+
+    async def send(self, msg: OutboundMessage) -> None:
+        """Send a message through iMessage. Raises on delivery failure.
+
+        Note: after a sidecar restart, the first outbound message to a group
+        chat may fail with a 404 if no inbound message has been received yet
+        (group chat spaces are not resolvable via the SDK's user-lookup API).
+        The channel manager's retry will typically succeed once the next
+        inbound message populates the sidecar's space cache.
+        """
+        if not self._client:
+            raise RuntimeError("iMessage sidecar not connected")
+
+        # #4: nothing to send
+        if not msg.content and not msg.media:
+            self.logger.debug("send() called with empty content and media; skipping")
+            return
+
+        sidecar_url = self.config.sidecar_url
+
+        if msg.content:
+            try:
+                payload = {"space": msg.chat_id, "text": msg.content}
+                resp = await self._client.post(f"{sidecar_url}/send", json=payload)
+                resp.raise_for_status()
+            except Exception:
+                self.logger.exception("Error sending message")
+                raise
+
+        for media_path in msg.media or []:
+            try:
+                mime, _ = mimetypes.guess_type(media_path)
+                payload = {
+                    "space": msg.chat_id,
+                    "filePath": media_path,
+                    "mimetype": mime or "application/octet-stream",
+                    "fileName": media_path.rsplit("/", 1)[-1],
+                }
+                resp = await self._client.post(
+                    f"{sidecar_url}/send-attachment", json=payload
+                )
+                resp.raise_for_status()
+            except Exception:
+                self.logger.exception("Error sending media {}", media_path)
+                raise
+
+    def _spawn_sidecar(self, sidecar_dir: Path) -> None:
+        """Spawn the Node.js sidecar as a subprocess."""
+        node_bin = self.config.node_bin or shutil.which("node") or "node"
+        port = self.config.sidecar_port
+
+        # Detect orphan sidecar from a previous crash: if the port is already
+        # in use, the old process is still alive.  Fail fast instead of
+        # spawning another sidecar that will immediately fail to bind.
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.settimeout(0.5)
+            if sock.connect_ex(("127.0.0.1", port)) == 0:
+                raise RuntimeError(
+                    f"Port {port} is already in use — a sidecar from a previous "
+                    "crash may still be running. Kill it and retry."
+                )
+        finally:
+            sock.close()
+
+        env = {
+            **os.environ,
+            "PROJECT_ID": self.config.project_id,
+            "PROJECT_SECRET": self.config.project_secret,
+            "PORT": str(port),
+        }
+
+        self.logger.info("Starting iMessage sidecar (node={}, port={})...", node_bin, port)
+        self._proc = subprocess.Popen(
+            [node_bin, "dist/index.js"],
+            cwd=sidecar_dir,
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    async def _handle_inbound(self, data: dict) -> None:
+        """Handle an inbound message from the sidecar."""
+        if data.get("type") != "message":
+            return
+
+        sender = data.get("sender", "")
+        chat_id = data.get("chat_id", "")
+        content = data.get("content", "")
+        message_id = data.get("message_id", "")
+        is_group = bool(data.get("is_group", False))
+        was_mentioned = bool(data.get("was_mentioned", False))
+        raw_media = data.get("media") or []
+
+        # Group mention policy
+        if is_group and self.config.group_policy == "mention":
+            if not was_mentioned:
+                # Also check mention_patterns against content
+                hit = any(
+                    pattern in content
+                    for pattern in (self.config.mention_patterns or [])
+                )
+                if not hit:
+                    return
+
+        # Dedup
+        if message_id:
+            if message_id in self._processed_message_ids:
+                return
+            self._processed_message_ids[message_id] = None
+            while len(self._processed_message_ids) > 1000:
+                self._processed_message_ids.popitem(last=False)
+
+        # Media: sidecar sends metadata (filename + mimetype); bytes via
+        # content.read() is TODO in the sidecar.
+        # For now, tag content with [file: filename] markers.
+        # Inbound media paths are empty until content.read() is implemented;
+        # the tags below let the LLM know about attachments.
+        if raw_media:
+            for m in raw_media:
+                fname = m.get("fileName", "")
+                mime = m.get("mimetype", "")
+                if mime and mime.startswith("image/"):
+                    tag = f"[image: {fname}]"
+                else:
+                    tag = f"[file: {fname}]"
+                content = f"{content}\n{tag}" if content else tag
+
+        # TODO: voice transcription — gated on sidecar content.read() support
+
+        await self._handle_message(
+            sender_id=sender,
+            chat_id=chat_id,
+            content=content,
+            media=[],  # TODO: real paths once sidecar supports content.read()
+            metadata={
+                "message_id": message_id,
+                "is_group": is_group,
+                "was_mentioned": was_mentioned,
+            },
+            is_dm=not is_group,
+        )
+
+
+def _ensure_sidecar_setup() -> Path:
+    """
+    Ensure the iMessage sidecar is installed and built.
+
+    Copies sidecar source from the package or source tree into the runtime
+    bridge directory, using source-hash caching to skip rebuilds when nothing
+    changed.  Returns the built sidecar directory.
+
+    Raises RuntimeError if npm is not found or the sidecar cannot be built.
+    """
+    from nanobot.config.paths import get_bridge_install_dir
+
+    user_sidecar = get_bridge_install_dir() / "imessage-sidecar"
+    stamp_file = user_sidecar / ".nanobot-sidecar-source-hash"
+
+    # Find source sidecar — package tree first, then source tree
+    current_file = Path(__file__)
+    pkg_sidecar = current_file.parent.parent / "bridge" / "imessage-sidecar"
+    src_sidecar = current_file.parent.parent.parent / "bridge" / "imessage-sidecar"
+
+    source = None
+    if (pkg_sidecar / "package.json").exists():
+        source = pkg_sidecar
+    elif (src_sidecar / "package.json").exists():
+        source = src_sidecar
+
+    if not source:
+        raise RuntimeError(
+            "iMessage sidecar source not found. "
+            "Try reinstalling: pip install --force-reinstall nanobot"
+        )
+
+    def source_hash(root: Path) -> str:
+        digest = hashlib.sha256()
+        for path in sorted(root.rglob("*")):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(root)
+            if rel.parts and rel.parts[0] in {"node_modules", "dist"}:
+                continue
+            digest.update(rel.as_posix().encode("utf-8"))
+            digest.update(b"\0")
+            digest.update(path.read_bytes())
+            digest.update(b"\0")
+        return digest.hexdigest()
+
+    expected_hash = source_hash(source)
+    current_hash = stamp_file.read_text().strip() if stamp_file.exists() else None
+
+    if (user_sidecar / "dist" / "index.js").exists() and current_hash == expected_hash:
+        return user_sidecar
+
+    if (user_sidecar / "dist" / "index.js").exists() and current_hash != expected_hash:
+        logger.info("iMessage sidecar source changed; rebuilding...")
+
+    npm_path = shutil.which("npm")
+    if not npm_path:
+        raise RuntimeError("npm not found. Please install Node.js >= 18.17.")
+
+    logger.info("Setting up iMessage sidecar...")
+    user_sidecar.parent.mkdir(parents=True, exist_ok=True)
+    if user_sidecar.exists():
+        shutil.rmtree(user_sidecar)
+    shutil.copytree(
+        source, user_sidecar, ignore=shutil.ignore_patterns("node_modules", "dist")
+    )
+
+    logger.info("  Installing dependencies...")
+    subprocess.run(
+        [npm_path, "install"], cwd=user_sidecar, check=True, capture_output=True
+    )
+
+    logger.info("  Building...")
+    subprocess.run(
+        [npm_path, "run", "build"], cwd=user_sidecar, check=True, capture_output=True
+    )
+    stamp_file.write_text(expected_hash + "\n")
+
+    logger.info("iMessage sidecar ready")
+    return user_sidecar

--- a/nanobot/channels/imessage.py
+++ b/nanobot/channels/imessage.py
@@ -2,12 +2,14 @@
 
 import asyncio
 import hashlib
+import io
 import json
 import mimetypes
 import os
 import shutil
 import socket
 import subprocess
+import threading
 from collections import OrderedDict
 from contextlib import suppress
 from pathlib import Path
@@ -60,6 +62,7 @@ class IMessageChannel(BaseChannel):
         self._proc: subprocess.Popen | None = None
         self._client: httpx.AsyncClient | None = None
         self._inbound_client: httpx.AsyncClient | None = None
+        self._stderr_thread: threading.Thread | None = None
         self._processed_message_ids: OrderedDict[str, None] = OrderedDict()
 
     async def login(self, force: bool = False) -> bool:
@@ -231,8 +234,19 @@ class IMessageChannel(BaseChannel):
             cwd=sidecar_dir,
             env=env,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
         )
+        # Forward sidecar stderr to nanobot logger on a daemon thread so it
+        # never blocks the main loop.  stdout stays DEVNULL — spectrum-ts
+        # already logs to stderr via its own structured logger.
+        if self._proc.stderr:
+            self._stderr_thread = threading.Thread(
+                target=_forward_stderr,
+                args=(self._proc.stderr, self.logger),
+                daemon=True,
+            )
+            self._stderr_thread.start()
 
     async def _handle_inbound(self, data: dict) -> None:
         """Handle an inbound message from the sidecar."""
@@ -295,6 +309,18 @@ class IMessageChannel(BaseChannel):
             },
             is_dm=not is_group,
         )
+
+
+def _forward_stderr(stream: io.TextIOBase, logger: Any) -> None:
+    """Read lines from *stream* and forward them to *logger* at WARNING level.
+
+    Runs on a daemon thread so it never blocks the event loop.  Exits when
+    the stream is closed (sidecar exits or pipe is broken).
+    """
+    for line in stream:
+        line = line.rstrip("\n")
+        if line:
+            logger.warning("sidecar: {}", line)
 
 
 def _ensure_sidecar_setup() -> Path:

--- a/tests/channels/test_imessage_channel.py
+++ b/tests/channels/test_imessage_channel.py
@@ -1,0 +1,243 @@
+"""Tests for iMessage channel: send() branches, sidecar integration, space resolution."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.channels.imessage import IMessageChannel
+
+
+def _make_channel(**overrides) -> IMessageChannel:
+    """Create an IMessageChannel with a mock httpx client wired up."""
+    bus = MagicMock()
+    bus.publish_inbound = AsyncMock()
+    cfg = {"enabled": True, "project_id": "sp-test", "project_secret": "s-test", "allow_from": ["*"]}
+    cfg.update(overrides)
+    ch = IMessageChannel(cfg, bus)
+    ch._client = AsyncMock()
+    ch._running = True
+    return ch
+
+
+def _mock_response(status: int = 200, json_body: dict | None = None):
+    """Create a mock httpx response with raise_for_status wired up."""
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = json_body or {}
+    if status >= 400:
+
+        def _raise():
+            import httpx
+
+            raise httpx.HTTPStatusError("error", request=MagicMock(), response=resp)
+
+        resp.raise_for_status.side_effect = _raise
+    else:
+        resp.raise_for_status.return_value = resp
+    return resp
+
+
+# ── #4: send() four-branch coverage ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_text_only():
+    """Only text content → single POST /send."""
+    ch = _make_channel()
+    ch._client.post.return_value = _mock_response(200, {"ok": True})
+
+    msg = OutboundMessage(channel="imessage", chat_id="space-1", content="hello")
+    await ch.send(msg)
+
+    ch._client.post.assert_called_once()
+    url = ch._client.post.call_args[0][0]
+    payload = ch._client.post.call_args[1]["json"]
+    assert url.endswith("/send")
+    assert payload == {"space": "space-1", "text": "hello"}
+
+
+@pytest.mark.asyncio
+async def test_send_media_only():
+    """Only media (empty content) → single POST /send-attachment."""
+    ch = _make_channel()
+    ch._client.post.return_value = _mock_response(200, {"ok": True})
+
+    msg = OutboundMessage(
+        channel="imessage", chat_id="space-1", content="", media=["/tmp/photo.jpg"]
+    )
+    await ch.send(msg)
+
+    ch._client.post.assert_called_once()
+    url = ch._client.post.call_args[0][0]
+    payload = ch._client.post.call_args[1]["json"]
+    assert url.endswith("/send-attachment")
+    assert payload["filePath"] == "/tmp/photo.jpg"
+    assert payload["fileName"] == "photo.jpg"
+
+
+@pytest.mark.asyncio
+async def test_send_both_text_and_media():
+    """Both content and media → two POSTs: /send then /send-attachment."""
+    ch = _make_channel()
+    ch._client.post.return_value = _mock_response(200, {"ok": True})
+
+    msg = OutboundMessage(
+        channel="imessage",
+        chat_id="space-1",
+        content="check this",
+        media=["/tmp/doc.pdf"],
+    )
+    await ch.send(msg)
+
+    assert ch._client.post.call_count == 2
+    calls = ch._client.post.call_args_list
+    text_url = calls[0][0][0]
+    text_payload = calls[0][1]["json"]
+    media_url = calls[1][0][0]
+    media_payload = calls[1][1]["json"]
+
+    assert text_url.endswith("/send")
+    assert text_payload["text"] == "check this"
+    assert media_url.endswith("/send-attachment")
+    assert media_payload["filePath"] == "/tmp/doc.pdf"
+
+
+@pytest.mark.asyncio
+async def test_send_empty_skips_post():
+    """Both content and media empty → no POST at all, just debug log."""
+    ch = _make_channel()
+    ch._client.post.return_value = _mock_response(200, {"ok": True})
+
+    msg = OutboundMessage(channel="imessage", chat_id="space-1", content="", media=[])
+    await ch.send(msg)
+
+    ch._client.post.assert_not_called()
+
+
+# ── #5: client not connected → raise ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_raises_when_client_not_connected():
+    """send() must raise RuntimeError when _client is None."""
+    ch = _make_channel()
+    ch._client = None
+
+    msg = OutboundMessage(channel="imessage", chat_id="space-1", content="hi")
+    with pytest.raises(RuntimeError, match="not connected"):
+        await ch.send(msg)
+
+
+# ── #3: space resolution cold-start (sidecar 404 → raise) ─────────────
+
+
+@pytest.mark.asyncio
+async def test_send_raises_on_sidecar_404():
+    """When sidecar returns 404 (space not found), Python raises."""
+    ch = _make_channel()
+    ch._client.post.return_value = _mock_response(404, {"error": "Space not found: space-99"})
+
+    msg = OutboundMessage(channel="imessage", chat_id="space-99", content="hi")
+    with pytest.raises(Exception):
+        await ch.send(msg)
+
+
+# ── Sidecar integration mock ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sidecar_inbound_dispatches_to_handle_message():
+    """Verify that an inbound NDJSON line from sidecar triggers _handle_message."""
+    ch = _make_channel()
+    line = json.dumps({
+        "type": "message",
+        "sender": "+1234567890",
+        "chat_id": "space-1",
+        "content": "hello",
+        "message_id": "msg-001",
+        "is_group": False,
+        "was_mentioned": False,
+        "media": [],
+    })
+
+    await ch._handle_inbound(json.loads(line))
+
+    ch.bus.publish_inbound.assert_called_once()
+    inbound = ch.bus.publish_inbound.call_args[0][0]
+    assert inbound.channel == "imessage"
+    assert inbound.sender_id == "+1234567890"
+    assert inbound.content == "hello"
+
+
+@pytest.mark.asyncio
+async def test_sidecar_inbound_dedup():
+    """Duplicate message IDs are dropped."""
+    ch = _make_channel()
+    data = {
+        "type": "message",
+        "sender": "+1234567890",
+        "chat_id": "space-1",
+        "content": "hello",
+        "message_id": "msg-dup",
+        "is_group": False,
+        "was_mentioned": False,
+        "media": [],
+    }
+
+    await ch._handle_inbound(dict(data))
+    assert ch.bus.publish_inbound.call_count == 1
+
+    await ch._handle_inbound(dict(data))
+    assert ch.bus.publish_inbound.call_count == 1  # still 1
+
+
+@pytest.mark.asyncio
+async def test_sidecar_send_routing():
+    """POST /send and /send-attachment hit the correct URLs with correct payloads."""
+    ch = _make_channel()
+    ch._client.post.return_value = _mock_response(200, {"ok": True})
+
+    # text
+    await ch.send(OutboundMessage(channel="imessage", chat_id="s1", content="hi"))
+    assert ch._client.post.call_args_list[-1][0][0].endswith("/send")
+
+    # attachment
+    ch._client.post.reset_mock()
+    await ch.send(OutboundMessage(channel="imessage", chat_id="s1", content="", media=["/f.png"]))
+    assert ch._client.post.call_args_list[-1][0][0].endswith("/send-attachment")
+
+
+@pytest.mark.asyncio
+async def test_single_inbound_consumer_guard():
+    """Verify that the sidecar single-consumer guard is present in the source."""
+    import pathlib
+
+    src = (
+        pathlib.Path(__file__).parent.parent.parent
+        / "bridge"
+        / "imessage-sidecar"
+        / "src"
+        / "index.ts"
+    ).read_text()
+    assert "inboundGeneration" in src
+    assert "myGeneration !== inboundGeneration" in src
+
+def test_spawn_sidecar_raises_when_port_in_use(monkeypatch):
+    """_spawn_sidecar() should raise RuntimeError if the sidecar port is occupied."""
+    import socket
+    from pathlib import Path
+
+    ch = _make_channel()
+    ch.config.sidecar_port = 18998
+    monkeypatch.setattr("nanobot.channels.imessage.subprocess.Popen", lambda *args, **kwargs: None)
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(("127.0.0.1", ch.config.sidecar_port))
+        sock.listen(1)
+        with pytest.raises(RuntimeError, match="already in use"):
+            ch._spawn_sidecar(Path("/tmp/fake-sidecar"))
+    finally:
+        sock.close()


### PR DESCRIPTION
## What

Adds an **iMessage** chat channel backed by [Photon Spectrum](https://photon.codes/), following the same Python‑channel + Node‑sidecar pattern as the existing WhatsApp bridge. This brings iMessage to nanobot with no Mac relay and no self‑hosting — the same approach Hermes Agent uses.

iMessage has no official API, and Photon's `spectrum-ts` SDK is TypeScript‑only, so the channel is split in two:

- **`nanobot/channels/imessage.py`** — the nanobot channel (auto‑discovered by the registry, no wiring needed). Spawns and supervises the sidecar, streams inbound over loopback, POSTs outbound.
- **`bridge/imessage-sidecar/`** — a thin Node sidecar that wraps `spectrum-ts` and exposes it over HTTP loopback. It only translates; all business logic (dedup, auth/pairing, mention gating, media tagging) stays in Python.

## How it works

iMessage ⇄ Photon (spectrum-ts) ⇄ Node sidecar ⇄ HTTP loopback ⇄ Python channel ⇄ nanobot bus

- **Inbound** — sidecar consumes `app.messages` and forwards each as an NDJSON line over `GET /inbound`; Python dedupes and dispatches to the bus, reconnecting if the stream drops.
- **Outbound** — Python POSTs to `/send` (text) and `/send-attachment` (media); the sidecar resolves the space and calls `space.send(...)`.

## Setup

1. Create a project at https://app.photon.codes and grab `projectId` + `projectSecret`.
2. Node.js ≥ 18.17 on PATH.
3. Config:

   ```json
   {
     "channels": {
       "imessage": {
         "enabled": true,
         "projectId": "...",
         "projectSecret": "...",
         "sidecarUrl": "http://127.0.0.1:8789"
       }
     }
   }
   ```

4. `nanobot gateway` — the sidecar is installed/built and spawned automatically.

## Testing

- Python: 11 unit tests (`tests/channels/test_imessage_channel.py`) — `send()` branch coverage (text / media / both / empty), 404→raise, inbound dispatch, dedup, routing, single‑consumer guard, port‑in‑use detection. Full suite: `4284 passed, no new failures`.
- Sidecar (TS): 5 unit tests (resolveSpace × 4 + single‑consumer guard) via `node --test`.
- Real‑device (Photon): verified end‑to‑end against a live Photon project — inbound delivery, and outbound on cold start (`/send` with no prior inbound message succeeded after the phone‑from‑space‑ID fix in 6a946e0).

## Known limitations (tracked as TODO in code)

- Group‑chat outbound on cold start: group space IDs are opaque and can’t be resolved from a phone number; the first outbound to a group before any inbound message returns 404. The channel‑manager retry recovers once an inbound message populates the space cache.
- Inbound attachments are metadata‑only: filename + MIME type are surfaced to the agent as `[image:]` / `[file:]` tags; byte access (`content.read()`) is not wired yet.
- Voice transcription is gated on the above.
- Device‑code login not implemented; credentials are configured manually.

## Notes

- Built‑in channels are auto‑discovered, so no registry changes were needed.
- The sidecar lives in its own directory and port; it does not touch the WhatsApp bridge.