### PR TITLE
fix: apply enabledTools filtering to MCP resources and prompts (#4519)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1811,7 +1811,7 @@ Use `toolTimeout` to override the default 30s per-call timeout for slow servers:
 }
 ```
 
-Use `enabledTools` to register only a subset of tools from an MCP server:
+Use `enabledTools` to register only a subset of capabilities from an MCP server:
 
 ```json
 {
@@ -1827,11 +1827,11 @@ Use `enabledTools` to register only a subset of tools from an MCP server:
 }
 ```
 
-`enabledTools` accepts either the raw MCP tool name (for example `read_file`) or the wrapped nanobot tool name (for example `mcp_filesystem_write_file`).
+`enabledTools` gates MCP tools, resources, and prompts. It accepts raw MCP names (for example `read_file`) and wrapped nanobot names (for example `mcp_filesystem_write_file`, `mcp_filesystem_resource_file`, or `mcp_filesystem_prompt_plan`).
 
 - Omit `enabledTools`, or set it to `["*"]`, to register all capabilities (tools, resources, and prompts).
-- Set `enabledTools` to `[]` to register no tools from that server. Resources and prompts are also skipped, since they have no per-name filter.
-- Set `enabledTools` to a non-empty list of names to register only those tools — resources and prompts are not registered.
+- If a tool, resource, and prompt share the same raw name, that raw entry allows each matching capability.
+- Use wrapped names such as `mcp_<server>_resource_<name>` or `mcp_<server>_prompt_<name>` to target a specific capability.
 
 MCP tools are automatically discovered and registered on startup. The LLM can use them alongside built-in tools — no extra configuration needed.
 

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -761,7 +761,9 @@ async def connect_mcp_servers(
             registered_count = 0
             matched_enabled_tools: set[str] = set()
             available_raw_names = [tool_def.name for tool_def in tools.tools]
-            available_wrapped_names = [_sanitize_name(f"mcp_{name}_{tool_def.name}") for tool_def in tools.tools]
+            available_wrapped_names = [
+                _sanitize_name(f"mcp_{name}_{tool_def.name}") for tool_def in tools.tools
+            ]
             for tool_def in tools.tools:
                 wrapped_name = _sanitize_name(f"mcp_{name}_{tool_def.name}")
                 if (
@@ -785,6 +787,76 @@ async def connect_mcp_servers(
                     if wrapped_name in enabled_tools:
                         matched_enabled_tools.add(wrapped_name)
 
+            try:
+                resources_result = await session.list_resources()
+                for resource in resources_result.resources:
+                    wrapped_name = _sanitize_name(f"mcp_{name}_resource_{resource.name}")
+                    available_raw_names.append(resource.name)
+                    available_wrapped_names.append(wrapped_name)
+                    if (
+                        not allow_all_tools
+                        and resource.name not in enabled_tools
+                        and wrapped_name not in enabled_tools
+                    ):
+                        logger.debug(
+                            "MCP: skipping resource '{}' from server '{}' (not in enabledTools)",
+                            wrapped_name,
+                            name,
+                        )
+                        continue
+                    wrapper = MCPResourceWrapper(
+                        session, name, resource, resource_timeout=cfg.tool_timeout
+                    )
+                    registry.register(wrapper)
+                    registered_count += 1
+                    logger.debug(
+                        "MCP: registered resource '{}' from server '{}'",
+                        wrapper.name,
+                        name,
+                    )
+                    if enabled_tools:
+                        if resource.name in enabled_tools:
+                            matched_enabled_tools.add(resource.name)
+                        if wrapped_name in enabled_tools:
+                            matched_enabled_tools.add(wrapped_name)
+            except Exception as e:
+                logger.debug("MCP server '{}': resources not supported or failed: {}", name, e)
+
+            try:
+                prompts_result = await session.list_prompts()
+                for prompt in prompts_result.prompts:
+                    wrapped_name = _sanitize_name(f"mcp_{name}_prompt_{prompt.name}")
+                    available_raw_names.append(prompt.name)
+                    available_wrapped_names.append(wrapped_name)
+                    if (
+                        not allow_all_tools
+                        and prompt.name not in enabled_tools
+                        and wrapped_name not in enabled_tools
+                    ):
+                        logger.debug(
+                            "MCP: skipping prompt '{}' from server '{}' (not in enabledTools)",
+                            wrapped_name,
+                            name,
+                        )
+                        continue
+                    wrapper = MCPPromptWrapper(
+                        session, name, prompt, prompt_timeout=cfg.tool_timeout
+                    )
+                    registry.register(wrapper)
+                    registered_count += 1
+                    logger.debug(
+                        "MCP: registered prompt '{}' from server '{}'",
+                        wrapper.name,
+                        name,
+                    )
+                    if enabled_tools:
+                        if prompt.name in enabled_tools:
+                            matched_enabled_tools.add(prompt.name)
+                        if wrapped_name in enabled_tools:
+                            matched_enabled_tools.add(wrapped_name)
+            except Exception as e:
+                logger.debug("MCP server '{}': prompts not supported or failed: {}", name, e)
+
             if enabled_tools and not allow_all_tools:
                 unmatched_enabled_tools = sorted(enabled_tools - matched_enabled_tools)
                 if unmatched_enabled_tools:
@@ -796,58 +868,6 @@ async def connect_mcp_servers(
                         ", ".join(available_raw_names) or "(none)",
                         ", ".join(available_wrapped_names) or "(none)",
                     )
-
-            # Only register resources and prompts when no tool restriction is
-            # active.  enabledTools is a per-*tool* allowlist; resources and
-            # prompts have no equivalent name filter, so they must be skipped
-            # whenever the operator specified a tool subset.  An empty list
-            # (deny-all) or a list of specific tool names both indicate that
-            # the operator intended to restrict capabilities — registering
-            # unrestricted resource/prompt wrappers would violate that intent.
-            # The default ["*"] (allow-all) means no restriction was intended.
-            register_extras = allow_all_tools
-            if register_extras:
-                try:
-                    resources_result = await session.list_resources()
-                    for resource in resources_result.resources:
-                        wrapper = MCPResourceWrapper(
-                            session, name, resource, resource_timeout=cfg.tool_timeout
-                        )
-                        registry.register(wrapper)
-                        registered_count += 1
-                        logger.debug(
-                            "MCP: registered resource '{}' from server '{}'",
-                            wrapper.name,
-                            name,
-                        )
-                except Exception as e:
-                    logger.debug(
-                        "MCP server '{}': resources not supported or failed: {}", name, e
-                    )
-
-                try:
-                    prompts_result = await session.list_prompts()
-                    for prompt in prompts_result.prompts:
-                        wrapper = MCPPromptWrapper(
-                            session, name, prompt, prompt_timeout=cfg.tool_timeout
-                        )
-                        registry.register(wrapper)
-                        registered_count += 1
-                        logger.debug(
-                            "MCP: registered prompt '{}' from server '{}'",
-                            wrapper.name,
-                            name,
-                        )
-                except Exception as e:
-                    logger.debug(
-                        "MCP server '{}': prompts not supported or failed: {}", name, e
-                    )
-            else:
-                logger.info(
-                    "MCP server '{}': skipping resource/prompt registration "
-                    "(enabledTools does not include '*' — only tools allowed)",
-                    name,
-                )
 
             logger.info(
                 "MCP server '{}': connected, {} capabilities registered", name, registered_count

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -484,6 +484,60 @@ async def test_connect_mcp_servers_enabled_tools_specific_list_blocks_resources_
 
 
 @pytest.mark.asyncio
+async def test_connect_mcp_servers_enabled_tools_supports_raw_resource_and_prompt_names(
+    fake_mcp_runtime: dict[str, object | None],
+) -> None:
+    fake_mcp_runtime["session"] = _make_fake_session_with_capabilities(
+        tool_names=["demo"],
+        resource_names=["secret_data", "other_data"],
+        prompt_names=["admin_prompt", "other_prompt"],
+    )
+    registry = ToolRegistry()
+    stacks = await connect_mcp_servers(
+        {"test": MCPServerConfig(command="fake", enabled_tools=["secret_data", "admin_prompt"])},
+        registry,
+    )
+    for stack in stacks.values():
+        await stack.aclose()
+
+    assert registry.tool_names == [
+        "mcp_test_resource_secret_data",
+        "mcp_test_prompt_admin_prompt",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_connect_mcp_servers_enabled_tools_supports_wrapped_resource_and_prompt_names(
+    fake_mcp_runtime: dict[str, object | None],
+) -> None:
+    fake_mcp_runtime["session"] = _make_fake_session_with_capabilities(
+        tool_names=["demo"],
+        resource_names=["secret data", "other data"],
+        prompt_names=["admin prompt", "other prompt"],
+    )
+    registry = ToolRegistry()
+    stacks = await connect_mcp_servers(
+        {
+            "test": MCPServerConfig(
+                command="fake",
+                enabled_tools=[
+                    "mcp_test_resource_secret_data",
+                    "mcp_test_prompt_admin_prompt",
+                ],
+            )
+        },
+        registry,
+    )
+    for stack in stacks.values():
+        await stack.aclose()
+
+    assert registry.tool_names == [
+        "mcp_test_resource_secret_data",
+        "mcp_test_prompt_admin_prompt",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_connect_mcp_servers_enabled_tools_wildcard_allows_resources_and_prompts(
     fake_mcp_runtime: dict[str, object | None],
 ) -> None:


### PR DESCRIPTION
Fixes #4519.

The enabledTools allowlist in connect_mcp_servers() filtered only tool wrappers but registered resource and prompt wrappers unconditionally, letting them bypass the configured scope.

This applies the same allowlist logic to resources and prompts: both the raw MCP name and the wrapped name (mcp_{server}_resource_{name} / mcp_{server}_prompt_{name}) are checked against enabledTools. When "*" is not in the list, unlisted resources and prompts are skipped.

The unmatched-entries warning now accounts for tools, resources, and prompts collectively.

New tests cover:
- enabledTools with raw resource/prompt names
- enabledTools with wrapped (sanitized) resource/prompt names
- Existing deny-all and specific-list tests already assert resources/prompts are blocked
