### PR TITLE
fix: deduplicate tool call IDs in non-stream parser (#4059)

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -1131,14 +1131,21 @@ class OpenAICompatProvider(LLMProvider):
                 if reasoning_content is None:
                     reasoning_content = m.get("reasoning_content")
 
+            # Deduplicate tool call IDs (same pattern as streaming path)
+            # Some providers reuse the same ID for parallel tool calls.
+            _seen_tc_ids: set[str] = set()
             parsed_tool_calls = []
             for tc in raw_tool_calls:
                 tc_map = self._maybe_mapping(tc) or {}
                 fn = self._maybe_mapping(tc_map.get("function")) or {}
                 args = parse_tool_arguments(fn.get("arguments", {}))
                 ec, prov, fn_prov = _extract_tc_extras(tc)
+                raw_id = str(tc_map.get("id") or _short_tool_id())
+                if not raw_id or raw_id in _seen_tc_ids:
+                    raw_id = _short_tool_id()
+                _seen_tc_ids.add(raw_id)
                 parsed_tool_calls.append(ToolCallRequest(
-                    id=str(tc_map.get("id") or _short_tool_id()),
+                    id=raw_id,
                     name=str(fn.get("name") or ""),
                     arguments=args,
                     extra_content=ec,

--- a/tests/agent/test_gemini_thought_signature.py
+++ b/tests/agent/test_gemini_thought_signature.py
@@ -11,7 +11,6 @@ from unittest.mock import patch
 from nanobot.providers.base import ToolCallRequest
 from nanobot.providers.openai_compat_provider import OpenAICompatProvider
 
-
 GEMINI_EXTRA = {"google": {"thought_signature": "sig-abc-123"}}
 
 
@@ -123,6 +122,47 @@ def test_parse_dict_preserves_extra_content() -> None:
 
     payload = tc.to_openai_tool_call()
     assert payload["extra_content"] == GEMINI_EXTRA
+
+
+def test_parse_dict_deduplicates_duplicate_tool_call_ids() -> None:
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        provider = OpenAICompatProvider()
+
+    response_dict = {
+        "choices": [
+            {
+                "message": {
+                    "content": None,
+                    "tool_calls": [{
+                        "id": "call_same",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": '{"path":"a.txt"}'},
+                    }],
+                },
+                "finish_reason": "tool_calls",
+            },
+            {
+                "message": {
+                    "content": None,
+                    "tool_calls": [{
+                        "id": "call_same",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": '{"path":"b.txt"}'},
+                    }],
+                },
+                "finish_reason": "tool_calls",
+            },
+        ],
+    }
+
+    result = provider._parse(response_dict)
+
+    ids = [tc.id for tc in result.tool_calls]
+    assert len(ids) == 2
+    assert ids[0] == "call_same"
+    assert ids[1] != "call_same"
+    assert len(set(ids)) == 2
+    assert [tc.arguments for tc in result.tool_calls] == [{"path": "a.txt"}, {"path": "b.txt"}]
 
 
 # ── _parse_chunks: streaming round-trip ───────────────────────────────


### PR DESCRIPTION
Fixes #4059.

## Summary

The OpenAI-compatible streaming parser already normalizes duplicate or missing tool call IDs, but the non-stream parser kept provider IDs as-is. Some OpenAI-compatible providers can return parallel tool calls with the same `tool_call_id`, which makes the runner emit duplicate tool results with the same ID.

This applies the same per-message deduplication pattern from `_parse_chunks()` to the non-stream `_parse()` path.

## Changes

- Track seen tool call IDs while parsing non-stream responses
- Generate a short fallback ID when a provider ID is missing or duplicated
- Preserve tool call arguments and provider metadata while only changing duplicate IDs
- Add regression coverage for duplicate IDs across non-stream tool calls

## Compatibility

This only changes duplicate or missing tool call IDs in parsed non-stream responses. Unique provider IDs are preserved unchanged.

## Verification

- GitHub Actions test matrix: 4/4 passed