### PR TITLE
fix(webui): prevent iOS Safari auto-zoom on textarea focus

### DIFF
--- a/webui/src/components/thread/ThreadComposer.tsx
+++ b/webui/src/components/thread/ThreadComposer.tsx
@@ -1566,10 +1566,10 @@ export function ThreadComposer({
     "w-full resize-none bg-transparent",
     isHero
       ? cn(
-          "min-h-[78px] px-4 text-[15px] leading-6 sm:px-5",
+          "min-h-[78px] px-4 text-[16px] sm:text-[15px] leading-6 sm:px-5",
           relaxedHeroInput ? "pb-2 pt-[27px]" : "pb-1.5 pt-4",
         )
-      : "min-h-[50px] px-3.5 pb-1.5 pt-3 text-[13.5px] leading-5 sm:px-4",
+      : "min-h-[50px] px-3.5 pb-1.5 pt-3 text-[16px] sm:text-[13.5px] leading-5 sm:px-4",
   );
 
   return (


### PR DESCRIPTION
## Summary

Use 16px base font-size on mobile to prevent iOS Safari's automatic page zoom when focusing input fields. Desktop sizes unchanged via responsive breakpoint.

## Changes

- Changed textarea font-size from 13.5px/15px to 16px on mobile
- Added responsive breakpoints (sm:text-[15px]/sm:text-[13.5px]) to preserve desktop sizing
- Targets iOS Safari's minimum 16px threshold for auto-zoom prevention

## Testing

- Verified textarea focus no longer triggers page zoom on iOS Safari
- Desktop rendering unchanged at sm breakpoint and above
- No visual regression on desktop layouts

Fixes #4388