### PR TITLE
fix: advance dream cursor when Dream is disabled to prevent prompt bloat (#4242)

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -479,6 +479,9 @@ class MemoryStore:
     def set_last_dream_cursor(self, cursor: int) -> None:
         self._dream_cursor_file.write_text(str(cursor), encoding="utf-8")
 
+    def get_latest_cursor(self) -> int:
+        return max(self._next_cursor() - 1, 0)
+
     def build_dream_prompt(self, *, max_entries: int = 20) -> tuple[str, int] | None:
         """Build the Dream prompt with unprocessed history context.
 

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1146,7 +1146,9 @@ def _run_gateway(
         console.print(f"[green]✓[/green] Dream: {dream_cfg.describe_schedule()}")
     else:
         console.print("[yellow]○[/yellow] Dream: disabled")
-        agent.context.memory.set_last_dream_cursor(agent.context.memory.get_latest_cursor())
+        latest = agent.context.memory.get_latest_cursor()
+        if agent.context.memory.get_last_dream_cursor() < latest:
+            agent.context.memory.set_last_dream_cursor(latest)
 
     # Register Heartbeat system job (idempotent on restart)
     if hb_cfg.enabled:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1146,6 +1146,7 @@ def _run_gateway(
         console.print(f"[green]✓[/green] Dream: {dream_cfg.describe_schedule()}")
     else:
         console.print("[yellow]○[/yellow] Dream: disabled")
+        agent.context.memory.set_last_dream_cursor(agent.context.memory.get_latest_cursor())
 
     # Register Heartbeat system job (idempotent on restart)
     if hb_cfg.enabled:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -153,6 +153,12 @@ def _install_gateway_shutdown_handlers(
     return restore
 
 
+def _advance_dream_cursor_if_behind(memory: Any) -> None:
+    latest = memory.get_latest_cursor()
+    if memory.get_last_dream_cursor() < latest:
+        memory.set_last_dream_cursor(latest)
+
+
 class SafeFileHistory(FileHistory):
     """FileHistory subclass that sanitizes surrogate characters on write.
 
@@ -1146,9 +1152,7 @@ def _run_gateway(
         console.print(f"[green]✓[/green] Dream: {dream_cfg.describe_schedule()}")
     else:
         console.print("[yellow]○[/yellow] Dream: disabled")
-        latest = agent.context.memory.get_latest_cursor()
-        if agent.context.memory.get_last_dream_cursor() < latest:
-            agent.context.memory.set_last_dream_cursor(latest)
+        _advance_dream_cursor_if_behind(agent.context.memory)
 
     # Register Heartbeat system job (idempotent on restart)
     if hb_cfg.enabled:

--- a/tests/agent/test_memory_store.py
+++ b/tests/agent/test_memory_store.py
@@ -330,6 +330,27 @@ class TestDreamCursor:
     def test_initial_cursor_is_zero(self, store):
         assert store.get_last_dream_cursor() == 0
 
+    def test_returns_zero_when_empty(self, store):
+        assert store.get_latest_cursor() == 0
+
+    def test_returns_cursor_of_last_entry(self, store):
+        store.append_history("event 1")
+        store.append_history("event 2")
+        store.append_history("event 3")
+
+        assert store.get_latest_cursor() == 3
+
+    def test_returns_zero_when_no_entries(self, store):
+        store.history_file.write_text("", encoding="utf-8")
+
+        assert store.get_latest_cursor() == 0
+
+    def test_matches_next_cursor_minus_one(self, store):
+        store.append_history("event 1")
+        store.append_history("event 2")
+
+        assert store.get_latest_cursor() == max(store._next_cursor() - 1, 0)
+
     def test_set_and_get_cursor(self, store):
         store.set_last_dream_cursor(5)
         assert store.get_last_dream_cursor() == 5

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from typer.testing import CliRunner
 
+from nanobot.agent.memory import MemoryStore
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.cli import commands as cli_commands
 from nanobot.cli.commands import app
@@ -138,6 +139,19 @@ def test_gateway_tty_signal_mode_restores_ctrl_c(monkeypatch) -> None:
     finally:
         os.close(master_fd)
         os.close(slave_fd)
+
+
+def test_disabled_dream_cursor_only_advances_when_behind(tmp_path) -> None:
+    store = MemoryStore(tmp_path)
+    store.append_history("first")
+    store.append_history("second")
+
+    cli_commands._advance_dream_cursor_if_behind(store)
+    assert store.get_last_dream_cursor() == 2
+
+    store.set_last_dream_cursor(10)
+    cli_commands._advance_dream_cursor_if_behind(store)
+    assert store.get_last_dream_cursor() == 10
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #4242.

Problem: When dream.enabled is set to false, the Dream cron job is correctly not registered, but the dream cursor (.dream_cursor) is never advanced. The read_recent_history_for_prompt() method in context.py uses this cursor to determine which history entries are unprocessed. Since the cursor stays at its initial value (0), every history entry appears unprocessed and gets injected into the system prompt via the Recent History section. This grows without bound over time, wasting tokens in every LLM call.

Fix: Add get_latest_cursor() method to MemoryStore that returns the cursor of the most recent history entry. At gateway startup, when Dream is disabled, fast-forward the dream cursor to the latest entry so no stale entries accumulate.

Testing: 47 tests pass in test_memory_store.py, including 4 new tests for get_latest_cursor(). Ruff check passes on both changed files.

Scope: 3 files changed (memory.py, commands.py, test_memory_store.py). 25 lines added. No behavior change when Dream is enabled.