### PR TITLE
test: fix flaky test_keeps_n_most_recent due to identical mtimes

### DIFF
--- a/tests/agent/test_dream_session.py
+++ b/tests/agent/test_dream_session.py
@@ -24,8 +24,13 @@ class TestDreamSessionKey:
 
 class TestPruneDreamSessions:
     def test_keeps_n_most_recent(self, tmp_path):
+        import os
+        import time
+
         sessions_dir = tmp_path / "sessions"
         sessions_dir.mkdir()
+
+        base_time = time.time() - 100
 
         for i in range(15):
             key = f"dream:20260528-{100000 + i:06d}"
@@ -37,6 +42,7 @@ class TestPruneDreamSessions:
                 f'"updated_at": "2026-05-28T10:00:{i:02d}"}}\n',
                 encoding="utf-8",
             )
+            os.utime(path, (base_time + i, base_time + i))
 
         normal_path = sessions_dir / "telegram_123.jsonl"
         normal_path.write_text('{"_type": "metadata"}\n', encoding="utf-8")


### PR DESCRIPTION
## Description
Resolves a flaky test where tight-loop file creation resulted in identical sub-millisecond mtimes across modern filesystems. 

Because `MemoryStore.prune_dream_sessions` sorts files by `st_mtime`, having identical timestamps caused it to fall back to arbitrary glob ordering. As a result, it would inconsistently delete the wrong files and cause the test to fail.

We fix this by explicitly ensuring sequential `mtime` values using `os.utime()` during the test file creation loop, maintaining the expected deterministic behavior without injecting artificial sleeps.