### PR TITLE
dream(prompt): add memory hygiene directives

### DIFF
--- a/nanobot/templates/agent/dream.md
+++ b/nanobot/templates/agent/dream.md
@@ -48,6 +48,8 @@ Always strip these bracketed tags from saved memory content.
 
 ## Delete-or-keep
 
+**Size discipline:** MEMORY.md is loaded whole into every agent turn with no truncation. The larger it is, the more aggressively this run must prioritize net reduction (merge, delete, migrate) over adding new entries.
+
 **Always delete:**
 - Same fact at multiple locations — keep canonical copy only
 - Merged/closed PR notes, resolved incidents, superseded info
@@ -68,6 +70,7 @@ Always strip these bracketed tags from saved memory content.
 - Concrete command examples, API endpoints, CLI flags, file paths
 - Step-by-step procedures that recur across conversations
 - Service-specific configuration patterns
+- Stable mechanism/procedure descriptions disguised as memories (not one-off lessons or events)
 - After migrating content to a skill, delete it from the source file (MEMORY.md or USER.md) to maintain MECE
 
 **Never delete:**
@@ -80,6 +83,8 @@ Always strip these bracketed tags from saved memory content.
 - Architecture decisions: keep indefinitely unless explicitly superseded
 - Infrastructure details: update in place when changed; do not keep obsolete configs
 - Tool/service integrations: remove if the service is no longer used
+
+**Time format:** use absolute dates only (YYYY-MM-DD). Never use relative time words (e.g., today/yesterday/recently/最近/今天) — they rot.
 
 When removing: prefer deleting individual items over entire sections.
 
@@ -100,6 +105,7 @@ For [SKILL] entries:
 
 ## Editing
 - Inspect current file contents before editing; they are not embedded in the prompt to keep context compact.
+- Before adding a new entry, scan the file for same-keyword or same-topic entries; merge into an existing entry when possible instead of appending.
 - Batch changes into as few calls as possible. Surgical edits only.
 
 Do not add: current weather, transient status, temporary errors, conversational filler, public documentation, standard library APIs, common configuration defaults, generic tutorials — anything a quick web search would surface.


### PR DESCRIPTION
## Summary

Four small additions (net +6 lines) to `nanobot/templates/agent/dream.md` — the prompt that drives Dream memory-consolidation runs — to curb MEMORY.md bloat, close a within-file dedup gap, and keep stored facts from rotting. Prompt-level only; no code changes.

## Changes

| Directive | Location | Adds |
|---|---|---|
| **Size discipline** | top of `Delete-or-keep` | The larger MEMORY.md is, the more this run must prioritize net reduction (merge/delete/migrate) over additions |
| **Migrate criterion** | `Migrate to SKILL.md` bullet list | New bullet: "Stable mechanism/procedure descriptions disguised as memories (not one-off lessons or events)" — extends the existing migrate triggers alongside commands/procedures/configs. Scope unchanged from existing rules (batch-driven, passive) |
| **Time format** | end of `Delete-or-keep` | Require absolute dates (YYYY-MM-DD); ban relative words (today/recently/...) that rot |
| **Merge-first** | `Editing` | Scan for same-keyword/same-topic entries and merge instead of appending |

No behavioral change to existing rules — the reactive migration rule still says "delete from source to maintain MECE", and the new criterion shares the same batch-driven scope.

## Why

The directives in this PR are **adapted from** the [`neat-freak`](https://github.com/KKKKhazix/khazix-skills/tree/main/neat-freak) skill (by `KKKKhazix/khazix-skills`) — a knowledge-base cleanup skill originally built for multi-layer doc/memory sync across CLAUDE.md, docs/, and agent memory. The full neat-freak design (three-audience memory/CLAUDE/docs split, cross-project alignment, proactive global scanning, post-run self-check checklist) does **not** map onto nanobot's model, so I filtered it to only what fits:

- nanobot's Dream only touches **4 memory files** (`SOUL.md`/`USER.md`/`MEMORY.md`/`skills/*/SKILL.md`) — no `docs/` or `CLAUDE.md` layer.
- nanobot enforces memory quality **entirely in the prompt** — code has no size caps, no MECE checks, no timestamp validation (loading is whole-read, no truncation: see `context.py` `_load_bootstrap_files` and `MemoryStore.get_memory_context`).

So the transferable part of neat-freak is its memory-hygiene discipline (size budget, graduation criterion, merge-over-append, absolute time), re-expressed as Dream prompt directives that stay within the run's normal batch-driven scope.

## Solve

- **Unbounded MEMORY.md growth.** `context.py` loads MEMORY.md whole into every turn with no truncation, so bloat inflates every system prompt with nothing to counteract it. *Size discipline* gives Dream a net-reduction bias when the file is large (merge/delete during normal batch processing).
- **Stable knowledge accumulating in MEMORY.md.** When the current history batch surfaces a stable mechanism/procedure description, it now migrates to SKILL.md instead of being filed as a strategic fact. (Passive/batch-scoped — does not scan unrelated old MEMORY.md content.)
- **Relative-time rot.** No date-format rule existed, so "today"/"recently" accumulated and went stale silently. *Time format* pins dates to YYYY-MM-DD (the history input Dream receives is already absolute-timestamped, so the LLM has a reference to copy).
- **Same-file dedup gap.** Existing rules only covered conflicts (`Corrections: edit existing`) and cross-file (`MECE: remove from others`); non-conflict, same-topic, within-file redundancy was unaddressed. *Merge-first* closes it.

## Verification

- Template renders cleanly (`render_template("agent/dream.md", ...)` → 111 lines).
- `tests/agent/test_dream.py` + `tests/command/test_builtin_dream.py` → **31 passed**.

## Notes

An earlier revision included an "Active scan" directive that proactively read the whole MEMORY.md to find skill-like entries. @chengyongru's review correctly flagged that it expanded the run's blast radius beyond the triggering history batch (a small conversation could rewrite/create unrelated skill files from old memory). That directive has been **removed**; the migration criterion is now a passive bullet sharing the existing batch-driven scope.
