### PR TITLE
fix(webui): clear stuck streaming after reconnect and improve stop reliability

### DIFF
--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -346,11 +346,7 @@ class WebSocketChannel(BaseChannel):
     async def _hydrate_after_subscribe(self, chat_id: str) -> None:
         """Replay goal/run strip state after subscribe (same-process refresh)."""
         await self._maybe_push_active_goal_state(chat_id)
-        t0 = websocket_turn_wall_started_at(chat_id)
-        if t0 is not None:
-            await self.send_goal_status(chat_id, "running", started_at=t0)
-        else:
-            await self.send_goal_status(chat_id, "idle")
+        await self._maybe_push_turn_run_wall_clock(chat_id)
 
     async def _send_event(self, connection: Any, event: str, **fields: Any) -> None:
         """Send a control event (attached, error, ...) to a single connection."""

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -346,7 +346,11 @@ class WebSocketChannel(BaseChannel):
     async def _hydrate_after_subscribe(self, chat_id: str) -> None:
         """Replay goal/run strip state after subscribe (same-process refresh)."""
         await self._maybe_push_active_goal_state(chat_id)
-        await self._maybe_push_turn_run_wall_clock(chat_id)
+        t0 = websocket_turn_wall_started_at(chat_id)
+        if t0 is not None:
+            await self.send_goal_status(chat_id, "running", started_at=t0)
+        else:
+            await self.send_goal_status(chat_id, "idle")
 
     async def _send_event(self, connection: Any, event: str, **fields: Any) -> None:
         """Send a control event (attached, error, ...) to a single connection."""

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -130,6 +130,15 @@ async def cmd_stop(ctx: CommandContext) -> OutboundMessage:
     loop = ctx.loop
     msg = ctx.msg
     total = await loop._cancel_active_tasks(ctx.key)
+    # Also drain pending queue to prevent mid-turn injection deadlock
+    pending = loop._pending_queues.pop(ctx.key, None)
+    if pending is not None:
+        while not pending.empty():
+            try:
+                pending.get_nowait()
+                total += 1
+            except Exception:
+                break
     content = f"Stopped {total} task(s)." if total else "No active task to stop."
     return OutboundMessage(
         channel=msg.channel, chat_id=msg.chat_id, content=content,

--- a/tests/channels/test_websocket_reconnect_idle.py
+++ b/tests/channels/test_websocket_reconnect_idle.py
@@ -1,0 +1,61 @@
+"""Test websocket reconnect pushes idle status when no turn is active."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nanobot.channels.websocket import WebSocketChannel
+
+
+@pytest.mark.asyncio
+async def test_hydrate_after_subscribe_pushes_idle_when_no_turn_active():
+    """Reconnecting client should receive idle status when no turn is running."""
+    channel = WebSocketChannel.__new__(WebSocketChannel)
+    channel.gateway = MagicMock()
+    channel.gateway.session_manager = MagicMock()
+    channel.gateway.session_manager.read_session_file = MagicMock(return_value={})
+    
+    sent_events = []
+    
+    async def mock_send_goal_state(chat_id, blob):
+        sent_events.append(("goal_state", chat_id, blob))
+    
+    async def mock_send_goal_status(chat_id, status, **kwargs):
+        sent_events.append(("goal_status", chat_id, status, kwargs))
+    
+    channel.send_goal_state = mock_send_goal_state
+    channel.send_goal_status = mock_send_goal_status
+    
+    with patch("nanobot.channels.websocket.websocket_turn_wall_started_at", return_value=None):
+        await channel._hydrate_after_subscribe("test-chat")
+    
+    # Should have pushed idle status
+    assert any(e[0] == "goal_status" and e[2] == "idle" for e in sent_events)
+
+
+@pytest.mark.asyncio
+async def test_hydrate_after_subscribe_pushes_running_when_turn_active():
+    """Reconnecting client should receive running status when turn is active."""
+    channel = WebSocketChannel.__new__(WebSocketChannel)
+    channel.gateway = MagicMock()
+    channel.gateway.session_manager = MagicMock()
+    channel.gateway.session_manager.read_session_file = MagicMock(return_value={})
+    
+    sent_events = []
+    
+    async def mock_send_goal_state(chat_id, blob):
+        sent_events.append(("goal_state", chat_id, blob))
+    
+    async def mock_send_goal_status(chat_id, status, **kwargs):
+        sent_events.append(("goal_status", chat_id, status, kwargs))
+    
+    channel.send_goal_state = mock_send_goal_state
+    channel.send_goal_status = mock_send_goal_status
+    
+    with patch("nanobot.channels.websocket.websocket_turn_wall_started_at", return_value=1234567890.0):
+        await channel._hydrate_after_subscribe("test-chat")
+    
+    # Should have pushed running status with started_at
+    running_events = [e for e in sent_events if e[0] == "goal_status" and e[2] == "running"]
+    assert len(running_events) == 1
+    assert running_events[0][3]["started_at"] == 1234567890.0

--- a/tests/channels/test_websocket_reconnect_idle.py
+++ b/tests/channels/test_websocket_reconnect_idle.py
@@ -1,6 +1,6 @@
-"""Test websocket reconnect pushes idle status when no turn is active."""
+"""Test websocket subscribe hydration only replays known active turns."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -8,29 +8,28 @@ from nanobot.channels.websocket import WebSocketChannel
 
 
 @pytest.mark.asyncio
-async def test_hydrate_after_subscribe_pushes_idle_when_no_turn_active():
-    """Reconnecting client should receive idle status when no turn is running."""
+async def test_hydrate_after_subscribe_is_quiet_when_no_turn_active():
+    """Subscribe hydration must not inject an idle event into normal message order."""
     channel = WebSocketChannel.__new__(WebSocketChannel)
     channel.gateway = MagicMock()
     channel.gateway.session_manager = MagicMock()
     channel.gateway.session_manager.read_session_file = MagicMock(return_value={})
-    
+
     sent_events = []
-    
+
     async def mock_send_goal_state(chat_id, blob):
         sent_events.append(("goal_state", chat_id, blob))
-    
+
     async def mock_send_goal_status(chat_id, status, **kwargs):
         sent_events.append(("goal_status", chat_id, status, kwargs))
-    
+
     channel.send_goal_state = mock_send_goal_state
     channel.send_goal_status = mock_send_goal_status
-    
+
     with patch("nanobot.channels.websocket.websocket_turn_wall_started_at", return_value=None):
         await channel._hydrate_after_subscribe("test-chat")
-    
-    # Should have pushed idle status
-    assert any(e[0] == "goal_status" and e[2] == "idle" for e in sent_events)
+
+    assert sent_events == []
 
 
 @pytest.mark.asyncio
@@ -40,22 +39,21 @@ async def test_hydrate_after_subscribe_pushes_running_when_turn_active():
     channel.gateway = MagicMock()
     channel.gateway.session_manager = MagicMock()
     channel.gateway.session_manager.read_session_file = MagicMock(return_value={})
-    
+
     sent_events = []
-    
+
     async def mock_send_goal_state(chat_id, blob):
         sent_events.append(("goal_state", chat_id, blob))
-    
+
     async def mock_send_goal_status(chat_id, status, **kwargs):
         sent_events.append(("goal_status", chat_id, status, kwargs))
-    
+
     channel.send_goal_state = mock_send_goal_state
     channel.send_goal_status = mock_send_goal_status
-    
+
     with patch("nanobot.channels.websocket.websocket_turn_wall_started_at", return_value=1234567890.0):
         await channel._hydrate_after_subscribe("test-chat")
-    
-    # Should have pushed running status with started_at
+
     running_events = [e for e in sent_events if e[0] == "goal_status" and e[2] == "running"]
     assert len(running_events) == 1
     assert running_events[0][3]["started_at"] == 1234567890.0

--- a/tests/command/test_stop_pending_queue.py
+++ b/tests/command/test_stop_pending_queue.py
@@ -16,12 +16,12 @@ async def test_cmd_stop_drains_pending_queue():
     mock_loop = MagicMock()
     mock_loop._cancel_active_tasks = AsyncMock(return_value=1)
     mock_loop._pending_queues = {}
-    
+
     pending = asyncio.Queue()
     await pending.put("msg1")
     await pending.put("msg2")
     mock_loop._pending_queues["test-session"] = pending
-    
+
     ctx = CommandContext(
         msg=MagicMock(channel="websocket", chat_id="test-chat", metadata={}),
         session=None,
@@ -29,9 +29,9 @@ async def test_cmd_stop_drains_pending_queue():
         raw="/stop",
         loop=mock_loop,
     )
-    
+
     result = await cmd_stop(ctx)
-    
+
     assert isinstance(result, OutboundMessage)
     assert "Stopped 3 task(s)" in result.content  # 1 cancelled + 2 drained
     assert "test-session" not in mock_loop._pending_queues
@@ -43,10 +43,10 @@ async def test_cmd_stop_with_empty_pending_queue():
     mock_loop = MagicMock()
     mock_loop._cancel_active_tasks = AsyncMock(return_value=2)
     mock_loop._pending_queues = {}
-    
+
     pending = asyncio.Queue()
     mock_loop._pending_queues["test-session"] = pending
-    
+
     ctx = CommandContext(
         msg=MagicMock(channel="websocket", chat_id="test-chat", metadata={}),
         session=None,
@@ -54,9 +54,9 @@ async def test_cmd_stop_with_empty_pending_queue():
         raw="/stop",
         loop=mock_loop,
     )
-    
+
     result = await cmd_stop(ctx)
-    
+
     assert "Stopped 2 task(s)" in result.content
     assert "test-session" not in mock_loop._pending_queues
 
@@ -67,7 +67,7 @@ async def test_cmd_stop_no_pending_queue():
     mock_loop = MagicMock()
     mock_loop._cancel_active_tasks = AsyncMock(return_value=0)
     mock_loop._pending_queues = {}
-    
+
     ctx = CommandContext(
         msg=MagicMock(channel="websocket", chat_id="test-chat", metadata={}),
         session=None,
@@ -75,7 +75,7 @@ async def test_cmd_stop_no_pending_queue():
         raw="/stop",
         loop=mock_loop,
     )
-    
+
     result = await cmd_stop(ctx)
-    
+
     assert "No active task to stop" in result.content

--- a/tests/command/test_stop_pending_queue.py
+++ b/tests/command/test_stop_pending_queue.py
@@ -1,0 +1,81 @@
+"""Test cmd_stop drains pending queue to prevent mid-turn injection deadlock."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.command.builtin import cmd_stop
+from nanobot.command.router import CommandContext
+
+
+@pytest.mark.asyncio
+async def test_cmd_stop_drains_pending_queue():
+    """cmd_stop should drain pending queue in addition to cancelling active tasks."""
+    mock_loop = MagicMock()
+    mock_loop._cancel_active_tasks = AsyncMock(return_value=1)
+    mock_loop._pending_queues = {}
+    
+    pending = asyncio.Queue()
+    await pending.put("msg1")
+    await pending.put("msg2")
+    mock_loop._pending_queues["test-session"] = pending
+    
+    ctx = CommandContext(
+        msg=MagicMock(channel="websocket", chat_id="test-chat", metadata={}),
+        session=None,
+        key="test-session",
+        raw="/stop",
+        loop=mock_loop,
+    )
+    
+    result = await cmd_stop(ctx)
+    
+    assert isinstance(result, OutboundMessage)
+    assert "Stopped 3 task(s)" in result.content  # 1 cancelled + 2 drained
+    assert "test-session" not in mock_loop._pending_queues
+
+
+@pytest.mark.asyncio
+async def test_cmd_stop_with_empty_pending_queue():
+    """cmd_stop should work correctly when pending queue is empty."""
+    mock_loop = MagicMock()
+    mock_loop._cancel_active_tasks = AsyncMock(return_value=2)
+    mock_loop._pending_queues = {}
+    
+    pending = asyncio.Queue()
+    mock_loop._pending_queues["test-session"] = pending
+    
+    ctx = CommandContext(
+        msg=MagicMock(channel="websocket", chat_id="test-chat", metadata={}),
+        session=None,
+        key="test-session",
+        raw="/stop",
+        loop=mock_loop,
+    )
+    
+    result = await cmd_stop(ctx)
+    
+    assert "Stopped 2 task(s)" in result.content
+    assert "test-session" not in mock_loop._pending_queues
+
+
+@pytest.mark.asyncio
+async def test_cmd_stop_no_pending_queue():
+    """cmd_stop should work when no pending queue exists."""
+    mock_loop = MagicMock()
+    mock_loop._cancel_active_tasks = AsyncMock(return_value=0)
+    mock_loop._pending_queues = {}
+    
+    ctx = CommandContext(
+        msg=MagicMock(channel="websocket", chat_id="test-chat", metadata={}),
+        session=None,
+        key="test-session",
+        raw="/stop",
+        loop=mock_loop,
+    )
+    
+    result = await cmd_stop(ctx)
+    
+    assert "No active task to stop" in result.content

--- a/webui/src/lib/nanobot-client.ts
+++ b/webui/src/lib/nanobot-client.ts
@@ -425,6 +425,13 @@ export class NanobotClient {
     for (const handler of this.statusHandlers) handler(status);
   }
 
+  private clearRunStatusesForReconnect(): void {
+    if (this.runStartedAtByChatId.size === 0) return;
+    const chatIds = [...this.runStartedAtByChatId.keys()];
+    this.runStartedAtByChatId.clear();
+    for (const chatId of chatIds) this.emitRunStatus(chatId, null);
+  }
+
   private handleOpen(): void {
     this.setStatus("open");
     this.reconnectAttempts = 0;
@@ -629,6 +636,7 @@ export class NanobotClient {
   }
 
   private scheduleReconnect(): void {
+    this.clearRunStatusesForReconnect();
     this.setStatus("reconnecting");
     const attempt = this.reconnectAttempts++;
     // Exponential backoff: 0.5s, 1s, 2s, 4s, capped.

--- a/webui/src/tests/nanobot-client.test.ts
+++ b/webui/src/tests/nanobot-client.test.ts
@@ -188,6 +188,32 @@ describe("NanobotClient", () => {
     expect(client.getRunStartedAt("chat-strip")).toBeNull();
   });
 
+  it("clears stale run strip when reconnecting after a dropped socket", async () => {
+    const client = new NanobotClient({
+      url: "ws://test",
+      reconnect: true,
+      maxBackoffMs: 10,
+      socketFactory: (url) => new FakeSocket(url) as unknown as WebSocket,
+    });
+    const handler = vi.fn();
+    client.onRunStatus(handler);
+    client.connect();
+    lastSocket().fakeOpen();
+    lastSocket().fakeMessage({
+      event: "goal_status",
+      chat_id: "chat-strip",
+      status: "running",
+      started_at: 12_345,
+    });
+
+    lastSocket().close();
+
+    expect(client.getRunStartedAt("chat-strip")).toBeNull();
+    expect(handler).toHaveBeenLastCalledWith("chat-strip", null);
+    await vi.advanceTimersByTimeAsync(20);
+    expect(FakeSocket.instances.length).toBeGreaterThan(1);
+  });
+
   it("clears run strip when a turn_end arrives without idle", () => {
     const client = new NanobotClient({
       url: "ws://test",


### PR DESCRIPTION
Fixes #4500 (Bug 2 and Bug 3)

## Problem

After a gateway self-restart or websocket reconnect, the WebUI can keep showing the previous turn as processing even though the server-side in-memory turn registry was cleared. The stop button can also report "No active task to stop" while a message is still sitting in the active session's pending injection queue.

## Summary

- Clear stale WebUI run-strip state when the websocket enters reconnecting state.
- Keep backend subscribe hydration quiet unless the server can prove a turn is still running in the same process.
- Preserve existing websocket event ordering for normal `ready`, `attach`, `new_chat`, and `message` flows.
- Drain the active session pending queue from `/stop` so queued mid-turn messages do not keep the session stuck.

## Testing

- `uv run --extra dev python -m pytest tests/channels/test_websocket_reconnect_idle.py tests/channels/test_websocket_channel.py tests/channels/test_websocket_integration.py tests/channels/test_websocket_envelope_media.py tests/command/test_stop_pending_queue.py tests/agent/test_task_cancel.py tests/agent/test_runner_injections.py -q`
- `uv run --extra dev ruff check nanobot/channels/websocket.py nanobot/command/builtin.py tests/channels/test_websocket_reconnect_idle.py tests/command/test_stop_pending_queue.py`
- `npm test -- --run src/tests/nanobot-client.test.ts`
- `npm run lint -- src/lib/nanobot-client.ts src/tests/nanobot-client.test.ts`
- `git diff --check`

## Notes

CI is green on the follow-up commit.
