### PR TITLE
Fix raw <thinking> tags in reasoning output

### DIFF
--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -34,6 +34,7 @@ from nanobot.utils.helpers import (
     extract_reasoning,
     find_legal_message_start,
     maybe_persist_tool_result,
+    strip_reasoning_tags,
     strip_think,
     truncate_text,
 )
@@ -766,8 +767,10 @@ class AgentRunner:
             async def _thinking(delta: str) -> None:
                 if not delta:
                     return
-                context.streamed_reasoning = True
-                await hook.emit_reasoning(delta)
+                delta = strip_reasoning_tags(delta)
+                if delta:
+                    context.streamed_reasoning = True
+                    await hook.emit_reasoning(delta)
 
             async def _stream_recover() -> None:
                 await hook.on_stream_end(context, resuming=True)

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -759,18 +759,24 @@ class AgentRunner:
                 await live_file_edits.update(delta)
 
         if wants_streaming:
+            thinking_buf = ""
+
             async def _stream(delta: str) -> None:
                 if delta:
                     context.streamed_content = True
                 await hook.on_stream(context, delta)
 
             async def _thinking(delta: str) -> None:
+                nonlocal thinking_buf
                 if not delta:
                     return
-                delta = strip_reasoning_tags(delta)
-                if delta:
+                prev_clean = strip_reasoning_tags(thinking_buf)
+                thinking_buf += delta
+                new_clean = strip_reasoning_tags(thinking_buf)
+                incremental = new_clean[len(prev_clean):]
+                if incremental:
                     context.streamed_reasoning = True
-                    await hook.emit_reasoning(delta)
+                    await hook.emit_reasoning(incremental)
 
             async def _stream_recover() -> None:
                 await hook.on_stream_end(context, resuming=True)

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -84,10 +84,15 @@ def strip_reasoning_tags(text: object) -> str:
     """Remove wrapper tags from text that is already known to be reasoning."""
     if not isinstance(text, str):
         return ""
+    partial_reasoning_tag = (
+        r"</?(?:t|th|thi|thin|think|thinki|thinkin|thinking|tho|thou|thoug|though|thought)>?"
+    )
+    text = re.sub(rf"^\s*(?:{partial_reasoning_tag})$", "", text)
     text = re.sub(r"^\s*<(?:think|thinking|thought)/>\s*", "", text)
     text = re.sub(r"\s*<(?:think|thinking|thought)/>\s*$", "", text)
     text = re.sub(r"^\s*<(?:think|thinking|thought)>\s*", "", text)
     text = re.sub(r"\s*</(?:think|thinking|thought)>\s*$", "", text)
+    text = re.sub(rf"\s*(?:{partial_reasoning_tag})$", "", text)
     return text.strip()
 
 

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -15,6 +15,27 @@ import tiktoken
 from loguru import logger
 
 
+def _tag_regex(tags: tuple[str, ...]) -> str:
+    return rf"(?:{'|'.join(re.escape(tag) for tag in tags)})"
+
+
+_THINKING_TAGS = ("think", "thinking", "thought")
+_INLINE_SELF_CLOSING_PRESERVED_TAGS = frozenset({"think", "thought"})
+_INLINE_SELF_CLOSING_THINKING_TAGS = tuple(
+    tag for tag in _THINKING_TAGS if tag not in _INLINE_SELF_CLOSING_PRESERVED_TAGS
+)
+_THINKING_TAG = _tag_regex(_THINKING_TAGS)
+_INLINE_SELF_CLOSING_THINKING_TAG = _tag_regex(_INLINE_SELF_CLOSING_THINKING_TAGS)
+_THINKING_TAG_PREFIX = "|".join(
+    sorted(
+        {re.escape(tag[:i]) for tag in _THINKING_TAGS for i in range(1, len(tag) + 1)},
+        key=len,
+        reverse=True,
+    )
+)
+_PARTIAL_THINKING_TAG = rf"</?(?:{_THINKING_TAG_PREFIX})>?"
+
+
 def strip_think(text: str) -> str:
     """Remove thinking blocks, unclosed trailing tags, and tokenizer-level
     template leaks occasionally emitted by some models (notably Gemma 4's
@@ -42,38 +63,28 @@ def strip_think(text: str) -> str:
     assistant discusses the tokens themselves.
     """
     # Well-formed blocks first.
-    text = re.sub(r"<think>[\s\S]*?</think>", "", text)
-    text = re.sub(r"^\s*<think>[\s\S]*$", "", text)
-    text = re.sub(r"<thinking>[\s\S]*?</thinking>", "", text)
-    text = re.sub(r"^\s*<thinking>[\s\S]*$", "", text)
-    text = re.sub(r"<thought>[\s\S]*?</thought>", "", text)
-    text = re.sub(r"^\s*<thought>[\s\S]*$", "", text)
+    text = re.sub(rf"<(?P<tag>{_THINKING_TAG})>[\s\S]*?</(?P=tag)>", "", text)
+    text = re.sub(rf"^\s*<{_THINKING_TAG}>[\s\S]*$", "", text)
     # Self-closing `<thinking/>` is an empty marker, not user-visible text.
-    text = re.sub(r"^\s*<thinking/>\s*", "", text)
-    text = re.sub(r"\s*<thinking/>\s*$", "", text)
+    text = re.sub(rf"^\s*<{_INLINE_SELF_CLOSING_THINKING_TAG}/>\s*", "", text)
+    text = re.sub(rf"\s*<{_INLINE_SELF_CLOSING_THINKING_TAG}/>\s*$", "", text)
     # Malformed opening tags: `<think` / `<thinking` / `<thought` where the next char is
     # NOT one that could continue a valid tag / identifier name. Explicitly
     # listing ASCII tag-name chars (letters, digits, `_`, `-`, `:`) plus
     # `>` / `/` — we can't use `\w` here because in Python's default
     # Unicode regex mode it matches CJK characters too, which would defeat
     # the primary fix for `<think广场…` leaks.
-    text = re.sub(r"<think(?![A-Za-z0-9_\-:>/])", "", text)
-    text = re.sub(r"<thinking(?![A-Za-z0-9_\-:>/])", "", text)
-    text = re.sub(r"<thought(?![A-Za-z0-9_\-:>/])", "", text)
+    text = re.sub(rf"<{_THINKING_TAG}(?![A-Za-z0-9_\-:>/])", "", text)
     # Edge-only orphan closing tags (start or end of text).
-    text = re.sub(r"^\s*</think>\s*", "", text)
-    text = re.sub(r"\s*</think>\s*$", "", text)
-    text = re.sub(r"^\s*</thinking>\s*", "", text)
-    text = re.sub(r"\s*</thinking>\s*$", "", text)
-    text = re.sub(r"^\s*</thought>\s*", "", text)
-    text = re.sub(r"\s*</thought>\s*$", "", text)
+    text = re.sub(rf"^\s*</{_THINKING_TAG}>\s*", "", text)
+    text = re.sub(rf"\s*</{_THINKING_TAG}>\s*$", "", text)
     # Edge-only channel markers (harmony / Gemma 4 variant leaks).
     text = re.sub(r"^\s*<\|?channel\|?>\s*", "", text)
     # Stream chunks may end in the middle of a control tag. Strip only known
     # control-token prefixes at the very end.
     partial_control_tag = (
-        r"</?(?:t|th|thi|thin|think|thinki|thinkin|thinking|tho|thou|thoug|though|thought)>?"
-        r"|<\|?(?:c|ch|cha|chan|chann|channe|channel)(?:\|?>?)?"
+        rf"{_PARTIAL_THINKING_TAG}|"
+        r"<\|?(?:c|ch|cha|chan|chann|channe|channel)(?:\|?>?)?"
     )
     text = re.sub(rf"(?:{partial_control_tag})$", "", text)
     text = re.sub(r"^\s*<\|?$", "", text)
@@ -84,15 +95,12 @@ def strip_reasoning_tags(text: object) -> str:
     """Remove wrapper tags from text that is already known to be reasoning."""
     if not isinstance(text, str):
         return ""
-    partial_reasoning_tag = (
-        r"</?(?:t|th|thi|thin|think|thinki|thinkin|thinking|tho|thou|thoug|though|thought)>?"
-    )
-    text = re.sub(rf"^\s*(?:{partial_reasoning_tag})$", "", text)
-    text = re.sub(r"^\s*<(?:think|thinking|thought)/>\s*", "", text)
-    text = re.sub(r"\s*<(?:think|thinking|thought)/>\s*$", "", text)
-    text = re.sub(r"^\s*<(?:think|thinking|thought)>\s*", "", text)
-    text = re.sub(r"\s*</(?:think|thinking|thought)>\s*$", "", text)
-    text = re.sub(rf"\s*(?:{partial_reasoning_tag})$", "", text)
+    text = re.sub(rf"^\s*(?:{_PARTIAL_THINKING_TAG})$", "", text)
+    text = re.sub(rf"^\s*<{_THINKING_TAG}/>\s*", "", text)
+    text = re.sub(rf"\s*<{_THINKING_TAG}/>\s*$", "", text)
+    text = re.sub(rf"^\s*<{_THINKING_TAG}>\s*", "", text)
+    text = re.sub(rf"\s*</{_THINKING_TAG}>\s*$", "", text)
+    text = re.sub(rf"\s*(?:{_PARTIAL_THINKING_TAG})$", "", text)
     return text.strip()
 
 
@@ -104,12 +112,8 @@ def extract_think(text: str) -> tuple[str | None, str]:
     text but not surfaced — :func:`strip_think` handles that case.
     """
     parts: list[str] = []
-    for m in re.finditer(r"<think>([\s\S]*?)</think>", text):
-        parts.append(m.group(1).strip())
-    for m in re.finditer(r"<thinking>([\s\S]*?)</thinking>", text):
-        parts.append(m.group(1).strip())
-    for m in re.finditer(r"<thought>([\s\S]*?)</thought>", text):
-        parts.append(m.group(1).strip())
+    for m in re.finditer(rf"<(?P<tag>{_THINKING_TAG})>([\s\S]*?)</(?P=tag)>", text):
+        parts.append(m.group(2).strip())
     thinking = "\n\n".join(parts) if parts else None
     return thinking, strip_think(text)
 

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -20,12 +20,8 @@ def _tag_regex(tags: tuple[str, ...]) -> str:
 
 
 _THINKING_TAGS = ("think", "thinking", "thought")
-_INLINE_SELF_CLOSING_PRESERVED_TAGS = frozenset({"think", "thought"})
-_INLINE_SELF_CLOSING_THINKING_TAGS = tuple(
-    tag for tag in _THINKING_TAGS if tag not in _INLINE_SELF_CLOSING_PRESERVED_TAGS
-)
 _THINKING_TAG = _tag_regex(_THINKING_TAGS)
-_INLINE_SELF_CLOSING_THINKING_TAG = _tag_regex(_INLINE_SELF_CLOSING_THINKING_TAGS)
+_INLINE_SELF_CLOSING_THINKING_TAG = r"(?:thinking)"
 _THINKING_TAG_PREFIX = "|".join(
     sorted(
         {re.escape(tag[:i]) for tag in _THINKING_TAGS for i in range(1, len(tag) + 1)},
@@ -95,7 +91,6 @@ def strip_reasoning_tags(text: object) -> str:
     """Remove wrapper tags from text that is already known to be reasoning."""
     if not isinstance(text, str):
         return ""
-    text = re.sub(rf"^\s*(?:{_PARTIAL_THINKING_TAG})$", "", text)
     text = re.sub(rf"^\s*<{_THINKING_TAG}/>\s*", "", text)
     text = re.sub(rf"\s*<{_THINKING_TAG}/>\s*$", "", text)
     text = re.sub(rf"^\s*<{_THINKING_TAG}>\s*", "", text)

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -21,7 +21,8 @@ def strip_think(text: str) -> str:
     Ollama renderer).
 
     Covers:
-      1. Well-formed `<think>...</think>` and `<thought>...</thought>` blocks.
+      1. Well-formed `<think>...</think>`, `<thinking>...</thinking>`,
+         and `<thought>...</thought>` blocks.
       2. Streaming prefixes where the block is never closed.
       3. *Malformed* opening tags missing the `>` — e.g. `<think广场…`. The
          model sometimes emits the tag name directly followed by user-facing
@@ -30,8 +31,8 @@ def strip_think(text: str) -> str:
       4. Harmony-style channel markers like `<channel|>` / `<|channel|>`
          **at the start of the text** — conservative to avoid eating
          explanatory prose that mentions these tokens.
-      5. Orphan closing tags `</think>` / `</thought>` **at the very start
-         or end of the text** only, for the same reason.
+      5. Orphan closing tags `</think>` / `</thinking>` / `</thought>`
+         **at the very start or end of the text** only, for the same reason.
       6. Trailing partial control tags split across stream chunks, such as
          `<thi`, `<thin`, or `<tho`.
 
@@ -43,19 +44,27 @@ def strip_think(text: str) -> str:
     # Well-formed blocks first.
     text = re.sub(r"<think>[\s\S]*?</think>", "", text)
     text = re.sub(r"^\s*<think>[\s\S]*$", "", text)
+    text = re.sub(r"<thinking>[\s\S]*?</thinking>", "", text)
+    text = re.sub(r"^\s*<thinking>[\s\S]*$", "", text)
     text = re.sub(r"<thought>[\s\S]*?</thought>", "", text)
     text = re.sub(r"^\s*<thought>[\s\S]*$", "", text)
-    # Malformed opening tags: `<think` / `<thought` where the next char is
+    # Self-closing `<thinking/>` is an empty marker, not user-visible text.
+    text = re.sub(r"^\s*<thinking/>\s*", "", text)
+    text = re.sub(r"\s*<thinking/>\s*$", "", text)
+    # Malformed opening tags: `<think` / `<thinking` / `<thought` where the next char is
     # NOT one that could continue a valid tag / identifier name. Explicitly
     # listing ASCII tag-name chars (letters, digits, `_`, `-`, `:`) plus
     # `>` / `/` — we can't use `\w` here because in Python's default
     # Unicode regex mode it matches CJK characters too, which would defeat
     # the primary fix for `<think广场…` leaks.
     text = re.sub(r"<think(?![A-Za-z0-9_\-:>/])", "", text)
+    text = re.sub(r"<thinking(?![A-Za-z0-9_\-:>/])", "", text)
     text = re.sub(r"<thought(?![A-Za-z0-9_\-:>/])", "", text)
     # Edge-only orphan closing tags (start or end of text).
     text = re.sub(r"^\s*</think>\s*", "", text)
     text = re.sub(r"\s*</think>\s*$", "", text)
+    text = re.sub(r"^\s*</thinking>\s*", "", text)
+    text = re.sub(r"\s*</thinking>\s*$", "", text)
     text = re.sub(r"^\s*</thought>\s*", "", text)
     text = re.sub(r"\s*</thought>\s*$", "", text)
     # Edge-only channel markers (harmony / Gemma 4 variant leaks).
@@ -63,7 +72,7 @@ def strip_think(text: str) -> str:
     # Stream chunks may end in the middle of a control tag. Strip only known
     # control-token prefixes at the very end.
     partial_control_tag = (
-        r"</?(?:t|th|thi|thin|think|tho|thou|thoug|though|thought)>?"
+        r"</?(?:t|th|thi|thin|think|thinki|thinkin|thinking|tho|thou|thoug|though|thought)>?"
         r"|<\|?(?:c|ch|cha|chan|chann|channe|channel)(?:\|?>?)?"
     )
     text = re.sub(rf"(?:{partial_control_tag})$", "", text)
@@ -71,8 +80,17 @@ def strip_think(text: str) -> str:
     return text.strip()
 
 
+def strip_reasoning_tags(text: str) -> str:
+    """Remove wrapper tags from text that is already known to be reasoning."""
+    text = re.sub(r"^\s*<(?:think|thinking|thought)/>\s*", "", text)
+    text = re.sub(r"\s*<(?:think|thinking|thought)/>\s*$", "", text)
+    text = re.sub(r"^\s*<(?:think|thinking|thought)>\s*", "", text)
+    text = re.sub(r"\s*</(?:think|thinking|thought)>\s*$", "", text)
+    return text.strip()
+
+
 def extract_think(text: str) -> tuple[str | None, str]:
-    """Extract thinking content from inline ``<think>`` / ``<thought>`` blocks.
+    """Extract thinking content from inline thinking tags.
 
     Returns ``(thinking_text, cleaned_text)``. Only closed blocks are
     extracted; unclosed streaming prefixes are stripped from the cleaned
@@ -80,6 +98,8 @@ def extract_think(text: str) -> tuple[str | None, str]:
     """
     parts: list[str] = []
     for m in re.finditer(r"<think>([\s\S]*?)</think>", text):
+        parts.append(m.group(1).strip())
+    for m in re.finditer(r"<thinking>([\s\S]*?)</thinking>", text):
         parts.append(m.group(1).strip())
     for m in re.finditer(r"<thought>([\s\S]*?)</thought>", text):
         parts.append(m.group(1).strip())
@@ -144,10 +164,10 @@ def extract_reasoning(
     final answer.
     """
     if reasoning_content:
-        return reasoning_content, strip_think(content) if content else content
+        return strip_reasoning_tags(reasoning_content), strip_think(content) if content else content
     if thinking_blocks:
         parts = [
-            tb.get("thinking", "")
+            strip_reasoning_tags(tb.get("thinking", ""))
             for tb in thinking_blocks
             if isinstance(tb, dict) and tb.get("type") == "thinking"
         ]
@@ -411,7 +431,11 @@ def build_assistant_message(
     if tool_calls:
         msg["tool_calls"] = tool_calls
     if reasoning_content is not None or thinking_blocks:
-        msg["reasoning_content"] = reasoning_content if reasoning_content is not None else ""
+        msg["reasoning_content"] = (
+            strip_reasoning_tags(reasoning_content)
+            if reasoning_content is not None
+            else ""
+        )
     if thinking_blocks:
         msg["thinking_blocks"] = thinking_blocks
     return msg

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -80,8 +80,10 @@ def strip_think(text: str) -> str:
     return text.strip()
 
 
-def strip_reasoning_tags(text: str) -> str:
+def strip_reasoning_tags(text: object) -> str:
     """Remove wrapper tags from text that is already known to be reasoning."""
+    if not isinstance(text, str):
+        return ""
     text = re.sub(r"^\s*<(?:think|thinking|thought)/>\s*", "", text)
     text = re.sub(r"\s*<(?:think|thinking|thought)/>\s*$", "", text)
     text = re.sub(r"^\s*<(?:think|thinking|thought)>\s*", "", text)

--- a/tests/agent/test_runner_reasoning.py
+++ b/tests/agent/test_runner_reasoning.py
@@ -405,3 +405,42 @@ async def test_runner_strips_thinking_tags_from_native_thinking_deltas():
 
     assert result.final_content == "done"
     assert hook.emitted == ["Preparing final response"]
+
+
+@pytest.mark.asyncio
+async def test_runner_ignores_empty_thinking_marker_before_final_reasoning():
+    from nanobot.agent.runner import AgentRunner, AgentRunSpec
+
+    provider = MagicMock()
+
+    async def chat_stream_with_retry(
+        *, on_content_delta=None, on_thinking_delta=None, **kwargs
+    ):
+        if on_thinking_delta:
+            await on_thinking_delta("<thinking/>")
+        if on_content_delta:
+            await on_content_delta("done")
+        return LLMResponse(
+            content="done",
+            reasoning_content="Preparing final response",
+            tool_calls=[],
+            usage={},
+        )
+
+    provider.chat_stream_with_retry = chat_stream_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+
+    hook = _StreamRecordingHook()
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "q"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=3,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        hook=hook,
+    ))
+
+    assert result.final_content == "done"
+    assert hook.emitted == ["Preparing final response"]

--- a/tests/agent/test_runner_reasoning.py
+++ b/tests/agent/test_runner_reasoning.py
@@ -381,8 +381,8 @@ async def test_runner_strips_thinking_tags_from_native_thinking_deltas():
         *, on_content_delta=None, on_thinking_delta=None, **kwargs
     ):
         if on_thinking_delta:
-            await on_thinking_delta("<thinking>")
-            await on_thinking_delta("Preparing final response")
+            await on_thinking_delta("<thinking")
+            await on_thinking_delta(">Preparing final response")
             await on_thinking_delta("</thinking>")
         if on_content_delta:
             await on_content_delta("done")

--- a/tests/agent/test_runner_reasoning.py
+++ b/tests/agent/test_runner_reasoning.py
@@ -369,3 +369,39 @@ async def test_runner_streams_native_thinking_deltas_without_post_hoc_dup():
 
     assert result.final_content == "done"
     assert hook.emitted == ["part1", "part2"]
+
+
+@pytest.mark.asyncio
+async def test_runner_strips_thinking_tags_from_native_thinking_deltas():
+    from nanobot.agent.runner import AgentRunner, AgentRunSpec
+
+    provider = MagicMock()
+
+    async def chat_stream_with_retry(
+        *, on_content_delta=None, on_thinking_delta=None, **kwargs
+    ):
+        if on_thinking_delta:
+            await on_thinking_delta("<thinking>")
+            await on_thinking_delta("Preparing final response")
+            await on_thinking_delta("</thinking>")
+        if on_content_delta:
+            await on_content_delta("done")
+        return LLMResponse(content="done", tool_calls=[], usage={})
+
+    provider.chat_stream_with_retry = chat_stream_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+
+    hook = _StreamRecordingHook()
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "q"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=3,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        hook=hook,
+    ))
+
+    assert result.final_content == "done"
+    assert hook.emitted == ["Preparing final response"]

--- a/tests/utils/test_strip_think.py
+++ b/tests/utils/test_strip_think.py
@@ -1,4 +1,9 @@
-from nanobot.utils.helpers import extract_reasoning, extract_think, strip_think
+from nanobot.utils.helpers import (
+    extract_reasoning,
+    extract_think,
+    strip_reasoning_tags,
+    strip_think,
+)
 
 
 class TestStripThinkTag:
@@ -26,6 +31,15 @@ class TestStripThinkTag:
 
     def test_self_closing_tag_not_matched(self):
         assert strip_think("<thought/>some text") == "<thought/>some text"
+
+    def test_thinking_alias_closed_tag(self):
+        assert strip_think("Hello <thinking>reasoning</thinking> World") == "Hello  World"
+
+    def test_thinking_alias_unclosed_trailing_tag(self):
+        assert strip_think("<thinking>ongoing...") == ""
+
+    def test_self_closing_thinking_marker_at_start_stripped(self):
+        assert strip_think("<thinking/>some text") == "some text"
 
     def test_normal_text_unchanged(self):
         assert strip_think("Just normal text") == "Just normal text"
@@ -165,6 +179,12 @@ class TestExtractThink:
         assert thinking == "reasoning content"
         assert clean == "Hello  World"
 
+    def test_single_thinking_block(self):
+        text = "Hello <thinking>reasoning content</thinking> World"
+        thinking, clean = extract_think(text)
+        assert thinking == "reasoning content"
+        assert clean == "Hello  World"
+
     def test_multiple_think_blocks(self):
         text = "A<think>first</think>B<thought>second</thought>C"
         thinking, clean = extract_think(text)
@@ -230,6 +250,24 @@ squares = [x**2 for x in range(10)]
 class TestExtractReasoning:
     """Single source of truth for reasoning extraction across all providers."""
 
+    def test_strips_tags_from_dedicated_reasoning_content(self):
+        reasoning, content = extract_reasoning(
+            "<thinking>Preparing final response",
+            None,
+            "visible answer",
+        )
+        assert reasoning == "Preparing final response"
+        assert content == "visible answer"
+
+    def test_self_closing_thinking_marker_in_reasoning_content(self):
+        reasoning, content = extract_reasoning(
+            "<thinking/>Preparing final response",
+            None,
+            "visible answer",
+        )
+        assert reasoning == "Preparing final response"
+        assert content == "visible answer"
+
     def test_prefers_reasoning_content_and_strips_inline_think(self):
         # Dedicated field wins; inline tags are still scrubbed from content.
         reasoning, content = extract_reasoning(
@@ -271,3 +309,21 @@ class TestExtractReasoning:
         )
         assert reasoning == "plan"
         assert content == "answer"
+
+
+class TestStripReasoningTags:
+
+    def test_unclosed_thinking_wrapper_keeps_reasoning_body(self):
+        assert strip_reasoning_tags("<thinking>Preparing final response") == (
+            "Preparing final response"
+        )
+
+    def test_self_closing_thinking_marker_keeps_reasoning_body(self):
+        assert strip_reasoning_tags("<thinking/>Preparing final response") == (
+            "Preparing final response"
+        )
+
+    def test_closing_thinking_wrapper_removed(self):
+        assert strip_reasoning_tags("Preparing final response</thinking>") == (
+            "Preparing final response"
+        )

--- a/tests/utils/test_strip_think.py
+++ b/tests/utils/test_strip_think.py
@@ -327,3 +327,6 @@ class TestStripReasoningTags:
         assert strip_reasoning_tags("Preparing final response</thinking>") == (
             "Preparing final response"
         )
+
+    def test_non_string_reasoning_ignored(self):
+        assert strip_reasoning_tags(object()) == ""


### PR DESCRIPTION
## Summary
- normalize <thinking> blocks alongside existing <think>/<thought> handling
- strip wrapper tags from dedicated reasoning content without dropping reasoning text
- clean native streaming thinking deltas before WebUI receives them

## Tests
- ./.venv/bin/python -m pytest tests/utils/test_strip_think.py tests/agent/test_runner_reasoning.py -q
- ./.venv/bin/python -m ruff check nanobot/agent/runner.py nanobot/utils/helpers.py
- ./.venv/bin/python -m ruff check tests/agent/test_runner_reasoning.py tests/utils/test_strip_think.py

Note: full `ruff check nanobot/` still reports pre-existing import-order/name issues outside this PR's files.

Fixes HKUDS/nanobot#4465