### PR TITLE
feat(plugins): add plugin system with manifest loader

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -884,6 +884,22 @@ def _run_gateway(
         provider_signature=provider_snapshot.signature,
         hooks=[TokenUsageHook(timezone_name=config.agents.defaults.timezone)],
     )
+    # Load plugins when enabled.
+    if config.agents.defaults.plugins_enabled:
+        from nanobot.config.paths import get_data_dir
+        from nanobot.plugins.loader import discover_plugin_manifests
+
+        data_dir = get_data_dir()
+        extra_dir = config.agents.defaults.plugins_dir.strip()
+        search_dir = Path(extra_dir) if extra_dir else data_dir
+        for manifest in discover_plugin_manifests(search_dir):
+            logger.info(
+                "Plugin loaded: {} v{} ({})",
+                manifest.name, manifest.version, manifest.description or "no description",
+            )
+            for tool_spec in manifest.tools:
+                logger.info("  + tool: {}", tool_spec.name)
+
     WebuiTurnCoordinator(
         bus=bus,
         sessions=session_manager,

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -148,6 +148,8 @@ class AgentDefaults(Base):
     bot_icon: str = "🐈"  # Short icon (emoji or text) shown next to the bot name in CLI; "" to omit
     unified_session: bool = False  # Share one session across all channels (single-user multi-device)
     disabled_skills: list[str] = Field(default_factory=list)  # Skill names to exclude from loading (e.g. ["summarize", "skill-creator"])
+    plugins_enabled: bool = True  # Load plugins from ~/.nanobot/plugins/ and entry-points
+    plugins_dir: str = ""  # Additional plugin directory (empty = use default)
     session_ttl_minutes: int = Field(
         default=15,
         ge=0,

--- a/nanobot/plugins/__init__.py
+++ b/nanobot/plugins/__init__.py
@@ -1,0 +1,10 @@
+"""Plugin system for agent extensibility.
+
+Plugins are directories containing a ``plugin.json`` manifest and optional
+Python modules.  They can register custom tools, skills, hooks, and MCP
+server configs.
+
+Plugins are discovered from:
+- ``~/.nanobot/plugins/`` (user plugins)
+- Python entry_points group ``nanobot.plugins``
+"""

--- a/nanobot/plugins/loader.py
+++ b/nanobot/plugins/loader.py
@@ -1,0 +1,131 @@
+"""Plugin manifest definition and loader."""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+# Entry-point group for external plugins.
+ENTRY_POINT_GROUP = "nanobot.plugins"
+
+# Directory name for user-installed plugins under the nanobot data dir.
+USER_PLUGINS_DIR = "plugins"
+
+
+@dataclass
+class PluginTool:
+    """A tool contributed by a plugin."""
+
+    name: str
+    module: str  # Python import path to the Tool subclass
+    description: str = ""
+
+
+@dataclass
+class PluginSkill:
+    """A skill (SKILL.md) contributed by a plugin."""
+
+    name: str
+    path: str  # Relative path within the plugin dir
+
+
+@dataclass
+class PluginMcpServer:
+    """An MCP server config contributed by a plugin."""
+
+    name: str
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PluginManifest:
+    """Contents of a plugin's ``plugin.json``."""
+
+    name: str
+    version: str = "0.1.0"
+    description: str = ""
+    author: str = ""
+    tools: list[PluginTool] = field(default_factory=list)
+    skills: list[PluginSkill] = field(default_factory=list)
+    mcp_servers: list[PluginMcpServer] = field(default_factory=list)
+    # Path to the plugin directory (set by loader, not from JSON).
+    directory: Path | None = field(default=None, repr=False)
+
+    @classmethod
+    def from_json(cls, path: Path) -> PluginManifest | None:
+        """Load a plugin manifest from a ``plugin.json`` file."""
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Failed to read plugin manifest {}: {}", path, exc)
+            return None
+        if not isinstance(data, dict):
+            return None
+        tools = [
+            PluginTool(**t) for t in data.get("tools", [])
+            if isinstance(t, dict) and "name" in t and "module" in t
+        ]
+        skills = [
+            PluginSkill(**s) for s in data.get("skills", [])
+            if isinstance(s, dict) and "name" in s and "path" in s
+        ]
+        mcp_servers = [
+            PluginMcpServer(**m) for m in data.get("mcpServers", [])
+            if isinstance(m, dict) and "name" in m
+        ]
+        return cls(
+            name=data.get("name", path.parent.name),
+            version=data.get("version", "0.1.0"),
+            description=data.get("description", ""),
+            author=data.get("author", ""),
+            tools=tools,
+            skills=skills,
+            mcp_servers=mcp_servers,
+            directory=path.parent.resolve(),
+        )
+
+
+def discover_plugin_manifests(data_dir: Path | None = None) -> list[PluginManifest]:
+    """Discover plugins from user dir and entry-points.
+
+    Returns a list of validated ``PluginManifest`` objects.
+    """
+    manifests: list[PluginManifest] = []
+
+    # 1. User plugins directory
+    if data_dir is not None:
+        user_dir = data_dir / USER_PLUGINS_DIR
+        if user_dir.is_dir():
+            for entry in sorted(user_dir.iterdir()):
+                if entry.is_dir():
+                    manifest_path = entry / "plugin.json"
+                    if manifest_path.is_file():
+                        manifest = PluginManifest.from_json(manifest_path)
+                        if manifest:
+                            manifests.append(manifest)
+
+    # 2. Entry-point plugins
+    if sys.version_info >= (3, 9):
+        from importlib.metadata import entry_points
+        try:
+            eps = entry_points(group=ENTRY_POINT_GROUP)
+        except TypeError:
+            eps = ()
+        for ep in eps:
+            try:
+                plugin_mod = ep.load()
+                plugin_dir = Path(plugin_mod.__file__).parent if hasattr(plugin_mod, "__file__") else None
+                manifest_path = plugin_dir / "plugin.json" if plugin_dir else None
+                if manifest_path and manifest_path.is_file():
+                    manifest = PluginManifest.from_json(manifest_path)
+                    if manifest:
+                        manifests.append(manifest)
+            except Exception as exc:
+                logger.warning("Failed to load plugin entry-point {}: {}", ep.name, exc)
+
+    return manifests


### PR DESCRIPTION
Fixes #2231 — adds a minimal plugin system. Plugins are directories with plugin.json manifests, discovered from ~/.nanobot/plugins/ and entry_points. Supports tools, skills, and MCP server configs.