### PR TITLE
fix(web): pass proxy to DDGS client for DuckDuckGo search

### DIFF
--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -759,7 +759,7 @@ class WebSearchTool(Tool):
             # We run it in a thread to avoid blocking the loop
             from ddgs import DDGS
 
-            ddgs = DDGS(timeout=10)
+            ddgs = DDGS(timeout=10, proxy=self.proxy)
             raw = await asyncio.wait_for(
                 asyncio.to_thread(ddgs.text, query, max_results=n),
                 timeout=self.config.timeout,

--- a/tests/tools/test_web_search_tool.py
+++ b/tests/tools/test_web_search_tool.py
@@ -369,21 +369,25 @@ async def test_duckduckgo_search(monkeypatch):
 async def test_duckduckgo_search_passes_proxy(monkeypatch):
     """DDGS client must receive the configured proxy so search works behind a proxy."""
     captured: dict = {}
+    proxy_url = "http://proxy.example:8080"
 
     class ProxyCaptorDDGS:
         def __init__(self, **kw):
             captured.update(kw)
 
         def text(self, query, max_results=5):
-            return [{"title": "Proxied", "href": "https://ddg.example", "body": "OK"}]
+            return [{"title": "Result", "href": "https://example.com", "body": "OK"}]
 
     monkeypatch.setattr("ddgs.DDGS", ProxyCaptorDDGS)
 
-    tool = _tool(provider="duckduckgo")
-    tool.proxy = "http://192.168.1.1:8080"
-    result = await tool.execute(query="hello")
-    assert captured.get("proxy") == "http://192.168.1.1:8080"
-    assert "Proxied" in result
+    tool = WebSearchTool(
+        config=WebSearchConfig(provider="duckduckgo"),
+        proxy=proxy_url,
+    )
+    result = await tool.execute(query="test")
+    assert captured["proxy"] == proxy_url
+    assert captured["timeout"] == 10
+    assert "Result" in result
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_web_search_tool.py
+++ b/tests/tools/test_web_search_tool.py
@@ -366,6 +366,27 @@ async def test_duckduckgo_search(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_duckduckgo_search_passes_proxy(monkeypatch):
+    """DDGS client must receive the configured proxy so search works behind a proxy."""
+    captured: dict = {}
+
+    class ProxyCaptorDDGS:
+        def __init__(self, **kw):
+            captured.update(kw)
+
+        def text(self, query, max_results=5):
+            return [{"title": "Proxied", "href": "https://ddg.example", "body": "OK"}]
+
+    monkeypatch.setattr("ddgs.DDGS", ProxyCaptorDDGS)
+
+    tool = _tool(provider="duckduckgo")
+    tool.proxy = "http://192.168.1.1:8080"
+    result = await tool.execute(query="hello")
+    assert captured.get("proxy") == "http://192.168.1.1:8080"
+    assert "Proxied" in result
+
+
+@pytest.mark.asyncio
 async def test_brave_fallback_to_duckduckgo_when_no_key(monkeypatch):
     class MockDDGS:
         def __init__(self, **kw):


### PR DESCRIPTION
## Problem

The DuckDuckGo search provider instantiates `DDGS(timeout=10)` without passing the configured proxy. This makes `web_search` with `provider: duckduckgo` completely unusable in environments that require a proxy (e.g. behind the GFW), since DDGS cannot reach DuckDuckGo without it.

## Root Cause

In `nanobot/agent/tools/web.py`, the `WebSearchTool` class stores the configured proxy as `self.proxy`, but the DDGS client constructor was called without forwarding it:

```python
# Before (broken behind proxy)
ddgs = DDGS(timeout=10)

# After (proxy forwarded)
ddgs = DDGS(timeout=10, proxy=self.proxy)
```

The `ddgs` library supports a `proxy` parameter natively, and `self.proxy` already holds the value from config — it was simply not passed through.

## Changes

- **`nanobot/agent/tools/web.py`**: Pass `proxy=self.proxy` to `DDGS()` constructor
- **`tests/tools/test_web_search_tool.py`**: Add `test_duckduckgo_search_passes_proxy` verifying the proxy kwarg is forwarded to the DDGS client

## Testing

All 39 web search tool tests pass, including the new one:

```
.venv/bin/python3 -m pytest tests/tools/test_web_search_tool.py -q
39 passed
```