### PR TITLE
docs: remove misleading ultra-lightweight claim from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
   </p>
 </div>
 
-🐈 **nanobot** is an open-source, ultra-lightweight personal AI agent you can truly own. It keeps the agent core small and readable while giving you the practical pieces for real long-running work: WebUI, chat channels, tools, memory, MCP, model routing, automation, and deployment.
+🐈 **nanobot** is an open-source personal AI agent you can truly own. It keeps the agent core small and readable while giving you the practical pieces for real long-running work: WebUI, chat channels, tools, memory, MCP, model routing, automation, and deployment.
 
 ## Start Here
 


### PR DESCRIPTION
## Summary

Remove the "ultra-lightweight" claim from the README tagline, as the Dockerfile requires both Python and Node.js runtimes, making the claim inaccurate.

**Before:**
> 🐈 **nanobot** is an open-source, ultra-lightweight personal AI agent you can truly own.

**After:**
> 🐈 **nanobot** is an open-source personal AI agent you can truly own.

## Motivation

As noted in issue #660, the project describes itself as "ultra-lightweight" but the Dockerfile installs both Python 3.12 AND Node.js 24, resulting in a ~400MB+ image. This is a significant footprint that contradicts the "ultra-lightweight" branding.

The fix updates the tagline to accurately reflect that nanobot is an open-source personal AI agent without the misleading lightweight claim.

Closes #660