### PR TITLE
fix(exec): default Windows commands to PowerShell and allow shell parameter

### DIFF
--- a/.agent/gotchas.md
+++ b/.agent/gotchas.md
@@ -16,7 +16,7 @@ Example valid usage:
 ## Windows Compatibility
 
 nanobot explicitly supports Windows. Key differences to keep in mind:
-- `ExecTool` uses `cmd /c` on Windows instead of `sh -c` (`shell.py`).
+- `ExecTool` defaults to PowerShell on Windows (`pwsh` when available, otherwise Windows PowerShell); pass `shell="cmd"` for cmd.exe syntax or cmd built-ins (`shell.py`).
 - `cli/commands.py` forces `sys.stdout`/`stderr` to UTF-8 on startup to handle emoji and multilingual input.
 - MCP stdio server commands are normalized for Windows path separators (`mcp.py`).
 - Always use `pathlib.Path` for path manipulation; do not assume `/` separators.

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -90,9 +90,13 @@ class _PreparedCommand:
         ),
         shell=StringSchema(
             (
-                "Optional shell binary to launch. Windows: powershell, pwsh, cmd."
+                "Override the Windows shell only when needed. Omit to use "
+                "PowerShell by default (pwsh when available, else powershell). "
+                "Pass 'cmd' only for cmd.exe syntax or cmd built-ins."
                 if _IS_WINDOWS
-                else "Optional shell binary to launch. Unix: sh, bash, zsh."
+                else "Override the Unix shell only when needed. Omit to use "
+                "bash by default. Pass 'sh' for POSIX sh or 'zsh' for "
+                "zsh-specific syntax."
             ),
             nullable=True,
         ),

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -234,6 +234,8 @@ class ExecTool(Tool):
             "inspection and apply_patch/write_file/edit_file for file changes "
             "instead of cat, shell find/grep, echo, or sed. "
             "Use -y or --yes flags to avoid interactive prompts. "
+            "On Windows, use PowerShell syntax by default; pass shell='cmd' "
+            "only for cmd-specific commands. "
             "For long-running or interactive commands, pass yield_time_ms; "
             "if the command keeps running, exec returns a session_id that can "
             "be polled or written to with write_stdin. Output is truncated at "

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -491,14 +491,17 @@ class ExecTool(Tool):
             program = shell_program or default_program
             program_name = PureWindowsPath(program).name.lower()
             if program_name in ("cmd", "cmd.exe"):
-                return await asyncio.create_subprocess_exec(
-                    program, "/c", command,
+                cmd_env = {**env, "COMSPEC": program}
+                return await asyncio.create_subprocess_shell(
+                    command,
                     stdin=stdin,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                     cwd=cwd,
-                    env=env,
+                    env=cmd_env,
                 )
+            command = ExecTool._normalize_powershell_command(command)
+            command = f"{command}\nif ($LASTEXITCODE -ne $null) {{ exit $LASTEXITCODE }}"
             return await asyncio.create_subprocess_exec(
                 program, "-NoProfile", "-NonInteractive", "-Command", command,
                 stdin=stdin,
@@ -521,6 +524,29 @@ class ExecTool(Tool):
             cwd=cwd,
             env=env,
         )
+
+    @staticmethod
+    def _normalize_powershell_command(command: str) -> str:
+        stripped = command.lstrip()
+        if not stripped or stripped[0] not in {"'", '"'}:
+            return command
+
+        quote = stripped[0]
+        end = stripped.find(quote, 1)
+        if end == -1 or end + 1 >= len(stripped) or not stripped[end + 1].isspace():
+            return command
+
+        executable = stripped[1:end]
+        looks_like_windows_executable = (
+            bool(re.match(r"^[A-Za-z]:[\\/]", executable))
+            or executable.startswith(r"\\")
+            or executable.lower().endswith((".exe", ".cmd", ".bat", ".ps1"))
+        )
+        if not looks_like_windows_executable:
+            return command
+
+        leading = command[: len(command) - len(stripped)]
+        return f"{leading}& {stripped}"
 
     @staticmethod
     def _resolve_shell(shell: str | None) -> tuple[str | None, str | None]:

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -9,7 +9,7 @@ import shutil
 import sys
 from contextlib import suppress
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
 
 from loguru import logger
@@ -471,9 +471,9 @@ class ExecTool(Tool):
             # Default to PowerShell so single-line and multi-line commands
             # share the same shell semantics.  cmd.exe is reachable via the
             # explicit shell="cmd" parameter (see _resolve_shell).
-            default_program = shutil.which("powershell") or "powershell"
+            default_program = shutil.which("pwsh") or shutil.which("powershell") or "powershell"
             program = shell_program or default_program
-            program_name = Path(program).name.lower()
+            program_name = PureWindowsPath(program).name.lower()
             if program_name in ("cmd", "cmd.exe"):
                 return await asyncio.create_subprocess_shell(
                     command,
@@ -484,7 +484,7 @@ class ExecTool(Tool):
                     env=env,
                 )
             return await asyncio.create_subprocess_exec(
-                program, "-NoProfile", "-Command", command,
+                program, "-NoProfile", "-NonInteractive", "-Command", command,
                 stdin=stdin,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -89,7 +89,11 @@ class _PreparedCommand:
             maximum=600,
         ),
         shell=StringSchema(
-            "Optional shell binary to launch. Unix: sh, bash, zsh. Windows: powershell, pwsh, cmd.",
+            (
+                "Optional shell binary to launch. Windows: powershell, pwsh, cmd."
+                if _IS_WINDOWS
+                else "Optional shell binary to launch. Unix: sh, bash, zsh."
+            ),
             nullable=True,
         ),
         login=BooleanSchema(
@@ -227,6 +231,13 @@ class ExecTool(Tool):
 
     @property
     def description(self) -> str:
+        platform_note = (
+            "On Windows, use PowerShell syntax by default; pass shell='cmd' "
+            "only for cmd-specific commands. "
+            if _IS_WINDOWS
+            else "On Unix, commands run through bash by default; pass shell='sh' "
+            "or shell='zsh' when needed. "
+        )
         return (
             "Execute a shell command and return its output. "
             "Use this for tests, builds, package commands, git commands, and "
@@ -234,8 +245,7 @@ class ExecTool(Tool):
             "inspection and apply_patch/write_file/edit_file for file changes "
             "instead of cat, shell find/grep, echo, or sed. "
             "Use -y or --yes flags to avoid interactive prompts. "
-            "On Windows, use PowerShell syntax by default; pass shell='cmd' "
-            "only for cmd-specific commands. "
+            f"{platform_note}"
             "For long-running or interactive commands, pass yield_time_ms; "
             "if the command keeps running, exec returns a session_id that can "
             "be polled or written to with write_stdin. Output is truncated at "

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -89,7 +89,7 @@ class _PreparedCommand:
             maximum=600,
         ),
         shell=StringSchema(
-            "Optional shell binary to launch. On Unix, supports sh, bash, or zsh.",
+            "Optional shell binary to launch. Unix: sh, bash, zsh. Windows: powershell, pwsh, cmd.",
             nullable=True,
         ),
         login=BooleanSchema(
@@ -468,17 +468,23 @@ class ExecTool(Tool):
     ) -> asyncio.subprocess.Process:
         """Launch *command* in a platform-appropriate shell."""
         if _IS_WINDOWS:
-            if "\n" in command:
-                return await asyncio.create_subprocess_exec(
-                    "powershell", "-NoProfile", "-Command", command,
+            # Default to PowerShell so single-line and multi-line commands
+            # share the same shell semantics.  cmd.exe is reachable via the
+            # explicit shell="cmd" parameter (see _resolve_shell).
+            default_program = shutil.which("powershell") or "powershell"
+            program = shell_program or default_program
+            program_name = Path(program).name.lower()
+            if program_name in ("cmd", "cmd.exe"):
+                return await asyncio.create_subprocess_shell(
+                    command,
                     stdin=stdin,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                     cwd=cwd,
                     env=env,
                 )
-            return await asyncio.create_subprocess_shell(
-                command,
+            return await asyncio.create_subprocess_exec(
+                program, "-NoProfile", "-Command", command,
                 stdin=stdin,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
@@ -504,10 +510,33 @@ class ExecTool(Tool):
     def _resolve_shell(shell: str | None) -> tuple[str | None, str | None]:
         if not shell:
             return None, None
-        if _IS_WINDOWS:
-            return None, ToolResult.error("Error: shell parameter is not supported on Windows")
         if "\0" in shell or "\n" in shell or "\r" in shell:
             return None, ToolResult.error("Error: shell contains invalid characters")
+        if _IS_WINDOWS:
+            win_allowed = {"powershell", "powershell.exe", "pwsh", "pwsh.exe", "cmd", "cmd.exe"}
+            path = Path(shell).expanduser()
+            if path.is_absolute():
+                name = path.name.lower()
+                if name not in win_allowed:
+                    return None, ToolResult.error(
+                        f"Error: unsupported shell {shell!r}. "
+                        "Allowed: powershell, pwsh, cmd"
+                    )
+                if not path.is_file():
+                    return None, ToolResult.error(f"Error: shell is not found: {shell}")
+                return str(path), None
+            if "/" in shell or "\\" in shell:
+                return None, ToolResult.error("Error: shell must be a shell name or absolute path")
+            if shell.lower() not in win_allowed:
+                return None, ToolResult.error(
+                    f"Error: unsupported shell {shell!r}. "
+                    "Allowed: powershell, pwsh, cmd"
+                )
+            if shell.lower() in ("cmd", "cmd.exe"):
+                resolved = os.environ.get("COMSPEC") or shutil.which("cmd") or "cmd"
+                return resolved, None
+            resolved = shutil.which(shell) or shell
+            return resolved, None
         allowed = {"sh", "bash", "zsh"}
         path = Path(shell).expanduser()
         if path.is_absolute():

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -491,8 +491,8 @@ class ExecTool(Tool):
             program = shell_program or default_program
             program_name = PureWindowsPath(program).name.lower()
             if program_name in ("cmd", "cmd.exe"):
-                return await asyncio.create_subprocess_shell(
-                    command,
+                return await asyncio.create_subprocess_exec(
+                    program, "/c", command,
                     stdin=stdin,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,

--- a/tests/tools/test_exec_platform.py
+++ b/tests/tools/test_exec_platform.py
@@ -116,32 +116,37 @@ class TestSpawnUnix:
 class TestSpawnWindows:
 
     @pytest.mark.asyncio
-    async def test_single_line_uses_shell(self):
+    async def test_single_line_uses_powershell(self):
+        """Single-line commands on Windows now route through PowerShell."""
         env = {"COMSPEC": r"C:\Windows\system32\cmd.exe", "PATH": ""}
         with (
             patch("nanobot.agent.tools.shell._IS_WINDOWS", True),
-            patch("asyncio.create_subprocess_shell", new_callable=AsyncMock) as mock_shell,
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
         ):
-            mock_shell.return_value = AsyncMock()
+            mock_exec.return_value = AsyncMock()
             await ExecTool._spawn("dir", r"C:\work", env)
 
-        args = mock_shell.call_args[0]
-        assert "dir" in args
+        args = mock_exec.call_args[0]
+        assert "powershell" in args[0].lower()
+        assert "-NoProfile" in args
+        assert "-Command" in args
+        assert "dir" in args[-1]
 
-        kwargs = mock_shell.call_args[1]
+        kwargs = mock_exec.call_args[1]
         assert kwargs["stdin"] == asyncio.subprocess.DEVNULL
 
     @pytest.mark.asyncio
     async def test_single_line_passes_cwd_and_env(self):
+        """PowerShell should receive cwd and env from the caller."""
         env = {"PATH": "/usr/bin"}
         with (
             patch("nanobot.agent.tools.shell._IS_WINDOWS", True),
-            patch("asyncio.create_subprocess_shell", new_callable=AsyncMock) as mock_shell,
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
         ):
-            mock_shell.return_value = AsyncMock()
+            mock_exec.return_value = AsyncMock()
             await ExecTool._spawn("echo hi", r"C:\work", env)
 
-        kwargs = mock_shell.call_args[1]
+        kwargs = mock_exec.call_args[1]
         assert kwargs["cwd"] == r"C:\work"
         assert kwargs["env"] == env
 
@@ -156,7 +161,7 @@ class TestSpawnWindows:
             await ExecTool._spawn('python -c "print(1)\nprint(2)"', r"C:\work", env)
 
         args = mock_exec.call_args[0]
-        assert args[0] == "powershell"
+        assert "powershell" in args[0].lower()
         assert "-NoProfile" in args
         assert "-Command" in args
         assert "print(1)" in args[-1]
@@ -165,6 +170,24 @@ class TestSpawnWindows:
         kwargs = mock_exec.call_args[1]
         assert kwargs["cwd"] == r"C:\work"
         assert kwargs["env"] == env
+
+    @pytest.mark.asyncio
+    async def test_explicit_cmd_shell_uses_create_subprocess_shell(self):
+        """Explicit shell='cmd' should use create_subprocess_shell."""
+        env = {"COMSPEC": r"C:\Windows\system32\cmd.exe", "PATH": ""}
+        with (
+            patch("nanobot.agent.tools.shell._IS_WINDOWS", True),
+            patch("asyncio.create_subprocess_shell", new_callable=AsyncMock) as mock_shell,
+        ):
+            mock_shell.return_value = AsyncMock()
+            await ExecTool._spawn(
+                "dir", r"C:\work", env,
+                shell_program=r"C:\Windows\system32\cmd.exe",
+            )
+
+        mock_shell.assert_called_once()
+        kwargs = mock_shell.call_args[1]
+        assert kwargs["cwd"] == r"C:\work"
 
 
 # ---------------------------------------------------------------------------
@@ -488,7 +511,7 @@ class TestExtractAbsolutePaths:
 # ---------------------------------------------------------------------------
 
 class TestWindowsMultilineExec:
-    """Verify multi-line commands on Windows route through PowerShell."""
+    """Verify commands on Windows route through PowerShell (now the default)."""
 
     @pytest.mark.asyncio
     async def test_multiline_python_uses_powershell(self):
@@ -509,7 +532,7 @@ class TestWindowsMultilineExec:
         assert "2" in result
         assert "Exit code: 0" in result
         args = mock_exec.call_args[0]
-        assert args[0] == "powershell"
+        assert "powershell" in args[0].lower()
 
     @pytest.mark.asyncio
     async def test_multiline_node_uses_powershell(self):
@@ -528,10 +551,11 @@ class TestWindowsMultilineExec:
 
         assert "1" in result
         args = mock_exec.call_args[0]
-        assert args[0] == "powershell"
+        assert "powershell" in args[0].lower()
 
     @pytest.mark.asyncio
-    async def test_single_line_uses_shell(self):
+    async def test_single_line_uses_powershell(self):
+        """Single-line commands also route through PowerShell now."""
         mock_proc = AsyncMock()
         mock_proc.communicate.return_value = (b"1\n", b"")
         mock_proc.returncode = 0
@@ -563,3 +587,60 @@ class TestWindowsMultilineExec:
 
         assert "1" in result
         mock_spawn.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _resolve_shell — Windows support
+# ---------------------------------------------------------------------------
+
+class TestResolveShellWindows:
+    """shell parameter is now accepted on Windows."""
+
+    @pytest.mark.asyncio
+    async def test_shell_powershell_accepted(self):
+        """shell='powershell' should resolve and route through PowerShell."""
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"hello\n", b"")
+        mock_proc.returncode = 0
+
+        with (
+            patch("nanobot.agent.tools.shell._IS_WINDOWS", True),
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
+            patch.object(ExecTool, "_guard_command", return_value=None),
+        ):
+            mock_exec.return_value = mock_proc
+            tool = ExecTool()
+            result = await tool.execute(command="echo hello", shell="powershell")
+
+        assert "hello" in result
+        args = mock_exec.call_args[0]
+        assert "powershell" in args[0].lower()
+
+    @pytest.mark.asyncio
+    async def test_shell_cmd_accepted(self):
+        """shell='cmd' should use create_subprocess_shell."""
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"hello\n", b"")
+        mock_proc.returncode = 0
+
+        with (
+            patch("nanobot.agent.tools.shell._IS_WINDOWS", True),
+            patch("asyncio.create_subprocess_shell", new_callable=AsyncMock) as mock_shell,
+            patch.object(ExecTool, "_guard_command", return_value=None),
+        ):
+            mock_shell.return_value = mock_proc
+            tool = ExecTool()
+            result = await tool.execute(command="echo hello", shell="cmd")
+
+        assert "hello" in result
+        mock_shell.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_shell_bash_rejected_on_windows(self):
+        """shell='bash' should still be rejected on Windows."""
+        with patch("nanobot.agent.tools.shell._IS_WINDOWS", True):
+            tool = ExecTool()
+            result = await tool.execute(command="echo hello", shell="bash")
+
+        assert "Error: unsupported shell" in result
+        assert "Allowed: powershell, pwsh, cmd" in result

--- a/tests/tools/test_exec_platform.py
+++ b/tests/tools/test_exec_platform.py
@@ -175,23 +175,57 @@ class TestSpawnWindows:
         assert kwargs["env"] == env
 
     @pytest.mark.asyncio
-    async def test_explicit_cmd_shell_uses_cmd_c(self):
-        """Explicit shell='cmd' should launch the resolved cmd.exe with /c."""
+    async def test_explicit_cmd_shell_uses_raw_shell_string(self):
+        """Explicit shell='cmd' should preserve raw cmd.exe quoting semantics."""
         env = {"COMSPEC": r"C:\Windows\system32\cmd.exe", "PATH": ""}
+        with (
+            patch("nanobot.agent.tools.shell._IS_WINDOWS", True),
+            patch("asyncio.create_subprocess_shell", new_callable=AsyncMock) as mock_shell,
+        ):
+            mock_shell.return_value = AsyncMock()
+            await ExecTool._spawn(
+                'echo "a & b"', r"C:\work", env,
+                shell_program=r"C:\Windows\system32\cmd.exe",
+            )
+
+        args = mock_shell.call_args[0]
+        assert args == ('echo "a & b"',)
+        kwargs = mock_shell.call_args[1]
+        assert kwargs["cwd"] == r"C:\work"
+        assert kwargs["env"] == {
+            "COMSPEC": r"C:\Windows\system32\cmd.exe",
+            "PATH": "",
+        }
+
+    @pytest.mark.asyncio
+    async def test_powershell_preserves_last_native_exit_code(self):
+        """PowerShell -Command should forward native process exit codes."""
+        env = {"PATH": ""}
         with (
             patch("nanobot.agent.tools.shell._IS_WINDOWS", True),
             patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
         ):
             mock_exec.return_value = AsyncMock()
-            await ExecTool._spawn(
-                "dir", r"C:\work", env,
-                shell_program=r"C:\Windows\system32\cmd.exe",
-            )
+            await ExecTool._spawn("cmd /c exit 7", r"C:\work", env)
 
-        args = mock_exec.call_args[0]
-        assert args[:3] == (r"C:\Windows\system32\cmd.exe", "/c", "dir")
-        kwargs = mock_exec.call_args[1]
-        assert kwargs["cwd"] == r"C:\work"
+        command = mock_exec.call_args[0][-1]
+        assert "cmd /c exit 7" in command
+        assert "if ($LASTEXITCODE -ne $null) { exit $LASTEXITCODE }" in command
+
+    @pytest.mark.asyncio
+    async def test_powershell_invokes_quoted_windows_executable_path(self):
+        """PowerShell needs & before quoted executable paths with arguments."""
+        env = {"PATH": ""}
+        command = r'"D:\Program Files\Python\python.exe" -u -c "print(1)"'
+        with (
+            patch("nanobot.agent.tools.shell._IS_WINDOWS", True),
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
+        ):
+            mock_exec.return_value = AsyncMock()
+            await ExecTool._spawn(command, r"C:\work", env)
+
+        powershell_command = mock_exec.call_args[0][-1]
+        assert powershell_command.startswith("& " + command)
 
     @pytest.mark.asyncio
     async def test_prefers_pwsh_when_available(self):
@@ -645,23 +679,23 @@ class TestResolveShellWindows:
 
     @pytest.mark.asyncio
     async def test_shell_cmd_accepted(self):
-        """shell='cmd' should use the resolved cmd.exe with /c."""
+        """shell='cmd' should preserve the command string for cmd.exe parsing."""
         mock_proc = AsyncMock()
-        mock_proc.communicate.return_value = (b"hello\n", b"")
+        mock_proc.communicate.return_value = (b'"a & b"\n', b"")
         mock_proc.returncode = 0
 
         with (
             patch("nanobot.agent.tools.shell._IS_WINDOWS", True),
-            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
+            patch("asyncio.create_subprocess_shell", new_callable=AsyncMock) as mock_shell,
             patch.object(ExecTool, "_guard_command", return_value=None),
         ):
-            mock_exec.return_value = mock_proc
+            mock_shell.return_value = mock_proc
             tool = ExecTool()
-            result = await tool.execute(command="echo hello", shell="cmd")
+            result = await tool.execute(command='echo "a & b"', shell="cmd")
 
-        assert "hello" in result
-        args = mock_exec.call_args[0]
-        assert args[1:3] == ("/c", "echo hello")
+        assert '"a & b"' in result
+        args = mock_shell.call_args[0]
+        assert args == ('echo "a & b"',)
 
     @pytest.mark.asyncio
     async def test_shell_bash_rejected_on_windows(self):
@@ -675,11 +709,12 @@ class TestResolveShellWindows:
 
 
 @pytest.mark.skipif(
-    sys.platform != "win32" or shutil.which("pwsh") is None,
-    reason="requires Windows with PowerShell 7",
+    sys.platform != "win32",
+    reason="requires Windows",
 )
 class TestWindowsRealExec:
 
+    @pytest.mark.skipif(shutil.which("pwsh") is None, reason="requires PowerShell 7")
     @pytest.mark.asyncio
     async def test_single_line_and_separator_uses_pwsh(self):
         result = await ExecTool(timeout=10).execute(command="echo before && echo after")
@@ -687,3 +722,17 @@ class TestWindowsRealExec:
         assert "before" in result
         assert "after" in result
         assert "Exit code: 0" in result
+
+    @pytest.mark.asyncio
+    async def test_explicit_cmd_preserves_embedded_quotes(self):
+        result = await ExecTool(timeout=10).execute(command='echo "a & b"', shell="cmd")
+
+        assert '"a & b"' in result
+        assert r'\"a & b\"' not in result
+        assert "Exit code: 0" in result
+
+    @pytest.mark.asyncio
+    async def test_default_powershell_preserves_native_exit_code(self):
+        result = await ExecTool(timeout=10).execute(command="cmd /c exit 7")
+
+        assert "Exit code: 7" in result

--- a/tests/tools/test_exec_platform.py
+++ b/tests/tools/test_exec_platform.py
@@ -6,6 +6,7 @@ platform-specific binaries (all subprocess calls are mocked).
 """
 
 import asyncio
+import shutil
 import sys
 from unittest.mock import AsyncMock, patch
 
@@ -127,8 +128,9 @@ class TestSpawnWindows:
             await ExecTool._spawn("dir", r"C:\work", env)
 
         args = mock_exec.call_args[0]
-        assert "powershell" in args[0].lower()
+        assert any(shell in args[0].lower() for shell in ("pwsh", "powershell"))
         assert "-NoProfile" in args
+        assert "-NonInteractive" in args
         assert "-Command" in args
         assert "dir" in args[-1]
 
@@ -161,8 +163,9 @@ class TestSpawnWindows:
             await ExecTool._spawn('python -c "print(1)\nprint(2)"', r"C:\work", env)
 
         args = mock_exec.call_args[0]
-        assert "powershell" in args[0].lower()
+        assert any(shell in args[0].lower() for shell in ("pwsh", "powershell"))
         assert "-NoProfile" in args
+        assert "-NonInteractive" in args
         assert "-Command" in args
         assert "print(1)" in args[-1]
         assert "print(2)" in args[-1]
@@ -188,6 +191,28 @@ class TestSpawnWindows:
         mock_shell.assert_called_once()
         kwargs = mock_shell.call_args[1]
         assert kwargs["cwd"] == r"C:\work"
+
+    @pytest.mark.asyncio
+    async def test_prefers_pwsh_when_available(self):
+        env = {"PATH": ""}
+
+        def fake_which(command):
+            if command == "pwsh":
+                return r"C:\Program Files\PowerShell\7\pwsh.exe"
+            if command == "powershell":
+                return r"C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe"
+            return None
+
+        with (
+            patch("nanobot.agent.tools.shell._IS_WINDOWS", True),
+            patch("nanobot.agent.tools.shell.shutil.which", side_effect=fake_which),
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
+        ):
+            mock_exec.return_value = AsyncMock()
+            await ExecTool._spawn("dir", r"C:\work", env)
+
+        args = mock_exec.call_args[0]
+        assert "pwsh" in args[0].lower()
 
 
 # ---------------------------------------------------------------------------
@@ -532,7 +557,7 @@ class TestWindowsMultilineExec:
         assert "2" in result
         assert "Exit code: 0" in result
         args = mock_exec.call_args[0]
-        assert "powershell" in args[0].lower()
+        assert any(shell in args[0].lower() for shell in ("pwsh", "powershell"))
 
     @pytest.mark.asyncio
     async def test_multiline_node_uses_powershell(self):
@@ -551,7 +576,7 @@ class TestWindowsMultilineExec:
 
         assert "1" in result
         args = mock_exec.call_args[0]
-        assert "powershell" in args[0].lower()
+        assert any(shell in args[0].lower() for shell in ("pwsh", "powershell"))
 
     @pytest.mark.asyncio
     async def test_single_line_uses_powershell(self):
@@ -615,6 +640,7 @@ class TestResolveShellWindows:
         assert "hello" in result
         args = mock_exec.call_args[0]
         assert "powershell" in args[0].lower()
+        assert "-NonInteractive" in args
 
     @pytest.mark.asyncio
     async def test_shell_cmd_accepted(self):
@@ -644,3 +670,18 @@ class TestResolveShellWindows:
 
         assert "Error: unsupported shell" in result
         assert "Allowed: powershell, pwsh, cmd" in result
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32" or shutil.which("pwsh") is None,
+    reason="requires Windows with PowerShell 7",
+)
+class TestWindowsRealExec:
+
+    @pytest.mark.asyncio
+    async def test_single_line_and_separator_uses_pwsh(self):
+        result = await ExecTool(timeout=10).execute(command="echo before && echo after")
+
+        assert "before" in result
+        assert "after" in result
+        assert "Exit code: 0" in result

--- a/tests/tools/test_exec_platform.py
+++ b/tests/tools/test_exec_platform.py
@@ -175,21 +175,22 @@ class TestSpawnWindows:
         assert kwargs["env"] == env
 
     @pytest.mark.asyncio
-    async def test_explicit_cmd_shell_uses_create_subprocess_shell(self):
-        """Explicit shell='cmd' should use create_subprocess_shell."""
+    async def test_explicit_cmd_shell_uses_cmd_c(self):
+        """Explicit shell='cmd' should launch the resolved cmd.exe with /c."""
         env = {"COMSPEC": r"C:\Windows\system32\cmd.exe", "PATH": ""}
         with (
             patch("nanobot.agent.tools.shell._IS_WINDOWS", True),
-            patch("asyncio.create_subprocess_shell", new_callable=AsyncMock) as mock_shell,
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
         ):
-            mock_shell.return_value = AsyncMock()
+            mock_exec.return_value = AsyncMock()
             await ExecTool._spawn(
                 "dir", r"C:\work", env,
                 shell_program=r"C:\Windows\system32\cmd.exe",
             )
 
-        mock_shell.assert_called_once()
-        kwargs = mock_shell.call_args[1]
+        args = mock_exec.call_args[0]
+        assert args[:3] == (r"C:\Windows\system32\cmd.exe", "/c", "dir")
+        kwargs = mock_exec.call_args[1]
         assert kwargs["cwd"] == r"C:\work"
 
     @pytest.mark.asyncio
@@ -644,22 +645,23 @@ class TestResolveShellWindows:
 
     @pytest.mark.asyncio
     async def test_shell_cmd_accepted(self):
-        """shell='cmd' should use create_subprocess_shell."""
+        """shell='cmd' should use the resolved cmd.exe with /c."""
         mock_proc = AsyncMock()
         mock_proc.communicate.return_value = (b"hello\n", b"")
         mock_proc.returncode = 0
 
         with (
             patch("nanobot.agent.tools.shell._IS_WINDOWS", True),
-            patch("asyncio.create_subprocess_shell", new_callable=AsyncMock) as mock_shell,
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
             patch.object(ExecTool, "_guard_command", return_value=None),
         ):
-            mock_shell.return_value = mock_proc
+            mock_exec.return_value = mock_proc
             tool = ExecTool()
             result = await tool.execute(command="echo hello", shell="cmd")
 
         assert "hello" in result
-        mock_shell.assert_called_once()
+        args = mock_exec.call_args[0]
+        assert args[1:3] == ("/c", "echo hello")
 
     @pytest.mark.asyncio
     async def test_shell_bash_rejected_on_windows(self):

--- a/tests/tools/test_tool_descriptions.py
+++ b/tests/tools/test_tool_descriptions.py
@@ -63,10 +63,14 @@ def test_exec_tool_shell_guidance_matches_platform() -> None:
 
     shell_parameter = ExecTool().parameters["properties"]["shell"]["description"].lower()
     if sys.platform == "win32":
+        assert "override the windows shell only when needed" in shell_parameter
+        assert "omit to use powershell by default" in shell_parameter
         assert "powershell" in shell_parameter
         assert "cmd" in shell_parameter
         assert "unix" not in shell_parameter
     else:
+        assert "override the unix shell only when needed" in shell_parameter
+        assert "omit to use bash by default" in shell_parameter
         assert "unix" in shell_parameter
         assert "powershell" not in shell_parameter
         assert "cmd" not in shell_parameter

--- a/tests/tools/test_tool_descriptions.py
+++ b/tests/tools/test_tool_descriptions.py
@@ -1,3 +1,6 @@
+import sys
+from unittest.mock import patch
+
 from nanobot.agent.tools.apply_patch import ApplyPatchTool
 from nanobot.agent.tools.exec_session import ListExecSessionsTool, WriteStdinTool
 from nanobot.agent.tools.filesystem import EditFileTool, ReadFileTool, WriteFileTool
@@ -44,3 +47,26 @@ def test_coding_tool_descriptions_steer_discovery_and_shell_usage() -> None:
     assert "do not use this to start new commands" in write_stdin
     assert "wait_for" in write_stdin
     assert "recover a session_id" in list_sessions
+
+
+def test_exec_tool_shell_guidance_matches_platform() -> None:
+    with patch("nanobot.agent.tools.shell._IS_WINDOWS", False):
+        unix_description = ExecTool().description.lower()
+    assert "on unix" in unix_description
+    assert "powershell" not in unix_description
+    assert "cmd-specific" not in unix_description
+
+    with patch("nanobot.agent.tools.shell._IS_WINDOWS", True):
+        windows_description = ExecTool().description.lower()
+    assert "powershell syntax" in windows_description
+    assert "shell='cmd'" in windows_description
+
+    shell_parameter = ExecTool().parameters["properties"]["shell"]["description"].lower()
+    if sys.platform == "win32":
+        assert "powershell" in shell_parameter
+        assert "cmd" in shell_parameter
+        assert "unix" not in shell_parameter
+    else:
+        assert "unix" in shell_parameter
+        assert "powershell" not in shell_parameter
+        assert "cmd" not in shell_parameter


### PR DESCRIPTION
## Summary

Fixes #4544 — single-line commands on Windows were routed through `cmd.exe` while multi-line commands used PowerShell. This caused:

- Cross-drive `cd` silently failing (`cmd` needs `cd /d`)
- POSIX-style `$VAR` / `$(...)` staying literal under `cmd.exe`
- Behavior diverging based on whether the command contained a newline
- The `shell` parameter being rejected on Windows

## Changes

### `nanobot/agent/tools/shell.py`

- Route Windows commands through PowerShell by default, preferring `pwsh` when available and falling back to Windows PowerShell.
- Keep `cmd.exe` available through the explicit `shell="cmd"` escape hatch, launched as the resolved `cmd.exe /c <command>`.
- Accept `shell` on Windows for `powershell`, `pwsh`, and `cmd`, while rejecting unsupported shells.
- Tailor exec tool guidance by platform so Unix tool descriptions do not mention PowerShell/cmd options.

### Tests

- Cover the new Windows default for single-line and multi-line commands.
- Cover explicit `shell="cmd"` routing through `cmd.exe /c`.
- Cover Windows shell allowlist rejection.
- Cover platform-specific exec tool description/schema guidance.
- Add a real Windows `pwsh` smoke test for `echo before && echo after`.

## Verification

- GitHub Actions — all checks passing
- `uv run --extra dev python .verify/pr-4545-platform-description/consumer_exec_tool_schema.py` — pass
- `uv run --extra dev python -m pytest tests/tools/test_tool_descriptions.py tests/tools/test_exec_platform.py -q` — 42 passed
- `uv run --extra dev python -m pytest tests/tools/test_exec_platform.py tests/tools/test_tool_descriptions.py tests/tools/test_exec_session_tools.py tests/tools/test_exec_security.py tests/agent/test_workspace_scope.py -q` — 128 passed, 1 skipped
- Real Windows `shell="cmd"` smoke via `ExecTool.execute(command="echo cmd-ok", shell="cmd")` — pass
- `ruff check nanobot/agent/tools/shell.py tests/tools/test_tool_descriptions.py tests/tools/test_exec_platform.py` — pass
- Previous full tools run: `uv run --extra dev python -m pytest tests/tools -q` — 571 passed, 22 skipped