### PR TITLE
fix(webui): prevent iOS Safari composer zoom

### DIFF
--- a/webui/src/components/thread/ThreadComposer.tsx
+++ b/webui/src/components/thread/ThreadComposer.tsx
@@ -1566,10 +1566,10 @@ export function ThreadComposer({
     "w-full resize-none bg-transparent",
     isHero
       ? cn(
-          "min-h-[78px] px-4 text-[15px] leading-6 sm:px-5",
+          "min-h-[78px] px-4 text-[16px] leading-6 sm:px-5",
           relaxedHeroInput ? "pb-2 pt-[27px]" : "pb-1.5 pt-4",
         )
-      : "min-h-[50px] px-3.5 pb-1.5 pt-3 text-[13.5px] leading-5 sm:px-4",
+      : "min-h-[50px] px-3.5 pb-1.5 pt-3 text-[16px] leading-5 sm:px-4",
   );
 
   return (

--- a/webui/src/tests/thread-composer.test.tsx
+++ b/webui/src/tests/thread-composer.test.tsx
@@ -281,6 +281,7 @@ describe("ThreadComposer", () => {
     const input = screen.getByPlaceholderText("Ask anything...");
     expect(input).toBeInTheDocument();
     expect(input.className).toContain("min-h-[78px]");
+    expect(input.className).toContain("text-[16px]");
     expect(input.className).toContain("pt-[27px]");
     fireEvent.change(input, { target: { value: "1" } });
     expect(input.className).toContain("pt-[27px]");
@@ -302,6 +303,7 @@ describe("ThreadComposer", () => {
     expect(screen.getByTestId("composer-model-logo-openai")).toBeInTheDocument();
     const input = screen.getByPlaceholderText("Type your message...");
     expect(input.className).toContain("min-h-[50px]");
+    expect(input.className).toContain("text-[16px]");
     expect(input.parentElement?.parentElement?.className).toContain("max-w-[49.5rem]");
     expect(input.parentElement?.parentElement?.className).toContain("rounded-[22px]");
     expect(input.parentElement?.parentElement?.className).toContain("shadow-[0_12px_30px_rgba(15,23,42,0.07)]");


### PR DESCRIPTION
## Summary
- Set WebUI composer textarea text to 16px for both hero and thread variants.
- Add regression assertions so the composer input keeps the iOS-safe font size.

## Why
Fixes #4388. iOS Safari auto-zooms focused form controls when their text size is below 16px, which distorted the WebUI composer on mobile.

## Validation
- `npm run test -- src/tests/thread-composer.test.tsx`
- `npm run build`
- `npm run lint`

Note: I could not verify on a physical iOS Safari device from this environment.