### PR TITLE
fix(mcp): redact credentials from URLs before logging

### DIFF
--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -174,7 +174,8 @@ def _redact_url(url: str) -> str:
     """
     try:
         parts = urllib.parse.urlsplit(url)
-        netloc = parts.hostname or ""
+        hostname = parts.hostname or ""
+        netloc = f"[{hostname}]" if ":" in hostname else hostname
         if parts.port:
             netloc = f"{netloc}:{parts.port}"
         return urllib.parse.urlunsplit((parts.scheme, netloc, parts.path, "", ""))

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -166,12 +166,28 @@ async def _probe_http_url(url: str, timeout: float = 3.0) -> bool:
         return False
 
 
+def _redact_url(url: str) -> str:
+    """Strip credentials and query/fragment before logging an MCP URL.
+
+    Server URLs may embed secrets (``https://user:token@host/sse`` or a
+    ``?token=`` query); only scheme, host, port, and path are safe to log.
+    """
+    try:
+        parts = urllib.parse.urlsplit(url)
+        netloc = parts.hostname or ""
+        if parts.port:
+            netloc = f"{netloc}:{parts.port}"
+        return urllib.parse.urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+    except Exception:
+        return "<redacted-url>"
+
+
 async def _validate_mcp_request_url(request: httpx.Request) -> None:
     """Validate each outgoing MCP HTTP request, including redirect targets."""
     ok, error = validate_url_target(str(request.url))
     if not ok:
         raise httpx.RequestError(
-            f"Blocked unsafe MCP URL {request.url} ({error})",
+            f"Blocked unsafe MCP URL {_redact_url(str(request.url))} ({error})",
             request=request,
         )
 
@@ -774,7 +790,7 @@ async def connect_mcp_servers(
                     logger.warning(
                         "MCP server '{}': blocked unsafe URL {} ({})",
                         name,
-                        cfg.url,
+                        _redact_url(cfg.url),
                         error,
                     )
                     await server_stack.aclose()
@@ -795,7 +811,7 @@ async def connect_mcp_servers(
                 read, write = await server_stack.enter_async_context(stdio_client(params))
             elif transport_type == "sse":
                 if not await _probe_http_url(cfg.url):
-                    logger.warning("MCP server '{}': {} unreachable, skipping", name, cfg.url)
+                    logger.warning("MCP server '{}': {} unreachable, skipping", name, _redact_url(cfg.url))
                     await server_stack.aclose()
                     return name, None
 
@@ -822,7 +838,7 @@ async def connect_mcp_servers(
                 )
             elif transport_type == "streamableHttp":
                 if not await _probe_http_url(cfg.url):
-                    logger.warning("MCP server '{}': {} unreachable, skipping", name, cfg.url)
+                    logger.warning("MCP server '{}': {} unreachable, skipping", name, _redact_url(cfg.url))
                     await server_stack.aclose()
                     return name, None
 

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -170,7 +170,8 @@ def _redact_url(url: str) -> str:
     """Strip credentials and query/fragment before logging an MCP URL.
 
     Server URLs may embed secrets (``https://user:token@host/sse`` or a
-    ``?token=`` query); only scheme, host, port, and path are safe to log.
+    ``?token=`` query). Some deployments also put opaque tokens in the path, so
+    log only the origin and a path placeholder.
     """
     try:
         parts = urllib.parse.urlsplit(url)
@@ -178,7 +179,8 @@ def _redact_url(url: str) -> str:
         netloc = f"[{hostname}]" if ":" in hostname else hostname
         if parts.port:
             netloc = f"{netloc}:{parts.port}"
-        return urllib.parse.urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+        path = "/..." if parts.path and parts.path != "/" else parts.path
+        return urllib.parse.urlunsplit((parts.scheme, netloc, path, "", ""))
     except Exception:
         return "<redacted-url>"
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1245,10 +1245,12 @@ async def test_connect_mcp_servers_enabled_tools_matches_sanitized_name(
 @pytest.mark.parametrize(
     "url, expected",
     [
-        ("https://user:secret@host.example/sse", "https://host.example/sse"),
-        ("https://host.example:8443/mcp?token=abc#frag", "https://host.example:8443/mcp"),
-        ("https://user:secret@[::1]:8443/sse?token=abc", "https://[::1]:8443/sse"),
-        ("https://host.example/sse", "https://host.example/sse"),
+        ("https://user:secret@host.example/sse", "https://host.example/..."),
+        ("https://host.example:8443/mcp?token=abc#frag", "https://host.example:8443/..."),
+        ("https://user:secret@[::1]:8443/sse?token=abc", "https://[::1]:8443/..."),
+        ("https://host.example/sse", "https://host.example/..."),
+        ("https://host.example", "https://host.example"),
+        ("https://host.example/", "https://host.example/"),
     ],
 )
 def test_redact_url_strips_credentials_and_query(url: str, expected: str) -> None:

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1247,6 +1247,7 @@ async def test_connect_mcp_servers_enabled_tools_matches_sanitized_name(
     [
         ("https://user:secret@host.example/sse", "https://host.example/sse"),
         ("https://host.example:8443/mcp?token=abc#frag", "https://host.example:8443/mcp"),
+        ("https://user:secret@[::1]:8443/sse?token=abc", "https://[::1]:8443/sse"),
         ("https://host.example/sse", "https://host.example/sse"),
     ],
 )

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1240,3 +1240,15 @@ async def test_connect_mcp_servers_enabled_tools_matches_sanitized_name(
         await stack.aclose()
 
     assert registry.tool_names == ["mcp_test_My_Tool"]
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("https://user:secret@host.example/sse", "https://host.example/sse"),
+        ("https://host.example:8443/mcp?token=abc#frag", "https://host.example:8443/mcp"),
+        ("https://host.example/sse", "https://host.example/sse"),
+    ],
+)
+def test_redact_url_strips_credentials_and_query(url: str, expected: str) -> None:
+    assert mcp_mod._redact_url(url) == expected


### PR DESCRIPTION
## Problem

MCP server URLs can carry secrets ??either in userinfo (`https://user:token@host/sse`) or in a query string (`?token=...`). A few connect/validate paths log the raw URL:

- `_validate_mcp_request_url` raises `Blocked unsafe MCP URL {request.url} ...`
- `connect_single_server` logs `cfg.url` when a URL is blocked or unreachable (three sites)

If an operator configures a credential-bearing MCP URL, those credentials can end up in log files, which are frequently shared, screenshotted, or shipped to log aggregators (CWE-532).

## Fix

Add a small `_redact_url()` helper that keeps only scheme / host / port / path (dropping userinfo, query, and fragment) and use it at the four sites that log a server or request URL.

This is logging-only ??no connection behavior changes, and valid configs are unaffected.

## Tests

Added `test_redact_url_strips_credentials_and_query` covering userinfo, query + fragment, and a plain URL.

```
pytest tests/tools/test_mcp_tool.py     # 59 passed
ruff check nanobot/agent/tools/mcp.py tests/tools/test_mcp_tool.py   # All checks passed
```
