### PR TITLE
fix: skip sendRichMessage when streaming preview exists (#4470)

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -907,8 +907,11 @@ class TelegramChannel(BaseChannel):
                 thread_kwargs["message_thread_id"] = message_thread_id
             raw_text = buf.text
 
-            # Try sendRichMessage for final output (Bot API 10.1)
-            if not getattr(self, "_rich_send_disabled", False):
+            # Try sendRichMessage for final output (Bot API 10.1).
+            # Skip when a streaming preview already exists to avoid the
+            # delete-and-resend pattern that causes flickering and drops
+            # line breaks (issue #4470).
+            if not buf.message_id and not getattr(self, "_rich_send_disabled", False):
                 reply_params = None
                 if reply_to_message_id := meta.get("message_id"):
                     reply_params = {"message_id": int(reply_to_message_id), "allow_sending_without_reply": True}


### PR DESCRIPTION
Fixes #4470.

Problem: Since the sendRichMessage integration (Bot API 10.1), Telegram streaming responses exhibit two regressions:

1. Line breaks are not respected -- the final message arrives as a single continuous block.
2. Message flickering -- the gateway deletes the streaming preview and sends a new message via sendRichMessage, causing a visible delete-and-rewrite effect.

Both bugs share the same root cause: when _stream_end fires and a streaming preview already exists (buf.message_id is set), the code tries sendRichMessage first. On success it deletes the preview and sends a fresh message. This delete-and-resend pattern drops line breaks (sendRichMessage renders markdown differently than the legacy HTML edit path) and produces the flicker users see.

Fix: Gate the sendRichMessage path on not buf.message_id. When a streaming preview already exists, fall through to the legacy edit_message_text path which correctly converts markdown to HTML with preserved line breaks and edits in-place without deletion.

sendRichMessage is still used for non-streaming messages (the send_message path in _send) where no preview exists.

Testing: All 88 existing Telegram channel tests pass. ruff clean.

Scope: One condition added to nanobot/channels/telegram.py (stream_end handler). No other files touched.