### PR TITLE
fix(context): block-aligned replay-window eviction to keep prefix cache warm (#4222)

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -202,6 +202,7 @@ class AgentLoop:
         session_ttl_minutes: int = 0,
         consolidation_ratio: float = 0.5,
         max_messages: int = 120,
+        max_messages_eviction_stride: int = 16,
         hooks: list[AgentHook] | None = None,
         unified_session: bool = False,
         disabled_skills: list[str] | None = None,
@@ -293,6 +294,7 @@ class AgentLoop:
         )
         self._unified_session = unified_session
         self._max_messages = max_messages if max_messages > 0 else 120
+        self._max_messages_eviction_stride = max(1, max_messages_eviction_stride)
         self._running = False
         self._mcp_servers = mcp_servers or {}
         self._mcp_stacks: dict[str, AsyncExitStack] = {}
@@ -391,6 +393,7 @@ class AgentLoop:
             session_ttl_minutes=defaults.session_ttl_minutes,
             consolidation_ratio=defaults.consolidation_ratio,
             max_messages=defaults.max_messages,
+            max_messages_eviction_stride=defaults.max_messages_eviction_stride,
             tools_config=config.tools,
             model_presets=preset_helpers.configured_model_presets(config),
             model_preset=defaults.model_preset,
@@ -1184,6 +1187,7 @@ class AgentLoop:
             "max_messages": self._max_messages,
             "max_tokens": self._replay_token_budget(),
             "extend_to_user": is_subagent,
+            "eviction_stride": self._max_messages_eviction_stride,
         }
         history = session.get_history(**_hist_kwargs)
         workspace_scope = self.workspace_scopes.for_message(msg, session.metadata)
@@ -1462,6 +1466,7 @@ class AgentLoop:
             "max_messages": self._max_messages,
             "max_tokens": self._replay_token_budget(),
             "extend_to_user": False,
+            "eviction_stride": self._max_messages_eviction_stride,
         }
         ctx.history = ctx.session.get_history(**_hist_kwargs)
         self._runtime_events().record_turn_runtime(

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1173,6 +1173,7 @@ class AgentLoop:
         await self.consolidator.maybe_consolidate_by_tokens(
             session,
             replay_max_messages=self._max_messages,
+            replay_eviction_stride=self._max_messages_eviction_stride,
         )
         is_subagent = msg.sender_id == "subagent"
         if is_subagent and self._persist_subagent_followup(session, msg):
@@ -1229,6 +1230,7 @@ class AgentLoop:
             self.consolidator.maybe_consolidate_by_tokens(
                 session,
                 replay_max_messages=self._max_messages,
+                replay_eviction_stride=self._max_messages_eviction_stride,
             )
         )
         content = final_content or "Background task completed."
@@ -1450,6 +1452,7 @@ class AgentLoop:
             await self.consolidator.maybe_consolidate_by_tokens(
                 ctx.session,
                 replay_max_messages=self._max_messages,
+                replay_eviction_stride=self._max_messages_eviction_stride,
             )
         self._set_tool_context(
             ctx.msg.channel,
@@ -1560,6 +1563,7 @@ class AgentLoop:
                 self.consolidator.maybe_consolidate_by_tokens(
                     ctx.session,
                     replay_max_messages=self._max_messages,
+                    replay_eviction_stride=self._max_messages_eviction_stride,
                 )
             )
         self._clear_pending_user_turn(ctx.session)

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -723,6 +723,7 @@ class Consolidator:
     def _replay_overflow_boundary(
         session: Session,
         replay_max_messages: int | None,
+        replay_eviction_stride: int = 0,
     ) -> int | None:
         if not replay_max_messages or replay_max_messages <= 0:
             return None
@@ -735,6 +736,7 @@ class Consolidator:
             tail_messages,
             replay_max_messages,
             extend_to_user=True,
+            eviction_stride=replay_eviction_stride,
         )
         sliced = tail[start_idx:]
         for i, (_idx, message) in enumerate(sliced):
@@ -760,9 +762,14 @@ class Consolidator:
         self,
         session: Session,
         replay_max_messages: int | None,
+        replay_eviction_stride: int = 0,
     ) -> str | None:
         """Archive messages that would be hidden by the replay message window."""
-        end_idx = self._replay_overflow_boundary(session, replay_max_messages)
+        end_idx = self._replay_overflow_boundary(
+            session,
+            replay_max_messages,
+            replay_eviction_stride,
+        )
         if end_idx is None:
             return None
         chunk = session.messages[session.last_consolidated:end_idx]
@@ -883,6 +890,7 @@ class Consolidator:
         session: Session,
         *,
         replay_max_messages: int | None = None,
+        replay_eviction_stride: int = 0,
     ) -> None:
         """Loop: archive old messages until prompt fits within safe budget.
 
@@ -906,6 +914,7 @@ class Consolidator:
             last_summary = await self._consolidate_replay_overflow(
                 session,
                 replay_max_messages,
+                replay_eviction_stride,
             )
             try:
                 estimated, source = self.estimate_session_prompt_tokens(

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -158,6 +158,12 @@ class AgentDefaults(Base):
         default=120,
         ge=0,
     )  # Max messages to replay from session history (0 = use default 120, respects token budget)
+    max_messages_eviction_stride: int = Field(
+        default=16,
+        ge=1,
+        validation_alias=AliasChoices("maxMessagesEvictionStride"),
+        serialization_alias="maxMessagesEvictionStride",
+    )  # Evict the replay window in blocks of this size so the prefix stays byte-stable for prompt caching (1 = legacy slide-one-at-a-time; see #4222)
     consolidation_ratio: float = Field(
         default=0.5,
         ge=0.1,

--- a/nanobot/sdk/clients.py
+++ b/nanobot/sdk/clients.py
@@ -154,6 +154,7 @@ class RuntimeClient:
         await self._loop.consolidator.maybe_consolidate_by_tokens(
             session,
             replay_max_messages=self._loop._max_messages,
+            replay_eviction_stride=self._loop._max_messages_eviction_stride,
         )
         return snapshot_from_session(self._loop.sessions.get_or_create(session_key))
 

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -136,11 +136,16 @@ class Session:
         *,
         max_tokens: int = 0,
         extend_to_user: bool = False,
+        eviction_stride: int = 0,
     ) -> list[dict[str, Any]]:
         """Return unconsolidated messages for LLM input.
 
         History is sliced by message count first (``max_messages``), then by
         token budget from the tail (``max_tokens``) when provided.
+
+        ``eviction_stride`` quantizes the count-based slice boundary so it only
+        advances in whole blocks, keeping the replayed prefix byte-stable for
+        prompt caching (see issue #4222 and ``recent_message_start_index``).
         """
         unconsolidated = self.messages[self.last_consolidated:]
         max_messages = max_messages if max_messages > 0 else 120
@@ -148,6 +153,7 @@ class Session:
             unconsolidated,
             max_messages,
             extend_to_user=extend_to_user,
+            eviction_stride=eviction_stride,
         )
         sliced = unconsolidated[start_idx:]
 

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -351,11 +351,33 @@ def recent_message_start_index(
     max_messages: int,
     *,
     extend_to_user: bool = False,
+    eviction_stride: int = 0,
 ) -> int:
-    """Return the start index for a recent replay window."""
+    """Return the start index for a recent replay window.
+
+    With the default ``eviction_stride`` of 0 (or 1) the window slides one
+    message at a time: every new turn past ``max_messages`` advances the start
+    index by one, so the replayed prefix shifts on every turn and a byte-prefix
+    prompt cache misses continuously (see issue #4222).
+
+    When ``eviction_stride > 1`` the start index is quantized down to a multiple
+    of the stride, so it only advances in whole ``eviction_stride``-sized blocks.
+    Between block boundaries the window start is fixed, so the replayed prefix is
+    byte-identical across turns and stays cache-resident. This only ever keeps
+    *more* messages than the plain slice (the start index can only move earlier),
+    so no history is lost; it just bounds the extra context to ``eviction_stride``.
+    """
     if max_messages <= 0:
         return len(messages)
     start_idx = max(0, len(messages) - max_messages)
+    # Clamp the stride to the window size so block alignment never keeps more
+    # than ~2x ``max_messages`` messages, even if a large stride is configured
+    # for a small window.
+    stride = min(eviction_stride, max_messages)
+    if stride > 1 and start_idx > 0:
+        # Floor to a block boundary so the window start only moves every
+        # ``stride`` messages instead of on every turn.
+        start_idx -= start_idx % stride
     if not extend_to_user or len(messages) <= max_messages:
         return start_idx
     if any(messages[i].get("role") == "user" for i in range(start_idx, len(messages))):

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -366,6 +366,14 @@ def recent_message_start_index(
     byte-identical across turns and stays cache-resident. This only ever keeps
     *more* messages than the plain slice (the start index can only move earlier),
     so no history is lost; it just bounds the extra context to ``eviction_stride``.
+
+    The stride is clamped to ``max_messages`` (below), so the window re-anchors at
+    least once per ``max_messages`` turns and the live window stays within
+    ``[max_messages, 2 * max_messages)``. A consequence worth noting: pairing a
+    *small* ``max_messages`` with a *large* ``eviction_stride`` makes the effective
+    stride equal to ``max_messages``, so the window can hold up to ~2x
+    ``max_messages`` messages before re-anchoring — eviction still happens every
+    ``max_messages`` turns, it just retains a larger byte-stable block in between.
     """
     if max_messages <= 0:
         return len(messages)

--- a/tests/agent/test_auto_compact.py
+++ b/tests/agent/test_auto_compact.py
@@ -223,7 +223,12 @@ class TestAgentLoopTTLParam:
         kwargs = session.get_history.call_args.kwargs
         assert isinstance(kwargs.get("max_tokens"), int)
         assert kwargs["max_tokens"] > 0
-        assert set(kwargs) == {"max_messages", "max_tokens", "extend_to_user"}
+        assert set(kwargs) == {
+            "max_messages",
+            "max_tokens",
+            "extend_to_user",
+            "eviction_stride",
+        }
 
     @pytest.mark.asyncio
     async def test_session_file_cap_archives_and_trims_old_messages(self, tmp_path):

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -232,6 +232,35 @@ class TestConsolidatorTokenBudget:
         assert session.metadata["_last_summary"]["text"] == "old conversation summary"
         consolidator.sessions.save.assert_called()
 
+    async def test_replay_window_overflow_uses_eviction_stride(
+        self,
+        consolidator,
+    ):
+        """Preflight replay consolidation must match the model replay window."""
+        consolidator._SAFETY_BUFFER = 0
+        session = Session(key="test:replay-stride")
+        for i in range(20):
+            session.add_message("user", f"u{i}")
+
+        consolidator.sessions._session_cache[session.key] = session
+        consolidator.estimate_session_prompt_tokens = MagicMock(return_value=(100, "tiktoken"))
+        consolidator.archive = AsyncMock(return_value="old conversation summary")
+
+        await consolidator.maybe_consolidate_by_tokens(
+            session,
+            replay_max_messages=10,
+            replay_eviction_stride=4,
+        )
+
+        archived_chunk = consolidator.archive.await_args.args[0]
+        assert archived_chunk[0]["content"] == "u0"
+        assert archived_chunk[-1]["content"] == "u7"
+        assert session.last_consolidated == 8
+
+        history = session.get_history(max_messages=10, eviction_stride=4)
+        assert history[0]["content"] == "u8"
+        assert len(history) == 12
+
     async def test_replay_window_overflow_extends_to_long_recent_user_turn(
         self,
         consolidator,

--- a/tests/agent/test_loop_consolidation_tokens.py
+++ b/tests/agent/test_loop_consolidation_tokens.py
@@ -209,6 +209,7 @@ async def test_preflight_consolidation_receives_pending_summary(tmp_path) -> Non
     loop.consolidator.maybe_consolidate_by_tokens.assert_any_await(
         session,
         replay_max_messages=loop._max_messages,
+        replay_eviction_stride=loop._max_messages_eviction_stride,
     )
 
 

--- a/tests/agent/test_message_window_eviction_stride.py
+++ b/tests/agent/test_message_window_eviction_stride.py
@@ -1,0 +1,71 @@
+"""Block-aligned eviction keeps the replay-window prefix byte-stable (issue #4222).
+
+The legacy count-based slice advances its start index by one on every turn once a
+conversation passes ``max_messages``, so the replayed prefix shifts every turn and a
+byte-prefix prompt cache misses continuously. ``eviction_stride`` quantizes that
+boundary to whole blocks, so the prefix is identical across the turns within a block.
+"""
+
+from __future__ import annotations
+
+from nanobot.session.manager import SessionManager
+from nanobot.utils.helpers import recent_message_start_index
+
+
+def _msgs(n: int) -> list[dict]:
+    return [{"role": "user", "content": f"m{i}"} for i in range(n)]
+
+
+def test_window_slides_one_at_a_time_without_stride() -> None:
+    # Legacy behavior (the #4222 bug): start advances by one every appended turn.
+    assert recent_message_start_index(_msgs(20), 10) == 10
+    assert recent_message_start_index(_msgs(21), 10) == 11  # shifted -> cache miss
+
+
+def test_window_is_quantized_to_blocks_with_stride() -> None:
+    max_messages, stride = 10, 4
+    starts = [
+        recent_message_start_index(_msgs(n), max_messages, eviction_stride=stride)
+        for n in range(20, 28)  # raw start would be 10,11,12,13,14,15,16,17
+    ]
+    # Floored to multiples of the stride: the start only moves every `stride` turns.
+    assert starts == [8, 8, 12, 12, 12, 12, 16, 16]
+
+
+def test_quantized_start_only_ever_keeps_more_messages() -> None:
+    # The block alignment can only move the start earlier, so no history is lost.
+    max_messages, stride = 10, 4
+    for n in range(11, 40):
+        raw = recent_message_start_index(_msgs(n), max_messages)
+        quantized = recent_message_start_index(_msgs(n), max_messages, eviction_stride=stride)
+        assert quantized <= raw
+        assert n - quantized <= max_messages + stride  # overshoot is bounded
+
+
+def test_get_history_prefix_is_byte_stable_within_a_block(tmp_path) -> None:
+    manager = SessionManager(tmp_path)
+    session = manager.get_or_create("stride-stable")
+    for i in range(20):
+        session.add_message("user", f"m{i}")
+
+    before = session.get_history(max_messages=10, eviction_stride=4)
+    session.add_message("user", "m20")
+    after = session.get_history(max_messages=10, eviction_stride=4)
+
+    # Same quantized start (8) -> the next turn is a clean append: the whole prior
+    # window is the byte-identical prefix of the new one, so the cache stays warm.
+    assert after[: len(before)] == before
+
+
+def test_get_history_prefix_shifts_without_stride(tmp_path) -> None:
+    manager = SessionManager(tmp_path)
+    session = manager.get_or_create("stride-legacy")
+    for i in range(20):
+        session.add_message("user", f"m{i}")
+
+    before = session.get_history(max_messages=10, eviction_stride=1)
+    session.add_message("user", "m20")
+    after = session.get_history(max_messages=10, eviction_stride=1)
+
+    # Legacy slide-by-one: the window shifted, so the prefix is NOT preserved.
+    assert after[: len(before)] != before


### PR DESCRIPTION
Fixes the `max_messages` half of #4222: continuous prefix/prompt-cache invalidation from the replay window.

## The bug

`Session.get_history()` → `recent_message_start_index()` slices to the last `max_messages` messages with `start_idx = len(messages) - max_messages`. Once a conversation passes `max_messages` (default 120, easily reached), **every turn drops the oldest message and shifts the start by one**. The byte prefix sent to the LLM changes every turn, so byte-prefix prompt caching (Anthropic `cache_control`, DeepSeek/OpenAI prefix cache) misses continuously. The only workaround today is setting `max_messages` huge to disable truncation — which defeats the point.

## The fix: block-aligned eviction

Quantize the window start to whole blocks. New `max_messages_eviction_stride` (config `maxMessagesEvictionStride`, default **16**) floors `start_idx` to a multiple of the stride, so it only advances every `stride` messages. Between block boundaries the window start is **fixed**, so the replayed prefix is byte-identical across turns and stays cache-resident; it re-anchors (and pays one prefix recompute) once per `stride` turns instead of every turn.

Two safety properties keep this conservative:
- **No history is lost** — the quantized start can only move *earlier* than the plain slice, never later.
- **Bounded overshoot** — the stride is clamped to `max_messages`, so the window never holds more than ~2× `max_messages`.
- Set the stride to **1** to restore the exact legacy slide-one-at-a-time behavior.

Plumbed `AgentLoop → get_history → recent_message_start_index`.

## Scope note

This targets the `max_messages` boundary-drift mechanism (the one with "no fix except disabling truncation"). The microcompact half of #4222 is left for a follow-up — `compacted_tool_call_ids` + `_apply_recorded_compactions` already make compaction sticky, so it's a smaller, separable problem and I didn't want to mix two concerns in one PR.

## Tests

New `tests/agent/test_message_window_eviction_stride.py`:
- legacy slide-by-one (documents the bug),
- block quantization (`[8,8,12,12,12,12,16,16]`),
- the keeps-more / bounded-overshoot invariant,
- **end-to-end byte-stability** via `Session.get_history` (the new turn's prefix == the whole prior window), plus the legacy-shift contrast.

Updated `test_auto_compact`'s `get_history` kwargs assertion (one new kwarg). Full `tests/agent` suite (1222) + config/session/history tests green; `ruff` clean. No formatting churn.

Refs #4222.
