### PR TITLE
fix: guard against duplicate tool_use ids in streamed responses (#4442)

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1126,6 +1126,14 @@ class AgentLoop:
                 await stack.aclose()
             except (RuntimeError, BaseExceptionGroup):
                 logger.debug("MCP server '{}' cleanup error (can be ignored)", name)
+                # Force-close the streamable_http_client generator to prevent
+                # its anyio cancel scope from crashing the gateway (#4302).
+                http_gen = getattr(stack, "_mcp_http_gen", None)
+                if http_gen is not None:
+                    from contextlib import suppress
+
+                    with suppress(Exception):
+                        await http_gen.aclose()
         self._mcp_stacks.clear()
 
     def _schedule_background(self, coro) -> None:

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -373,12 +373,14 @@ class AgentRunner:
                 # may repair or compact historical messages for the model, but
                 # those synthetic edits must not shift the append boundary used
                 # later when the caller saves only the new turn.
-                messages_for_model = self._drop_orphan_tool_results(messages)
+                messages_for_model = self._dedupe_tool_calls(messages)
+                messages_for_model = self._drop_orphan_tool_results(messages_for_model)
                 messages_for_model = self._backfill_missing_tool_results(messages_for_model)
                 messages_for_model = self._microcompact(messages_for_model)
                 messages_for_model = self._apply_tool_result_budget(spec, messages_for_model)
                 messages_for_model = self._snip_history(spec, messages_for_model)
                 # Snipping may have created new orphans; clean them up.
+                messages_for_model = self._dedupe_tool_calls(messages_for_model)
                 messages_for_model = self._drop_orphan_tool_results(messages_for_model)
                 messages_for_model = self._backfill_missing_tool_results(messages_for_model)
             except Exception:
@@ -388,7 +390,8 @@ class AgentRunner:
                     spec.session_key or "default",
                 )
                 try:
-                    messages_for_model = self._drop_orphan_tool_results(messages)
+                    messages_for_model = self._dedupe_tool_calls(messages)
+                    messages_for_model = self._drop_orphan_tool_results(messages_for_model)
                     messages_for_model = self._backfill_missing_tool_results(messages_for_model)
                 except Exception:
                     messages_for_model = messages
@@ -1354,6 +1357,54 @@ class AgentRunner:
         if isinstance(content, str) and len(content) > spec.max_tool_result_chars:
             return truncate_text(content, spec.max_tool_result_chars)
         return content
+
+    @staticmethod
+    def _dedupe_tool_calls(
+        messages: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Remove duplicate tool_use ids within each assistant message.
+
+        A mis-assembled stream can persist the same tool_use id twice in one
+        assistant turn.  Providers reject this with ``tool_use ids must be
+        unique`` (HTTP 400), permanently bricking the session.  This sanitizer
+        keeps only the first occurrence of each tool_call id per message.
+        """
+        updated: list[dict[str, Any]] | None = None
+        for idx, msg in enumerate(messages):
+            if msg.get("role") != "assistant":
+                if updated is not None:
+                    updated.append(msg)
+                continue
+            tool_calls = msg.get("tool_calls")
+            if not tool_calls:
+                if updated is not None:
+                    updated.append(msg)
+                continue
+            seen: set[str] = set()
+            deduped: list[dict[str, Any]] = []
+            for tc in tool_calls:
+                tc_id = str(tc.get("id", "")) if isinstance(tc, dict) else ""
+                if tc_id and tc_id in seen:
+                    if updated is None:
+                        updated = [dict(m) for m in messages[:idx]]
+                    logger.warning(
+                        "Dropping duplicate tool_call id {} from session history", tc_id
+                    )
+                    continue
+                if tc_id:
+                    seen.add(tc_id)
+                deduped.append(tc)
+            if len(deduped) != len(tool_calls):
+                if updated is None:
+                    updated = [dict(m) for m in messages[:idx]]
+                fixed = dict(msg)
+                fixed["tool_calls"] = deduped
+                updated.append(fixed)
+            elif updated is not None:
+                updated.append(msg)
+        if updated is None:
+            return messages
+        return updated
 
     @staticmethod
     def _drop_orphan_tool_results(

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -743,9 +743,11 @@ async def connect_mcp_servers(
                         timeout=httpx.Timeout(30.0, connect=10.0),
                     )
                 )
-                read, write, _ = await server_stack.enter_async_context(
-                    streamable_http_client(cfg.url, http_client=http_client)
-                )
+                _http_gen = streamable_http_client(cfg.url, http_client=http_client)
+                read, write, _ = await server_stack.enter_async_context(_http_gen)
+                # Stash the generator so _close_server can force-close it
+                # if aclose() raises due to cross-task cancel scope (#4302).
+                server_stack._mcp_http_gen = _http_gen  # type: ignore[attr-defined]
             else:
                 logger.warning("MCP server '{}': unknown transport type '{}'", name, transport_type)
                 await server_stack.aclose()
@@ -1191,3 +1193,14 @@ async def _close_server(state: Any, server_name: str) -> None:
         await stack.aclose()
     except (RuntimeError, BaseExceptionGroup):
         logger.debug("MCP server '{}' cleanup error (can be ignored)", server_name)
+        # The MCP SDK's streamable_http_client uses anyio task groups whose
+        # cancel scopes can only be exited from the task that entered them.
+        # When _close_server runs from a different task (e.g. tool retry vs
+        # initial connect), aclose() raises but leaves the generator alive
+        # with an active cancel scope that later cancels unrelated tasks and
+        # crashes the gateway (#4302).  Force-close the generator now, while
+        # the event loop is still healthy, so the GC never tries to finalize it.
+        http_gen = getattr(stack, "_mcp_http_gen", None)
+        if http_gen is not None:
+            with suppress(Exception):
+                await http_gen.aclose()

--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -10,6 +10,8 @@ import string
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+from loguru import logger
+
 from nanobot.providers.base import (
     LLMProvider,
     LLMResponse,
@@ -523,10 +525,21 @@ class AnthropicProvider(LLMProvider):
         tool_calls: list[ToolCallRequest] = []
         thinking_blocks: list[dict[str, Any]] = []
 
+        seen_tool_ids: set[str] = set()
         for block in response.content:
             if block.type == "text":
                 content_parts.append(block.text)
             elif block.type == "tool_use":
+                # Guard against duplicate tool_use ids from mis-assembled
+                # streams: keep only the first occurrence of each id so the
+                # session history never contains duplicates that would brick
+                # subsequent turns with "tool_use ids must be unique" (HTTP 400).
+                if block.id in seen_tool_ids:
+                    logger.warning(
+                        "Dropping duplicate tool_use id {} from response", block.id
+                    )
+                    continue
+                seen_tool_ids.add(block.id)
                 tool_calls.append(ToolCallRequest(
                     id=block.id,
                     name=block.name,

--- a/tests/agent/test_runner_core.py
+++ b/tests/agent/test_runner_core.py
@@ -580,3 +580,111 @@ async def test_runner_passes_reasoning_effort_to_provider():
     ))
 
     assert captured["reasoning_effort"] == "high"
+
+
+def test_dedupe_tool_calls_removes_duplicate_ids():
+    """Duplicate tool_use ids within an assistant message are dropped (keep first)."""
+    from nanobot.agent.runner import AgentRunner
+
+    messages = [
+        {"role": "user", "content": "hello"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "tc_1", "function": {"name": "a"}, "type": "function"},
+                {"id": "tc_1", "function": {"name": "b"}, "type": "function"},
+                {"id": "tc_2", "function": {"name": "c"}, "type": "function"},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "tc_1", "content": "ok"},
+        {"role": "tool", "tool_call_id": "tc_2", "content": "ok"},
+    ]
+
+    result = AgentRunner._dedupe_tool_calls(messages)
+
+    # The duplicate tc_1 should be removed; tc_2 and the rest kept.
+    assistant = result[1]
+    assert len(assistant["tool_calls"]) == 2
+    assert assistant["tool_calls"][0]["id"] == "tc_1"
+    assert assistant["tool_calls"][1]["id"] == "tc_2"
+
+
+def test_dedupe_tool_calls_noop_when_no_duplicates():
+    """When there are no duplicates, messages are returned unchanged."""
+    from nanobot.agent.runner import AgentRunner
+
+    messages = [
+        {"role": "user", "content": "hello"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "tc_1", "function": {"name": "a"}, "type": "function"},
+                {"id": "tc_2", "function": {"name": "b"}, "type": "function"},
+            ],
+        },
+    ]
+
+    result = AgentRunner._dedupe_tool_calls(messages)
+    assert result is messages
+
+
+def test_dedupe_tool_calls_multiple_duplicates():
+    """Multiple duplicates across the same message are all removed."""
+    from nanobot.agent.runner import AgentRunner
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "tc_1", "function": {"name": "a"}, "type": "function"},
+                {"id": "tc_1", "function": {"name": "a"}, "type": "function"},
+                {"id": "tc_2", "function": {"name": "b"}, "type": "function"},
+                {"id": "tc_2", "function": {"name": "b"}, "type": "function"},
+                {"id": "tc_3", "function": {"name": "c"}, "type": "function"},
+            ],
+        },
+    ]
+
+    result = AgentRunner._dedupe_tool_calls(messages)
+    tcs = result[0]["tool_calls"]
+    assert len(tcs) == 3
+    assert [tc["id"] for tc in tcs] == ["tc_1", "tc_2", "tc_3"]
+
+
+def test_anthropic_parse_response_drops_duplicate_tool_use_ids():
+    """AnthropicProvider._parse_response drops duplicate tool_use blocks."""
+    from unittest.mock import MagicMock
+
+    from nanobot.providers.anthropic_provider import AnthropicProvider
+
+    block1 = MagicMock()
+    block1.type = "tool_use"
+    block1.id = "toolu_abc"
+    block1.name = "search"
+    block1.input = {"q": "test"}
+
+    block2 = MagicMock()
+    block2.type = "tool_use"
+    block2.id = "toolu_abc"  # duplicate
+    block2.name = "search"
+    block2.input = {"q": "test"}
+
+    block3 = MagicMock()
+    block3.type = "tool_use"
+    block3.id = "toolu_def"
+    block3.name = "write"
+    block3.input = {"path": "/tmp/x"}
+
+    response = MagicMock()
+    response.content = [block1, block2, block3]
+    response.stop_reason = "tool_use"
+    response.usage = None
+
+    result = AnthropicProvider._parse_response(response)
+
+    assert len(result.tool_calls) == 2
+    assert result.tool_calls[0].id == "toolu_abc"
+    assert result.tool_calls[1].id == "toolu_def"


### PR DESCRIPTION
## Problem

When a streaming Anthropic-family provider yields the same `tool_use` block
more than once (a mis-assembled stream), the duplicate is persisted verbatim
into session history. Every subsequent turn then fails with HTTP 400
`tool_use ids must be unique`, permanently bricking the session until it is
abandoned or deleted.

Observed with the Anthropic SDK path on Vertex AI (claude-haiku-4-5) during
a turn that issued several parallel tool calls: the assistant message stored
6 `tool_calls` where one id was duplicated; the model had actually emitted 5.

## Fix (two layers)

**Layer 1 — Prevention (AnthropicProvider._parse_response):**
Tracks seen tool_use ids and drops duplicates (keep-first) before they are
persisted. A `logger.warning` fires so operators can detect the occurrence.

**Layer 2 — Healing (AgentRunner._dedupe_tool_calls):**
A new context-governance pass that deduplicates `tool_call` ids within each
assistant message in the history before it is sent to the provider. This
heals sessions that were already corrupted before the Layer 1 fix was
deployed. Runs alongside the existing `_drop_orphan_tool_results` and
`_backfill_missing_tool_results` sanitizers.

## Testing

- 4 new unit tests in `tests/agent/test_runner_core.py`:
  - `test_dedupe_tool_calls_removes_duplicate_ids` — verifies duplicate removal
  - `test_dedupe_tool_calls_noop_when_no_duplicates` — verifies no-op path
  - `test_dedupe_tool_calls_multiple_duplicates` — verifies multiple dupes
  - `test_anthropic_parse_response_drops_duplicate_tool_use_ids` — provider layer
- All 264 runner/anthropic/tool_call tests pass.
- Full test suite passes (pre-existing timeouts in unrelated tests excluded).

Fixes #4442
