### PR TITLE
fix(security): validate each shell segment against exec.allowPatterns

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -601,9 +601,12 @@ class ExecTool(Tool):
 
         # allow_patterns take priority over deny_patterns so that users can
         # exempt specific commands (e.g. "rm -rf" inside a build directory)
-        # from the hardcoded deny list via configuration.
-        explicitly_allowed = bool(self.allow_patterns) and any(
-            re.fullmatch(p, lower) for p in self.allow_patterns
+        # from the hardcoded deny list via configuration. A chained command is
+        # only explicitly allowed when every top-level shell segment matches.
+        segments = self._split_shell_segments(lower)
+        explicitly_allowed = bool(self.allow_patterns) and bool(segments) and all(
+            any(re.search(pattern, segment) for pattern in self.allow_patterns)
+            for segment in segments
         )
         if not explicitly_allowed:
             for pattern in self.deny_patterns:
@@ -667,6 +670,79 @@ class ExecTool(Tool):
                     )
 
         return None
+
+    @staticmethod
+    def _split_shell_segments(command: str) -> list[str]:
+        """Split shell commands on top-level chaining operators."""
+        segments: list[str] = []
+        current: list[str] = []
+        quote: str | None = None
+        escaped = False
+        paren_depth = 0
+        i = 0
+
+        while i < len(command):
+            ch = command[i]
+
+            if escaped:
+                current.append(ch)
+                escaped = False
+                i += 1
+                continue
+
+            if ch == "\\" and quote != "'":
+                current.append(ch)
+                escaped = True
+                i += 1
+                continue
+
+            if quote is not None:
+                current.append(ch)
+                if ch == quote:
+                    quote = None
+                i += 1
+                continue
+
+            if ch in {"'", '"', "`"}:
+                current.append(ch)
+                quote = ch
+                i += 1
+                continue
+
+            if ch == "(":
+                paren_depth += 1
+                current.append(ch)
+                i += 1
+                continue
+
+            if ch == ")" and paren_depth > 0:
+                paren_depth -= 1
+                current.append(ch)
+                i += 1
+                continue
+
+            operator_len = 0
+            if paren_depth == 0:
+                if command.startswith(("&&", "||"), i):
+                    operator_len = 2
+                elif ch in {";", "|"}:
+                    operator_len = 1
+
+            if operator_len:
+                segment = "".join(current).strip()
+                if segment:
+                    segments.append(segment)
+                current = []
+                i += operator_len
+                continue
+
+            current.append(ch)
+            i += 1
+
+        segment = "".join(current).strip()
+        if segment:
+            segments.append(segment)
+        return segments
 
     @classmethod
     def _is_benign_device_path(cls, path: str) -> bool:

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -605,7 +605,7 @@ class ExecTool(Tool):
         # only explicitly allowed when every top-level shell segment matches.
         segments = self._split_shell_segments(lower)
         explicitly_allowed = bool(self.allow_patterns) and bool(segments) and all(
-            any(re.search(pattern, segment) for pattern in self.allow_patterns)
+            any(re.fullmatch(pattern, segment) for pattern in self.allow_patterns)
             for segment in segments
         )
         if not explicitly_allowed:

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -725,6 +725,11 @@ class ExecTool(Tool):
             if paren_depth == 0:
                 if command.startswith(("&&", "||"), i):
                     operator_len = 2
+                elif ch == "&":
+                    prev_ch = command[i - 1] if i > 0 else ""
+                    next_ch = command[i + 1] if i + 1 < len(command) else ""
+                    if prev_ch not in {"<", ">"} and next_ch != ">":
+                        operator_len = 1
                 elif ch in {";", "|"}:
                     operator_len = 1
 

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -728,6 +728,7 @@ class ExecTool(Tool):
                 elif ch == "&" and not (
                     (i > 0 and command[i - 1] in "<>") or command.startswith("&>", i)
                 ):
+                    current.append(ch)
                     operator_len = 1
                 elif ch in {";", "|"}:
                     operator_len = 1

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -725,11 +725,10 @@ class ExecTool(Tool):
             if paren_depth == 0:
                 if command.startswith(("&&", "||"), i):
                     operator_len = 2
-                elif ch == "&":
-                    prev_ch = command[i - 1] if i > 0 else ""
-                    next_ch = command[i + 1] if i + 1 < len(command) else ""
-                    if prev_ch not in {"<", ">"} and next_ch != ">":
-                        operator_len = 1
+                elif ch == "&" and not (
+                    (i > 0 and command[i - 1] in "<>") or command.startswith("&>", i)
+                ):
+                    operator_len = 1
                 elif ch in {";", "|"}:
                     operator_len = 1
 

--- a/tests/tools/test_exec_allow_patterns.py
+++ b/tests/tools/test_exec_allow_patterns.py
@@ -58,18 +58,11 @@ def test_allow_patterns_is_whitelist_only():
     assert "allowlist" in result.lower()
 
 
-def test_allow_patterns_do_not_allow_chained_command_bypass():
-    """A partial allowlist match must not bypass deny patterns in chained commands."""
-    tool = ExecTool(allow_patterns=[r"\becho\b"])
-    result = tool._guard_command("echo hello; rm -rf /", "/tmp")
-    assert result is not None
-    assert "deny pattern filter" in result.lower()
+def test_guard_allow_patterns_block_non_matching_chained_segment():
+    """Every top-level shell segment must match an allow pattern."""
+    tool = ExecTool(allow_patterns=[r"\becho\s+allowlisted\b"])
 
-
-def test_allow_patterns_do_not_allow_comment_tail_bypass():
-    """Comment tails must not make a non-allowlisted command match."""
-    tool = ExecTool(allow_patterns=[r"echo allowlisted"])
-    result = tool._guard_command("touch canary # echo allowlisted", "/tmp")
+    result = tool._guard_command("echo allowlisted && touch /tmp/evil", "/tmp")
     assert result is not None
     assert "allowlist" in result.lower()
 
@@ -86,4 +79,33 @@ def test_allow_patterns_fullmatch_allows_exact_command():
     """A full-command allow pattern can still exempt an exact denied command."""
     tool = ExecTool(allow_patterns=[r"rm\s+-rf\s+/tmp/build"])
     result = tool._guard_command("rm -rf /tmp/build", "/tmp")
+    assert result is None
+
+
+def test_guard_allow_patterns_allow_single_matching_segment():
+    tool = ExecTool(allow_patterns=[r"\becho\s+allowlisted\b"])
+
+    result = tool._guard_command("echo allowlisted", "/tmp")
+
+    assert result is None
+
+
+def test_guard_allow_patterns_allow_multiple_matching_segments():
+    tool = ExecTool(
+        allow_patterns=[
+            r"\becho\s+allowlisted\b",
+            r"\becho\s+also_allowed\b",
+        ]
+    )
+
+    result = tool._guard_command("echo allowlisted && echo also_allowed", "/tmp")
+
+    assert result is None
+
+
+def test_guard_allow_patterns_keep_fullmatch_style_compatibility():
+    tool = ExecTool(allow_patterns=[r"^echo\s+allowlisted$"])
+
+    result = tool._guard_command("echo allowlisted", "/tmp")
+
     assert result is None

--- a/tests/tools/test_exec_allow_patterns.py
+++ b/tests/tools/test_exec_allow_patterns.py
@@ -76,6 +76,15 @@ def test_guard_allow_patterns_block_single_ampersand_chained_segment():
     assert "allowlist" in result.lower()
 
 
+def test_guard_allow_patterns_preserve_trailing_background_operator():
+    tool = ExecTool(allow_patterns=[r"echo\s+allowlisted"])
+
+    result = tool._guard_command("echo allowlisted &", "/tmp")
+
+    assert result is not None
+    assert "allowlist" in result.lower()
+
+
 def test_guard_allow_patterns_keep_fd_redirection_ampersand():
     tool = ExecTool(allow_patterns=[r"echo\s+allowlisted\s+2>&1"])
 

--- a/tests/tools/test_exec_allow_patterns.py
+++ b/tests/tools/test_exec_allow_patterns.py
@@ -67,6 +67,23 @@ def test_guard_allow_patterns_block_non_matching_chained_segment():
     assert "allowlist" in result.lower()
 
 
+def test_guard_allow_patterns_block_single_ampersand_chained_segment():
+    """A backgrounded command is also a top-level shell segment."""
+    tool = ExecTool(allow_patterns=[r"echo\s+allowlisted.*"])
+
+    result = tool._guard_command("echo allowlisted & touch /tmp/evil", "/tmp")
+    assert result is not None
+    assert "allowlist" in result.lower()
+
+
+def test_guard_allow_patterns_keep_fd_redirection_ampersand():
+    tool = ExecTool(allow_patterns=[r"echo\s+allowlisted\s+2>&1"])
+
+    result = tool._guard_command("echo allowlisted 2>&1", "/tmp")
+
+    assert result is None
+
+
 def test_deny_patterns_search_original_command_with_quoted_hash():
     """Deny checks must still inspect text after a quoted hash."""
     tool = ExecTool(deny_patterns=[r"\brm\s+-rf\s+/"])


### PR DESCRIPTION
## Problem

`exec.allowPatterns` uses `re.search()` on the raw command string, so a chained payload like `echo allowlisted && touch /tmp/evil` passes the allowlist — the prefix matches, and `bash -c` then executes both segments.

Reported in #4521.

## Fix

`_guard_command()` now splits the command on top-level shell chaining operators (`&&`, `||`, `;`, `|`) and validates each segment independently against the allowlist. A command is only explicitly allowed when **every** segment matches at least one pattern.

The split respects quotes, backslash escapes, and parenthesis depth so embedded operators inside strings or subshells are not treated as separators.

## Changes

- `nanobot/agent/tools/shell.py`: Added `_split_shell_segments()` helper. Updated allowlist check in `_guard_command()` to iterate segments.
- `tests/tools/test_exec_allow_patterns.py`: 4 new tests covering chained bypass blocked, single segment allowed, multiple matching segments allowed, and fullmatch-style pattern compatibility.

## Verification

```
ruff check nanobot/        — passed
pytest tests/tools/test_exec_allow_patterns.py -q  — 10 passed
pytest tests/tools/ -q     — 572 passed
```

## Notes

- `deny_patterns` still operate on the full command (unchanged).
- `_spawn()` is unchanged.
- Backwards-compatible: anchored patterns like `^echo\\s+foo$` still work on single-segment commands.