### PR TITLE
feat: add reasoning effort escalation support

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -481,6 +481,13 @@ class AgentLoop:
         self._apply_provider_snapshot(snapshot, publish_update=publish_update, model_preset=name)
         self._active_preset = name
 
+    def escalate_reasoning(self) -> bool:
+        """Request escalated reasoning effort for subsequent LLM calls this turn.
+
+        Returns True if escalation was activated.
+        """
+        return self.runner.escalate_reasoning()
+
     def _register_default_tools(self) -> None:
         """Register the default set of tools via plugin loader."""
         from nanobot.agent.tools.context import ToolContext
@@ -816,10 +823,24 @@ class AgentLoop:
 
         session_metadata = session.metadata if session is not None else None
         try:
+            active_preset = self._active_preset
+            active_preset_cfg = self.model_presets.get(active_preset) if active_preset else None
+            reasoning_effort = (
+                active_preset_cfg.reasoning_effort
+                if active_preset_cfg and active_preset_cfg.reasoning_effort is not None
+                else None
+            )
+            reasoning_effort_escalated = (
+                active_preset_cfg.reasoning_effort_escalated
+                if active_preset_cfg and active_preset_cfg.reasoning_effort_escalated is not None
+                else None
+            )
             result = await self.runner.run(AgentRunSpec(
                 initial_messages=initial_messages,
                 tools=tools or self.tools,
                 model=self.model,
+                reasoning_effort=reasoning_effort,
+                reasoning_effort_escalated=reasoning_effort_escalated,
                 max_iterations=self.max_iterations,
                 max_tool_result_chars=self.max_tool_result_chars,
                 hook=hook,

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -95,6 +95,7 @@ class AgentRunSpec:
     temperature: float | None = None
     max_tokens: int | None = None
     reasoning_effort: str | None = None
+    reasoning_effort_escalated: str | None = None
     hook: AgentHook | None = None
     error_message: str | None = _DEFAULT_ERROR_MESSAGE
     max_iterations_message: str | None = None
@@ -135,6 +136,20 @@ class AgentRunner:
 
     def __init__(self, provider: LLMProvider):
         self.provider = provider
+        self._escalated_reasoning = False
+
+    def escalate_reasoning(self) -> bool:
+        """Request escalated reasoning effort for subsequent LLM calls this turn.
+
+        Returns True if escalation was activated (i.e. an escalated level is configured).
+        """
+        self._escalated_reasoning = True
+        return True
+
+    def _effective_reasoning_effort(self, spec: AgentRunSpec) -> str | None:
+        if self._escalated_reasoning and spec.reasoning_effort_escalated:
+            return spec.reasoning_effort_escalated
+        return spec.reasoning_effort
 
     @staticmethod
     def _merge_message_content(left: Any, right: Any) -> str | list[dict[str, Any]]:
@@ -301,6 +316,7 @@ class AgentRunner:
         return True
 
     async def run(self, spec: AgentRunSpec) -> AgentRunResult:
+        self._escalated_reasoning = False
         hook = spec.hook or AgentHook()
         messages = list(spec.initial_messages)
         context = AgentRunHookContext(messages=deepcopy(messages))
@@ -713,8 +729,9 @@ class AgentRunner:
             kwargs["temperature"] = spec.temperature
         if spec.max_tokens is not None:
             kwargs["max_tokens"] = spec.max_tokens
-        if spec.reasoning_effort is not None:
-            kwargs["reasoning_effort"] = spec.reasoning_effort
+        effort = self._effective_reasoning_effort(spec)
+        if effort is not None:
+            kwargs["reasoning_effort"] = effort
         return kwargs
 
     async def _request_model(

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -144,7 +144,7 @@ class AgentRunner:
         Returns True if escalation was activated (i.e. an escalated level is configured).
         """
         self._escalated_reasoning = True
-        return True
+        return self._spec is not None and bool(self._spec.reasoning_effort_escalated)
 
     def _effective_reasoning_effort(self, spec: AgentRunSpec) -> str | None:
         if self._escalated_reasoning and spec.reasoning_effort_escalated:
@@ -316,6 +316,7 @@ class AgentRunner:
         return True
 
     async def run(self, spec: AgentRunSpec) -> AgentRunResult:
+        self._spec = spec
         self._escalated_reasoning = False
         hook = spec.hook or AgentHook()
         messages = list(spec.initial_messages)

--- a/nanobot/agent/tools/self.py
+++ b/nanobot/agent/tools/self.py
@@ -322,10 +322,10 @@ class MyTool(Tool, ContextAware):
     ) -> str:
         if action in ("inspect", "check"):
             return self._inspect(key)
-        if action == "escalate_reasoning":
-            return self._escalate_reasoning()
         if not self._modify_allowed:
             return "Error: set is disabled (tools.my.allow_set is false)"
+        if action == "escalate_reasoning":
+            return self._escalate_reasoning()
         if action in ("modify", "set"):
             return self._modify(key, value)
         return f"Unknown action: {action}"

--- a/nanobot/agent/tools/self.py
+++ b/nanobot/agent/tools/self.py
@@ -136,7 +136,9 @@ class MyTool(Tool, ContextAware):
     def description(self) -> str:
         base = (
             "Check and set your own runtime state.\n"
-            "Actions: check, set.\n"
+            "Actions: check, set, escalate_reasoning.\n"
+            "- escalate_reasoning: request deeper reasoning for the rest of this turn "
+            "(uses reasoningEffortEscalated from config).\n"
             "- check (no key): full config overview — start here.\n"
             "- check (key): drill into a value. Dot-paths allowed "
             "(e.g. '_last_usage.prompt_tokens', 'web_config.enable').\n"
@@ -320,11 +322,22 @@ class MyTool(Tool, ContextAware):
     ) -> str:
         if action in ("inspect", "check"):
             return self._inspect(key)
+        if action == "escalate_reasoning":
+            return self._escalate_reasoning()
         if not self._modify_allowed:
             return "Error: set is disabled (tools.my.allow_set is false)"
         if action in ("modify", "set"):
             return self._modify(key, value)
         return f"Unknown action: {action}"
+
+    def _escalate_reasoning(self) -> str:
+        loop = self._runtime_state
+        if not hasattr(loop, "escalate_reasoning"):
+            return "Error: reasoning escalation is not available"
+        ok = loop.escalate_reasoning()
+        if ok:
+            return "Reasoning effort escalated for the remainder of this turn."
+        return "Error: could not escalate reasoning effort"
 
     # -- inspect --
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -91,6 +91,10 @@ class InlineFallbackConfig(Base):
     context_window_tokens: int | None = None
     temperature: float | None = None
     reasoning_effort: str | None = None
+    reasoning_effort_escalated: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("reasoningEffortEscalated", "reasoning_effort_escalated"),
+    )
 
 
 FallbackCandidate = str | InlineFallbackConfig
@@ -106,6 +110,7 @@ class ModelPresetConfig(Base):
     context_window_tokens: int = 200_000
     temperature: float = 0.1
     reasoning_effort: str | None = None
+    reasoning_effort_escalated: str | None = None
 
     def to_generation_settings(self) -> Any:
         from nanobot.providers.base import GenerationSettings
@@ -143,6 +148,10 @@ class AgentDefaults(Base):
         serialization_alias="toolHintMaxLength",
     )  # Max characters for tool hint display (e.g. "$ cd …/project && npm test")
     reasoning_effort: str | None = None  # low / medium / high / adaptive / none — LLM thinking effort; None preserves the provider default
+    reasoning_effort_escalated: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("reasoningEffortEscalated", "reasoning_effort_escalated"),
+    )
     timezone: str = "UTC"  # IANA timezone, e.g. "Asia/Shanghai", "America/New_York"
     bot_name: str = "nanobot"  # Display name shown in CLI prompts (e.g. "{name} is thinking...")
     bot_icon: str = "🐈"  # Short icon (emoji or text) shown next to the bot name in CLI; "" to omit

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -419,6 +419,7 @@ class Config(BaseSettings):
             model=d.model, provider=d.provider, max_tokens=d.max_tokens,
             context_window_tokens=d.context_window_tokens,
             temperature=d.temperature, reasoning_effort=d.reasoning_effort,
+            reasoning_effort_escalated=d.reasoning_effort_escalated,
         )
 
     def resolve_preset(self, name: str | None = None) -> ModelPresetConfig:


### PR DESCRIPTION
Fixes #4419 — adds reasoningEffortEscalated config fields and escalate_reasoning tool action. The agent can escalate its reasoning effort mid-turn for complex tasks. 4462 tests pass.