### PR TITLE
feat(spawn): add per-subagent model override to the spawn tool (#4231)

### DIFF
--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -256,7 +256,7 @@ class SubagentManager:
                 result = await self.runner.run(AgentRunSpec(
                     initial_messages=messages,
                     tools=tools,
-                    model=model or self.model,
+                    model=self.model if model is None else model,
                     temperature=temperature,
                     max_iterations=self.max_iterations,
                     max_tool_result_chars=self.max_tool_result_chars,

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -164,8 +164,13 @@ class SubagentManager:
         origin_message_id: str | None = None,
         temperature: float | None = None,
         workspace_scope: WorkspaceScope | None = None,
+        model: str | None = None,
     ) -> str:
-        """Spawn a subagent to execute a task in the background."""
+        """Spawn a subagent to execute a task in the background.
+
+        ``model`` overrides the model for this subagent only (it does not mutate
+        the manager's shared model); it defaults to the parent agent's model.
+        """
         task_id = str(uuid.uuid4())[:8]
         display_label = label or task[:30] + ("..." if len(task) > 30 else "")
         origin = {"channel": origin_channel, "chat_id": origin_chat_id, "session_key": session_key}
@@ -188,6 +193,7 @@ class SubagentManager:
                 origin_message_id,
                 temperature,
                 workspace_scope,
+                model,
             )
         )
         self._running_tasks[task_id] = bg_task
@@ -217,6 +223,7 @@ class SubagentManager:
         origin_message_id: str | None = None,
         temperature: float | None = None,
         workspace_scope: WorkspaceScope | None = None,
+        model: str | None = None,
     ) -> None:
         """Execute the subagent task and announce the result."""
         logger.info("Subagent [{}] starting task: {}", task_id, label)
@@ -249,7 +256,7 @@ class SubagentManager:
                 result = await self.runner.run(AgentRunSpec(
                     initial_messages=messages,
                     tools=tools,
-                    model=self.model,
+                    model=model or self.model,
                     temperature=temperature,
                     max_iterations=self.max_iterations,
                     max_tool_result_chars=self.max_tool_result_chars,

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -27,6 +27,12 @@ if TYPE_CHECKING:
             minimum=0.0,
             maximum=2.0,
         ),
+        model=StringSchema(
+            "Optional model id for this subagent only (e.g. delegate a heavy "
+            "task to a stronger reasoning model, or a simple one to a cheaper, "
+            "faster model). Must be a model the configured provider serves. "
+            "Defaults to the parent agent's model."
+        ),
         required=["task"],
     )
 )
@@ -73,6 +79,7 @@ class SpawnTool(Tool, ContextAware):
         task: str,
         label: str | None = None,
         temperature: float | None = None,
+        model: str | None = None,
         **kwargs: Any,
     ) -> str:
         """Spawn a subagent to execute the given task."""
@@ -93,4 +100,5 @@ class SpawnTool(Tool, ContextAware):
             origin_message_id=self._origin_message_id.get(),
             temperature=temperature,
             workspace_scope=current_workspace_scope(),
+            model=model,
         )

--- a/tests/agent/test_subagent_model_override.py
+++ b/tests/agent/test_subagent_model_override.py
@@ -1,0 +1,91 @@
+"""Per-spawn model override for subagents (issue #4231).
+
+A spawned subagent inherits the parent agent's model by default, but ``spawn``
+now accepts an optional ``model`` so the agent can delegate a heavy task to a
+stronger model (or a simple one to a cheaper/faster model) for that subagent
+only, without mutating the manager's shared model.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.agent.runner import AgentRunResult
+from nanobot.agent.subagent import SubagentManager, SubagentStatus
+from nanobot.agent.tools.spawn import SpawnTool
+from nanobot.bus.queue import MessageBus
+from nanobot.providers.base import LLMProvider
+
+
+def _manager(tmp_path) -> SubagentManager:
+    provider = MagicMock(spec=LLMProvider)
+    provider.get_default_model.return_value = "parent-model"
+    sm = SubagentManager(
+        provider=provider,
+        workspace=tmp_path,
+        bus=MessageBus(),
+        model="parent-model",
+        max_tool_result_chars=16_000,
+    )
+    sm.runner.run = AsyncMock(
+        return_value=AgentRunResult(final_content="ok", messages=[], stop_reason="completed")
+    )
+    sm._announce_result = AsyncMock()
+    return sm
+
+
+def _status() -> SubagentStatus:
+    return SubagentStatus(task_id="t1", label="label", task_description="task", started_at=0.0)
+
+
+@pytest.mark.asyncio
+async def test_run_subagent_uses_override_model(tmp_path):
+    sm = _manager(tmp_path)
+
+    await sm._run_subagent(
+        "t1", "task", "label", {"channel": "cli", "chat_id": "direct"}, _status(),
+        model="strong-reasoner",
+    )
+
+    spec = sm.runner.run.call_args.args[0]
+    assert spec.model == "strong-reasoner"
+    # The override is per-spawn only: the manager's shared model is untouched.
+    assert sm.model == "parent-model"
+
+
+@pytest.mark.asyncio
+async def test_run_subagent_defaults_to_manager_model(tmp_path):
+    sm = _manager(tmp_path)
+
+    await sm._run_subagent(
+        "t1", "task", "label", {"channel": "cli", "chat_id": "direct"}, _status(),
+    )
+
+    spec = sm.runner.run.call_args.args[0]
+    assert spec.model == "parent-model"
+
+
+@pytest.mark.asyncio
+async def test_spawn_tool_forwards_model_to_manager():
+    manager = MagicMock()
+    manager.get_running_count.return_value = 0
+    manager.max_concurrent_subagents = 4
+    manager.spawn = AsyncMock(return_value="started")
+
+    tool = SpawnTool(manager=manager)
+    await tool.execute(task="do the hard thing", model="strong-reasoner")
+
+    assert manager.spawn.await_args.kwargs["model"] == "strong-reasoner"
+
+
+@pytest.mark.asyncio
+async def test_spawn_tool_model_defaults_to_none():
+    manager = MagicMock()
+    manager.get_running_count.return_value = 0
+    manager.max_concurrent_subagents = 4
+    manager.spawn = AsyncMock(return_value="started")
+
+    tool = SpawnTool(manager=manager)
+    await tool.execute(task="simple thing")
+
+    assert manager.spawn.await_args.kwargs["model"] is None


### PR DESCRIPTION
Implements #4231: a per-subagent model override on the `spawn` tool.

## Problem

`spawn` only accepted `task` / `label` / `temperature`, so every subagent inherited the parent agent's model (`self.model`) with no way to route one task differently. That blocks the common patterns the issue calls out: default to a light/cheap model and delegate a heavy task to a stronger reasoning model, or push a trivial subtask to a faster model — all without switching the session-wide model.

## Change

Add an optional `model` parameter to the `spawn` tool, threaded:

```
spawn tool → SubagentManager.spawn(model=…) → _run_subagent(model=…) → AgentRunSpec(model=model or self.model)
```

- **Defaults to the parent model** (`model or self.model`) — no behavior change when omitted.
- **Per-spawn only.** Deliberately does *not* use `set_provider()` (which mutates the manager's shared `model`/`provider` and would leak into concurrent and subsequent subagents). Threading the value into the per-run `AgentRunSpec` keeps the override scoped to exactly one subagent.
- **Scope:** same-provider model routing (the model must be one the configured provider serves). Cross-provider / `modelPresets` resolution is a clean follow-up; I kept this minimal and low-risk per CONTRIBUTING.

## Tests

New `tests/agent/test_subagent_model_override.py`:
- override reaches `AgentRunSpec.model`,
- the manager's shared `model` stays untouched (per-spawn isolation),
- default path uses the parent model,
- the `spawn` tool forwards `model` to the manager (and defaults it to `None`).

Full `tests/agent` suite (1226) green; `ruff` clean. No formatting churn.

Refs #4231.
