### PR TITLE
Add WebUI session timestamps and Markdown export

### DIFF
--- a/nanobot/webui/sidebar_state.py
+++ b/nanobot/webui/sidebar_state.py
@@ -44,7 +44,7 @@ def default_webui_sidebar_state() -> dict[str, Any]:
         "view": {
             "density": "comfortable",
             "show_previews": False,
-            "show_timestamps": False,
+            "show_timestamps": True,
             "show_archived": False,
             "sort": "updated_desc",
         },

--- a/tests/utils/test_webui_sidebar_state.py
+++ b/tests/utils/test_webui_sidebar_state.py
@@ -48,7 +48,7 @@ def test_sidebar_state_normalizes_old_or_partial_payload(tmp_path, monkeypatch) 
     assert state["view"] == {
         "density": "comfortable",
         "show_previews": False,
-        "show_timestamps": False,
+        "show_timestamps": True,
         "show_archived": True,
         "sort": "updated_desc",
     }

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -43,12 +43,17 @@ import type {
 } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { fetchSettings, fetchWorkspaces } from "@/lib/api";
+import { fetchSettings, fetchWebuiThread, fetchWorkspaces } from "@/lib/api";
 import {
   createRuntimeHost,
   getHostApi,
   toRuntimeSurface,
 } from "@/lib/runtime";
+import {
+  buildSessionMarkdown,
+  downloadMarkdownFile,
+  sessionMarkdownFilename,
+} from "@/lib/session-export";
 import { projectNameFromPath } from "@/lib/workspace";
 
 type BootState =
@@ -1348,6 +1353,27 @@ function Shell({
     setPendingDelete({ key, label, automations });
   }, [getSessionAutomations]);
 
+  const onExportMarkdown = useCallback(async (key: string, label: string) => {
+    const session = sessions.find((s) => s.key === key);
+    if (!session) return;
+    const title = label.trim()
+      || sidebarState.title_overrides[key]
+      || session.title
+      || deriveTitle(session.preview, t("chat.newChat"));
+    try {
+      const thread = await fetchWebuiThread(token, key);
+      const markdown = buildSessionMarkdown({
+        session,
+        title,
+        messages: thread?.messages ?? [],
+        locale: i18n.resolvedLanguage,
+      });
+      downloadMarkdownFile(sessionMarkdownFilename(title, key), markdown);
+    } catch (e) {
+      console.error("Failed to export session markdown", e);
+    }
+  }, [i18n.resolvedLanguage, sessions, sidebarState.title_overrides, t, token]);
+
   const headerTitle = activeSession
     ? sidebarState.title_overrides[activeSession.key] ||
       activeSession.title ||
@@ -1394,6 +1420,7 @@ function Shell({
     onTogglePin,
     onRequestRename,
     onToggleArchive,
+    onExportMarkdown,
     onToggleGroup,
     onRequestRenameProject,
     onNewChatInProject,

--- a/webui/src/components/ChatList.tsx
+++ b/webui/src/components/ChatList.tsx
@@ -7,6 +7,7 @@ import {
 import {
   Archive,
   ArchiveRestore,
+  Download,
   Folder,
   MoreHorizontal,
   Pencil,
@@ -40,8 +41,8 @@ import type { ChatSummary, SidebarDensity, SidebarSortMode } from "@/lib/types";
 
 const INITIAL_VISIBLE_SESSIONS = 160;
 const VISIBLE_SESSIONS_INCREMENT = 160;
-const ACTION_MENU_CONTENT_CLASS = "w-[8.5rem] min-w-[8.5rem]";
-const ACTION_MENU_ITEM_CLASS = "grid w-[7.75rem] grid-cols-[1rem_minmax(0,1fr)] items-center gap-2";
+const ACTION_MENU_CONTENT_CLASS = "w-[10.25rem] min-w-[10.25rem]";
+const ACTION_MENU_ITEM_CLASS = "grid w-[9.5rem] grid-cols-[1rem_minmax(0,1fr)] items-center gap-2";
 
 interface ChatListProps {
   sessions: ChatSummary[];
@@ -51,6 +52,7 @@ interface ChatListProps {
   onTogglePin: (key: string) => void;
   onRequestRename: (key: string, label: string) => void;
   onToggleArchive: (key: string) => void;
+  onExportMarkdown?: (key: string, label: string) => void;
   onToggleGroup?: (groupId: string) => void;
   onRequestRenameProject?: (projectKey: string, label: string) => void;
   onNewChatInProject?: (projectPath: string, projectName: string) => void;
@@ -80,6 +82,7 @@ export const ChatList = memo(function ChatList({
   onTogglePin,
   onRequestRename,
   onToggleArchive,
+  onExportMarkdown,
   onToggleGroup,
   onRequestRenameProject,
   onNewChatInProject,
@@ -333,6 +336,15 @@ export const ChatList = memo(function ChatList({
                                 <Pencil className="h-4 w-4 shrink-0" />
                                 {t("chat.rename")}
                               </DropdownMenuItem>
+                              {onExportMarkdown ? (
+                                <DropdownMenuItem
+                                  onSelect={() => onExportMarkdown(s.key, title)}
+                                  className={ACTION_MENU_ITEM_CLASS}
+                                >
+                                  <Download className="h-4 w-4 shrink-0" />
+                                  {t("chat.exportMarkdown")}
+                                </DropdownMenuItem>
+                              ) : null}
                               <DropdownMenuItem
                                 onSelect={() => onToggleArchive(s.key)}
                                 className={ACTION_MENU_ITEM_CLASS}

--- a/webui/src/components/Sidebar.tsx
+++ b/webui/src/components/Sidebar.tsx
@@ -31,6 +31,7 @@ interface SidebarProps {
   onTogglePin: (key: string) => void;
   onRequestRename: (key: string, label: string) => void;
   onToggleArchive: (key: string) => void;
+  onExportMarkdown?: (key: string, label: string) => void;
   onToggleGroup: (groupId: string) => void;
   onRequestRenameProject: (projectKey: string, label: string) => void;
   onNewChatInProject: (projectPath: string, projectName: string) => void;
@@ -201,6 +202,7 @@ export function Sidebar(props: SidebarProps) {
             onTogglePin={props.onTogglePin}
             onRequestRename={props.onRequestRename}
             onToggleArchive={props.onToggleArchive}
+            onExportMarkdown={props.onExportMarkdown}
             onToggleGroup={props.onToggleGroup}
             onRequestRenameProject={props.onRequestRenameProject}
             onNewChatInProject={props.onNewChatInProject}

--- a/webui/src/hooks/useSidebarState.ts
+++ b/webui/src/hooks/useSidebarState.ts
@@ -18,7 +18,7 @@ export const DEFAULT_SIDEBAR_STATE: SidebarStatePayload = {
   view: {
     density: "comfortable",
     show_previews: false,
-    show_timestamps: false,
+    show_timestamps: true,
     show_archived: false,
     sort: "updated_desc",
   },
@@ -86,6 +86,9 @@ export function normalizeSidebarState(raw: unknown): SidebarStatePayload {
   const sort = ["updated_desc", "created_desc", "title_asc"].includes(view.sort)
     ? view.sort
     : "updated_desc";
+  const showTimestamps = typeof view.show_timestamps === "boolean"
+    ? view.show_timestamps
+    : DEFAULT_SIDEBAR_STATE.view.show_timestamps;
   return {
     schema_version: 1,
     pinned_keys: uniqueStrings(value.pinned_keys),
@@ -97,7 +100,7 @@ export function normalizeSidebarState(raw: unknown): SidebarStatePayload {
     view: {
       density,
       show_previews: Boolean(view.show_previews),
-      show_timestamps: Boolean(view.show_timestamps),
+      show_timestamps: showTimestamps,
       show_archived: Boolean(view.show_archived),
       sort,
     },

--- a/webui/src/i18n/locales/en/common.json
+++ b/webui/src/i18n/locales/en/common.json
@@ -663,6 +663,7 @@
     "renameProjectDescription": "Choose a local sidebar name for this project.",
     "renameProjectPlaceholder": "Project name",
     "renameSave": "Save",
+    "exportMarkdown": "Export markdown",
     "archive": "Archive",
     "unarchive": "Unarchive",
     "showArchived": "Show archived",

--- a/webui/src/i18n/locales/es/common.json
+++ b/webui/src/i18n/locales/es/common.json
@@ -663,6 +663,7 @@
     "renameProjectDescription": "Choose a local sidebar name for this project.",
     "renameProjectPlaceholder": "Project name",
     "renameSave": "Save",
+    "exportMarkdown": "Export markdown",
     "archive": "Archive",
     "unarchive": "Unarchive",
     "showArchived": "Show archived",

--- a/webui/src/i18n/locales/fr/common.json
+++ b/webui/src/i18n/locales/fr/common.json
@@ -663,6 +663,7 @@
     "renameProjectDescription": "Choose a local sidebar name for this project.",
     "renameProjectPlaceholder": "Project name",
     "renameSave": "Save",
+    "exportMarkdown": "Export markdown",
     "archive": "Archive",
     "unarchive": "Unarchive",
     "showArchived": "Show archived",

--- a/webui/src/i18n/locales/id/common.json
+++ b/webui/src/i18n/locales/id/common.json
@@ -663,6 +663,7 @@
     "renameProjectDescription": "Choose a local sidebar name for this project.",
     "renameProjectPlaceholder": "Project name",
     "renameSave": "Save",
+    "exportMarkdown": "Export markdown",
     "archive": "Archive",
     "unarchive": "Unarchive",
     "showArchived": "Show archived",

--- a/webui/src/i18n/locales/ja/common.json
+++ b/webui/src/i18n/locales/ja/common.json
@@ -663,6 +663,7 @@
     "renameProjectDescription": "Choose a local sidebar name for this project.",
     "renameProjectPlaceholder": "Project name",
     "renameSave": "Save",
+    "exportMarkdown": "Export markdown",
     "archive": "Archive",
     "unarchive": "Unarchive",
     "showArchived": "Show archived",

--- a/webui/src/i18n/locales/ko/common.json
+++ b/webui/src/i18n/locales/ko/common.json
@@ -663,6 +663,7 @@
     "renameProjectDescription": "Choose a local sidebar name for this project.",
     "renameProjectPlaceholder": "Project name",
     "renameSave": "Save",
+    "exportMarkdown": "Export markdown",
     "archive": "Archive",
     "unarchive": "Unarchive",
     "showArchived": "Show archived",

--- a/webui/src/i18n/locales/vi/common.json
+++ b/webui/src/i18n/locales/vi/common.json
@@ -663,6 +663,7 @@
     "renameProjectDescription": "Choose a local sidebar name for this project.",
     "renameProjectPlaceholder": "Project name",
     "renameSave": "Save",
+    "exportMarkdown": "Export markdown",
     "archive": "Archive",
     "unarchive": "Unarchive",
     "showArchived": "Show archived",

--- a/webui/src/i18n/locales/zh-CN/common.json
+++ b/webui/src/i18n/locales/zh-CN/common.json
@@ -663,6 +663,7 @@
     "renameProjectDescription": "为这个项目设置一个仅用于 WebUI 侧边栏的名称。",
     "renameProjectPlaceholder": "项目名称",
     "renameSave": "保存",
+    "exportMarkdown": "导出 Markdown",
     "archive": "归档",
     "unarchive": "取消归档",
     "showArchived": "显示归档",

--- a/webui/src/i18n/locales/zh-TW/common.json
+++ b/webui/src/i18n/locales/zh-TW/common.json
@@ -663,6 +663,7 @@
     "renameProjectDescription": "為這個專案設定僅用於 WebUI 側邊欄的名稱。",
     "renameProjectPlaceholder": "專案名稱",
     "renameSave": "儲存",
+    "exportMarkdown": "匯出 Markdown",
     "archive": "封存",
     "unarchive": "取消封存",
     "showArchived": "顯示封存",

--- a/webui/src/lib/session-export.ts
+++ b/webui/src/lib/session-export.ts
@@ -1,0 +1,166 @@
+import { fmtDateTime } from "@/lib/format";
+import type { ChatSummary, ToolProgressEvent, UIFileEdit, UIMessage } from "@/lib/types";
+
+interface BuildSessionMarkdownOptions {
+  session: Pick<ChatSummary, "key" | "createdAt" | "updatedAt">;
+  title: string;
+  messages: UIMessage[];
+  locale?: string;
+}
+
+const ROLE_LABELS: Record<string, string> = {
+  user: "User",
+  assistant: "Assistant",
+  tool: "Tool",
+  system: "System",
+};
+
+function normalizeBlankLines(value: string): string {
+  return value.replace(/\r\n/g, "\n").trim();
+}
+
+function safeJsonSummary(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value.trim();
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function toolEventSummary(event: ToolProgressEvent): string {
+  const name = event.name?.trim() || "tool";
+  const phase = event.phase?.trim() || "event";
+  const suffix = event.error
+    ? `: ${safeJsonSummary(event.error)}`
+    : "";
+  return `- ${name} (${phase})${suffix}`;
+}
+
+function fileEditSummary(edit: UIFileEdit): string {
+  const operation = edit.operation === "delete" ? "deleted" : "edited";
+  const status = edit.status === "error" ? " failed" : "";
+  const binary = edit.binary ? ", binary" : "";
+  const delta = edit.operation === "delete"
+    ? ""
+    : `, +${edit.added}/-${edit.deleted}`;
+  const error = edit.error ? `: ${edit.error}` : "";
+  return `- ${operation}${status} ${edit.path}${delta}${binary}${error}`;
+}
+
+function activityLines(message: UIMessage): string[] {
+  const lines: string[] = [];
+  for (const trace of message.traces ?? []) {
+    const text = trace.trim();
+    if (text) lines.push(`- ${text}`);
+  }
+  const content = message.content.trim();
+  if (content && !lines.some((line) => line.slice(2) === content)) {
+    lines.push(`- ${content}`);
+  }
+  for (const event of message.toolEvents ?? []) {
+    lines.push(toolEventSummary(event));
+  }
+  for (const edit of message.fileEdits ?? []) {
+    lines.push(fileEditSummary(edit));
+  }
+  if (message.media?.length) {
+    for (const media of message.media) {
+      lines.push(`- ${media.kind}: ${media.name || media.url || "attachment"}`);
+    }
+  }
+  return lines;
+}
+
+function renderActivity(message: UIMessage, locale?: string): string {
+  const lines = activityLines(message);
+  if (!lines.length) return "";
+  const timestamp = fmtDateTime(message.createdAt, locale);
+  const label = timestamp ? `Activity - ${timestamp}` : "Activity";
+  return [
+    "<details>",
+    `<summary>${label}</summary>`,
+    "",
+    ...lines,
+    "",
+    "</details>",
+  ].join("\n");
+}
+
+function renderMessage(message: UIMessage, locale?: string): string {
+  if (message.kind === "trace") return renderActivity(message, locale);
+  const role = ROLE_LABELS[message.role] ?? message.role;
+  const timestamp = fmtDateTime(message.createdAt, locale);
+  const heading = timestamp ? `## ${role} - ${timestamp}` : `## ${role}`;
+  const content = normalizeBlankLines(message.content);
+  const parts = [heading];
+  if (message.reasoning?.trim()) {
+    parts.push(
+      "",
+      "<details>",
+      "<summary>Reasoning</summary>",
+      "",
+      normalizeBlankLines(message.reasoning),
+      "",
+      "</details>",
+    );
+  }
+  if (content) parts.push("", content);
+  if (message.media?.length) {
+    parts.push(
+      "",
+      ...message.media.map((media) => `- ${media.kind}: ${media.name || media.url || "attachment"}`),
+    );
+  }
+  return parts.join("\n");
+}
+
+export function buildSessionMarkdown({
+  session,
+  title,
+  messages,
+  locale,
+}: BuildSessionMarkdownOptions): string {
+  const cleanedTitle = title.trim() || "Nanobot session";
+  const metadata = [
+    `# ${cleanedTitle}`,
+    "",
+    `- Session: \`${session.key}\``,
+  ];
+  const createdAt = fmtDateTime(session.createdAt, locale);
+  const updatedAt = fmtDateTime(session.updatedAt, locale);
+  if (createdAt) metadata.push(`- Created: ${createdAt}`);
+  if (updatedAt) metadata.push(`- Last active: ${updatedAt}`);
+
+  const body = messages
+    .map((message) => renderMessage(message, locale))
+    .filter(Boolean);
+
+  if (!body.length) {
+    body.push("_No transcript messages were available._");
+  }
+  return [...metadata, "", ...body, ""].join("\n\n");
+}
+
+export function sessionMarkdownFilename(title: string, key: string): string {
+  const base = (title.trim() || key)
+    .toLowerCase()
+    .replace(/[^a-z0-9\u4e00-\u9fff]+/gi, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+  return `${base || "nanobot-session"}.md`;
+}
+
+export function downloadMarkdownFile(filename: string, markdown: string): void {
+  const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.rel = "noopener";
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 0);
+}

--- a/webui/src/tests/chat-list.test.tsx
+++ b/webui/src/tests/chat-list.test.tsx
@@ -56,6 +56,31 @@ describe("ChatList", () => {
     expect(text.indexOf("Middle chat")).toBeLessThan(text.indexOf("Older chat"));
   });
 
+  it("offers markdown export from each chat action menu", async () => {
+    const onExportMarkdown = vi.fn();
+
+    render(
+      <ChatList
+        sessions={[session({ chatId: "export", title: "Export me" })]}
+        activeKey={null}
+        onSelect={vi.fn()}
+        onRequestDelete={vi.fn()}
+        onTogglePin={vi.fn()}
+        onRequestRename={vi.fn()}
+        onToggleArchive={vi.fn()}
+        onExportMarkdown={onExportMarkdown}
+      />,
+    );
+
+    fireEvent.pointerDown(
+      screen.getByLabelText("Chat actions for Export me"),
+      { button: 0 },
+    );
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Export markdown" }));
+
+    expect(onExportMarkdown).toHaveBeenCalledWith("websocket:export", "Export me");
+  });
+
   it("groups WebUI chats by workspace project while preserving in-project sorting and activity", () => {
     const sessions = [
       session({

--- a/webui/src/tests/session-export.test.ts
+++ b/webui/src/tests/session-export.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSessionMarkdown,
+  sessionMarkdownFilename,
+} from "@/lib/session-export";
+import type { ChatSummary, UIMessage } from "@/lib/types";
+
+const session: ChatSummary = {
+  key: "websocket:chat-1",
+  channel: "websocket",
+  chatId: "chat-1",
+  createdAt: "2026-06-01T10:00:00Z",
+  updatedAt: "2026-06-01T10:05:00Z",
+  title: "Export demo",
+  preview: "",
+};
+
+describe("session-export", () => {
+  it("exports conversational messages as markdown while preserving code blocks", () => {
+    const messages: UIMessage[] = [
+      {
+        id: "u1",
+        role: "user",
+        content: "Please keep this code:\n\n```ts\nconst value = 1;\n```",
+        createdAt: Date.parse("2026-06-01T10:01:00Z"),
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "Done.",
+        createdAt: Date.parse("2026-06-01T10:02:00Z"),
+      },
+    ];
+
+    const markdown = buildSessionMarkdown({
+      session,
+      title: "Export demo",
+      messages,
+      locale: "en",
+    });
+
+    expect(markdown).toContain("# Export demo");
+    expect(markdown).toContain("- Session: `websocket:chat-1`");
+    expect(markdown).toContain("## User");
+    expect(markdown).toContain("```ts\nconst value = 1;\n```");
+    expect(markdown).toContain("## Assistant");
+    expect(markdown).toContain("Done.");
+  });
+
+  it("collapses trace, tool, and file edit activity into details", () => {
+    const markdown = buildSessionMarkdown({
+      session,
+      title: "Activity demo",
+      locale: "en",
+      messages: [
+        {
+          id: "trace-1",
+          role: "assistant",
+          kind: "trace",
+          content: "",
+          createdAt: Date.parse("2026-06-01T10:02:00Z"),
+          traces: ["Running shell command"],
+          toolEvents: [{ name: "shell", phase: "end" }],
+          fileEdits: [{
+            call_id: "edit-1",
+            tool: "edit",
+            path: "src/app.ts",
+            added: 2,
+            deleted: 1,
+            status: "done",
+          }],
+        },
+      ],
+    });
+
+    expect(markdown).toContain("<details>");
+    expect(markdown).toContain("<summary>Activity");
+    expect(markdown).toContain("- Running shell command");
+    expect(markdown).toContain("- shell (end)");
+    expect(markdown).toContain("- edited src/app.ts, +2/-1");
+    expect(markdown).toContain("</details>");
+  });
+
+  it("sanitizes exported filenames", () => {
+    expect(sessionMarkdownFilename("Fix / chat: export?", "websocket:chat-1"))
+      .toBe("fix-chat-export.md");
+  });
+});


### PR DESCRIPTION
## Summary
- show session relative timestamps in the WebUI sidebar by default
- add a sidebar action to export a session transcript as Markdown
- preserve message Markdown/code blocks and collapse tool, trace, and file-edit activity in exported transcripts

Fixes #4579

## Validation
- cd webui && bun run test -- session-export chat-list i18n
- .venv/bin/pytest tests/utils/test_webui_sidebar_state.py -q
- cd webui && bun run build
- browser smoke test for sidebar timestamp display and Markdown download

Note: `bun run lint` could not run locally because the eslint binary is missing in this checkout (`/bin/bash: eslint: command not found`).