### PR TITLE
fix: validate content block type in Anthropic assistant blocks (#4060)

### DIFF
--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 import re
 import secrets
 import string
@@ -280,7 +281,10 @@ class AnthropicProvider(LLMProvider):
                         # Anthropic requires every content block to declare a "type".
                         # A tool that returned a bare dict lands here; coerce it to
                         # a text block instead of emitting one that the API rejects.
-                        blocks.append({"type": "text", "text": str(item)})
+                        blocks.append({
+                            "type": "text",
+                            "text": AnthropicProvider._stringify_typeless_block(item),
+                        })
                     else:
                         blocks.append(item)
                 else:
@@ -324,10 +328,17 @@ class AnthropicProvider(LLMProvider):
                 # A tool that returned a bare dict (or a list of dicts) lands
                 # here; coerce it to a text block instead of emitting a block
                 # the API rejects with "content.0.type: Field required".
-                result.append({"type": "text", "text": str(item)})
+                result.append({
+                    "type": "text",
+                    "text": AnthropicProvider._stringify_typeless_block(item),
+                })
                 continue
             result.append(item)
         return result or "(empty)"
+
+    @staticmethod
+    def _stringify_typeless_block(block: dict[str, Any]) -> str:
+        return json.dumps(block, ensure_ascii=False, sort_keys=True, default=str)
 
     @staticmethod
     def _convert_image_block(block: dict[str, Any]) -> dict[str, Any] | None:

--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -275,7 +275,16 @@ class AnthropicProvider(LLMProvider):
             blocks.append({"type": "text", "text": content})
         elif isinstance(content, list):
             for item in content:
-                blocks.append(item if isinstance(item, dict) else {"type": "text", "text": str(item)})
+                if isinstance(item, dict):
+                    if not item.get("type"):
+                        # Anthropic requires every content block to declare a "type".
+                        # A tool that returned a bare dict lands here; coerce it to
+                        # a text block instead of emitting one that the API rejects.
+                        blocks.append({"type": "text", "text": str(item)})
+                    else:
+                        blocks.append(item)
+                else:
+                    blocks.append({"type": "text", "text": str(item)})
 
         for tc in msg.get("tool_calls") or []:
             if not isinstance(tc, dict):

--- a/tests/providers/test_anthropic_tool_result.py
+++ b/tests/providers/test_anthropic_tool_result.py
@@ -70,7 +70,7 @@ def test_convert_user_content_coerces_typeless_dict():
         {"foo": "bar"},
         {"type": "text", "text": "ok"},
     ])
-    assert result[0] == {"type": "text", "text": str({"foo": "bar"})}
+    assert result[0] == {"type": "text", "text": '{"foo": "bar"}'}
     assert result[1] == {"type": "text", "text": "ok"}
 
 
@@ -81,7 +81,16 @@ def test_convert_user_content_coerces_mixed_typeless():
         {"key": "val"},
     ])
     assert result[0] == {"type": "text", "text": "42"}
-    assert result[1] == {"type": "text", "text": str({"key": "val"})}
+    assert result[1] == {"type": "text", "text": '{"key": "val"}'}
+
+
+def test_assistant_blocks_coerce_typeless_dict_to_json_text():
+    blocks = AnthropicProvider._assistant_blocks({
+        "role": "assistant",
+        "content": [{"answer": "ok", "count": 2}],
+    })
+
+    assert blocks == [{"type": "text", "text": '{"answer": "ok", "count": 2}'}]
 
 
 def test_convert_assistant_message_repairs_history_tool_arguments():


### PR DESCRIPTION
Fixes #4060.

## Summary

Anthropic requires every assistant content block to include a `type` field. `_assistant_blocks()` passed dict items from assistant content lists through unchanged, so a typeless block like `{"text": "hi"}` could reach the Anthropic API and be rejected.

This normalizes typeless assistant dict blocks into text blocks, matching the existing user-content repair behavior.

## Changes

- Detect typeless dict blocks in `_assistant_blocks()`
- Convert typeless dict blocks into Anthropic text blocks instead of sending invalid payloads
- Stringify structured typeless blocks as JSON for readable fallback text
- Reuse the same JSON stringification helper for user-content typeless dict repair
- Add regression coverage for assistant typeless dict blocks

## Compatibility

Valid Anthropic blocks with an existing `type` are preserved unchanged. The fallback only applies to typeless dict blocks that would otherwise fail provider validation.

## Verification

- GitHub Actions test matrix: 4/4 passed