### PR TITLE
fix(context): make replay message cap internal

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -205,7 +205,6 @@ class AgentLoop:
         timezone: str | None = None,
         session_ttl_minutes: int = 0,
         consolidation_ratio: float = 0.5,
-        max_messages: int = 0,
         hooks: list[AgentHook] | None = None,
         unified_session: bool = False,
         disabled_skills: list[str] | None = None,
@@ -296,12 +295,7 @@ class AgentLoop:
             llm_wall_timeout_for_session=lambda sk: runner_wall_llm_timeout_s(self.sessions, sk),
         )
         self._unified_session = unified_session
-        self._explicit_max_messages = max_messages > 0
-        self._max_messages = (
-            max_messages
-            if self._explicit_max_messages
-            else replay_max_messages_for_context(self.context_window_tokens)
-        )
+        self._max_messages = replay_max_messages_for_context(self.context_window_tokens)
         self._running = False
         self._mcp_servers = mcp_servers or {}
         self._mcp_stacks: dict[str, AsyncExitStack] = {}
@@ -444,8 +438,7 @@ class AgentLoop:
         logger.info("Runtime model switched for next turn: {} -> {}", old_model, model)
 
     def _sync_replay_max_messages(self) -> None:
-        if not self._explicit_max_messages:
-            self._max_messages = replay_max_messages_for_context(self.context_window_tokens)
+        self._max_messages = replay_max_messages_for_context(self.context_window_tokens)
 
     def _refresh_provider_snapshot(self) -> None:
         if self._provider_snapshot_loader is None:

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -201,7 +201,7 @@ class AgentLoop:
         timezone: str | None = None,
         session_ttl_minutes: int = 0,
         consolidation_ratio: float = 0.5,
-        max_messages: int = 120,
+        max_messages: int = 500,
         hooks: list[AgentHook] | None = None,
         unified_session: bool = False,
         disabled_skills: list[str] | None = None,
@@ -292,7 +292,7 @@ class AgentLoop:
             llm_wall_timeout_for_session=lambda sk: runner_wall_llm_timeout_s(self.sessions, sk),
         )
         self._unified_session = unified_session
-        self._max_messages = max_messages if max_messages > 0 else 120
+        self._max_messages = max_messages if max_messages > 0 else 500
         self._running = False
         self._mcp_servers = mcp_servers or {}
         self._mcp_stacks: dict[str, AsyncExitStack] = {}

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -57,7 +57,7 @@ from nanobot.session.goal_state import (
     sustained_goal_active,
 )
 from nanobot.session.keys import UNIFIED_SESSION_KEY, session_key_for_channel
-from nanobot.session.manager import Session, SessionManager
+from nanobot.session.manager import DEFAULT_REPLAY_MAX_MESSAGES, Session, SessionManager
 from nanobot.utils.document import extract_documents, reference_non_image_attachments
 from nanobot.utils.helpers import image_placeholder_text
 from nanobot.utils.helpers import truncate_text as truncate_text_fn
@@ -201,7 +201,7 @@ class AgentLoop:
         timezone: str | None = None,
         session_ttl_minutes: int = 0,
         consolidation_ratio: float = 0.5,
-        max_messages: int = 500,
+        max_messages: int = DEFAULT_REPLAY_MAX_MESSAGES,
         hooks: list[AgentHook] | None = None,
         unified_session: bool = False,
         disabled_skills: list[str] | None = None,
@@ -292,7 +292,9 @@ class AgentLoop:
             llm_wall_timeout_for_session=lambda sk: runner_wall_llm_timeout_s(self.sessions, sk),
         )
         self._unified_session = unified_session
-        self._max_messages = max_messages if max_messages > 0 else 500
+        self._max_messages = (
+            max_messages if max_messages > 0 else DEFAULT_REPLAY_MAX_MESSAGES
+        )
         self._running = False
         self._mcp_servers = mcp_servers or {}
         self._mcp_stacks: dict[str, AsyncExitStack] = {}
@@ -390,7 +392,6 @@ class AgentLoop:
             disabled_skills=defaults.disabled_skills,
             session_ttl_minutes=defaults.session_ttl_minutes,
             consolidation_ratio=defaults.consolidation_ratio,
-            max_messages=defaults.max_messages,
             tools_config=config.tools,
             model_presets=preset_helpers.configured_model_presets(config),
             model_preset=defaults.model_preset,

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -57,7 +57,11 @@ from nanobot.session.goal_state import (
     sustained_goal_active,
 )
 from nanobot.session.keys import UNIFIED_SESSION_KEY, session_key_for_channel
-from nanobot.session.manager import DEFAULT_REPLAY_MAX_MESSAGES, Session, SessionManager
+from nanobot.session.manager import (
+    Session,
+    SessionManager,
+    replay_max_messages_for_context,
+)
 from nanobot.utils.document import extract_documents, reference_non_image_attachments
 from nanobot.utils.helpers import image_placeholder_text
 from nanobot.utils.helpers import truncate_text as truncate_text_fn
@@ -201,7 +205,7 @@ class AgentLoop:
         timezone: str | None = None,
         session_ttl_minutes: int = 0,
         consolidation_ratio: float = 0.5,
-        max_messages: int = DEFAULT_REPLAY_MAX_MESSAGES,
+        max_messages: int = 0,
         hooks: list[AgentHook] | None = None,
         unified_session: bool = False,
         disabled_skills: list[str] | None = None,
@@ -292,8 +296,11 @@ class AgentLoop:
             llm_wall_timeout_for_session=lambda sk: runner_wall_llm_timeout_s(self.sessions, sk),
         )
         self._unified_session = unified_session
+        self._explicit_max_messages = max_messages > 0
         self._max_messages = (
-            max_messages if max_messages > 0 else DEFAULT_REPLAY_MAX_MESSAGES
+            max_messages
+            if self._explicit_max_messages
+            else replay_max_messages_for_context(self.context_window_tokens)
         )
         self._running = False
         self._mcp_servers = mcp_servers or {}
@@ -422,6 +429,7 @@ class AgentLoop:
         self.runner.provider = provider
         self.subagents.set_provider(provider, model)
         self.consolidator.set_provider(provider, model, context_window_tokens)
+        self._sync_replay_max_messages()
         self._provider_signature = snapshot.signature
         if publish_update and self._runtime_model_publisher is not None:
             self._runtime_model_publisher(
@@ -434,6 +442,10 @@ class AgentLoop:
                 model_preset if model_preset is not None else self.model_preset,
             )
         logger.info("Runtime model switched for next turn: {} -> {}", old_model, model)
+
+    def _sync_replay_max_messages(self) -> None:
+        if not self._explicit_max_messages:
+            self._max_messages = replay_max_messages_for_context(self.context_window_tokens)
 
     def _refresh_provider_snapshot(self) -> None:
         if self._provider_snapshot_loader is None:

--- a/nanobot/agent/tools/self.py
+++ b/nanobot/agent/tools/self.py
@@ -438,6 +438,9 @@ class MyTool(Tool, ContextAware):
         setattr(self._runtime_state, key, value)
         if key == "model":
             self._runtime_state._active_preset = None
+        sync_replay = getattr(self._runtime_state, "_sync_replay_max_messages", None)
+        if key == "context_window_tokens" and callable(sync_replay):
+            sync_replay()
         if key == "max_iterations" and hasattr(self._runtime_state, "_sync_subagent_runtime_limits"):
             self._runtime_state._sync_subagent_runtime_limits()
         self._audit("modify", f"{key}: {old!r} -> {value!r}")

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -156,12 +156,12 @@ def _migrate_config(data: dict) -> dict:
     agents = data.get("agents", {})
     defaults = agents.get("defaults", {}) if isinstance(agents, dict) else {}
     if isinstance(defaults, dict):
-        legacy_max_message_keys = [
-            key for key in ("maxMessages", "max_messages") if key in defaults
-        ]
-        if legacy_max_message_keys:
-            for key in legacy_max_message_keys:
-                defaults.pop(key, None)
+        had_legacy_max_messages = (
+            "maxMessages" in defaults or "max_messages" in defaults
+        )
+        defaults.pop("maxMessages", None)
+        defaults.pop("max_messages", None)
+        if had_legacy_max_messages:
             # TODO(next version): Remove this legacy cleanup branch; the schema
             # will silently ignore this field once the warning grace period ends.
             logger.warning(

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 import pydantic
+from loguru import logger
 from pydantic import BaseModel
 
 from nanobot.config.schema import Config, _resolve_tool_config_refs
@@ -152,6 +153,23 @@ def _env_replace(match: re.Match[str]) -> str:
 
 def _migrate_config(data: dict) -> dict:
     """Migrate old config formats to current."""
+    agents = data.get("agents", {})
+    defaults = agents.get("defaults", {}) if isinstance(agents, dict) else {}
+    if isinstance(defaults, dict):
+        legacy_max_message_keys = [
+            key for key in ("maxMessages", "max_messages") if key in defaults
+        ]
+        if legacy_max_message_keys:
+            for key in legacy_max_message_keys:
+                defaults.pop(key, None)
+            # TODO(next version): Remove this legacy cleanup branch; the schema
+            # will silently ignore this field once the warning grace period ends.
+            logger.warning(
+                "agents.defaults.maxMessages/max_messages is legacy and ignored; "
+                "replay max messages is now an internal safety cap. Remove it from "
+                "config. This compatibility warning will be removed in the next version."
+            )
+
     # Move tools.exec.restrictToWorkspace → tools.restrictToWorkspace
     tools = data.get("tools", {})
     exec_cfg = tools.get("exec", {})

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -155,9 +155,9 @@ class AgentDefaults(Base):
         serialization_alias="idleCompactAfterMinutes",
     )  # Auto-compact idle threshold in minutes (0 = disabled)
     max_messages: int = Field(
-        default=120,
+        default=500,
         ge=0,
-    )  # Max messages to replay from session history (0 = use default 120, respects token budget)
+    )  # Last-resort max messages to replay from session history (0 = use default 500)
     consolidation_ratio: float = Field(
         default=0.5,
         ge=0.1,

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -154,10 +154,6 @@ class AgentDefaults(Base):
         validation_alias=AliasChoices("idleCompactAfterMinutes", "sessionTtlMinutes"),
         serialization_alias="idleCompactAfterMinutes",
     )  # Auto-compact idle threshold in minutes (0 = disabled)
-    max_messages: int = Field(
-        default=500,
-        ge=0,
-    )  # Last-resort max messages to replay from session history (0 = use default 500)
     consolidation_ratio: float = Field(
         default=0.5,
         ge=0.1,

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -27,7 +27,9 @@ from nanobot.utils.helpers import (
 from nanobot.utils.subagent_channel_display import scrub_subagent_announce_body
 
 FILE_MAX_MESSAGES = 2000
-DEFAULT_REPLAY_MAX_MESSAGES = 500
+MIN_REPLAY_MAX_MESSAGES = 120
+REPLAY_TOKENS_PER_MESSAGE = 100
+DEFAULT_REPLAY_MAX_MESSAGES = FILE_MAX_MESSAGES
 _MESSAGE_TIME_PREFIX_RE = re.compile(r"^\[Message Time: [^\]]+\]\n?")
 _LOCAL_IMAGE_BREADCRUMB_RE = re.compile(r"^\[image: (?:/|~)[^\]]+\]\s*$")
 _TOOL_CALL_ECHO_RE = re.compile(r'^\s*(?:generate_image|message)\([^)]*\)\s*$')
@@ -42,6 +44,15 @@ _FORK_VOLATILE_METADATA_KEYS = {
     "title",
     "title_user_edited",
 }
+
+
+def replay_max_messages_for_context(context_window_tokens: int | None) -> int:
+    if not context_window_tokens or context_window_tokens <= 0:
+        return DEFAULT_REPLAY_MAX_MESSAGES
+    return min(
+        FILE_MAX_MESSAGES,
+        max(MIN_REPLAY_MAX_MESSAGES, context_window_tokens // REPLAY_TOKENS_PER_MESSAGE),
+    )
 
 
 def _sanitize_assistant_replay_text(content: str) -> str:

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -29,7 +29,6 @@ from nanobot.utils.subagent_channel_display import scrub_subagent_announce_body
 FILE_MAX_MESSAGES = 2000
 MIN_REPLAY_MAX_MESSAGES = 120
 REPLAY_TOKENS_PER_MESSAGE = 100
-DEFAULT_REPLAY_MAX_MESSAGES = FILE_MAX_MESSAGES
 _MESSAGE_TIME_PREFIX_RE = re.compile(r"^\[Message Time: [^\]]+\]\n?")
 _LOCAL_IMAGE_BREADCRUMB_RE = re.compile(r"^\[image: (?:/|~)[^\]]+\]\s*$")
 _TOOL_CALL_ECHO_RE = re.compile(r'^\s*(?:generate_image|message)\([^)]*\)\s*$')
@@ -48,7 +47,7 @@ _FORK_VOLATILE_METADATA_KEYS = {
 
 def replay_max_messages_for_context(context_window_tokens: int | None) -> int:
     if not context_window_tokens or context_window_tokens <= 0:
-        return DEFAULT_REPLAY_MAX_MESSAGES
+        return FILE_MAX_MESSAGES
     return min(
         FILE_MAX_MESSAGES,
         max(MIN_REPLAY_MAX_MESSAGES, context_window_tokens // REPLAY_TOKENS_PER_MESSAGE),
@@ -144,7 +143,7 @@ class Session:
 
     def get_history(
         self,
-        max_messages: int = DEFAULT_REPLAY_MAX_MESSAGES,
+        max_messages: int = FILE_MAX_MESSAGES,
         *,
         max_tokens: int = 0,
         extend_to_user: bool = False,
@@ -155,7 +154,7 @@ class Session:
         token budget from the tail (``max_tokens``) when provided.
         """
         unconsolidated = self.messages[self.last_consolidated:]
-        max_messages = max_messages if max_messages > 0 else DEFAULT_REPLAY_MAX_MESSAGES
+        max_messages = max_messages if max_messages > 0 else FILE_MAX_MESSAGES
         start_idx = recent_message_start_index(
             unconsolidated,
             max_messages,

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -132,7 +132,7 @@ class Session:
 
     def get_history(
         self,
-        max_messages: int = 120,
+        max_messages: int = 500,
         *,
         max_tokens: int = 0,
         extend_to_user: bool = False,
@@ -143,7 +143,7 @@ class Session:
         token budget from the tail (``max_tokens``) when provided.
         """
         unconsolidated = self.messages[self.last_consolidated:]
-        max_messages = max_messages if max_messages > 0 else 120
+        max_messages = max_messages if max_messages > 0 else 500
         start_idx = recent_message_start_index(
             unconsolidated,
             max_messages,

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -27,6 +27,7 @@ from nanobot.utils.helpers import (
 from nanobot.utils.subagent_channel_display import scrub_subagent_announce_body
 
 FILE_MAX_MESSAGES = 2000
+DEFAULT_REPLAY_MAX_MESSAGES = 500
 _MESSAGE_TIME_PREFIX_RE = re.compile(r"^\[Message Time: [^\]]+\]\n?")
 _LOCAL_IMAGE_BREADCRUMB_RE = re.compile(r"^\[image: (?:/|~)[^\]]+\]\s*$")
 _TOOL_CALL_ECHO_RE = re.compile(r'^\s*(?:generate_image|message)\([^)]*\)\s*$')
@@ -132,7 +133,7 @@ class Session:
 
     def get_history(
         self,
-        max_messages: int = 500,
+        max_messages: int = DEFAULT_REPLAY_MAX_MESSAGES,
         *,
         max_tokens: int = 0,
         extend_to_user: bool = False,
@@ -143,7 +144,7 @@ class Session:
         token budget from the tail (``max_tokens``) when provided.
         """
         unconsolidated = self.messages[self.last_consolidated:]
-        max_messages = max_messages if max_messages > 0 else 500
+        max_messages = max_messages if max_messages > 0 else DEFAULT_REPLAY_MAX_MESSAGES
         start_idx = recent_message_start_index(
             unconsolidated,
             max_messages,

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -38,7 +38,6 @@ def make_loop(
     model: str = "test-model",
     context_window_tokens: int = 128_000,
     session_ttl_minutes: int = 0,
-    max_messages: int = 120,
     unified_session: bool = False,
     mcp_servers: dict | None = None,
     tools_config=None,
@@ -64,7 +63,6 @@ def make_loop(
         model=model,
         context_window_tokens=context_window_tokens,
         session_ttl_minutes=session_ttl_minutes,
-        max_messages=max_messages,
         unified_session=unified_session,
     )
     if mcp_servers is not None:
@@ -79,8 +77,8 @@ def make_loop(
     if patch_deps:
         with patch("nanobot.agent.loop.ContextBuilder"), \
              patch("nanobot.agent.loop.SessionManager"), \
-             patch("nanobot.agent.loop.SubagentManager") as MockSubMgr:
-            MockSubMgr.return_value.cancel_by_session = AsyncMock(return_value=0)
+             patch("nanobot.agent.loop.SubagentManager") as mock_sub_mgr:
+            mock_sub_mgr.return_value.cancel_by_session = AsyncMock(return_value=0)
             return AgentLoop(**kwargs)
     return AgentLoop(**kwargs)
 

--- a/tests/agent/test_max_messages_config.py
+++ b/tests/agent/test_max_messages_config.py
@@ -13,7 +13,7 @@ from nanobot.bus.queue import MessageBus
 from nanobot.providers.base import LLMResponse
 from nanobot.session.manager import Session
 
-DEFAULT_MAX_MESSAGES = 120
+DEFAULT_MAX_MESSAGES = 500
 
 
 def _make_loop(tmp_path: Path, max_messages: int = DEFAULT_MAX_MESSAGES) -> AgentLoop:

--- a/tests/agent/test_max_messages_config.py
+++ b/tests/agent/test_max_messages_config.py
@@ -11,20 +11,31 @@ from nanobot.agent.loop import AgentLoop
 from nanobot.bus.events import InboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.providers.base import LLMResponse
-from nanobot.session.manager import DEFAULT_REPLAY_MAX_MESSAGES, Session
+from nanobot.providers.factory import ProviderSnapshot
+from nanobot.session.manager import (
+    DEFAULT_REPLAY_MAX_MESSAGES,
+    Session,
+    replay_max_messages_for_context,
+)
 
 DEFAULT_MAX_MESSAGES = DEFAULT_REPLAY_MAX_MESSAGES
 
 
-def _make_loop(tmp_path: Path, max_messages: int = DEFAULT_MAX_MESSAGES) -> AgentLoop:
+def _make_loop(
+    tmp_path: Path,
+    max_messages: int = 0,
+    context_window_tokens: int = 200_000,
+) -> AgentLoop:
     provider = MagicMock()
     provider.get_default_model.return_value = "test-model"
+    provider.generation.max_tokens = 4096
     return AgentLoop(
         bus=MessageBus(),
         provider=provider,
         workspace=tmp_path,
         model="test-model",
         max_messages=max_messages,
+        context_window_tokens=context_window_tokens,
     )
 
 
@@ -51,23 +62,56 @@ def _tool_round(call_id: str) -> list[dict]:
 
 
 class TestMaxMessagesInit:
-    """Verify AgentLoop stores the config value correctly."""
+    """Verify AgentLoop derives the internal replay cap correctly."""
 
-    def test_default_is_builtin_limit(self, tmp_path: Path) -> None:
+    def test_context_formula(self) -> None:
+        assert replay_max_messages_for_context(8_000) == 120
+        assert replay_max_messages_for_context(32_768) == 327
+        assert replay_max_messages_for_context(200_000) == DEFAULT_MAX_MESSAGES
+
+    def test_default_for_200k_context_reaches_file_cap(self, tmp_path: Path) -> None:
         loop = _make_loop(tmp_path)
         assert loop._max_messages == DEFAULT_MAX_MESSAGES
+
+    def test_default_scales_with_context_window(self, tmp_path: Path) -> None:
+        loop = _make_loop(tmp_path, context_window_tokens=32_768)
+        assert loop._max_messages == 327
 
     def test_positive_value_stored(self, tmp_path: Path) -> None:
         loop = _make_loop(tmp_path, max_messages=25)
         assert loop._max_messages == 25
 
-    def test_zero_uses_builtin_limit(self, tmp_path: Path) -> None:
+    def test_zero_uses_context_derived_limit(self, tmp_path: Path) -> None:
         loop = _make_loop(tmp_path, max_messages=0)
         assert loop._max_messages == DEFAULT_MAX_MESSAGES
 
     def test_negative_treated_as_builtin_limit(self, tmp_path: Path) -> None:
         """Negative values should not produce negative slicing."""
         loop = _make_loop(tmp_path, max_messages=-5)
+        assert loop._max_messages == DEFAULT_MAX_MESSAGES
+
+    def test_provider_refresh_resyncs_context_derived_limit(self, tmp_path: Path) -> None:
+        old_provider = MagicMock()
+        old_provider.get_default_model.return_value = "old-model"
+        old_provider.generation.max_tokens = 4096
+        new_provider = MagicMock()
+        new_provider.generation.max_tokens = 4096
+        loop = AgentLoop(
+            bus=MessageBus(),
+            provider=old_provider,
+            workspace=tmp_path,
+            model="old-model",
+            context_window_tokens=32_768,
+            provider_snapshot_loader=lambda: ProviderSnapshot(
+                provider=new_provider,
+                model="new-model",
+                context_window_tokens=200_000,
+                signature=("new-model",),
+            ),
+        )
+
+        assert loop._max_messages == 327
+        loop._refresh_provider_snapshot()
         assert loop._max_messages == DEFAULT_MAX_MESSAGES
 
 

--- a/tests/agent/test_max_messages_config.py
+++ b/tests/agent/test_max_messages_config.py
@@ -1,4 +1,4 @@
-"""Tests for max_messages config wiring into session history replay."""
+"""Tests for the internal max_messages replay cap."""
 
 from __future__ import annotations
 
@@ -11,9 +11,9 @@ from nanobot.agent.loop import AgentLoop
 from nanobot.bus.events import InboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.providers.base import LLMResponse
-from nanobot.session.manager import Session
+from nanobot.session.manager import DEFAULT_REPLAY_MAX_MESSAGES, Session
 
-DEFAULT_MAX_MESSAGES = 500
+DEFAULT_MAX_MESSAGES = DEFAULT_REPLAY_MAX_MESSAGES
 
 
 def _make_loop(tmp_path: Path, max_messages: int = DEFAULT_MAX_MESSAGES) -> AgentLoop:
@@ -103,10 +103,10 @@ class TestGetHistoryWithMaxMessages:
 
 
 class TestMaxMessagesIntegration:
-    """Verify the config flows from AgentLoop into get_history calls."""
+    """Verify AgentLoop passes the replay cap into get_history calls."""
 
     @pytest.mark.asyncio
-    async def test_process_message_passes_config_to_history_call(self, tmp_path: Path) -> None:
+    async def test_process_message_passes_limit_to_history_call(self, tmp_path: Path) -> None:
         """The real message path should pass max_messages into session history replay."""
         loop = _make_loop(tmp_path, max_messages=25)
         loop.provider.chat_with_retry = AsyncMock(
@@ -127,7 +127,7 @@ class TestMaxMessagesIntegration:
         assert mock_hist.call_args.kwargs["extend_to_user"] is False
 
     @pytest.mark.asyncio
-    async def test_zero_config_passes_builtin_limit_to_history_call(self, tmp_path: Path) -> None:
+    async def test_zero_limit_passes_builtin_limit_to_history_call(self, tmp_path: Path) -> None:
         loop = _make_loop(tmp_path, max_messages=0)
         loop.provider.chat_with_retry = AsyncMock(
             return_value=LLMResponse(content="ok", tool_calls=[], usage={})
@@ -182,31 +182,3 @@ class TestMaxMessagesIntegration:
         sent_text = "\n".join(str(message.get("content")) for message in sent_messages)
         assert "new question" in sent_text
         assert "long older turn" not in sent_text
-
-
-class TestSchemaConfig:
-    """Verify the config schema accepts max_messages."""
-
-    def test_schema_default(self) -> None:
-        from nanobot.config.schema import AgentDefaults
-
-        defaults = AgentDefaults()
-        assert defaults.max_messages == DEFAULT_MAX_MESSAGES
-
-    def test_schema_accepts_zero_as_builtin_limit(self) -> None:
-        from nanobot.config.schema import AgentDefaults
-
-        defaults = AgentDefaults(max_messages=0)
-        assert defaults.max_messages == 0
-
-    def test_schema_accepts_positive(self) -> None:
-        from nanobot.config.schema import AgentDefaults
-
-        defaults = AgentDefaults(max_messages=25)
-        assert defaults.max_messages == 25
-
-    def test_schema_rejects_negative(self) -> None:
-        from nanobot.config.schema import AgentDefaults
-
-        with pytest.raises(Exception):  # Pydantic validation error
-            AgentDefaults(max_messages=-1)

--- a/tests/agent/test_max_messages_config.py
+++ b/tests/agent/test_max_messages_config.py
@@ -13,17 +13,14 @@ from nanobot.bus.queue import MessageBus
 from nanobot.providers.base import LLMResponse
 from nanobot.providers.factory import ProviderSnapshot
 from nanobot.session.manager import (
-    DEFAULT_REPLAY_MAX_MESSAGES,
+    FILE_MAX_MESSAGES,
     Session,
     replay_max_messages_for_context,
 )
 
-DEFAULT_MAX_MESSAGES = DEFAULT_REPLAY_MAX_MESSAGES
-
 
 def _make_loop(
     tmp_path: Path,
-    max_messages: int = 0,
     context_window_tokens: int = 200_000,
 ) -> AgentLoop:
     provider = MagicMock()
@@ -34,7 +31,6 @@ def _make_loop(
         provider=provider,
         workspace=tmp_path,
         model="test-model",
-        max_messages=max_messages,
         context_window_tokens=context_window_tokens,
     )
 
@@ -67,28 +63,15 @@ class TestMaxMessagesInit:
     def test_context_formula(self) -> None:
         assert replay_max_messages_for_context(8_000) == 120
         assert replay_max_messages_for_context(32_768) == 327
-        assert replay_max_messages_for_context(200_000) == DEFAULT_MAX_MESSAGES
+        assert replay_max_messages_for_context(200_000) == FILE_MAX_MESSAGES
 
     def test_default_for_200k_context_reaches_file_cap(self, tmp_path: Path) -> None:
         loop = _make_loop(tmp_path)
-        assert loop._max_messages == DEFAULT_MAX_MESSAGES
+        assert loop._max_messages == FILE_MAX_MESSAGES
 
     def test_default_scales_with_context_window(self, tmp_path: Path) -> None:
         loop = _make_loop(tmp_path, context_window_tokens=32_768)
         assert loop._max_messages == 327
-
-    def test_positive_value_stored(self, tmp_path: Path) -> None:
-        loop = _make_loop(tmp_path, max_messages=25)
-        assert loop._max_messages == 25
-
-    def test_zero_uses_context_derived_limit(self, tmp_path: Path) -> None:
-        loop = _make_loop(tmp_path, max_messages=0)
-        assert loop._max_messages == DEFAULT_MAX_MESSAGES
-
-    def test_negative_treated_as_builtin_limit(self, tmp_path: Path) -> None:
-        """Negative values should not produce negative slicing."""
-        loop = _make_loop(tmp_path, max_messages=-5)
-        assert loop._max_messages == DEFAULT_MAX_MESSAGES
 
     def test_provider_refresh_resyncs_context_derived_limit(self, tmp_path: Path) -> None:
         old_provider = MagicMock()
@@ -112,7 +95,7 @@ class TestMaxMessagesInit:
 
         assert loop._max_messages == 327
         loop._refresh_provider_snapshot()
-        assert loop._max_messages == DEFAULT_MAX_MESSAGES
+        assert loop._max_messages == FILE_MAX_MESSAGES
 
 
 class TestGetHistoryWithMaxMessages:
@@ -121,7 +104,7 @@ class TestGetHistoryWithMaxMessages:
     def test_default_uses_builtin_limit(self) -> None:
         session = _populated_session(80)
         history = session.get_history()
-        assert len(history) <= DEFAULT_MAX_MESSAGES
+        assert len(history) <= FILE_MAX_MESSAGES
 
     def test_explicit_max_messages_limits_output(self) -> None:
         session = _populated_session(40)  # 80 messages total
@@ -137,7 +120,7 @@ class TestGetHistoryWithMaxMessages:
     def test_max_messages_zero_uses_builtin_limit(self) -> None:
         session = _populated_session(80)  # 160 messages total
         history = session.get_history(max_messages=0)
-        assert len(history) <= DEFAULT_MAX_MESSAGES
+        assert len(history) <= FILE_MAX_MESSAGES
 
     def test_small_session_unaffected(self) -> None:
         """When session has fewer messages than max_messages, all are returned."""
@@ -152,7 +135,8 @@ class TestMaxMessagesIntegration:
     @pytest.mark.asyncio
     async def test_process_message_passes_limit_to_history_call(self, tmp_path: Path) -> None:
         """The real message path should pass max_messages into session history replay."""
-        loop = _make_loop(tmp_path, max_messages=25)
+        loop = _make_loop(tmp_path)
+        loop._max_messages = 25
         loop.provider.chat_with_retry = AsyncMock(
             return_value=LLMResponse(content="ok", tool_calls=[], usage={})
         )
@@ -171,8 +155,11 @@ class TestMaxMessagesIntegration:
         assert mock_hist.call_args.kwargs["extend_to_user"] is False
 
     @pytest.mark.asyncio
-    async def test_zero_limit_passes_builtin_limit_to_history_call(self, tmp_path: Path) -> None:
-        loop = _make_loop(tmp_path, max_messages=0)
+    async def test_default_limit_passes_context_derived_limit_to_history_call(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        loop = _make_loop(tmp_path)
         loop.provider.chat_with_retry = AsyncMock(
             return_value=LLMResponse(content="ok", tool_calls=[], usage={})
         )
@@ -186,7 +173,7 @@ class TestMaxMessagesIntegration:
             )
 
         assert result is not None
-        assert mock_hist.call_args.kwargs["max_messages"] == DEFAULT_MAX_MESSAGES
+        assert mock_hist.call_args.kwargs["max_messages"] == FILE_MAX_MESSAGES
         assert mock_hist.call_args.kwargs["extend_to_user"] is False
 
     @pytest.mark.asyncio
@@ -195,7 +182,8 @@ class TestMaxMessagesIntegration:
         tmp_path: Path,
     ) -> None:
         """A live user turn should not extend history to an older long tool turn."""
-        loop = _make_loop(tmp_path, max_messages=6)
+        loop = _make_loop(tmp_path)
+        loop._max_messages = 6
         loop.provider.chat_with_retry = AsyncMock(
             return_value=LLMResponse(content="ok", tool_calls=[], usage={})
         )

--- a/tests/agent/tools/test_self_tool.py
+++ b/tests/agent/tools/test_self_tool.py
@@ -236,10 +236,12 @@ class TestModifyRestricted:
 
     @pytest.mark.asyncio
     async def test_modify_context_window_valid(self):
-        tool = _make_tool()
+        loop = _make_mock_loop(_sync_replay_max_messages=MagicMock())
+        tool = _make_tool(runtime_state=loop)
         result = await tool.execute(action="set", key="context_window_tokens", value=131072)
         assert "Set context_window_tokens" in result
-        assert tool._runtime_state.context_window_tokens == 131072
+        assert loop.context_window_tokens == 131072
+        loop._sync_replay_max_messages.assert_called_once_with()
 
     @pytest.mark.asyncio
     async def test_modify_none_value_for_restricted_int(self):

--- a/tests/config/test_config_migration.py
+++ b/tests/config/test_config_migration.py
@@ -2,6 +2,8 @@ import json
 import socket
 from unittest.mock import patch
 
+import pytest
+
 from nanobot.config.loader import load_config, save_config
 from nanobot.security.network import validate_url_target
 
@@ -91,6 +93,41 @@ def test_onboard_does_not_crash_with_legacy_memory_window(tmp_path, monkeypatch)
     result = runner.invoke(app, ["onboard"], input="n\n")
 
     assert result.exit_code == 0
+
+
+@pytest.mark.parametrize("field_name", ["maxMessages", "max_messages"])
+def test_load_config_warns_and_ignores_legacy_max_messages(tmp_path, field_name) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"agents": {"defaults": {field_name: 25, "maxTokens": 1234}}}),
+        encoding="utf-8",
+    )
+
+    with patch("nanobot.config.loader.logger.warning") as warning:
+        config = load_config(config_path)
+
+    assert config.agents.defaults.max_tokens == 1234
+    assert not hasattr(config.agents.defaults, "max_messages")
+    warning.assert_called_once()
+    message = warning.call_args.args[0]
+    assert "legacy and ignored" in message
+    assert "next version" in message
+
+
+def test_save_config_drops_legacy_max_messages(tmp_path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"agents": {"defaults": {"maxMessages": 25}}}),
+        encoding="utf-8",
+    )
+
+    with patch("nanobot.config.loader.logger.warning"):
+        config = load_config(config_path)
+    save_config(config, config_path)
+    saved = json.loads(config_path.read_text(encoding="utf-8"))
+
+    assert "maxMessages" not in saved["agents"]["defaults"]
+    assert "max_messages" not in saved["agents"]["defaults"]
 
 
 def test_onboard_refresh_backfills_missing_channel_fields(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Make the replay message cap an internal fallback instead of a user-facing config setting.

This PR:
- removes `agents.defaults.maxMessages` / `max_messages` from `AgentDefaults` so new configs no longer expose it;
- preserves backward compatibility for existing config files by ignoring the legacy field with a warning;
- tells users the compatibility warning itself will be removed in the next version;
- saves rewritten configs without the legacy field;
- derives the internal replay cap from the active context window: roughly `context_window_tokens // 100`, with a floor of 120 messages and a ceiling of the existing 2000-message session file cap.

For the default 200k context window this resolves to 2000 messages, so normal trimming is governed by token consolidation and idle auto-compact instead of a small rolling message window.

## Why

#4222 showed that a small rolling message cap causes prompt/prefix cache churn once a conversation crosses the cap: each new turn shifts the replay window by one message, so providers that rely on byte-identical prefixes miss cache continuously.

Normal history reduction should be owned by consolidation and idle auto-compact. The message-count cap is only a coarse safety fallback, so it should not be another public context-policy knob.

This addresses the `max_messages` half of #4222. It does not change the separate microcompact behavior.

## Checks

- `python -m pytest tests/agent/test_max_messages_config.py tests/config/test_config_migration.py tests/agent/test_session_manager_history.py tests/agent/test_consolidator.py::TestConsolidatorTokenBudget::test_replay_window_overflow_is_archived_even_under_token_budget tests/agent/test_runtime_refresh.py tests/agent/test_self_model_preset.py tests/agent/tools/test_self_tool.py::TestModifyRestricted::test_modify_context_window_valid -q`
- `python -m pytest tests/config tests/agent/test_auto_compact.py tests/agent/test_consolidation_ratio.py tests/agent/test_runtime_refresh.py tests/test_nanobot_facade.py -q`
- `ruff check nanobot/agent/loop.py nanobot/config/loader.py nanobot/session/manager.py tests/agent/conftest.py tests/agent/test_max_messages_config.py`

Refs #4222.