### PR TITLE
docs: add v0.2.2 release news

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 
 ## 📢 News
 
+- **2026-06-23** 🚀 Released **v0.2.2** — **The Durability Release** makes nanobot sturdier for daily agent work: segmented WebUI transcripts, first-class Python SDK runtime controls, automation management, richer search/STT providers, and stronger gateway/session/provider reliability. Please see [release notes](https://github.com/HKUDS/nanobot/releases/tag/v0.2.2) for details.
 - **2026-06-20** 💬 Telegram rich messages, safer SDK concurrency, smoother Quick Start.
 - **2026-06-19** 🔎 Firecrawl app, OpenAI image edits, safer session deletion.
 - **2026-06-18** 💬 Feishu recovery, Keenable search, Mistral polish, workspace-aware git.
@@ -65,11 +66,11 @@
 - **2026-06-14** 🖼️ Themed cover, partner links, stronger Codex image streaming.
 - **2026-06-13** 🗓️ Session-bound automations, sturdier WhatsApp, faster WebUI startup.
 - **2026-06-12** 💬 Slack allowlisted channels can require mentions.
-- **2026-06-11** ✂️ Fenced-code message splitting.
 
 <details>
 <summary>Earlier news</summary>
 
+- **2026-06-11** ✂️ Fenced-code message splitting.
 - **2026-06-10** 📜 Segmented transcripts, Exa/Bocha search, StepFun/SiliconFlow ASR.
 - **2026-06-09** 🎙️ Shared voice input, more STT providers, TeX and email polish.
 - **2026-06-08** 🧮 Token heatmap fix, safer MCP HTTP probing, docs cleanup.


### PR DESCRIPTION
## Summary

- add the v0.2.2 release entry to the README News section
- keep the visible News list capped at 10 entries by moving 2026-06-11 into Earlier news

## Notes

This is a post-release docs-only update. It does not change runtime code, packaging, or WebUI assets.

## Checks

- Verified the visible News section still has 10 entries
