### PR TITLE
[codex] enforce MCP enabledTools for resources and prompts

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1706,7 +1706,7 @@ Use `toolTimeout` to override the default 30s per-call timeout for slow servers:
 }
 ```
 
-Use `enabledTools` to register only a subset of tools from an MCP server:
+Use `enabledTools` to register only a subset of model-callable capabilities from an MCP server:
 
 ```json
 {
@@ -1722,10 +1722,10 @@ Use `enabledTools` to register only a subset of tools from an MCP server:
 }
 ```
 
-`enabledTools` accepts either the raw MCP tool name (for example `read_file`) or the wrapped nanobot tool name (for example `mcp_filesystem_write_file`).
+`enabledTools` accepts either the raw MCP capability name (for example `read_file`) or the wrapped nanobot tool name (for example `mcp_filesystem_write_file`, `mcp_docs_resource_index`, or `mcp_docs_prompt_research`).
 
-- Omit `enabledTools`, or set it to `["*"]`, to register all tools.
-- Set `enabledTools` to `[]` to register no tools from that server.
+- Omit `enabledTools`, or set it to `["*"]`, to register all tools, resources, and prompts.
+- Set `enabledTools` to `[]` to register no capabilities from that server.
 - Set `enabledTools` to a non-empty list of names to register only that subset.
 
 MCP tools are automatically discovered and registered on startup. The LLM can use them alongside built-in tools — no extra configuration needed.

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -121,6 +121,30 @@ def _sanitize_name(name: str) -> str:
     return _SANITIZE_RE.sub("_", re.sub(r"[^a-zA-Z0-9_-]", "_", name))
 
 
+def _mcp_capability_allowed(
+    enabled_tools: set[str],
+    *,
+    allow_all: bool,
+    raw_name: str,
+    wrapped_name: str,
+) -> bool:
+    """Return whether an MCP tool/resource/prompt wrapper is allowed by enabledTools."""
+    return allow_all or raw_name in enabled_tools or wrapped_name in enabled_tools
+
+
+def _record_mcp_allowlist_match(
+    enabled_tools: set[str],
+    matched_enabled_tools: set[str],
+    *,
+    raw_name: str,
+    wrapped_name: str,
+) -> None:
+    if raw_name in enabled_tools:
+        matched_enabled_tools.add(raw_name)
+    if wrapped_name in enabled_tools:
+        matched_enabled_tools.add(wrapped_name)
+
+
 def _is_transient(exc: BaseException) -> bool:
     """Check if an exception looks like a transient connection error."""
     return type(exc).__name__ in _TRANSIENT_EXC_NAMES
@@ -755,19 +779,31 @@ async def connect_mcp_servers(
             session = await server_stack.enter_async_context(ClientSession(read, write))
             await session.initialize()
 
-            tools = await session.list_tools()
             enabled_tools = set(cfg.enabled_tools)
             allow_all_tools = "*" in enabled_tools
             registered_count = 0
             matched_enabled_tools: set[str] = set()
-            available_raw_names = [tool_def.name for tool_def in tools.tools]
-            available_wrapped_names = [_sanitize_name(f"mcp_{name}_{tool_def.name}") for tool_def in tools.tools]
+            available_raw_names: list[str] = []
+            available_wrapped_names: list[str] = []
+            if not allow_all_tools and not enabled_tools:
+                logger.info(
+                    "MCP server '{}': connected, {} capabilities registered",
+                    name,
+                    registered_count,
+                )
+                return name, server_stack
+
+            tools = await session.list_tools()
             for tool_def in tools.tools:
+                raw_name = tool_def.name
                 wrapped_name = _sanitize_name(f"mcp_{name}_{tool_def.name}")
-                if (
-                    not allow_all_tools
-                    and tool_def.name not in enabled_tools
-                    and wrapped_name not in enabled_tools
+                available_raw_names.append(raw_name)
+                available_wrapped_names.append(wrapped_name)
+                if not _mcp_capability_allowed(
+                    enabled_tools,
+                    allow_all=allow_all_tools,
+                    raw_name=raw_name,
+                    wrapped_name=wrapped_name,
                 ):
                     logger.debug(
                         "MCP: skipping tool '{}' from server '{}' (not in enabledTools)",
@@ -780,10 +816,84 @@ async def connect_mcp_servers(
                 logger.debug("MCP: registered tool '{}' from server '{}'", wrapper.name, name)
                 registered_count += 1
                 if enabled_tools:
-                    if tool_def.name in enabled_tools:
-                        matched_enabled_tools.add(tool_def.name)
-                    if wrapped_name in enabled_tools:
-                        matched_enabled_tools.add(wrapped_name)
+                    _record_mcp_allowlist_match(
+                        enabled_tools,
+                        matched_enabled_tools,
+                        raw_name=raw_name,
+                        wrapped_name=wrapped_name,
+                    )
+
+            try:
+                resources_result = await session.list_resources()
+                for resource in resources_result.resources:
+                    raw_name = resource.name
+                    wrapped_name = _sanitize_name(f"mcp_{name}_resource_{resource.name}")
+                    available_raw_names.append(raw_name)
+                    available_wrapped_names.append(wrapped_name)
+                    if not _mcp_capability_allowed(
+                        enabled_tools,
+                        allow_all=allow_all_tools,
+                        raw_name=raw_name,
+                        wrapped_name=wrapped_name,
+                    ):
+                        logger.debug(
+                            "MCP: skipping resource '{}' from server '{}' (not in enabledTools)",
+                            wrapped_name,
+                            name,
+                        )
+                        continue
+                    wrapper = MCPResourceWrapper(
+                        session, name, resource, resource_timeout=cfg.tool_timeout
+                    )
+                    registry.register(wrapper)
+                    registered_count += 1
+                    logger.debug(
+                        "MCP: registered resource '{}' from server '{}'", wrapper.name, name
+                    )
+                    if enabled_tools:
+                        _record_mcp_allowlist_match(
+                            enabled_tools,
+                            matched_enabled_tools,
+                            raw_name=raw_name,
+                            wrapped_name=wrapped_name,
+                        )
+            except Exception as e:
+                logger.debug("MCP server '{}': resources not supported or failed: {}", name, e)
+
+            try:
+                prompts_result = await session.list_prompts()
+                for prompt in prompts_result.prompts:
+                    raw_name = prompt.name
+                    wrapped_name = _sanitize_name(f"mcp_{name}_prompt_{prompt.name}")
+                    available_raw_names.append(raw_name)
+                    available_wrapped_names.append(wrapped_name)
+                    if not _mcp_capability_allowed(
+                        enabled_tools,
+                        allow_all=allow_all_tools,
+                        raw_name=raw_name,
+                        wrapped_name=wrapped_name,
+                    ):
+                        logger.debug(
+                            "MCP: skipping prompt '{}' from server '{}' (not in enabledTools)",
+                            wrapped_name,
+                            name,
+                        )
+                        continue
+                    wrapper = MCPPromptWrapper(
+                        session, name, prompt, prompt_timeout=cfg.tool_timeout
+                    )
+                    registry.register(wrapper)
+                    registered_count += 1
+                    logger.debug("MCP: registered prompt '{}' from server '{}'", wrapper.name, name)
+                    if enabled_tools:
+                        _record_mcp_allowlist_match(
+                            enabled_tools,
+                            matched_enabled_tools,
+                            raw_name=raw_name,
+                            wrapped_name=wrapped_name,
+                        )
+            except Exception as e:
+                logger.debug("MCP server '{}': prompts not supported or failed: {}", name, e)
 
             if enabled_tools and not allow_all_tools:
                 unmatched_enabled_tools = sorted(enabled_tools - matched_enabled_tools)
@@ -796,32 +906,6 @@ async def connect_mcp_servers(
                         ", ".join(available_raw_names) or "(none)",
                         ", ".join(available_wrapped_names) or "(none)",
                     )
-
-            try:
-                resources_result = await session.list_resources()
-                for resource in resources_result.resources:
-                    wrapper = MCPResourceWrapper(
-                        session, name, resource, resource_timeout=cfg.tool_timeout
-                    )
-                    registry.register(wrapper)
-                    registered_count += 1
-                    logger.debug(
-                        "MCP: registered resource '{}' from server '{}'", wrapper.name, name
-                    )
-            except Exception as e:
-                logger.debug("MCP server '{}': resources not supported or failed: {}", name, e)
-
-            try:
-                prompts_result = await session.list_prompts()
-                for prompt in prompts_result.prompts:
-                    wrapper = MCPPromptWrapper(
-                        session, name, prompt, prompt_timeout=cfg.tool_timeout
-                    )
-                    registry.register(wrapper)
-                    registered_count += 1
-                    logger.debug("MCP: registered prompt '{}' from server '{}'", wrapper.name, name)
-            except Exception as e:
-                logger.debug("MCP server '{}': prompts not supported or failed: {}", name, e)
 
             logger.info(
                 "MCP server '{}': connected, {} capabilities registered", name, registered_count

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -301,7 +301,7 @@ class MCPServerConfig(Base):
     url: str = ""  # HTTP/SSE: endpoint URL
     headers: dict[str, str] = Field(default_factory=dict)  # HTTP/SSE: custom headers
     tool_timeout: int = 30  # seconds before a tool call is cancelled
-    enabled_tools: list[str] = Field(default_factory=lambda: ["*"])  # Only register these tools; accepts raw MCP names or wrapped mcp_<server>_<tool> names; ["*"] = all tools; [] = no tools
+    enabled_tools: list[str] = Field(default_factory=lambda: ["*"])  # Only register these MCP capabilities; accepts raw MCP names or wrapped mcp_<server>_* names; ["*"] = all capabilities; [] = none
 
 
 def _lazy_default(module_path: str, class_name: str) -> Any:

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1059,6 +1059,26 @@ async def test_connect_mcp_servers_enabled_tools_allows_prompt_raw_name(
     assert registry.tool_names == ["mcp_test_prompt_prompt_c"]
 
 
+@pytest.mark.asyncio
+async def test_connect_mcp_servers_enabled_tools_allows_prompt_wrapped_name(
+    fake_mcp_runtime: dict[str, object | None],
+) -> None:
+    fake_mcp_runtime["session"] = _make_fake_session_with_capabilities(
+        tool_names=["tool_a"],
+        resource_names=["res_b"],
+        prompt_names=["prompt_c"],
+    )
+    registry = ToolRegistry()
+    stacks = await connect_mcp_servers(
+        {"test": MCPServerConfig(command="fake", enabled_tools=["mcp_test_prompt_prompt_c"])},
+        registry,
+    )
+    for stack in stacks.values():
+        await stack.aclose()
+
+    assert registry.tool_names == ["mcp_test_prompt_prompt_c"]
+
+
 # ---------------------------------------------------------------------------
 # _sanitize_name tests
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -421,7 +421,11 @@ async def test_connect_mcp_servers_enabled_tools_supports_wrapped_names(
 async def test_connect_mcp_servers_enabled_tools_empty_list_registers_none(
     fake_mcp_runtime: dict[str, object | None],
 ) -> None:
-    fake_mcp_runtime["session"] = _make_fake_session(["demo", "other"])
+    fake_mcp_runtime["session"] = _make_fake_session_with_capabilities(
+        tool_names=["demo", "other"],
+        resource_names=["secret_resource"],
+        prompt_names=["secret_prompt"],
+    )
     registry = ToolRegistry()
     stacks = await connect_mcp_servers(
         {"test": MCPServerConfig(command="fake", enabled_tools=[])},
@@ -993,6 +997,66 @@ async def test_connect_registers_resources_and_prompts(
     assert "mcp_test_tool_a" in registry.tool_names
     assert "mcp_test_resource_res_b" in registry.tool_names
     assert "mcp_test_prompt_prompt_c" in registry.tool_names
+
+
+@pytest.mark.asyncio
+async def test_connect_mcp_servers_enabled_tools_filters_resources_and_prompts(
+    fake_mcp_runtime: dict[str, object | None],
+) -> None:
+    fake_mcp_runtime["session"] = _make_fake_session_with_capabilities(
+        tool_names=["tool_a"],
+        resource_names=["res_b"],
+        prompt_names=["prompt_c"],
+    )
+    registry = ToolRegistry()
+    stacks = await connect_mcp_servers(
+        {"test": MCPServerConfig(command="fake", enabled_tools=["tool_a"])},
+        registry,
+    )
+    for stack in stacks.values():
+        await stack.aclose()
+
+    assert registry.tool_names == ["mcp_test_tool_a"]
+
+
+@pytest.mark.asyncio
+async def test_connect_mcp_servers_enabled_tools_allows_resource_wrapped_name(
+    fake_mcp_runtime: dict[str, object | None],
+) -> None:
+    fake_mcp_runtime["session"] = _make_fake_session_with_capabilities(
+        tool_names=["tool_a"],
+        resource_names=["res_b"],
+        prompt_names=["prompt_c"],
+    )
+    registry = ToolRegistry()
+    stacks = await connect_mcp_servers(
+        {"test": MCPServerConfig(command="fake", enabled_tools=["mcp_test_resource_res_b"])},
+        registry,
+    )
+    for stack in stacks.values():
+        await stack.aclose()
+
+    assert registry.tool_names == ["mcp_test_resource_res_b"]
+
+
+@pytest.mark.asyncio
+async def test_connect_mcp_servers_enabled_tools_allows_prompt_raw_name(
+    fake_mcp_runtime: dict[str, object | None],
+) -> None:
+    fake_mcp_runtime["session"] = _make_fake_session_with_capabilities(
+        tool_names=["tool_a"],
+        resource_names=["res_b"],
+        prompt_names=["prompt_c"],
+    )
+    registry = ToolRegistry()
+    stacks = await connect_mcp_servers(
+        {"test": MCPServerConfig(command="fake", enabled_tools=["prompt_c"])},
+        registry,
+    )
+    for stack in stacks.values():
+        await stack.aclose()
+
+    assert registry.tool_names == ["mcp_test_prompt_prompt_c"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses #4434 and #4435.

- apply `tools.mcpServers.<name>.enabledTools` to all MCP model-callable capabilities: tools, resources, and prompts
- make `enabledTools: []` a true deny-all branch that skips MCP capability discovery/registration after initialization
- keep support for both raw MCP names and wrapped nanobot names, including resource and prompt wrappers
- update configuration docs/schema comments to describe the capability-level policy

## Root Cause

`connect_mcp_servers()` filtered only `session.list_tools()` results. Resource and prompt wrappers from `session.list_resources()` and `session.list_prompts()` were registered unconditionally, so a deny-all or narrow allowlist could still expose those capabilities to the model.

## Validation

- `uv run --extra dev ruff check nanobot/agent/tools/mcp.py tests/tools/test_mcp_tool.py nanobot/config/schema.py`
- `uv run --extra dev pytest tests/tools/test_mcp_tool.py -k "enabled_tools or resources_and_prompts"`
- `uv run --extra dev pytest tests/tools/test_mcp_tool.py`
- `uv run --extra dev pytest tests/tools/test_mcp_tool.py tests/webui/test_mcp_presets_api.py tests/webui/test_mcp_presets_runtime.py tests/agent/test_mcp_connection.py tests/agent/test_mcp_transient_retry.py`
