### PR TITLE
fix: prevent session key collision on disk (#4057)

### DIFF
--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -431,6 +431,18 @@ class SessionManager:
         """Collision-resistant encoding for internal session storage filenames."""
         return base64.urlsafe_b64encode(key.encode()).decode().rstrip("=")
 
+    @staticmethod
+    def _decode_storage_key(stem: str) -> str | None:
+        """Reverse _storage_key(): decode a base64url (no-padding) stem back to the original key."""
+        try:
+            # Restore padding stripped by rstrip("=")
+            padding = 4 - len(stem) % 4
+            if padding != 4:
+                stem += "=" * padding
+            return base64.urlsafe_b64decode(stem).decode("utf-8")
+        except Exception:
+            return None
+
     def _get_session_path(self, key: str) -> Path:
         """Get the collision-resistant workspace path for a session."""
         return self.sessions_dir / f"{self._storage_key(key)}.jsonl"
@@ -826,7 +838,8 @@ class SessionManager:
         sessions = []
 
         for path in self.sessions_dir.glob("*.jsonl"):
-            fallback_key = path.stem.replace("_", ":", 1)
+            decoded = self._decode_storage_key(path.stem)
+            fallback_key = decoded or path.stem.replace("_", ":", 1)
             try:
                 # Read the metadata line and a small preview for session lists.
                 with open(path, encoding="utf-8") as f:
@@ -834,7 +847,7 @@ class SessionManager:
                     if first_line:
                         data = json.loads(first_line)
                         if data.get("_type") == "metadata":
-                            key = data.get("key") or path.stem.replace("_", ":", 1)
+                            key = data.get("key") or fallback_key
                             metadata = data.get("metadata", {})
                             title = _metadata_title(metadata)
                             preview = ""

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -432,24 +432,16 @@ class SessionManager:
         return base64.urlsafe_b64encode(key.encode()).decode().rstrip("=")
 
     def _get_session_path(self, key: str) -> Path:
-        """Get the file path for a session, with backward compatibility."""
-        new_path = self.sessions_dir / f"{self.safe_key(key)}.jsonl"
-        if new_path.exists():
-            return new_path
-        old_path = self.sessions_dir / f"{safe_filename(key.replace(":", "_"))}.jsonl"
-        if old_path.exists():
-            return old_path
-        return new_path
+        """Get the collision-resistant workspace path for a session."""
+        return self.sessions_dir / f"{self.safe_key(key)}.jsonl"
+
+    def _get_legacy_lossy_path(self, key: str) -> Path:
+        """Previous workspace session path using lossy ':' to '_' replacement."""
+        return self.sessions_dir / f"{safe_filename(key.replace(':', '_'))}.jsonl"
 
     def _get_legacy_session_path(self, key: str) -> Path:
         """Legacy global session path (~/.nanobot/sessions/)."""
-        new_path = self.legacy_sessions_dir / f"{self.safe_key(key)}.jsonl"
-        if new_path.exists():
-            return new_path
-        old_path = self.legacy_sessions_dir / f"{safe_filename(key.replace(":", "_"))}.jsonl"
-        if old_path.exists():
-            return old_path
-        return new_path
+        return self.legacy_sessions_dir / f"{self.safe_key(key)}.jsonl"
 
     def get_or_create(self, key: str) -> Session:
         """
@@ -475,13 +467,19 @@ class SessionManager:
         """Load a session from disk."""
         path = self._get_session_path(key)
         if not path.exists():
-            legacy_path = self._get_legacy_session_path(key)
-            if legacy_path.exists():
+            fallback_paths = [
+                (self._get_legacy_lossy_path(key), "legacy lossy path"),
+                (self._get_legacy_session_path(key), "legacy path"),
+            ]
+            for fallback_path, description in fallback_paths:
+                if not fallback_path.exists():
+                    continue
                 try:
-                    shutil.move(str(legacy_path), str(path))
-                    logger.info("Migrated session {} from legacy path", key)
+                    shutil.move(str(fallback_path), str(path))
+                    logger.info("Migrated session {} from {}", key, description)
                 except Exception:
                     logger.exception("Failed to migrate session {}", key)
+                break
 
         if not path.exists():
             return None
@@ -663,7 +661,11 @@ class SessionManager:
 
         Returns True if at least one JSONL file was found and unlinked.
         """
-        paths = [self._get_session_path(key), self._get_legacy_session_path(key)]
+        paths = [
+            self._get_session_path(key),
+            self._get_legacy_lossy_path(key),
+            self._get_legacy_session_path(key),
+        ]
         self.invalidate(key)
         deleted = False
         for path in paths:

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -455,6 +455,24 @@ class SessionManager:
         """Legacy global session path (~/.nanobot/sessions/)."""
         return self.legacy_sessions_dir / f"{self.safe_key(key)}.jsonl"
 
+    @staticmethod
+    def _stored_key_for_path(path: Path) -> str | None:
+        """Read the stored session key from a JSONL metadata row, if present."""
+        try:
+            with open(path, encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    data = json.loads(line)
+                    if data.get("_type") == "metadata":
+                        stored_key = data.get("key")
+                        return stored_key if isinstance(stored_key, str) else None
+                    return None
+        except Exception:
+            return None
+        return None
+
     def get_or_create(self, key: str) -> Session:
         """
         Get an existing session or create a new one.
@@ -485,6 +503,15 @@ class SessionManager:
             ]
             for fallback_path, description in fallback_paths:
                 if not fallback_path.exists():
+                    continue
+                stored_key = self._stored_key_for_path(fallback_path)
+                if stored_key and stored_key != key:
+                    logger.info(
+                        "Skipping migration for {} from {} because it belongs to {}",
+                        key,
+                        description,
+                        stored_key,
+                    )
                     continue
                 try:
                     shutil.move(str(fallback_path), str(path))

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -423,17 +423,17 @@ class SessionManager:
 
     @staticmethod
     def safe_key(key: str) -> str:
-        """Collision-resistant encoding of a session key for use as a filename stem.
+        """Public helper used by HTTP handlers to map an arbitrary key to a stable filename stem."""
+        return safe_filename(key.replace(":", "_"))
 
-        Uses base64url (no padding) so distinct keys always map to distinct
-        filenames, unlike the previous replace(":", "_") approach which
-        could collide (e.g. telegram:a_b vs telegram:a:b).
-        """
+    @staticmethod
+    def _storage_key(key: str) -> str:
+        """Collision-resistant encoding for internal session storage filenames."""
         return base64.urlsafe_b64encode(key.encode()).decode().rstrip("=")
 
     def _get_session_path(self, key: str) -> Path:
         """Get the collision-resistant workspace path for a session."""
-        return self.sessions_dir / f"{self.safe_key(key)}.jsonl"
+        return self.sessions_dir / f"{self._storage_key(key)}.jsonl"
 
     def _get_legacy_lossy_path(self, key: str) -> Path:
         """Previous workspace session path using lossy ':' to '_' replacement."""

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -1,5 +1,6 @@
 """Session management for conversation history."""
 
+import base64
 import json
 import os
 import re
@@ -422,16 +423,33 @@ class SessionManager:
 
     @staticmethod
     def safe_key(key: str) -> str:
-        """Public helper used by HTTP handlers to map an arbitrary key to a stable filename stem."""
-        return safe_filename(key.replace(":", "_"))
+        """Collision-resistant encoding of a session key for use as a filename stem.
+
+        Uses base64url (no padding) so distinct keys always map to distinct
+        filenames, unlike the previous replace(":", "_") approach which
+        could collide (e.g. telegram:a_b vs telegram:a:b).
+        """
+        return base64.urlsafe_b64encode(key.encode()).decode().rstrip("=")
 
     def _get_session_path(self, key: str) -> Path:
-        """Get the file path for a session."""
-        return self.sessions_dir / f"{self.safe_key(key)}.jsonl"
+        """Get the file path for a session, with backward compatibility."""
+        new_path = self.sessions_dir / f"{self.safe_key(key)}.jsonl"
+        if new_path.exists():
+            return new_path
+        old_path = self.sessions_dir / f"{safe_filename(key.replace(":", "_"))}.jsonl"
+        if old_path.exists():
+            return old_path
+        return new_path
 
     def _get_legacy_session_path(self, key: str) -> Path:
         """Legacy global session path (~/.nanobot/sessions/)."""
-        return self.legacy_sessions_dir / f"{self.safe_key(key)}.jsonl"
+        new_path = self.legacy_sessions_dir / f"{self.safe_key(key)}.jsonl"
+        if new_path.exists():
+            return new_path
+        old_path = self.legacy_sessions_dir / f"{safe_filename(key.replace(":", "_"))}.jsonl"
+        if old_path.exists():
+            return old_path
+        return new_path
 
     def get_or_create(self, key: str) -> Session:
         """

--- a/nanobot/webui/session_list_index.py
+++ b/nanobot/webui/session_list_index.py
@@ -231,21 +231,8 @@ def _indexed_row_for_session(session: Session, path: Path) -> dict[str, Any]:
     }
 
 
-def _try_decode_storage_stem(stem: str) -> str | None:
-    """Try to decode a base64url (no-padding) session storage stem back to the original key."""
-    import base64
-
-    try:
-        padding = 4 - len(stem) % 4
-        if padding != 4:
-            stem += "=" * padding
-        return base64.urlsafe_b64decode(stem).decode("utf-8")
-    except Exception:
-        return None
-
-
 def _scan_session_row(session_manager: SessionManager, path: Path) -> dict[str, Any] | None:
-    storage_key = _try_decode_storage_stem(path.stem)
+    storage_key = SessionManager._decode_storage_key(path.stem)
     fallback_key = storage_key or path.stem.replace("_", ":", 1)
     try:
         with open(path, encoding="utf-8") as f:

--- a/nanobot/webui/session_list_index.py
+++ b/nanobot/webui/session_list_index.py
@@ -231,8 +231,22 @@ def _indexed_row_for_session(session: Session, path: Path) -> dict[str, Any]:
     }
 
 
+def _try_decode_storage_stem(stem: str) -> str | None:
+    """Try to decode a base64url (no-padding) session storage stem back to the original key."""
+    import base64
+
+    try:
+        padding = 4 - len(stem) % 4
+        if padding != 4:
+            stem += "=" * padding
+        return base64.urlsafe_b64decode(stem).decode("utf-8")
+    except Exception:
+        return None
+
+
 def _scan_session_row(session_manager: SessionManager, path: Path) -> dict[str, Any] | None:
-    fallback_key = path.stem.replace("_", ":", 1)
+    storage_key = _try_decode_storage_stem(path.stem)
+    fallback_key = storage_key or path.stem.replace("_", ":", 1)
     try:
         with open(path, encoding="utf-8") as f:
             first_line = f.readline().strip()

--- a/tests/agent/test_session_collision.py
+++ b/tests/agent/test_session_collision.py
@@ -40,8 +40,8 @@ def test_distinct_keys_have_distinct_filenames(tmp_path: Path, monkeypatch) -> N
     second = sm._get_session_path("telegram:a:b")
 
     assert first.name != second.name
-    assert first.name == f"{SessionManager.safe_key('telegram:a_b')}.jsonl"
-    assert second.name == f"{SessionManager.safe_key('telegram:a:b')}.jsonl"
+    assert sm.safe_key("telegram:a_b") == sm.safe_key("telegram:a:b")
+    assert sm._storage_key("telegram:a_b") != sm._storage_key("telegram:a:b")
 
 
 def test_save_uses_new_path_not_lossy(tmp_path: Path, monkeypatch) -> None:
@@ -93,14 +93,19 @@ def test_load_migrates_lossy_to_new_path(tmp_path: Path, monkeypatch) -> None:
     assert not lossy_path.exists()
 
 
-def test_safe_key_is_collision_resistant() -> None:
+def test_safe_key_is_lossy() -> None:
+    assert SessionManager.safe_key("telegram:a_b") == SessionManager.safe_key("telegram:a:b")
+
+
+def test_storage_key_is_collision_resistant() -> None:
     encoded = {
-        SessionManager.safe_key("a:b"),
-        SessionManager.safe_key("a_b"),
-        SessionManager.safe_key("a:b:c"),
+        SessionManager._storage_key("a:b"),
+        SessionManager._storage_key("a_b"),
+        SessionManager._storage_key("a:b:c"),
     }
 
     assert len(encoded) == 3
+    assert SessionManager._storage_key("telegram:a_b") != SessionManager._storage_key("telegram:a:b")
 
 
 def test_lossy_path_helper_returns_expected_path(tmp_path: Path, monkeypatch) -> None:
@@ -109,3 +114,32 @@ def test_lossy_path_helper_returns_expected_path(tmp_path: Path, monkeypatch) ->
     expected = sm.sessions_dir / f"{safe_filename(key.replace(':', '_'))}.jsonl"
 
     assert sm._get_legacy_lossy_path(key) == expected
+
+
+def test_storage_paths_are_distinct_when_keys_collide_under_safe_key(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    sm = _manager(tmp_path, monkeypatch)
+    first = Session(key="telegram:a_b")
+    first.add_message("user", "underscore history")
+    second = Session(key="telegram:a:b")
+    second.add_message("user", "colon history")
+
+    sm.save(first)
+    sm.save(second)
+
+    assert sm.safe_key(first.key) == sm.safe_key(second.key)
+    assert sm._get_session_path(first.key).exists()
+    assert sm._get_session_path(second.key).exists()
+    assert sm._get_session_path(first.key) != sm._get_session_path(second.key)
+
+    sm.invalidate(first.key)
+    sm.invalidate(second.key)
+    loaded_first = sm._load(first.key)
+    loaded_second = sm._load(second.key)
+
+    assert loaded_first is not None
+    assert loaded_second is not None
+    assert loaded_first.messages[0]["content"] == "underscore history"
+    assert loaded_second.messages[0]["content"] == "colon history"

--- a/tests/agent/test_session_collision.py
+++ b/tests/agent/test_session_collision.py
@@ -1,0 +1,111 @@
+"""Regression tests for collision-resistant session filenames."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from nanobot.session.manager import Session, SessionManager
+from nanobot.utils.helpers import safe_filename
+
+
+def _manager(tmp_path: Path, monkeypatch) -> SessionManager:
+    monkeypatch.setattr(
+        "nanobot.session.manager.get_legacy_sessions_dir",
+        lambda: tmp_path / "legacy_sessions",
+    )
+    return SessionManager(tmp_path / "workspace")
+
+
+def _write_session_file(path: Path, key: str, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    metadata = {
+        "_type": "metadata",
+        "key": key,
+        "created_at": datetime(2025, 1, 1).isoformat(),
+        "updated_at": datetime(2025, 1, 1).isoformat(),
+        "metadata": {"source": "test"},
+        "last_consolidated": 0,
+    }
+    message = {"role": "user", "content": content}
+    path.write_text(
+        json.dumps(metadata) + "\n" + json.dumps(message) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_distinct_keys_have_distinct_filenames(tmp_path: Path, monkeypatch) -> None:
+    sm = _manager(tmp_path, monkeypatch)
+
+    first = sm._get_session_path("telegram:a_b")
+    second = sm._get_session_path("telegram:a:b")
+
+    assert first.name != second.name
+    assert first.name == f"{SessionManager.safe_key('telegram:a_b')}.jsonl"
+    assert second.name == f"{SessionManager.safe_key('telegram:a:b')}.jsonl"
+
+
+def test_save_uses_new_path_not_lossy(tmp_path: Path, monkeypatch) -> None:
+    sm = _manager(tmp_path, monkeypatch)
+    key = "telegram:a:b"
+    session = Session(key=key)
+    session.add_message("user", "first")
+    sm.save(session)
+
+    new_path = sm._get_session_path(key)
+    lossy_path = sm._get_legacy_lossy_path(key)
+    _write_session_file(lossy_path, key, "stale lossy content")
+    stale_lossy = lossy_path.read_text(encoding="utf-8")
+
+    session.add_message("assistant", "latest content")
+    sm.save(session)
+
+    assert new_path.exists()
+    assert lossy_path.exists()
+    assert "latest content" in new_path.read_text(encoding="utf-8")
+    assert lossy_path.read_text(encoding="utf-8") == stale_lossy
+
+
+def test_load_falls_back_to_lossy_path(tmp_path: Path, monkeypatch) -> None:
+    sm = _manager(tmp_path, monkeypatch)
+    key = "telegram:legacy:lossy"
+    lossy_path = sm._get_legacy_lossy_path(key)
+    _write_session_file(lossy_path, key, "loaded from lossy")
+
+    session = sm._load(key)
+
+    assert session is not None
+    assert session.metadata == {"source": "test"}
+    assert session.messages[0]["content"] == "loaded from lossy"
+
+
+def test_load_migrates_lossy_to_new_path(tmp_path: Path, monkeypatch) -> None:
+    sm = _manager(tmp_path, monkeypatch)
+    key = "telegram:migrate:lossy"
+    new_path = sm._get_session_path(key)
+    lossy_path = sm._get_legacy_lossy_path(key)
+    _write_session_file(lossy_path, key, "migrate me")
+
+    session = sm._load(key)
+
+    assert session is not None
+    assert session.messages[0]["content"] == "migrate me"
+    assert new_path.exists()
+    assert not lossy_path.exists()
+
+
+def test_safe_key_is_collision_resistant() -> None:
+    encoded = {
+        SessionManager.safe_key("a:b"),
+        SessionManager.safe_key("a_b"),
+        SessionManager.safe_key("a:b:c"),
+    }
+
+    assert len(encoded) == 3
+
+
+def test_lossy_path_helper_returns_expected_path(tmp_path: Path, monkeypatch) -> None:
+    sm = _manager(tmp_path, monkeypatch)
+    key = "telegram:a:b"
+    expected = sm.sessions_dir / f"{safe_filename(key.replace(':', '_'))}.jsonl"
+
+    assert sm._get_legacy_lossy_path(key) == expected

--- a/tests/agent/test_session_collision.py
+++ b/tests/agent/test_session_collision.py
@@ -93,6 +93,31 @@ def test_load_migrates_lossy_to_new_path(tmp_path: Path, monkeypatch) -> None:
     assert not lossy_path.exists()
 
 
+def test_load_does_not_migrate_lossy_path_for_different_stored_key(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    sm = _manager(tmp_path, monkeypatch)
+    first_key = "telegram:a_b"
+    second_key = "telegram:a:b"
+    lossy_path = sm._get_legacy_lossy_path(first_key)
+    assert lossy_path == sm._get_legacy_lossy_path(second_key)
+    _write_session_file(lossy_path, first_key, "belongs to first")
+
+    loaded_second = sm._load(second_key)
+
+    assert loaded_second is None
+    assert lossy_path.exists()
+    assert not sm._get_session_path(second_key).exists()
+
+    loaded_first = sm._load(first_key)
+
+    assert loaded_first is not None
+    assert loaded_first.messages[0]["content"] == "belongs to first"
+    assert sm._get_session_path(first_key).exists()
+    assert not lossy_path.exists()
+
+
 def test_safe_key_is_lossy() -> None:
     assert SessionManager.safe_key("telegram:a_b") == SessionManager.safe_key("telegram:a:b")
 

--- a/tests/agent/test_session_delete.py
+++ b/tests/agent/test_session_delete.py
@@ -58,11 +58,11 @@ def test_read_session_file_missing(tmp_path: Path) -> None:
     assert sm.read_session_file("nope:none") is None
 
 
-def test_safe_key_matches_internal_path(tmp_path: Path) -> None:
+def test_storage_key_matches_internal_path(tmp_path: Path) -> None:
     sm = SessionManager(tmp_path)
     key = "telegram:abc/def"
     expected = sm._get_session_path(key).name
-    assert SessionManager.safe_key(key) + ".jsonl" == expected
+    assert SessionManager._storage_key(key) + ".jsonl" == expected
 
 
 def _write_legacy_session(legacy_dir: Path, key: str, roles: list[str]) -> Path:


### PR DESCRIPTION
Fix session key collision on disk (Fixes #4057) without breaking WebUI filename generation.

**Problem:** `SessionManager.safe_key()` replaced `:` with `_`, causing collisions between distinct keys like `telegram:a_b` and `telegram:a:b` (both became `telegram_a_b`). Two sessions would share or overwrite the same persisted history.

**Fix:** Split storage identity from public filename identity:

- `safe_key()` keeps the old lossy encoding (`safe_filename(key.replace(':', '_'))`) -- used by WebUI transcript/thread/session-list paths (transcript.py, thread_disk.py, session_list_index.py).
- New private `_storage_key()` uses base64url (no padding) for collision-resistant session filenames on disk.
- `_get_session_path()` now uses `_storage_key()`, so save/load/delete use collision-resistant paths.
- `_load()` checks new path first, then falls back to the old lossy path in sessions_dir, then the legacy ~/.nanobot/sessions/ path -- existing files are migrated to the new path on first access.
- `delete_session()` cleans up all three possible locations.
- `list_sessions()` and WebUI session list scanning use `_decode_storage_key()` to decode base64url storage stems before falling back to the old lossy guess -- corrupt-file repair works correctly for new filenames.

**Backward compatibility:** Existing session files at the old lossy path are read and migrated to the new collision-resistant path on first access via `_load()`. No data loss. WebUI transcript/thread file names are unchanged.

**Tests:** Added regression tests for distinct filenames, save/load/migration behavior, safe_key collision vs. storage-key collision resistance, and save/load for colliding keys. Updated existing path-matching tests to use `_storage_key()`.