### PR TITLE
fix(dream): inject existing workspace skills into Dream prompt

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -503,7 +503,23 @@ class MemoryStore:
         template = render_template(
             "agent/dream.md", strip=True, skill_creator_path=skill_creator_path,
         )
-        prompt = f"{template}\n\n## Conversation History\n{history_text}"
+
+        # Inject existing workspace skills so Dream can match before creating.
+        # Only workspace skills (not builtins) to keep the list focused on
+        # user-authored skills that Dream might duplicate.
+        from nanobot.agent.skills import SkillsLoader
+        loader = SkillsLoader(self.workspace)
+        workspace_skills = loader.list_skills(filter_unavailable=False)
+        workspace_skills = [s for s in workspace_skills if s.get("source") == "workspace"]
+        skills_section = ""
+        if workspace_skills:
+            lines = []
+            for entry in workspace_skills:
+                desc = loader._get_skill_description(entry["name"])
+                lines.append(f"- **{entry['name']}** — {desc}")
+            skills_section = "\n\n## Existing Workspace Skills\n" + "\n".join(lines)
+
+        prompt = f"{template}{skills_section}\n\n## Conversation History\n{history_text}"
         return (prompt, batch[-1]["cursor"])
 
     def build_dream_tools(self):

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -569,3 +569,50 @@ class TestDreamCommitMessage:
         ).strip()
         assert "dream: periodic memory consolidation" in log
         assert "Identified 2 new facts" in log
+
+
+class TestDreamSkillsSummary:
+    """Tests for workspace skills summary injection into Dream prompt."""
+
+    def test_prompt_includes_workspace_skills_summary(self, store, tmp_path):
+        """Existing workspace skills should appear in the Dream prompt."""
+        # Create a workspace skill
+        skill_dir = tmp_path / "skills" / "my-workflow"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: my-workflow\ndescription: Deploy to production.\n---\n\nSteps:\n1. Build\n2. Deploy\n",
+            encoding="utf-8",
+        )
+
+        store.append_history("I always deploy with ./deploy.sh")
+        result = store.build_dream_prompt()
+        assert result is not None
+        prompt, _ = result
+        assert "## Existing Workspace Skills" in prompt
+        assert "my-workflow" in prompt
+        assert "Deploy to production" in prompt
+
+    def test_prompt_omits_skills_section_when_no_skills(self, store):
+        """When no workspace skills exist, the section should not appear."""
+        store.append_history("hello world")
+        result = store.build_dream_prompt()
+        assert result is not None
+        prompt, _ = result
+        assert "## Existing Workspace Skills" not in prompt
+
+    def test_prompt_includes_multiple_skills(self, store, tmp_path):
+        """Multiple workspace skills should all appear in the summary."""
+        for name, desc in [("deploy", "Deploy skill"), ("test", "Test skill")]:
+            skill_dir = tmp_path / "skills" / name
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {desc}\n---\n\nContent.\n",
+                encoding="utf-8",
+            )
+
+        store.append_history("reviewing my workflows")
+        result = store.build_dream_prompt()
+        assert result is not None
+        prompt, _ = result
+        assert "deploy" in prompt
+        assert "test" in prompt


### PR DESCRIPTION
## Problem

Dream creates duplicate `skills/<name>/SKILL.md` directories on each run even when a workspace skill for that workflow already exists. The Dream prompt says "Check existing skill descriptions (listed above) before creating a new skill" but the existing skills are never actually listed in the prompt — the Dream agent has to proactively scan `skills/` to discover them, which it doesn't reliably do.

## Solution

`build_dream_prompt()` now scans workspace skills via `SkillsLoader` and injects a summary section before the history batch:

```
## Existing Workspace Skills
- **my-workflow** — Deploy to production.
- **testing** — Run test suite with coverage.
```

This gives the Dream agent direct visibility into existing skills so it can merge deltas instead of creating redundant siblings. Only workspace skills are listed (not builtins) to keep the list focused on user-authored skills that Dream might duplicate.

## Verification

```bash
pytest tests/agent/test_dream.py -xvs
```

All 27 tests pass, including 3 new tests:
- `test_prompt_includes_workspace_skills_summary` — workspace skills appear in prompt
- `test_prompt_omits_skills_section_when_no_skills` — no section when no workspace skills
- `test_prompt_includes_multiple_skills` — all workspace skills listed

Lint clean (`ruff check nanobot/agent/memory.py`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)