### PR TITLE
feat: add lifecycle wiki memory writer

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -72,6 +72,7 @@ class ContextBuilder:
         include_memory_recent_history: bool = True,
         session_key: str | None = None,
         unified_session: bool = False,
+        memory_query: str | None = None,
     ) -> str:
         """Build the system prompt from identity, bootstrap files, memory, and skills."""
         root = workspace or self.workspace
@@ -83,8 +84,12 @@ class ContextBuilder:
 
         parts.append(render_template("agent/tool_contract.md"))
 
-        memory = self.memory.get_memory_context()
-        if memory and not self._is_template_content(self.memory.read_memory(), "memory/MEMORY.md"):
+        memory_is_template = self._is_template_content(self.memory.read_memory(), "memory/MEMORY.md")
+        memory = self.memory.get_memory_context(
+            query=memory_query,
+            include_long_term=not memory_is_template,
+        )
+        if memory:
             parts.append(f"# Memory\n\n{memory}")
 
         always_skills = self.skills.get_always_skills()
@@ -242,6 +247,7 @@ class ContextBuilder:
                     include_memory_recent_history=include_memory_recent_history,
                     session_key=session_key,
                     unified_session=unified_session,
+                    memory_query=current_message,
                 ),
             },
             *history,

--- a/nanobot/agent/dream_writer.py
+++ b/nanobot/agent/dream_writer.py
@@ -1,0 +1,485 @@
+"""Structured Dream writer support for lifecycle memory concepts."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from nanobot.agent.memory_wiki import (
+    ACTIVE_STATUS,
+    INACTIVE_STATUSES,
+    MemoryWikiConcept,
+    MemoryWikiStore,
+    slugify_concept_id,
+)
+from nanobot.agent.tools.base import Tool, tool_parameters
+
+VALID_STATUSES = {ACTIVE_STATUS, *INACTIVE_STATUSES}
+EVENT_RE = re.compile(
+    r"^\[(?P<source>[^\]]*cursor[^\]]*)\](?:\s+\[[^\]]+\])?\s+"
+    r"\[(?P<tag>[a-z]+)\]\s+(?P<text>.+)$"
+)
+MARKER_RE = re.compile(r"\b[A-Z][A-Z0-9]+(?:-[A-Z0-9]+){1,}\b")
+DATE_RE = re.compile(r"\b20\d{2}-\d{2}-\d{2}\b")
+
+CONCEPT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "id": {"type": "string", "description": "Stable slug-safe concept id."},
+        "type": {"type": "string", "description": "Concept type, for example user_preference."},
+        "title": {"type": "string", "description": "Short human-readable concept title."},
+        "status": {
+            "type": "string",
+            "enum": sorted(VALID_STATUSES),
+            "description": "Lifecycle status. Only active concepts enter prompt context.",
+        },
+        "tags": {"type": "array", "items": {"type": "string"}},
+        "source": {"type": "array", "items": {"type": "string"}},
+        "body": {"type": "string", "description": "Atomic memory fact without history tags."},
+        "created_at": {"type": "string"},
+        "last_verified_at": {"type": "string"},
+        "expires_at": {"type": "string"},
+        "supersedes": {"type": "array", "items": {"type": "string"}},
+        "superseded_by": {"type": "array", "items": {"type": "string"}},
+        "confidence": {"type": "number"},
+    },
+    "required": ["id", "type", "title", "status", "tags", "source", "body"],
+}
+
+MEMORY_CONCEPTS_TOOL_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "concepts": {
+            "type": "array",
+            "items": CONCEPT_SCHEMA,
+            "description": "Lifecycle memory concepts to validate and write.",
+        }
+    },
+    "required": ["concepts"],
+}
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    errors: list[str]
+    warnings: list[str]
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+@dataclass(frozen=True)
+class WriterProviderCapability:
+    provider: str | None
+    model: str | None
+    reasoning_effort: str | None
+    supports_required_tool_choice: bool
+    supports_named_tool_choice: bool
+    selected_tool_choice: str
+    reason: str
+
+
+def build_memory_concepts_tool_schema() -> dict[str, Any]:
+    """Return an OpenAI-compatible schema for the structured writer tool."""
+    return {
+        "type": "function",
+        "function": {
+            "name": "write_memory_concepts",
+            "description": "Write derived memory wiki concepts with lifecycle metadata.",
+            "parameters": MEMORY_CONCEPTS_TOOL_PARAMETERS,
+        },
+    }
+
+
+def infer_writer_provider_capability(
+    *,
+    provider: str | None = None,
+    model: str | None = None,
+    reasoning_effort: str | None = None,
+) -> WriterProviderCapability:
+    """Infer safe Dream writer tool-choice settings from static provider config."""
+    provider_norm = (provider or "").lower()
+    model_norm = (model or "").lower()
+    thinking_enabled = bool(reasoning_effort and reasoning_effort.lower() not in {"none", "off", "false"})
+    deepseek_thinking = thinking_enabled and (
+        provider_norm == "deepseek" or model_norm.startswith("deepseek-") or "deepseek-v4" in model_norm
+    )
+    if deepseek_thinking:
+        return WriterProviderCapability(
+            provider=provider,
+            model=model,
+            reasoning_effort=reasoning_effort,
+            supports_required_tool_choice=False,
+            supports_named_tool_choice=False,
+            selected_tool_choice="auto",
+            reason="provider thinking mode rejects required or named tool choice",
+        )
+    return WriterProviderCapability(
+        provider=provider,
+        model=model,
+        reasoning_effort=reasoning_effort,
+        supports_required_tool_choice=True,
+        supports_named_tool_choice=True,
+        selected_tool_choice="required",
+        reason="required tool choice is allowed by static config",
+    )
+
+
+def repair_memory_concepts(
+    concepts: list[dict[str, Any]],
+    history_text: str = "",
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Repair obvious lifecycle operations before validation.
+
+    Model output is still the primary signal. This deterministic pass handles
+    simple cases the model should not be trusted to enforce alone: correction
+    tags, forget requests, expired facts, and duplicate active concepts.
+    """
+    current = {concept.id: concept for concept in _concepts_from_payloads(concepts)}
+    groups: dict[str, list[str]] = {}
+    for concept in current.values():
+        groups.setdefault(_concept_group(concept.id), []).append(concept.id)
+
+    for source, tag, text in _iter_history_events(history_text):
+        marker = _first_marker(text)
+        if tag == "skip":
+            continue
+        if tag == "correction" and "forget" in text.lower():
+            target = marker
+            if target:
+                target_id = slugify_concept_id(target)
+                existing = current.get(target_id)
+                if existing:
+                    existing.status = "forgotten"
+                    existing.source = _sorted_unique([*existing.source, source])
+                else:
+                    current[target_id] = MemoryWikiConcept(
+                        id=target_id,
+                        title=target,
+                        body=f"{target} was explicitly forgotten.",
+                        type="user_private_data",
+                        status="forgotten",
+                        tags=["forgotten"],
+                        source=[source],
+                    )
+            continue
+        if not marker:
+            continue
+
+        concept_id = slugify_concept_id(marker)
+        group = _concept_group(concept_id)
+        previous_ids = groups.setdefault(group, [])
+        if tag == "correction":
+            for previous_id in previous_ids:
+                previous = current.get(previous_id)
+                if previous and previous.status == ACTIVE_STATUS and previous.id != concept_id:
+                    previous.status = "invalidated"
+                    previous.superseded_by = _sorted_unique([*previous.superseded_by, concept_id])
+
+        expires_at = None
+        if tag == "ephemeral":
+            date = _first_date(text)
+            if date:
+                expires_at = f"{date}T23:59:59Z"
+
+        status = ACTIVE_STATUS
+        if expires_at and _is_expired(expires_at, now):
+            status = "expired"
+
+        concept = current.get(concept_id)
+        if concept is None:
+            concept = MemoryWikiConcept(
+                id=concept_id,
+                title=marker,
+                body=_body_after_marker(text, marker),
+                type=_infer_type(marker, text),
+                status=status,
+                tags=_sorted_unique(["dream", *_marker_tags(marker)]),
+                source=[source],
+                expires_at=expires_at,
+            )
+            current[concept_id] = concept
+        else:
+            event_body = _body_after_marker(text, marker)
+            concept.id = concept_id
+            concept.title = marker
+            concept.body = event_body
+            concept.type = _infer_type(marker, text)
+            concept.status = status
+            concept.tags = _sorted_unique([*concept.tags, *_marker_tags(marker)])
+            concept.source = _sorted_unique([*concept.source, source])
+            concept.expires_at = concept.expires_at or expires_at
+        if tag == "correction":
+            concept.supersedes = _sorted_unique([*concept.supersedes, *previous_ids])
+        if concept_id not in previous_ids:
+            previous_ids.append(concept_id)
+
+    _expire_old_active(current.values(), now)
+    _resolve_duplicate_active_groups(current.values())
+    return [concept_to_dict(concept) for concept in sorted(current.values(), key=lambda item: item.id)]
+
+
+def validate_memory_concepts(
+    concepts: list[dict[str, Any]] | list[MemoryWikiConcept],
+    *,
+    now: datetime | None = None,
+) -> ValidationResult:
+    """Validate lifecycle invariants for derived memory concepts."""
+    parsed = _concepts_from_payloads(concepts)
+    errors: list[str] = []
+    warnings: list[str] = []
+    seen: set[str] = set()
+    active_groups: dict[str, list[str]] = {}
+    ids = {concept.id for concept in parsed}
+
+    for concept in parsed:
+        if not concept.id:
+            errors.append("concept id is required")
+            continue
+        if concept.id in seen:
+            errors.append(f"duplicate concept id: {concept.id}")
+        seen.add(concept.id)
+        if concept.status not in VALID_STATUSES:
+            errors.append(f"{concept.id}: invalid status {concept.status!r}")
+        if not concept.title.strip():
+            errors.append(f"{concept.id}: title is required")
+        if not concept.body.strip():
+            errors.append(f"{concept.id}: body is required")
+        if concept.status == ACTIVE_STATUS and not concept.source:
+            errors.append(f"{concept.id}: active concept must include source")
+        if concept.status == ACTIVE_STATUS and _is_expired(concept.expires_at, now):
+            errors.append(f"{concept.id}: active concept is expired")
+        if concept.status == ACTIVE_STATUS and _looks_forgotten(concept):
+            errors.append(f"{concept.id}: forgotten/private removal cannot be active")
+        if concept.status == ACTIVE_STATUS:
+            active_groups.setdefault(_concept_group(concept.id), []).append(concept.id)
+        for ref in [*concept.supersedes, *concept.superseded_by]:
+            if ref and ref not in ids:
+                warnings.append(f"{concept.id}: supersession reference not found: {ref}")
+
+    for group, group_ids in active_groups.items():
+        if len(group_ids) > 1:
+            errors.append(f"{group}: multiple active concepts: {', '.join(sorted(group_ids))}")
+
+    return ValidationResult(errors=errors, warnings=warnings)
+
+
+def concept_to_dict(concept: MemoryWikiConcept) -> dict[str, Any]:
+    data = asdict(concept)
+    data.pop("path", None)
+    return {key: value for key, value in data.items() if value not in (None, [])}
+
+
+@tool_parameters(MEMORY_CONCEPTS_TOOL_PARAMETERS)
+class WriteMemoryConceptsTool(Tool):
+    """Dream-only tool that validates and writes derived memory concepts."""
+
+    def __init__(
+        self,
+        store: MemoryWikiStore,
+        *,
+        history_text: str = "",
+        now: datetime | None = None,
+    ) -> None:
+        self._store = store
+        self._history_text = history_text
+        self._now = now
+
+    @property
+    def name(self) -> str:
+        return "write_memory_concepts"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Validate and write derived memory wiki concepts. Use this for long-term "
+            "facts with lifecycle metadata instead of free-form memory edits."
+        )
+
+    async def execute(self, concepts: list[dict[str, Any]]) -> str:
+        repaired = repair_memory_concepts(concepts, self._history_text, now=self._now)
+        validation = validate_memory_concepts(repaired, now=self._now)
+        if not validation.ok:
+            return "Error: invalid memory concepts: " + "; ".join(validation.errors[:8])
+
+        parsed = _concepts_from_payloads(repaired)
+        for concept in parsed:
+            self._store.write_concept(concept)
+
+        active_ids = [concept.id for concept in parsed if concept.status == ACTIVE_STATUS]
+        summary = {
+            "status": "ok",
+            "written": len(parsed),
+            "active": active_ids,
+            "warnings": validation.warnings[:5],
+        }
+        return json.dumps(summary, ensure_ascii=False)
+
+
+def _concepts_from_payloads(payloads: list[dict[str, Any]] | list[MemoryWikiConcept]) -> list[MemoryWikiConcept]:
+    concepts: list[MemoryWikiConcept] = []
+    for idx, payload in enumerate(payloads, start=1):
+        if isinstance(payload, MemoryWikiConcept):
+            payload.id = slugify_concept_id(payload.id or payload.title)
+            payload.supersedes = [slugify_concept_id(item) for item in payload.supersedes]
+            payload.superseded_by = [slugify_concept_id(item) for item in payload.superseded_by]
+            concepts.append(payload)
+            continue
+        if not isinstance(payload, dict):
+            continue
+        title = str(payload.get("title") or payload.get("id") or f"memory-concept-{idx}")
+        concept = MemoryWikiConcept(
+            id=slugify_concept_id(payload.get("id") or title),
+            title=title,
+            body=str(payload.get("body") or payload.get("content") or ""),
+            type=str(payload.get("type") or "fact"),
+            status=str(payload.get("status") or ACTIVE_STATUS),
+            tags=_as_str_list(payload.get("tags")),
+            source=_as_str_list(payload.get("source")),
+            created_at=_optional_str(payload.get("created_at")),
+            last_verified_at=_optional_str(payload.get("last_verified_at")),
+            expires_at=_optional_str(payload.get("expires_at")),
+            supersedes=[slugify_concept_id(item) for item in _as_str_list(payload.get("supersedes"))],
+            superseded_by=[
+                slugify_concept_id(item) for item in _as_str_list(payload.get("superseded_by"))
+            ],
+            confidence=_as_float(payload.get("confidence")),
+        )
+        concepts.append(concept)
+    return concepts
+
+
+def _iter_history_events(history_text: str) -> list[tuple[str, str, str]]:
+    events: list[tuple[str, str, str]] = []
+    for line in history_text.splitlines():
+        match = EVENT_RE.match(line.strip())
+        if match:
+            events.append((match.group("source"), match.group("tag"), match.group("text")))
+    return events
+
+
+def _resolve_duplicate_active_groups(concepts: Any) -> None:
+    groups: dict[str, list[MemoryWikiConcept]] = {}
+    for concept in concepts:
+        if concept.status == ACTIVE_STATUS:
+            groups.setdefault(_concept_group(concept.id), []).append(concept)
+    for group_concepts in groups.values():
+        if len(group_concepts) <= 1:
+            continue
+        winner = sorted(group_concepts, key=_latest_source_key)[-1]
+        for concept in group_concepts:
+            if concept is winner:
+                continue
+            concept.status = "invalidated"
+            concept.superseded_by = _sorted_unique([*concept.superseded_by, winner.id])
+            winner.supersedes = _sorted_unique([*winner.supersedes, concept.id])
+
+
+def _expire_old_active(concepts: Any, now: datetime | None) -> None:
+    for concept in concepts:
+        if concept.status == ACTIVE_STATUS and _is_expired(concept.expires_at, now):
+            concept.status = "expired"
+
+
+def _latest_source_key(concept: MemoryWikiConcept) -> tuple[int, str]:
+    cursor = 0
+    for source in concept.source:
+        match = re.search(r"cursor:(\d+)", source)
+        if match:
+            cursor = max(cursor, int(match.group(1)))
+    return (cursor, concept.id)
+
+
+def _concept_group(value: str) -> str:
+    raw = slugify_concept_id(value)
+    return re.sub(r"-(old|current)$", "", raw)
+
+
+def _first_marker(text: str) -> str | None:
+    match = MARKER_RE.search(text)
+    return match.group(0) if match else None
+
+
+def _body_after_marker(text: str, marker: str) -> str:
+    idx = text.find(marker)
+    if idx < 0:
+        return text.strip()
+    body = text[idx + len(marker):].lstrip(": ").strip()
+    return body or marker
+
+
+def _first_date(text: str) -> str | None:
+    match = DATE_RE.search(text)
+    return match.group(0) if match else None
+
+
+def _marker_tags(marker: str) -> list[str]:
+    return [
+        slugify_concept_id(part)
+        for part in marker.split("-")
+        if part and part.lower() not in {"rlv", "holdout"}
+    ]
+
+
+def _infer_type(marker: str, text: str) -> str:
+    lowered = f"{marker} {text}".lower()
+    if "phone" in lowered or "private" in lowered:
+        return "user_private_data"
+    if any(token in lowered for token in ("lang", "bullet", "preferred", "prefers")):
+        return "user_preference"
+    if "demo" in lowered or "deadline" in lowered:
+        return "time_bound_fact"
+    if any(token in lowered for token in ("port", "index", "nanobot", "nanobook")):
+        return "project_decision"
+    return "fact"
+
+
+def _looks_forgotten(concept: MemoryWikiConcept) -> bool:
+    text = f"{concept.id} {concept.title} {concept.body} {' '.join(concept.tags)}".lower()
+    return "forgotten" in text or "asked to forget" in text
+
+
+def _is_expired(value: str | None, now: datetime | None = None) -> bool:
+    if not value:
+        return False
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return current.astimezone(timezone.utc) >= parsed.astimezone(timezone.utc)
+
+
+def _sorted_unique(values: list[str]) -> list[str]:
+    return sorted({str(value) for value in values if value})
+
+
+def _as_str_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if item is not None]
+    return [str(value)]
+
+
+def _optional_str(value: Any) -> str | None:
+    return None if value is None else str(value)
+
+
+def _as_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterator
 
 from loguru import logger
 
+from nanobot.agent.memory_wiki import MemoryWikiStore
 from nanobot.session.manager import Session
 from nanobot.utils.gitstore import GitStore
 from nanobot.utils.helpers import (
@@ -61,12 +62,14 @@ class MemoryStore:
         self.user_file = workspace / "USER.md"
         self._cursor_file = self.memory_dir / ".cursor"
         self._dream_cursor_file = self.memory_dir / ".dream_cursor"
+        self.wiki = MemoryWikiStore(self.memory_dir / "wiki")
+        self._last_dream_history_text = ""
         self._corruption_logged = False  # rate-limit invalid cursor warning
         self._malformed_entry_logged = False  # rate-limit bad history shape warning
         self._oversize_logged = False  # rate-limit oversized-entry warning
         self._append_lock = threading.Lock()  # serialize cursor allocation + append
         self._git = GitStore(workspace, tracked_files=[
-            "SOUL.md", "USER.md", "memory/MEMORY.md", "memory/.dream_cursor",
+            "SOUL.md", "USER.md", "memory/MEMORY.md", "memory/.dream_cursor", "memory/wiki/**",
         ])
         self._maybe_migrate_legacy_history()
 
@@ -230,9 +233,21 @@ class MemoryStore:
 
     # -- context injection (used by context.py) ------------------------------
 
-    def get_memory_context(self) -> str:
-        long_term = self.read_memory()
-        return f"## Long-term Memory\n{long_term}" if long_term else ""
+    def get_memory_context(
+        self,
+        query: str | None = None,
+        *,
+        include_long_term: bool = True,
+    ) -> str:
+        parts: list[str] = []
+        wiki_context = self.wiki.get_context(query=query)
+        if wiki_context:
+            parts.append(f"## Derived Memory Wiki\n{wiki_context}")
+
+        long_term = self.read_memory() if include_long_term else ""
+        if long_term:
+            parts.append(f"## Long-term Memory\n{long_term}")
+        return "\n\n".join(parts)
 
     # -- history.jsonl — append-only, JSONL format ---------------------------
 
@@ -493,9 +508,10 @@ class MemoryStore:
 
         batch = entries[:max_entries]
         history_text = "\n".join(
-            f"[{e['timestamp']}] {truncate_text(e['content'], 500)}"
+            f"[history:cursor:{e['cursor']}] [{e['timestamp']}] {truncate_text(e['content'], 500)}"
             for e in batch
         )
+        self._last_dream_history_text = history_text
         skill_creator_path = str(BUILTIN_SKILLS_DIR / "skill-creator" / "SKILL.md")
         template = render_template(
             "agent/dream.md", strip=True, skill_creator_path=skill_creator_path,
@@ -505,6 +521,7 @@ class MemoryStore:
 
     def build_dream_tools(self):
         """Build the restricted tool registry used by Dream runs."""
+        from nanobot.agent.dream_writer import WriteMemoryConceptsTool
         from nanobot.agent.skills import BUILTIN_SKILLS_DIR
         from nanobot.agent.tools.apply_patch import ApplyPatchTool
         from nanobot.agent.tools.file_state import FileStates
@@ -542,6 +559,10 @@ class MemoryStore:
             workspace=workspace,
             allowed_dir=skills_dir,
             file_states=file_states,
+        ))
+        tools.register(WriteMemoryConceptsTool(
+            self.wiki,
+            history_text=self._last_dream_history_text,
         ))
         return tools
 

--- a/nanobot/agent/memory_wiki.py
+++ b/nanobot/agent/memory_wiki.py
@@ -1,0 +1,330 @@
+"""Derived memory wiki storage with explicit lifecycle metadata."""
+
+from __future__ import annotations
+
+import os
+import re
+from contextlib import suppress
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from nanobot.utils.helpers import ensure_dir, truncate_text
+
+_FRONTMATTER_RE = re.compile(r"\A---\r?\n(?P<meta>.*?)\r?\n---\r?\n?(?P<body>.*)\Z", re.S)
+_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9_-]*")
+_SLUG_RE = re.compile(r"[^a-z0-9_-]+")
+
+ACTIVE_STATUS = "active"
+INACTIVE_STATUSES = {"invalidated", "forgotten", "superseded", "expired"}
+DEFAULT_CONTEXT_MAX_CHARS = 8_000
+DEFAULT_CONTEXT_MAX_ITEMS = 16
+
+
+@dataclass
+class MemoryWikiConcept:
+    """One derived memory concept stored as Markdown plus YAML frontmatter."""
+
+    id: str
+    title: str
+    body: str
+    type: str = "fact"
+    status: str = ACTIVE_STATUS
+    tags: list[str] = field(default_factory=list)
+    source: list[str] = field(default_factory=list)
+    created_at: str | None = None
+    last_verified_at: str | None = None
+    expires_at: str | None = None
+    supersedes: list[str] = field(default_factory=list)
+    superseded_by: list[str] = field(default_factory=list)
+    confidence: float | None = None
+    path: Path | None = None
+
+    def is_current(self, now: datetime | None = None) -> bool:
+        """Return True when this concept is active and not expired."""
+        if self.status != ACTIVE_STATUS:
+            return False
+        expires_at = _parse_datetime(self.expires_at)
+        if not expires_at:
+            return True
+        return _normalize_datetime(now) < expires_at
+
+    def source_label(self) -> str:
+        """Return a compact, deterministic source label for prompt context."""
+        return ", ".join(self.source) if self.source else "unknown"
+
+    def searchable_text(self) -> str:
+        return " ".join(
+            [
+                self.id,
+                self.type,
+                self.title,
+                " ".join(self.tags),
+                self.body,
+                self.source_label(),
+            ]
+        )
+
+    def to_markdown(self) -> str:
+        metadata: dict[str, Any] = {
+            "id": self.id,
+            "type": self.type,
+            "title": self.title,
+            "status": self.status,
+            "tags": self.tags,
+            "source": self.source,
+        }
+        optional = {
+            "created_at": self.created_at,
+            "last_verified_at": self.last_verified_at,
+            "expires_at": self.expires_at,
+            "supersedes": self.supersedes,
+            "superseded_by": self.superseded_by,
+            "confidence": self.confidence,
+        }
+        metadata.update({key: value for key, value in optional.items() if value not in (None, [])})
+        frontmatter = yaml.safe_dump(
+            metadata,
+            allow_unicode=False,
+            sort_keys=False,
+            default_flow_style=False,
+        ).strip()
+        body = self.body.strip()
+        return f"---\n{frontmatter}\n---\n{body}\n"
+
+
+class MemoryWikiStore:
+    """File-backed derived memory concepts with lifecycle-aware retrieval."""
+
+    def __init__(self, root: Path):
+        self.root = root
+
+    def write_concept(self, concept: MemoryWikiConcept) -> Path:
+        """Write a concept atomically and return its path."""
+        ensure_dir(self.root)
+        concept_id = _slugify(concept.id or concept.title)
+        path = self.root / f"{concept_id}.md"
+        concept.id = concept_id
+        concept.path = path
+        _atomic_write_text(path, concept.to_markdown())
+        return path
+
+    def read_concept(self, concept_id: str) -> MemoryWikiConcept | None:
+        path = self.root / f"{_slugify(concept_id)}.md"
+        return self._read_concept_file(path)
+
+    def mark_status(
+        self,
+        concept_id: str,
+        status: str,
+        *,
+        superseded_by: list[str] | None = None,
+    ) -> bool:
+        """Update a concept status without deleting the audit record."""
+        concept = self.read_concept(concept_id)
+        if not concept:
+            return False
+        concept.status = status
+        if superseded_by is not None:
+            concept.superseded_by = [_slugify(item) for item in superseded_by]
+        self.write_concept(concept)
+        return True
+
+    def iter_concepts(self) -> list[MemoryWikiConcept]:
+        """Return all parseable concepts, skipping missing and malformed files."""
+        if not self.root.exists():
+            return []
+        return [
+            concept
+            for path in sorted(self.root.glob("*.md"))
+            if (concept := self._read_concept_file(path)) is not None
+        ]
+
+    def current_concepts(self, now: datetime | None = None) -> list[MemoryWikiConcept]:
+        return [concept for concept in self.iter_concepts() if concept.is_current(now)]
+
+    def has_current_context(self, now: datetime | None = None) -> bool:
+        return bool(self.current_concepts(now))
+
+    def retrieve(
+        self,
+        query: str | None = None,
+        *,
+        now: datetime | None = None,
+        max_items: int = DEFAULT_CONTEXT_MAX_ITEMS,
+    ) -> list[MemoryWikiConcept]:
+        """Retrieve active concepts by lexical relevance."""
+        concepts = self.current_concepts(now)
+        if not concepts:
+            return []
+
+        query_tokens = _tokens(query or "")
+        if not query_tokens:
+            return sorted(concepts, key=_stable_concept_key)[:max_items]
+
+        scored = [(_score_concept(concept, query_tokens), concept) for concept in concepts]
+        matches = [(score, concept) for score, concept in scored if score > 0]
+        if not matches:
+            return []
+        return [
+            concept
+            for _score, concept in sorted(
+                matches,
+                key=lambda item: (-item[0], _stable_concept_key(item[1])),
+            )
+        ][:max_items]
+
+    def get_context(
+        self,
+        query: str | None = None,
+        *,
+        now: datetime | None = None,
+        max_chars: int = DEFAULT_CONTEXT_MAX_CHARS,
+        max_items: int = DEFAULT_CONTEXT_MAX_ITEMS,
+    ) -> str:
+        """Build bounded prompt context from active derived memories only."""
+        concepts = self.retrieve(query, now=now, max_items=max_items)
+        if not concepts:
+            return ""
+
+        lines = [
+            "Only active, non-expired derived memories are listed here. "
+            "Invalidated, forgotten, superseded, and expired memories are omitted.",
+        ]
+        for concept in concepts:
+            tags = f"; tags: {', '.join(concept.tags)}" if concept.tags else ""
+            source = f"; source: {concept.source_label()}"
+            meta = f"id: {concept.id}; type: {concept.type}; status: {concept.status}{tags}{source}"
+            body = " ".join(concept.body.strip().split())
+            lines.append(f"- {concept.title} ({meta})")
+            if body:
+                lines.append(f"  {truncate_text(body, 500)}")
+
+        return truncate_text("\n".join(lines), max_chars)
+
+    def _read_concept_file(self, path: Path) -> MemoryWikiConcept | None:
+        with suppress(OSError, UnicodeError, yaml.YAMLError):
+            text = path.read_text(encoding="utf-8")
+            match = _FRONTMATTER_RE.match(text)
+            if not match:
+                return None
+            metadata = yaml.safe_load(match.group("meta")) or {}
+            if not isinstance(metadata, dict):
+                return None
+            title = _as_str(metadata.get("title"))
+            if not title:
+                return None
+            return MemoryWikiConcept(
+                id=_slugify(_as_str(metadata.get("id")) or path.stem),
+                type=_as_str(metadata.get("type")) or "fact",
+                title=title,
+                status=_as_str(metadata.get("status")) or ACTIVE_STATUS,
+                tags=_as_list(metadata.get("tags")),
+                source=_as_list(metadata.get("source")),
+                created_at=_optional_str(metadata.get("created_at")),
+                last_verified_at=_optional_str(metadata.get("last_verified_at")),
+                expires_at=_optional_str(metadata.get("expires_at")),
+                supersedes=[_slugify(item) for item in _as_list(metadata.get("supersedes"))],
+                superseded_by=[
+                    _slugify(item) for item in _as_list(metadata.get("superseded_by"))
+                ],
+                confidence=_as_float(metadata.get("confidence")),
+                body=match.group("body").strip(),
+                path=path,
+            )
+        return None
+
+
+def slugify_concept_id(value: Any) -> str:
+    return _slugify(value)
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        f.write(content)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp_path, path)
+
+
+def _slugify(value: Any) -> str:
+    normalized = str(value).strip().lower().replace(" ", "-")
+    normalized = _SLUG_RE.sub("-", normalized).strip("-")
+    return normalized or "memory"
+
+
+def _stable_concept_key(concept: MemoryWikiConcept) -> tuple[str, str]:
+    return (concept.type.lower(), concept.title.lower())
+
+
+def _tokens(text: str) -> set[str]:
+    return set(_TOKEN_RE.findall(text.lower()))
+
+
+def _score_concept(concept: MemoryWikiConcept, query_tokens: set[str]) -> int:
+    text_tokens = _tokens(concept.searchable_text())
+    title_tokens = _tokens(concept.title)
+    tag_tokens = _tokens(" ".join(concept.tags))
+    source_tokens = _tokens(concept.source_label())
+    id_tokens = _tokens(concept.id)
+    score = 0
+    for token in query_tokens:
+        if token in text_tokens:
+            score += 1
+        if token in id_tokens:
+            score += 3
+        if token in title_tokens:
+            score += 2
+        if token in tag_tokens:
+            score += 2
+        if token in source_tokens:
+            score += 1
+    return score
+
+
+def _as_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if item is not None]
+    if isinstance(value, tuple):
+        return [str(item) for item in value if item is not None]
+    return [str(value)]
+
+
+def _as_str(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _as_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    with suppress(TypeError, ValueError):
+        return float(value)
+    return None
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    with suppress(ValueError):
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        return _normalize_datetime(parsed)
+    return None
+
+
+def _normalize_datetime(value: datetime | None) -> datetime:
+    current = value or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        return current.replace(tzinfo=timezone.utc)
+    return current.astimezone(timezone.utc)

--- a/nanobot/skills/memory/SKILL.md
+++ b/nanobot/skills/memory/SKILL.md
@@ -10,7 +10,8 @@ always: true
 
 - `SOUL.md` — Bot personality and communication style. **Managed by Dream.** Do NOT edit.
 - `USER.md` — User profile and preferences. **Managed by Dream.** Do NOT edit.
-- `memory/MEMORY.md` — Long-term facts (project context, important events). **Managed by Dream.** Do NOT edit.
+- `memory/MEMORY.md` — Legacy long-term facts (project context, important events). **Managed by Dream.** Do NOT edit.
+- `memory/wiki/*.md` — Derived wiki-style memory concepts with lifecycle metadata. **Managed by Dream.** Do NOT edit directly.
 - `memory/history.jsonl` — append-only JSONL, not loaded into context. Prefer the built-in `grep` tool to search it.
 
 ## Search Past Events
@@ -32,5 +33,6 @@ Examples (replace `keyword`):
 ## Important
 
 - **Do NOT edit SOUL.md, USER.md, or MEMORY.md.** They are automatically managed by Dream.
+- **Do NOT edit `memory/wiki/*.md` directly.** Dream writes lifecycle concepts with validation.
 - If you notice outdated information, it will be corrected when Dream runs next.
 - Users can view Dream's activity with the `/dream-log` command.

--- a/nanobot/templates/agent/dream.md
+++ b/nanobot/templates/agent/dream.md
@@ -1,4 +1,12 @@
-You are a memory consolidation engine. Your sole task is to analyze conversation history and maintain the user's long-term memory files (SOUL.md, USER.md, MEMORY.md, SKILL.md). You are ruthless about pruning: removing stale content is as important as adding new facts. You enforce MECE classification, write atomic facts, and never duplicate information across files.
+You are a memory consolidation engine. Your sole task is to analyze conversation history and maintain the user's long-term memory. You are ruthless about pruning: removing stale content is as important as adding new facts. You enforce MECE classification, write atomic facts, and never duplicate information across files.
+
+## Structured memory first
+Use `write_memory_concepts` for derived long-term facts whenever possible. This writes `memory/wiki/*.md` concept pages with lifecycle metadata:
+
+- `id`, `type`, `title`, `status`, `tags`, `source`, `body`
+- optional `created_at`, `last_verified_at`, `expires_at`, `supersedes`, `superseded_by`, `confidence`
+
+Only `active` non-expired concepts enter normal prompt context. Keep invalidated, forgotten, superseded, and expired concepts as audit records instead of current truth. Preserve cursor sources such as `history:cursor:123`.
 
 ## File routing
 Do NOT guess paths. Route each fact to its canonical file:
@@ -8,6 +16,7 @@ Do NOT guess paths. Route each fact to its canonical file:
 | SOUL.md | `SOUL.md` | Agent behavior rules, guardrails, interaction patterns, tool-use strategy |
 | USER.md | `USER.md` | Personal attributes: identity, preferences, habits, communication style (language, length, tone) |
 | MEMORY.md | `memory/MEMORY.md` | Project context: goals, architecture, strategic decisions, infrastructure overview, integrated services |
+| Wiki concepts | `memory/wiki/*.md` via `write_memory_concepts` | Derived atomic facts with lifecycle metadata and provenance |
 | SKILL.md | `skills/<name>/SKILL.md` | Reusable workflow templates with concrete steps, commands, and examples ([SKILL] entries only) |
 
 **Routing examples:**

--- a/nanobot/utils/gitstore.py
+++ b/nanobot/utils/gitstore.py
@@ -97,13 +97,16 @@ class GitStore:
             # Ensure tracked files exist (touch them if missing) so the initial
             # commit has something to track.
             for rel in self._tracked_files:
-                p = self._workspace / rel
+                p = self._workspace / self._add_path(rel)
+                if rel.endswith("/**"):
+                    p.mkdir(parents=True, exist_ok=True)
+                    continue
                 p.parent.mkdir(parents=True, exist_ok=True)
                 if not p.exists():
                     p.write_text("", encoding="utf-8")
 
             # Initial commit
-            porcelain.add(str(self._workspace), paths=[".gitignore"] + self._tracked_files)
+            porcelain.add(str(self._workspace), paths=[".gitignore", *self._tracked_add_paths()])
             porcelain.commit(
                 str(self._workspace),
                 message=b"init: nanobot memory store",
@@ -136,7 +139,7 @@ class GitStore:
                 return None
 
             msg_bytes = message.encode("utf-8") if isinstance(message, str) else message
-            porcelain.add(str(self._workspace), paths=self._tracked_files)
+            porcelain.add(str(self._workspace), paths=self._tracked_add_paths())
             sha_bytes = porcelain.commit(
                 str(self._workspace),
                 message=msg_bytes,
@@ -196,16 +199,31 @@ class GitStore:
         """Generate .gitignore content from tracked files."""
         dirs: set[str] = set()
         for f in self._tracked_files:
-            parent = str(Path(f).parent)
+            add_path = self._add_path(f)
+            if f.endswith("/**"):
+                dirs.add(add_path)
+            parent = str(Path(add_path).parent)
             if parent != ".":
-                dirs.add(parent)
+                parts = Path(parent).parts
+                for idx in range(1, len(parts) + 1):
+                    dirs.add(str(Path(*parts[:idx])))
         lines = ["/*"]
         for d in sorted(dirs):
             lines.append(f"!{d}/")
         for f in self._tracked_files:
-            lines.append(f"!{f}")
+            if f.endswith("/**"):
+                lines.append(f"!{self._add_path(f)}/**")
+            else:
+                lines.append(f"!{f}")
         lines.append("!.gitignore")
         return "\n".join(lines) + "\n"
+
+    def _tracked_add_paths(self) -> list[str]:
+        return [self._add_path(path) for path in self._tracked_files]
+
+    @staticmethod
+    def _add_path(path: str) -> str:
+        return path[:-3].rstrip("/\\") if path.endswith("/**") else path
 
     # -- query -----------------------------------------------------------------
 

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -128,6 +128,7 @@ class TestDreamTools:
             "apply_patch",
             "edit_file",
             "read_file",
+            "write_memory_concepts",
             "write_file",
         }
 

--- a/tests/agent/test_dream_writer.py
+++ b/tests/agent/test_dream_writer.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from nanobot.agent.dream_writer import (
+    WriteMemoryConceptsTool,
+    infer_writer_provider_capability,
+    repair_memory_concepts,
+    validate_memory_concepts,
+)
+from nanobot.agent.memory_wiki import MemoryWikiStore
+
+CONTROLLED = """
+[history:cursor:1] [2026-06-01 10:00] [durable] RLV-HOLDOUT-PORT-OLD: Gateway port 8765 was used.
+[history:cursor:4] [2026-06-02 10:00] [correction] RLV-HOLDOUT-PORT-CURRENT: Current gateway port is port 8877.
+[history:cursor:6] [2026-06-03 10:00] [permanent] RLV-HOLDOUT-PHONE: User phone number is 555-0100.
+[history:cursor:7] [2026-06-03 10:05] [correction] User asked to forget RLV-HOLDOUT-PHONE.
+[history:cursor:8] [2026-05-01 09:00] [ephemeral] RLV-HOLDOUT-DEMO-OLD: Ship demo on 2026-05-01.
+""".strip()
+
+
+def test_repair_memory_concepts_resolves_corrections_forgets_and_expiry() -> None:
+    repaired = repair_memory_concepts(
+        [
+            {
+                "id": "rlv-holdout-port-current",
+                "title": "Current port",
+                "body": "The model summarized this without the exact port.",
+                "type": "project_decision",
+                "status": "active",
+                "tags": [],
+                "source": ["history:cursor:4"],
+            }
+        ],
+        CONTROLLED,
+        now=datetime(2026, 6, 17, tzinfo=timezone.utc),
+    )
+    by_id = {item["id"]: item for item in repaired}
+
+    assert by_id["rlv-holdout-port-old"]["status"] == "invalidated"
+    assert by_id["rlv-holdout-port-current"]["status"] == "active"
+    assert "port 8877" in by_id["rlv-holdout-port-current"]["body"]
+    assert by_id["rlv-holdout-port-current"]["source"] == ["history:cursor:4"]
+    assert by_id["rlv-holdout-phone"]["status"] == "forgotten"
+    assert by_id["rlv-holdout-demo-old"]["status"] == "expired"
+
+    validation = validate_memory_concepts(repaired, now=datetime(2026, 6, 17, tzinfo=timezone.utc))
+    assert validation.ok
+
+
+def test_validator_rejects_duplicate_active_group_and_missing_source() -> None:
+    validation = validate_memory_concepts(
+        [
+            {
+                "id": "project-port-old",
+                "title": "Old port",
+                "body": "Use port 8765.",
+                "type": "project_decision",
+                "status": "active",
+                "tags": [],
+                "source": ["history:cursor:1"],
+            },
+            {
+                "id": "project-port-current",
+                "title": "Current port",
+                "body": "Use port 8877.",
+                "type": "project_decision",
+                "status": "active",
+                "tags": [],
+                "source": [],
+            },
+        ]
+    )
+
+    assert not validation.ok
+    assert any("multiple active concepts" in error for error in validation.errors)
+    assert any("must include source" in error for error in validation.errors)
+
+
+@pytest.mark.asyncio
+async def test_write_memory_concepts_tool_repairs_and_writes(tmp_path) -> None:
+    wiki = MemoryWikiStore(tmp_path / "memory" / "wiki")
+    tool = WriteMemoryConceptsTool(
+        wiki,
+        history_text=CONTROLLED,
+        now=datetime(2026, 6, 17, tzinfo=timezone.utc),
+    )
+
+    result = await tool.execute(concepts=[])
+
+    assert '"status": "ok"' in result
+    context = wiki.get_context("current port phone demo", now=datetime(2026, 6, 17, tzinfo=timezone.utc))
+    assert "port 8877" in context
+    assert "555-0100" not in context
+    assert "2026-05-01" not in context
+
+
+def test_provider_capability_marks_deepseek_thinking_required_tool_incompatible() -> None:
+    capability = infer_writer_provider_capability(
+        provider="deepseek",
+        model="deepseek-v4-flash",
+        reasoning_effort="medium",
+    )
+
+    assert capability.supports_required_tool_choice is False
+    assert capability.selected_tool_choice == "auto"
+
+
+def test_provider_capability_allows_required_tool_when_thinking_disabled() -> None:
+    capability = infer_writer_provider_capability(
+        provider="zhipu",
+        model="glm-5.1",
+        reasoning_effort="high",
+    )
+
+    assert capability.supports_required_tool_choice is True
+    assert capability.selected_tool_choice == "required"

--- a/tests/agent/test_memory_wiki.py
+++ b/tests/agent/test_memory_wiki.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from nanobot.agent.context import ContextBuilder
+from nanobot.agent.memory import MemoryStore
+from nanobot.agent.memory_wiki import MemoryWikiConcept, MemoryWikiStore
+from nanobot.utils.helpers import sync_workspace_templates
+
+
+def test_wiki_round_trip_preserves_lifecycle_metadata(tmp_path) -> None:
+    store = MemoryWikiStore(tmp_path / "memory" / "wiki")
+
+    store.write_concept(
+        MemoryWikiConcept(
+            id="User Language",
+            type="user_preference",
+            title="Current response language",
+            body="User currently prefers English for technical summaries.",
+            tags=["user", "language"],
+            source=["history:cursor:12"],
+            created_at="2026-06-01T10:00:00Z",
+            last_verified_at="2026-06-15T09:00:00Z",
+            confidence=0.96,
+        )
+    )
+
+    concept = store.read_concept("user-language")
+
+    assert concept is not None
+    assert concept.id == "user-language"
+    assert concept.type == "user_preference"
+    assert concept.status == "active"
+    assert concept.tags == ["user", "language"]
+    assert concept.source == ["history:cursor:12"]
+    assert concept.confidence == 0.96
+    assert "prefers English" in concept.body
+
+
+def test_retrieval_omits_invalidated_forgotten_and_expired_concepts(tmp_path) -> None:
+    store = MemoryWikiStore(tmp_path / "memory" / "wiki")
+    store.write_concept(
+        MemoryWikiConcept(
+            id="current-port",
+            type="project_decision",
+            title="Gateway port",
+            body="The current gateway port is 8877.",
+            tags=["gateway", "port"],
+            source=["history:cursor:4"],
+        )
+    )
+    store.write_concept(
+        MemoryWikiConcept(
+            id="old-port",
+            type="project_decision",
+            title="Old gateway port",
+            body="The gateway port was previously 8765.",
+            status="invalidated",
+            tags=["gateway", "port"],
+            source=["history:cursor:1"],
+            superseded_by=["current-port"],
+        )
+    )
+    store.write_concept(
+        MemoryWikiConcept(
+            id="phone-number",
+            type="user_private_data",
+            title="Forgotten phone number",
+            body="User phone number is 555-0100.",
+            status="forgotten",
+            tags=["user", "phone"],
+            source=["history:cursor:2"],
+        )
+    )
+    store.write_concept(
+        MemoryWikiConcept(
+            id="expired-demo",
+            type="time_bound_fact",
+            title="Expired demo date",
+            body="Ship the demo on 2026-05-01.",
+            tags=["demo", "deadline"],
+            source=["history:cursor:3"],
+            expires_at="2026-05-02T00:00:00Z",
+        )
+    )
+
+    context = store.get_context(
+        "What is the current gateway port and demo deadline?",
+        now=datetime(2026, 6, 17, tzinfo=timezone.utc),
+    )
+
+    assert "8877" in context
+    assert "history:cursor:4" in context
+    assert "8765" not in context
+    assert "555-0100" not in context
+    assert "2026-05-01" not in context
+
+
+def test_malformed_wiki_files_are_ignored(tmp_path) -> None:
+    store = MemoryWikiStore(tmp_path / "memory" / "wiki")
+    store.root.mkdir(parents=True)
+    (store.root / "broken.md").write_text("not frontmatter\nnot a concept", encoding="utf-8")
+    store.write_concept(
+        MemoryWikiConcept(
+            id="valid",
+            title="Valid concept",
+            body="This concept should still load.",
+            source=["history:cursor:1"],
+        )
+    )
+
+    concepts = store.iter_concepts()
+
+    assert [concept.id for concept in concepts] == ["valid"]
+
+
+def test_memory_store_combines_wiki_and_legacy_memory_without_wiki_files(tmp_path) -> None:
+    store = MemoryStore(tmp_path)
+
+    assert store.get_memory_context() == ""
+
+    store.write_memory("Legacy fact remains visible.")
+    assert "## Long-term Memory" in store.get_memory_context()
+    assert "Legacy fact remains visible." in store.get_memory_context()
+
+    store.wiki.write_concept(
+        MemoryWikiConcept(
+            id="current-language",
+            type="user_preference",
+            title="Current language",
+            body="User currently prefers English.",
+            tags=["language"],
+            source=["history:cursor:7"],
+        )
+    )
+
+    context = store.get_memory_context(query="language")
+
+    assert "## Derived Memory Wiki" in context
+    assert "User currently prefers English" in context
+    assert "source: history:cursor:7" in context
+    assert "## Long-term Memory" in context
+
+
+def test_context_builder_injects_wiki_when_memory_md_is_template(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    sync_workspace_templates(workspace, silent=True)
+    builder = ContextBuilder(workspace)
+    builder.memory.wiki.write_concept(
+        MemoryWikiConcept(
+            id="current-language",
+            type="user_preference",
+            title="Current language",
+            body="User currently prefers English.",
+            tags=["language"],
+            source=["history:cursor:7"],
+        )
+    )
+
+    prompt = builder.build_system_prompt(memory_query="language")
+
+    assert "# Memory\n\n## Derived Memory Wiki" in prompt
+    assert "User currently prefers English" in prompt
+    assert "# Memory\n\n## Long-term Memory" not in prompt
+    assert "This file is automatically updated by nanobot" not in prompt


### PR DESCRIPTION
## Summary
- add a lifecycle-aware derived memory wiki under `memory/wiki/*.md`
- add Dream-only `write_memory_concepts` with validation and deterministic repair for corrections, expiry, forgetting, supersession, and duplicate active facts
- inject only active, non-expired wiki concepts into prompt context while preserving legacy `MEMORY.md` fallback
- update Dream/memory contracts and add regression coverage

## Validation
- `ruff check nanobot/agent/memory_wiki.py nanobot/agent/dream_writer.py nanobot/agent/memory.py nanobot/agent/context.py nanobot/utils/gitstore.py tests/agent/test_memory_wiki.py tests/agent/test_dream_writer.py`
- `python -m pytest tests/agent/test_memory_wiki.py tests/agent/test_dream_writer.py tests/agent/test_dream.py tests/agent/test_context_prompt_cache.py tests/agent/test_memory_store.py -q` (`105 passed`)

## Experiment Notes
- real-data shadow benchmark used redacted local history snippets only; raw history, prompts, responses, and API keys were not committed
- final candidate gate: 10/10 live writer runs passed, min/mean score 100, current/stale/provenance pass 100%, selected writer hard failures 0
- `dsflash` was detected as incompatible with required/named tool choice while thinking mode is enabled, so `glm5.1` was selected for writer validation