### PR TITLE
feat(providers): support GitHub Copilot endpoint overrides for enterprise/GHE

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -677,6 +677,16 @@ nanobot agent -c ~/.nanobot-telegram/config.json -w /tmp/nanobot-telegram-test -
 
 GitHub Copilot uses OAuth instead of API keys. Requires a [GitHub account with a plan](https://github.com/features/copilot/plans) configured. No `providers.githubCopilot` block is needed in `config.json`; `nanobot provider login` stores the OAuth session outside config.
 
+For GitHub Enterprise / Copilot for Business, set the endpoint overrides you need before login:
+```bash
+export NANOBOT_GITHUB_COPILOT_CLIENT_ID="your-enterprise-client-id"
+export NANOBOT_GITHUB_DEVICE_CODE_URL="https://ghe.example/login/device/code"
+export NANOBOT_GITHUB_ACCESS_TOKEN_URL="https://ghe.example/login/oauth/access_token"
+export NANOBOT_GITHUB_USER_URL="https://api.ghe.example/user"
+export NANOBOT_COPILOT_TOKEN_URL="https://api.ghe.example/copilot_internal/v2/token"
+export NANOBOT_COPILOT_BASE_URL="https://copilot-api.ghe.example"
+```
+
 **1. Login:**
 ```bash
 nanobot provider login github-copilot

--- a/nanobot/providers/github_copilot_provider.py
+++ b/nanobot/providers/github_copilot_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 import webbrowser
 from collections.abc import Awaitable, Callable
@@ -27,6 +28,12 @@ EDITOR_VERSION = "vscode/1.99.0"
 EDITOR_PLUGIN_VERSION = "copilot-chat/0.26.0"
 _EXPIRY_SKEW_SECONDS = 60
 _LONG_LIVED_TOKEN_SECONDS = 315360000
+
+
+def _resolve(env_var: str, default: str) -> str:
+    """Allow GitHub Enterprise / Copilot for Business deployments to override defaults via env."""
+    value = os.environ.get(env_var)
+    return value.strip() if value and value.strip() else default
 
 
 def get_storage() -> FileTokenStorage:
@@ -68,11 +75,16 @@ def login_github_copilot(
     printer = print_fn or print
     timeout = httpx.Timeout(20.0, connect=20.0)
 
+    client_id = _resolve("NANOBOT_GITHUB_COPILOT_CLIENT_ID", GITHUB_COPILOT_CLIENT_ID)
+    device_code_url = _resolve("NANOBOT_GITHUB_DEVICE_CODE_URL", DEFAULT_GITHUB_DEVICE_CODE_URL)
+    access_token_url = _resolve("NANOBOT_GITHUB_ACCESS_TOKEN_URL", DEFAULT_GITHUB_ACCESS_TOKEN_URL)
+    user_url = _resolve("NANOBOT_GITHUB_USER_URL", DEFAULT_GITHUB_USER_URL)
+
     with httpx.Client(timeout=timeout, follow_redirects=True, trust_env=True) as client:
         response = client.post(
-            DEFAULT_GITHUB_DEVICE_CODE_URL,
+            device_code_url,
             headers={"Accept": "application/json", "User-Agent": USER_AGENT},
-            data={"client_id": GITHUB_COPILOT_CLIENT_ID, "scope": GITHUB_COPILOT_SCOPE},
+            data={"client_id": client_id, "scope": GITHUB_COPILOT_SCOPE},
         )
         response.raise_for_status()
         payload = response.json()
@@ -96,10 +108,10 @@ def login_github_copilot(
         token_expires_in = _LONG_LIVED_TOKEN_SECONDS
         while time.time() < deadline:
             poll = client.post(
-                DEFAULT_GITHUB_ACCESS_TOKEN_URL,
+                access_token_url,
                 headers={"Accept": "application/json", "User-Agent": USER_AGENT},
                 data={
-                    "client_id": GITHUB_COPILOT_CLIENT_ID,
+                    "client_id": client_id,
                     "device_code": device_code,
                     "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
                 },
@@ -132,7 +144,7 @@ def login_github_copilot(
             raise RuntimeError("GitHub device flow timed out.")
 
         user = client.get(
-            DEFAULT_GITHUB_USER_URL,
+            user_url,
             headers={
                 "Authorization": f"Bearer {access_token}",
                 "Accept": "application/vnd.github+json",
@@ -164,7 +176,7 @@ class GitHubCopilotProvider(OpenAICompatProvider):
         self._copilot_expires_at: float = 0.0
         super().__init__(
             api_key="no-key",
-            api_base=DEFAULT_COPILOT_BASE_URL,
+            api_base=_resolve("NANOBOT_COPILOT_BASE_URL", DEFAULT_COPILOT_BASE_URL),
             default_model=default_model,
             extra_headers={
                 "Editor-Version": EDITOR_VERSION,
@@ -186,7 +198,7 @@ class GitHubCopilotProvider(OpenAICompatProvider):
         timeout = httpx.Timeout(20.0, connect=20.0)
         async with httpx.AsyncClient(timeout=timeout, follow_redirects=True, trust_env=True) as client:
             response = await client.get(
-                DEFAULT_COPILOT_TOKEN_URL,
+                _resolve("NANOBOT_COPILOT_TOKEN_URL", DEFAULT_COPILOT_TOKEN_URL),
                 headers=_copilot_headers(github_token.access),
             )
             response.raise_for_status()

--- a/tests/providers/test_github_copilot_enterprise.py
+++ b/tests/providers/test_github_copilot_enterprise.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import pytest
+
 from nanobot.providers import github_copilot_provider as gc
 
 
@@ -30,3 +34,110 @@ def test_provider_api_base_honors_env_override(monkeypatch):
     monkeypatch.setenv("NANOBOT_COPILOT_BASE_URL", "https://copilot-api.acme.ghe.com")
     provider = gc.GitHubCopilotProvider()
     assert provider.api_base == "https://copilot-api.acme.ghe.com"
+
+
+def test_login_uses_enterprise_endpoint_overrides(monkeypatch):
+    monkeypatch.setenv("NANOBOT_GITHUB_COPILOT_CLIENT_ID", "enterprise-client-id")
+    monkeypatch.setenv("NANOBOT_GITHUB_DEVICE_CODE_URL", "https://ghe.example/login/device/code")
+    monkeypatch.setenv(
+        "NANOBOT_GITHUB_ACCESS_TOKEN_URL",
+        "https://ghe.example/login/oauth/access_token",
+    )
+    monkeypatch.setenv("NANOBOT_GITHUB_USER_URL", "https://api.ghe.example/user")
+    monkeypatch.setattr(gc.webbrowser, "open", lambda _url: None)
+
+    calls = []
+    saved = []
+
+    class FakeResponse:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._payload
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def post(self, url, *, headers, data):
+            calls.append(("post", url, data))
+            if url.endswith("/device/code"):
+                return FakeResponse(
+                    {
+                        "device_code": "device-code",
+                        "user_code": "user-code",
+                        "verification_uri": "https://ghe.example/device",
+                        "interval": 1,
+                        "expires_in": 60,
+                    }
+                )
+            return FakeResponse({"access_token": "github-token", "expires_in": 3600})
+
+        def get(self, url, *, headers):
+            calls.append(("get", url, headers))
+            return FakeResponse({"login": "enterprise-user"})
+
+    monkeypatch.setattr(gc.httpx, "Client", FakeClient)
+    monkeypatch.setattr(gc, "get_storage", lambda: SimpleNamespace(save=saved.append))
+
+    token = gc.login_github_copilot(print_fn=lambda _message: None)
+
+    assert token.access == "github-token"
+    assert saved[0].account_id == "enterprise-user"
+    assert calls[0] == (
+        "post",
+        "https://ghe.example/login/device/code",
+        {"client_id": "enterprise-client-id", "scope": gc.GITHUB_COPILOT_SCOPE},
+    )
+    assert calls[1][0:2] == ("post", "https://ghe.example/login/oauth/access_token")
+    assert calls[1][2]["client_id"] == "enterprise-client-id"
+    assert calls[2][0:2] == ("get", "https://api.ghe.example/user")
+
+
+@pytest.mark.asyncio
+async def test_copilot_token_exchange_uses_enterprise_endpoint_override(monkeypatch):
+    monkeypatch.setenv(
+        "NANOBOT_COPILOT_TOKEN_URL",
+        "https://api.ghe.example/copilot_internal/v2/token",
+    )
+    monkeypatch.setattr(gc, "_load_github_token", lambda: SimpleNamespace(access="github-token"))
+
+    calls = []
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"token": "copilot-token", "refresh_in": 120}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def get(self, url, *, headers):
+            calls.append((url, headers))
+            return FakeResponse()
+
+    monkeypatch.setattr(gc.httpx, "AsyncClient", FakeAsyncClient)
+
+    provider = gc.GitHubCopilotProvider()
+
+    assert await provider._get_copilot_access_token() == "copilot-token"
+    assert calls[0][0] == "https://api.ghe.example/copilot_internal/v2/token"

--- a/tests/providers/test_github_copilot_enterprise.py
+++ b/tests/providers/test_github_copilot_enterprise.py
@@ -1,0 +1,32 @@
+"""Regression tests for GitHub Enterprise / Copilot for Business endpoint overrides (#4220)."""
+
+from __future__ import annotations
+
+from nanobot.providers import github_copilot_provider as gc
+
+
+def test_resolve_falls_back_to_default_without_env(monkeypatch):
+    monkeypatch.delenv("NANOBOT_COPILOT_BASE_URL", raising=False)
+    assert gc._resolve("NANOBOT_COPILOT_BASE_URL", gc.DEFAULT_COPILOT_BASE_URL) == (
+        gc.DEFAULT_COPILOT_BASE_URL
+    )
+
+
+def test_resolve_uses_env_override_and_strips(monkeypatch):
+    monkeypatch.setenv("NANOBOT_COPILOT_TOKEN_URL", "  https://api.acme.ghe.com/copilot_internal/v2/token  ")
+    assert gc._resolve("NANOBOT_COPILOT_TOKEN_URL", gc.DEFAULT_COPILOT_TOKEN_URL) == (
+        "https://api.acme.ghe.com/copilot_internal/v2/token"
+    )
+
+
+def test_blank_env_override_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("NANOBOT_COPILOT_BASE_URL", "   ")
+    assert gc._resolve("NANOBOT_COPILOT_BASE_URL", gc.DEFAULT_COPILOT_BASE_URL) == (
+        gc.DEFAULT_COPILOT_BASE_URL
+    )
+
+
+def test_provider_api_base_honors_env_override(monkeypatch):
+    monkeypatch.setenv("NANOBOT_COPILOT_BASE_URL", "https://copilot-api.acme.ghe.com")
+    provider = gc.GitHubCopilotProvider()
+    assert provider.api_base == "https://copilot-api.acme.ghe.com"


### PR DESCRIPTION
Make the GitHub Copilot provider's endpoints (and client ID) overridable via env vars for GHE / Copilot for Business; public-GitHub defaults unchanged.

Closes #4220