### PR TITLE
perf(agent): prune low-value context payloads

### DIFF
--- a/nanobot/agent/context_governance.py
+++ b/nanobot/agent/context_governance.py
@@ -7,6 +7,7 @@ mutate an existing session history list in place.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -28,6 +29,10 @@ if TYPE_CHECKING:
 SNIP_SAFETY_BUFFER = 1024
 MICROCOMPACT_KEEP_RECENT = 10
 MICROCOMPACT_MIN_CHARS = 500
+STALE_ERROR_USER_TURNS = 4
+ADAPTIVE_TOOL_RESULT_MIN_CHARS = 4_000
+ADAPTIVE_TOOL_RESULT_BUDGET_RATIO = 0.08
+SUBAGENT_RESULT_MAX_CHARS = 6_000
 INFLIGHT_COMPACT_TARGET_RATIO = 0.85
 COMPACTABLE_TOOLS = frozenset({
     "read_file", "exec", "grep", "find_files",
@@ -63,7 +68,10 @@ class ContextGovernor:
     ) -> list[dict[str, Any]]:
         updated = self.drop_orphan_tool_results(messages)
         updated = self.backfill_missing_tool_results(updated)
+        updated = self.compact_subagent_announcements(updated)
         updated = self.apply_tool_result_budget(config, updated)
+        updated = self.compact_duplicate_tool_results(updated)
+        updated = self.compact_stale_error_tool_results(updated)
         updated = self.compact_inflight_overflow(config, updated, compacted_tool_call_ids)
         updated = self.snip_history(config, updated)
         updated = self.drop_orphan_tool_results(updated)
@@ -93,17 +101,20 @@ class ContextGovernor:
         tool_call_id: str,
         tool_name: str,
         result: Any,
+        *,
+        max_chars: int | None = None,
     ) -> Any:
         result = ensure_nonempty_tool_result(tool_name, result)
         if tool_name in TOOL_RESULT_OFFLOAD_EXEMPT_TOOLS:
             return result
+        max_chars = max_chars if max_chars is not None else config.max_tool_result_chars
         try:
             content = maybe_persist_tool_result(
                 config.workspace,
                 config.session_key,
                 tool_call_id,
                 result,
-                max_chars=config.max_tool_result_chars,
+                max_chars=max_chars,
             )
         except Exception:
             logger.exception(
@@ -112,8 +123,8 @@ class ContextGovernor:
                 config.session_key or "default",
             )
             content = result
-        if isinstance(content, str) and len(content) > config.max_tool_result_chars:
-            return truncate_text(content, config.max_tool_result_chars)
+        if isinstance(content, str) and len(content) > max_chars:
+            return truncate_text(content, max_chars)
         return content
 
     @staticmethod
@@ -189,6 +200,7 @@ class ContextGovernor:
         messages: list[dict[str, Any]],
     ) -> list[dict[str, Any]]:
         updated = messages
+        max_chars = self._effective_tool_result_chars(config)
         for idx, message in enumerate(messages):
             if message.get("role") != "tool":
                 continue
@@ -197,6 +209,7 @@ class ContextGovernor:
                 str(message.get("tool_call_id") or f"tool_{idx}"),
                 str(message.get("name") or "tool"),
                 message.get("content"),
+                max_chars=max_chars,
             )
             if normalized != message.get("content"):
                 if updated is messages:
@@ -312,10 +325,179 @@ class ContextGovernor:
 
         return system_messages + self._legal_history_tail(kept, non_system)
 
+    def compact_subagent_announcements(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Trim oversized persisted subagent announcements before model replay."""
+        updated = messages
+        for idx, message in enumerate(messages):
+            content = message.get("content")
+            if message.get("role") != "user" or not isinstance(content, str):
+                continue
+            compacted = self._compact_subagent_announcement(content)
+            if compacted == content:
+                continue
+            if updated is messages:
+                updated = [dict(m) for m in messages]
+            updated[idx]["content"] = compacted
+        return updated
+
+    def compact_duplicate_tool_results(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Compact older duplicate compactable tool results in the model copy.
+
+        The raw session history remains intact. Only exact repeats of the same
+        tool name and normalized arguments are compacted, and the newest result
+        stays visible as the recovery path for the model.
+        """
+        tool_signatures = self._tool_call_signatures(messages)
+        seen: dict[tuple[str, str], list[int]] = {}
+        for idx, msg in enumerate(messages):
+            if not self._is_compactable_tool_result(msg):
+                continue
+            call_id = str(msg.get("tool_call_id") or "")
+            signature = tool_signatures.get(call_id)
+            if signature is None:
+                continue
+            seen.setdefault(signature, []).append(idx)
+
+        compact_indexes = {idx for indexes in seen.values() for idx in indexes[:-1]}
+        if not compact_indexes:
+            return messages
+
+        updated = [dict(m) for m in messages]
+        for idx in sorted(compact_indexes):
+            self._compact_tool_result_at(updated, idx)
+        return updated
+
+    def compact_stale_error_tool_results(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Compact old failed tool payloads after several newer user turns."""
+        turns_after = 0
+        compact_indexes: list[int] = []
+        for idx in range(len(messages) - 1, -1, -1):
+            msg = messages[idx]
+            if msg.get("role") == "user":
+                turns_after += 1
+                continue
+            if turns_after < STALE_ERROR_USER_TURNS:
+                continue
+            if not self._is_compactable_tool_result(msg, min_chars=0):
+                continue
+            content = msg.get("content")
+            if isinstance(content, str) and content.lstrip().startswith("Error:"):
+                compact_indexes.append(idx)
+
+        if not compact_indexes:
+            return messages
+
+        updated = [dict(m) for m in messages]
+        for idx in compact_indexes:
+            self._compact_tool_result_at(updated, idx)
+        return updated
+
     @staticmethod
     def _summary_for(message: dict[str, Any]) -> str:
         name = message.get("name", "tool")
         return f"[{name} result omitted from context]"
+
+    @classmethod
+    def _is_compacted_summary(cls, message: dict[str, Any]) -> bool:
+        content = message.get("content")
+        return isinstance(content, str) and content == cls._summary_for(message)
+
+    @classmethod
+    def _is_compactable_tool_result(
+        cls,
+        message: dict[str, Any],
+        *,
+        min_chars: int = MICROCOMPACT_MIN_CHARS,
+    ) -> bool:
+        if message.get("role") != "tool" or message.get("name") not in COMPACTABLE_TOOLS:
+            return False
+        if cls._is_compacted_summary(message):
+            return False
+        content = message.get("content")
+        return isinstance(content, str) and len(content) >= min_chars
+
+    @classmethod
+    def _tool_call_signatures(
+        cls,
+        messages: list[dict[str, Any]],
+    ) -> dict[str, tuple[str, str]]:
+        signatures: dict[str, tuple[str, str]] = {}
+        for msg in messages:
+            if msg.get("role") != "assistant":
+                continue
+            for tool_call in msg.get("tool_calls") or []:
+                if not isinstance(tool_call, dict) or not tool_call.get("id"):
+                    continue
+                func = tool_call.get("function")
+                if not isinstance(func, dict):
+                    continue
+                name = str(func.get("name") or "")
+                if name not in COMPACTABLE_TOOLS:
+                    continue
+                signatures[str(tool_call["id"])] = (
+                    name,
+                    cls._normalize_tool_arguments(func.get("arguments")),
+                )
+        return signatures
+
+    @staticmethod
+    def _normalize_tool_arguments(arguments: Any) -> str:
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except Exception:
+                return arguments.strip()
+        try:
+            return json.dumps(arguments, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        except TypeError:
+            return str(arguments)
+
+    @staticmethod
+    def _effective_tool_result_chars(config: ContextGovernanceConfig) -> int:
+        limit = config.max_tool_result_chars
+        budget = ContextGovernor.input_budget(config)
+        if budget <= 0:
+            return limit
+        adaptive = max(
+            ADAPTIVE_TOOL_RESULT_MIN_CHARS,
+            int(budget * ADAPTIVE_TOOL_RESULT_BUDGET_RATIO),
+        )
+        return min(limit, adaptive)
+
+    @staticmethod
+    def _compact_subagent_announcement(content: str) -> str:
+        normalized = content.replace("\r\n", "\n")
+        stripped = normalized.lstrip()
+        if not stripped.startswith("[Subagent"):
+            return content
+        lower = normalized.lower()
+        result_marker = "\nresult:\n"
+        result_idx = lower.find(result_marker)
+        if result_idx == -1:
+            result_marker = "\nresult:"
+            result_idx = lower.find(result_marker)
+        if result_idx == -1:
+            return content
+
+        result_start = result_idx + len(result_marker)
+        after_result = normalized[result_start:].lstrip()
+        instruction_marker = "summarize this naturally"
+        instruction_idx = after_result.lower().find(instruction_marker)
+        if instruction_idx == -1:
+            result_text = after_result.rstrip()
+            instruction = ""
+        else:
+            result_text = after_result[:instruction_idx].rstrip()
+            instruction = after_result[instruction_idx:].lstrip()
+
+        if len(result_text) <= SUBAGENT_RESULT_MAX_CHARS:
+            return content
+
+        prefix = normalized[:result_start]
+        compacted_result = truncate_text(result_text, SUBAGENT_RESULT_MAX_CHARS)
+        compacted_result += "\n\n[Subagent result truncated for context replay.]"
+        suffix = f"\n\n{instruction}" if instruction else ""
+        return f"{prefix}{compacted_result}{suffix}"
 
     def _legal_history_tail(
         self,

--- a/nanobot/agent/context_governance.py
+++ b/nanobot/agent/context_governance.py
@@ -7,6 +7,7 @@ mutate an existing session history list in place.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -344,11 +345,11 @@ class ContextGovernor:
         """Compact older duplicate compactable tool results in the model copy.
 
         The raw session history remains intact. Only exact repeats of the same
-        tool name and normalized arguments are compacted, and the newest result
-        stays visible as the recovery path for the model.
+        tool name, normalized arguments, user turn, and content are compacted,
+        and the newest result stays visible as the recovery path for the model.
         """
         tool_signatures = self._tool_call_signatures(messages)
-        seen: dict[tuple[str, str, int], list[int]] = {}
+        seen: dict[tuple[str, str, int, str], list[int]] = {}
         for idx, msg in enumerate(messages):
             if not self._is_compactable_tool_result(msg):
                 continue
@@ -356,7 +357,8 @@ class ContextGovernor:
             signature = tool_signatures.get(call_id)
             if signature is None:
                 continue
-            seen.setdefault(signature, []).append(idx)
+            content = str(msg.get("content") or "")
+            seen.setdefault((*signature, self._content_digest(content)), []).append(idx)
 
         compact_indexes = {idx for indexes in seen.values() for idx in indexes[:-1]}
         if not compact_indexes:
@@ -374,11 +376,13 @@ class ContextGovernor:
         for idx in range(len(messages) - 1, -1, -1):
             msg = messages[idx]
             if msg.get("role") == "user":
+                if self._is_subagent_announcement(msg.get("content")):
+                    continue
                 turns_after += 1
                 continue
             if turns_after < STALE_ERROR_USER_TURNS:
                 continue
-            if not self._is_compactable_tool_result(msg, min_chars=0):
+            if not self._is_compactable_tool_result(msg):
                 continue
             content = msg.get("content")
             if isinstance(content, str) and content.lstrip().startswith("Error:"):
@@ -458,6 +462,10 @@ class ContextGovernor:
             return str(arguments)
 
     @staticmethod
+    def _content_digest(content: str) -> str:
+        return hashlib.sha256(content.encode("utf-8", errors="replace")).hexdigest()
+
+    @staticmethod
     def _effective_tool_result_chars(config: ContextGovernanceConfig) -> int:
         limit = config.max_tool_result_chars
         budget = ContextGovernor.input_budget(config)
@@ -472,8 +480,7 @@ class ContextGovernor:
     @staticmethod
     def _compact_subagent_announcement(content: str) -> str:
         normalized = content.replace("\r\n", "\n")
-        stripped = normalized.lstrip()
-        if not stripped.startswith("[Subagent"):
+        if not ContextGovernor._is_subagent_announcement(normalized):
             return content
         lower = normalized.lower()
         result_marker = "\nresult:\n"
@@ -503,6 +510,10 @@ class ContextGovernor:
         compacted_result += "\n\n[Subagent result truncated for context replay.]"
         suffix = f"\n\n{instruction}" if instruction else ""
         return f"{prefix}{compacted_result}{suffix}"
+
+    @staticmethod
+    def _is_subagent_announcement(content: Any) -> bool:
+        return isinstance(content, str) and content.lstrip().startswith("[Subagent")
 
     def _legal_history_tail(
         self,

--- a/nanobot/agent/context_governance.py
+++ b/nanobot/agent/context_governance.py
@@ -348,7 +348,7 @@ class ContextGovernor:
         stays visible as the recovery path for the model.
         """
         tool_signatures = self._tool_call_signatures(messages)
-        seen: dict[tuple[str, str], list[int]] = {}
+        seen: dict[tuple[str, str, int], list[int]] = {}
         for idx, msg in enumerate(messages):
             if not self._is_compactable_tool_result(msg):
                 continue
@@ -420,9 +420,13 @@ class ContextGovernor:
     def _tool_call_signatures(
         cls,
         messages: list[dict[str, Any]],
-    ) -> dict[str, tuple[str, str]]:
-        signatures: dict[str, tuple[str, str]] = {}
+    ) -> dict[str, tuple[str, str, int]]:
+        signatures: dict[str, tuple[str, str, int]] = {}
+        user_turn = 0
         for msg in messages:
+            if msg.get("role") == "user":
+                user_turn += 1
+                continue
             if msg.get("role") != "assistant":
                 continue
             for tool_call in msg.get("tool_calls") or []:
@@ -437,6 +441,7 @@ class ContextGovernor:
                 signatures[str(tool_call["id"])] = (
                     name,
                     cls._normalize_tool_arguments(func.get("arguments")),
+                    user_turn,
                 )
         return signatures
 

--- a/nanobot/agent/context_governance.py
+++ b/nanobot/agent/context_governance.py
@@ -70,9 +70,9 @@ class ContextGovernor:
         updated = self.drop_orphan_tool_results(messages)
         updated = self.backfill_missing_tool_results(updated)
         updated = self.compact_subagent_announcements(updated)
-        updated = self.apply_tool_result_budget(config, updated)
         updated = self.compact_duplicate_tool_results(updated)
         updated = self.compact_stale_error_tool_results(updated)
+        updated = self.apply_tool_result_budget(config, updated)
         updated = self.compact_inflight_overflow(config, updated, compacted_tool_call_ids)
         updated = self.snip_history(config, updated)
         updated = self.drop_orphan_tool_results(updated)
@@ -493,14 +493,14 @@ class ContextGovernor:
 
         result_start = result_idx + len(result_marker)
         after_result = normalized[result_start:].lstrip()
-        instruction_marker = "summarize this naturally"
-        instruction_idx = after_result.lower().find(instruction_marker)
+        instruction_marker = "\n\nsummarize this naturally"
+        instruction_idx = after_result.lower().rfind(instruction_marker)
         if instruction_idx == -1:
             result_text = after_result.rstrip()
             instruction = ""
         else:
             result_text = after_result[:instruction_idx].rstrip()
-            instruction = after_result[instruction_idx:].lstrip()
+            instruction = after_result[instruction_idx + 2:].lstrip()
 
         if len(result_text) <= SUBAGENT_RESULT_MAX_CHARS:
             return content

--- a/tests/agent/test_runner_governance.py
+++ b/tests/agent/test_runner_governance.py
@@ -821,6 +821,63 @@ def test_compact_duplicate_tool_results_preserves_same_turn_different_content():
     assert result[4]["content"] == second
 
 
+def test_prepare_for_model_compacts_large_duplicates_before_persisting(tmp_path, monkeypatch):
+    provider = MagicMock()
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    content = "identical output\n" * 400
+    messages = [
+        {"role": "system", "content": "sys"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "old",
+                "type": "function",
+                "function": {"name": "exec", "arguments": '{"cmd":"pytest -q"}'},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "old", "name": "exec", "content": content},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "new",
+                "type": "function",
+                "function": {"name": "exec", "arguments": '{"cmd":"pytest -q"}'},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "new", "name": "exec", "content": content},
+    ]
+    spec = AgentRunSpec(
+        initial_messages=messages,
+        tools=tools,
+        model="test-model",
+        max_iterations=1,
+        max_tool_result_chars=4_000,
+        workspace=tmp_path,
+        session_key="cli:test",
+    )
+
+    monkeypatch.setattr(
+        "nanobot.agent.context_governance.estimate_prompt_tokens_chain",
+        lambda *_args, **_kwargs: (0, "test"),
+    )
+
+    result = ContextGovernor().prepare_for_model(
+        _governance_config(provider, tools, spec),
+        messages,
+        set(),
+    )
+
+    assert result[2]["content"] == "[exec result omitted from context]"
+    assert result[4]["content"].startswith("[tool output persisted]")
+    assert "new.txt" in result[4]["content"]
+    assert "old.txt" not in result[2]["content"]
+    assert messages[2]["content"] == content
+    assert messages[4]["content"] == content
+
+
 def test_compact_duplicate_tool_results_skips_different_arguments():
     content = "search output\n" * 80
     messages = [
@@ -928,6 +985,27 @@ def test_compact_subagent_announcements_trims_large_result_only():
     assert "Task: inspect the project" in compacted
     assert "[Subagent result truncated for context replay.]" in compacted
     assert "Summarize this naturally for the user" in compacted
+    assert len(compacted) < len(content)
+
+
+def test_compact_subagent_announcements_uses_final_instruction_marker():
+    quoted_marker = "A fixture says: Summarize this naturally but this is result text.\n"
+    long_result = quoted_marker + ("x" * (SUBAGENT_RESULT_MAX_CHARS + 500))
+    content = (
+        "[Subagent 'research' completed successfully]\n\n"
+        "Task: inspect the project\n\n"
+        f"Result:\n{long_result}\n\n"
+        "Summarize this naturally for the user. Keep the conclusion."
+    )
+    messages = [{"role": "user", "content": content}]
+
+    result = ContextGovernor().compact_subagent_announcements(messages)
+
+    assert result is not messages
+    compacted = result[0]["content"]
+    assert quoted_marker.rstrip() in compacted
+    assert "[Subagent result truncated for context replay.]" in compacted
+    assert "Summarize this naturally for the user. Keep the conclusion." in compacted
     assert len(compacted) < len(content)
 
 

--- a/tests/agent/test_runner_governance.py
+++ b/tests/agent/test_runner_governance.py
@@ -787,6 +787,40 @@ def test_compact_duplicate_tool_results_preserves_cross_turn_snapshots():
     assert result[5]["content"] == content
 
 
+def test_compact_duplicate_tool_results_preserves_same_turn_different_content():
+    first = "pytest failed: test_a\n" * 80
+    second = "pytest passed\n" * 80
+    messages = [
+        {"role": "system", "content": "sys"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "first",
+                "type": "function",
+                "function": {"name": "exec", "arguments": '{"cmd":"pytest -q"}'},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "first", "name": "exec", "content": first},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "second",
+                "type": "function",
+                "function": {"name": "exec", "arguments": '{"cmd":"pytest -q"}'},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "second", "name": "exec", "content": second},
+    ]
+
+    result = ContextGovernor().compact_duplicate_tool_results(messages)
+
+    assert result is messages
+    assert result[2]["content"] == first
+    assert result[4]["content"] == second
+
+
 def test_compact_duplicate_tool_results_skips_different_arguments():
     content = "search output\n" * 80
     messages = [
@@ -819,7 +853,7 @@ def test_compact_duplicate_tool_results_skips_different_arguments():
 
 
 def test_compact_stale_error_tool_results_after_newer_user_turns():
-    error = "Error: RuntimeError: boom"
+    error = "Error: RuntimeError: boom\n" + ("traceback line\n" * 80)
     messages = [
         {"role": "system", "content": "sys"},
         {"role": "assistant", "content": "", "tool_calls": [{"id": "bad"}]},
@@ -838,6 +872,42 @@ def test_compact_stale_error_tool_results_after_newer_user_turns():
     assert result is not messages
     assert messages[2]["content"] == error
     assert result[2]["content"] == "[exec result omitted from context]"
+
+
+def test_compact_stale_error_tool_results_keeps_short_errors():
+    error = "Error: Permission denied"
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "bad"}]},
+        {"role": "tool", "tool_call_id": "bad", "name": "exec", "content": error},
+        {"role": "user", "content": "turn 1"},
+        {"role": "user", "content": "turn 2"},
+        {"role": "user", "content": "turn 3"},
+        {"role": "user", "content": "turn 4"},
+    ]
+
+    result = ContextGovernor().compact_stale_error_tool_results(messages)
+
+    assert result is messages
+    assert result[2]["content"] == error
+
+
+def test_compact_stale_error_tool_results_ignores_subagent_user_announcements():
+    error = "Error: RuntimeError: boom\n" + ("traceback line\n" * 80)
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "bad"}]},
+        {"role": "tool", "tool_call_id": "bad", "name": "exec", "content": error},
+        {"role": "user", "content": "[Subagent 'research' completed successfully]\n\nResult:\nok"},
+        {"role": "user", "content": "turn 1"},
+        {"role": "user", "content": "turn 2"},
+        {"role": "user", "content": "turn 3"},
+    ]
+
+    result = ContextGovernor().compact_stale_error_tool_results(messages)
+
+    assert result is messages
+    assert result[2]["content"] == error
 
 
 def test_compact_subagent_announcements_trims_large_result_only():

--- a/tests/agent/test_runner_governance.py
+++ b/tests/agent/test_runner_governance.py
@@ -10,6 +10,7 @@ import pytest
 from nanobot.agent.context_governance import (
     BACKFILL_CONTENT,
     MICROCOMPACT_KEEP_RECENT,
+    SUBAGENT_RESULT_MAX_CHARS,
     ContextGovernanceConfig,
     ContextGovernor,
 )
@@ -716,6 +717,144 @@ def test_microcompact_skips_non_compactable_tools(monkeypatch):
         set(),
     )
     assert result is messages  # no compactable tools found
+
+
+def test_compact_duplicate_tool_results_preserves_newest_result():
+    content = "duplicate output\n" * 80
+    messages = [
+        {"role": "system", "content": "sys"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "old",
+                "type": "function",
+                "function": {"name": "grep", "arguments": '{"pattern":"x","path":"."}'},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "old", "name": "grep", "content": content},
+        {"role": "user", "content": "try again"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "new",
+                "type": "function",
+                "function": {"name": "grep", "arguments": '{"path":".","pattern":"x"}'},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "new", "name": "grep", "content": content},
+    ]
+
+    result = ContextGovernor().compact_duplicate_tool_results(messages)
+
+    assert result is not messages
+    assert messages[2]["content"] == content
+    assert result[2]["content"] == "[grep result omitted from context]"
+    assert result[5]["content"] == content
+
+
+def test_compact_duplicate_tool_results_skips_different_arguments():
+    content = "search output\n" * 80
+    messages = [
+        {"role": "system", "content": "sys"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "first",
+                "type": "function",
+                "function": {"name": "web_search", "arguments": '{"query":"one"}'},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "first", "name": "web_search", "content": content},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "second",
+                "type": "function",
+                "function": {"name": "web_search", "arguments": '{"query":"two"}'},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "second", "name": "web_search", "content": content},
+    ]
+
+    result = ContextGovernor().compact_duplicate_tool_results(messages)
+
+    assert result is messages
+
+
+def test_compact_stale_error_tool_results_after_newer_user_turns():
+    error = "Error: RuntimeError: boom"
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "bad"}]},
+        {"role": "tool", "tool_call_id": "bad", "name": "exec", "content": error},
+        {"role": "user", "content": "turn 1"},
+        {"role": "assistant", "content": "reply 1"},
+        {"role": "user", "content": "turn 2"},
+        {"role": "assistant", "content": "reply 2"},
+        {"role": "user", "content": "turn 3"},
+        {"role": "assistant", "content": "reply 3"},
+        {"role": "user", "content": "turn 4"},
+    ]
+
+    result = ContextGovernor().compact_stale_error_tool_results(messages)
+
+    assert result is not messages
+    assert messages[2]["content"] == error
+    assert result[2]["content"] == "[exec result omitted from context]"
+
+
+def test_compact_subagent_announcements_trims_large_result_only():
+    long_result = "x" * (SUBAGENT_RESULT_MAX_CHARS + 500)
+    content = (
+        "[Subagent 'research' completed successfully]\n\n"
+        "Task: inspect the project\n\n"
+        f"Result:\n{long_result}\n\n"
+        "Summarize this naturally for the user. Keep it brief."
+    )
+    messages = [{"role": "user", "content": content}]
+
+    result = ContextGovernor().compact_subagent_announcements(messages)
+
+    assert result is not messages
+    assert messages[0]["content"] == content
+    compacted = result[0]["content"]
+    assert "Task: inspect the project" in compacted
+    assert "[Subagent result truncated for context replay.]" in compacted
+    assert "Summarize this naturally for the user" in compacted
+    assert len(compacted) < len(content)
+
+
+def test_apply_tool_result_budget_uses_adaptive_limit_for_tight_context():
+    provider = MagicMock()
+    provider.generation = SimpleNamespace(max_tokens=0)
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    content = "x" * 5_000
+    messages = [{"role": "tool", "tool_call_id": "exec_1", "name": "exec", "content": content}]
+    spec = AgentRunSpec(
+        initial_messages=messages,
+        tools=tools,
+        model="test-model",
+        max_iterations=1,
+        max_tool_result_chars=16_000,
+        context_window_tokens=100_000,
+        context_block_limit=50_000,
+        max_tokens=0,
+    )
+
+    result = ContextGovernor().apply_tool_result_budget(
+        _governance_config(provider, tools, spec),
+        messages,
+    )
+
+    assert result is not messages
+    assert messages[0]["content"] == content
+    assert result[0]["content"].startswith("x" * 4_000)
+    assert len(result[0]["content"]) < len(content)
 
 
 def test_governance_repairs_orphans_after_snip():

--- a/tests/agent/test_runner_governance.py
+++ b/tests/agent/test_runner_governance.py
@@ -719,7 +719,7 @@ def test_microcompact_skips_non_compactable_tools(monkeypatch):
     assert result is messages  # no compactable tools found
 
 
-def test_compact_duplicate_tool_results_preserves_newest_result():
+def test_compact_duplicate_tool_results_preserves_newest_result_in_same_turn():
     content = "duplicate output\n" * 80
     messages = [
         {"role": "system", "content": "sys"},
@@ -733,7 +733,6 @@ def test_compact_duplicate_tool_results_preserves_newest_result():
             }],
         },
         {"role": "tool", "tool_call_id": "old", "name": "grep", "content": content},
-        {"role": "user", "content": "try again"},
         {
             "role": "assistant",
             "content": "",
@@ -751,6 +750,40 @@ def test_compact_duplicate_tool_results_preserves_newest_result():
     assert result is not messages
     assert messages[2]["content"] == content
     assert result[2]["content"] == "[grep result omitted from context]"
+    assert result[4]["content"] == content
+
+
+def test_compact_duplicate_tool_results_preserves_cross_turn_snapshots():
+    content = "duplicate output\n" * 80
+    messages = [
+        {"role": "system", "content": "sys"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "old",
+                "type": "function",
+                "function": {"name": "grep", "arguments": '{"pattern":"x","path":"."}'},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "old", "name": "grep", "content": content},
+        {"role": "user", "content": "try again after changing files"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "new",
+                "type": "function",
+                "function": {"name": "grep", "arguments": '{"path":".","pattern":"x"}'},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "new", "name": "grep", "content": content},
+    ]
+
+    result = ContextGovernor().compact_duplicate_tool_results(messages)
+
+    assert result is messages
+    assert result[2]["content"] == content
     assert result[5]["content"] == content
 
 


### PR DESCRIPTION
## Summary
- compact oversized persisted subagent announcements before model replay while keeping task/header/instruction context
- adapt tool-result replay limits to tight context budgets without changing persisted history
- compact older duplicate compactable tool results only when tool name, normalized arguments, user turn, and raw result content all match
- preserve repeated exec/grep/read_file snapshots across later turns, same-turn state changes, and persisted-reference normalization
- compact only large stale errored tool outputs after several newer human user turns, keeping short high-signal errors intact and ignoring subagent announcements for staleness aging
- add focused ContextGovernor regression coverage for adaptive limits, subagent trimming, stale errors, duplicate pruning, raw duplicate identity before persistence, and quoted subagent instruction markers

## Review Follow-up
- addresses the original concern that repeated tool calls with identical names/arguments can represent different local states after user turns or file changes
- addresses same-turn snapshot safety by requiring identical result content before duplicate compaction
- deduplicates before tool-result budget persistence so identical oversized raw outputs are still recognized even when persisted references would use different per-call paths
- keeps short stale errors visible and avoids counting internal subagent announcements as newer user turns
- narrows subagent instruction parsing to the final instruction paragraph so quoted marker text inside large results does not bypass trimming

## Verification
- uv run --extra dev pytest tests/agent/test_runner_governance.py -q
- uv run --extra dev ruff check nanobot/agent/context_governance.py tests/agent/test_runner_governance.py

Related to #4588