### PR TITLE
fix(streaming): skip non-file-edit tools in apply_final_call_ids to prevent id corruption

### DIFF
--- a/nanobot/utils/file_edit_events.py
+++ b/nanobot/utils/file_edit_events.py
@@ -529,6 +529,9 @@ class StreamingFileEditTracker:
         """Keep final start/end events keyed to any earlier streamed placeholder."""
         used_canonicals: set[str] = set()
         for tool_call in final_tool_calls:
+            name = getattr(tool_call, "name", None)
+            if not is_file_edit_tool(name):
+                continue
             canonical = self.canonical_call_id_for(tool_call)
             if canonical and canonical not in used_canonicals:
                 try:

--- a/tests/utils/test_file_edit_events.py
+++ b/tests/utils/test_file_edit_events.py
@@ -412,6 +412,41 @@ def test_streaming_tracker_applies_canonical_call_id_to_final_tool(tmp_path: Pat
     asyncio.run(run())
 
 
+def test_streaming_tracker_does_not_remap_non_file_edit_final_tool(tmp_path: Path) -> None:
+    events: list[dict] = []
+
+    async def emit(batch: list[dict]) -> None:
+        events.extend(batch)
+
+    async def run() -> None:
+        tracker = StreamingFileEditTracker(workspace=tmp_path, tools={}, emit=emit)
+        await tracker.update({
+            "index": 0,
+            "name": "read_file",
+            "arguments_delta": '{"path":"matched.md"}',
+        })
+        await tracker.update({
+            "index": 1,
+            "name": "write_file",
+            "arguments_delta": '{"path":"matched.md","content":"one\\n',
+        })
+        read_final = SimpleNamespace(
+            id="read-unique",
+            name="read_file",
+            arguments={"path": "matched.md"},
+        )
+        write_final = SimpleNamespace(
+            id="write-final",
+            name="write_file",
+            arguments={"path": "matched.md", "content": "one\n"},
+        )
+        tracker.apply_final_call_ids([read_final, write_final])
+        assert read_final.id == "read-unique"
+        assert write_final.id == "idx:1"
+
+    asyncio.run(run())
+
+
 def test_streaming_tracker_does_not_restore_duplicate_canonical_ids(tmp_path: Path) -> None:
     events: list[dict] = []
 


### PR DESCRIPTION
## Summary

Fixes #4595

`StreamingFileEditTracker.apply_final_call_ids()` was overwriting correct, unique `tool_call.id` values for non-file-edit tools (e.g. `read_file`) when streaming with parallel tool calls. This produced duplicate `tool_use` ids in the persisted session, causing every subsequent turn to be rejected by Anthropic-compatible providers with `"tool_use ids must be unique"`.

## Root cause

The tracker creates `_StreamingFileEditState` entries for all streamed tool calls, not just file-edit tools. `apply_final_call_ids` then iterates over all final tool calls and calls `canonical_call_id_for`, whose `matches_final_tool_call` falls through from id-matching to a greedy name+path match. When multiple non-file-edit tools (like `read_file`) stream in parallel, the greedy `self.path is None` branch matches the wrong streaming state and overwrites a correct id with a stale one from a different call.

## Fix

Add a guard at the top of the `apply_final_call_ids` loop to skip any tool that is not in `TRACKED_FILE_EDIT_TOOLS` (`write_file`, `edit_file`, `apply_patch`). The existing `is_file_edit_tool()` helper already encodes this check. Non-file-edit tools keep the authoritative id from `get_final_message()` untouched.

## Test

Added `test_streaming_tracker_does_not_remap_non_file_edit_final_tool` which streams a `read_file` and a `write_file` call in parallel, then asserts:
- `read_file` id is preserved (`"read-unique"`)
- `write_file` id is correctly remapped to its streaming key (`"idx:1"`)
