### PR TITLE
fix: inject existing workspace skills into Dream prompt (#4467)

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -484,6 +484,8 @@ class MemoryStore:
 
         Returns ``(prompt, last_cursor)`` or ``None`` if nothing to process.
         """
+        import yaml
+
         from nanobot.agent.skills import BUILTIN_SKILLS_DIR
 
         last_cursor = self.get_last_dream_cursor()
@@ -500,7 +502,33 @@ class MemoryStore:
         template = render_template(
             "agent/dream.md", strip=True, skill_creator_path=skill_creator_path,
         )
-        prompt = f"{template}\n\n## Conversation History\n{history_text}"
+        skill_lines: list[str] = []
+        skills_dir = self.workspace / "skills"
+        if skills_dir.exists():
+            for skill_dir in sorted(skills_dir.iterdir()):
+                skill_file = skill_dir / "SKILL.md"
+                if not skill_dir.is_dir() or not skill_file.exists():
+                    continue
+                content = skill_file.read_text(encoding="utf-8")
+                match = re.match(r"^---\s*\r?\n(.*?)\r?\n---\s*\r?\n?", content, re.DOTALL)
+                if not match:
+                    continue
+                try:
+                    metadata = yaml.safe_load(match.group(1))
+                except yaml.YAMLError:
+                    continue
+                if not isinstance(metadata, dict):
+                    continue
+                name = metadata.get("name") or skill_dir.name
+                description = metadata.get("description")
+                if not description:
+                    continue
+                skill_lines.append(f"- {name}: {description}")
+        existing_skills = (
+            "\n\n## Existing Workspace Skills\n" + "\n".join(skill_lines)
+            if skill_lines else ""
+        )
+        prompt = f"{template}{existing_skills}\n\n## Conversation History\n{history_text}"
         return (prompt, batch[-1]["cursor"])
 
     def build_dream_tools(self):

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -522,6 +522,10 @@ class MemoryStore:
                 name = metadata.get("name") or skill_dir.name
                 description = metadata.get("description")
                 if not description:
+                    logger.warning(
+                        "Skill '{}' has no description in frontmatter, skipping for Dream",
+                        name,
+                    )
                     continue
                 skill_lines.append(f"- {name}: {description}")
         existing_skills = (

--- a/nanobot/templates/agent/dream.md
+++ b/nanobot/templates/agent/dream.md
@@ -44,7 +44,7 @@ Always strip these bracketed tags from saved memory content.
 
 ## Skill-to-skill MECE
 - If a new skill overlaps with an existing skill, merge the delta into the existing skill instead of creating a redundant one
-- Check existing skill descriptions (listed above) before creating a new skill
+- Check the Existing Workspace Skills section below before creating a new skill. If a similar skill exists, read it with read_file and merge the delta into it instead of creating a redundant skill.
 
 ## Delete-or-keep
 
@@ -90,7 +90,7 @@ When removing: prefer deleting individual items over entire sections.
 - Capture confirmed approaches the user validated
 
 ## Skill discovery & creation
-Flag [SKILL] only when ALL are true: repeatable workflow appeared 2+ times, involves clear steps (not vague preferences), substantial enough for its own instruction set. Check existing skills to avoid redundancy.
+Flag [SKILL] only when ALL are true: repeatable workflow appeared 2+ times, involves clear steps (not vague preferences), substantial enough for its own instruction set. Check existing skills to avoid redundancy. Before creating a new skill, check the Existing Workspace Skills section. If a similar skill exists, read the existing skill with read_file and merge improvements into it.
 
 For [SKILL] entries:
 - Create `skills/<name>/SKILL.md`; reference `{{ skill_creator_path }}` for format

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -61,6 +61,22 @@ class TestBuildDreamPrompt:
         prompt, _ = result
         assert "skill-creator" in prompt
 
+    def test_prompt_includes_existing_workspace_skills(self, store):
+        skill_dir = store.workspace / "skills" / "existing"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: existing\ndescription: Merge into this skill.\n---\n\nSteps.\n",
+            encoding="utf-8",
+        )
+        store.append_history("test")
+
+        result = store.build_dream_prompt()
+
+        assert result is not None
+        prompt, _ = result
+        assert "## Existing Workspace Skills\n- existing: Merge into this skill." in prompt
+        assert prompt.index("## Existing Workspace Skills") < prompt.index("## Conversation History")
+
     def test_truncates_long_entries(self, store):
         long_content = "x" * 2000
         store.append_history(long_content)


### PR DESCRIPTION
Fixes #4467.

Problem: Dream creates duplicate workspace skills on each run instead of merging improvements into existing ones. The build_dream_prompt() method renders the Dream template but does not inject a summary of existing workspace skills, so Dream cannot see what already exists.

Fix: Inject a compact Existing Workspace Skills section into the Dream prompt by scanning workspace/skills/*/SKILL.md frontmatter. Update the Dream template to explicitly reference this section and instruct Dream to read and merge into similar skills before creating new ones.

Testing: Added test_prompt_includes_existing_workspace_skills regression test. All 25 tests in tests/agent/test_dream.py pass.

Scope: 3 files changed (nanobot/agent/memory.py, nanobot/templates/agent/dream.md, tests/agent/test_dream.py). No behavioral changes to existing Dream features.