### PR TITLE
fix(restart): use subprocess.Popen + sys.exit on Windows instead of os.execv

### DIFF
--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import subprocess
 import sys
 import time
 from contextlib import suppress
@@ -138,7 +139,7 @@ async def cmd_stop(ctx: CommandContext) -> OutboundMessage:
 
 
 async def cmd_restart(ctx: CommandContext) -> OutboundMessage:
-    """Restart the process in-place via os.execv."""
+    """Restart the process."""
     msg = ctx.msg
     set_restart_notice_to_env(
         channel=msg.channel,
@@ -148,7 +149,18 @@ async def cmd_restart(ctx: CommandContext) -> OutboundMessage:
 
     async def _do_restart():
         await asyncio.sleep(1)
-        os.execv(sys.executable, [sys.executable, "-m", "nanobot"] + sys.argv[1:])
+        if sys.platform == "win32":
+            # os.execv on Windows confuses service managers (nssm/winsw)
+            # because it spawns a new process instead of replacing the
+            # image.  Spawn a detached child and exit cleanly so service
+            # managers see a normal exit and can restart per their config.
+            subprocess.Popen(
+                [sys.executable, "-m", "nanobot"] + sys.argv[1:],
+                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+            )
+            sys.exit(0)
+        else:
+            os.execv(sys.executable, [sys.executable, "-m", "nanobot"] + sys.argv[1:])
 
     asyncio.create_task(_do_restart())
     return OutboundMessage(


### PR DESCRIPTION
@
## Summary

Fixes #4513 — `/restart` on Windows under service managers (nssm, winsw) causes inconsistent process state.

`os.execv` on Windows does not truly replace the process image — it spawns a new process and terminates the old one. This confuses Windows service managers:

- **"Restart application" on exit**: nssm tries to restart → two nanobot instances fight for the same port
- **"Stop service" on exit**: service shows "stopped" but nanobot is still running

## Change

In `nanobot/command/builtin.py`, `cmd_restart()` now uses a platform-aware restart:

- **Windows**: `subprocess.Popen` with `CREATE_NEW_PROCESS_GROUP` + `sys.exit(0)` — clean exit lets the service manager see a normal termination
- **Unix**: unchanged, continues to use `os.execv`

## Verification

- `ruff check nanobot/command/builtin.py` — clean
- `pytest tests/command/` — 39 passed
@