### PR TITLE
fix(pairing): normalize sender IDs to str in the pairing store

### DIFF
--- a/nanobot/pairing/store.py
+++ b/nanobot/pairing/store.py
@@ -44,10 +44,7 @@ def _load() -> dict[str, Any]:
         logger.warning("Corrupted pairing store, resetting")
         return {"approved": {}, "pending": {}}
 
-    # Convert approved lists to sets for O(1) lookup. Sender IDs are normalized
-    # to str so lookups match is_approved()/revoke(), which coerce with str():
-    # IDs may be numeric (e.g. Telegram/QQ) in code or in a hand-edited
-    # pairing.json, and an int entry would never match the str() lookup.
+    # Convert approved lists to str sets for O(1) lookup.
     for channel, users in data.get("approved", {}).items():
         data["approved"][channel] = {str(u) for u in users}
     return data
@@ -113,9 +110,6 @@ def approve_code(code: str) -> tuple[str, str] | None:
         if info is None:
             return None
         channel = info["channel"]
-        # Coerce to str: a hand-edited pending entry may carry a numeric
-        # sender_id, which would otherwise add an int to the (str-normalized)
-        # approved set and break _save()'s sorted() on the mixed-type set.
         sender_id = str(info["sender_id"])
         data.setdefault("approved", {}).setdefault(channel, set()).add(sender_id)
         _save(data)

--- a/nanobot/pairing/store.py
+++ b/nanobot/pairing/store.py
@@ -113,7 +113,10 @@ def approve_code(code: str) -> tuple[str, str] | None:
         if info is None:
             return None
         channel = info["channel"]
-        sender_id = info["sender_id"]
+        # Coerce to str: a hand-edited pending entry may carry a numeric
+        # sender_id, which would otherwise add an int to the (str-normalized)
+        # approved set and break _save()'s sorted() on the mixed-type set.
+        sender_id = str(info["sender_id"])
         data.setdefault("approved", {}).setdefault(channel, set()).add(sender_id)
         _save(data)
         logger.info("Approved pairing code {} for {}@{}", code, sender_id, channel)

--- a/nanobot/pairing/store.py
+++ b/nanobot/pairing/store.py
@@ -44,9 +44,12 @@ def _load() -> dict[str, Any]:
         logger.warning("Corrupted pairing store, resetting")
         return {"approved": {}, "pending": {}}
 
-    # Convert approved lists to sets for O(1) lookup
+    # Convert approved lists to sets for O(1) lookup. Sender IDs are normalized
+    # to str so lookups match is_approved()/revoke(), which coerce with str():
+    # IDs may be numeric (e.g. Telegram/QQ) in code or in a hand-edited
+    # pairing.json, and an int entry would never match the str() lookup.
     for channel, users in data.get("approved", {}).items():
-        data["approved"][channel] = set(users)
+        data["approved"][channel] = {str(u) for u in users}
     return data
 
 
@@ -87,7 +90,7 @@ def generate_code(
 
         data.setdefault("pending", {})[code] = {
             "channel": channel,
-            "sender_id": sender_id,
+            "sender_id": str(sender_id),
             "created_at": time.time(),
             "expires_at": time.time() + ttl,
         }
@@ -162,12 +165,13 @@ def revoke(channel: str, sender_id: str) -> bool:
         data = _load()
         approved: dict[str, set[str]] = data.get("approved", {})
         users = approved.get(channel, set())
-        if sender_id in users:
-            users.discard(sender_id)
+        sid = str(sender_id)
+        if sid in users:
+            users.discard(sid)
             if not users:
                 del approved[channel]
             _save(data)
-            logger.info("Revoked {} from {}", sender_id, channel)
+            logger.info("Revoked {} from {}", sid, channel)
             return True
         return False
 

--- a/tests/pairing/test_store.py
+++ b/tests/pairing/test_store.py
@@ -189,6 +189,23 @@ class TestNonStringSenderId:
         assert store.revoke("telegram", 12345) is True
         assert store.is_approved("telegram", "12345") is False
 
+    def test_hand_edited_numeric_pending_does_not_corrupt_approved_set(self) -> None:
+        # A hand-edited *pending* entry may carry a numeric sender_id. Approving
+        # it must coerce to str so the approved set stays homogeneously str —
+        # otherwise the next _save()'s sorted() on a mixed int/str set raises
+        # TypeError (in fact approve_code()'s own _save() would already raise).
+        store._store_path().write_text(
+            '{"approved": {"telegram": ["111"]}, '
+            '"pending": {"ABCD-EFGH": {"channel": "telegram", "sender_id": 222, '
+            '"created_at": 1000.0, "expires_at": 9999999999.0}}}',
+            encoding="utf-8",
+        )
+        assert store.approve_code("ABCD-EFGH") == ("telegram", "222")
+        assert store.is_approved("telegram", 222) is True
+        # A subsequent write must not raise on a mixed-type set.
+        store.generate_code("telegram", 333)
+        assert store.get_approved("telegram") == ["111", "222"]
+
     def test_numeric_id_in_hand_edited_store(self) -> None:
         # Operators may edit pairing.json directly; a numeric entry must still
         # match the str() lookup that is_approved() performs.

--- a/tests/pairing/test_store.py
+++ b/tests/pairing/test_store.py
@@ -175,25 +175,16 @@ class TestHandlePairingCommand:
 
 
 class TestNonStringSenderId:
-    """Sender IDs may be numeric (e.g. Telegram/QQ). The store normalizes them
-    to str so writes/reads/removals stay consistent with is_approved()."""
-
     def test_numeric_sender_id_round_trip(self) -> None:
         code = store.generate_code("telegram", 12345)
         assert store.approve_code(code) == ("telegram", "12345")
-        # Approved regardless of whether the caller passes int or str.
         assert store.is_approved("telegram", 12345) is True
         assert store.is_approved("telegram", "12345") is True
         assert store.get_approved("telegram") == ["12345"]
-        # Revoke also works with a numeric id.
         assert store.revoke("telegram", 12345) is True
         assert store.is_approved("telegram", "12345") is False
 
     def test_hand_edited_numeric_pending_does_not_corrupt_approved_set(self) -> None:
-        # A hand-edited *pending* entry may carry a numeric sender_id. Approving
-        # it must coerce to str so the approved set stays homogeneously str —
-        # otherwise the next _save()'s sorted() on a mixed int/str set raises
-        # TypeError (in fact approve_code()'s own _save() would already raise).
         store._store_path().write_text(
             '{"approved": {"telegram": ["111"]}, '
             '"pending": {"ABCD-EFGH": {"channel": "telegram", "sender_id": 222, '
@@ -202,13 +193,10 @@ class TestNonStringSenderId:
         )
         assert store.approve_code("ABCD-EFGH") == ("telegram", "222")
         assert store.is_approved("telegram", 222) is True
-        # A subsequent write must not raise on a mixed-type set.
         store.generate_code("telegram", 333)
         assert store.get_approved("telegram") == ["111", "222"]
 
     def test_numeric_id_in_hand_edited_store(self) -> None:
-        # Operators may edit pairing.json directly; a numeric entry must still
-        # match the str() lookup that is_approved() performs.
         store._store_path().write_text(
             '{"approved": {"telegram": [12345]}, "pending": {}}',
             encoding="utf-8",

--- a/tests/pairing/test_store.py
+++ b/tests/pairing/test_store.py
@@ -174,6 +174,34 @@ class TestHandlePairingCommand:
         assert "Pending pairing requests:" in reply
 
 
+class TestNonStringSenderId:
+    """Sender IDs may be numeric (e.g. Telegram/QQ). The store normalizes them
+    to str so writes/reads/removals stay consistent with is_approved()."""
+
+    def test_numeric_sender_id_round_trip(self) -> None:
+        code = store.generate_code("telegram", 12345)
+        assert store.approve_code(code) == ("telegram", "12345")
+        # Approved regardless of whether the caller passes int or str.
+        assert store.is_approved("telegram", 12345) is True
+        assert store.is_approved("telegram", "12345") is True
+        assert store.get_approved("telegram") == ["12345"]
+        # Revoke also works with a numeric id.
+        assert store.revoke("telegram", 12345) is True
+        assert store.is_approved("telegram", "12345") is False
+
+    def test_numeric_id_in_hand_edited_store(self) -> None:
+        # Operators may edit pairing.json directly; a numeric entry must still
+        # match the str() lookup that is_approved() performs.
+        store._store_path().write_text(
+            '{"approved": {"telegram": [12345]}, "pending": {}}',
+            encoding="utf-8",
+        )
+        assert store.is_approved("telegram", "12345") is True
+        assert store.is_approved("telegram", 12345) is True
+        assert store.revoke("telegram", 12345) is True
+        assert store.is_approved("telegram", "12345") is False
+
+
 class TestStoreDurability:
     def test_corruption_recovery(self, tmp_path, monkeypatch) -> None:
         path = tmp_path / "pairing.json"


### PR DESCRIPTION
# fix(pairing): normalize sender IDs to str in the pairing store

> Branch: `fix/pairing-sender-id-coercion` · Files: `nanobot/pairing/store.py`, `tests/pairing/test_store.py`

## Summary
Fix a type-coercion inconsistency in the pairing store (`nanobot/pairing/store.py`) that can
silently deny an already-approved sender when the sender ID is numeric.

## The bug
`is_approved()` normalizes the sender ID with `str()` before checking membership:

```python
return str(sender_id) in approved.get(channel, set())
```

…but `generate_code()` stored the raw `sender_id`, `approve_code()` added that raw stored value to
the approved set, and `revoke()` compared the raw value. So a **numeric** sender ID (e.g. a
Telegram/QQ user id) takes this path:

- stored as `int` → approved set `{12345}`
- `is_approved(channel, 12345)` checks `"12345" in {12345}` → **False**

Result: an approved sender is **silently treated as unapproved** (a fail-closed denial), and
`revoke()` cannot remove a numeric entry. The same happens for a hand-edited `pairing.json`
containing a numeric id — which the store is explicitly designed to support ("small JSON file…
simple locking", per its module docstring).

Today the channel layer (`BaseChannel`) coerces with `str(sender_id)` at the call site, which masks
the bug in the standard flow — but the store's own contract is inconsistent, so any direct/SDK
caller, or a hand-edited file, hits it.

## The fix
Normalize sender IDs to `str` at every store boundary (the single source of truth), matching
`is_approved()`:

- `_load()` — coerce persisted approved IDs to `str` on read
- `generate_code()` — store `str(sender_id)`
- `approve_code()` — coerce the pending entry's `sender_id` before adding it to the approved set
- `revoke()` — compare/discard `str(sender_id)`

No behavior change for string sender IDs (the common path); fixes the numeric case.

### Review follow-up (edge case)
A first pass normalized only `_load()`, `generate_code()`, and `revoke()`. Review caught that a
**hand-edited `pending` entry** with a numeric `sender_id` flows through `approve_code()`, which
added the raw value to the (now str-normalized) approved set — producing a mixed-type set that
breaks `_save()`'s `sorted(list(users))` with a `TypeError`. Fixed by coercing in `approve_code()`
as well, so the approved set is always homogeneously `str`.

## Tests
Added `TestNonStringSenderId` in `tests/pairing/test_store.py`:
- numeric ID through generate → approve → `is_approved` → `revoke`
- a hand-edited store with a numeric **approved** entry
- a hand-edited numeric **pending** entry that must not corrupt the approved set (the review edge
  case — `approve_code()` would otherwise raise `TypeError` in its own `_save()`)

All fail before the fix and pass after.

```
pytest tests/pairing/test_store.py            # 30 passed
ruff check nanobot/pairing/store.py tests/pairing/test_store.py   # All checks passed!
```

## Scope
Small, focused, no new abstractions, no formatting churn.

