### PR TITLE
fix(provider): deduplicate parallel tool_use ids in AnthropicProvider

### DIFF
--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -539,6 +539,18 @@ class AnthropicProvider(LLMProvider):
                     "signature": getattr(block, "signature", ""),
                 })
 
+        # Some providers (e.g. Kimi / Anthropic-compatible endpoints) reuse the
+        # same tool_use id for parallel tool calls in streaming mode. Deduplicate
+        # before building the response so downstream tool messages don't collide.
+        _seen_tc_ids: set[str] = set()
+        deduped_tool_calls: list[ToolCallRequest] = []
+        for tc in tool_calls:
+            if not tc.id or tc.id in _seen_tc_ids:
+                continue
+            _seen_tc_ids.add(tc.id)
+            deduped_tool_calls.append(tc)
+        tool_calls = deduped_tool_calls
+
         stop_map = {"tool_use": "tool_calls", "end_turn": "stop", "max_tokens": "length"}
         finish_reason = stop_map.get(response.stop_reason or "", response.stop_reason or "stop")
 
@@ -553,12 +565,10 @@ class AnthropicProvider(LLMProvider):
                 "completion_tokens": response.usage.output_tokens,
                 "total_tokens": total_prompt_tokens + response.usage.output_tokens,
             }
-            for attr in ("cache_creation_input_tokens", "cache_read_input_tokens"):
-                val = getattr(response.usage, attr, 0)
-                if val:
-                    usage[attr] = val
-            # Normalize to cached_tokens for downstream consistency.
+            if cache_creation:
+                usage["cache_creation_input_tokens"] = cache_creation
             if cache_read:
+                usage["cache_read_input_tokens"] = cache_read
                 usage["cached_tokens"] = cache_read
 
         return LLMResponse(


### PR DESCRIPTION
## Summary

Deduplicate parallel `tool_use` IDs in `AnthropicProvider._parse_response()` so downstream `tool_result` messages don't collide.

## Background

Issue #4463 requests support for the Kimi Coding Plan endpoint. PR #4464 adds the `kimi_coding` provider routed through `AnthropicProvider`. While testing that integration, the Kimi Coding streaming endpoint returned:

```
invalid_request_error: tool call id grep:3 is duplicated
```

## Root cause

The Kimi Coding Anthropic-compatible endpoint reuses the same short `tool_use.id` (e.g. `grep:3`) across multiple parallel `tool_use` blocks. `AnthropicProvider` collected every block verbatim into `LLMResponse.tool_calls`, and the next agent loop wrote those duplicated IDs back into `tool_result` messages, which the server rejected.

`OpenAICompatProvider` already has identical deduplication logic, but `AnthropicProvider` did not.

## Changes

- Filter `tool_calls` to keep only the first occurrence of each `tool_use.id`.
- Refactor usage cache-token writes to use precomputed `cache_creation` / `cache_read` values instead of repeated `getattr(..., 0) or 0`.

## Related

- Closes #4473
- Relates to #4463
- Relates to #4464