### PR TITLE
test(exec): cover bwrap sandbox mounts

### DIFF
--- a/tests/tools/test_sandbox.py
+++ b/tests/tools/test_sandbox.py
@@ -57,6 +57,37 @@ class TestBwrapBackend:
         tmpfs_targets = {tokens[i + 1] for i in tmpfs_indices}
         assert str(ws.parent) in tmpfs_targets
 
+    def test_tmp_dir_mounted_as_tmpfs(self, tmp_path):
+        """Regression coverage for #1948: commands need writable scratch space."""
+        ws = tmp_path / "project"
+        result = wrap_command("bwrap", "touch /tmp/probe", str(ws), str(ws))
+        tokens = _parse(result)
+
+        tmpfs_indices = [i for i, t in enumerate(tokens) if t == "--tmpfs"]
+        tmpfs_targets = {tokens[i + 1] for i in tmpfs_indices}
+        assert "/tmp" in tmpfs_targets
+
+    def test_parent_mask_precedes_workspace_recreation(self, tmp_path):
+        ws = tmp_path / "project"
+        result = wrap_command("bwrap", "ls", str(ws), str(ws))
+        tokens = _parse(result)
+
+        parent_mask = next(
+            i for i, t in enumerate(tokens)
+            if t == "--tmpfs" and tokens[i + 1] == str(ws.parent)
+        )
+        workspace_dir = next(
+            i for i, t in enumerate(tokens)
+            if t == "--dir" and tokens[i + 1] == str(ws)
+        )
+        workspace_bind = next(
+            i for i, t in enumerate(tokens)
+            if t == "--bind" and tokens[i + 1] == str(ws) and tokens[i + 2] == str(ws)
+        )
+        chdir = tokens.index("--chdir")
+
+        assert parent_mask < workspace_dir < workspace_bind < chdir
+
     def test_cwd_inside_workspace(self, tmp_path):
         ws = tmp_path / "project"
         sub = ws / "src" / "lib"


### PR DESCRIPTION
## Summary

- Add regression coverage that the bwrap backend mounts `/tmp` as tmpfs for shell scratch space.
- Assert the workspace parent tmpfs mask is installed before the workspace mount is recreated and rebound.
- Keep the checks at command-construction level so they do not require bubblewrap to be installed locally.

## Validation

- `uv run --extra dev pytest tests/tools/test_sandbox.py -q`
- `uv run --extra dev pytest tests/tools/test_exec_platform.py::TestSandboxPlatform -q`
- `uv run --extra dev ruff check tests/tools/test_sandbox.py`
- `git diff --check`

Refs #1948.