### PR TITLE
fix(runner): add generic repeated-tool-call guard for all tools

### DIFF
--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -51,6 +51,7 @@ from nanobot.utils.runtime import (
     build_length_recovery_message,
     ensure_nonempty_tool_result,
     is_blank_text,
+    record_tool_call_result,
     repeated_external_lookup_error,
     repeated_tool_call_error,
     repeated_workspace_violation_error,
@@ -1056,13 +1057,13 @@ class AgentRunner:
 
             for tool_call, result in zip(batch, batch_results):
                 _, event, _ = result
-                sig = tool_call_signature(tool_call.name, tool_call.arguments)
-                if sig is not None:
-                    if event.get("status") == "error":
-                        if event.get("detail") != "repeated identical tool call blocked":
-                            tool_call_counts[sig] = tool_call_counts.get(sig, 0) + 1
-                    else:
-                        tool_call_counts[sig] = 0
+                if event.get("detail") != "repeated identical tool call blocked":
+                    record_tool_call_result(
+                        tool_call.name,
+                        tool_call.arguments,
+                        event.get("status", "ok"),
+                        tool_call_counts,
+                    )
 
             tool_results.extend(batch_results)
 

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -52,6 +52,7 @@ from nanobot.utils.runtime import (
     ensure_nonempty_tool_result,
     is_blank_text,
     repeated_external_lookup_error,
+    repeated_tool_call_error,
     repeated_workspace_violation_error,
 )
 
@@ -361,6 +362,7 @@ class AgentRunner:
         stop_reason = "completed"
         tool_events: list[dict[str, str]] = []
         external_lookup_counts: dict[str, int] = {}
+        tool_call_counts: dict[str, int] = {}
         # Per-turn throttle for repeated attempts against the same outside target.
         workspace_violation_counts: dict[str, int] = {}
         empty_content_retries = 0
@@ -448,6 +450,7 @@ class AgentRunner:
                     response.tool_calls,
                     external_lookup_counts,
                     workspace_violation_counts,
+                    tool_call_counts,
                 )
                 tool_events.extend(new_events)
                 tools_used.extend(
@@ -1030,6 +1033,7 @@ class AgentRunner:
         tool_calls: list[ToolCallRequest],
         external_lookup_counts: dict[str, int],
         workspace_violation_counts: dict[str, int],
+        tool_call_counts: dict[str, int],
     ) -> tuple[list[Any], list[dict[str, str]], BaseException | None]:
         batches = self._partition_tool_batches(spec, tool_calls)
         tool_results: list[tuple[Any, dict[str, str], BaseException | None]] = []
@@ -1037,7 +1041,7 @@ class AgentRunner:
             if spec.concurrent_tools and len(batch) > 1:
                 batch_results = await asyncio.gather(*(
                     self._run_tool(
-                        spec, tool_call, external_lookup_counts, workspace_violation_counts,
+                        spec, tool_call, external_lookup_counts, workspace_violation_counts, tool_call_counts,
                     )
                     for tool_call in batch
                 ))
@@ -1046,7 +1050,7 @@ class AgentRunner:
                 batch_results = []
                 for tool_call in batch:
                     result = await self._run_tool(
-                        spec, tool_call, external_lookup_counts, workspace_violation_counts,
+                        spec, tool_call, external_lookup_counts, workspace_violation_counts, tool_call_counts,
                     )
                     tool_results.append(result)
                     batch_results.append(result)
@@ -1067,8 +1071,25 @@ class AgentRunner:
         tool_call: ToolCallRequest,
         external_lookup_counts: dict[str, int],
         workspace_violation_counts: dict[str, int],
+        tool_call_counts: dict[str, int],
     ) -> tuple[Any, dict[str, str], BaseException | None]:
         hint = "\n\n[Analyze the error above and try a different approach.]"
+
+        repeat_error = repeated_tool_call_error(
+            tool_call.name,
+            tool_call.arguments,
+            tool_call_counts,
+        )
+        if repeat_error:
+            event = {
+                "name": tool_call.name,
+                "status": "error",
+                "detail": "repeated identical tool call blocked",
+            }
+            if spec.fail_on_tool_error:
+                return repeat_error + hint, event, RuntimeError(repeat_error)
+            return repeat_error + hint, event, None
+
         lookup_error = repeated_external_lookup_error(
             tool_call.name,
             tool_call.arguments,

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -55,7 +55,6 @@ from nanobot.utils.runtime import (
     repeated_external_lookup_error,
     repeated_tool_call_error,
     repeated_workspace_violation_error,
-    tool_call_signature,
 )
 
 GoalContinueMessage = str | Callable[[], str | None]

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -54,6 +54,7 @@ from nanobot.utils.runtime import (
     repeated_external_lookup_error,
     repeated_tool_call_error,
     repeated_workspace_violation_error,
+    tool_call_signature,
 )
 
 GoalContinueMessage = str | Callable[[], str | None]
@@ -1045,15 +1046,25 @@ class AgentRunner:
                     )
                     for tool_call in batch
                 ))
-                tool_results.extend(batch_results)
             else:
                 batch_results = []
                 for tool_call in batch:
                     result = await self._run_tool(
                         spec, tool_call, external_lookup_counts, workspace_violation_counts, tool_call_counts,
                     )
-                    tool_results.append(result)
                     batch_results.append(result)
+
+            for tool_call, result in zip(batch, batch_results):
+                _, event, _ = result
+                sig = tool_call_signature(tool_call.name, tool_call.arguments)
+                if sig is not None:
+                    if event.get("status") == "error":
+                        if event.get("detail") != "repeated identical tool call blocked":
+                            tool_call_counts[sig] = tool_call_counts.get(sig, 0) + 1
+                    else:
+                        tool_call_counts[sig] = 0
+
+            tool_results.extend(batch_results)
 
         results: list[Any] = []
         events: list[dict[str, str]] = []

--- a/nanobot/utils/runtime.py
+++ b/nanobot/utils/runtime.py
@@ -175,6 +175,26 @@ def repeated_tool_call_error(
     )
 
 
+def record_tool_call_result(
+    tool_name: str,
+    arguments: Any,
+    status: str,
+    seen_counts: dict[str, int],
+) -> None:
+    """Record tool execution outcome to track repeated failures.
+
+    A successful execution clears all tracked failures, as a state change
+    implies previously failing tools might now succeed (e.g. polling).
+    """
+    if status != "error":
+        seen_counts.clear()
+        return
+
+    signature = tool_call_signature(tool_name, arguments)
+    if signature is not None:
+        seen_counts[signature] = seen_counts.get(signature, 0) + 1
+
+
 # Workspace-boundary violations are soft errors, with per-target throttling.
 
 _OUTSIDE_PATH_PATTERN = re.compile(r"(?:^|[\s|>'\"])((?:/[^\s\"'>;|<]+)|(?:~[^\s\"'>;|<]+))")

--- a/nanobot/utils/runtime.py
+++ b/nanobot/utils/runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 from typing import Any
@@ -11,6 +12,10 @@ from loguru import logger
 from nanobot.utils.helpers import stringify_text_blocks
 
 _MAX_REPEAT_EXTERNAL_LOOKUPS = 2
+
+# Limit identical tool calls in a turn to prevent infinite loops
+_MAX_REPEAT_TOOL_CALLS = 2
+_EXTERNAL_LOOKUP_TOOL_NAMES = frozenset({"web_fetch", "web_search"})
 
 # Third same-target workspace violation in a turn escalates to "stop retrying".
 _MAX_REPEAT_WORKSPACE_VIOLATIONS = 2
@@ -124,6 +129,50 @@ def repeated_external_lookup_error(
     return (
         "Error: repeated external lookup blocked. "
         "Use the results you already have to answer, or try a meaningfully different source."
+    )
+
+
+def tool_call_signature(tool_name: str, arguments: Any) -> str | None:
+    """Stable signature for generic repeated tool calls we want to throttle."""
+    if tool_name in _EXTERNAL_LOOKUP_TOOL_NAMES:
+        return None
+
+    if not isinstance(arguments, dict):
+        return f"{tool_name}:none"
+
+    try:
+        args_json = json.dumps(arguments, sort_keys=True)
+    except Exception:
+        args_json = str(arguments)
+
+    return f"{tool_name}:{args_json}"
+
+
+def repeated_tool_call_error(
+    tool_name: str,
+    arguments: Any,
+    seen_counts: dict[str, int],
+) -> str | None:
+    """Block identical repeated tool calls after a small retry budget."""
+    signature = tool_call_signature(tool_name, arguments)
+    if signature is None:
+        return None
+
+    count = seen_counts.get(signature, 0) + 1
+    seen_counts[signature] = count
+    if count <= _MAX_REPEAT_TOOL_CALLS:
+        return None
+
+    logger.warning(
+        "Blocking identical repeated tool call {} on attempt {}",
+        signature[:160],
+        count,
+    )
+    return (
+        "Error: repeated identical tool call blocked. "
+        "You have already called this tool with these exact arguments multiple times. "
+        "Doing it again will not change the result. "
+        "Use the results you already have, or try a meaningfully different approach."
     )
 
 

--- a/nanobot/utils/runtime.py
+++ b/nanobot/utils/runtime.py
@@ -158,20 +158,19 @@ def repeated_tool_call_error(
     if signature is None:
         return None
 
-    count = seen_counts.get(signature, 0) + 1
-    seen_counts[signature] = count
-    if count <= _MAX_REPEAT_TOOL_CALLS:
+    count = seen_counts.get(signature, 0)
+    if count < _MAX_REPEAT_TOOL_CALLS:
         return None
 
     logger.warning(
         "Blocking identical repeated tool call {} on attempt {}",
         signature[:160],
-        count,
+        count + 1,
     )
     return (
         "Error: repeated identical tool call blocked. "
-        "You have already called this tool with these exact arguments multiple times. "
-        "Doing it again will not change the result. "
+        "You have already called this tool with these exact arguments multiple times "
+        "and it failed. Doing it again will not change the result. "
         "Use the results you already have, or try a meaningfully different approach."
     )
 

--- a/tests/agent/test_loop_runner_integration.py
+++ b/tests/agent/test_loop_runner_integration.py
@@ -299,14 +299,10 @@ async def test_subagent_max_iterations_announces_existing_fallback(tmp_path, mon
     bus = MessageBus()
     provider = MagicMock()
     provider.get_default_model.return_value = "test-model"
-    call_idx = {"n": 0}
-    async def fake_chat(*args, **kwargs):
-        call_idx["n"] += 1
-        return LLMResponse(
-            content="working",
-            tool_calls=[ToolCallRequest(id="call_1", name="list_dir", arguments={"path": str(call_idx["n"])})],
-        )
-    provider.chat_with_retry = fake_chat
+    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(
+        content="working",
+        tool_calls=[ToolCallRequest(id="call_1", name="list_dir", arguments={"path": "."})],
+    ))
     mgr = SubagentManager(
         provider=provider,
         workspace=tmp_path,

--- a/tests/agent/test_loop_runner_integration.py
+++ b/tests/agent/test_loop_runner_integration.py
@@ -299,10 +299,14 @@ async def test_subagent_max_iterations_announces_existing_fallback(tmp_path, mon
     bus = MessageBus()
     provider = MagicMock()
     provider.get_default_model.return_value = "test-model"
-    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(
-        content="working",
-        tool_calls=[ToolCallRequest(id="call_1", name="list_dir", arguments={"path": "."})],
-    ))
+    call_idx = {"n": 0}
+    async def fake_chat(*args, **kwargs):
+        call_idx["n"] += 1
+        return LLMResponse(
+            content="working",
+            tool_calls=[ToolCallRequest(id="call_1", name="list_dir", arguments={"path": str(call_idx["n"])})],
+        )
+    provider.chat_with_retry = fake_chat
     mgr = SubagentManager(
         provider=provider,
         workspace=tmp_path,

--- a/tests/agent/test_runner_tool_execution.py
+++ b/tests/agent/test_runner_tool_execution.py
@@ -126,6 +126,7 @@ async def test_runner_batches_read_only_tools_before_exclusive_work():
         ],
         {},
         {},
+        {},
     )
 
     assert shared_events[0:2] == ["start:read_a", "start:read_b"]
@@ -167,6 +168,7 @@ async def test_runner_does_not_batch_exclusive_read_only_tools():
             ToolCallRequest(id="ddg1", name="ddg_like", arguments={}),
             ToolCallRequest(id="ro2", name="read_b", arguments={}),
         ],
+        {},
         {},
         {},
     )

--- a/tests/agent/test_runner_tool_execution.py
+++ b/tests/agent/test_runner_tool_execution.py
@@ -360,3 +360,84 @@ async def test_runner_blocks_repeated_external_fetches():
         if msg.get("role") == "tool" and msg.get("tool_call_id") == "call_3"
     ][0]
     assert "repeated external lookup blocked" in blocked_tool_message["content"]
+
+
+@pytest.mark.asyncio
+async def test_runner_allows_repeated_successful_interleaved_calls():
+    provider = MagicMock()
+    call_count = {"n": 0}
+    captured_messages = []
+
+    async def chat_with_retry(*, messages, **kwargs):
+        call_count["n"] += 1
+        n = call_count["n"]
+        if n == 1:
+            return LLMResponse(content="", tool_calls=[ToolCallRequest(id=f"c{n}", name="read_file", arguments={"path": "x"})], usage={})
+        elif n == 2:
+            return LLMResponse(content="", tool_calls=[ToolCallRequest(id=f"c{n}", name="edit", arguments={"path": "x", "content": "1"})], usage={})
+        elif n == 3:
+            return LLMResponse(content="", tool_calls=[ToolCallRequest(id=f"c{n}", name="read_file", arguments={"path": "x"})], usage={})
+        elif n == 4:
+            return LLMResponse(content="", tool_calls=[ToolCallRequest(id=f"c{n}", name="edit", arguments={"path": "x", "content": "2"})], usage={})
+        elif n == 5:
+            return LLMResponse(content="", tool_calls=[ToolCallRequest(id=f"c{n}", name="read_file", arguments={"path": "x"})], usage={})
+        else:
+            captured_messages[:] = messages
+            return LLMResponse(content="done", tool_calls=[], usage={})
+
+    provider.chat_with_retry = chat_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    tools.execute = AsyncMock(return_value="ok")
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "do edit"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=6,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    ))
+
+    assert result.final_content == "done"
+    assert tools.execute.await_count == 5
+    for msg in result.messages:
+        if msg.get("role") == "tool":
+            assert "repeated identical tool call blocked" not in str(msg.get("content"))
+
+
+@pytest.mark.asyncio
+async def test_runner_blocks_repeated_failing_calls():
+    provider = MagicMock()
+    call_count = {"n": 0}
+
+    async def chat_with_retry(*, messages, **kwargs):
+        call_count["n"] += 1
+        n = call_count["n"]
+        if n <= 3:
+            return LLMResponse(content="", tool_calls=[ToolCallRequest(id=f"c{n}", name="read_file", arguments={"path": "fail.txt"})], usage={})
+        else:
+            return LLMResponse(content="done", tool_calls=[], usage={})
+
+    provider.chat_with_retry = chat_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    tools.execute = AsyncMock(side_effect=Exception("not found"))
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "read"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=4,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    ))
+
+    assert result.final_content == "done"
+    assert tools.execute.await_count == 2
+    
+    blocked_tool_message = [
+        msg for msg in result.messages
+        if msg.get("role") == "tool" and msg.get("tool_call_id") == "c3"
+    ][0]
+    assert "repeated identical tool call blocked" in blocked_tool_message["content"]

--- a/tests/utils/test_repeated_tool_call_throttle.py
+++ b/tests/utils/test_repeated_tool_call_throttle.py
@@ -1,0 +1,81 @@
+from nanobot.utils.runtime import repeated_tool_call_error, tool_call_signature
+
+
+def test_tool_call_signature_stability():
+    arg1 = {"a": 1, "b": 2}
+    arg2 = {"b": 2, "a": 1}
+    assert tool_call_signature("dummy_tool", arg1) == tool_call_signature("dummy_tool", arg2)
+    assert tool_call_signature("dummy", {"x": 1}) != tool_call_signature("dummy", {"y": 1})
+
+def test_tool_call_signature_not_dict():
+    assert tool_call_signature("dummy_tool", "string") == "dummy_tool:none"
+
+def test_tool_call_signature_list():
+    assert tool_call_signature("dummy", [1, 2, 3]) == "dummy:none"
+
+def test_tool_call_signature_none():
+    assert tool_call_signature("dummy", None) == "dummy:none"
+    assert tool_call_signature("dummy", 123) == "dummy:none"
+
+def test_tool_call_signature_external_lookups():
+    assert tool_call_signature("web_search", {"query": "hello"}) is None
+
+def test_tool_call_signature_web_fetch():
+    assert tool_call_signature("web_fetch", {"url": "https://foo.com"}) is None
+
+def test_repeated_tool_call_error_under_limit():
+    counts = {}
+    args = {"test": "abc"}
+
+    res1 = repeated_tool_call_error("my_tool", args, counts)
+    assert res1 is None
+    assert counts[tool_call_signature("my_tool", args)] == 1
+
+    res2 = repeated_tool_call_error("my_tool", args, counts)
+    assert res2 is None
+    assert counts[tool_call_signature("my_tool", args)] == 2
+
+def test_repeated_tool_call_error_over_limit():
+    counts = {}
+    args = {"test": "abc"}
+    repeated_tool_call_error("my_tool", args, counts)
+    repeated_tool_call_error("my_tool", args, counts)
+
+    res3 = repeated_tool_call_error("my_tool", args, counts)
+    assert res3 is not None
+    assert "blocked" in res3.lower()
+
+def test_repeated_tool_call_error_diff_tools():
+    counts = {}
+    repeated_tool_call_error("tool_a", {"a": 1}, counts)
+    repeated_tool_call_error("tool_a", {"a": 1}, counts)
+
+    res = repeated_tool_call_error("tool_b", {"a": 1}, counts)
+    assert res is None
+
+def test_repeated_tool_call_error_diff_args():
+    counts = {}
+    repeated_tool_call_error("tool_a", {"a": 1}, counts)
+    repeated_tool_call_error("tool_a", {"a": 1}, counts)
+
+    res = repeated_tool_call_error("tool_a", {"b": 2}, counts)
+    assert res is None
+
+def test_repeated_tool_call_error_excluded_tools_dont_increment():
+    counts = {}
+    repeated_tool_call_error("web_search", {"query": "test"}, counts)
+    repeated_tool_call_error("web_search", {"query": "test"}, counts)
+    res3 = repeated_tool_call_error("web_search", {"query": "test"}, counts)
+    assert res3 is None
+    assert not counts  # should be empty
+
+def test_signature_unserializable_objects():
+    class DummyObj:
+        def __str__(self): return "custom"
+
+    arg = {"obj": DummyObj()}
+    sig = tool_call_signature("tool", arg)
+    assert sig is not None
+
+def test_tool_call_signature_empty_dict():
+    assert tool_call_signature("tool", {}) == "tool:{}"

--- a/tests/utils/test_repeated_tool_call_throttle.py
+++ b/tests/utils/test_repeated_tool_call_throttle.py
@@ -24,50 +24,34 @@ def test_tool_call_signature_web_fetch():
     assert tool_call_signature("web_fetch", {"url": "https://foo.com"}) is None
 
 def test_repeated_tool_call_error_under_limit():
-    counts = {}
     args = {"test": "abc"}
+    counts = {tool_call_signature("my_tool", args): 1}
 
     res1 = repeated_tool_call_error("my_tool", args, counts)
     assert res1 is None
-    assert counts[tool_call_signature("my_tool", args)] == 1
-
-    res2 = repeated_tool_call_error("my_tool", args, counts)
-    assert res2 is None
-    assert counts[tool_call_signature("my_tool", args)] == 2
 
 def test_repeated_tool_call_error_over_limit():
-    counts = {}
     args = {"test": "abc"}
-    repeated_tool_call_error("my_tool", args, counts)
-    repeated_tool_call_error("my_tool", args, counts)
+    counts = {tool_call_signature("my_tool", args): 2}
 
-    res3 = repeated_tool_call_error("my_tool", args, counts)
-    assert res3 is not None
-    assert "blocked" in res3.lower()
+    res = repeated_tool_call_error("my_tool", args, counts)
+    assert res is not None
+    assert "blocked" in res.lower()
 
 def test_repeated_tool_call_error_diff_tools():
-    counts = {}
-    repeated_tool_call_error("tool_a", {"a": 1}, counts)
-    repeated_tool_call_error("tool_a", {"a": 1}, counts)
-
+    counts = {tool_call_signature("tool_a", {"a": 1}): 2}
     res = repeated_tool_call_error("tool_b", {"a": 1}, counts)
     assert res is None
 
 def test_repeated_tool_call_error_diff_args():
-    counts = {}
-    repeated_tool_call_error("tool_a", {"a": 1}, counts)
-    repeated_tool_call_error("tool_a", {"a": 1}, counts)
-
+    counts = {tool_call_signature("tool_a", {"a": 1}): 2}
     res = repeated_tool_call_error("tool_a", {"b": 2}, counts)
     assert res is None
 
-def test_repeated_tool_call_error_excluded_tools_dont_increment():
-    counts = {}
-    repeated_tool_call_error("web_search", {"query": "test"}, counts)
-    repeated_tool_call_error("web_search", {"query": "test"}, counts)
-    res3 = repeated_tool_call_error("web_search", {"query": "test"}, counts)
-    assert res3 is None
-    assert not counts  # should be empty
+def test_repeated_tool_call_error_excluded_tools_dont_block():
+    counts = {tool_call_signature("web_search", {"query": "test"}): 2}
+    res = repeated_tool_call_error("web_search", {"query": "test"}, counts)
+    assert res is None
 
 def test_signature_unserializable_objects():
     class DummyObj:


### PR DESCRIPTION
Previously, the agent only guarded against repeated network-based tool calls (like web_fetch and web_search). When a generic tool (e.g. read_file or list_dir) was called repeatedly with identical arguments and failed, the agent could get stuck in an infinite loop.

This commit introduces a generic guard `repeated_tool_call_error` that:
- Generates a canonical signature for any tool call to identify exact repetitions
- Maintains a per-turn throttle dictionary `tool_call_counts` in `AgentRunner`
- Returns a runtime error if a tool is repeatedly executed with identical parameters beyond `_MAX_REPEAT_TOOL_CALLS`

The change prevents token exhaustion and loops while ensuring valid back-to-back non-identical calls continue to function.