### PR TITLE
optimization: reducing context/input tokens from tool uses by pruning, compression and processing tool outputs before inputting to context

### DIFF
--- a/nanobot/agent/context_governance.py
+++ b/nanobot/agent/context_governance.py
@@ -7,6 +7,7 @@ mutate an existing session history list in place.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -28,6 +29,9 @@ if TYPE_CHECKING:
 SNIP_SAFETY_BUFFER = 1024
 MICROCOMPACT_KEEP_RECENT = 10
 MICROCOMPACT_MIN_CHARS = 500
+TOOL_REPLAY_KEEP_FULL = 10
+TOOL_REPLAY_KEEP_SUMMARY = 50
+TOOL_REPLAY_SUMMARY_CHARS = 180
 INFLIGHT_COMPACT_TARGET_RATIO = 0.85
 COMPACTABLE_TOOLS = frozenset({
     "read_file", "exec", "grep", "find_files",
@@ -82,6 +86,7 @@ class ContextGovernor:
         updated = self.strip_malformed_tool_calls(updated)
         updated = self.drop_orphan_tool_results(updated)
         updated = self.backfill_missing_tool_results(updated)
+        updated = self.apply_tool_replay_window(updated)
         updated = self.apply_tool_result_budget(config, updated)
         updated = self.compact_inflight_overflow(config, updated, compacted_tool_call_ids)
         updated = self.snip_history(config, updated)
@@ -316,6 +321,74 @@ class ContextGovernor:
                 updated[idx]["content"] = normalized
         return updated
 
+    def apply_tool_replay_window(
+        self,
+        messages: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Keep recent tool calls useful while removing stale tool chatter.
+
+        The model-facing transcript keeps the newest 10 tool results verbatim,
+        rewrites the previous 50 tool results to one-line summaries, and drops
+        older assistant tool_call declarations plus their tool result messages.
+        Persisted session history is not modified.
+        """
+        tool_call_details = self._tool_call_details(messages)
+        ordered_tool_ids = [
+            str(msg.get("tool_call_id"))
+            for msg in messages
+            if msg.get("role") == "tool" and msg.get("tool_call_id") in tool_call_details
+        ]
+        if len(ordered_tool_ids) <= TOOL_REPLAY_KEEP_FULL:
+            return messages
+
+        summarize_start = max(0, len(ordered_tool_ids) - TOOL_REPLAY_KEEP_FULL - TOOL_REPLAY_KEEP_SUMMARY)
+        summarize_ids = set(ordered_tool_ids[summarize_start:-TOOL_REPLAY_KEEP_FULL])
+        remove_ids = set(ordered_tool_ids[:summarize_start])
+        if not summarize_ids and not remove_ids:
+            return messages
+
+        updated: list[dict[str, Any]] = []
+        changed = False
+        for msg in messages:
+            role = msg.get("role")
+            if role == "assistant" and msg.get("tool_calls"):
+                kept_calls = []
+                for tool_call in msg.get("tool_calls") or []:
+                    tool_id = tool_call.get("id") if isinstance(tool_call, dict) else None
+                    if tool_id and str(tool_id) in remove_ids:
+                        changed = True
+                        continue
+                    kept_calls.append(tool_call)
+                if len(kept_calls) == len(msg.get("tool_calls") or []):
+                    updated.append(msg)
+                    continue
+                repaired = dict(msg)
+                if kept_calls:
+                    repaired["tool_calls"] = kept_calls
+                    updated.append(repaired)
+                elif repaired.get("content"):
+                    repaired.pop("tool_calls", None)
+                    updated.append(repaired)
+                continue
+
+            if role == "tool":
+                tool_id = msg.get("tool_call_id")
+                tool_id = str(tool_id) if tool_id else ""
+                if tool_id in remove_ids:
+                    changed = True
+                    continue
+                if tool_id in summarize_ids:
+                    summary = self._tool_replay_summary(msg, tool_call_details.get(tool_id, {}))
+                    if msg.get("content") != summary:
+                        repaired = dict(msg)
+                        repaired["content"] = summary
+                        updated.append(repaired)
+                        changed = True
+                        continue
+            updated.append(msg)
+
+        return updated if changed else messages
+
     def compact_inflight_overflow(
         self,
         config: ContextGovernanceConfig,
@@ -423,6 +496,58 @@ class ContextGovernor:
         kept.reverse()
 
         return system_messages + self._legal_history_tail(kept, non_system)
+
+    @staticmethod
+    def _tool_call_details(messages: list[dict[str, Any]]) -> dict[str, dict[str, str]]:
+        details: dict[str, dict[str, str]] = {}
+        for msg in messages:
+            if msg.get("role") != "assistant":
+                continue
+            for tool_call in msg.get("tool_calls") or []:
+                if not isinstance(tool_call, dict) or not tool_call.get("id"):
+                    continue
+                fn = tool_call.get("function") if isinstance(tool_call.get("function"), dict) else {}
+                name = fn.get("name") or tool_call.get("name") or "tool"
+                details[str(tool_call["id"])] = {
+                    "name": str(name),
+                    "arguments": ContextGovernor._short_tool_arguments(str(name), fn.get("arguments")),
+                }
+        return details
+
+    @staticmethod
+    def _short_tool_arguments(tool_name: str, arguments: Any) -> str:
+        if isinstance(arguments, str):
+            raw = arguments
+        else:
+            raw = json.dumps(arguments or {}, ensure_ascii=False, sort_keys=True)
+        try:
+            parsed = json.loads(raw) if isinstance(raw, str) else raw
+        except Exception:
+            parsed = raw
+        if isinstance(parsed, dict):
+            if tool_name == "exec":
+                command = parsed.get("command") or parsed.get("cmd")
+                if command:
+                    return f"command={truncate_text(str(command), 90)}"
+            keys = ",".join(str(key) for key in list(parsed)[:4])
+            if len(parsed) > 4:
+                keys += ",..."
+            return f"args={{{keys}}}" if keys else "args={}"
+        return f"args={truncate_text(str(parsed), 90)}"
+
+    @staticmethod
+    def _tool_replay_summary(message: dict[str, Any], details: dict[str, str]) -> str:
+        name = str(message.get("name") or details.get("name") or "tool")
+        arguments = details.get("arguments") or "args={}"
+        content = message.get("content")
+        output = content if isinstance(content, str) else repr(content)
+        output = " ".join(output.split())
+        if not output:
+            output = "(no output)"
+        return truncate_text(
+            f"[{name} result summarized for context: {arguments}; output={output}]",
+            TOOL_REPLAY_SUMMARY_CHARS,
+        )
 
     @staticmethod
     def _summary_for(message: dict[str, Any]) -> str:

--- a/nanobot/agent/tools/command_output_compaction.py
+++ b/nanobot/agent/tools/command_output_compaction.py
@@ -80,9 +80,9 @@ def compact_command_output(
     family = _command_family(command)
     compacted = _route_compactor(family, output)
     if compacted is None:
-        compacted = _generic_compact(output.stdout, output.max_chars)
-        if output.stderr.strip():
-            compacted = _join_sections([compacted, _error_focused(output.stderr, output.max_chars // 3)])
+        # Unknown plain stdout keeps the legacy raw-output path so ExecTool's
+        # final head/tail truncation continues to preserve exact command text.
+        return combined or "(no output)"
 
     compacted = _fit(compacted, output.max_chars)
     if compacted == combined:

--- a/nanobot/agent/tools/command_output_compaction.py
+++ b/nanobot/agent/tools/command_output_compaction.py
@@ -1,0 +1,398 @@
+"""Token-oriented compaction for shell command output.
+
+The shell tool still executes the user's command normally.  This module only
+reshapes large model-facing stdout/stderr payloads so routine command noise
+does not crowd out useful context.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_COMPACT_TRIGGER_CHARS = 8_000
+MIN_COMPACT_TARGET_CHARS = 2_000
+ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+PROGRESS_RE = re.compile(r"\r|(?:^|\s)(?:\d{1,3}%|[=\-#>]{8,}|\d+(?:\.\d+)?\s*(?:kB|MB|GB)/s)")
+FILE_LINE_RE = re.compile(r"(?:^|\s)([^\s:]+\.(?:py|js|jsx|ts|tsx|go|rs|rb|java|kt|cs|cpp|c|h|hpp|yaml|yml|json|toml|md)):(\d+)(?::(\d+))?")
+DIFF_FILE_RE = re.compile(r"^diff --git a/(.+?) b/(.+)$")
+HUNK_RE = re.compile(r"^@@ .+ @@")
+
+TEST_COMMANDS = {
+    "pytest", "py.test", "unittest", "tox", "nox", "jest", "vitest", "mocha", "ava",
+    "playwright", "cypress", "rspec", "rake", "go", "cargo", "dotnet", "mvn", "gradle",
+    "gradlew", "phpunit", "bats", "ctest", "zig",
+}
+LINT_COMMANDS = {
+    "ruff", "eslint", "mypy", "pyright", "tsc", "biome", "prettier", "black", "isort",
+    "flake8", "pylint", "golangci-lint", "rubocop", "clippy", "shellcheck", "stylelint",
+    "hadolint", "yamllint", "markdownlint", "swiftlint", "ktlint",
+}
+BUILD_COMMANDS = {
+    "make", "cmake", "ninja", "npm", "pnpm", "yarn", "bun", "pip", "uv", "poetry", "hatch",
+    "cargo", "go", "dotnet", "mvn", "gradle", "gradlew", "docker", "podman", "terraform",
+    "pulumi", "webpack", "vite", "next", "tsup", "rollup", "esbuild", "bazel", "buck",
+}
+JSON_COMMANDS = {"jq", "curl", "http", "wget", "aws", "gcloud", "az", "kubectl", "gh", "glab"}
+TABLE_COMMANDS = {"psql", "mysql", "sqlite3", "duckdb", "docker", "podman", "kubectl", "helm", "ps", "df", "du"}
+LIST_COMMANDS = {"ls", "tree", "find", "fd", "rg", "grep", "ag", "ack", "wc"}
+DIFF_COMMANDS = {"git", "diff", "delta"}
+
+
+@dataclass(slots=True)
+class CommandOutput:
+    command: str
+    stdout: str
+    stderr: str
+    exit_code: int | None
+    max_chars: int
+
+    @property
+    def combined(self) -> str:
+        return _combine(self.stdout, self.stderr, self.exit_code)
+
+
+def compact_command_output(
+    *,
+    command: str,
+    stdout: str,
+    stderr: str,
+    exit_code: int | None,
+    max_chars: int,
+) -> str:
+    """Return compact model-facing output for a completed shell command."""
+    output = CommandOutput(
+        command=command,
+        stdout=_strip_control_noise(stdout),
+        stderr=_strip_control_noise(stderr),
+        exit_code=exit_code,
+        max_chars=max(max_chars, MIN_COMPACT_TARGET_CHARS),
+    )
+    combined = output.combined
+    if len(combined) <= min(DEFAULT_COMPACT_TRIGGER_CHARS, output.max_chars):
+        return combined or "(no output)"
+
+    family = _command_family(command)
+    compacted = _route_compactor(family, output)
+    if compacted is None:
+        compacted = _generic_compact(output.stdout, output.max_chars)
+        if output.stderr.strip():
+            compacted = _join_sections([compacted, _error_focused(output.stderr, output.max_chars // 3)])
+
+    compacted = _fit(compacted, output.max_chars)
+    if compacted == combined:
+        compacted = _middle_truncate(combined, output.max_chars)
+
+    header = (
+        f"[command output compacted: {len(combined):,} -> {len(compacted):,} chars"
+        f"; command={family or 'shell'}]"
+    )
+    return _join_sections([header, compacted, f"Exit code: {exit_code}"])
+
+
+def _route_compactor(family: str | None, output: CommandOutput) -> str | None:
+    text = output.stdout
+    if _looks_like_json(text) or family in JSON_COMMANDS:
+        compacted = _json_compact(text, output.max_chars)
+        if compacted:
+            return compacted
+    if family == "git":
+        return _git_compact(output.command, text, output.max_chars)
+    if family in DIFF_COMMANDS or _looks_like_diff(text):
+        return _diff_compact(text, output.max_chars)
+    if family in TEST_COMMANDS or _looks_like_test_output(text):
+        return _failure_focused(text, output.max_chars)
+    if family in LINT_COMMANDS or _looks_like_lint_output(text):
+        return _lint_compact(text, output.max_chars)
+    if family in BUILD_COMMANDS:
+        return _build_compact(text, output.max_chars)
+    if output.exit_code not in (0, None):
+        return _join_sections([
+            _error_focused(output.stderr or text, output.max_chars // 2),
+            _generic_compact(text, output.max_chars // 2) if text else "",
+        ])
+    if family in TABLE_COMMANDS or _looks_like_table(text):
+        return _table_compact(text, output.max_chars)
+    if family in LIST_COMMANDS:
+        return _listing_compact(text, output.max_chars)
+    return None
+
+
+def _command_family(command: str) -> str | None:
+    try:
+        parts = shlex.split(command, posix=True)
+    except ValueError:
+        parts = command.split()
+    while parts and ("=" in parts[0] and not parts[0].startswith("-")):
+        key = parts[0].split("=", 1)[0]
+        if not key.replace("_", "").isalnum():
+            break
+        parts.pop(0)
+    while parts and parts[0] in {"sudo", "env", "command", "time", "nice", "nohup"}:
+        parts.pop(0)
+    if not parts:
+        return None
+    return Path(parts[0]).name.lower()
+
+
+def _combine(stdout: str, stderr: str, exit_code: int | None) -> str:
+    parts = []
+    if stdout:
+        parts.append(stdout.rstrip())
+    if stderr.strip():
+        parts.append(f"STDERR:\n{stderr.rstrip()}")
+    parts.append(f"Exit code: {exit_code}")
+    return "\n".join(parts)
+
+
+def _strip_control_noise(text: str) -> str:
+    if not text:
+        return ""
+    text = ANSI_RE.sub("", text.replace("\r\n", "\n"))
+    lines = []
+    for line in text.splitlines():
+        if "\r" in line:
+            line = line.split("\r")[-1]
+        if PROGRESS_RE.search(line) and not any(word in line.lower() for word in _IMPORTANT_WORDS):
+            continue
+        lines.append(line.rstrip())
+    return "\n".join(lines).strip()
+
+
+_IMPORTANT_WORDS = ("error", "failed", "failure", "warning", "warn", "traceback", "exception")
+
+
+def _generic_compact(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    json_summary = _json_compact(text, max_chars)
+    if json_summary:
+        return json_summary
+    if _looks_like_table(text):
+        return _table_compact(text, max_chars)
+    return _join_sections([_dedupe_lines(text, max_chars // 2), _head_tail(text, max_chars // 2)])
+
+
+def _json_compact(text: str, max_chars: int) -> str | None:
+    stripped = text.strip()
+    if not _looks_like_json(stripped):
+        return None
+    try:
+        data = json.loads(stripped)
+    except Exception:
+        return None
+    summary = _json_shape(data)
+    rendered = json.dumps(summary, ensure_ascii=False, indent=2)
+    return _fit(rendered, max_chars)
+
+
+def _json_shape(value: Any, depth: int = 0) -> Any:
+    if depth >= 3:
+        return _json_leaf(value)
+    if isinstance(value, dict):
+        keys = list(value.keys())
+        shaped = {str(k): _json_shape(value[k], depth + 1) for k in keys[:20]}
+        if len(keys) > 20:
+            shaped["..."] = f"{len(keys) - 20} more keys"
+        return {"type": "object", "keys": len(keys), "sample": shaped}
+    if isinstance(value, list):
+        sample = [_json_shape(v, depth + 1) for v in value[:3]]
+        return {"type": "array", "items": len(value), "sample": sample}
+    return _json_leaf(value)
+
+
+def _json_leaf(value: Any) -> Any:
+    if isinstance(value, str):
+        return value if len(value) <= 120 else value[:117] + "..."
+    return value
+
+
+def _git_compact(command: str, text: str, max_chars: int) -> str:
+    lower = command.lower()
+    if " diff" in lower or lower.startswith("git diff") or _looks_like_diff(text):
+        return _diff_compact(text, max_chars)
+    if " status" in lower:
+        return _head_tail(text, max_chars, head=80, tail=20)
+    if " log" in lower:
+        return _head_tail(text, max_chars, head=60, tail=0)
+    return _generic_compact(text, max_chars)
+
+
+def _diff_compact(text: str, max_chars: int) -> str:
+    files: list[str] = []
+    kept: list[str] = []
+    hunk_context = 0
+    for line in text.splitlines():
+        match = DIFF_FILE_RE.match(line)
+        if match:
+            files.append(match.group(2))
+            kept.append(line)
+            continue
+        if HUNK_RE.match(line):
+            kept.append(line)
+            hunk_context = 8
+            continue
+        if hunk_context > 0 and (line.startswith(("+", "-")) or line.strip()):
+            kept.append(line)
+            hunk_context -= 1
+    summary = [f"Changed files: {len(files)}"]
+    summary.extend(f"- {path}" for path in files[:80])
+    if len(files) > 80:
+        summary.append(f"- ... {len(files) - 80} more files")
+    return _fit(_join_sections(["\n".join(summary), "\n".join(kept)]), max_chars)
+
+
+def _failure_focused(text: str, max_chars: int) -> str:
+    lines = text.splitlines()
+    important = _important_lines(lines)
+    summary = _summary_lines(lines)
+    if not important:
+        return _head_tail(text, max_chars)
+    return _fit(_join_sections(["Summary:", "\n".join(summary), "Failures/errors:", "\n".join(important)]), max_chars)
+
+
+def _lint_compact(text: str, max_chars: int) -> str:
+    lines = text.splitlines()
+    by_file: Counter[str] = Counter()
+    important: list[str] = []
+    for line in lines:
+        match = FILE_LINE_RE.search(line)
+        if match:
+            by_file[match.group(1)] += 1
+            important.append(line.strip())
+        elif any(word in line.lower() for word in _IMPORTANT_WORDS):
+            important.append(line.strip())
+    summary = [f"Files with diagnostics: {len(by_file)}"]
+    summary.extend(f"- {path}: {count}" for path, count in by_file.most_common(40))
+    return _fit(_join_sections(["\n".join(summary), "Diagnostics:", "\n".join(important[:300])]), max_chars)
+
+
+def _build_compact(text: str, max_chars: int) -> str:
+    lines = text.splitlines()
+    important = _important_lines(lines)
+    if important:
+        return _fit(_join_sections(["Build diagnostics:", "\n".join(important), "Tail:", "\n".join(lines[-40:])]), max_chars)
+    return _head_tail(text, max_chars, head=40, tail=60)
+
+
+def _table_compact(text: str, max_chars: int) -> str:
+    lines = [line for line in text.splitlines() if line.strip()]
+    if len(lines) <= 80 and len(text) <= max_chars:
+        return text
+    head = lines[:30]
+    tail = lines[-20:] if len(lines) > 50 else []
+    omitted = max(0, len(lines) - len(head) - len(tail))
+    middle = [f"... {omitted:,} rows omitted ..."] if omitted else []
+    return _fit("\n".join(head + middle + tail), max_chars)
+
+
+def _listing_compact(text: str, max_chars: int) -> str:
+    lines = [line.rstrip() for line in text.splitlines() if line.strip()]
+    if len(lines) <= 120 and len(text) <= max_chars:
+        return text
+    suffix_counts = Counter(Path(line.split()[-1]).suffix or "[no suffix]" for line in lines if line.split())
+    summary = [f"Entries: {len(lines)}"]
+    summary.extend(f"- {suffix}: {count}" for suffix, count in suffix_counts.most_common(20))
+    return _fit(_join_sections(["\n".join(summary), _head_tail("\n".join(lines), max_chars // 2)]), max_chars)
+
+
+def _error_focused(text: str, max_chars: int) -> str:
+    lines = text.splitlines()
+    important = _important_lines(lines)
+    return _fit("\n".join(important or lines[-80:]), max_chars)
+
+
+def _important_lines(lines: list[str]) -> list[str]:
+    kept: list[str] = []
+    for idx, line in enumerate(lines):
+        lower = line.lower()
+        if any(word in lower for word in _IMPORTANT_WORDS) or FILE_LINE_RE.search(line):
+            start = max(0, idx - 2)
+            end = min(len(lines), idx + 4)
+            kept.extend(lines[start:end])
+    return _dedupe_preserve_order([line for line in kept if line.strip()])[:500]
+
+
+def _summary_lines(lines: list[str]) -> list[str]:
+    return [
+        line.strip()
+        for line in lines
+        if line.strip() and any(token in line.lower() for token in ("passed", "failed", "error", "warning", "collected", "total", "summary"))
+    ][:80]
+
+
+def _dedupe_lines(text: str, max_chars: int) -> str:
+    lines = _dedupe_preserve_order([line for line in text.splitlines() if line.strip()])
+    return _fit("\n".join(lines), max_chars)
+
+
+def _dedupe_preserve_order(lines: list[str]) -> list[str]:
+    seen: set[str] = set()
+    kept: list[str] = []
+    for line in lines:
+        key = re.sub(r"\d+", "#", line.strip())
+        if key in seen:
+            continue
+        seen.add(key)
+        kept.append(line)
+    return kept
+
+
+def _looks_like_json(text: str) -> bool:
+    stripped = text.strip()
+    return len(stripped) >= 2 and stripped[0] in "[{" and stripped[-1] in "]}"
+
+
+def _looks_like_diff(text: str) -> bool:
+    return "diff --git " in text or "\n@@ " in text
+
+
+def _looks_like_table(text: str) -> bool:
+    lines = [line for line in text.splitlines() if line.strip()]
+    if len(lines) < 20:
+        return False
+    pipe_rows = sum(1 for line in lines[:50] if "|" in line)
+    spaced_rows = sum(1 for line in lines[:50] if len(re.split(r"\s{2,}", line.strip())) >= 3)
+    return pipe_rows >= 10 or spaced_rows >= 10
+
+
+def _looks_like_test_output(text: str) -> bool:
+    lower = text.lower()
+    return " traceback " in lower or " failed" in lower or " failures" in lower or " tests passed" in lower
+
+
+def _looks_like_lint_output(text: str) -> bool:
+    return bool(FILE_LINE_RE.search(text)) and any(word in text.lower() for word in ("error", "warning", "lint"))
+
+
+def _head_tail(text: str, max_chars: int, *, head: int = 80, tail: int = 80) -> str:
+    lines = text.splitlines()
+    if len(text) <= max_chars:
+        return text
+    head_lines = lines[:head]
+    tail_lines = lines[-tail:] if tail else []
+    omitted = max(0, len(lines) - len(head_lines) - len(tail_lines))
+    return _fit("\n".join(head_lines + [f"... {omitted:,} lines omitted ..."] + tail_lines), max_chars)
+
+
+def _fit(text: str, max_chars: int) -> str:
+    return text if len(text) <= max_chars else _middle_truncate(text, max_chars)
+
+
+def _middle_truncate(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    marker = f"\n\n... ({len(text) - max_chars:,} chars omitted by command-output compactor) ...\n\n"
+    budget = max(0, max_chars - len(marker))
+    head = budget // 2
+    tail = budget - head
+    return text[:head].rstrip() + marker + text[-tail:].lstrip()
+
+
+def _join_sections(sections: list[str]) -> str:
+    return "\n\n".join(section.strip() for section in sections if section and section.strip())

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -17,6 +17,7 @@ from pydantic import Field
 
 from nanobot.agent.tools.base import Tool, tool_parameters
 from nanobot.agent.tools.context import current_request_session_key
+from nanobot.agent.tools.command_output_compaction import compact_command_output
 from nanobot.agent.tools.exec_session import (
     DEFAULT_EXEC_SESSION_MANAGER,
     DEFAULT_MAX_OUTPUT_CHARS,
@@ -288,21 +289,14 @@ class ExecTool(Tool):
                 await self._kill_process(process)
                 raise
 
-            output_parts = []
-
-            if stdout:
-                output_parts.append(stdout.decode("utf-8", errors="replace"))
-
-            if stderr:
-                stderr_text = stderr.decode("utf-8", errors="replace")
-                if stderr_text.strip():
-                    output_parts.append(f"STDERR:\n{stderr_text}")
-
-            output_parts.append(f"\nExit code: {process.returncode}")
-
-            result = "\n".join(output_parts) if output_parts else "(no output)"
-
             max_len = clamp_session_int(max_output_chars, self._MAX_OUTPUT, 1000, MAX_OUTPUT_CHARS)
+            result = compact_command_output(
+                command=prepared.command,
+                stdout=stdout.decode("utf-8", errors="replace") if stdout else "",
+                stderr=stderr.decode("utf-8", errors="replace") if stderr else "",
+                exit_code=process.returncode,
+                max_chars=max_len,
+            )
             if len(result) > max_len:
                 half = max_len // 2
                 result = (

--- a/tests/agent/test_runner_governance.py
+++ b/tests/agent/test_runner_governance.py
@@ -247,6 +247,72 @@ def test_drop_orphan_tool_results_removes_unmatched_tool_messages():
     ]
 
 
+def test_apply_tool_replay_window_keeps_10_summarizes_50_removes_rest():
+    messages = [{"role": "user", "content": "run many commands"}]
+    for idx in range(65):
+        messages.extend([
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": f"call_{idx}",
+                        "type": "function",
+                        "function": {
+                            "name": "exec",
+                            "arguments": f'{{"command":"cmd {idx}"}}',
+                        },
+                    },
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": f"call_{idx}",
+                "name": "exec",
+                "content": f"output {idx} " + ("x" * 300),
+            },
+        ])
+
+    compacted = ContextGovernor().apply_tool_replay_window(messages)
+
+    tool_messages = [msg for msg in compacted if msg.get("role") == "tool"]
+    tool_ids = [msg["tool_call_id"] for msg in tool_messages]
+    assert tool_ids == [f"call_{idx}" for idx in range(5, 65)]
+    assert all(
+        "result summarized for context" in str(msg.get("content"))
+        for msg in tool_messages[:50]
+    )
+    assert all(
+        str(msg.get("content")).startswith(f"output {idx}")
+        for idx, msg in zip(range(55, 65), tool_messages[50:])
+    )
+    assistant_call_ids = [
+        call["id"]
+        for msg in compacted
+        for call in msg.get("tool_calls") or []
+    ]
+    assert assistant_call_ids == [f"call_{idx}" for idx in range(5, 65)]
+    assert compacted[0] is messages[0]
+    assert messages[2]["tool_call_id"] == "call_0"  # original history is untouched
+
+
+def test_apply_tool_replay_window_leaves_latest_10_unchanged():
+    messages = [{"role": "user", "content": "run commands"}]
+    for idx in range(10):
+        messages.extend([
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": f"call_{idx}", "type": "function", "function": {"name": "exec"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": f"call_{idx}", "name": "exec", "content": "ok"},
+        ])
+
+    assert ContextGovernor().apply_tool_replay_window(messages) is messages
+
+
 @pytest.mark.asyncio
 async def test_backfill_noop_when_complete():
     """Complete message chains should not be modified."""

--- a/tests/tools/test_command_output_compaction.py
+++ b/tests/tools/test_command_output_compaction.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+
+from nanobot.agent.tools.command_output_compaction import compact_command_output
+
+
+def test_compact_command_output_leaves_small_output_unchanged():
+    result = compact_command_output(
+        command="echo hello",
+        stdout="hello\n",
+        stderr="",
+        exit_code=0,
+        max_chars=10_000,
+    )
+
+    assert result == "hello\nExit code: 0"
+
+
+def test_compact_command_output_summarizes_large_json():
+    payload = [{"id": i, "name": f"item-{i}", "nested": {"value": i}} for i in range(500)]
+
+    result = compact_command_output(
+        command="curl https://api.example.test/items",
+        stdout=json.dumps(payload),
+        stderr="",
+        exit_code=0,
+        max_chars=4_000,
+    )
+
+    assert "command output compacted" in result
+    assert '"type": "array"' in result
+    assert '"items": 500' in result
+    assert "Exit code: 0" in result
+    assert len(result) < 4_500
+
+
+def test_compact_command_output_focuses_lint_diagnostics():
+    lines = [f"src/module_{i}.py:{i}:1: E999 example lint failure" for i in range(250)]
+    lines.extend(f"noise line {i}" for i in range(2000))
+
+    result = compact_command_output(
+        command="ruff check src",
+        stdout="\n".join(lines),
+        stderr="",
+        exit_code=1,
+        max_chars=5_000,
+    )
+
+    assert "command output compacted" in result
+    assert "src/module_0.py:0:1" in result
+    assert "noise line 1999" not in result
+    assert "Exit code: 1" in result
+
+
+def test_compact_command_output_summarizes_git_diff():
+    diff = "\n".join(
+        [
+            "diff --git a/a.py b/a.py",
+            "index 111..222 100644",
+            "--- a/a.py",
+            "+++ b/a.py",
+            "@@ -1,3 +1,3 @@",
+        ]
+        + [f"-old line {i}\n+new line {i}" for i in range(500)]
+    )
+
+    result = compact_command_output(
+        command="git diff",
+        stdout=diff,
+        stderr="",
+        exit_code=0,
+        max_chars=3_000,
+    )
+
+    assert "Changed files: 1" in result
+    assert "- a.py" in result
+    assert "@@ -1,3 +1,3 @@" in result
+    assert "Exit code: 0" in result

--- a/tests/tools/test_exec_session_tools.py
+++ b/tests/tools/test_exec_session_tools.py
@@ -104,6 +104,22 @@ def test_exec_one_shot_accepts_max_output_tokens_alias(tmp_path):
     assert "Exit code: 0" in result
 
 
+def test_exec_one_shot_compacts_large_command_output(tmp_path):
+    async def run() -> str:
+        tool = ExecTool(working_dir=str(tmp_path), timeout=5)
+        command = _python_command(
+            "import json; print(json.dumps([{'id': i, 'name': 'item'} for i in range(400)]))"
+        )
+        return await tool.execute(command=command, max_output_tokens=4000)
+
+    result = asyncio.run(run())
+
+    assert "command output compacted" in result
+    assert '"type": "array"' in result
+    assert '"items": 400' in result
+    assert "Exit code: 0" in result
+
+
 def test_exec_accepts_supported_shell_parameter(tmp_path):
     async def run() -> str:
         tool = ExecTool(working_dir=str(tmp_path), timeout=5)


### PR DESCRIPTION
related to  #4581 

## Summary
- add a standalone command-output compaction module for large/noisy one-shot exec results
- route common command families through focused compactors for JSON, diffs, lint/test/build diagnostics, tables, listings, and logs/noise
- keep small exec outputs unchanged and preserve exit codes/failure-focused diagnostics
- preserve legacy raw head/tail truncation for unknown plain stdout, fixing `test_exec_head_tail_truncation`
- add model-facing historical tool replay windowing: latest 10 tool calls stay full, previous 50 are one-line summaries, older tool-call/result pairs are removed from context
- add direct compactor tests, an ExecTool integration regression, and ContextGovernor replay-window tests

## Verification
- `.venv/bin/python -m py_compile nanobot/agent/tools/command_output_compaction.py nanobot/agent/tools/shell.py nanobot/agent/context_governance.py tests/agent/test_runner_governance.py tests/tools/test_tool_validation.py tests/tools/test_command_output_compaction.py tests/tools/test_exec_session_tools.py`
- `rtk git diff --check`
- direct smoke: unknown large Python stdout preserves raw head/tail path
- direct smoke: `ExecTool` reproducer for `test_exec_head_tail_truncation` starts with raw `A` output and includes exit code
- direct smoke: replay window keeps calls 55-64 full, summarizes calls 5-54, removes calls 0-4

## Notes
- `uv run python -m pytest ...` still cannot run in this checkout because the local environment has no `pytest` module installed. The full CI run reported one failure before this fix: `tests/tools/test_tool_validation.py::test_exec_head_tail_truncation`.
- `python -m ruff ...` could not be run because the active Python has no `ruff` module installed.
