### PR TITLE
fix(memory): block Dream from creating duplicate skills via write guard

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -506,6 +506,102 @@ class MemoryStore:
         prompt = f"{template}\n\n## Conversation History\n{history_text}"
         return (prompt, batch[-1]["cursor"])
 
+
+class _DreamSkillWriteGuard:
+    """Wrapper that blocks Dream from creating duplicate skill directories.
+
+    When Dream tries to write ``skills/<name>/SKILL.md`` and a similar skill
+    already exists, the guard returns an error directing Dream to edit the
+    existing skill instead.
+    """
+
+    def __init__(self, inner: Any, skills_dir: Path) -> None:
+        self._inner = inner
+        self._skills_dir = skills_dir
+
+    # --- delegate Tool interface to inner ----------------------------------
+    @property
+    def name(self) -> str:
+        return self._inner.name
+
+    @property
+    def description(self) -> str:
+        return self._inner.description
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return self._inner.parameters
+
+    @property
+    def read_only(self) -> bool:
+        return self._inner.read_only
+
+    @property
+    def concurrency_safe(self) -> bool:
+        return self._inner.concurrency_safe
+
+    @property
+    def exclusive(self) -> bool:
+        return self._inner.exclusive
+
+    _scopes = {"core", "subagent", "memory"}
+
+    async def execute(self, **kwargs: Any) -> str:
+        path: str | None = kwargs.get("path")
+        if path and self._is_skill_creation(path):
+            conflict = self._check_conflict(path)
+            if conflict:
+                return (
+                    f"Error: A similar skill '{conflict}' already exists at "
+                    f"skills/{conflict}/SKILL.md. Do NOT create a new skill. "
+                    f"Instead, read the existing skill with read_file and merge "
+                    f"your changes into it using edit_file or apply_patch."
+                )
+        return await self._inner.execute(**kwargs)
+
+    def _is_skill_creation(self, path: str) -> bool:
+        """True if *path* targets a SKILL.md inside a skills/ subdirectory."""
+        parts = Path(path).parts
+        return (
+            len(parts) >= 3
+            and parts[0] == "skills"
+            and parts[-1] == "SKILL.md"
+        )
+
+    def _check_conflict(self, path: str) -> str | None:
+        new_name = Path(path).parts[1]
+        existing = _DreamSkillWriteGuard._existing_skill_names(self._skills_dir)
+        return _DreamSkillWriteGuard._skill_name_conflicts(new_name, existing)
+
+    @staticmethod
+    def _existing_skill_names(skills_dir: Path) -> list[str]:
+        """Return lowercase names of existing workspace skills."""
+        if not skills_dir.is_dir():
+            return []
+        return [
+            d.name.lower()
+            for d in skills_dir.iterdir()
+            if d.is_dir() and (d / "SKILL.md").is_file()
+        ]
+
+    @staticmethod
+    def _skill_name_conflicts(new_name: str, existing: list[str]) -> str | None:
+        """Return the existing skill name if *new_name* would duplicate one."""
+        low = new_name.lower()
+        for name in existing:
+            if low == name:
+                return name
+            # prefix/suffix: "deploy" matches "deploy-workflow"
+            if low.startswith(name + "-") or name.startswith(low + "-"):
+                return name
+            # word overlap: "web-deploy" matches "deploy-staging"
+            new_words = set(low.replace("_", "-").split("-"))
+            old_words = set(name.replace("_", "-").split("-"))
+            shared = new_words & old_words - {"skill", "tool", "util", "helper"}
+            if len(shared) >= 2:
+                return name
+        return None
+
     def build_dream_tools(self):
         """Build the restricted tool registry used by Dream runs."""
         from nanobot.agent.skills import BUILTIN_SKILLS_DIR
@@ -541,11 +637,17 @@ class MemoryStore:
             extra_write_allowed_files=editable_files,
             file_states=file_states,
         ))
-        tools.register(WriteFileTool(
+
+        # Wrap WriteFileTool with a dedup guard so Dream merges into existing
+        # skills instead of creating redundant siblings.
+        inner_write = WriteFileTool(
             workspace=workspace,
             allowed_dir=skills_dir,
             file_states=file_states,
-        ))
+        )
+        guard = _DreamSkillWriteGuard(inner_write, skills_dir)
+        tools.register(guard)
+
         return tools
 
     @staticmethod

--- a/tests/agent/test_dream_tools.py
+++ b/tests/agent/test_dream_tools.py
@@ -1,7 +1,24 @@
-from nanobot.config.schema import Config
-from nanobot.agent.tools.loader import ToolLoader
+from unittest.mock import AsyncMock
+
+import pytest
+
+from nanobot.agent.memory import _DreamSkillWriteGuard
 from nanobot.agent.tools.context import ToolContext
+from nanobot.agent.tools.loader import ToolLoader
 from nanobot.agent.tools.registry import ToolRegistry
+from nanobot.config.schema import Config
+
+
+class _MockWriteFileTool:
+    name = "write_file"
+    description = "mock write file"
+    parameters = {}
+    read_only = False
+    concurrency_safe = False
+    exclusive = False
+
+    def __init__(self) -> None:
+        self.execute = AsyncMock(return_value="wrote file")
 
 
 def test_tool_loader_scope_memory_only_returns_memory_tools():
@@ -17,3 +34,94 @@ def test_tool_loader_scope_memory_only_returns_memory_tools():
     assert "list_dir" not in names
     assert "exec" not in names
     assert "message" not in names
+
+
+def test_dream_skill_write_guard_is_skill_creation(tmp_path):
+    guard = _DreamSkillWriteGuard(_MockWriteFileTool(), tmp_path / "skills")
+
+    assert guard._is_skill_creation("skills/my-skill/SKILL.md") is True
+    assert guard._is_skill_creation("skills/foo/SKILL.md") is True
+    assert guard._is_skill_creation("SOUL.md") is False
+    assert guard._is_skill_creation("skills/foo/other.md") is False
+    assert guard._is_skill_creation("skills/SKILL.md") is False
+
+
+@pytest.mark.parametrize(
+    ("new_name", "existing", "expected"),
+    [
+        ("my-skill", ["my-skill"], "my-skill"),
+        ("deploy", ["deploy-workflow"], "deploy-workflow"),
+        ("deploy-workflow", ["deploy"], "deploy"),
+        ("unrelated", ["deploy", "test"], None),
+        ("github-deploy-tool", ["github-deploy-staging"], "github-deploy-staging"),
+        ("new-skill", [], None),
+    ],
+)
+def test_dream_skill_write_guard_skill_name_conflicts(new_name, existing, expected):
+    assert _DreamSkillWriteGuard._skill_name_conflicts(new_name, existing) == expected
+
+
+def test_dream_skill_write_guard_existing_skill_names(tmp_path):
+    skills_dir = tmp_path / "skills"
+    (skills_dir / "My-Skill").mkdir(parents=True)
+    (skills_dir / "My-Skill" / "SKILL.md").write_text("# My Skill", encoding="utf-8")
+    (skills_dir / "Other_Skill").mkdir()
+    (skills_dir / "Other_Skill" / "SKILL.md").write_text("# Other Skill", encoding="utf-8")
+    (skills_dir / "draft").mkdir()
+    (skills_dir / "draft" / "notes.md").write_text("not a skill", encoding="utf-8")
+    (skills_dir / "SKILL.md").write_text("not a directory", encoding="utf-8")
+
+    assert sorted(_DreamSkillWriteGuard._existing_skill_names(skills_dir)) == [
+        "my-skill",
+        "other_skill",
+    ]
+
+
+def test_dream_skill_write_guard_existing_skill_names_empty_dir(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+
+    assert _DreamSkillWriteGuard._existing_skill_names(skills_dir) == []
+
+
+def test_dream_skill_write_guard_existing_skill_names_missing_dir(tmp_path):
+    assert _DreamSkillWriteGuard._existing_skill_names(tmp_path / "missing") == []
+
+
+async def test_dream_skill_write_guard_execute_blocks_duplicate_creation(tmp_path):
+    skills_dir = tmp_path / "skills"
+    existing_skill_dir = skills_dir / "existing-skill"
+    existing_skill_dir.mkdir(parents=True)
+    (existing_skill_dir / "SKILL.md").write_text("# Existing Skill", encoding="utf-8")
+    inner = _MockWriteFileTool()
+    guard = _DreamSkillWriteGuard(inner, skills_dir)
+
+    result = await guard.execute(
+        path="skills/existing-skill/SKILL.md",
+        content="# Replacement",
+    )
+
+    inner.execute.assert_not_called()
+    assert "existing-skill" in result
+    assert "Do NOT create a new skill" in result
+
+    result = await guard.execute(
+        path="skills/new-unique-skill/SKILL.md",
+        content="# New Skill",
+    )
+
+    inner.execute.assert_called_once_with(
+        path="skills/new-unique-skill/SKILL.md",
+        content="# New Skill",
+    )
+    assert result == "wrote file"
+
+
+async def test_dream_skill_write_guard_execute_passes_non_skill_paths(tmp_path):
+    inner = _MockWriteFileTool()
+    guard = _DreamSkillWriteGuard(inner, tmp_path / "skills")
+
+    result = await guard.execute(path="SOUL.md", content="updated soul")
+
+    inner.execute.assert_called_once_with(path="SOUL.md", content="updated soul")
+    assert result == "wrote file"


### PR DESCRIPTION
## Summary

Adds a write guard to Dream's tool set that blocks creation of duplicate skill directories. When Dream tries to write `skills/<name>/SKILL.md` and a similar skill already exists, the guard returns an error directing Dream to edit the existing skill instead.

## Problem

Dream sometimes creates new `skills/<name>/SKILL.md` directories even when an existing workspace skill covers the same topic. The Dream template already instructs Dream to check existing skills, but this isn't reliably followed at the prompt level.

## Solution

A `_DreamSkillWriteGuard` wrapper around `WriteFileTool` in `build_dream_tools()` that intercepts skill path writes. Before allowing a write to `skills/*/SKILL.md`, it checks for existing similar skills using:

- **Exact match** (case-insensitive)
- **Prefix/suffix match** — `deploy` matches `deploy-workflow`
- **Word overlap** — `github-deploy-tool` matches `github-deploy-staging` (2+ shared words after splitting on hyphens)

If a match is found, Dream gets an error message telling it to read and merge into the existing skill instead.

## Linked Issue

Fixes #4467

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I searched for existing PRs that might duplicate this one
- [x] I have read the CONTRIBUTING guide
- [x] My code follows the project's code style
- [x] I have added tests that verify the fix
- [x] All new and existing tests pass locally

## How to Test

```bash
# Run the new guard tests
python -m pytest tests/agent/test_dream_tools.py -x -v

# Verify ruff passes
ruff check nanobot/agent/memory.py tests/agent/test_dream_tools.py
```

The guard only applies to Dream tool builds (via `build_dream_tools()`), not regular agent tool builds. It wraps `WriteFileTool` and delegates all non-skill-path writes unchanged.
