### PR TITLE
fix(tools): gate MCP resource and prompt registration behind enabledTools

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1724,9 +1724,9 @@ Use `enabledTools` to register only a subset of tools from an MCP server:
 
 `enabledTools` accepts either the raw MCP tool name (for example `read_file`) or the wrapped nanobot tool name (for example `mcp_filesystem_write_file`).
 
-- Omit `enabledTools`, or set it to `["*"]`, to register all tools.
-- Set `enabledTools` to `[]` to register no tools from that server.
-- Set `enabledTools` to a non-empty list of names to register only that subset.
+- Omit `enabledTools`, or set it to `["*"]`, to register all capabilities (tools, resources, and prompts).
+- Set `enabledTools` to `[]` to register no tools from that server. Resources and prompts are also skipped, since they have no per-name filter.
+- Set `enabledTools` to a non-empty list of names to register only those tools — resources and prompts are not registered.
 
 MCP tools are automatically discovered and registered on startup. The LLM can use them alongside built-in tools — no extra configuration needed.
 

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -842,6 +842,12 @@ async def connect_mcp_servers(
                     logger.debug(
                         "MCP server '{}': prompts not supported or failed: {}", name, e
                     )
+            else:
+                logger.info(
+                    "MCP server '{}': skipping resource/prompt registration "
+                    "(enabledTools does not include '*' — only tools allowed)",
+                    name,
+                )
 
             logger.info(
                 "MCP server '{}': connected, {} capabilities registered", name, registered_count

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -797,31 +797,51 @@ async def connect_mcp_servers(
                         ", ".join(available_wrapped_names) or "(none)",
                     )
 
-            try:
-                resources_result = await session.list_resources()
-                for resource in resources_result.resources:
-                    wrapper = MCPResourceWrapper(
-                        session, name, resource, resource_timeout=cfg.tool_timeout
-                    )
-                    registry.register(wrapper)
-                    registered_count += 1
+            # Only register resources and prompts when no tool restriction is
+            # active.  enabledTools is a per-*tool* allowlist; resources and
+            # prompts have no equivalent name filter, so they must be skipped
+            # whenever the operator specified a tool subset.  An empty list
+            # (deny-all) or a list of specific tool names both indicate that
+            # the operator intended to restrict capabilities — registering
+            # unrestricted resource/prompt wrappers would violate that intent.
+            # The default ["*"] (allow-all) means no restriction was intended.
+            register_extras = allow_all_tools
+            if register_extras:
+                try:
+                    resources_result = await session.list_resources()
+                    for resource in resources_result.resources:
+                        wrapper = MCPResourceWrapper(
+                            session, name, resource, resource_timeout=cfg.tool_timeout
+                        )
+                        registry.register(wrapper)
+                        registered_count += 1
+                        logger.debug(
+                            "MCP: registered resource '{}' from server '{}'",
+                            wrapper.name,
+                            name,
+                        )
+                except Exception as e:
                     logger.debug(
-                        "MCP: registered resource '{}' from server '{}'", wrapper.name, name
+                        "MCP server '{}': resources not supported or failed: {}", name, e
                     )
-            except Exception as e:
-                logger.debug("MCP server '{}': resources not supported or failed: {}", name, e)
 
-            try:
-                prompts_result = await session.list_prompts()
-                for prompt in prompts_result.prompts:
-                    wrapper = MCPPromptWrapper(
-                        session, name, prompt, prompt_timeout=cfg.tool_timeout
+                try:
+                    prompts_result = await session.list_prompts()
+                    for prompt in prompts_result.prompts:
+                        wrapper = MCPPromptWrapper(
+                            session, name, prompt, prompt_timeout=cfg.tool_timeout
+                        )
+                        registry.register(wrapper)
+                        registered_count += 1
+                        logger.debug(
+                            "MCP: registered prompt '{}' from server '{}'",
+                            wrapper.name,
+                            name,
+                        )
+                except Exception as e:
+                    logger.debug(
+                        "MCP server '{}': prompts not supported or failed: {}", name, e
                     )
-                    registry.register(wrapper)
-                    registered_count += 1
-                    logger.debug("MCP: registered prompt '{}' from server '{}'", wrapper.name, name)
-            except Exception as e:
-                logger.debug("MCP server '{}': prompts not supported or failed: {}", name, e)
 
             logger.info(
                 "MCP server '{}': connected, {} capabilities registered", name, registered_count

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -301,7 +301,7 @@ class MCPServerConfig(Base):
     url: str = ""  # HTTP/SSE: endpoint URL
     headers: dict[str, str] = Field(default_factory=dict)  # HTTP/SSE: custom headers
     tool_timeout: int = 30  # seconds before a tool call is cancelled
-    enabled_tools: list[str] = Field(default_factory=lambda: ["*"])  # Only register these tools; accepts raw MCP names or wrapped mcp_<server>_<tool> names; ["*"] = all tools; [] = no tools
+    enabled_tools: list[str] = Field(default_factory=lambda: ["*"])  # Only register these tools; accepts raw MCP names or wrapped mcp_<server>_<tool> names; ["*"] = all capabilities (tools, resources, prompts); any restriction = only listed tools, no resources/prompts
 
 
 def _lazy_default(module_path: str, class_name: str) -> Any:

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -434,6 +434,79 @@ async def test_connect_mcp_servers_enabled_tools_empty_list_registers_none(
 
 
 @pytest.mark.asyncio
+async def test_connect_mcp_servers_enabled_tools_empty_list_blocks_resources_and_prompts(
+    fake_mcp_runtime: dict[str, object | None],
+) -> None:
+    """enabledTools: [] (deny-all) must also block resource and prompt registration."""
+    fake_mcp_runtime["session"] = _make_fake_session_with_capabilities(
+        tool_names=["demo"],
+        resource_names=["secret_data"],
+        prompt_names=["admin_prompt"],
+    )
+    registry = ToolRegistry()
+    stacks = await connect_mcp_servers(
+        {"test": MCPServerConfig(command="fake", enabled_tools=[])},
+        registry,
+    )
+    for stack in stacks.values():
+        await stack.aclose()
+
+    assert registry.tool_names == []
+    # Resources and prompts must also be blocked
+    assert not any("secret_data" in name for name in registry.tool_names)
+    assert not any("admin_prompt" in name for name in registry.tool_names)
+
+
+@pytest.mark.asyncio
+async def test_connect_mcp_servers_enabled_tools_specific_list_blocks_resources_and_prompts(
+    fake_mcp_runtime: dict[str, object | None],
+) -> None:
+    """enabledTools with specific tool names must not leak resources or prompts."""
+    fake_mcp_runtime["session"] = _make_fake_session_with_capabilities(
+        tool_names=["demo", "other"],
+        resource_names=["secret_data"],
+        prompt_names=["admin_prompt"],
+    )
+    registry = ToolRegistry()
+    stacks = await connect_mcp_servers(
+        {"test": MCPServerConfig(command="fake", enabled_tools=["demo"])},
+        registry,
+    )
+    for stack in stacks.values():
+        await stack.aclose()
+
+    # Only the allowed tool should be registered
+    assert "mcp_test_demo" in registry.tool_names
+    assert "mcp_test_other" not in registry.tool_names
+    # Resources and prompts must not leak
+    assert not any("secret_data" in name for name in registry.tool_names)
+    assert not any("admin_prompt" in name for name in registry.tool_names)
+
+
+@pytest.mark.asyncio
+async def test_connect_mcp_servers_enabled_tools_wildcard_allows_resources_and_prompts(
+    fake_mcp_runtime: dict[str, object | None],
+) -> None:
+    """enabledTools: ['*'] should allow all tools, resources, and prompts."""
+    fake_mcp_runtime["session"] = _make_fake_session_with_capabilities(
+        tool_names=["demo"],
+        resource_names=["public_data"],
+        prompt_names=["help_prompt"],
+    )
+    registry = ToolRegistry()
+    stacks = await connect_mcp_servers(
+        {"test": MCPServerConfig(command="fake", enabled_tools=["*"])},
+        registry,
+    )
+    for stack in stacks.values():
+        await stack.aclose()
+
+    assert "mcp_test_demo" in registry.tool_names
+    assert any("public_data" in name for name in registry.tool_names)
+    assert any("help_prompt" in name for name in registry.tool_names)
+
+
+@pytest.mark.asyncio
 async def test_connect_mcp_servers_enabled_tools_warns_on_unknown_entries(
     fake_mcp_runtime: dict[str, object | None], monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

The `enabledTools` allowlist on MCP servers was only enforced for tools returned by `session.list_tools()`. Resources (`session.list_resources()`) and prompts (`session.list_prompts()`) were registered unconditionally, allowing a deny-all or restrictive `enabledTools` config to leak resource and prompt capabilities to the model.

## Problem

With `enabledTools: []` (deny-all), ordinary MCP tools are correctly blocked, but MCP resources and prompts from the same server are still exposed to the model and can be executed through the `POST /v1/chat/completions` path. This turns a deny-all MCP configuration into a partial deny.

The vulnerable logic in `connect_mcp_servers()`:
- Tools are filtered through `enabledTools`
- Resources and prompts are registered immediately after with no gate

## Fix

Resources and prompts are now only registered when `allow_all_tools` is true (the default `["*"]` wildcard). Any explicit tool restriction — including `enabledTools: []` (deny-all) or a list of specific tool names — also blocks resource and prompt registration from that server.

## Verification

```bash
# Run the full MCP test suite (54 tests)
pytest tests/tools/test_mcp_tool.py -v
```

All 54 tests pass, including 3 new tests:
- `test_connect_mcp_servers_enabled_tools_empty_list_blocks_resources_and_prompts` — deny-all blocks resources/prompts
- `test_connect_mcp_servers_enabled_tools_specific_list_blocks_resources_and_prompts` — specific tool list blocks resources/prompts
- `test_connect_mcp_servers_enabled_tools_wildcard_allows_resources_and_prompts` — wildcard allows everything

Fixes #4435