### PR TITLE
fix: change exec login-shell default from true to false (#4518)

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -541,8 +541,9 @@ class ExecTool(Tool):
     def _build_env(self) -> dict[str, str]:
         """Build a minimal environment for subprocess execution.
 
-        On Unix, only HOME/LANG/TERM are passed; ``bash -l`` sources the
-        user's profile which sets PATH and other essentials.
+        On Unix, only HOME/LANG/TERM are passed by default. If callers request
+        ``login=True``, bash/zsh may source the user's profile and add PATH or
+        other variables.
 
         On Windows, ``cmd.exe`` has no login-profile mechanism, so a curated
         set of system variables (including PATH) is forwarded.  API keys and

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -93,8 +93,8 @@ class _PreparedCommand:
             nullable=True,
         ),
         login=BooleanSchema(
-            description="Whether to run bash/zsh with login shell semantics (default true).",
-            default=True,
+            description="Whether to run bash/zsh with login shell semantics (default false).",
+            default=False,
             nullable=True,
         ),
         yield_time_ms=IntegerSchema(
@@ -432,7 +432,7 @@ class ExecTool(Tool):
             env=env,
             timeout=effective_timeout,
             shell_program=shell_program,
-            login=True if login is None else login,
+            login=False if login is None else login,
         )
 
     def _compose_path(self, current_path: str) -> str:
@@ -461,7 +461,7 @@ class ExecTool(Tool):
     async def _spawn(
         command: str, cwd: str, env: dict[str, str],
         shell_program: str | None = None,
-        login: bool = True,
+        login: bool = False,
         *,
         stdin: int = asyncio.subprocess.DEVNULL,
     ) -> asyncio.subprocess.Process:

--- a/tests/tools/test_exec_platform.py
+++ b/tests/tools/test_exec_platform.py
@@ -105,7 +105,7 @@ class TestSpawnUnix:
 
         args = mock_exec.call_args[0]
         assert "bash" in args[0]
-        assert "-l" in args
+        assert "-l" not in args
         assert "-c" in args
         assert "echo hi" in args
 

--- a/tests/tools/test_exec_platform.py
+++ b/tests/tools/test_exec_platform.py
@@ -400,6 +400,29 @@ class TestExecuteEndToEnd:
         assert "hello world" in result
         assert "Exit code: 0" in result
 
+    @pytest.mark.asyncio
+    async def test_execute_defaults_to_non_login_shell(self):
+        """The public execute path must not silently request a login shell."""
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"ok\n", b"")
+        mock_proc.returncode = 0
+        captured_login = []
+
+        async def capture_spawn(cmd, cwd, env, shell_program=None, login=None, *, stdin=None):
+            captured_login.append(login)
+            return mock_proc
+
+        with (
+            patch("nanobot.agent.tools.shell._IS_WINDOWS", False),
+            patch.object(ExecTool, "_spawn", side_effect=capture_spawn),
+            patch.object(ExecTool, "_guard_command", return_value=None),
+        ):
+            tool = ExecTool()
+            await tool.execute(command="echo ok")
+            await tool.execute(command="echo ok", login=True)
+
+        assert captured_login == [False, True]
+
 
 # ---------------------------------------------------------------------------
 # _extract_absolute_paths - UNC path support


### PR DESCRIPTION
Fixes #4518.

The exec tool defaults login=True for bash/zsh, which causes the shell to source
~/.bash_profile and similar startup files. This reintroduces secrets from shell
startup files into the exec environment, even though _build_env() intentionally
starts with a curated environment.

Changes:
- _prepare_command(): default login=False when login is None
- _spawn(): default login=False
- Schema: default=False (was True)

The login parameter can still be explicitly set to True by callers that need
login-shell behavior, but it no longer happens silently by default.
