### PR TITLE
fix(mcp): force-close streamable_http generator on reconnect failure

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1126,6 +1126,14 @@ class AgentLoop:
                 await stack.aclose()
             except (RuntimeError, BaseExceptionGroup):
                 logger.debug("MCP server '{}' cleanup error (can be ignored)", name)
+                # Force-close the streamable_http_client generator to prevent
+                # its anyio cancel scope from crashing the gateway (#4302).
+                http_gen = getattr(stack, "_mcp_http_gen", None)
+                if http_gen is not None:
+                    from contextlib import suppress
+
+                    with suppress(Exception):
+                        await http_gen.aclose()
         self._mcp_stacks.clear()
 
     def _schedule_background(self, coro) -> None:

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1130,8 +1130,6 @@ class AgentLoop:
                 # its anyio cancel scope from crashing the gateway (#4302).
                 http_gen = getattr(stack, "_mcp_http_gen", None)
                 if http_gen is not None:
-                    from contextlib import suppress
-
                     with suppress(Exception):
                         await http_gen.aclose()
         self._mcp_stacks.clear()

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -745,9 +745,12 @@ async def connect_mcp_servers(
                 )
                 _http_gen = streamable_http_client(cfg.url, http_client=http_client)
                 read, write, _ = await server_stack.enter_async_context(_http_gen)
-                # Stash the generator so _close_server can force-close it
-                # if aclose() raises due to cross-task cancel scope (#4302).
-                server_stack._mcp_http_gen = _http_gen  # type: ignore[attr-defined]
+                # Stash the underlying async generator so _close_server can
+                # force-close it if stack.aclose() raises due to cross-task
+                # cancel scope (#4302).  streamable_http_client() returns an
+                # _AsyncGeneratorContextManager which has no aclose(); the
+                # real async generator lives at .gen.
+                server_stack._mcp_http_gen = _http_gen.gen  # type: ignore[attr-defined]
             else:
                 logger.warning("MCP server '{}': unknown transport type '{}'", name, transport_type)
                 await server_stack.aclose()

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -743,9 +743,11 @@ async def connect_mcp_servers(
                         timeout=httpx.Timeout(30.0, connect=10.0),
                     )
                 )
-                read, write, _ = await server_stack.enter_async_context(
-                    streamable_http_client(cfg.url, http_client=http_client)
-                )
+                _http_gen = streamable_http_client(cfg.url, http_client=http_client)
+                read, write, _ = await server_stack.enter_async_context(_http_gen)
+                # Stash the generator so _close_server can force-close it
+                # if aclose() raises due to cross-task cancel scope (#4302).
+                server_stack._mcp_http_gen = _http_gen  # type: ignore[attr-defined]
             else:
                 logger.warning("MCP server '{}': unknown transport type '{}'", name, transport_type)
                 await server_stack.aclose()
@@ -1191,3 +1193,14 @@ async def _close_server(state: Any, server_name: str) -> None:
         await stack.aclose()
     except (RuntimeError, BaseExceptionGroup):
         logger.debug("MCP server '{}' cleanup error (can be ignored)", server_name)
+        # The MCP SDK's streamable_http_client uses anyio task groups whose
+        # cancel scopes can only be exited from the task that entered them.
+        # When _close_server runs from a different task (e.g. tool retry vs
+        # initial connect), aclose() raises but leaves the generator alive
+        # with an active cancel scope that later cancels unrelated tasks and
+        # crashes the gateway (#4302).  Force-close the generator now, while
+        # the event loop is still healthy, so the GC never tries to finalize it.
+        http_gen = getattr(stack, "_mcp_http_gen", None)
+        if http_gen is not None:
+            with suppress(Exception):
+                await http_gen.aclose()

--- a/tests/agent/test_mcp_http_gen_aclose.py
+++ b/tests/agent/test_mcp_http_gen_aclose.py
@@ -1,0 +1,72 @@
+"""Regression test for #4302: force-close streamable_http generator.
+
+Verifies that the stashed ``_mcp_http_gen`` attribute is the raw async
+generator (not the ``_AsyncGeneratorContextManager`` wrapper) so that
+``.aclose()`` actually closes the underlying transport.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager_gen_has_aclose():
+    """_AsyncGeneratorContextManager has no aclose(); .gen does."""
+
+    @asynccontextmanager
+    async def _fake_transport():
+        yield "read", "write"
+
+    cm = _fake_transport()
+    # The context manager wrapper itself must NOT have aclose()
+    assert not hasattr(cm, "aclose"), (
+        "_AsyncGeneratorContextManager should not have aclose()"
+    )
+    # The underlying generator MUST have aclose()
+    assert hasattr(cm.gen, "aclose"), (
+        "Underlying async generator must have aclose()"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stashing_gen_allows_aclose():
+    """Stashing .gen (not the CM) lets cleanup code call aclose() successfully."""
+    closed = False
+
+    @asynccontextmanager
+    async def _fake_transport():
+        nonlocal closed
+        try:
+            yield "read", "write"
+        finally:
+            closed = True
+
+    cm = _fake_transport()
+    await cm.__aenter__()
+
+    # Simulate what the fix does: stash cm.gen
+    stashed = cm.gen
+    assert hasattr(stashed, "aclose")
+
+    # Calling aclose() on the generator should work
+    await stashed.aclose()
+    assert closed, "Generator finally block should have run"
+
+
+@pytest.mark.asyncio
+async def test_stashing_cm_aclose_raises():
+    """Stashing the CM (old code) means aclose() raises AttributeError."""
+    @asynccontextmanager
+    async def _fake_transport():
+        yield "read", "write"
+
+    cm = _fake_transport()
+    await cm.__aenter__()
+
+    # Old code stashed cm directly — aclose() would raise
+    with pytest.raises(AttributeError, match="aclose"):
+        await cm.aclose()

--- a/tests/agent/test_mcp_http_gen_aclose.py
+++ b/tests/agent/test_mcp_http_gen_aclose.py
@@ -7,7 +7,6 @@ generator (not the ``_AsyncGeneratorContextManager`` wrapper) so that
 
 from __future__ import annotations
 
-import asyncio
 from contextlib import asynccontextmanager
 
 import pytest


### PR DESCRIPTION
## Problem

Gateway crashes with `RuntimeError: Attempted to exit cancel scope in a different task than it was entered in` when an MCP server session terminates and the reconnection code path runs `_close_server`.

The root cause is the MCP SDK's `streamable_http_client` using anyio task groups internally. When `_close_server` (or `close_mcp`) calls `stack.aclose()` from a different task than the one that created the connection, the generator's `__aexit__` tries to exit a cancel scope from the wrong task context. The error is caught, but the generator is left alive with an active cancel scope. Later, when the GC or event-loop shutdown tries to finalize the generator, the cancel scope leaks and cancels unrelated tasks, crashing the process.

Closes #4302

## Fix

Two changes:

1. **`nanobot/agent/tools/mcp.py`**: Store a reference to the `streamable_http_client` generator on the exit stack at connection time. In `_close_server`, after catching the `RuntimeError` from `stack.aclose()`, explicitly call `aclose()` on the stashed generator to fully terminate it while the event loop is still healthy.

2. **`nanobot/agent/loop.py`**: Apply the same pattern in `close_mcp()` which has the identical cleanup code path during shutdown.

## Testing

- All 89 MCP-specific tests pass (test_mcp_tool.py, test_mcp_connection.py, test_mcp_transient_retry.py)
- Full test suite: 1335 passed, 2 skipped (pre-existing email channel timeout unrelated)
- ruff check clean

## Notes

The fix targets the `streamable_http` transport specifically. The `stdio` and `sse` transports do not use anyio cancel scopes and are not affected by this cross-task cleanup issue.
