### PR TITLE
fix(webui): preserve fork replies during history refresh

### DIFF
--- a/webui/src/components/thread/ThreadShell.tsx
+++ b/webui/src/components/thread/ThreadShell.tsx
@@ -44,7 +44,9 @@ function projectWebuiThreadMessages(messages: UIMessage[]): UIMessage[] {
   return scrubSubagentUiMessages(normalizeLegacyLongTaskMessages(messages));
 }
 
-function sameMessageShape(a: UIMessage, b: UIMessage): boolean {
+type MessageShape = Pick<UIMessage, "role" | "kind" | "content">;
+
+function sameMessageShape(a: MessageShape, b: MessageShape): boolean {
   return (
     a.role === b.role
     && (a.kind ?? "") === (b.kind ?? "")
@@ -52,9 +54,51 @@ function sameMessageShape(a: UIMessage, b: UIMessage): boolean {
   );
 }
 
+function durableMessageShape(message: UIMessage): MessageShape | null {
+  if (message.kind === "trace") return null;
+  if (message.role !== "user" && message.role !== "assistant") return null;
+  if (message.role === "assistant" && !message.content.trim() && !message.media?.length) {
+    return null;
+  }
+  return {
+    role: message.role,
+    kind: message.kind,
+    content: message.content,
+  };
+}
+
+function preservesDurableMessages(current: UIMessage[], snapshot: UIMessage[]): boolean {
+  // Canonical history refreshes can race with live websocket messages after fork/send.
+  // Never accept a refreshed snapshot that drops a user/assistant message already shown.
+  const expected = current
+    .map(durableMessageShape)
+    .filter((message): message is MessageShape => message !== null);
+  if (expected.length === 0) return true;
+  const candidates = snapshot
+    .map(durableMessageShape)
+    .filter((message): message is MessageShape => message !== null);
+
+  let cursor = 0;
+  for (const message of expected) {
+    let found = false;
+    while (cursor < candidates.length) {
+      const candidate = candidates[cursor];
+      cursor += 1;
+      if (sameMessageShape(message, candidate)) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) return false;
+  }
+  return true;
+}
+
 function isStaleThreadSnapshot(current: UIMessage[], snapshot: UIMessage[]): boolean {
-  if (current.length === 0 || snapshot.length >= current.length) return false;
+  if (current.length === 0) return false;
   if (snapshot.length === 0) return true;
+  if (!preservesDurableMessages(current, snapshot)) return true;
+  if (snapshot.length >= current.length) return false;
   return snapshot.every((message, index) => sameMessageShape(current[index], message));
 }
 

--- a/webui/src/tests/thread-shell.test.tsx
+++ b/webui/src/tests/thread-shell.test.tsx
@@ -931,6 +931,75 @@ describe("ThreadShell", () => {
     await waitFor(() => expect(screen.getByText("live assistant reply")).toBeInTheDocument());
   });
 
+  it("keeps live fork replies when a canonical refresh is missing an earlier assistant answer", async () => {
+    const client = makeClient();
+    let historyCalls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("websocket%3Achat-fork/webui-thread")) {
+          historyCalls += 1;
+          return httpJson(
+            transcriptFromSimpleMessages(
+              historyCalls === 1
+                ? [{ role: "user", content: "first fork question" }]
+                : [
+                    { role: "user", content: "first fork question" },
+                    { role: "user", content: "second fork question" },
+                  ],
+            ),
+          );
+        }
+        return {
+          ok: false,
+          status: 404,
+          json: async () => ({}),
+        };
+      }),
+    );
+
+    render(
+      wrap(
+        client,
+        <ThreadShell
+          session={session("chat-fork")}
+          title="Chat chat-fork"
+          onToggleSidebar={() => {}}
+          onNewChat={() => {}}
+        />,
+      ),
+    );
+
+    await waitFor(() => expect(screen.getByText("first fork question")).toBeInTheDocument());
+    await act(async () => {
+      client._emitChat("chat-fork", {
+        event: "message",
+        chat_id: "chat-fork",
+        text: "first fork answer",
+      });
+    });
+    expect(screen.getByText("first fork answer")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Message input"), {
+      target: { value: "second fork question" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expectSendMessageWithTurn(client, "chat-fork", "second fork question"),
+    );
+    expect(screen.getByText("second fork question")).toBeInTheDocument();
+
+    await act(async () => {
+      client._emitSessionUpdate("chat-fork");
+    });
+
+    await waitFor(() => expect(historyCalls).toBe(2));
+    expect(screen.getByText("first fork question")).toBeInTheDocument();
+    expect(screen.getByText("first fork answer")).toBeInTheDocument();
+    expect(screen.getByText("second fork question")).toBeInTheDocument();
+  });
+
   it("does not refetch thread history on turn_end", async () => {
     const client = makeClient();
     let historyCalls = 0;


### PR DESCRIPTION
## Summary

Fix a WebUI fork race where an already-rendered assistant reply could disappear after the next message triggered a canonical history refresh.

The failing shape is:

1. A forked thread receives a live assistant reply over the websocket.
2. The user sends the next message.
3. A `session_updated` refresh returns a canonical snapshot that contains the new user turn but is still missing the earlier assistant reply.
4. The old stale-snapshot guard only rejected shorter prefix snapshots, so it accepted this out-of-order snapshot and overwrote the in-memory thread with one missing reply.

The transcript on disk can still be complete, but the WebUI state has already lost that visible reply.

## Changes

- Treat a refreshed thread snapshot as stale if it drops any durable user/assistant message already shown in the current UI state.
- Keep trace/empty assistant placeholder rows out of that durable-message check so live activity rows can still be replaced by canonical history.
- Add a focused regression test for the fork/send/session-refresh race.

## Validation

- `cd webui && bun run test -- thread-shell useSessions useNanobotStream`
- `cd webui && bun run build`
- `git diff --check`
