### PR TITLE
Show WebUI session timestamps by default

### DIFF
--- a/nanobot/webui/sidebar_state.py
+++ b/nanobot/webui/sidebar_state.py
@@ -44,7 +44,7 @@ def default_webui_sidebar_state() -> dict[str, Any]:
         "view": {
             "density": "comfortable",
             "show_previews": False,
-            "show_timestamps": False,
+            "show_timestamps": True,
             "show_archived": False,
             "sort": "updated_desc",
         },

--- a/tests/utils/test_webui_sidebar_state.py
+++ b/tests/utils/test_webui_sidebar_state.py
@@ -48,7 +48,7 @@ def test_sidebar_state_normalizes_old_or_partial_payload(tmp_path, monkeypatch) 
     assert state["view"] == {
         "density": "comfortable",
         "show_previews": False,
-        "show_timestamps": False,
+        "show_timestamps": True,
         "show_archived": True,
         "sort": "updated_desc",
     }

--- a/webui/src/hooks/useSidebarState.ts
+++ b/webui/src/hooks/useSidebarState.ts
@@ -18,7 +18,7 @@ export const DEFAULT_SIDEBAR_STATE: SidebarStatePayload = {
   view: {
     density: "comfortable",
     show_previews: false,
-    show_timestamps: false,
+    show_timestamps: true,
     show_archived: false,
     sort: "updated_desc",
   },
@@ -86,6 +86,9 @@ export function normalizeSidebarState(raw: unknown): SidebarStatePayload {
   const sort = ["updated_desc", "created_desc", "title_asc"].includes(view.sort)
     ? view.sort
     : "updated_desc";
+  const showTimestamps = typeof view.show_timestamps === "boolean"
+    ? view.show_timestamps
+    : DEFAULT_SIDEBAR_STATE.view.show_timestamps;
   return {
     schema_version: 1,
     pinned_keys: uniqueStrings(value.pinned_keys),
@@ -97,7 +100,7 @@ export function normalizeSidebarState(raw: unknown): SidebarStatePayload {
     view: {
       density,
       show_previews: Boolean(view.show_previews),
-      show_timestamps: Boolean(view.show_timestamps),
+      show_timestamps: showTimestamps,
       show_archived: Boolean(view.show_archived),
       sort,
     },


### PR DESCRIPTION
## Summary
- enable WebUI sidebar session timestamps by default for new and partial sidebar state payloads
- preserve an explicit user-disabled timestamp setting
- align backend sidebar state defaults and tests

Part of #4579. This PR covers only the session timestamp sidebar change; Markdown export is split into a separate PR.

## Validation
- .venv/bin/pytest tests/utils/test_webui_sidebar_state.py -q
- cd webui && bun run build