### PR TITLE
fix: exclude archived keys in heartbeat & fallback missing session timestamps

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1065,8 +1065,15 @@ def _run_gateway(
     def _pick_heartbeat_target() -> tuple[str, str]:
         """Pick a routable channel/chat target for heartbeat-triggered messages."""
         enabled = set(channels.enabled_channels)
+
+        from nanobot.webui.sidebar_state import read_webui_sidebar_state
+        sidebar_state = read_webui_sidebar_state()
+        archived_keys = set(sidebar_state.get("archived_keys", []))
+
         for item in session_manager.list_sessions():
             key = item.get("key") or ""
+            if key in archived_keys:
+                continue
             if ":" not in key:
                 continue
             channel, chat_id = key.split(":", 1)

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -5,7 +5,7 @@ import os
 import select
 import signal
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from contextlib import nullcontext, suppress
 from pathlib import Path
 from typing import Any
@@ -61,6 +61,7 @@ from nanobot.utils.restart import (  # noqa: E402
     format_restart_completed_message,
     should_show_cli_restart_notice,
 )
+from nanobot.webui.sidebar_state import read_webui_sidebar_state  # noqa: E402
 
 
 def _sanitize_surrogates(text: str) -> str:
@@ -209,6 +210,29 @@ def _heartbeat_has_active_tasks(content: str) -> bool:
             continue
         return True
     return False
+
+
+def _pick_heartbeat_target_from_sessions(
+    *,
+    enabled_channels: Iterable[str],
+    sessions: Iterable[dict[str, Any]],
+    archived_keys: Iterable[str],
+) -> tuple[str, str]:
+    enabled = set(enabled_channels)
+    archived = set(archived_keys)
+    for item in sessions:
+        key = item.get("key") or ""
+        if key in archived:
+            continue
+        if ":" not in key:
+            continue
+        channel, chat_id = key.split(":", 1)
+        if channel in {"cli", "system"}:
+            continue
+        if channel in enabled and chat_id:
+            return channel, chat_id
+    return "cli", "direct"
+
 
 # ---------------------------------------------------------------------------
 # CLI input: prompt_toolkit for editing, paste, history, and display
@@ -1064,24 +1088,12 @@ def _run_gateway(
 
     def _pick_heartbeat_target() -> tuple[str, str]:
         """Pick a routable channel/chat target for heartbeat-triggered messages."""
-        enabled = set(channels.enabled_channels)
-
-        from nanobot.webui.sidebar_state import read_webui_sidebar_state
         sidebar_state = read_webui_sidebar_state()
-        archived_keys = set(sidebar_state.get("archived_keys", []))
-
-        for item in session_manager.list_sessions():
-            key = item.get("key") or ""
-            if key in archived_keys:
-                continue
-            if ":" not in key:
-                continue
-            channel, chat_id = key.split(":", 1)
-            if channel in {"cli", "system"}:
-                continue
-            if channel in enabled and chat_id:
-                return channel, chat_id
-        return "cli", "direct"
+        return _pick_heartbeat_target_from_sessions(
+            enabled_channels=channels.enabled_channels,
+            sessions=session_manager.list_sessions(),
+            archived_keys=sidebar_state.get("archived_keys", []),
+        )
 
     if channels.enabled_channels:
         console.print(f"[green]✓[/green] Channels enabled: {', '.join(channels.enabled_channels)}")

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -843,11 +843,13 @@ class SessionManager:
                                 if not fallback_preview and item.get("role") == "assistant":
                                     fallback_preview = text
                             preview = preview or fallback_preview
+                            from datetime import datetime
+                            fallback_time = datetime.fromtimestamp(path.stat().st_mtime).isoformat()
                             sessions.append(
                                 {
                                     "key": key,
-                                    "created_at": data.get("created_at"),
-                                    "updated_at": data.get("updated_at"),
+                                    "created_at": data.get("created_at") or fallback_time,
+                                    "updated_at": data.get("updated_at") or fallback_time,
                                     "title": title,
                                     "preview": preview,
                                     "path": str(path),

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -843,7 +843,6 @@ class SessionManager:
                                 if not fallback_preview and item.get("role") == "assistant":
                                     fallback_preview = text
                             preview = preview or fallback_preview
-                            from datetime import datetime
                             fallback_time = datetime.fromtimestamp(path.stat().st_mtime).isoformat()
                             sessions.append(
                                 {

--- a/nanobot/webui/session_list_index.py
+++ b/nanobot/webui/session_list_index.py
@@ -269,13 +269,20 @@ def _scan_session_row(session_manager: SessionManager, path: Path) -> dict[str, 
                 if not fallback_preview and item.get("role") == "assistant":
                     fallback_preview = text
             signature = _file_signature(path)
+            created_at_s = data.get("created_at")
+            updated_at_s = data.get("updated_at")
+            if not created_at_s or not updated_at_s:
+                from datetime import datetime
+                fallback_time = datetime.fromtimestamp(signature["mtime_ns"] / 1e9).isoformat()
+                created_at_s = created_at_s or fallback_time
+                updated_at_s = updated_at_s or fallback_time
             key = data.get("key") or fallback_key
             activity_signature = _webui_activity_signature(key)
             activity_updated_at = _webui_activity_updated_at(activity_signature)
             return {
                 "key": key,
-                "created_at": data.get("created_at"),
-                "updated_at": _latest_updated_at(data.get("updated_at"), activity_updated_at),
+                "created_at": created_at_s,
+                "updated_at": _latest_updated_at(updated_at_s, activity_updated_at),
                 "title": _metadata_title(data.get("metadata", {})),
                 "preview": preview or fallback_preview,
                 "file": path.name,

--- a/nanobot/webui/session_list_index.py
+++ b/nanobot/webui/session_list_index.py
@@ -272,7 +272,6 @@ def _scan_session_row(session_manager: SessionManager, path: Path) -> dict[str, 
             created_at_s = data.get("created_at")
             updated_at_s = data.get("updated_at")
             if not created_at_s or not updated_at_s:
-                from datetime import datetime
                 fallback_time = datetime.fromtimestamp(signature["mtime_ns"] / 1e9).isoformat()
                 created_at_s = created_at_s or fallback_time
                 updated_at_s = updated_at_s or fallback_time

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1247,6 +1247,21 @@ def test_heartbeat_skips_bundled_template():
     assert _heartbeat_has_active_tasks(load_bundled_template("HEARTBEAT.md")) is False
 
 
+def test_heartbeat_target_skips_archived_webui_sessions():
+    from nanobot.cli.commands import _pick_heartbeat_target_from_sessions
+
+    target = _pick_heartbeat_target_from_sessions(
+        enabled_channels=["websocket"],
+        archived_keys=["websocket:archived"],
+        sessions=[
+            {"key": "websocket:archived"},
+            {"key": "websocket:active"},
+        ],
+    )
+
+    assert target == ("websocket", "active")
+
+
 def _write_instance_config(tmp_path: Path) -> Path:
     config_file = tmp_path / "instance" / "config.json"
     config_file.parent.mkdir(parents=True)

--- a/tests/webui/test_session_list_index.py
+++ b/tests/webui/test_session_list_index.py
@@ -171,3 +171,40 @@ def test_webui_session_list_rescans_when_transcript_changes(
 
 def list_webui_sessions(manager: SessionManager) -> list[dict]:
     return session_list_index.list_webui_sessions(manager)
+
+
+def test_webui_session_list_fallback_time_when_missing(tmp_path: Path) -> None:
+    manager = SessionManager(tmp_path)
+    path = manager._get_session_path("websocket:missing-time")
+    path.write_text(
+        '{"_type": "metadata", "key": "websocket:missing-time"}\n'
+        '{"_type": "message", "role": "user", "content": "hello"}\n',
+        encoding="utf-8",
+    )
+
+    rows = list_webui_sessions(manager)
+    assert len(rows) == 1
+    assert rows[0]["key"] == "websocket:missing-time"
+    assert rows[0]["created_at"] is not None
+    assert rows[0]["updated_at"] is not None
+    datetime.fromisoformat(rows[0]["created_at"])
+    datetime.fromisoformat(rows[0]["updated_at"])
+
+
+def test_session_manager_list_sessions_fallback_time_when_missing(tmp_path: Path) -> None:
+    manager = SessionManager(tmp_path)
+    path = manager._get_session_path("websocket:missing-time2")
+    path.write_text(
+        '{"_type": "metadata", "key": "websocket:missing-time2"}\n'
+        '{"_type": "message", "role": "user", "content": "hello"}\n',
+        encoding="utf-8",
+    )
+
+    sessions = manager.list_sessions()
+    assert len(sessions) == 1
+    assert sessions[0]["key"] == "websocket:missing-time2"
+    assert sessions[0]["created_at"] is not None
+    assert sessions[0]["updated_at"] is not None
+    datetime.fromisoformat(sessions[0]["created_at"])
+    datetime.fromisoformat(sessions[0]["updated_at"])
+


### PR DESCRIPTION
This PR introduces two fixes and corresponding tests:
1. Heartbeat targets now exclude archived keys.
2. Fallback to file modification time when created_at or updated_at are missing in session metadata.