### PR TITLE
feat(web): configure web_fetch provider

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1621,12 +1621,12 @@ Create a key at [keenable.ai](https://keenable.ai). You can also set `KEENABLE_A
 ### Web Fetch
 
 > [!TIP]
-> If you are having issues with JS proof-of-work or Cloudflare captchas, set a random user agent and disable Jina Reader:
+> If you are having issues with JS proof-of-work or Cloudflare captchas, set a random user agent and force the local readability fetch provider:
 > ```json
-> { "tools": { "web": { "userAgent": "Not-A-Browser", "fetch": { "useJinaReader": false } } } }
+> { "tools": { "web": { "userAgent": "Not-A-Browser", "fetch": { "provider": "readability" } } } }
 > ```
 
-nanobot by default uses [Jina Reader](https://jina.ai/reader/), a third-party API, to convert arbitrary pages into Markdown format for easy digestion by the LLM, with a local fallback based on [readability-lxml](https://github.com/buriy/python-readability) if the former fails.
+nanobot by default uses automatic fetching, trying configured remote providers first and falling back to local conversion based on [readability-lxml](https://github.com/buriy/python-readability) if needed.
 
 If you want to always use the local conversion, you can force it using:
 
@@ -1635,7 +1635,7 @@ If you want to always use the local conversion, you can force it using:
   "tools": {
     "web": {
       "fetch": {
-        "useJinaReader": false
+        "provider": "readability"
       }
     }
   }
@@ -1646,7 +1646,13 @@ If you want to always use the local conversion, you can force it using:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `useJinaReader` | boolean | `true` | If true, Jina Reader will be preferred over the local conversion |
+| `enable` | boolean | `true` | Enable the `web_fetch` tool |
+| `provider` | string | `"auto"` | Fetch provider: `auto`, `tavily`, `jina`, or `readability` |
+| `apiKey` | string | `""` | API key for providers such as Tavily Extract |
+| `baseUrl` | string | `""` | Override provider base URL |
+| `timeout` | integer | `30` | Provider request timeout in seconds |
+
+Legacy `useJinaReader: false` is still accepted when `provider` is not set and is treated as `provider: "readability"`.
 
 ## Image Generation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1626,7 +1626,7 @@ Create a key at [keenable.ai](https://keenable.ai). You can also set `KEENABLE_A
 > { "tools": { "web": { "userAgent": "Not-A-Browser", "fetch": { "provider": "readability" } } } }
 > ```
 
-nanobot by default uses automatic fetching, trying configured remote providers first and falling back to local conversion based on [readability-lxml](https://github.com/buriy/python-readability) if needed.
+nanobot by default uses automatic fetching. In `auto` mode it tries Tavily Extract only when `tools.web.fetch.apiKey` or `TAVILY_API_KEY` is configured, then tries [Jina Reader](https://jina.ai/reader/), and finally falls back to local conversion based on [readability-lxml](https://github.com/buriy/python-readability) if needed.
 
 If you want to always use the local conversion, you can force it using:
 
@@ -1648,7 +1648,7 @@ If you want to always use the local conversion, you can force it using:
 |--------|------|---------|-------------|
 | `enable` | boolean | `true` | Enable the `web_fetch` tool |
 | `provider` | string | `"auto"` | Fetch provider: `auto`, `tavily`, `jina`, or `readability` |
-| `apiKey` | string | `""` | API key for providers such as Tavily Extract |
+| `apiKey` | string | `""` | API key for providers such as Tavily Extract. This is separate from `tools.web.search.apiKey` |
 | `baseUrl` | string | `""` | Override provider base URL |
 | `timeout` | integer | `30` | Provider request timeout in seconds |
 

--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -12,7 +12,7 @@ from urllib.parse import quote, urljoin, urlparse
 
 import httpx
 from loguru import logger
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from nanobot.agent.tools.base import Tool, tool_parameters
 from nanobot.agent.tools.schema import (
@@ -46,7 +46,25 @@ class WebSearchConfig(Base):
 
 class WebFetchConfig(Base):
     """Web fetch tool configuration."""
-    use_jina_reader: bool = True
+    enable: bool = True
+    provider: str = "auto"  # auto | tavily | jina | readability
+    api_key: str = ""
+    base_url: str = ""
+    timeout: int = 30
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_legacy_jina_reader(cls, data: Any) -> Any:
+        """Map legacy useJinaReader=false to provider=readability."""
+        if not isinstance(data, dict):
+            return data
+        has_provider = bool(data.get("provider"))
+        if has_provider:
+            return data
+        legacy = data.get("useJinaReader", data.get("use_jina_reader"))
+        if legacy is False:
+            return {**data, "provider": "readability"}
+        return data
 
 
 class WebToolsConfig(Base):
@@ -855,7 +873,7 @@ class WebFetchTool(Tool):
 
     @classmethod
     def enabled(cls, ctx: Any) -> bool:
-        return ctx.config.web.enable
+        return bool(ctx.config.web.enable and ctx.config.web.fetch.enable)
 
     @classmethod
     def create(cls, ctx: Any) -> Tool:
@@ -863,13 +881,22 @@ class WebFetchTool(Tool):
             config=ctx.config.web.fetch,
             proxy=ctx.config.web.proxy,
             user_agent=ctx.config.web.user_agent,
+            search_api_key=ctx.config.web.search.api_key,
         )
 
-    def __init__(self, config: WebFetchConfig | None = None, proxy: str | None = None, user_agent: str | None = None, max_chars: int = 50000):
+    def __init__(
+        self,
+        config: WebFetchConfig | None = None,
+        proxy: str | None = None,
+        user_agent: str | None = None,
+        max_chars: int = 50000,
+        search_api_key: str = "",
+    ):
         self.config = config if config is not None else WebFetchConfig()
         self.proxy = proxy
         self.user_agent = user_agent or _DEFAULT_USER_AGENT
         self.max_chars = max_chars
+        self.search_api_key = search_api_key
 
     @property
     def read_only(self) -> bool:
@@ -914,12 +941,77 @@ class WebFetchTool(Tool):
         except Exception as e:
             logger.debug("Pre-fetch image detection failed for {}: {}", url, e)
 
+        provider = (self.config.provider or "auto").strip().lower()
+        if provider not in {"auto", "tavily", "jina", "readability", "local"}:
+            return json.dumps({"error": f"Unknown fetch provider: {provider}", "url": url}, ensure_ascii=False)
+
         result = None
-        if self.config.use_jina_reader:
+        if provider in {"auto", "tavily"}:
+            result = await self._fetch_tavily(url, extract_mode, max_chars)
+            if result is not None or provider == "tavily":
+                return result or await self._fetch_readability(url, extract_mode, max_chars)
+
+        if provider in {"auto", "jina"}:
             result = await self._fetch_jina(url, max_chars)
-        if result is None:
-            result = await self._fetch_readability(url, extract_mode, max_chars)
-        return result
+            if result is not None or provider == "jina":
+                return result or await self._fetch_readability(url, extract_mode, max_chars)
+
+        return await self._fetch_readability(url, extract_mode, max_chars)
+
+    def _tavily_api_key(self) -> str:
+        return (
+            self.config.api_key.strip()
+            or os.environ.get("TAVILY_API_KEY", "").strip()
+            or self.search_api_key.strip()
+        )
+
+    async def _fetch_tavily(self, url: str, extract_mode: str, max_chars: int) -> str | None:
+        """Try fetching via Tavily Extract API. Returns None on failure."""
+        api_key = self._tavily_api_key()
+        if not api_key:
+            logger.debug("Tavily Extract API key not configured, falling back")
+            return None
+        try:
+            base_url = (self.config.base_url or "https://api.tavily.com").rstrip("/")
+            timeout = max(int(self.config.timeout or 30), 1)
+            payload = {
+                "urls": [url],
+                "extract_depth": "advanced",
+                "format": "text" if extract_mode == "text" else "markdown",
+                "include_images": False,
+            }
+            headers = {
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+                "User-Agent": self.user_agent,
+            }
+            async with httpx.AsyncClient(proxy=self.proxy, timeout=timeout) as client:
+                r = await client.post(f"{base_url}/extract", headers=headers, json=payload)
+                if r.status_code == 429:
+                    logger.debug("Tavily Extract rate limited, falling back")
+                    return None
+                r.raise_for_status()
+
+            data = r.json()
+            results = data.get("results", []) or []
+            if not results:
+                return None
+            item = results[0]
+            text = item.get("raw_content") or item.get("content") or ""
+            if not text:
+                return None
+            truncated = len(text) > max_chars
+            if truncated:
+                text = text[:max_chars]
+            text = f"{_UNTRUSTED_BANNER}\n\n{text}"
+            return json.dumps({
+                "url": url, "finalUrl": item.get("url", url), "status": r.status_code,
+                "extractor": "tavily", "truncated": truncated, "length": len(text),
+                "untrusted": True, "text": text,
+            }, ensure_ascii=False)
+        except Exception as e:
+            logger.debug("Tavily Extract failed for {}, falling back: {}", url, e)
+            return None
 
     async def _fetch_jina(self, url: str, max_chars: int) -> str | None:
         """Try fetching via Jina Reader API. Returns None on failure."""

--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -881,7 +881,6 @@ class WebFetchTool(Tool):
             config=ctx.config.web.fetch,
             proxy=ctx.config.web.proxy,
             user_agent=ctx.config.web.user_agent,
-            search_api_key=ctx.config.web.search.api_key,
         )
 
     def __init__(
@@ -890,13 +889,11 @@ class WebFetchTool(Tool):
         proxy: str | None = None,
         user_agent: str | None = None,
         max_chars: int = 50000,
-        search_api_key: str = "",
     ):
         self.config = config if config is not None else WebFetchConfig()
         self.proxy = proxy
         self.user_agent = user_agent or _DEFAULT_USER_AGENT
         self.max_chars = max_chars
-        self.search_api_key = search_api_key
 
     @property
     def read_only(self) -> bool:
@@ -942,7 +939,7 @@ class WebFetchTool(Tool):
             logger.debug("Pre-fetch image detection failed for {}: {}", url, e)
 
         provider = (self.config.provider or "auto").strip().lower()
-        if provider not in {"auto", "tavily", "jina", "readability", "local"}:
+        if provider not in {"auto", "tavily", "jina", "readability"}:
             return json.dumps({"error": f"Unknown fetch provider: {provider}", "url": url}, ensure_ascii=False)
 
         result = None
@@ -962,7 +959,6 @@ class WebFetchTool(Tool):
         return (
             self.config.api_key.strip()
             or os.environ.get("TAVILY_API_KEY", "").strip()
-            or self.search_api_key.strip()
         )
 
     async def _fetch_tavily(self, url: str, extract_mode: str, max_chars: int) -> str | None:

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -1353,7 +1353,7 @@ def update_web_search_settings(query: QueryParams) -> dict[str, Any]:
     fetch_provider = _query_first_alias(query, "fetch_provider", "fetchProvider")
     if fetch_provider is not None:
         normalized_provider = fetch_provider.strip().lower()
-        if normalized_provider not in {"auto", "tavily", "jina", "readability", "local"}:
+        if normalized_provider not in {"auto", "tavily", "jina", "readability"}:
             raise WebUISettingsError("unknown web fetch provider")
         previous = web_config.fetch.provider
         set_fetch_value("provider", normalized_provider)

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -840,7 +840,11 @@ def settings_payload(
                 "timeout": search_config.timeout,
             },
             "fetch": {
-                "use_jina_reader": config.tools.web.fetch.use_jina_reader,
+                "enable": config.tools.web.fetch.enable,
+                "provider": config.tools.web.fetch.provider,
+                "api_key_hint": _mask_secret_hint(config.tools.web.fetch.api_key),
+                "base_url": config.tools.web.fetch.base_url or None,
+                "timeout": config.tools.web.fetch.timeout,
             },
         },
         "image_generation": {
@@ -1283,10 +1287,11 @@ def update_web_search_settings(query: QueryParams) -> dict[str, Any]:
             changed = True
 
     def set_fetch_value(attr: str, value: object) -> None:
-        nonlocal changed
+        nonlocal changed, restart_required
         if getattr(web_config.fetch, attr) != value:
             setattr(web_config.fetch, attr, value)
             changed = True
+            restart_required = True
 
     if search_config.provider != provider_name:
         search_config.provider = provider_name
@@ -1335,15 +1340,53 @@ def update_web_search_settings(query: QueryParams) -> dict[str, Any]:
             raise WebUISettingsError("timeout must be between 1 and 120")
         set_search_value("timeout", parsed_timeout)
 
-    use_jina_reader = _query_first_alias(query, "use_jina_reader", "useJinaReader")
-    if use_jina_reader is not None:
-        normalized = use_jina_reader.strip().lower()
+    fetch_enable = _query_first_alias(query, "fetch_enable", "fetchEnable")
+    if fetch_enable is not None:
+        normalized = fetch_enable.strip().lower()
         if normalized not in {"1", "0", "true", "false", "yes", "no"}:
-            raise WebUISettingsError("use_jina_reader must be boolean")
-        previous_jina_reader = web_config.fetch.use_jina_reader
-        set_fetch_value("use_jina_reader", normalized in {"1", "true", "yes"})
-        if web_config.fetch.use_jina_reader != previous_jina_reader:
+            raise WebUISettingsError("fetch_enable must be boolean")
+        previous = web_config.fetch.enable
+        set_fetch_value("enable", normalized in {"1", "true", "yes"})
+        if web_config.fetch.enable != previous:
             restart_required = True
+
+    fetch_provider = _query_first_alias(query, "fetch_provider", "fetchProvider")
+    if fetch_provider is not None:
+        normalized_provider = fetch_provider.strip().lower()
+        if normalized_provider not in {"auto", "tavily", "jina", "readability", "local"}:
+            raise WebUISettingsError("unknown web fetch provider")
+        previous = web_config.fetch.provider
+        set_fetch_value("provider", normalized_provider)
+        if web_config.fetch.provider != previous:
+            restart_required = True
+    else:
+        use_jina_reader = _query_first_alias(query, "use_jina_reader", "useJinaReader")
+        if use_jina_reader is not None:
+            normalized = use_jina_reader.strip().lower()
+            if normalized not in {"1", "0", "true", "false", "yes", "no"}:
+                raise WebUISettingsError("use_jina_reader must be boolean")
+            set_fetch_value(
+                "provider",
+                "auto" if normalized in {"1", "true", "yes"} else "readability",
+            )
+
+    fetch_api_key = _query_first_alias(query, "fetch_api_key", "fetchApiKey")
+    if fetch_api_key is not None:
+        set_fetch_value("api_key", fetch_api_key.strip())
+
+    fetch_base_url = _query_first_alias(query, "fetch_base_url", "fetchBaseUrl")
+    if fetch_base_url is not None:
+        set_fetch_value("base_url", fetch_base_url.strip())
+
+    fetch_timeout = _query_first_alias(query, "fetch_timeout", "fetchTimeout")
+    if fetch_timeout is not None:
+        try:
+            parsed_fetch_timeout = int(fetch_timeout)
+        except ValueError:
+            raise WebUISettingsError("fetch_timeout must be an integer") from None
+        if parsed_fetch_timeout < 1 or parsed_fetch_timeout > 120:
+            raise WebUISettingsError("fetch_timeout must be between 1 and 120")
+        set_fetch_value("timeout", parsed_fetch_timeout)
 
     if changed:
         save_config(config)

--- a/tests/channels/test_websocket_channel.py
+++ b/tests/channels/test_websocket_channel.py
@@ -1761,7 +1761,8 @@ async def test_settings_api_returns_safe_subset_and_updates_whitelist(
         assert body["web_search"]["provider"] == "brave"
         assert body["web_search"]["api_key_hint"] == "brav••••cret"
         assert body["web_search"]["max_results"] == 5
-        assert body["web"]["fetch"]["use_jina_reader"] is True
+        assert body["web"]["fetch"]["enable"] is True
+        assert body["web"]["fetch"]["provider"] == "auto"
         search_providers = {provider["name"]: provider for provider in body["web_search"]["providers"]}
         assert search_providers["duckduckgo"]["credential"] == "none"
         assert search_providers["exa"]["credential"] == "api_key"
@@ -1900,7 +1901,7 @@ async def test_settings_api_returns_safe_subset_and_updates_whitelist(
             "http://127.0.0.1:"
             f"{port}/api/settings/web-search/update?provider=searxng"
             "&base_url=https%3A%2F%2Fsearch.example.com"
-            "&max_results=8&timeout=45&use_jina_reader=false",
+            "&max_results=8&timeout=45&fetch_provider=readability",
             headers={"Authorization": "Bearer tok"},
         )
         assert search_updated.status_code == 200
@@ -1911,7 +1912,7 @@ async def test_settings_api_returns_safe_subset_and_updates_whitelist(
         assert search_body["web_search"]["api_key_hint"] is None
         assert search_body["web_search"]["base_url"] == "https://search.example.com"
         assert search_body["web_search"]["max_results"] == 8
-        assert search_body["web"]["fetch"]["use_jina_reader"] is False
+        assert search_body["web"]["fetch"]["provider"] == "readability"
 
         network_safety_updated = await _http_get(
             "http://127.0.0.1:"
@@ -1992,7 +1993,7 @@ async def test_settings_api_returns_safe_subset_and_updates_whitelist(
         assert saved.tools.web.search.base_url == "https://search.example.com"
         assert saved.tools.web.search.max_results == 8
         assert saved.tools.web.search.timeout == 45
-        assert saved.tools.web.fetch.use_jina_reader is False
+        assert saved.tools.web.fetch.provider == "readability"
         assert saved.tools.webui_allow_local_service_access is False
         assert saved.tools.image_generation.enabled is True
         assert saved.tools.image_generation.provider == "openrouter"

--- a/tests/tools/test_tool_loader.py
+++ b/tests/tools/test_tool_loader.py
@@ -298,6 +298,17 @@ def test_web_fetch_tool_create():
     assert isinstance(tool, WebFetchTool)
 
 
+def test_web_fetch_tool_enabled_uses_fetch_toggle():
+    from nanobot.agent.tools.web import WebFetchTool
+    mock_config = MagicMock()
+    mock_config.web.enable = True
+    mock_config.web.fetch.enable = True
+    ctx = ToolContext(config=mock_config, workspace="/tmp")
+    assert WebFetchTool.enabled(ctx) is True
+    mock_config.web.fetch.enable = False
+    assert WebFetchTool.enabled(ctx) is False
+
+
 def test_image_gen_tool_config_cls():
     from nanobot.agent.tools.image_generation import ImageGenerationTool, ImageGenerationToolConfig
     assert ImageGenerationTool.config_key == "image_generation"

--- a/tests/tools/test_web_fetch_security.py
+++ b/tests/tools/test_web_fetch_security.py
@@ -29,6 +29,11 @@ def _fake_resolve_public(hostname, port, family=0, type_=0):
     return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
 
 
+def test_web_fetch_legacy_use_jina_reader_false_maps_to_readability():
+    cfg = WebFetchConfig.model_validate({"useJinaReader": False})
+    assert cfg.provider == "readability"
+
+
 @pytest.mark.asyncio
 async def test_web_fetch_blocks_private_ip():
     tool = WebFetchTool()
@@ -100,7 +105,7 @@ async def test_web_fetch_result_contains_untrusted_flag():
 @pytest.mark.asyncio
 async def test_web_fetch_can_skip_jina_and_use_custom_user_agent(monkeypatch):
     tool = WebFetchTool(
-        config=WebFetchConfig(use_jina_reader=False),
+        config=WebFetchConfig(provider="readability"),
         user_agent="nanobot-test-agent",
     )
     seen_headers: list[dict] = []
@@ -166,8 +171,66 @@ async def test_web_fetch_can_skip_jina_and_use_custom_user_agent(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_web_fetch_tavily_provider_uses_extract(monkeypatch):
+    tool = WebFetchTool(
+        config=WebFetchConfig(provider="tavily"),
+        search_api_key="tavily-key",
+        user_agent="nanobot-test-agent",
+    )
+    seen: dict[str, object] = {}
+
+    async def _skip_prefetch(*args, **kwargs):
+        raise RuntimeError("skip image prefetch")
+
+    class FakeResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "results": [
+                    {
+                        "url": "https://example.com/page",
+                        "raw_content": "Extracted with Tavily",
+                    }
+                ]
+            }
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, headers=None, json=None, **kwargs):
+            seen["url"] = url
+            seen["headers"] = headers
+            seen["json"] = json
+            return FakeResponse()
+
+    monkeypatch.setattr("nanobot.agent.tools.web._stream_with_safe_redirects", _skip_prefetch)
+    monkeypatch.setattr("nanobot.agent.tools.web.httpx.AsyncClient", FakeClient)
+
+    with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve_public):
+        result = await tool.execute(url="https://example.com/page")
+
+    data = json.loads(result)
+    assert data["extractor"] == "tavily"
+    assert "Extracted with Tavily" in data["text"]
+    assert seen["url"] == "https://api.tavily.com/extract"
+    assert seen["headers"]["Authorization"] == "Bearer tavily-key"
+    assert seen["json"]["urls"] == ["https://example.com/page"]
+
+
+@pytest.mark.asyncio
 async def test_web_fetch_falls_back_when_readability_dependency_is_missing(monkeypatch):
-    tool = WebFetchTool(config=WebFetchConfig(use_jina_reader=False))
+    tool = WebFetchTool(config=WebFetchConfig(provider="readability"))
 
     class FakeResponse:
         status_code = 200
@@ -208,7 +271,7 @@ async def test_web_fetch_falls_back_when_readability_dependency_is_missing(monke
 
 @pytest.mark.asyncio
 async def test_web_fetch_blocks_private_redirect_before_readability_request(monkeypatch):
-    tool = WebFetchTool(config=WebFetchConfig(use_jina_reader=False))
+    tool = WebFetchTool(config=WebFetchConfig(provider="readability"))
     requested: list[str] = []
 
     class FakeStreamResponse:
@@ -270,7 +333,7 @@ async def test_web_fetch_blocks_private_redirect_before_readability_request(monk
 
 @pytest.mark.asyncio
 async def test_web_fetch_blocks_private_redirect_before_returning_image(monkeypatch):
-    tool = WebFetchTool(config=WebFetchConfig(use_jina_reader=False))
+    tool = WebFetchTool(config=WebFetchConfig(provider="readability"))
 
     def handler(request: httpx.Request) -> httpx.Response:
         if str(request.url) == "https://example.com/image.png":
@@ -313,7 +376,7 @@ async def test_web_fetch_blocks_private_redirect_before_returning_image(monkeypa
 
 @pytest.mark.asyncio
 async def test_web_fetch_does_not_request_private_redirect_target(monkeypatch):
-    tool = WebFetchTool(config=WebFetchConfig(use_jina_reader=False))
+    tool = WebFetchTool(config=WebFetchConfig(provider="readability"))
     requested: list[str] = []
 
     def handler(request: httpx.Request) -> httpx.Response:

--- a/tests/tools/test_web_fetch_security.py
+++ b/tests/tools/test_web_fetch_security.py
@@ -35,6 +35,20 @@ def test_web_fetch_legacy_use_jina_reader_false_maps_to_readability():
 
 
 @pytest.mark.asyncio
+async def test_web_fetch_rejects_local_provider_alias(monkeypatch):
+    tool = WebFetchTool(config=WebFetchConfig(provider="local"))
+
+    async def _skip_prefetch(*args, **kwargs):
+        raise RuntimeError("skip image prefetch")
+
+    monkeypatch.setattr("nanobot.agent.tools.web._stream_with_safe_redirects", _skip_prefetch)
+    with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve_public):
+        result = await tool.execute(url="https://example.com/page")
+    data = json.loads(result)
+    assert data["error"] == "Unknown fetch provider: local"
+
+
+@pytest.mark.asyncio
 async def test_web_fetch_blocks_private_ip():
     tool = WebFetchTool()
     with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve_private):
@@ -173,8 +187,7 @@ async def test_web_fetch_can_skip_jina_and_use_custom_user_agent(monkeypatch):
 @pytest.mark.asyncio
 async def test_web_fetch_tavily_provider_uses_extract(monkeypatch):
     tool = WebFetchTool(
-        config=WebFetchConfig(provider="tavily"),
-        search_api_key="tavily-key",
+        config=WebFetchConfig(provider="tavily", api_key="tavily-key"),
         user_agent="nanobot-test-agent",
     )
     seen: dict[str, object] = {}
@@ -226,6 +239,12 @@ async def test_web_fetch_tavily_provider_uses_extract(monkeypatch):
     assert seen["url"] == "https://api.tavily.com/extract"
     assert seen["headers"]["Authorization"] == "Bearer tavily-key"
     assert seen["json"]["urls"] == ["https://example.com/page"]
+
+
+def test_web_fetch_tavily_key_does_not_use_search_key(monkeypatch):
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    tool = WebFetchTool(config=WebFetchConfig(provider="tavily"))
+    assert tool._tavily_api_key() == ""
 
 
 @pytest.mark.asyncio

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -384,6 +384,9 @@ const DEFAULT_WEB_SEARCH_FORM: WebSearchSettingsUpdate = {
   maxResults: 5,
   timeout: 30,
   fetchProvider: "auto",
+  fetchApiKey: "",
+  fetchBaseUrl: "",
+  fetchTimeout: 30,
 };
 
 const WEB_FETCH_PROVIDERS = [
@@ -460,6 +463,9 @@ function webSearchFormFromPayload(
     maxResults: payload.web_search.max_results,
     timeout: payload.web_search.timeout,
     fetchProvider: payload.web.fetch.provider,
+    fetchApiKey: "",
+    fetchBaseUrl: payload.web.fetch.base_url ?? "",
+    fetchTimeout: payload.web.fetch.timeout,
   };
 }
 
@@ -610,6 +616,8 @@ export function SettingsView({
   );
   const [webSearchKeyVisible, setWebSearchKeyVisible] = useState(false);
   const [webSearchKeyEditing, setWebSearchKeyEditing] = useState(false);
+  const [webFetchKeyVisible, setWebFetchKeyVisible] = useState(false);
+  const [webFetchKeyEditing, setWebFetchKeyEditing] = useState(false);
   const [form, setForm] = useState<AgentSettingsDraft>(() =>
     initialSettings ? agentDraftFromPayload(initialSettings) : DEFAULT_AGENT_SETTINGS_DRAFT,
   );
@@ -1176,17 +1184,30 @@ export function SettingsView({
 
     setWebSearchSaving(true);
     try {
+      const fetchProviderChanged =
+        (webSearchForm.fetchProvider ?? settings.web.fetch.provider) !== settings.web.fetch.provider;
+      const fetchBaseUrlChanged =
+        (webSearchForm.fetchBaseUrl ?? settings.web.fetch.base_url ?? "") !==
+        (settings.web.fetch.base_url ?? "");
+      const fetchTimeoutChanged =
+        (webSearchForm.fetchTimeout ?? settings.web.fetch.timeout) !== settings.web.fetch.timeout;
       const webFetchRestartRequired =
-        (webSearchForm.fetchProvider ?? settings.web.fetch.provider) !==
-        settings.web.fetch.provider;
+        fetchProviderChanged ||
+        fetchBaseUrlChanged ||
+        fetchTimeoutChanged ||
+        !!webSearchForm.fetchApiKey?.trim();
       const update: WebSearchSettingsUpdate = {
         provider: webSearchForm.provider,
         maxResults: webSearchForm.maxResults,
         timeout: webSearchForm.timeout,
         fetchProvider: webSearchForm.fetchProvider,
+        fetchBaseUrl: webSearchForm.fetchBaseUrl ?? "",
+        fetchTimeout: webSearchForm.fetchTimeout,
       };
       if (provider.credential === "api_key" && apiKey) update.apiKey = apiKey;
       if (provider.credential === "base_url") update.baseUrl = baseUrl;
+      const fetchApiKey = webSearchForm.fetchApiKey?.trim() ?? "";
+      if (fetchApiKey) update.fetchApiKey = fetchApiKey;
       const payload = await updateWebSearchSettings(token, update);
       applyPayload(payload);
       if (payload.requires_restart || webFetchRestartRequired) {
@@ -1200,9 +1221,14 @@ export function SettingsView({
         maxResults: payload.web_search.max_results,
         timeout: payload.web_search.timeout,
         fetchProvider: payload.web.fetch.provider,
+        fetchApiKey: "",
+        fetchBaseUrl: payload.web.fetch.base_url ?? "",
+        fetchTimeout: payload.web.fetch.timeout,
       }));
       setWebSearchKeyVisible(false);
       setWebSearchKeyEditing(false);
+      setWebFetchKeyVisible(false);
+      setWebFetchKeyEditing(false);
       setError(null);
     } catch (err) {
       setError((err as Error).message);
@@ -1240,9 +1266,14 @@ export function SettingsView({
       maxResults: settings.web_search.max_results,
       timeout: settings.web_search.timeout,
       fetchProvider: settings.web.fetch.provider,
+      fetchApiKey: "",
+      fetchBaseUrl: settings.web.fetch.base_url ?? "",
+      fetchTimeout: settings.web.fetch.timeout,
     });
     setWebSearchKeyVisible(false);
     setWebSearchKeyEditing(false);
+    setWebFetchKeyVisible(false);
+    setWebFetchKeyEditing(false);
   }, [settings]);
 
   const handleWebSearchProviderChange = useCallback((provider: string) => {
@@ -1254,6 +1285,9 @@ export function SettingsView({
       maxResults: prev.maxResults ?? settings.web_search.max_results,
       timeout: prev.timeout ?? settings.web_search.timeout,
       fetchProvider: prev.fetchProvider ?? settings.web.fetch.provider,
+      fetchApiKey: prev.fetchApiKey ?? "",
+      fetchBaseUrl: prev.fetchBaseUrl ?? settings.web.fetch.base_url ?? "",
+      fetchTimeout: prev.fetchTimeout ?? settings.web.fetch.timeout,
     }));
     setWebSearchKeyVisible(false);
     setWebSearchKeyEditing(false);
@@ -1558,6 +1592,8 @@ export function SettingsView({
             form={webSearchForm}
             keyVisible={webSearchKeyVisible}
             keyEditing={webSearchKeyEditing}
+            fetchKeyVisible={webFetchKeyVisible}
+            fetchKeyEditing={webFetchKeyEditing}
             saving={webSearchSaving}
             onChangeForm={setWebSearchForm}
             onChangeProvider={handleWebSearchProviderChange}
@@ -1566,6 +1602,12 @@ export function SettingsView({
               setWebSearchKeyEditing((editing) => !editing);
               setWebSearchKeyVisible(false);
               setWebSearchForm((prev) => ({ ...prev, apiKey: "" }));
+            }}
+            onToggleFetchKey={() => setWebFetchKeyVisible((visible) => !visible)}
+            onToggleFetchKeyEditing={() => {
+              setWebFetchKeyEditing((editing) => !editing);
+              setWebFetchKeyVisible(false);
+              setWebSearchForm((prev) => ({ ...prev, fetchApiKey: "" }));
             }}
             onReset={resetWebSearchDraft}
             onSave={saveWebSearch}
@@ -3191,11 +3233,15 @@ function WebSettings({
   form,
   keyVisible,
   keyEditing,
+  fetchKeyVisible,
+  fetchKeyEditing,
   saving,
   onChangeForm,
   onChangeProvider,
   onToggleKey,
   onToggleKeyEditing,
+  onToggleFetchKey,
+  onToggleFetchKeyEditing,
   onReset,
   onSave,
   showBrandLogos,
@@ -3207,11 +3253,15 @@ function WebSettings({
   form: WebSearchSettingsUpdate;
   keyVisible: boolean;
   keyEditing: boolean;
+  fetchKeyVisible: boolean;
+  fetchKeyEditing: boolean;
   saving: boolean;
   onChangeForm: Dispatch<SetStateAction<WebSearchSettingsUpdate>>;
   onChangeProvider: (provider: string) => void;
   onToggleKey: () => void;
   onToggleKeyEditing: () => void;
+  onToggleFetchKey: () => void;
+  onToggleFetchKeyEditing: () => void;
   onReset: () => void;
   onSave: () => void;
   showBrandLogos: boolean;
@@ -3232,14 +3282,27 @@ function WebSettings({
   const apiKey = form.apiKey?.trim() ?? "";
   const baseUrl = form.baseUrl?.trim() ?? "";
   const effectiveFetchProvider = form.fetchProvider ?? settings.web.fetch.provider;
+  const fetchApiKey = form.fetchApiKey?.trim() ?? "";
+  const fetchBaseUrl = form.fetchBaseUrl?.trim() ?? "";
+  const effectiveFetchTimeout = form.fetchTimeout ?? settings.web.fetch.timeout;
+  const showTavilyFetchConfig = effectiveFetchProvider === "auto" || effectiveFetchProvider === "tavily";
+  const hasExistingFetchSecret = !!settings.web.fetch.api_key_hint;
+  const showFetchKeyInput = showTavilyFetchConfig && (!hasExistingFetchSecret || fetchKeyEditing);
   const dirty =
     form.provider !== settings.web_search.provider ||
     apiKey.length > 0 ||
     baseUrl !== (settings.web_search.base_url ?? "") ||
     form.maxResults !== settings.web_search.max_results ||
     form.timeout !== settings.web_search.timeout ||
-    effectiveFetchProvider !== settings.web.fetch.provider;
-  const fetchProviderDirty = effectiveFetchProvider !== settings.web.fetch.provider;
+    effectiveFetchProvider !== settings.web.fetch.provider ||
+    fetchApiKey.length > 0 ||
+    fetchBaseUrl !== (settings.web.fetch.base_url ?? "") ||
+    effectiveFetchTimeout !== settings.web.fetch.timeout;
+  const fetchSettingsDirty =
+    effectiveFetchProvider !== settings.web.fetch.provider ||
+    fetchApiKey.length > 0 ||
+    fetchBaseUrl !== (settings.web.fetch.base_url ?? "") ||
+    effectiveFetchTimeout !== settings.web.fetch.timeout;
   const missingCredential =
     selectedProvider?.credential === "api_key"
       ? !apiKey && !hasExistingSecret
@@ -3388,6 +3451,91 @@ function WebSettings({
               onChange={(fetchProvider) => onChangeForm((prev) => ({ ...prev, fetchProvider }))}
             />
           </SettingsRow>
+          {showTavilyFetchConfig ? (
+            <>
+              <SettingsRow
+                title={tx("settings.rows.fetchApiKey", "Tavily Extract API key")}
+                description={tx("settings.help.fetchApiKey", "Used by web_fetch for Tavily Extract. Leave blank to use TAVILY_API_KEY from the gateway environment.")}
+              >
+                <div className="relative w-[280px] max-w-full">
+                  {showFetchKeyInput ? (
+                    <>
+                      <Input
+                        type={fetchKeyVisible ? "text" : "password"}
+                        value={form.fetchApiKey ?? ""}
+                        onChange={(event) =>
+                          onChangeForm((prev) => ({ ...prev, fetchApiKey: event.target.value }))
+                        }
+                        placeholder={
+                          hasExistingFetchSecret
+                            ? t("settings.byok.apiKeyConfiguredPlaceholder")
+                            : t("settings.byok.apiKeyPlaceholder")
+                        }
+                        className="h-9 rounded-full pr-11 text-[13px]"
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={onToggleFetchKey}
+                        aria-label={
+                          fetchKeyVisible ? t("settings.byok.hideApiKey") : t("settings.byok.showApiKey")
+                        }
+                        className="absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2 rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
+                      >
+                        {fetchKeyVisible ? (
+                          <EyeOff className="h-3.5 w-3.5" aria-hidden />
+                        ) : (
+                          <Eye className="h-3.5 w-3.5" aria-hidden />
+                        )}
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      <div className="flex h-9 items-center rounded-full border border-input bg-background px-3 pr-11 text-[13px] text-muted-foreground">
+                        {settings.web.fetch.api_key_hint ?? t("settings.byok.configuredKeyHint")}
+                      </div>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={onToggleFetchKeyEditing}
+                        aria-label={t("settings.actions.edit")}
+                        className="absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2 rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
+                      >
+                        <Pencil className="h-3.5 w-3.5" aria-hidden />
+                      </Button>
+                    </>
+                  )}
+                </div>
+              </SettingsRow>
+              <SettingsRow
+                title={tx("settings.rows.fetchBaseUrl", "Tavily Extract base URL")}
+                description={tx("settings.help.fetchBaseUrl", "Optional override for Tavily-compatible extract endpoints.")}
+              >
+                <Input
+                  value={form.fetchBaseUrl ?? ""}
+                  onChange={(event) =>
+                    onChangeForm((prev) => ({ ...prev, fetchBaseUrl: event.target.value }))
+                  }
+                  placeholder="https://api.tavily.com"
+                  className="h-9 w-[280px] rounded-full text-[13px]"
+                />
+              </SettingsRow>
+            </>
+          ) : null}
+          <SettingsRow
+            title={tx("settings.rows.fetchTimeout", "Fetch timeout")}
+            description={tx("settings.help.fetchTimeout", "Seconds before a web_fetch provider request times out.")}
+          >
+            <NumberInput
+              value={effectiveFetchTimeout}
+              min={1}
+              max={120}
+              onChange={(fetchTimeout) => onChangeForm((prev) => ({ ...prev, fetchTimeout }))}
+              suffix="s"
+            />
+          </SettingsRow>
           <RestartSettingsFooter
             dirty={dirty}
             saving={saving}
@@ -3398,7 +3546,7 @@ function WebSettings({
                 ? t("settings.byok.webSearch.missingCredential")
                 : requiresRestartPending && !dirty
                   ? tx("settings.status.savedRestartApply", "Saved. Restart when ready.")
-                  : fetchProviderDirty
+                  : fetchSettingsDirty
                     ? tx("settings.status.restartAfterSaving", "Save changes, then restart when ready.")
                     : dirty
                       ? t("settings.byok.webSearch.saveHint")

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -383,8 +383,15 @@ const DEFAULT_WEB_SEARCH_FORM: WebSearchSettingsUpdate = {
   baseUrl: "",
   maxResults: 5,
   timeout: 30,
-  useJinaReader: true,
+  fetchProvider: "auto",
 };
+
+const WEB_FETCH_PROVIDERS = [
+  { name: "auto", label: "Auto" },
+  { name: "tavily", label: "Tavily Extract" },
+  { name: "jina", label: "Jina Reader" },
+  { name: "readability", label: "Local readability" },
+];
 
 const DEFAULT_IMAGE_GENERATION_FORM: ImageGenerationSettingsUpdate = {
   enabled: false,
@@ -452,7 +459,7 @@ function webSearchFormFromPayload(
     baseUrl: payload.web_search.base_url ?? "",
     maxResults: payload.web_search.max_results,
     timeout: payload.web_search.timeout,
-    useJinaReader: payload.web.fetch.use_jina_reader,
+    fetchProvider: payload.web.fetch.provider,
   };
 }
 
@@ -1170,13 +1177,13 @@ export function SettingsView({
     setWebSearchSaving(true);
     try {
       const webFetchRestartRequired =
-        (webSearchForm.useJinaReader ?? settings.web.fetch.use_jina_reader) !==
-        settings.web.fetch.use_jina_reader;
+        (webSearchForm.fetchProvider ?? settings.web.fetch.provider) !==
+        settings.web.fetch.provider;
       const update: WebSearchSettingsUpdate = {
         provider: webSearchForm.provider,
         maxResults: webSearchForm.maxResults,
         timeout: webSearchForm.timeout,
-        useJinaReader: webSearchForm.useJinaReader,
+        fetchProvider: webSearchForm.fetchProvider,
       };
       if (provider.credential === "api_key" && apiKey) update.apiKey = apiKey;
       if (provider.credential === "base_url") update.baseUrl = baseUrl;
@@ -1192,7 +1199,7 @@ export function SettingsView({
         baseUrl: payload.web_search.base_url ?? prev.baseUrl ?? "",
         maxResults: payload.web_search.max_results,
         timeout: payload.web_search.timeout,
-        useJinaReader: payload.web.fetch.use_jina_reader,
+        fetchProvider: payload.web.fetch.provider,
       }));
       setWebSearchKeyVisible(false);
       setWebSearchKeyEditing(false);
@@ -1232,7 +1239,7 @@ export function SettingsView({
       baseUrl: settings.web_search.base_url ?? "",
       maxResults: settings.web_search.max_results,
       timeout: settings.web_search.timeout,
-      useJinaReader: settings.web.fetch.use_jina_reader,
+      fetchProvider: settings.web.fetch.provider,
     });
     setWebSearchKeyVisible(false);
     setWebSearchKeyEditing(false);
@@ -1246,7 +1253,7 @@ export function SettingsView({
       baseUrl: provider === settings.web_search.provider ? settings.web_search.base_url ?? "" : "",
       maxResults: prev.maxResults ?? settings.web_search.max_results,
       timeout: prev.timeout ?? settings.web_search.timeout,
-      useJinaReader: prev.useJinaReader ?? settings.web.fetch.use_jina_reader,
+      fetchProvider: prev.fetchProvider ?? settings.web.fetch.provider,
     }));
     setWebSearchKeyVisible(false);
     setWebSearchKeyEditing(false);
@@ -3224,15 +3231,15 @@ function WebSettings({
   const showKeyInput = selectedProvider?.credential === "api_key" && (!hasExistingSecret || keyEditing);
   const apiKey = form.apiKey?.trim() ?? "";
   const baseUrl = form.baseUrl?.trim() ?? "";
-  const effectiveJinaReader = form.useJinaReader ?? settings.web.fetch.use_jina_reader;
+  const effectiveFetchProvider = form.fetchProvider ?? settings.web.fetch.provider;
   const dirty =
     form.provider !== settings.web_search.provider ||
     apiKey.length > 0 ||
     baseUrl !== (settings.web_search.base_url ?? "") ||
     form.maxResults !== settings.web_search.max_results ||
     form.timeout !== settings.web_search.timeout ||
-    effectiveJinaReader !== settings.web.fetch.use_jina_reader;
-  const jinaReaderDirty = effectiveJinaReader !== settings.web.fetch.use_jina_reader;
+    effectiveFetchProvider !== settings.web.fetch.provider;
+  const fetchProviderDirty = effectiveFetchProvider !== settings.web.fetch.provider;
   const missingCredential =
     selectedProvider?.credential === "api_key"
       ? !apiKey && !hasExistingSecret
@@ -3371,14 +3378,14 @@ function WebSettings({
             />
           </SettingsRow>
           <SettingsRow
-            title={tx("settings.rows.jinaReader", "Jina reader")}
-            description={tx("settings.help.jinaReader", "Use Jina Reader for web_fetch when available.")}
+            title={tx("settings.rows.fetchProvider", "Fetch provider")}
+            description={tx("settings.help.fetchProvider", "Provider used by web_fetch when reading page content.")}
           >
-            <ToggleButton
-              checked={effectiveJinaReader}
-              onChange={(useJinaReader) => onChangeForm((prev) => ({ ...prev, useJinaReader }))}
-              ariaLabel={tx("settings.rows.jinaReader", "Jina reader")}
-              label={effectiveJinaReader ? tx("settings.values.on", "On") : tx("settings.values.off", "Off")}
+            <ProviderPicker
+              providers={WEB_FETCH_PROVIDERS}
+              value={effectiveFetchProvider}
+              emptyLabel={tx("settings.placeholders.fetchProvider", "Select fetch provider")}
+              onChange={(fetchProvider) => onChangeForm((prev) => ({ ...prev, fetchProvider }))}
             />
           </SettingsRow>
           <RestartSettingsFooter
@@ -3391,7 +3398,7 @@ function WebSettings({
                 ? t("settings.byok.webSearch.missingCredential")
                 : requiresRestartPending && !dirty
                   ? tx("settings.status.savedRestartApply", "Saved. Restart when ready.")
-                  : jinaReaderDirty
+                  : fetchProviderDirty
                     ? tx("settings.status.restartAfterSaving", "Save changes, then restart when ready.")
                     : dirty
                       ? t("settings.byok.webSearch.saveHint")

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -3290,6 +3290,10 @@ function WebSettings({
 }) {
   const { t } = useTranslation();
   const tx = (key: string, fallback: string) => t(key, { defaultValue: fallback });
+  const fetchProviders = WEB_FETCH_PROVIDERS.map((provider) => ({
+    ...provider,
+    label: tx(`settings.fetchProviders.${provider.name}`, provider.label),
+  }));
   const selectedProvider =
     settings.web_search.providers.find((provider) => provider.name === form.provider) ??
     settings.web_search.providers[0];
@@ -3464,7 +3468,7 @@ function WebSettings({
             description={tx("settings.help.fetchProvider", "Provider used by web_fetch when reading page content.")}
           >
             <ProviderPicker
-              providers={WEB_FETCH_PROVIDERS}
+              providers={fetchProviders}
               value={effectiveFetchProvider}
               emptyLabel={tx("settings.placeholders.fetchProvider", "Select fetch provider")}
               onChange={(fetchProvider) => onChangeForm((prev) => ({ ...prev, fetchProvider }))}

--- a/webui/src/i18n/locales/en/common.json
+++ b/webui/src/i18n/locales/en/common.json
@@ -146,6 +146,10 @@
       "maxResults": "Max results",
       "timeout": "Timeout",
       "jinaReader": "Jina reader",
+      "fetchProvider": "Fetch provider",
+      "fetchApiKey": "Tavily Extract API key",
+      "fetchBaseUrl": "Tavily Extract base URL",
+      "fetchTimeout": "Fetch timeout",
       "imageGeneration": "Image generation",
       "imageProvider": "Image provider",
       "imageProviderStatus": "Provider status",
@@ -192,6 +196,10 @@
       "maxResults": "Results returned by each web_search call.",
       "timeout": "Seconds before a search provider request times out.",
       "jinaReader": "Use Jina Reader for web_fetch when available.",
+      "fetchProvider": "Provider used by web_fetch when reading page content.",
+      "fetchApiKey": "Used by web_fetch for Tavily Extract. Leave blank to use TAVILY_API_KEY from the gateway environment.",
+      "fetchBaseUrl": "Optional override for Tavily-compatible extract endpoints.",
+      "fetchTimeout": "Seconds before a web_fetch provider request times out.",
       "imageGeneration": "Expose generate_image in chats when a configured image provider is available.",
       "imageProvider": "Choose the registry provider used by generate_image.",
       "imageProviderStatus": "Image generation reuses provider credentials from Providers.",
@@ -217,6 +225,15 @@
       "transcriptionProviderStatus": "API keys stay under providers, not in transcription settings.",
       "transcriptionModel": "Leave as the resolved default unless your provider needs a custom model id.",
       "transcriptionLanguage": "Optional ISO-639 hint such as en, zh, ja, or ko."
+    },
+    "placeholders": {
+      "fetchProvider": "Select fetch provider"
+    },
+    "fetchProviders": {
+      "auto": "Auto",
+      "tavily": "Tavily Extract",
+      "jina": "Jina Reader",
+      "readability": "Local readability"
     },
     "timezone": {
       "select": "Select timezone",

--- a/webui/src/i18n/locales/es/common.json
+++ b/webui/src/i18n/locales/es/common.json
@@ -125,6 +125,10 @@
       "maxResults": "Resultados máximos",
       "timeout": "Tiempo de espera",
       "jinaReader": "Lector Jina",
+      "fetchProvider": "Proveedor de fetch",
+      "fetchApiKey": "Clave API de Tavily Extract",
+      "fetchBaseUrl": "URL base de Tavily Extract",
+      "fetchTimeout": "Tiempo de espera de fetch",
       "imageGeneration": "Generación de imágenes",
       "imageProvider": "Proveedor de imágenes",
       "imageProviderStatus": "Estado del proveedor",
@@ -169,6 +173,10 @@
       "maxResults": "Resultados devueltos por cada llamada web_search.",
       "timeout": "Segundos antes de que una solicitud de búsqueda expire.",
       "jinaReader": "Usa Jina Reader para web_fetch cuando esté disponible.",
+      "fetchProvider": "Proveedor usado por web_fetch para leer contenido de páginas.",
+      "fetchApiKey": "Usada por web_fetch para Tavily Extract. Déjala vacía para usar TAVILY_API_KEY del entorno del gateway.",
+      "fetchBaseUrl": "Sobrescritura opcional para endpoints Extract compatibles con Tavily.",
+      "fetchTimeout": "Segundos antes de que expire una solicitud del proveedor web_fetch.",
       "imageGeneration": "Expone generate_image en chats cuando hay un proveedor de imagen configurado.",
       "imageProvider": "Elige el proveedor registrado usado por generate_image.",
       "imageProviderStatus": "La generación de imágenes reutiliza credenciales de Proveedores.",
@@ -198,6 +206,15 @@
       "transcriptionProviderStatus": "Las claves API permanecen en proveedores, no en la configuracion de transcripcion.",
       "transcriptionModel": "Dejalo como el valor predeterminado resuelto salvo que el proveedor necesite un id de modelo personalizado.",
       "transcriptionLanguage": "Pista ISO-639 opcional, como en, zh, ja o ko."
+    },
+    "placeholders": {
+      "fetchProvider": "Seleccionar proveedor de fetch"
+    },
+    "fetchProviders": {
+      "auto": "Auto",
+      "tavily": "Tavily Extract",
+      "jina": "Jina Reader",
+      "readability": "Readability local"
     },
     "values": {
       "light": "Claro",

--- a/webui/src/i18n/locales/fr/common.json
+++ b/webui/src/i18n/locales/fr/common.json
@@ -125,6 +125,10 @@
       "maxResults": "Résultats max.",
       "timeout": "Délai d’attente",
       "jinaReader": "Lecteur Jina",
+      "fetchProvider": "Fournisseur de récupération",
+      "fetchApiKey": "Clé API Tavily Extract",
+      "fetchBaseUrl": "URL de base Tavily Extract",
+      "fetchTimeout": "Délai de récupération",
       "imageGeneration": "Génération d’images",
       "imageProvider": "Fournisseur d’images",
       "imageProviderStatus": "État du fournisseur",
@@ -169,6 +173,10 @@
       "maxResults": "Résultats renvoyés par chaque appel web_search.",
       "timeout": "Nombre de secondes avant l’expiration d’une requête de recherche.",
       "jinaReader": "Utilise Jina Reader pour web_fetch lorsque disponible.",
+      "fetchProvider": "Fournisseur utilisé par web_fetch pour lire le contenu des pages.",
+      "fetchApiKey": "Utilisée par web_fetch pour Tavily Extract. Laissez vide pour utiliser TAVILY_API_KEY depuis l’environnement de la passerelle.",
+      "fetchBaseUrl": "Remplacement facultatif pour les endpoints Extract compatibles Tavily.",
+      "fetchTimeout": "Nombre de secondes avant l’expiration d’une requête de fournisseur web_fetch.",
       "imageGeneration": "Expose generate_image dans les chats lorsqu’un fournisseur d’image configuré est disponible.",
       "imageProvider": "Choisissez le fournisseur inscrit utilisé par generate_image.",
       "imageProviderStatus": "La génération d’images réutilise les identifiants des fournisseurs.",
@@ -198,6 +206,15 @@
       "transcriptionProviderStatus": "Les cles API restent dans les fournisseurs, pas dans les reglages de transcription.",
       "transcriptionModel": "Laissez le modele resolu par defaut sauf si votre fournisseur exige un id personnalise.",
       "transcriptionLanguage": "Indice ISO-639 facultatif, comme en, zh, ja ou ko."
+    },
+    "placeholders": {
+      "fetchProvider": "Sélectionner un fournisseur de récupération"
+    },
+    "fetchProviders": {
+      "auto": "Auto",
+      "tavily": "Tavily Extract",
+      "jina": "Jina Reader",
+      "readability": "Readability locale"
     },
     "values": {
       "light": "Clair",

--- a/webui/src/i18n/locales/id/common.json
+++ b/webui/src/i18n/locales/id/common.json
@@ -125,6 +125,10 @@
       "maxResults": "Hasil maksimum",
       "timeout": "Batas waktu",
       "jinaReader": "Pembaca Jina",
+      "fetchProvider": "Penyedia fetch",
+      "fetchApiKey": "API key Tavily Extract",
+      "fetchBaseUrl": "Base URL Tavily Extract",
+      "fetchTimeout": "Batas waktu fetch",
       "imageGeneration": "Pembuatan gambar",
       "imageProvider": "Penyedia gambar",
       "imageProviderStatus": "Status penyedia",
@@ -169,6 +173,10 @@
       "maxResults": "Resultados devueltos por cada llamada web_search.",
       "timeout": "Segundos antes de que una solicitud de búsqueda expire.",
       "jinaReader": "Usa Jina Reader para web_fetch cuando esté disponible.",
+      "fetchProvider": "Penyedia yang digunakan web_fetch untuk membaca konten halaman.",
+      "fetchApiKey": "Digunakan web_fetch untuk Tavily Extract. Kosongkan untuk memakai TAVILY_API_KEY dari lingkungan gateway.",
+      "fetchBaseUrl": "Override opsional untuk endpoint Extract yang kompatibel dengan Tavily.",
+      "fetchTimeout": "Detik sebelum permintaan penyedia web_fetch habis waktu.",
       "imageGeneration": "Expone generate_image en chats cuando hay un proveedor de imagen configurado.",
       "imageProvider": "Elige el proveedor registrado usado por generate_image.",
       "imageProviderStatus": "La generación de imágenes reutiliza credenciales de Proveedores.",
@@ -198,6 +206,15 @@
       "transcriptionProviderStatus": "API key tetap berada di providers, bukan di pengaturan transkripsi.",
       "transcriptionModel": "Biarkan memakai default yang teresolusi kecuali penyedia membutuhkan id model khusus.",
       "transcriptionLanguage": "Petunjuk ISO-639 opsional, seperti en, zh, ja, atau ko."
+    },
+    "placeholders": {
+      "fetchProvider": "Pilih penyedia fetch"
+    },
+    "fetchProviders": {
+      "auto": "Otomatis",
+      "tavily": "Tavily Extract",
+      "jina": "Jina Reader",
+      "readability": "Readability lokal"
     },
     "values": {
       "light": "Terang",

--- a/webui/src/i18n/locales/ja/common.json
+++ b/webui/src/i18n/locales/ja/common.json
@@ -125,6 +125,10 @@
       "maxResults": "最大結果数",
       "timeout": "タイムアウト",
       "jinaReader": "Jina リーダー",
+      "fetchProvider": "取得プロバイダー",
+      "fetchApiKey": "Tavily Extract API キー",
+      "fetchBaseUrl": "Tavily Extract ベース URL",
+      "fetchTimeout": "取得タイムアウト",
       "imageGeneration": "画像生成",
       "imageProvider": "画像プロバイダー",
       "imageProviderStatus": "プロバイダー状態",
@@ -169,6 +173,10 @@
       "maxResults": "各 web_search 呼び出しで返す結果数です。",
       "timeout": "検索プロバイダーのリクエストがタイムアウトするまでの秒数です。",
       "jinaReader": "利用可能な場合、web_fetch に Jina Reader を使います。",
+      "fetchProvider": "web_fetch がページ内容を読むときに使用するプロバイダーです。",
+      "fetchApiKey": "web_fetch が Tavily Extract を使うための API キーです。空欄の場合は gateway 環境の TAVILY_API_KEY を使用します。",
+      "fetchBaseUrl": "Tavily 互換 Extract エンドポイントの任意の上書きです。",
+      "fetchTimeout": "web_fetch プロバイダーのリクエストがタイムアウトするまでの秒数です。",
       "imageGeneration": "画像プロバイダーが設定済みのとき、チャットで generate_image を有効にします。",
       "imageProvider": "generate_image で使用する登録済みプロバイダーを選択します。",
       "imageProviderStatus": "画像生成は「プロバイダー」の認証情報を再利用します。",
@@ -198,6 +206,15 @@
       "transcriptionProviderStatus": "APIキーは文字起こし設定ではなくプロバイダー側に保存されます。",
       "transcriptionModel": "プロバイダーがカスタムモデルIDを必要としない限り、解決済みのデフォルトのままにします。",
       "transcriptionLanguage": "en、zh、ja、ko などの任意の ISO-639 ヒント。"
+    },
+    "placeholders": {
+      "fetchProvider": "取得プロバイダーを選択"
+    },
+    "fetchProviders": {
+      "auto": "自動",
+      "tavily": "Tavily Extract",
+      "jina": "Jina Reader",
+      "readability": "ローカル readability"
     },
     "values": {
       "light": "ライト",

--- a/webui/src/i18n/locales/ko/common.json
+++ b/webui/src/i18n/locales/ko/common.json
@@ -125,6 +125,10 @@
       "maxResults": "최대 결과 수",
       "timeout": "타임아웃",
       "jinaReader": "Jina 리더",
+      "fetchProvider": "가져오기 제공자",
+      "fetchApiKey": "Tavily Extract API 키",
+      "fetchBaseUrl": "Tavily Extract 기본 URL",
+      "fetchTimeout": "가져오기 타임아웃",
       "imageGeneration": "이미지 생성",
       "imageProvider": "이미지 제공자",
       "imageProviderStatus": "제공자 상태",
@@ -169,6 +173,10 @@
       "maxResults": "각 web_search 호출에서 반환되는 결과 수입니다.",
       "timeout": "검색 제공자 요청이 타임아웃되기 전의 초입니다.",
       "jinaReader": "가능할 때 web_fetch에 Jina Reader를 사용합니다.",
+      "fetchProvider": "web_fetch가 페이지 내용을 읽을 때 사용하는 제공자입니다.",
+      "fetchApiKey": "web_fetch가 Tavily Extract를 사용할 때 필요한 API 키입니다. 비워 두면 gateway 환경의 TAVILY_API_KEY를 사용합니다.",
+      "fetchBaseUrl": "Tavily 호환 Extract 엔드포인트를 선택적으로 재정의합니다.",
+      "fetchTimeout": "web_fetch 제공자 요청이 타임아웃되기 전의 초입니다.",
       "imageGeneration": "구성된 이미지 제공자가 있을 때 채팅에서 generate_image를 노출합니다.",
       "imageProvider": "generate_image에 사용할 등록 제공자를 선택합니다.",
       "imageProviderStatus": "이미지 생성은 제공자 자격 증명을 재사용합니다.",
@@ -198,6 +206,15 @@
       "transcriptionProviderStatus": "API 키는 transcription 설정이 아니라 providers 아래에 유지됩니다.",
       "transcriptionModel": "제공자가 사용자 지정 모델 ID를 요구하지 않으면 해석된 기본값을 사용하세요.",
       "transcriptionLanguage": "en, zh, ja, ko 같은 선택적 ISO-639 힌트입니다."
+    },
+    "placeholders": {
+      "fetchProvider": "가져오기 제공자 선택"
+    },
+    "fetchProviders": {
+      "auto": "자동",
+      "tavily": "Tavily Extract",
+      "jina": "Jina Reader",
+      "readability": "로컬 readability"
     },
     "values": {
       "light": "라이트",

--- a/webui/src/i18n/locales/vi/common.json
+++ b/webui/src/i18n/locales/vi/common.json
@@ -125,6 +125,10 @@
       "maxResults": "Kết quả tối đa",
       "timeout": "Thời gian chờ",
       "jinaReader": "Trình đọc Jina",
+      "fetchProvider": "Nhà cung cấp fetch",
+      "fetchApiKey": "API key Tavily Extract",
+      "fetchBaseUrl": "Base URL Tavily Extract",
+      "fetchTimeout": "Thời gian chờ fetch",
       "imageGeneration": "Tạo hình ảnh",
       "imageProvider": "Nhà cung cấp hình ảnh",
       "imageProviderStatus": "Trạng thái nhà cung cấp",
@@ -169,6 +173,10 @@
       "maxResults": "Resultados devueltos por cada llamada web_search.",
       "timeout": "Segundos antes de que una solicitud de búsqueda expire.",
       "jinaReader": "Usa Jina Reader para web_fetch cuando esté disponible.",
+      "fetchProvider": "Nhà cung cấp được web_fetch dùng để đọc nội dung trang.",
+      "fetchApiKey": "Được web_fetch dùng cho Tavily Extract. Để trống để dùng TAVILY_API_KEY từ môi trường gateway.",
+      "fetchBaseUrl": "Ghi đè tùy chọn cho endpoint Extract tương thích Tavily.",
+      "fetchTimeout": "Số giây trước khi yêu cầu nhà cung cấp web_fetch hết thời gian chờ.",
       "imageGeneration": "Expone generate_image en chats cuando hay un proveedor de imagen configurado.",
       "imageProvider": "Elige el proveedor registrado usado por generate_image.",
       "imageProviderStatus": "La generación de imágenes reutiliza credenciales de Proveedores.",
@@ -198,6 +206,15 @@
       "transcriptionProviderStatus": "API key nam trong providers, khong nam trong cai dat transcription.",
       "transcriptionModel": "Giu mac dinh da resolve tru khi nha cung cap can id model tuy chinh.",
       "transcriptionLanguage": "Goi y ISO-639 tuy chon, nhu en, zh, ja hoac ko."
+    },
+    "placeholders": {
+      "fetchProvider": "Chọn nhà cung cấp fetch"
+    },
+    "fetchProviders": {
+      "auto": "Tự động",
+      "tavily": "Tavily Extract",
+      "jina": "Jina Reader",
+      "readability": "Readability cục bộ"
     },
     "values": {
       "light": "Sáng",

--- a/webui/src/i18n/locales/zh-CN/common.json
+++ b/webui/src/i18n/locales/zh-CN/common.json
@@ -146,6 +146,10 @@
       "maxResults": "最大结果数",
       "timeout": "超时",
       "jinaReader": "Jina 阅读器",
+      "fetchProvider": "抓取提供商",
+      "fetchApiKey": "Tavily Extract API Key",
+      "fetchBaseUrl": "Tavily Extract 基础 URL",
+      "fetchTimeout": "抓取超时",
       "imageGeneration": "图片生成",
       "imageProvider": "图片提供商",
       "imageProviderStatus": "提供商状态",
@@ -192,6 +196,10 @@
       "maxResults": "每次 web_search 调用返回的结果数。",
       "timeout": "搜索提供商请求超时前的秒数。",
       "jinaReader": "可用时为 web_fetch 使用 Jina Reader。",
+      "fetchProvider": "web_fetch 读取网页内容时使用的提供商。",
+      "fetchApiKey": "web_fetch 使用 Tavily Extract 时的 API Key。留空则使用网关环境变量 TAVILY_API_KEY。",
+      "fetchBaseUrl": "可选，用于覆盖 Tavily 兼容 Extract 端点。",
+      "fetchTimeout": "web_fetch 提供商请求超时前的秒数。",
       "imageGeneration": "配置图片提供商后，在聊天中开放 generate_image。",
       "imageProvider": "选择 generate_image 使用的注册提供商。",
       "imageProviderStatus": "图片生成会复用「提供商」里的凭据。",
@@ -217,6 +225,15 @@
       "transcriptionProviderStatus": "API Key 仍保存在 providers 里，不写进 transcription 设置。",
       "transcriptionModel": "除非提供商需要自定义模型 ID，否则保持解析后的默认值即可。",
       "transcriptionLanguage": "可选 ISO-639 语言提示，例如 en、zh、ja 或 ko。"
+    },
+    "placeholders": {
+      "fetchProvider": "选择抓取提供商"
+    },
+    "fetchProviders": {
+      "auto": "自动",
+      "tavily": "Tavily Extract",
+      "jina": "Jina Reader",
+      "readability": "本地 readability"
     },
     "timezone": {
       "select": "选择时区",

--- a/webui/src/i18n/locales/zh-TW/common.json
+++ b/webui/src/i18n/locales/zh-TW/common.json
@@ -125,6 +125,10 @@
       "maxResults": "最大結果數",
       "timeout": "逾時",
       "jinaReader": "Jina 閱讀器",
+      "fetchProvider": "抓取供應商",
+      "fetchApiKey": "Tavily Extract API Key",
+      "fetchBaseUrl": "Tavily Extract 基礎 URL",
+      "fetchTimeout": "抓取逾時",
       "imageGeneration": "圖片生成",
       "imageProvider": "圖片供應商",
       "imageProviderStatus": "供應商狀態",
@@ -169,6 +173,10 @@
       "maxResults": "每次 web_search 呼叫返回的結果數。",
       "timeout": "搜尋供應商請求逾時前的秒數。",
       "jinaReader": "可用時為 web_fetch 使用 Jina Reader。",
+      "fetchProvider": "web_fetch 讀取網頁內容時使用的供應商。",
+      "fetchApiKey": "web_fetch 使用 Tavily Extract 時的 API Key。留空則使用 gateway 環境變數 TAVILY_API_KEY。",
+      "fetchBaseUrl": "可選，用於覆寫 Tavily 相容 Extract 端點。",
+      "fetchTimeout": "web_fetch 供應商請求逾時前的秒數。",
       "imageGeneration": "配置圖片供應商後，在聊天中開放 generate_image。",
       "imageProvider": "選擇 generate_image 使用的註冊供應商。",
       "imageProviderStatus": "圖片生成會重用「供應商」中的憑證。",
@@ -198,6 +206,15 @@
       "transcriptionProviderStatus": "API Key 仍保存在 providers 裡，不寫進 transcription 設定。",
       "transcriptionModel": "除非提供商需要自訂模型 ID，否則保持解析後的預設值即可。",
       "transcriptionLanguage": "可選 ISO-639 語言提示，例如 en、zh、ja 或 ko。"
+    },
+    "placeholders": {
+      "fetchProvider": "選擇抓取供應商"
+    },
+    "fetchProviders": {
+      "auto": "自動",
+      "tavily": "Tavily Extract",
+      "jina": "Jina Reader",
+      "readability": "本機 readability"
     },
     "values": {
       "light": "淺色",

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -613,9 +613,10 @@ export async function updateWebSearchSettings(
   if (update.baseUrl !== undefined) query.set("base_url", update.baseUrl);
   if (update.maxResults !== undefined) query.set("max_results", String(update.maxResults));
   if (update.timeout !== undefined) query.set("timeout", String(update.timeout));
-  if (update.useJinaReader !== undefined) {
-    query.set("use_jina_reader", String(update.useJinaReader));
-  }
+  if (update.fetchProvider !== undefined) query.set("fetch_provider", update.fetchProvider);
+  if (update.fetchApiKey !== undefined) query.set("fetch_api_key", update.fetchApiKey);
+  if (update.fetchBaseUrl !== undefined) query.set("fetch_base_url", update.fetchBaseUrl);
+  if (update.fetchTimeout !== undefined) query.set("fetch_timeout", String(update.fetchTimeout));
   return request<SettingsPayload>(
     `${base}/api/settings/web-search/update?${query}`,
     token,

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -410,7 +410,11 @@ export interface SettingsPayload {
       timeout: number;
     };
     fetch: {
-      use_jina_reader: boolean;
+      enable: boolean;
+      provider: string;
+      api_key_hint?: string | null;
+      base_url?: string | null;
+      timeout: number;
     };
   };
   image_generation: {
@@ -725,7 +729,10 @@ export interface WebSearchSettingsUpdate {
   baseUrl?: string;
   maxResults?: number;
   timeout?: number;
-  useJinaReader?: boolean;
+  fetchProvider?: string;
+  fetchApiKey?: string;
+  fetchBaseUrl?: string;
+  fetchTimeout?: number;
 }
 
 export interface NetworkSafetySettingsUpdate {

--- a/webui/src/tests/api.test.ts
+++ b/webui/src/tests/api.test.ts
@@ -352,11 +352,11 @@ describe("webui API helpers", () => {
       baseUrl: "https://search.example.com",
       maxResults: 8,
       timeout: 45,
-      useJinaReader: false,
+      fetchProvider: "readability",
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "/api/settings/web-search/update?provider=searxng&base_url=https%3A%2F%2Fsearch.example.com&max_results=8&timeout=45&use_jina_reader=false",
+      "/api/settings/web-search/update?provider=searxng&base_url=https%3A%2F%2Fsearch.example.com&max_results=8&timeout=45&fetch_provider=readability",
       expect.objectContaining({
         headers: { Authorization: "Bearer tok" },
       }),

--- a/webui/src/tests/api.test.ts
+++ b/webui/src/tests/api.test.ts
@@ -353,10 +353,13 @@ describe("webui API helpers", () => {
       maxResults: 8,
       timeout: 45,
       fetchProvider: "readability",
+      fetchApiKey: "tvly-test",
+      fetchBaseUrl: "https://extract.example.com",
+      fetchTimeout: 60,
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "/api/settings/web-search/update?provider=searxng&base_url=https%3A%2F%2Fsearch.example.com&max_results=8&timeout=45&fetch_provider=readability",
+      "/api/settings/web-search/update?provider=searxng&base_url=https%3A%2F%2Fsearch.example.com&max_results=8&timeout=45&fetch_provider=readability&fetch_api_key=tvly-test&fetch_base_url=https%3A%2F%2Fextract.example.com&fetch_timeout=60",
       expect.objectContaining({
         headers: { Authorization: "Bearer tok" },
       }),

--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -88,7 +88,7 @@ function baseSettingsPayload() {
       proxy: null,
       user_agent: null,
       search: { max_results: 5, timeout: 30 },
-      fetch: { use_jina_reader: true },
+      fetch: { enable: true, provider: "auto", api_key_hint: null, base_url: null, timeout: 30 },
     },
     image_generation: {
       enabled: false,
@@ -1434,7 +1434,7 @@ describe("App layout", () => {
                 proxy: null,
                 user_agent: null,
                 search: { max_results: 5, timeout: 30 },
-                fetch: { use_jina_reader: true },
+                fetch: { enable: true, provider: "auto", api_key_hint: null, base_url: null, timeout: 30 },
               },
               image_generation: {
                 enabled: false,
@@ -1769,7 +1769,7 @@ describe("App layout", () => {
                 proxy: null,
                 user_agent: null,
                 search: { max_results: 5, timeout: 30 },
-                fetch: { use_jina_reader: true },
+                fetch: { enable: true, provider: "auto", api_key_hint: null, base_url: null, timeout: 30 },
               },
               image_generation: {
                 enabled: false,

--- a/webui/src/tests/settings-view.test.tsx
+++ b/webui/src/tests/settings-view.test.tsx
@@ -56,7 +56,7 @@ function settingsPayload(): SettingsPayload {
       proxy: null,
       user_agent: null,
       search: { max_results: 5, timeout: 30 },
-      fetch: { use_jina_reader: true },
+      fetch: { enable: true, provider: "auto", api_key_hint: null, base_url: null, timeout: 30 },
     },
     image_generation: {
       enabled: false,

--- a/webui/src/tests/settings-view.test.tsx
+++ b/webui/src/tests/settings-view.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { SettingsView } from "@/components/settings/SettingsView";
 import { ClientProvider } from "@/providers/ClientProvider";
+import type { SettingsSectionKey } from "@/components/settings/SettingsView";
 import type { SettingsPayload } from "@/lib/types";
 
 function jsonResponse(body: unknown): Response {
@@ -159,7 +160,7 @@ const installedAnyGen = {
 
 function renderSettingsView(
   options: {
-    initialSection?: "overview" | "apps" | "automations" | "advanced" | "models";
+    initialSection?: SettingsSectionKey;
     initialSettings?: SettingsPayload;
     showSidebar?: boolean;
     onSettingsChange?: (payload: SettingsPayload) => void;
@@ -333,6 +334,52 @@ describe("SettingsView Apps catalog", () => {
     expect(screen.queryByText("Token activity")).not.toBeInTheDocument();
     expect(screen.queryByText("Total tokens")).not.toBeInTheDocument();
     expect(screen.queryByText("Peak tokens")).not.toBeInTheDocument();
+  });
+
+  it("saves web fetch provider credentials from browser settings", async () => {
+    const basePayload = settingsPayload();
+    const updatedPayload: SettingsPayload = {
+      ...basePayload,
+      web: {
+        ...basePayload.web,
+        fetch: {
+          enable: true,
+          provider: "auto",
+          api_key_hint: "tav••••test",
+          base_url: "https://extract.example.com",
+          timeout: 60,
+        },
+      },
+      requires_restart: true,
+    };
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith("/api/settings/web-search/update?")) return jsonResponse(updatedPayload);
+      return jsonResponse(basePayload);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderSettingsView({ initialSection: "browser", initialSettings: basePayload });
+
+    fireEvent.change(screen.getByPlaceholderText("Enter API key"), {
+      target: { value: "tvly-test" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("https://api.tavily.com"), {
+      target: { value: "https://extract.example.com" },
+    });
+    fireEvent.change(screen.getAllByRole("spinbutton")[2], {
+      target: { value: "60" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/settings/web-search/update?provider=duckduckgo&max_results=5&timeout=30&fetch_provider=auto&fetch_api_key=tvly-test&fetch_base_url=https%3A%2F%2Fextract.example.com&fetch_timeout=60",
+        expect.objectContaining({
+          headers: { Authorization: "Bearer tok" },
+        }),
+      ),
+    );
   });
 
   it("aligns token activity days with the configured timezone", async () => {

--- a/webui/src/tests/thread-shell.test.tsx
+++ b/webui/src/tests/thread-shell.test.tsx
@@ -172,7 +172,7 @@ function modelSettings(model: string, provider: string): SettingsPayload {
       proxy: null,
       user_agent: null,
       search: { max_results: 5, timeout: 30 },
-      fetch: { use_jina_reader: true },
+      fetch: { enable: true, provider: "auto", api_key_hint: null, base_url: null, timeout: 30 },
     },
     image_generation: {
       enabled: false,


### PR DESCRIPTION
## Summary / 摘要
- Add configurable `web_fetch` provider support with `auto`, `tavily`, `jina`, and `readability` modes.
- 新增可配置的 `web_fetch` provider，支持 `auto`、`tavily`、`jina` 和 `readability` 模式。
- Replace the previous `useJinaReader`-style toggle with explicit provider selection in config, WebUI settings, docs, and tests.
- 将原来的 `useJinaReader` 开关改为更明确的 provider 选择，并同步更新配置、WebUI、文档和测试。
- Preserve backward compatibility by mapping legacy `useJinaReader: false` configs to `provider: "readability"` when no provider is set.
- 保持向后兼容：当旧配置中没有设置 `provider` 且 `useJinaReader: false` 时，自动等价为 `provider: "readability"`。
## Test plan / 测试计划
- Compiled changed Python files with `python -m compileall`.
- 已使用 `python -m compileall` 编译检查修改过的 Python 文件。
- Updated backend and WebUI tests for the new fetch provider payload.
- 已更新后端和 WebUI 测试，以适配新的 fetch provider 配置结构。
