### PR TITLE
feat: implement mcp server idle timeout auto-kill

### DIFF
--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import re
 import shutil
+import time
 import urllib.parse
 from collections.abc import Awaitable, Callable
 from contextlib import AsyncExitStack, suppress
@@ -44,6 +45,8 @@ _WINDOWS_SHELL_LAUNCHERS: frozenset[str] = frozenset(("npx", "npm", "pnpm", "yar
 _SANITIZE_RE = re.compile(r"_+")
 _RELOAD_LOCKS: WeakKeyDictionary[Any, asyncio.Lock] = WeakKeyDictionary()
 _ReconnectCallback = Callable[[str, str, Tool], Awaitable[Tool | None]]
+_mcp_last_accessed: dict[str, float] = {}
+_mcp_watchdog_tasks: dict[str, asyncio.Task] = {}
 
 
 def _is_malformed_mcp_progress_notification(message: Any) -> bool:
@@ -345,6 +348,7 @@ class MCPToolWrapper(_MCPWrapperBase):
         retried_transient = False
         refreshed_session = False
         while True:
+            _mcp_last_accessed[self._server_name] = time.time()
             try:
                 result = await asyncio.wait_for(
                     self._session.call_tool(self._original_name, arguments=kwargs),
@@ -448,6 +452,7 @@ class MCPResourceWrapper(_MCPWrapperBase):
         retried_transient = False
         refreshed_session = False
         while True:
+            _mcp_last_accessed[self._server_name] = time.time()
             try:
                 result = await asyncio.wait_for(
                     self._session.read_resource(self._uri),
@@ -564,6 +569,7 @@ class MCPPromptWrapper(_MCPWrapperBase):
         retried_transient = False
         refreshed_session = False
         while True:
+            _mcp_last_accessed[self._server_name] = time.time()
             try:
                 result = await asyncio.wait_for(
                     self._session.get_prompt(self._prompt_name, arguments=kwargs),
@@ -966,6 +972,16 @@ async def connect_missing_servers(state: Any, registry: ToolRegistry) -> None:
         state._mcp_stacks.update(connected)
         _attach_reconnect_handlers(state, registry, connected)
         state._mcp_connected = bool(state._mcp_stacks)
+        for name in connected:
+            _mcp_last_accessed[name] = time.time()
+            cfg = getattr(state, "_mcp_servers", {}).get(name)
+            idle_timeout = getattr(cfg, "idle_timeout", 0) if cfg else 0
+            if idle_timeout > 0:
+                if name in _mcp_watchdog_tasks:
+                    _mcp_watchdog_tasks[name].cancel()
+                _mcp_watchdog_tasks[name] = asyncio.create_task(
+                    _mcp_idle_watchdog(state, name, idle_timeout)
+                )
         if connected:
             logger.info("MCP connected servers: {}", sorted(connected))
         else:
@@ -1209,7 +1225,26 @@ def _unregister_server_tools(state: Any, registry: ToolRegistry, server_name: st
     return removed
 
 
+async def _mcp_idle_watchdog(state: Any, name: str, timeout: int) -> None:
+    try:
+        while True:
+            await asyncio.sleep(5.0)
+            if name not in getattr(state, "_mcp_stacks", {}):
+                break
+            last_used = _mcp_last_accessed.get(name, 0)
+            if last_used and (time.time() - last_used) > timeout:
+                logger.info("MCP server '{}' idled for {}s, closing...", name, timeout)
+                await _close_server(state, name)
+                break
+    except asyncio.CancelledError:
+        pass
+
+
 async def _close_server(state: Any, server_name: str) -> None:
+    if server_name in _mcp_watchdog_tasks:
+        _mcp_watchdog_tasks[server_name].cancel()
+        _mcp_watchdog_tasks.pop(server_name, None)
+    _mcp_last_accessed.pop(server_name, None)
     stack = state._mcp_stacks.pop(server_name, None)
     if stack is None:
         return

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -331,6 +331,7 @@ class MCPServerConfig(Base):
     url: str = ""  # HTTP/SSE: endpoint URL
     headers: dict[str, str] = Field(default_factory=dict)  # HTTP/SSE: custom headers
     tool_timeout: int = 30  # seconds before a tool call is cancelled
+    idle_timeout: int = Field(default=0, ge=0, le=86400)  # seconds before an idle server is killed (0 = disabled)
     enabled_tools: list[str] = Field(default_factory=lambda: ["*"])  # Only register these tools; accepts raw MCP names or wrapped mcp_<server>_<tool> names; ["*"] = all capabilities (tools, resources, prompts); any restriction = only listed tools, no resources/prompts
 
 

--- a/nanobot/webui/mcp_presets_api.py
+++ b/nanobot/webui/mcp_presets_api.py
@@ -1104,6 +1104,13 @@ def _custom_server_from_query(query: QueryParams) -> tuple[str, MCPServerConfig]
             tool_timeout = max(5, min(int(raw_timeout), 600))
         except ValueError as exc:
             raise McpPresetError("tool_timeout must be an integer") from exc
+    raw_idle = (_query_first(query, "idle_timeout") or "").strip()
+    idle_timeout = 0
+    if raw_idle:
+        try:
+            idle_timeout = max(0, min(int(raw_idle), 86400))
+        except ValueError as exc:
+            raise McpPresetError("idle_timeout must be an integer") from exc
     cfg = MCPServerConfig(
         type=transport,
         command=command if transport == "stdio" else "",
@@ -1113,6 +1120,7 @@ def _custom_server_from_query(query: QueryParams) -> tuple[str, MCPServerConfig]
         url=url if transport in {"sse", "streamableHttp"} else "",
         headers=_parse_string_map(_query_first(query, "headers")),
         tool_timeout=tool_timeout,
+        idle_timeout=idle_timeout,
         enabled_tools=_parse_enabled_tools(_query_first(query, "enabled_tools")),
     )
     return name, cfg
@@ -1140,6 +1148,11 @@ def _mcp_server_config(name: str, raw: Any) -> tuple[str, MCPServerConfig]:
         timeout_int = max(5, min(int(tool_timeout), 600))
     except (TypeError, ValueError):
         timeout_int = _DEFAULT_CUSTOM_TIMEOUT
+    idle_timeout = raw.get("idleTimeout", raw.get("idle_timeout", 0))
+    try:
+        idle_timeout_int = max(0, min(int(idle_timeout), 86400))
+    except (TypeError, ValueError):
+        idle_timeout_int = 0
     if not isinstance(args, list) or not all(isinstance(item, str) for item in args):
         raise McpPresetError(f"MCP server '{server_name}' args must be a string array")
     if not isinstance(env, dict) or not all(isinstance(k, str) and isinstance(v, str) for k, v in env.items()):
@@ -1157,6 +1170,7 @@ def _mcp_server_config(name: str, raw: Any) -> tuple[str, MCPServerConfig]:
         url=url if transport in {"sse", "streamableHttp"} else "",
         headers=dict(headers),
         tool_timeout=timeout_int,
+        idle_timeout=idle_timeout_int,
         enabled_tools=list(enabled_tools),
     )
 


### PR DESCRIPTION
## Proposal / Feature Summary
Implement an auto-kill watchdog for idle MCP servers to prevent resource leaks (zombie processes) and free up system memory when servers are unused.

This introduces a new `idle_timeout` parameter to `MCPServerConfig`. When an MCP server is not accessed (no tool calls, no resources read, no prompts fetched) for the duration of `idle_timeout` seconds, nanobot will gracefully close its `AsyncExitStack`.

## Why this is needed
Long-running agents or multiple connected MCP servers can accumulate dormant processes, consuming memory. By automatically suspending idle servers, nanobot maintains a lean, calm, and humane resource footprint without user intervention. The existing lazy-loading mechanism seamlessly reconnects to the server on the next tool invocation.

## Changes Made
- Added `idle_timeout` (default 0, disabled) to `MCPServerConfig` (`schema.py`).
- Updated `mcp_presets_api.py` to support configuring `idle_timeout` from the WebUI.
- Introduced `_mcp_idle_watchdog` in `mcp.py` to monitor `_mcp_last_accessed` timers globally per server.
- Automatically handles watchdog cancellation on shutdown to ensure zero task leaks.