### PR TITLE
fix(cli): show search engines (incl. Keenable) in onboard wizard

### DIFF
--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -36,6 +36,24 @@ _VOLCENGINE_TIME_RANGES = {"OneDay", "OneWeek", "OneMonth", "OneYear"}
 _VOLCENGINE_DATE_RANGE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}\.\.\d{4}-\d{2}-\d{2}$")
 
 
+# Single source of truth for selectable search providers (CLI wizard + WebUI).
+# "credential" describes what each provider needs: none / api_key / base_url /
+# optional_api_key.
+SEARCH_PROVIDER_OPTIONS: tuple[dict[str, str], ...] = (
+    {"name": "duckduckgo", "label": "DuckDuckGo", "credential": "none"},
+    {"name": "brave", "label": "Brave Search", "credential": "api_key"},
+    {"name": "tavily", "label": "Tavily", "credential": "api_key"},
+    {"name": "searxng", "label": "SearXNG", "credential": "base_url"},
+    {"name": "jina", "label": "Jina", "credential": "api_key"},
+    {"name": "kagi", "label": "Kagi", "credential": "api_key"},
+    {"name": "exa", "label": "Exa", "credential": "api_key"},
+    {"name": "olostep", "label": "Olostep", "credential": "api_key"},
+    {"name": "bocha", "label": "Bocha", "credential": "api_key"},
+    {"name": "volcengine", "label": "Volcengine Search", "credential": "api_key"},
+    {"name": "keenable", "label": "Keenable", "credential": "optional_api_key"},
+)
+
+
 class WebSearchConfig(Base):
     """Web search configuration."""
     provider: str = "duckduckgo"

--- a/nanobot/cli/onboard.py
+++ b/nanobot/cli/onboard.py
@@ -608,18 +608,25 @@ def _handle_model_preset_field(
         setattr(working_model, field_name, new_value)
 
 
-def _handle_provider_field(
-    working_model: BaseModel, field_name: str, field_display: str, current_value: Any
+def _set_field_from_choices(
+    working_model: BaseModel, field_name: str, field_display: str,
+    choices: list[str], default_choice: str
 ) -> None:
-    """Handle the 'provider' field with a list of registered providers."""
-    provider_names = sorted(_get_provider_names().keys())
-    choices = ["auto"] + provider_names
-    default_choice = str(current_value) if current_value else "auto"
+    """Prompt to pick one of ``choices`` and set the field (no-op on back/cancel)."""
     new_value = _select_with_back(field_display, choices, default=default_choice)
     if new_value is _BACK_PRESSED:
         return
     if new_value is not None:
         setattr(working_model, field_name, new_value)
+
+
+def _handle_provider_field(
+    working_model: BaseModel, field_name: str, field_display: str, current_value: Any
+) -> None:
+    """Handle the 'provider' field with a list of registered LLM providers."""
+    choices = ["auto"] + sorted(_get_provider_names().keys())
+    default_choice = str(current_value) if current_value else "auto"
+    _set_field_from_choices(working_model, field_name, field_display, choices, default_choice)
 
 
 def _handle_fallback_models_field(
@@ -689,12 +696,8 @@ def _handle_search_provider_field(
     from nanobot.agent.tools.web import SEARCH_PROVIDER_OPTIONS
 
     choices = [opt["name"] for opt in SEARCH_PROVIDER_OPTIONS]
-    default_choice = str(current_value) if current_value in choices else choices[0]
-    new_value = _select_with_back(field_display, choices, default=default_choice)
-    if new_value is _BACK_PRESSED:
-        return
-    if new_value is not None:
-        setattr(working_model, field_name, new_value)
+    default_choice = current_value if current_value in choices else choices[0]
+    _set_field_from_choices(working_model, field_name, field_display, choices, default_choice)
 
 
 _FIELD_HANDLERS: dict[str, Any] = {
@@ -705,18 +708,15 @@ _FIELD_HANDLERS: dict[str, Any] = {
     "fallback_models": _handle_fallback_models_field,
 }
 
-# Handlers keyed by (model class name, field name); take precedence over the
-# name-only handlers above. Needed because the bare "provider" field name is
-# shared by LLM configs (LLM provider list) and WebSearchConfig (search engines).
-_TYPED_FIELD_HANDLERS: dict[tuple[str, str], Any] = {
-    ("WebSearchConfig", "provider"): _handle_search_provider_field,
-}
-
 
 def _resolve_field_handler(model: BaseModel, field_name: str) -> Any:
-    """Resolve a field handler, preferring model-type-specific handlers."""
-    typed = _TYPED_FIELD_HANDLERS.get((type(model).__name__, field_name))
-    return typed or _FIELD_HANDLERS.get(field_name)
+    """Resolve the handler for a field. WebSearchConfig shares the bare "provider"
+    name with LLM configs but needs the search-engine picker, not the LLM list."""
+    if field_name == "provider":
+        from nanobot.agent.tools.web import WebSearchConfig
+        if isinstance(model, WebSearchConfig):
+            return _handle_search_provider_field
+    return _FIELD_HANDLERS.get(field_name)
 
 
 def _is_str_or_none(annotation: Any) -> bool:

--- a/nanobot/cli/onboard.py
+++ b/nanobot/cli/onboard.py
@@ -682,6 +682,21 @@ def _handle_fallback_models_field(
             items.clear()
 
 
+def _handle_search_provider_field(
+    working_model: BaseModel, field_name: str, field_display: str, current_value: Any
+) -> None:
+    """Handle the web-search 'provider' field with the search-engine list."""
+    from nanobot.agent.tools.web import SEARCH_PROVIDER_OPTIONS
+
+    choices = [opt["name"] for opt in SEARCH_PROVIDER_OPTIONS]
+    default_choice = str(current_value) if current_value in choices else choices[0]
+    new_value = _select_with_back(field_display, choices, default=default_choice)
+    if new_value is _BACK_PRESSED:
+        return
+    if new_value is not None:
+        setattr(working_model, field_name, new_value)
+
+
 _FIELD_HANDLERS: dict[str, Any] = {
     "model": _handle_model_field,
     "context_window_tokens": _handle_context_window_field,
@@ -689,6 +704,19 @@ _FIELD_HANDLERS: dict[str, Any] = {
     "provider": _handle_provider_field,
     "fallback_models": _handle_fallback_models_field,
 }
+
+# Handlers keyed by (model class name, field name); take precedence over the
+# name-only handlers above. Needed because the bare "provider" field name is
+# shared by LLM configs (LLM provider list) and WebSearchConfig (search engines).
+_TYPED_FIELD_HANDLERS: dict[tuple[str, str], Any] = {
+    ("WebSearchConfig", "provider"): _handle_search_provider_field,
+}
+
+
+def _resolve_field_handler(model: BaseModel, field_name: str) -> Any:
+    """Resolve a field handler, preferring model-type-specific handlers."""
+    typed = _TYPED_FIELD_HANDLERS.get((type(model).__name__, field_name))
+    return typed or _FIELD_HANDLERS.get(field_name)
 
 
 def _is_str_or_none(annotation: Any) -> bool:
@@ -778,7 +806,7 @@ def _configure_pydantic_model(
             continue
 
         # Registered special-field handlers
-        handler = _FIELD_HANDLERS.get(field_name)
+        handler = _resolve_field_handler(working_model, field_name)
         if handler:
             handler(working_model, field_name, field_display, current_value)
             continue

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -16,6 +16,7 @@ from zoneinfo import ZoneInfo
 import httpx
 
 from nanobot import __version__
+from nanobot.agent.tools.web import SEARCH_PROVIDER_OPTIONS
 from nanobot.audio.transcription import resolve_transcription_config
 from nanobot.audio.transcription_registry import (
     resolve_transcription_provider,
@@ -79,19 +80,7 @@ _NATIVE_RESTART_BEHAVIOR_BY_SECTION = {
     "apps": "engineRestart",
 }
 
-_WEB_SEARCH_PROVIDER_OPTIONS: tuple[dict[str, str], ...] = (
-    {"name": "duckduckgo", "label": "DuckDuckGo", "credential": "none"},
-    {"name": "brave", "label": "Brave Search", "credential": "api_key"},
-    {"name": "tavily", "label": "Tavily", "credential": "api_key"},
-    {"name": "searxng", "label": "SearXNG", "credential": "base_url"},
-    {"name": "jina", "label": "Jina", "credential": "api_key"},
-    {"name": "kagi", "label": "Kagi", "credential": "api_key"},
-    {"name": "exa", "label": "Exa", "credential": "api_key"},
-    {"name": "olostep", "label": "Olostep", "credential": "api_key"},
-    {"name": "bocha", "label": "Bocha", "credential": "api_key"},
-    {"name": "volcengine", "label": "Volcengine Search", "credential": "api_key"},
-    {"name": "keenable", "label": "Keenable", "credential": "optional_api_key"},
-)
+_WEB_SEARCH_PROVIDER_OPTIONS = SEARCH_PROVIDER_OPTIONS
 _WEB_SEARCH_PROVIDER_BY_NAME = {
     provider["name"]: provider for provider in _WEB_SEARCH_PROVIDER_OPTIONS
 }

--- a/tests/agent/test_onboard_logic.py
+++ b/tests/agent/test_onboard_logic.py
@@ -1333,3 +1333,27 @@ class TestModelPresetWizard:
         defaults = AgentDefaults()
         _handle_provider_field(defaults, "provider", "Provider", "auto")
         assert defaults.provider == "anthropic"
+
+    def test_search_provider_field_handler(self, monkeypatch):
+        """_handle_search_provider_field should set the search engine from choices."""
+        from nanobot.agent.tools.web import WebSearchConfig
+        from nanobot.cli.onboard import _handle_search_provider_field
+
+        monkeypatch.setattr(onboard_wizard, "_select_with_back", lambda *a, **kw: "keenable")
+
+        cfg = WebSearchConfig()
+        _handle_search_provider_field(cfg, "provider", "Provider", "duckduckgo")
+        assert cfg.provider == "keenable"
+
+    def test_provider_field_dispatch_is_model_type_aware(self):
+        """WebSearchConfig.provider must not be hijacked by the LLM provider handler."""
+        from nanobot.agent.tools.web import WebSearchConfig
+        from nanobot.cli.onboard import (
+            _handle_provider_field,
+            _handle_search_provider_field,
+            _resolve_field_handler,
+        )
+        from nanobot.config.schema import AgentDefaults
+
+        assert _resolve_field_handler(WebSearchConfig(), "provider") is _handle_search_provider_field
+        assert _resolve_field_handler(AgentDefaults(), "provider") is _handle_provider_field


### PR DESCRIPTION
## Problem

In `nanobot onboard --wizard`, the web-search **provider** field showed the **LLM** provider list (anthropic, openai, …) instead of search engines, and **Keenable never appeared at all**.

Two root causes:

1. **Field-handler collision.** `_configure_pydantic_model` dispatched handlers by bare field name (`_FIELD_HANDLERS["provider"] = _handle_provider_field`). `WebSearchConfig` also has a field named `provider`, so it was hijacked by the LLM-provider handler.
2. **Keenable was never wired into the CLI wizard.** When Keenable landed, it was added to the search tool and the **WebUI** picker only — never the CLI.

## Fix

- Add a single source of truth for selectable search providers — `SEARCH_PROVIDER_OPTIONS` in `nanobot/agent/tools/web.py`. The WebUI settings now import it instead of duplicating the list.
- Add a `WebSearchConfig`-aware search-provider picker to the wizard, and resolve handlers by model type (via `isinstance`) so the LLM-provider and search-provider fields no longer collide.
- Factor the shared "pick from a list and set the field" tail into `_set_field_from_choices`, used by both provider handlers.

## Tests

- New: search-provider handler sets the engine from the picker.
- New: handler dispatch is model-type-aware (WebSearchConfig → search picker, AgentDefaults → LLM picker).
- `tests/agent/test_onboard_logic.py` and `tests/webui/test_settings_api.py` pass (148); `ruff` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)