### PR TITLE
fix(weixin): stream LLM calls + buffer reply delivery to dodge non-stream relay bug

### DIFF
--- a/nanobot/channels/weixin.py
+++ b/nanobot/channels/weixin.py
@@ -1246,16 +1246,26 @@ class WeixinChannel(BaseChannel):
         meta = metadata or {}
         if meta.get("_reasoning_delta") or meta.get("_reasoning"):
             return
-        if delta:
+        is_end = meta.get("_stream_end")
+        # Accumulate intermediate deltas. The _stream_end message's own content
+        # (present when the manager coalesces deltas into the end message) is
+        # folded into `full` below instead of appended here, so a send retry
+        # recomputes the same `full` from an unchanged buffer rather than
+        # double-counting that delta.
+        if delta and not is_end:
             self._stream_buffers.setdefault(chat_id, []).append(delta)
-        if not meta.get("_stream_end"):
+        if not is_end:
             return
-        full = "".join(self._stream_buffers.pop(chat_id, [])).strip()
+        full = ("".join(self._stream_buffers.get(chat_id, [])) + (delta or "")).strip()
         await self._flush_tool_hints(chat_id)
         if full:
+            # Send before clearing the buffer: if the send raises, the buffer is
+            # left intact so ChannelManager._send_with_retry can re-deliver the
+            # same _stream_end message instead of silently losing the reply.
             await self.send(
                 OutboundMessage(channel=self.name, chat_id=chat_id, content=full)
             )
+        self._stream_buffers.pop(chat_id, None)
 
     async def _start_typing(self, chat_id: str, context_token: str = "") -> None:
         """Start typing indicator immediately when a message is received."""

--- a/nanobot/channels/weixin.py
+++ b/nanobot/channels/weixin.py
@@ -129,6 +129,13 @@ class WeixinConfig(Base):
     token: str = ""  # Manually set token, or obtained via QR login
     state_dir: str = ""  # Default: ~/.nanobot/weixin/
     poll_timeout: int = DEFAULT_LONG_POLL_TIMEOUT_S  # seconds for long-poll
+    # Default on: WeChat iLink has no native incremental delivery (send_delta is
+    # buffered and the final answer is still sent in one shot), so streaming has
+    # zero user-facing effect here — it only switches the LLM call to the
+    # streaming API. That avoids upstream Anthropic relays that drop tool_use
+    # id/name/input on the non-streaming Messages path (a common third-party
+    # relay bug). Set to false only if a relay's streaming/SSE path is broken.
+    streaming: bool = True
 
 
 class WeixinChannel(BaseChannel):
@@ -167,6 +174,10 @@ class WeixinChannel(BaseChannel):
         self._typing_tickets: dict[str, dict[str, Any]] = {}
         self._context_token_at: dict[str, float] = {}
         self._pending_tool_hints: dict[str, list[str]] = {}
+        # Buffers streamed content deltas per chat. WeChat iLink has no native
+        # incremental delivery, so when streaming is enabled we accumulate the
+        # deltas and flush the full reply in one shot at _stream_end.
+        self._stream_buffers: dict[str, list[str]] = {}
 
     # ------------------------------------------------------------------
     # State persistence
@@ -1223,14 +1234,28 @@ class WeixinChannel(BaseChannel):
     async def send_delta(
         self, chat_id: str, delta: str, metadata: dict[str, Any] | None = None
     ) -> None:
-        """Weixin iLink does not support native streaming deltas.
+        """Deliver a streamed reply to WeChat.
 
-        We only hook ``_stream_end`` so buffered tool hints are flushed even
-        when the final answer carries the ``_streamed`` flag and bypasses
-        :meth:`send`.
+        WeChat iLink has no native incremental delivery, and the manager
+        bypasses :meth:`send` for the ``_streamed`` final answer. So we
+        accumulate the content deltas here and flush the full reply as a
+        single message at ``_stream_end`` — otherwise a streamed reply would
+        never reach the user. Reasoning deltas are invisible in WeChat and are
+        dropped.
         """
-        if metadata and metadata.get("_stream_end"):
-            await self._flush_tool_hints(chat_id)
+        meta = metadata or {}
+        if meta.get("_reasoning_delta") or meta.get("_reasoning"):
+            return
+        if delta:
+            self._stream_buffers.setdefault(chat_id, []).append(delta)
+        if not meta.get("_stream_end"):
+            return
+        full = "".join(self._stream_buffers.pop(chat_id, [])).strip()
+        await self._flush_tool_hints(chat_id)
+        if full:
+            await self.send(
+                OutboundMessage(channel=self.name, chat_id=chat_id, content=full)
+            )
 
     async def _start_typing(self, chat_id: str, context_token: str = "") -> None:
         """Start typing indicator immediately when a message is received."""

--- a/tests/channels/test_weixin_channel.py
+++ b/tests/channels/test_weixin_channel.py
@@ -1765,6 +1765,44 @@ async def test_buffer_flushed_on_stream_end() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stream_end_flushes_buffered_answer() -> None:
+    channel, _bus = _make_channel()
+    channel._client = object()
+    channel._token = "token"
+    channel._context_tokens["wx-user"] = "ctx-1"
+    channel._context_token_at["wx-user"] = time.time()
+    channel._send_text = AsyncMock()
+
+    await channel.send_delta("wx-user", "hello ", {"_stream_delta": True})
+    await channel.send_delta("wx-user", "world", {"_stream_end": True})
+
+    channel._send_text.assert_awaited_once_with("wx-user", "hello world", "ctx-1")
+    assert "wx-user" not in channel._stream_buffers
+
+
+@pytest.mark.asyncio
+async def test_stream_end_send_failure_keeps_buffer_for_retry() -> None:
+    channel, _bus = _make_channel()
+    channel._client = object()
+    channel._token = "token"
+    channel._context_tokens["wx-user"] = "ctx-1"
+    channel._context_token_at["wx-user"] = time.time()
+    channel._send_text = AsyncMock(side_effect=RuntimeError("temporary send failure"))
+
+    await channel.send_delta("wx-user", "hello ", {"_stream_delta": True})
+    with pytest.raises(RuntimeError):
+        await channel.send_delta("wx-user", "world", {"_stream_end": True})
+
+    assert channel._stream_buffers["wx-user"] == ["hello "]
+
+    channel._send_text = AsyncMock()
+    await channel.send_delta("wx-user", "world", {"_stream_end": True})
+
+    channel._send_text.assert_awaited_once_with("wx-user", "hello world", "ctx-1")
+    assert "wx-user" not in channel._stream_buffers
+
+
+@pytest.mark.asyncio
 async def test_stop_clears_buffer() -> None:
     channel, _bus = _make_channel()
     channel._pending_tool_hints["wx-user"] = ["hint1", "hint2"]


### PR DESCRIPTION
## Problem

`WeixinConfig` had no `streaming` field, so a `channels.weixin.streaming`
setting was silently dropped by pydantic. `supports_streaming` stayed `False`,
forcing the **non-streaming** Messages API for WeChat.

Some upstream Anthropic-compatible relays drop `tool_use` `id`/`name`/`input`
on the non-streaming path while handling the streaming (SSE) path correctly.
On such a relay every WeChat tool call breaks — `tool_use` comes back with
`name=null`, which is unusable and crashes the turn. (Telegram was unaffected
because it already defaults to streaming.)

## Fix

Two parts, both in `weixin.py`:

**1. Add a `streaming` field (default `True`).**
WeChat iLink has no native incremental delivery, so streaming has **zero
user-facing effect** here — it only switches the LLM call from the
non-streaming to the streaming API, dodging the relay's broken non-stream
`tool_use` serialization. Set `false` only if a specific relay's SSE path is
broken.

**2. Make `send_delta` actually deliver the streamed reply.**
WeChat's `send_delta` previously dropped content, and the manager bypasses
`send` for the `_streamed` final answer — so once streaming is on, a streamed
reply would never reach the user and the typing indicator never stopped.
`send_delta` now **buffers content deltas and flushes the full reply in one
shot at `_stream_end`** (and stops typing via `send`). Reasoning deltas stay
dropped (invisible in WeChat).

Part 2 is required for part 1: without it, enabling streaming silently loses
every WeChat reply.

## Testing

- `WeixinConfig().streaming` defaults to `True`; a config override loads
  correctly (previously the field was silently dropped).
- Live: same request returns valid `tool_use` on the streaming path vs
  `id/name/input = null` on the non-streaming path through an affected relay.
- Live WeChat: a batch of messages (plain + tool-calling) all return complete
  replies, typing stops, no malformed tool calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
