### PR TITLE
fix(telegram): add rich_message config option for Telegram Web compat (#4488)

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -351,6 +351,9 @@ class TelegramConfig(Base):
     streaming: bool = True
     # Enable inline keyboard buttons in Telegram messages.
     inline_keyboards: bool = False
+    # Disable sendRichMessage (Bot API 10.1) for clients that don't render it
+    # (e.g. Telegram Web shows "This message is not supported on the web version").
+    rich_message: bool = True
     stream_edit_interval: float = Field(default=_STREAM_EDIT_INTERVAL_DEFAULT, ge=0.1)
     webhook_url: str = ""
     webhook_listen_host: str = "127.0.0.1"
@@ -801,8 +804,10 @@ class TelegramChannel(BaseChannel):
             # Bot API 10.1 rich fast-path: send raw markdown via sendRichMessage.
             # All non-blockquote content tries rich first; _rich_send_disabled
             # latches off permanently if the server doesn't support it.
+            # Skip when rich_message config is False (Telegram Web compat).
             if (
-                not render_as_blockquote
+                self.config.rich_message
+                and not render_as_blockquote
                 and not getattr(self, "_rich_send_disabled", False)
             ):
                 rich_ok = await self._try_send_rich(
@@ -911,7 +916,12 @@ class TelegramChannel(BaseChannel):
             # Skip when a streaming preview already exists to avoid the
             # delete-and-resend pattern that causes flickering and drops
             # line breaks (issue #4470).
-            if not buf.message_id and not getattr(self, "_rich_send_disabled", False):
+            # Also skip when rich_message config is False (Telegram Web compat).
+            if (
+                self.config.rich_message
+                and not buf.message_id
+                and not getattr(self, "_rich_send_disabled", False)
+            ):
                 reply_params = None
                 if reply_to_message_id := meta.get("message_id"):
                     reply_params = {"message_id": int(reply_to_message_id), "allow_sending_without_reply": True}

--- a/tests/channels/test_telegram_channel.py
+++ b/tests/channels/test_telegram_channel.py
@@ -506,6 +506,23 @@ async def test_send_rich_bad_request_does_not_latch_capability() -> None:
 
 
 @pytest.mark.asyncio
+async def test_send_rich_message_disabled_via_config() -> None:
+    """When rich_message=False, sendRichMessage is never called."""
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_message=False),
+        MessageBus(),
+    )
+    channel._app = _FakeApp(lambda: None)
+    channel._app.bot.do_api_request = AsyncMock()
+
+    await channel.send(OutboundMessage(channel="telegram", chat_id="123", content="**hello**"))
+
+    channel._app.bot.do_api_request.assert_not_awaited()
+    assert len(channel._app.bot.sent_messages) == 1
+    assert channel._app.bot.sent_messages[0]["text"]
+
+
+@pytest.mark.asyncio
 async def test_on_error_logs_network_issues_as_warning(monkeypatch) -> None:
     from telegram.error import NetworkError
 


### PR DESCRIPTION
## Problem

Telegram Web shows "This message is not supported on the web version of Telegram" for messages sent via `sendRichMessage` (Bot API 10.1). The message appears fine on the Android app, but Telegram Web cannot render the rich message format.

The issue was introduced by the rich messages feature that sends markdown content via `sendRichMessage` instead of the legacy `sendMessage` path.

## Solution

Add a `rich_message: bool` config field (default `True`) to `TelegramConfig`. Users affected by this regression can opt out by setting `rich_message: false` in their Telegram channel config.

When `rich_message: false`, the channel skips `sendRichMessage` entirely and always falls through to the legacy `sendMessage` with HTML parse mode — which Telegram Web renders correctly.

## Changes

- **`nanobot/channels/telegram.py`**: Added `rich_message: bool = True` to `TelegramConfig`. Both the `send()` fast-path and the streaming final-output path check `self.config.rich_message` before calling `_try_send_rich()`.
- **`tests/channels/test_telegram_channel.py`**: Added `test_send_rich_message_disabled_via_config` verifying that `rich_message=False` skips `sendRichMessage` and uses the legacy path.

## Verification

- All 89 telegram channel tests pass
- Lint: all checks passed
- The fix is config-gated (opt-in to disable), preserving the default behavior for users who don't hit this issue

Closes #4488
