### PR TITLE
fix(webui): WebM→WAV conversion for Xiaomi MiMo ASR transcription

### DIFF
--- a/webui/src/components/thread/ThreadComposer.tsx
+++ b/webui/src/components/thread/ThreadComposer.tsx
@@ -172,6 +172,7 @@ interface ThreadComposerProps {
   workspaceError?: string | null;
   onWorkspaceScopeChange?: (scope: WorkspaceScopePayload) => void;
   pendingQueueKey?: string | null;
+  transcriptionProvider?: string | null;
 }
 
 const COMMAND_ICONS: Record<string, LucideIcon> = {
@@ -782,6 +783,7 @@ export function ThreadComposer({
   workspaceError = null,
   onWorkspaceScopeChange,
   pendingQueueKey = null,
+  transcriptionProvider = null,
 }: ThreadComposerProps) {
   const { t } = useTranslation();
   const [value, setValue] = useState("");
@@ -1193,6 +1195,7 @@ export function ThreadComposer({
     onError: setVoiceError,
     onTranscript: appendTranscription,
     onTranscribeAudio,
+    wantsWav: transcriptionProvider === "xiaomi_mimo",
   });
 
   useEffect(() => {

--- a/webui/src/components/thread/ThreadShell.tsx
+++ b/webui/src/components/thread/ThreadShell.tsx
@@ -736,6 +736,7 @@ export function ThreadShell({
           workspaceError={workspaceError}
           onWorkspaceScopeChange={onWorkspaceScopeChange}
           pendingQueueKey={chatId}
+          transcriptionProvider={settingsSnapshot?.transcription?.provider}
         />
       ) : (
         <ThreadComposer
@@ -765,6 +766,7 @@ export function ThreadShell({
           workspaceScopeDisabled={workspaceScopeDisabled}
           workspaceError={workspaceError}
           onWorkspaceScopeChange={onWorkspaceScopeChange}
+          transcriptionProvider={settingsSnapshot?.transcription?.provider}
         />
       )}
     </>

--- a/webui/src/hooks/useVoiceRecorder.ts
+++ b/webui/src/hooks/useVoiceRecorder.ts
@@ -42,6 +42,8 @@ interface VoiceRecorderOptions {
   onError: (key: VoiceRecorderErrorKey) => void;
   onTranscript: (text: string) => void;
   onTranscribeAudio?: (dataUrl: string, options?: { durationMs?: number }) => Promise<string>;
+  /** When true, convert recorded audio to WAV before sending (needed for providers that don't support WebM). */
+  wantsWav?: boolean;
 }
 
 export function useVoiceRecorder({
@@ -50,6 +52,7 @@ export function useVoiceRecorder({
   onError,
   onTranscript,
   onTranscribeAudio,
+  wantsWav = false,
 }: VoiceRecorderOptions) {
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<BlobPart[]>([]);
@@ -223,7 +226,9 @@ export function useVoiceRecorder({
           return;
         }
         setState("transcribing");
-        void blobToDataUrl(new Blob(chunks, { type: mimeType }))
+        const blob = new Blob(chunks, { type: mimeType });
+        const audioPromise = wantsWav ? convertBlobToWav(blob) : blobToDataUrl(blob);
+        void audioPromise
           .then((dataUrl) => onTranscribeAudio(dataUrl, { durationMs }))
           .then(onTranscript)
           .catch((error) => onError(transcriptionErrorKey(error)))
@@ -260,6 +265,7 @@ export function useVoiceRecorder({
     startWaveform,
     state,
     stopRecording,
+    wantsWav,
   ]);
 
   const startRecordingWithDeferredStop = useCallback(() => {
@@ -412,6 +418,90 @@ function blobToDataUrl(blob: Blob): Promise<string> {
     reader.onerror = () => reject(reader.error ?? new Error("read_failed"));
     reader.readAsDataURL(blob);
   });
+}
+
+/**
+ * Convert any browser-recorded audio blob (typically webm/opus) to WAV
+ * using the Web Audio API. This avoids sending unsupported formats
+ * (e.g. webm) to ASR providers that only accept wav/mp3/mpeg.
+ */
+async function convertBlobToWav(blob: Blob): Promise<string> {
+  const AudioCtx = audioContextConstructor();
+  if (!AudioCtx) return blobToDataUrl(blob);
+
+  const arrayBuffer = await blob.arrayBuffer();
+  const ctx = new AudioCtx();
+  try {
+    const audioBuffer = await ctx.decodeAudioData(arrayBuffer);
+    const wavBlob = audioBufferToWav(audioBuffer);
+    return blobToDataUrl(wavBlob);
+  } finally {
+    void ctx.close();
+  }
+}
+
+/**
+ * Encode an AudioBuffer as a 16-bit PCM WAV Blob.
+ */
+function audioBufferToWav(buffer: AudioBuffer): Blob {
+  const numChannels = buffer.numberOfChannels;
+  const sampleRate = buffer.sampleRate;
+  const format = 1; // PCM
+  const bitsPerSample = 16;
+
+  // Interleave channels
+  const channels: Float32Array[] = [];
+  for (let ch = 0; ch < numChannels; ch++) {
+    channels.push(buffer.getChannelData(ch));
+  }
+  const length = channels[0].length;
+  const interleaved = new Int16Array(length * numChannels);
+  for (let i = 0; i < length; i++) {
+    for (let ch = 0; ch < numChannels; ch++) {
+      const sample = Math.max(-1, Math.min(1, channels[ch][i]));
+      interleaved[i * numChannels + ch] = sample < 0
+        ? sample * 0x8000
+        : sample * 0x7FFF;
+    }
+  }
+
+  const byteRate = sampleRate * numChannels * (bitsPerSample / 8);
+  const blockAlign = numChannels * (bitsPerSample / 8);
+  const dataSize = interleaved.byteLength;
+  const headerSize = 44;
+  const totalSize = headerSize + dataSize;
+
+  const buffer2 = new ArrayBuffer(totalSize);
+  const view = new DataView(buffer2);
+
+  // RIFF header
+  writeString(view, 0, "RIFF");
+  view.setUint32(4, totalSize - 8, true);
+  writeString(view, 8, "WAVE");
+
+  // fmt sub-chunk
+  writeString(view, 12, "fmt ");
+  view.setUint32(16, 16, true); // sub-chunk size
+  view.setUint16(20, format, true);
+  view.setUint16(22, numChannels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, byteRate, true);
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, bitsPerSample, true);
+
+  // data sub-chunk
+  writeString(view, 36, "data");
+  view.setUint32(40, dataSize, true);
+
+  new Int16Array(buffer2, headerSize).set(interleaved);
+
+  return new Blob([buffer2], { type: "audio/wav" });
+}
+
+function writeString(view: DataView, offset: number, str: string): void {
+  for (let i = 0; i < str.length; i++) {
+    view.setUint8(offset + i, str.charCodeAt(i));
+  }
 }
 
 function transcriptionErrorKey(error: unknown): VoiceRecorderErrorKey {

--- a/webui/src/tests/thread-composer.test.tsx
+++ b/webui/src/tests/thread-composer.test.tsx
@@ -226,7 +226,20 @@ function mockVoiceRecorder(blob = new Blob(["voice"], { type: "audio/webm" })) {
   return { getUserMedia, stopTrack };
 }
 
-function mockVoiceAudioInput(sample = 128, state: AudioContextState = "running") {
+function mockVoiceAudioInput(
+  sample = 128,
+  state: AudioContextState = "running",
+  decodedChannels?: Float32Array[],
+) {
+  const decodeAudioDataMock = vi.fn(async () => {
+    if (!decodedChannels) throw new Error("decodeAudioData not mocked");
+    return {
+      numberOfChannels: decodedChannels.length,
+      sampleRate: 16_000,
+      getChannelData: (channel: number) => decodedChannels[channel],
+    } as AudioBuffer;
+  });
+
   class FakeAudioContext {
     state = state;
 
@@ -244,6 +257,7 @@ function mockVoiceAudioInput(sample = 128, state: AudioContextState = "running")
     }
 
     close = vi.fn(async () => undefined);
+    decodeAudioData = decodeAudioDataMock;
     resume = vi.fn(async () => undefined);
   }
 
@@ -254,12 +268,22 @@ function mockVoiceAudioInput(sample = 128, state: AudioContextState = "running")
   vi.spyOn(window, "cancelAnimationFrame").mockImplementation((id) =>
     window.clearTimeout(id as unknown as number)
   );
+  return { decodeAudioData: decodeAudioDataMock };
 }
 
 async function waitForVoiceCapture(): Promise<void> {
   await act(async () => {
     await new Promise((resolve) => setTimeout(resolve, 700));
   });
+}
+
+function bytesFromDataUrl(dataUrl: string): Uint8Array {
+  const [, base64 = ""] = dataUrl.split(",");
+  return Uint8Array.from(atob(base64), (char) => char.charCodeAt(0));
+}
+
+function ascii(bytes: Uint8Array, offset: number, length: number): string {
+  return String.fromCharCode(...bytes.slice(offset, offset + length));
 }
 
 describe("ThreadComposer", () => {
@@ -335,6 +359,47 @@ describe("ThreadComposer", () => {
     ));
     await waitFor(() => expect(screen.getByLabelText("Message input")).toHaveValue("hello voice"));
     expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("converts voice recordings to wav for Xiaomi MiMo transcription", async () => {
+    mockVoiceRecorder(new Blob([new Uint8Array([1, 2, 3, 4])], { type: "audio/webm" }));
+    const { decodeAudioData } = mockVoiceAudioInput(
+      180,
+      "running",
+      [new Float32Array([0, 0.5, -0.5])],
+    );
+    const onTranscribeAudio = vi.fn(async () => "mimo voice");
+    render(
+      <ThreadComposer
+        onSend={vi.fn()}
+        onTranscribeAudio={onTranscribeAudio}
+        placeholder="Type your message..."
+        transcriptionProvider="xiaomi_mimo"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Voice input" }));
+    expect(await screen.findByLabelText("Recording 0:00")).toBeInTheDocument();
+    await waitForVoiceCapture();
+    fireEvent.click(await screen.findByRole("button", { name: "Stop recording" }));
+
+    await waitFor(() => expect(onTranscribeAudio).toHaveBeenCalledTimes(1));
+    const [dataUrl, options] = onTranscribeAudio.mock.calls[0];
+    expect(dataUrl).toMatch(/^data:audio\/wav;base64,/);
+    expect(options).toEqual(expect.objectContaining({ durationMs: expect.any(Number) }));
+    expect(decodeAudioData).toHaveBeenCalledTimes(1);
+
+    const bytes = bytesFromDataUrl(dataUrl);
+    const view = new DataView(bytes.buffer);
+    expect(ascii(bytes, 0, 4)).toBe("RIFF");
+    expect(ascii(bytes, 8, 4)).toBe("WAVE");
+    expect(ascii(bytes, 12, 4)).toBe("fmt ");
+    expect(view.getUint16(20, true)).toBe(1);
+    expect(view.getUint16(22, true)).toBe(1);
+    expect(view.getUint32(24, true)).toBe(16_000);
+    expect(view.getUint16(34, true)).toBe(16);
+    expect(ascii(bytes, 36, 4)).toBe("data");
+    await waitFor(() => expect(screen.getByLabelText("Message input")).toHaveValue("mimo voice"));
   });
 
   it("does not start duplicate voice recordings while microphone access is pending", async () => {


### PR DESCRIPTION
## Summary

Fixes #4492

MiMo ASR (`xiaomi_mimo`) only accepts wav/mp3/mpeg formats. Browsers record WebM/Opus by default, causing transcription failures on the WebUI.

## Changes

- Add frontend WebM→WAV converter (`convertBlobToWav`) in `useVoiceRecorder.ts` using Web Audio API
- **Scoped to `xiaomi_mimo` only** — other providers receive the original format unchanged
- Read `transcription.provider` from settings and pass `wantsWav` flag through the component tree

## Why MiMo-specific?

MiMo is the only provider that rejects WebM. Global conversion would risk regressions for other providers. The conditional approach keeps the blast radius minimal.

## Testing

Tested and confirmed working on a live WebUI deployment with MiMo ASR.