### PR TITLE
feat(api): require api_key when binding to all interfaces (parity with WS gateway)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -107,6 +107,7 @@ File operations have path traversal protection, but:
 **API Calls:**
 - All external API calls use HTTPS by default
 - Timeouts are configured to prevent hanging requests
+- The OpenAI-compatible API server must set `api.api_key` when binding to `0.0.0.0` or `::`; otherwise startup fails to prevent unauthenticated network access
 - Consider using a firewall to restrict outbound connections if needed
 
 **WhatsApp Bridge:**

--- a/docs/openai-api.md
+++ b/docs/openai-api.md
@@ -12,6 +12,32 @@ Run the CLI check first. If `nanobot agent -m "Hello!"` fails, fix provider or c
 
 For setup help, see [`quick-start.md`](./quick-start.md), [`providers.md`](./providers.md), and [`troubleshooting.md`](./troubleshooting.md).
 
+## Authentication
+
+Local-only `127.0.0.1` usage does not require an API key. If you bind the API
+server to all interfaces with `api.host: "0.0.0.0"` or `"::"`, nanobot requires
+`api.apiKey`; otherwise startup fails to avoid exposing an unauthenticated agent
+endpoint on the network.
+
+```json
+{
+  "api": {
+    "host": "0.0.0.0",
+    "port": 8900,
+    "apiKey": "${NANOBOT_API_KEY}"
+  }
+}
+```
+
+When `api.apiKey` is set, send it as a Bearer token on API routes. The health
+endpoint remains unauthenticated so local probes and load balancers can still
+check process health.
+
+```bash
+curl http://127.0.0.1:8900/v1/models \
+  -H "Authorization: Bearer $NANOBOT_API_KEY"
+```
+
 ## Behavior
 
 - Session isolation: pass `"session_id"` in the request body to isolate conversations; omit for a shared default session (`api:default`)

--- a/nanobot/api/server.py
+++ b/nanobot/api/server.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hmac
 import json as _json
 import time
 import uuid
@@ -392,7 +393,10 @@ async def handle_health(request: web.Request) -> web.Response:
 
 
 def create_app(
-    agent_loop, model_name: str = "nanobot", request_timeout: float = 120.0
+    agent_loop,
+    model_name: str = "nanobot",
+    request_timeout: float = 120.0,
+    api_key: str = "",
 ) -> web.Application:
     """Create the aiohttp application.
 
@@ -400,12 +404,34 @@ def create_app(
         agent_loop: An initialized AgentLoop instance.
         model_name: Model name reported in responses.
         request_timeout: Per-request timeout in seconds.
+        api_key: Optional API key for Bearer-token authentication.
     """
     app = web.Application(client_max_size=20 * 1024 * 1024)  # 20MB for base64 images
     app["agent_loop"] = agent_loop
     app["model_name"] = model_name
     app["request_timeout"] = request_timeout
     app["session_locks"] = {}  # per-user locks, keyed by session_key
+
+    @web.middleware
+    async def auth_middleware(request: web.Request, handler) -> web.StreamResponse:
+        if not api_key:
+            return await handler(request)
+        # Allow unauthenticated health checks.
+        if request.path == "/health":
+            return await handler(request)
+        auth = request.headers.get("Authorization", "")
+        if not auth.startswith("Bearer "):
+            return web.json_response(
+                {"error": "Missing Authorization header. Use: Bearer <api_key>"},
+                status=401,
+            )
+        if not hmac.compare_digest(auth[len("Bearer "):], api_key):
+            return web.json_response(
+                {"error": "Invalid API key"}, status=401,
+            )
+        return await handler(request)
+
+    app.middlewares.append(auth_middleware)
 
     app.router.add_post("/v1/chat/completions", handle_chat_completions)
     app.router.add_get("/v1/models", handle_models)

--- a/nanobot/api/server.py
+++ b/nanobot/api/server.py
@@ -421,14 +421,9 @@ def create_app(
             return await handler(request)
         auth = request.headers.get("Authorization", "")
         if not auth.startswith("Bearer "):
-            return web.json_response(
-                {"error": "Missing Authorization header. Use: Bearer <api_key>"},
-                status=401,
-            )
+            return _error_json(401, "Missing Authorization header. Use: Bearer <api_key>")
         if not hmac.compare_digest(auth[len("Bearer "):], api_key):
-            return web.json_response(
-                {"error": "Invalid API key"}, status=401,
-            )
+            return _error_json(401, "Invalid API key")
         return await handler(request)
 
     app.middlewares.append(auth_middleware)

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -798,14 +798,24 @@ def serve(
     console.print(f"  [cyan]Model[/cyan]    : {model_name}{preset_tag}")
     console.print("  [cyan]Session[/cyan]  : api:default")
     console.print(f"  [cyan]Timeout[/cyan]  : {timeout}s")
+    api_key = api_cfg.api_key.strip() if api_cfg.api_key else ""
     if host in {"0.0.0.0", "::"}:
+        if not api_key:
+            console.print(
+                "[red]Error: host is 0.0.0.0 (all interfaces) but api_key is not set. "
+                "Set api.api_key in config to prevent unauthenticated access.[/red]"
+            )
+            raise typer.Exit(1)
         console.print(
-            "[yellow]Warning:[/yellow] API is bound to all interfaces. "
-            "Only do this behind a trusted network boundary, firewall, or reverse proxy."
+            "[yellow]API is bound to all interfaces "
+            "(authentication required).[/yellow]"
         )
     console.print()
 
-    api_app = create_app(agent_loop, model_name=model_name, request_timeout=timeout)
+    api_app = create_app(
+        agent_loop, model_name=model_name, request_timeout=timeout,
+        api_key=api_key,
+    )
 
     async def on_startup(_app):
         await agent_loop._connect_mcp()

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -310,6 +310,18 @@ class ApiConfig(Base):
     host: str = "127.0.0.1"  # Safer default: local-only bind.
     port: int = 8900
     timeout: float = 120.0  # Per-request timeout in seconds.
+    api_key: str = Field(default="", repr=False)
+
+    @model_validator(mode="after")
+    def wildcard_host_requires_auth(self) -> "ApiConfig":
+        if self.host not in ("0.0.0.0", "::"):
+            return self
+        if self.api_key.strip():
+            return self
+        raise ValueError(
+            "host is 0.0.0.0 (all interfaces) but api_key is not set "
+            "- set api.api_key to prevent unauthenticated access"
+        )
 
 
 class GatewayConfig(Base):

--- a/tests/agent/test_onboard_logic.py
+++ b/tests/agent/test_onboard_logic.py
@@ -853,10 +853,11 @@ class TestApiServerRegistration:
         config = Config()
         from nanobot.config.schema import ApiConfig
 
-        new_api = ApiConfig(host="0.0.0.0", port=9999)
+        new_api = ApiConfig(host="0.0.0.0", port=9999, api_key="secret")
         _SETTINGS_SETTER["API Server"](config, new_api)
         assert config.api.host == "0.0.0.0"
         assert config.api.port == 9999
+        assert config.api.api_key == "secret"
 
 
 class TestMainMenuUpdate:

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1364,10 +1364,16 @@ def _patch_serve_runtime(monkeypatch, config: Config, seen: dict[str, object]) -
         async def close_mcp(self) -> None:
             return None
 
-    def _fake_create_app(agent_loop, model_name: str, request_timeout: float):
+    def _fake_create_app(
+        agent_loop,
+        model_name: str,
+        request_timeout: float,
+        api_key: str = "",
+    ):
         seen["agent_loop"] = agent_loop
         seen["model_name"] = model_name
         seen["request_timeout"] = request_timeout
+        seen["api_key"] = api_key
         return _FakeApiApp()
 
     def _fake_run_app(api_app, host: str, port: int, print):
@@ -2310,6 +2316,7 @@ def test_serve_uses_api_config_defaults_and_workspace_override(
     assert seen["host"] == "127.0.0.2"
     assert seen["port"] == 18900
     assert seen["request_timeout"] == 45.0
+    assert seen["api_key"] == ""
 
 
 def test_serve_cli_options_override_api_config(monkeypatch, tmp_path: Path) -> None:
@@ -2341,6 +2348,35 @@ def test_serve_cli_options_override_api_config(monkeypatch, tmp_path: Path) -> N
     assert seen["host"] == "127.0.0.1"
     assert seen["port"] == 18901
     assert seen["request_timeout"] == 46.0
+    assert seen["api_key"] == ""
+
+
+def test_serve_passes_configured_api_key(monkeypatch, tmp_path: Path) -> None:
+    config_file = _write_instance_config(tmp_path)
+    config = Config()
+    config.api.api_key = " secret "
+    seen: dict[str, object] = {}
+
+    _patch_serve_runtime(monkeypatch, config, seen)
+
+    result = runner.invoke(app, ["serve", "--config", str(config_file)])
+
+    assert result.exit_code == 0
+    assert seen["api_key"] == "secret"
+
+
+def test_serve_rejects_wildcard_host_without_api_key(monkeypatch, tmp_path: Path) -> None:
+    config_file = _write_instance_config(tmp_path)
+    config = Config()
+    seen: dict[str, object] = {}
+
+    _patch_serve_runtime(monkeypatch, config, seen)
+
+    result = runner.invoke(app, ["serve", "--config", str(config_file), "--host", "0.0.0.0"])
+
+    assert result.exit_code == 1
+    assert "api_key is not set" in result.stdout
+    assert "api_app" not in seen
 
 
 def test_channels_login_requires_channel_name() -> None:

--- a/tests/config/test_config_load_errors.py
+++ b/tests/config/test_config_load_errors.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from nanobot.config.loader import load_config
+from nanobot.config.schema import ApiConfig
 
 
 def test_load_config_missing_file_uses_defaults(tmp_path) -> None:
@@ -28,3 +29,16 @@ def test_load_config_invalid_schema_fails_fast(tmp_path) -> None:
 
     with pytest.raises(ValueError, match="Failed to load config"):
         load_config(config_path)
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "::"])
+def test_api_config_requires_key_for_wildcard_hosts(host: str) -> None:
+    with pytest.raises(ValueError, match="api_key is not set"):
+        ApiConfig(host=host)
+
+
+def test_api_config_allows_wildcard_host_with_key() -> None:
+    config = ApiConfig(host="0.0.0.0", api_key="secret")
+
+    assert config.host == "0.0.0.0"
+    assert config.api_key == "secret"

--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -110,6 +110,25 @@ async def test_missing_messages_returns_400(aiohttp_client, app) -> None:
 
 @pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")
 @pytest.mark.asyncio
+async def test_api_key_protects_api_routes_but_not_health(aiohttp_client, mock_agent) -> None:
+    app = create_app(mock_agent, model_name="test-model", api_key="secret")
+    client = await aiohttp_client(app)
+
+    health = await client.get("/health")
+    missing = await client.get("/v1/models")
+    wrong = await client.get("/v1/models", headers={"Authorization": "Bearer wrong"})
+    ok = await client.get("/v1/models", headers={"Authorization": "Bearer secret"})
+
+    assert health.status == 200
+    assert missing.status == 401
+    assert wrong.status == 401
+    assert ok.status == 200
+    assert (await missing.json())["error"]["message"].startswith("Missing Authorization")
+    assert (await wrong.json())["error"]["message"] == "Invalid API key"
+
+
+@pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")
+@pytest.mark.asyncio
 async def test_no_user_message_returns_400(aiohttp_client, app) -> None:
     client = await aiohttp_client(app)
     resp = await client.post(


### PR DESCRIPTION
@
## Summary

Fixes #4490 — brings the OpenAI-compatible API server to auth parity with the WebSocket gateway.

The API server had no authentication while the WS gateway already refuses wildcard binds without a token. When bound to `0.0.0.0`, anyone could drive the agent.

## Changes

### `nanobot/config/schema.py`
- Added `api_key` field to `ApiConfig` (default empty, `repr=False`)
- Added `wildcard_host_requires_auth` model_validator mirroring the WS gateway pattern

### `nanobot/api/server.py`
- Added `api_key` parameter to `create_app()`
- Added Bearer-token auth middleware — returns 401 for missing/invalid tokens
- `/health` endpoint remains unauthenticated

### `nanobot/cli/commands.py`
- Replaced wildcard-host warning with hard error when `api_key` is unset
- Passes `api_key` from config to `create_app()`

## Verification
- `ruff check` — clean on all three files
- `pytest tests/test_openai_api.py` — 21 passed

## ⚠️ Migration Note

**Breaking change:** Users who bind the API server to `0.0.0.0` or `::` must now set an `api_key` in their config:

```toml
[api]
host = "0.0.0.0"
api_key = "your-secret-token"
```

Without it, startup will fail with a `ValueError`. Localhost binds (`127.0.0.1`, `::1`) are unaffected.
@