### PR TITLE
feat(subagent): native A2A peer delegation with cross-delegation depth guard (#4179)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2008,6 +2008,41 @@ Subagents also stop immediately when one of their tools returns an execution err
 | `agents.defaults.failOnToolError` | `true` | Stop a spawned subagent when a tool execution fails. Set to `false` to return tool errors to the subagent model so it can recover within the same run. |
 
 
+## Peer Agents (A2A Delegation)
+
+`spawn` runs a generic, anonymous subagent. To build a small **team** of named teammates with distinct roles — e.g. a Supervisor that hands research to a Researcher and drafting to a Writer — register them under `agents.peers`. Each peer can carry its own system prompt and model while reusing the shared subagent execution and message-bus infrastructure:
+
+```json
+{
+  "agents": {
+    "peers": [
+      {
+        "name": "researcher",
+        "role": "gathers and verifies primary sources",
+        "systemPrompt": "You are the Researcher. Find primary sources and cite them.",
+        "model": "anthropic/claude-haiku-4-5"
+      },
+      {
+        "name": "writer",
+        "role": "turns findings into a clear reply"
+      }
+    ],
+    "defaults": {
+      "maxConcurrentSubagents": 3,
+      "maxDelegationDepth": 3
+    }
+  }
+}
+```
+
+When at least one peer is configured, the agent gains a `delegate(peer, task)` tool. The named peer runs its task and reports back, the same way a spawned subagent does. A peer may itself `delegate` further down the chain (Supervisor → Researcher → …); `maxDelegationDepth` bounds how deep that chain can go so cross-delegation can't run away. Because delegated peers count against `maxConcurrentSubagents`, raise that limit if you expect several teammates to work at once.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `agents.peers` | `[]` | Roster of named peer agents. Each entry needs a unique `name`; `role`, `systemPrompt`, and `model` are optional. |
+| `agents.defaults.maxDelegationDepth` | `3` | Maximum length of a chained `delegate` sequence (A→B→C…) before `delegate` refuses, to bound runaway cross-delegation. |
+
+
 ## Auto Compact
 
 When a user is idle for longer than a configured threshold, nanobot **proactively** compresses the older part of the session context into a summary while keeping a recent legal suffix of live messages. This reduces token cost and first-token latency when the user returns — instead of re-processing a long stale context with an expired KV cache, the model receives a compact summary, the most recent live context, and fresh input.

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -205,6 +205,8 @@ class AgentLoop:
         hooks: list[AgentHook] | None = None,
         unified_session: bool = False,
         disabled_skills: list[str] | None = None,
+        peers: dict[str, Any] | None = None,
+        max_delegation_depth: int | None = None,
         tools_config: ToolsConfig | None = None,
         image_generation_provider_config: ProviderConfig | None = None,
         image_generation_provider_configs: dict[str, ProviderConfig] | None = None,
@@ -290,6 +292,8 @@ class AgentLoop:
             max_concurrent_subagents=max_concurrent_subagents,
             fail_on_tool_error=fail_on_tool_error,
             llm_wall_timeout_for_session=lambda sk: runner_wall_llm_timeout_s(self.sessions, sk),
+            peers=peers,
+            max_delegation_depth=max_delegation_depth,
         )
         self._unified_session = unified_session
         self._max_messages = max_messages if max_messages > 0 else 120
@@ -388,6 +392,8 @@ class AgentLoop:
             timezone=defaults.timezone,
             unified_session=defaults.unified_session,
             disabled_skills=defaults.disabled_skills,
+            peers={peer.name: peer for peer in config.agents.peers},
+            max_delegation_depth=defaults.max_delegation_depth,
             session_ttl_minutes=defaults.session_ttl_minutes,
             consolidation_ratio=defaults.consolidation_ratio,
             max_messages=defaults.max_messages,

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import time
 import uuid
+from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
@@ -18,7 +19,7 @@ from nanobot.agent.tools.loader import ToolLoader
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.bus.events import InboundMessage
 from nanobot.bus.queue import MessageBus
-from nanobot.config.schema import AgentDefaults, ToolsConfig
+from nanobot.config.schema import AgentDefaults, PeerAgentConfig, ToolsConfig
 from nanobot.providers.base import LLMProvider
 from nanobot.security.workspace_access import (
     WorkspaceScope,
@@ -27,6 +28,20 @@ from nanobot.security.workspace_access import (
     workspace_sandbox_status,
 )
 from nanobot.utils.prompt_templates import render_template
+
+# Tracks how deep the current peer-delegation chain is (A→B→C…). Subagents run
+# in their own asyncio tasks, which copy the contextvar at creation time, so a
+# peer bound to depth N sees depth N for any ``delegate`` it issues and passes
+# N+1 to its delegate — letting ``SubagentManager`` cap runaway cross-delegation.
+_CURRENT_DELEGATION_DEPTH: ContextVar[int] = ContextVar(
+    "nanobot_delegation_depth",
+    default=0,
+)
+
+
+def current_delegation_depth() -> int:
+    """Return the delegation depth of the currently executing (sub)agent."""
+    return _CURRENT_DELEGATION_DEPTH.get()
 
 
 @dataclass(slots=True)
@@ -88,6 +103,8 @@ class SubagentManager:
         max_concurrent_subagents: int | None = None,
         fail_on_tool_error: bool | None = None,
         llm_wall_timeout_for_session: Callable[[str | None], float | None] | None = None,
+        peers: dict[str, PeerAgentConfig] | None = None,
+        max_delegation_depth: int | None = None,
     ):
         defaults = AgentDefaults()
         self.provider = provider
@@ -112,6 +129,12 @@ class SubagentManager:
             fail_on_tool_error
             if fail_on_tool_error is not None
             else defaults.fail_on_tool_error
+        )
+        self.peers: dict[str, PeerAgentConfig] = dict(peers or {})
+        self.max_delegation_depth = (
+            max_delegation_depth
+            if max_delegation_depth is not None
+            else defaults.max_delegation_depth
         )
         self.runner = AgentRunner(provider)
         self._llm_wall_timeout_for_session = llm_wall_timeout_for_session
@@ -145,6 +168,9 @@ class SubagentManager:
                 restrict_to_workspace=cfg.restrict_to_workspace,
                 workspace=root,
             ),
+            # Exposed so a peer subagent can re-delegate down the chain; only the
+            # peer-gated, depth-bounded ``delegate`` tool is subagent-scoped.
+            subagent_manager=self,
         )
         ToolLoader().load(ctx, registry, scope="subagent")
         return registry
@@ -164,10 +190,20 @@ class SubagentManager:
         origin_message_id: str | None = None,
         temperature: float | None = None,
         workspace_scope: WorkspaceScope | None = None,
+        peer: str | None = None,
+        delegation_depth: int = 0,
     ) -> str:
-        """Spawn a subagent to execute a task in the background."""
+        """Spawn a subagent to execute a task in the background.
+
+        When ``peer`` names a registered peer agent (see #4179), the subagent
+        assumes that peer's role (system prompt + model) instead of the generic
+        subagent persona. ``delegation_depth`` carries the position in the
+        delegation chain so nested ``delegate`` calls can be bounded.
+        """
+        peer_cfg = self.peers.get(peer) if peer else None
         task_id = str(uuid.uuid4())[:8]
-        display_label = label or task[:30] + ("..." if len(task) > 30 else "")
+        default_label = (peer if peer_cfg else None) or task[:30] + ("..." if len(task) > 30 else "")
+        display_label = label or default_label
         origin = {"channel": origin_channel, "chat_id": origin_chat_id, "session_key": session_key}
 
         status = SubagentStatus(
@@ -188,6 +224,8 @@ class SubagentManager:
                 origin_message_id,
                 temperature,
                 workspace_scope,
+                peer_cfg,
+                delegation_depth,
             )
         )
         self._running_tasks[task_id] = bg_task
@@ -217,6 +255,8 @@ class SubagentManager:
         origin_message_id: str | None = None,
         temperature: float | None = None,
         workspace_scope: WorkspaceScope | None = None,
+        peer_cfg: PeerAgentConfig | None = None,
+        delegation_depth: int = 0,
     ) -> None:
         """Execute the subagent task and announce the result."""
         logger.info("Subagent [{}] starting task: {}", task_id, label)
@@ -232,7 +272,11 @@ class SubagentManager:
                 cfg = self._subagent_tools_config()
                 cfg.restrict_to_workspace = workspace_scope.restrict_to_workspace
             tools = self._build_tools(workspace=root, tools_config=cfg)
-            system_prompt = self._build_subagent_prompt(workspace=root)
+            if peer_cfg is not None and peer_cfg.system_prompt:
+                system_prompt = peer_cfg.system_prompt
+            else:
+                system_prompt = self._build_subagent_prompt(workspace=root)
+            run_model = (peer_cfg.model if peer_cfg is not None else None) or self.model
             messages: list[dict[str, Any]] = [
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": task},
@@ -245,11 +289,12 @@ class SubagentManager:
                 else None
             )
             token = bind_workspace_scope(workspace_scope) if workspace_scope is not None else None
+            depth_token: Token[int] = _CURRENT_DELEGATION_DEPTH.set(delegation_depth)
             try:
                 result = await self.runner.run(AgentRunSpec(
                     initial_messages=messages,
                     tools=tools,
-                    model=self.model,
+                    model=run_model,
                     temperature=temperature,
                     max_iterations=self.max_iterations,
                     max_tool_result_chars=self.max_tool_result_chars,
@@ -264,6 +309,7 @@ class SubagentManager:
                     llm_timeout_s=llm_timeout,
                 ))
             finally:
+                _CURRENT_DELEGATION_DEPTH.reset(depth_token)
                 if token is not None:
                     reset_workspace_scope(token)
             status.phase = "done"

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -13,7 +13,7 @@ from loguru import logger
 
 from nanobot.agent.hook import AgentHook, AgentHookContext
 from nanobot.agent.runner import AgentRunner, AgentRunSpec
-from nanobot.agent.tools.context import ToolContext
+from nanobot.agent.tools.context import ContextAware, RequestContext, ToolContext
 from nanobot.agent.tools.file_state import FileStates
 from nanobot.agent.tools.loader import ToolLoader
 from nanobot.agent.tools.registry import ToolRegistry
@@ -175,6 +175,28 @@ class SubagentManager:
         ToolLoader().load(ctx, registry, scope="subagent")
         return registry
 
+    @staticmethod
+    def _bind_tool_context(
+        tools: ToolRegistry,
+        origin: dict[str, str],
+        origin_message_id: str | None,
+    ) -> None:
+        """Set the origin request context on a subagent's ContextAware tools.
+
+        Without this, a `delegate` issued from inside a peer subagent would read the
+        ContextAware defaults (cli/direct) and route its result to the wrong session.
+        """
+        request_ctx = RequestContext(
+            channel=origin["channel"],
+            chat_id=origin["chat_id"],
+            message_id=origin_message_id,
+            session_key=origin.get("session_key") or f"{origin['channel']}:{origin['chat_id']}",
+        )
+        for name in tools.tool_names:
+            tool = tools.get(name)
+            if isinstance(tool, ContextAware):
+                tool.set_context(request_ctx)
+
     def set_provider(self, provider: LLMProvider, model: str) -> None:
         self.provider = provider
         self.model = model
@@ -272,6 +294,12 @@ class SubagentManager:
                 cfg = self._subagent_tools_config()
                 cfg.restrict_to_workspace = workspace_scope.restrict_to_workspace
             tools = self._build_tools(workspace=root, tools_config=cfg)
+            # Bind the subagent's tools to the *origin* request context so a peer
+            # that re-delegates (A→B→C) routes its delegate from the right session
+            # instead of the ContextAware defaults (cli/direct). _build_tools makes a
+            # fresh registry, so without this the nested delegate would announce to
+            # the wrong place. Mirrors AgentLoop._update_tool_context.
+            self._bind_tool_context(tools, origin, origin_message_id)
             if peer_cfg is not None and peer_cfg.system_prompt:
                 system_prompt = peer_cfg.system_prompt
             else:

--- a/nanobot/agent/tools/delegate.py
+++ b/nanobot/agent/tools/delegate.py
@@ -1,0 +1,128 @@
+"""Delegate tool for handing a task to a registered peer agent (A2A, see #4179)."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import TYPE_CHECKING, Any
+
+from nanobot.agent.subagent import current_delegation_depth
+from nanobot.agent.tools.base import Tool, tool_parameters
+from nanobot.agent.tools.context import ContextAware, RequestContext
+from nanobot.agent.tools.schema import StringSchema, tool_parameters_schema
+from nanobot.security.workspace_access import current_workspace_scope
+
+if TYPE_CHECKING:
+    from nanobot.agent.subagent import SubagentManager
+
+
+@tool_parameters(
+    tool_parameters_schema(
+        peer=StringSchema("Name of the registered peer agent to delegate to"),
+        task=StringSchema("The task for the peer agent to complete"),
+        label=StringSchema("Optional short label for the task (for display)"),
+        required=["peer", "task"],
+    )
+)
+class DelegateTool(Tool, ContextAware):
+    """Delegate a task to a named peer agent within the same server/gateway.
+
+    Unlike ``spawn`` (which runs a generic background subagent), ``delegate``
+    routes work to a *registered* peer that assumes a distinct role (its own
+    system prompt and model). Chained delegation (A→B→C) is bounded by the
+    manager's ``max_delegation_depth`` to prevent runaway cross-delegation.
+    """
+
+    # Available to peer subagents too, so a peer can re-delegate down the chain.
+    _scopes: set[str] = {"core", "subagent"}
+
+    def __init__(self, manager: "SubagentManager"):
+        self._manager = manager
+        self._origin_channel: ContextVar[str] = ContextVar("delegate_origin_channel", default="cli")
+        self._origin_chat_id: ContextVar[str] = ContextVar("delegate_origin_chat_id", default="direct")
+        self._session_key: ContextVar[str] = ContextVar("delegate_session_key", default="cli:direct")
+        self._origin_message_id: ContextVar[str | None] = ContextVar(
+            "delegate_origin_message_id",
+            default=None,
+        )
+
+    @classmethod
+    def enabled(cls, ctx: Any) -> bool:
+        manager = getattr(ctx, "subagent_manager", None)
+        return bool(manager is not None and getattr(manager, "peers", None))
+
+    @classmethod
+    def create(cls, ctx: Any) -> Tool:
+        return cls(manager=ctx.subagent_manager)
+
+    def set_context(self, ctx: RequestContext) -> None:
+        """Set the origin context for peer announcements."""
+        self._origin_channel.set(ctx.channel)
+        self._origin_chat_id.set(ctx.chat_id)
+        self._session_key.set(ctx.session_key or f"{ctx.channel}:{ctx.chat_id}")
+        self._origin_message_id.set(ctx.message_id)
+
+    @property
+    def name(self) -> str:
+        return "delegate"
+
+    def _roster(self) -> str:
+        lines = []
+        for peer in self._manager.peers.values():
+            role = f" — {peer.role}" if peer.role else ""
+            lines.append(f"{peer.name}{role}")
+        return "; ".join(lines)
+
+    @property
+    def description(self) -> str:
+        roster = self._roster() or "(none configured)"
+        return (
+            "Delegate a task to a registered peer agent that has its own role. "
+            "Use this to collaborate with specialized teammates instead of doing "
+            "everything yourself. The peer works independently and reports back "
+            f"when done. Available peers: {roster}."
+        )
+
+    async def execute(
+        self,
+        peer: str,
+        task: str,
+        label: str | None = None,
+        **kwargs: Any,
+    ) -> str:
+        """Delegate the given task to a named peer agent."""
+        depth = current_delegation_depth()
+        max_depth = self._manager.max_delegation_depth
+        if depth >= max_depth:
+            return (
+                f"Cannot delegate: maximum delegation depth reached "
+                f"(depth {depth}/{max_depth}). Complete this task directly "
+                f"instead of handing it off further."
+            )
+
+        if peer not in self._manager.peers:
+            available = ", ".join(self._manager.peers) or "(none)"
+            return (
+                f"Cannot delegate: unknown peer '{peer}'. "
+                f"Available peers: {available}."
+            )
+
+        running = self._manager.get_running_count()
+        limit = self._manager.max_concurrent_subagents
+        if running >= limit:
+            return (
+                f"Cannot delegate to '{peer}': concurrency limit reached "
+                f"({running}/{limit} running). Wait for a running agent "
+                f"to complete before delegating again."
+            )
+
+        return await self._manager.spawn(
+            task=task,
+            label=label,
+            origin_channel=self._origin_channel.get(),
+            origin_chat_id=self._origin_chat_id.get(),
+            session_key=self._session_key.get(),
+            origin_message_id=self._origin_message_id.get(),
+            workspace_scope=current_workspace_scope(),
+            peer=peer,
+            delegation_depth=depth + 1,
+        )

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -165,13 +165,33 @@ class AgentDefaults(Base):
         validation_alias=AliasChoices("consolidationRatio"),
         serialization_alias="consolidationRatio",
     )  # Consolidation target ratio (0.5 = 50% of budget retained after compression)
+    max_delegation_depth: int = Field(
+        default=3,
+        ge=0,
+        validation_alias=AliasChoices("maxDelegationDepth"),
+        serialization_alias="maxDelegationDepth",
+    )  # Max chained peer delegations (A→B→C…) before refusing, to bound cross-delegation loops
     dream: DreamConfig = Field(default_factory=DreamConfig)
+
+
+class PeerAgentConfig(Base):
+    """A named peer agent in the A2A roster (see #4179).
+
+    Each peer can assume a distinct role via its own system prompt and model,
+    while reusing the shared subagent execution + message-bus infrastructure.
+    """
+
+    name: str  # Unique identifier the agent uses to address this peer in ``delegate``
+    role: str = ""  # Short description surfaced to the LLM for delegation routing
+    system_prompt: str | None = None  # Overrides the default subagent prompt for this peer
+    model: str | None = None  # Optional per-peer model override (falls back to the shared model)
 
 
 class AgentsConfig(Base):
     """Agent configuration."""
 
     defaults: AgentDefaults = Field(default_factory=AgentDefaults)
+    peers: list[PeerAgentConfig] = Field(default_factory=list)  # A2A peer roster (#4179)
 
 
 class ProviderConfig(Base):

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -193,6 +193,24 @@ class AgentsConfig(Base):
     defaults: AgentDefaults = Field(default_factory=AgentDefaults)
     peers: list[PeerAgentConfig] = Field(default_factory=list)  # A2A peer roster (#4179)
 
+    @model_validator(mode="after")
+    def _check_unique_peer_names(self) -> AgentsConfig:
+        """Reject duplicate peer names so the roster can't silently drop a peer.
+
+        Peers are keyed by name downstream (``{p.name: p for p in peers}``), so a
+        duplicate would otherwise be deduplicated last-wins and the agent could
+        delegate to a peer that was overwritten.
+        """
+        seen: set[str] = set()
+        dupes: set[str] = set()
+        for peer in self.peers:
+            (dupes if peer.name in seen else seen).add(peer.name)
+        if dupes:
+            raise ValueError(
+                f"duplicate peer name(s) in agents.peers: {', '.join(sorted(dupes))}"
+            )
+        return self
+
 
 class ProviderConfig(Base):
     """LLM provider configuration."""

--- a/tests/agent/test_peer_delegation.py
+++ b/tests/agent/test_peer_delegation.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pydantic import ValidationError
 
 from nanobot.agent.runner import AgentRunResult
 from nanobot.agent.subagent import (
@@ -20,7 +21,7 @@ from nanobot.agent.subagent import (
 from nanobot.agent.tools.context import RequestContext, ToolContext
 from nanobot.agent.tools.delegate import DelegateTool
 from nanobot.bus.queue import MessageBus
-from nanobot.config.schema import PeerAgentConfig
+from nanobot.config.schema import AgentsConfig, PeerAgentConfig
 from nanobot.providers.base import LLMProvider
 
 
@@ -225,3 +226,16 @@ async def test_delegate_allowed_below_max_depth():
 
     assert result == "started"
     sm.spawn.assert_awaited_once()
+
+
+# --- config validation -------------------------------------------------------
+
+
+def test_duplicate_peer_names_rejected():
+    with pytest.raises(ValidationError, match="duplicate peer name"):
+        AgentsConfig(peers=[PeerAgentConfig(name="researcher"), PeerAgentConfig(name="researcher")])
+
+
+def test_unique_peer_names_accepted():
+    cfg = AgentsConfig(peers=[PeerAgentConfig(name="researcher"), PeerAgentConfig(name="writer")])
+    assert [p.name for p in cfg.peers] == ["researcher", "writer"]

--- a/tests/agent/test_peer_delegation.py
+++ b/tests/agent/test_peer_delegation.py
@@ -1,0 +1,227 @@
+"""Tests for A2A peer-agent delegation (#4179).
+
+Covers the peer roster, role-scoped subagent execution (custom system prompt +
+model), the ``delegate`` tool's gating/validation, and the cross-delegation
+depth guard that bounds A→B→C chains.
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.agent.runner import AgentRunResult
+from nanobot.agent.subagent import (
+    _CURRENT_DELEGATION_DEPTH,
+    SubagentManager,
+    SubagentStatus,
+    current_delegation_depth,
+)
+from nanobot.agent.tools.context import RequestContext, ToolContext
+from nanobot.agent.tools.delegate import DelegateTool
+from nanobot.bus.queue import MessageBus
+from nanobot.config.schema import PeerAgentConfig
+from nanobot.providers.base import LLMProvider
+
+
+def _manager(peers=None, max_delegation_depth=3, max_concurrent_subagents=8):
+    provider = MagicMock(spec=LLMProvider)
+    provider.get_default_model.return_value = "parent-model"
+    return SubagentManager(
+        provider=provider,
+        workspace=Path("/tmp"),
+        bus=MessageBus(),
+        model="parent-model",
+        max_tool_result_chars=16_000,
+        max_concurrent_subagents=max_concurrent_subagents,
+        peers={p.name: p for p in (peers or [])},
+        max_delegation_depth=max_delegation_depth,
+    )
+
+
+def _status():
+    return SubagentStatus(task_id="t1", label="l", task_description="task", started_at=0.0)
+
+
+# --- Role-scoped execution ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_peer_system_prompt_and_model_reach_runner():
+    """A peer's system prompt and model override the generic subagent persona."""
+    peer = PeerAgentConfig(
+        name="researcher",
+        role="gathers sources",
+        system_prompt="You are Researcher. Find primary sources.",
+        model="peer-model",
+    )
+    sm = _manager(peers=[peer])
+    sm.runner.run = AsyncMock(
+        return_value=AgentRunResult(final_content="ok", messages=[], stop_reason="completed")
+    )
+    sm._announce_result = AsyncMock()
+
+    await sm._run_subagent(
+        "t1", "task", "researcher", {"channel": "cli", "chat_id": "direct"}, _status(),
+        peer_cfg=peer, delegation_depth=1,
+    )
+
+    spec = sm.runner.run.call_args.args[0]
+    assert spec.model == "peer-model"
+    assert spec.initial_messages[0]["content"] == "You are Researcher. Find primary sources."
+
+
+@pytest.mark.asyncio
+async def test_peer_without_overrides_falls_back_to_defaults():
+    """A peer with no system_prompt/model reuses the shared subagent prompt/model."""
+    peer = PeerAgentConfig(name="writer", role="drafts replies")
+    sm = _manager(peers=[peer])
+    sm.runner.run = AsyncMock(
+        return_value=AgentRunResult(final_content="ok", messages=[], stop_reason="completed")
+    )
+    sm._announce_result = AsyncMock()
+
+    await sm._run_subagent(
+        "t1", "task", "writer", {"channel": "cli", "chat_id": "direct"}, _status(),
+        peer_cfg=peer, delegation_depth=1,
+    )
+
+    spec = sm.runner.run.call_args.args[0]
+    assert spec.model == "parent-model"
+    # Default subagent prompt is rendered, not an empty/peer-specific one.
+    assert spec.initial_messages[0]["content"]
+    assert "You are Researcher" not in spec.initial_messages[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_non_peer_subagent_unaffected():
+    """Plain spawn (no peer) keeps the default model and prompt."""
+    sm = _manager()
+    sm.runner.run = AsyncMock(
+        return_value=AgentRunResult(final_content="ok", messages=[], stop_reason="completed")
+    )
+    sm._announce_result = AsyncMock()
+
+    await sm._run_subagent(
+        "t1", "task", "label", {"channel": "cli", "chat_id": "direct"}, _status(),
+    )
+
+    spec = sm.runner.run.call_args.args[0]
+    assert spec.model == "parent-model"
+
+
+@pytest.mark.asyncio
+async def test_delegation_depth_visible_during_run():
+    """The running peer observes its delegation depth via the contextvar."""
+    peer = PeerAgentConfig(name="researcher")
+    sm = _manager(peers=[peer])
+    seen = {}
+
+    async def _capture(spec):
+        seen["depth"] = current_delegation_depth()
+        return AgentRunResult(final_content="ok", messages=[], stop_reason="completed")
+
+    sm.runner.run = AsyncMock(side_effect=_capture)
+    sm._announce_result = AsyncMock()
+
+    await sm._run_subagent(
+        "t1", "task", "researcher", {"channel": "cli", "chat_id": "direct"}, _status(),
+        peer_cfg=peer, delegation_depth=2,
+    )
+
+    assert seen["depth"] == 2
+    # Restored after the run completes.
+    assert current_delegation_depth() == 0
+
+
+# --- delegate tool: gating + validation -------------------------------------
+
+
+def _ctx(manager):
+    return ToolContext(config=None, workspace="/tmp", subagent_manager=manager)
+
+
+def test_delegate_tool_disabled_without_peers():
+    assert DelegateTool.enabled(_ctx(_manager())) is False
+
+
+def test_delegate_tool_enabled_with_peers():
+    sm = _manager(peers=[PeerAgentConfig(name="researcher")])
+    assert DelegateTool.enabled(_ctx(sm)) is True
+
+
+def test_delegate_tool_description_lists_roster():
+    sm = _manager(peers=[PeerAgentConfig(name="researcher", role="finds sources")])
+    tool = DelegateTool(manager=sm)
+    assert "researcher" in tool.description
+    assert "finds sources" in tool.description
+
+
+@pytest.mark.asyncio
+async def test_delegate_unknown_peer_errors():
+    sm = _manager(peers=[PeerAgentConfig(name="researcher")])
+    sm.spawn = AsyncMock()
+    tool = DelegateTool(manager=sm)
+    tool.set_context(RequestContext(channel="cli", chat_id="direct", session_key="cli:direct"))
+
+    result = await tool.execute(peer="ghost", task="do it")
+
+    assert "unknown peer" in result.lower()
+    assert "researcher" in result
+    sm.spawn.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delegate_forwards_peer_and_increments_depth():
+    sm = _manager(peers=[PeerAgentConfig(name="researcher")])
+    sm.spawn = AsyncMock(return_value="started")
+    tool = DelegateTool(manager=sm)
+    tool.set_context(RequestContext(channel="cli", chat_id="direct", session_key="cli:direct"))
+
+    token = _CURRENT_DELEGATION_DEPTH.set(1)
+    try:
+        result = await tool.execute(peer="researcher", task="find sources")
+    finally:
+        _CURRENT_DELEGATION_DEPTH.reset(token)
+
+    assert result == "started"
+    kwargs = sm.spawn.call_args.kwargs
+    assert kwargs["peer"] == "researcher"
+    assert kwargs["delegation_depth"] == 2
+
+
+# --- depth guard (floor control) --------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delegate_refused_at_max_depth():
+    sm = _manager(peers=[PeerAgentConfig(name="researcher")], max_delegation_depth=2)
+    sm.spawn = AsyncMock()
+    tool = DelegateTool(manager=sm)
+    tool.set_context(RequestContext(channel="cli", chat_id="direct", session_key="cli:direct"))
+
+    token = _CURRENT_DELEGATION_DEPTH.set(2)  # already at the cap
+    try:
+        result = await tool.execute(peer="researcher", task="recurse")
+    finally:
+        _CURRENT_DELEGATION_DEPTH.reset(token)
+
+    assert "maximum delegation depth" in result.lower()
+    sm.spawn.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delegate_allowed_below_max_depth():
+    sm = _manager(peers=[PeerAgentConfig(name="researcher")], max_delegation_depth=2)
+    sm.spawn = AsyncMock(return_value="started")
+    tool = DelegateTool(manager=sm)
+    tool.set_context(RequestContext(channel="cli", chat_id="direct", session_key="cli:direct"))
+
+    token = _CURRENT_DELEGATION_DEPTH.set(1)  # below the cap
+    try:
+        result = await tool.execute(peer="researcher", task="ok")
+    finally:
+        _CURRENT_DELEGATION_DEPTH.reset(token)
+
+    assert result == "started"
+    sm.spawn.assert_awaited_once()

--- a/tests/agent/test_peer_delegation.py
+++ b/tests/agent/test_peer_delegation.py
@@ -239,3 +239,37 @@ def test_duplicate_peer_names_rejected():
 def test_unique_peer_names_accepted():
     cfg = AgentsConfig(peers=[PeerAgentConfig(name="researcher"), PeerAgentConfig(name="writer")])
     assert [p.name for p in cfg.peers] == ["researcher", "writer"]
+
+
+# --- nested delegation: origin context propagates to peer subagent tools -----
+
+
+@pytest.mark.asyncio
+async def test_nested_delegate_inherits_origin_not_defaults():
+    """A peer that re-delegates must route from the origin session, not cli/direct.
+
+    _build_tools makes a fresh registry whose ContextAware tools are never
+    set_context()'d, so without _bind_tool_context the nested delegate would use
+    the cli/direct defaults. Verify the bind fixes it.
+    """
+    sm = _manager(peers=[PeerAgentConfig(name="researcher")])
+    tools = sm._build_tools()  # subagent-scope registry; includes delegate (peers set)
+    assert tools.has("delegate")
+
+    origin = {"channel": "telegram", "chat_id": "grp1", "session_key": "telegram:grp1"}
+    sm._bind_tool_context(tools, origin, "msg-42")
+
+    delegate = tools.get("delegate")
+    sm.spawn = AsyncMock(return_value="started")
+    token = _CURRENT_DELEGATION_DEPTH.set(1)
+    try:
+        await delegate.execute(peer="researcher", task="dig deeper")
+    finally:
+        _CURRENT_DELEGATION_DEPTH.reset(token)
+
+    kwargs = sm.spawn.call_args.kwargs
+    assert kwargs["origin_channel"] == "telegram"
+    assert kwargs["origin_chat_id"] == "grp1"
+    assert kwargs["session_key"] == "telegram:grp1"
+    assert kwargs["origin_message_id"] == "msg-42"
+    assert kwargs["delegation_depth"] == 2


### PR DESCRIPTION
Closes part of #4179.

## What the issue asks for

A native Agent-to-Agent (A2A) mechanism so a *team* of agents (e.g. Supervisor → Researcher → Writer) can collaborate, instead of `spawn` only running anonymous, single-purpose background subagents. The issue lists three mechanics: (1) an agent registry, (2) mention-based routing in each channel, and (3) horizontal message-bus routing between peers.

## Current behavior

`SubagentManager.spawn` always runs a **generic** subagent: a fixed `_build_subagent_prompt`, the shared model, and a result announced back to the *parent*. There is no notion of a named teammate with its own role, and nothing stops an agent from delegating in an unbounded chain.

## This PR (the decoupled core — mechanics 1 & 3)

I deliberately scoped this to the **channel-agnostic** core and left per-channel `@mention` parsing (mechanic 2) for a follow-up — parsing usernames inside each of the ~20 channel modules is the wrong layer to start at, and routing belongs below the channels.

- **Peer roster** — `agents.peers`: a list of `{ name, role, systemPrompt?, model? }`. Each peer assumes a distinct role (its own system prompt + model) while reusing the existing `SubagentManager` + `MessageBus` execution path.
- **`delegate(peer, task)` tool** — gated on having peers configured. It validates the peer name, respects the existing concurrency limit, and routes the task to that registered peer, which reports back exactly like a spawned subagent. The roster (names + roles) is surfaced in the tool description so the model knows who it can hand work to.
- **Cross-delegation depth guard (floor control)** — `delegate` is *subagent-scoped*, so a peer can re-delegate down the chain (Supervisor → Researcher → …). A `delegation depth` contextvar is bound per run and `agents.defaults.maxDelegationDepth` caps the chain, so A→B→A… can't run away. This is the piece the issue doesn't mention but that any horizontal delegation needs.

## Why this over the issue's literal proposal

The issue frames routing as "expand channel parsing in `telegram.py`/`discord.py`". Putting addressing in each channel duplicates logic across every platform and couples orchestration to the chat surface. Keeping the registry + delegation in `SubagentManager` (below the bus) makes it work for **every** channel at once and keeps the channels dumb. A later PR can add an optional `@peer` parse that simply emits a `delegate` call — but the mechanism shouldn't depend on it.

## Tests

`tests/agent/test_peer_delegation.py` (11 tests): peer system-prompt + model reach the runner; non-peer/no-override paths fall back to defaults unchanged; the depth contextvar is visible during a run and restored after; `delegate` is gated on peers; unknown-peer and at-max-depth are refused without spawning; and `delegate` forwards the peer and increments depth. Full suite green (1371 passed), `ruff` clean on changed files.
