### PR TITLE
fix(gateway): tolerate cancelled channel tasks during shutdown

### DIFF
--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -252,6 +252,10 @@ class ChannelManager:
             try:
                 await channel.stop()
                 logger.info("Stopped {} channel", name)
+            except asyncio.CancelledError:
+                if asyncio.current_task() and asyncio.current_task().cancelling():
+                    raise
+                logger.debug("Channel {} stop task was already cancelled", name)
             except Exception:
                 logger.exception("Error stopping {}", name)
 

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -827,6 +827,10 @@ class WebSocketChannel(BaseChannel):
         if self._server_task:
             try:
                 await self._server_task
+            except asyncio.CancelledError:
+                if asyncio.current_task() and asyncio.current_task().cancelling():
+                    raise
+                self.logger.debug("server task was already cancelled during shutdown")
             except Exception as e:
                 self.logger.warning("server task error during shutdown: {}", e)
             self._server_task = None

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -80,6 +80,29 @@ def _signal_name(signum: int) -> str:
     return f"signal {signum}"
 
 
+def _ensure_gateway_tty_signal_mode() -> None:
+    """Keep foreground gateway Ctrl+C usable even after a raw-mode TTY leak."""
+    try:
+        fd = sys.stdin.fileno()
+        if not os.isatty(fd):
+            return
+    except Exception:
+        return
+
+    with suppress(Exception):
+        import termios
+
+        attrs = termios.tcgetattr(fd)
+        lflag = attrs[3]
+        required = termios.ISIG | termios.ICANON | termios.ECHO
+        if (lflag & required) == required:
+            return
+        attrs[3] = lflag | required
+        termios.tcsetattr(fd, termios.TCSANOW, attrs)
+        termios.tcflush(fd, termios.TCIFLUSH)
+        logger.debug("Restored foreground gateway TTY signal mode")
+
+
 def _install_gateway_shutdown_handlers(
     loop: asyncio.AbstractEventLoop,
     shutdown_event: asyncio.Event,
@@ -1166,6 +1189,7 @@ def _run_gateway(
         runtime_tasks: asyncio.Future | None = None
         runtime_tasks_drained = False
         shutdown_event = asyncio.Event()
+        _ensure_gateway_tty_signal_mode()
         restore_shutdown_handlers = _install_gateway_shutdown_handlers(
             asyncio.get_running_loop(),
             shutdown_event,

--- a/tests/channels/test_channel_plugins.py
+++ b/tests/channels/test_channel_plugins.py
@@ -1223,6 +1223,43 @@ async def test_stop_all_handles_channel_exception():
 
 
 @pytest.mark.asyncio
+async def test_stop_all_handles_channel_stop_cancelled_task():
+    """stop_all should treat a channel's already-cancelled internals as stopped."""
+
+    class _StopCancelledChannel(BaseChannel):
+        name = "stopcancelled"
+        display_name = "Stop Cancelled"
+
+        async def start(self) -> None:
+            pass
+
+        async def stop(self) -> None:
+            raise asyncio.CancelledError("server task cancelled")
+
+        async def send(self, msg: OutboundMessage) -> None:
+            pass
+
+    fake_config = SimpleNamespace(
+        channels=ChannelsConfig(),
+        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+    )
+
+    mgr = ChannelManager.__new__(ChannelManager)
+    mgr.config = fake_config
+    mgr.bus = MessageBus()
+    next_channel = _StartableChannel(fake_config, mgr.bus)
+    mgr.channels = {
+        "stopcancelled": _StopCancelledChannel(fake_config, mgr.bus),
+        "next": next_channel,
+    }
+    mgr._dispatch_task = None
+
+    await mgr.stop_all()
+
+    assert next_channel.stopped is True
+
+
+@pytest.mark.asyncio
 async def test_start_all_no_channels_logs_warning():
     """start_all should log warning when no channels are enabled."""
     fake_config = SimpleNamespace(

--- a/tests/channels/test_websocket_channel.py
+++ b/tests/channels/test_websocket_channel.py
@@ -96,6 +96,27 @@ def _basic_handler(bus: Any, **kw: Any) -> GatewayServices:
     )
 
 
+@pytest.mark.asyncio
+async def test_stop_treats_cancelled_server_task_as_shutdown() -> None:
+    channel = _ch(MessageBus())
+    channel._running = True
+    channel._stop_event = asyncio.Event()
+
+    async def _server_task() -> None:
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(_server_task())
+    await asyncio.sleep(0)
+    task.cancel()
+    await asyncio.sleep(0)
+    channel._server_task = task
+
+    await channel.stop()
+
+    assert channel._server_task is None
+    assert task.cancelled()
+
+
 @pytest.fixture()
 def bus() -> MagicMock:
     b = MagicMock()

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -109,6 +109,37 @@ def test_gateway_signal_handler_first_signal_stops_and_second_forces() -> None:
     asyncio.run(_run())
 
 
+def test_gateway_tty_signal_mode_restores_ctrl_c(monkeypatch) -> None:
+    try:
+        import os
+        import pty
+        import termios
+    except ImportError:  # pragma: no cover - platform without POSIX termios
+        pytest.skip("termios unavailable")
+
+    master_fd, slave_fd = pty.openpty()
+
+    class _Stdin:
+        def fileno(self) -> int:
+            return slave_fd
+
+    try:
+        attrs = termios.tcgetattr(slave_fd)
+        attrs[3] &= ~(termios.ISIG | termios.ICANON | termios.ECHO)
+        termios.tcsetattr(slave_fd, termios.TCSANOW, attrs)
+
+        monkeypatch.setattr(cli_commands.sys, "stdin", _Stdin())
+        cli_commands._ensure_gateway_tty_signal_mode()
+
+        restored = termios.tcgetattr(slave_fd)
+        assert restored[3] & termios.ISIG
+        assert restored[3] & termios.ICANON
+        assert restored[3] & termios.ECHO
+    finally:
+        os.close(master_fd)
+        os.close(slave_fd)
+
+
 @pytest.fixture
 def mock_paths():
     """Mock config/workspace paths for test isolation."""


### PR DESCRIPTION
## Summary

Fix the remaining foreground gateway shutdown problems after #4454.

There were two separate shutdown failure modes:

1. `WebSocketChannel.stop()` awaited an internal server task that had already been cancelled. On Python 3.11, `asyncio.CancelledError` is not caught by `except Exception`, so it escaped `ChannelManager.stop_all()` and caused `asyncio.run()` teardown to print the MCP/anyio cancel-scope traceback again.
2. A foreground terminal can be left in raw-ish mode by a previous TUI flow (`-isig -icanon -echo`). In that state, keyboard Ctrl+C is delivered as a literal `^C` byte instead of SIGINT, so the gateway signal handler never runs.

## Changes

- Treat an already-cancelled WebSocket server task as a normal shutdown result, unless the stop coroutine itself is being externally cancelled.
- Make `ChannelManager.stop_all()` apply the same rule for channel-level `CancelledError`, so one channel's already-cancelled internals do not abort the rest of gateway cleanup.
- On foreground gateway startup, restore basic TTY signal mode (`ISIG`, `ICANON`, `ECHO`) when stdin is a TTY and those bits are missing. `nanobot gateway` is not a raw-mode UI, so Ctrl+C should always be usable there.
- Add focused regression tests for channel cancellation and broken TTY signal mode.

## Validation

- `python -m pytest tests/cli/test_commands.py tests/channels/test_websocket_channel.py::test_stop_treats_cancelled_server_task_as_shutdown tests/channels/test_channel_plugins.py::test_stop_all_handles_channel_stop_cancelled_task -q`
- `python -m ruff check nanobot/cli/commands.py tests/cli/test_commands.py nanobot/channels/websocket.py nanobot/channels/manager.py tests/channels/test_websocket_channel.py tests/channels/test_channel_plugins.py`
- `git diff --check`
- Process smoke: start `nanobot gateway` from current source, wait for MCP `playwright` to connect, send `SIGINT`, verify return code `0` and no `asyncio.run() shutdown`, `Attempted to exit cancel scope`, `asyncio.exceptions.CancelledError`, or traceback output.
- PTY smoke: start `nanobot gateway` inside a pseudo-terminal deliberately configured with `-isig -icanon -echo`, write the Ctrl+C byte (`\x03`), verify the gateway restores signal mode, receives SIGINT, exits with code `0`, and prints no shutdown traceback.
