### PR TITLE
fix(config): guard tool-key migration against null sections

### DIFF
--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -189,14 +189,18 @@ def _migrate_config(data: dict) -> dict:
         # in a sub-config keeps `web` / `exec` / `my` symmetric and gives room
         # to grow.
         if "myEnabled" in tools or "mySet" in tools:
-            my_cfg = tools.setdefault("my", {})
-            if "myEnabled" in tools and "enable" not in my_cfg:
-                my_cfg["enable"] = tools.pop("myEnabled")
-            else:
-                tools.pop("myEnabled", None)
-            if "mySet" in tools and "allowSet" not in my_cfg:
-                my_cfg["allowSet"] = tools.pop("mySet")
-            else:
-                tools.pop("mySet", None)
+            my_cfg = tools.get("my")
+            if "my" not in tools:
+                my_cfg = {}
+                tools["my"] = my_cfg
+            if isinstance(my_cfg, dict):
+                if "myEnabled" in tools and "enable" not in my_cfg:
+                    my_cfg["enable"] = tools.pop("myEnabled")
+                else:
+                    tools.pop("myEnabled", None)
+                if "mySet" in tools and "allowSet" not in my_cfg:
+                    my_cfg["allowSet"] = tools.pop("mySet")
+                else:
+                    tools.pop("mySet", None)
 
     return data

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -170,24 +170,33 @@ def _migrate_config(data: dict) -> dict:
                 "config. This compatibility warning will be removed in the next version."
             )
 
-    # Move tools.exec.restrictToWorkspace → tools.restrictToWorkspace
-    tools = data.get("tools", {})
-    exec_cfg = tools.get("exec", {})
-    if "restrictToWorkspace" in exec_cfg and "restrictToWorkspace" not in tools:
-        tools["restrictToWorkspace"] = exec_cfg.pop("restrictToWorkspace")
+    # Tool key migrations. Guard on dict shape (as the agents block above does)
+    # so a null `tools` / `tools.exec` falls through to schema validation rather
+    # than raising AttributeError here.
+    tools = data.get("tools")
+    if isinstance(tools, dict):
+        # Move tools.exec.restrictToWorkspace → tools.restrictToWorkspace
+        exec_cfg = tools.get("exec")
+        if (
+            isinstance(exec_cfg, dict)
+            and "restrictToWorkspace" in exec_cfg
+            and "restrictToWorkspace" not in tools
+        ):
+            tools["restrictToWorkspace"] = exec_cfg.pop("restrictToWorkspace")
 
-    # Move tools.myEnabled / tools.mySet → tools.my.{enable, allowSet}.
-    # The old flat keys shipped in the initial MyTool landing; wrapping them in a
-    # sub-config keeps `web` / `exec` / `my` symmetric and gives room to grow.
-    if "myEnabled" in tools or "mySet" in tools:
-        my_cfg = tools.setdefault("my", {})
-        if "myEnabled" in tools and "enable" not in my_cfg:
-            my_cfg["enable"] = tools.pop("myEnabled")
-        else:
-            tools.pop("myEnabled", None)
-        if "mySet" in tools and "allowSet" not in my_cfg:
-            my_cfg["allowSet"] = tools.pop("mySet")
-        else:
-            tools.pop("mySet", None)
+        # Move tools.myEnabled / tools.mySet → tools.my.{enable, allowSet}.
+        # The old flat keys shipped in the initial MyTool landing; wrapping them
+        # in a sub-config keeps `web` / `exec` / `my` symmetric and gives room
+        # to grow.
+        if "myEnabled" in tools or "mySet" in tools:
+            my_cfg = tools.setdefault("my", {})
+            if "myEnabled" in tools and "enable" not in my_cfg:
+                my_cfg["enable"] = tools.pop("myEnabled")
+            else:
+                tools.pop("myEnabled", None)
+            if "mySet" in tools and "allowSet" not in my_cfg:
+                my_cfg["allowSet"] = tools.pop("mySet")
+            else:
+                tools.pop("mySet", None)
 
     return data

--- a/tests/config/test_config_migration.py
+++ b/tests/config/test_config_migration.py
@@ -285,7 +285,14 @@ def test_load_config_accepts_legacy_local_preview_access(tmp_path) -> None:
     assert config.tools.webui_allow_local_service_access is False
 
 
-@pytest.mark.parametrize("payload", [{"tools": None}, {"tools": {"exec": None}}])
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"tools": None},
+        {"tools": {"exec": None}},
+        {"tools": {"my": None, "myEnabled": True}},
+    ],
+)
 def test_load_config_handles_null_tool_sections(tmp_path, payload) -> None:
     config_path = tmp_path / "config.json"
     config_path.write_text(json.dumps(payload), encoding="utf-8")

--- a/tests/config/test_config_migration.py
+++ b/tests/config/test_config_migration.py
@@ -283,3 +283,14 @@ def test_load_config_accepts_legacy_local_preview_access(tmp_path) -> None:
     config = load_config(config_path)
 
     assert config.tools.webui_allow_local_service_access is False
+
+
+@pytest.mark.parametrize("payload", [{"tools": None}, {"tools": {"exec": None}}])
+def test_load_config_handles_null_tool_sections(tmp_path, payload) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    # A null section is malformed, but migration must not crash with an uncaught
+    # AttributeError; it should surface as the normal config-load ValueError.
+    with pytest.raises(ValueError):
+        load_config(config_path)


### PR DESCRIPTION
## Problem

`load_config()` runs `_migrate_config()` before schema validation. The tool-key migration does:

```python
tools = data.get("tools", {})
exec_cfg = tools.get("exec", {})
```

`dict.get(key, default)` only returns the default when the key is **absent** ??when the key is present with a JSON `null`, it returns `None`. So a hand-edited config like `{"tools": null}` or `{"tools": {"exec": null}}` makes `_migrate_config` raise an uncaught `AttributeError` (`'NoneType' object has no attribute 'get'`).

That `AttributeError` is not in the `(json.JSONDecodeError, ValueError, pydantic.ValidationError)` set that `load_config` catches, so the user gets a raw traceback instead of the normal `Failed to load config from <path>` error.

The sibling `agents` / `defaults` migration right above already guards with `isinstance(agents, dict)`; the `tools` block did not.

## Fix

Guard the tool-key migration on dict shape (mirroring the existing `agents` handling), and also guard `tools.exec`. A malformed null section now falls through to schema validation and surfaces the normal config-load error. Valid configs are unaffected ??behavior is unchanged for every non-null shape.

## Tests

Added `test_load_config_handles_null_tool_sections` (parametrized over `{"tools": null}` and `{"tools": {"exec": null}}`), asserting a clean `ValueError` rather than a crash.

```
pytest tests/config/test_config_migration.py     # 15 passed
ruff check nanobot/config/loader.py tests/config/test_config_migration.py   # All checks passed
```
