### PR TITLE
fix(exec): extract absolute paths after equals sign in shell guard

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -918,6 +918,6 @@ class ExecTool(Tool):
             r"(?<![A-Za-z])(?:[A-Za-z]:[^\s\"'|><;]*|\\\\[^\s\"'|><;]+(?:\\[^\s\"'|><;]+)*)",
             command
         )
-        posix_paths = re.findall(r"(?:^|[\s|>'\"])(/[^\s\"'>;|<]+)", command) # POSIX: /absolute only
-        home_paths = re.findall(r"(?:^|[\s>'\"])(~[^\s\"'>;|<]*)", command) # POSIX/Windows home shortcut: ~
+        posix_paths = re.findall(r"(?:^|[\s|>='\"])(/[^\s\"'>;|<]+)", command) # POSIX: /absolute only
+        home_paths = re.findall(r"(?:^|[\s>='\"])(~[^\s\"'>;|<]*)", command) # POSIX/Windows home shortcut: ~
         return win_paths + posix_paths + home_paths

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -919,5 +919,5 @@ class ExecTool(Tool):
             command
         )
         posix_paths = re.findall(r"(?:^|[\s|>='\"])(/[^\s\"'>;|<]+)", command) # POSIX: /absolute only
-        home_paths = re.findall(r"(?:^|[\s>='\"])(~[^\s\"'>;|<]*)", command) # POSIX/Windows home shortcut: ~
+        home_paths = re.findall(r"(?:^|[\s>='\"])(~[/+][^\s\"'>;|<]*)", command) # POSIX/Windows home shortcut: ~/ or ~+
         return win_paths + posix_paths + home_paths

--- a/tests/tools/test_tool_validation.py
+++ b/tests/tools/test_tool_validation.py
@@ -289,6 +289,13 @@ def test_exec_extract_absolute_paths_captures_home_paths() -> None:
     assert "~/out.txt" in paths
 
 
+def test_exec_extract_absolute_paths_captures_paths_after_equals() -> None:
+    cmd = "curl --output=/etc/passwd --config=~/.nanobot/config.json"
+    paths = ExecTool._extract_absolute_paths(cmd)
+    assert "/etc/passwd" in paths
+    assert "~/.nanobot/config.json" in paths
+
+
 def test_exec_extract_absolute_paths_captures_quoted_paths() -> None:
     cmd = 'cat "/tmp/data.txt" "~/.nanobot/config.json"'
     paths = ExecTool._extract_absolute_paths(cmd)

--- a/tests/tools/test_tool_validation.py
+++ b/tests/tools/test_tool_validation.py
@@ -296,6 +296,12 @@ def test_exec_extract_absolute_paths_captures_paths_after_equals() -> None:
     assert "~/.nanobot/config.json" in paths
 
 
+def test_exec_extract_absolute_paths_does_not_capture_query_tilde() -> None:
+    cmd = 'python query.py --query \'{job=~"app"}\''
+    paths = ExecTool._extract_absolute_paths(cmd)
+    assert not any(p.startswith("~") for p in paths)
+
+
 def test_exec_extract_absolute_paths_captures_quoted_paths() -> None:
     cmd = 'cat "/tmp/data.txt" "~/.nanobot/config.json"'
     paths = ExecTool._extract_absolute_paths(cmd)
@@ -311,6 +317,15 @@ def test_exec_guard_blocks_home_path_outside_workspace(tmp_path) -> None:
         "Error: Command blocked by safety guard (path outside working dir)"
     )
     assert "hard policy boundary" in error
+
+
+def test_exec_guard_blocks_equals_home_path_outside_workspace(tmp_path) -> None:
+    tool = ExecTool(restrict_to_workspace=True)
+    error = tool._guard_command("cat --config=~/.nanobot/config.json", str(tmp_path))
+    assert error is not None
+    assert error.startswith(
+        "Error: Command blocked by safety guard (path outside working dir)"
+    )
 
 
 def test_exec_guard_blocks_quoted_home_path_outside_workspace(tmp_path) -> None:


### PR DESCRIPTION
## Summary

The shell workspace guard's `_extract_absolute_paths()` regex did not treat `=` as a path delimiter. Commands like `curl --output=/etc/passwd` bypassed containment, while the space-separated form was blocked.

## Changes

- `nanobot/agent/tools/shell.py`: include `=` in the POSIX absolute-path delimiter class, and narrow the home-path matcher so query operators like `=~` are not treated as home paths.
- `tests/tools/test_tool_validation.py`: regression tests for equals-delimited paths and `=~` false positives.

## Verification

```
python -m pytest tests/tools/test_tool_validation.py -q -k extract_absolute_paths
```

## Backwards compatibility

Existing space-delimited absolute and home paths still match. Only equals-delimited paths and the `=~` false-positive case change.

Fixes #4592
