### PR TITLE
fix(webui): restore code block copy fallback

### DIFF
--- a/webui/src/components/CodeBlock.tsx
+++ b/webui/src/components/CodeBlock.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import { useThemeValue } from "@/hooks/useTheme";
 import { hasAnsi, parseAnsiSegments, stripAnsi } from "@/lib/ansi";
+import { copyTextToClipboard } from "@/lib/clipboard";
 import { cn } from "@/lib/utils";
 
 interface CodeBlockProps {
@@ -192,8 +193,8 @@ export function CodeBlock({
   const renderAnsi = shouldRenderAnsi(language, code);
 
   const onCopy = useCallback(() => {
-    if (!navigator.clipboard) return;
-    navigator.clipboard.writeText(renderAnsi ? stripAnsi(code) : code).then(() => {
+    void copyTextToClipboard(renderAnsi ? stripAnsi(code) : code).then((ok) => {
+      if (!ok) return;
       setCopied(true);
       setTimeout(() => setCopied(false), 1_500);
     });

--- a/webui/src/tests/code-block.test.tsx
+++ b/webui/src/tests/code-block.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -143,6 +143,35 @@ describe("CodeBlock", () => {
       expect(writeText).toHaveBeenCalledWith("PASS");
     } finally {
       Reflect.deleteProperty(navigator, "clipboard");
+    }
+  });
+
+  it("copies with the textarea fallback when Clipboard API is unavailable", async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    const execCommand = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    try {
+      render(
+        <ThemeProvider theme="dark">
+          <CodeBlock language="ts" code="const value = 1;" highlight={false} />
+        </ThemeProvider>,
+      );
+
+      await user.click(screen.getByRole("button", { name: /copy/i }));
+
+      await waitFor(() => expect(execCommand).toHaveBeenCalledWith("copy"));
+      expect(screen.getByText("Copied")).toBeInTheDocument();
+    } finally {
+      Reflect.deleteProperty(navigator, "clipboard");
+      Reflect.deleteProperty(document, "execCommand");
     }
   });
 


### PR DESCRIPTION
## Summary
- Route WebUI code block copy actions through the shared clipboard helper.
- Add coverage for copying when the Clipboard API is unavailable.

## Root Cause
`CodeBlock` called `navigator.clipboard.writeText` directly, so copy did nothing in contexts where the Clipboard API is missing or unavailable. Assistant reply copy already used the shared fallback helper.

## Impact
Code block copy now works in the same fallback environments as assistant reply copy, without changing the visible UI.

## Verification
- `npm run test -- src/tests/code-block.test.tsx`
- `npm run build`
- `npm run lint`