### PR TITLE
feat(heartbeat): add channel/chat_id config for fixed delivery target

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1007,9 +1007,14 @@ def _run_gateway(
                 logger.debug("Heartbeat: HEARTBEAT.md has no active tasks")
                 return None
 
-            channel, chat_id = _pick_heartbeat_target()
-            if channel == "cli":
-                return None
+            # Use the configured fixed channel when set, otherwise pick the
+            # most recently active (legacy behaviour).
+            if hb_cfg.channel and hb_cfg.chat_id:
+                channel, chat_id = hb_cfg.channel, hb_cfg.chat_id
+            else:
+                channel, chat_id = _pick_heartbeat_target()
+                if channel == "cli":
+                    return None
 
             prompt = (
                 _HEARTBEAT_PREAMBLE

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -302,6 +302,8 @@ class HeartbeatConfig(Base):
     enabled: bool = True
     interval_s: int = 30 * 60  # 30 minutes
     keep_recent_messages: int = 8
+    channel: str = ""  # Fixed delivery channel (empty = most recently active)
+    chat_id: str = ""  # Fixed delivery chat_id (empty = most recently active)
 
 
 class ApiConfig(Base):


### PR DESCRIPTION
Fixes #4418 — adds optional channel and chat_id to HeartbeatConfig for fixed delivery routing instead of auto-picking the most recently active channel.