### PR TITLE
feat(whatsapp): send read receipts (blue double-check) for incoming messages

### DIFF
--- a/nanobot/channels/whatsapp.py
+++ b/nanobot/channels/whatsapp.py
@@ -499,9 +499,7 @@ class WhatsAppChannel(BaseChannel):
                 self._self_jids.add(jid)
                 self._self_jids.add(_bare_jid(jid))
 
-    async def _send_read_receipt(
-        self, client: Any, info: Any, source: Any, message_id: str
-    ) -> None:
+    async def _send_read_receipt(self, client: Any, source: Any, message_id: str) -> None:
         """Send a read receipt (blue double-check) for an incoming message.
 
         Best-effort: any failure is logged at debug level and swallowed so it
@@ -559,7 +557,7 @@ class WhatsAppChannel(BaseChannel):
                 self._processed_message_ids.popitem(last=False)
 
         # Mark the incoming message as read (blue double-check). Best-effort.
-        await self._send_read_receipt(client, info, source, message_id)
+        await self._send_read_receipt(client, source, message_id)
 
         participant_jid = _normalize_jid(_safe_attr(source, "Sender"))
         sender_alt_jid = _normalize_jid(_safe_attr(source, "SenderAlt"))

--- a/nanobot/channels/whatsapp.py
+++ b/nanobot/channels/whatsapp.py
@@ -499,6 +499,32 @@ class WhatsAppChannel(BaseChannel):
                 self._self_jids.add(jid)
                 self._self_jids.add(_bare_jid(jid))
 
+    async def _send_read_receipt(
+        self, client: Any, info: Any, source: Any, message_id: str
+    ) -> None:
+        """Send a read receipt (blue double-check) for an incoming message.
+
+        Best-effort: any failure is logged at debug level and swallowed so it
+        never blocks message processing.
+        """
+        if not message_id:
+            return
+        try:
+            from neonize.utils.enum import ReceiptType
+
+            chat = _safe_attr(source, "Chat")
+            sender = _safe_attr(source, "Sender")
+            if chat is None or sender is None:
+                return
+            await client.mark_read(
+                message_id,
+                chat=chat,
+                sender=sender,
+                receipt=ReceiptType.READ,
+            )
+        except Exception as exc:  # noqa: BLE001 - read receipt is best-effort
+            self.logger.debug("Failed to send WhatsApp read receipt: {}", exc)
+
     async def _handle_neonize_message(self, client: Any, event: Any) -> None:
         info = _safe_attr(event, "Info")
         message = _safe_attr(event, "Message")
@@ -531,6 +557,9 @@ class WhatsAppChannel(BaseChannel):
             self._processed_message_ids[message_id] = None
             while len(self._processed_message_ids) > 1000:
                 self._processed_message_ids.popitem(last=False)
+
+        # Mark the incoming message as read (blue double-check). Best-effort.
+        await self._send_read_receipt(client, info, source, message_id)
 
         participant_jid = _normalize_jid(_safe_attr(source, "Sender"))
         sender_alt_jid = _normalize_jid(_safe_attr(source, "SenderAlt"))

--- a/tests/channels/test_whatsapp_channel.py
+++ b/tests/channels/test_whatsapp_channel.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import sys
+import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -84,6 +86,23 @@ def _patch_neonize_api(monkeypatch) -> None:
             build_jid=lambda user, server="s.whatsapp.net": (user, server),
         ),
     )
+
+
+def _patch_receipt_type(monkeypatch):
+    neonize = types.ModuleType("neonize")
+    utils = types.ModuleType("neonize.utils")
+    enum = types.ModuleType("neonize.utils.enum")
+
+    class ReceiptType:
+        READ = "read"
+
+    enum.ReceiptType = ReceiptType
+    neonize.utils = utils
+    utils.enum = enum
+    monkeypatch.setitem(sys.modules, "neonize", neonize)
+    monkeypatch.setitem(sys.modules, "neonize.utils", utils)
+    monkeypatch.setitem(sys.modules, "neonize.utils.enum", enum)
+    return ReceiptType
 
 
 class _FakeLoginClient:
@@ -299,6 +318,60 @@ async def test_group_sender_id_uses_participant_not_group_jid() -> None:
     kwargs = ch._handle_message.await_args.kwargs
     assert kwargs["sender_id"] == "SENDERLID"
     assert kwargs["metadata"]["participant"] == "SENDERLID@lid"
+
+
+@pytest.mark.asyncio
+async def test_read_receipt_is_requested_once_after_dedup() -> None:
+    ch = _make_channel()
+    ch._send_read_receipt = AsyncMock()
+    ch._handle_message = AsyncMock()
+    client = SimpleNamespace(download_any=AsyncMock())
+    event = _event(
+        message=_Proto(conversation="hi"),
+        sender=_jid("15551234567", "s.whatsapp.net"),
+    )
+
+    await ch._handle_neonize_message(client, event)
+    await ch._handle_neonize_message(client, event)
+
+    ch._send_read_receipt.assert_awaited_once_with(
+        client,
+        event.Info.MessageSource,
+        "m1",
+    )
+    ch._handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_read_receipt_uses_mark_read_and_swallows_failures(monkeypatch) -> None:
+    receipt_type = _patch_receipt_type(monkeypatch)
+    ch = _make_channel()
+    source = _event(
+        message=_Proto(conversation="hi"),
+        sender=_jid("15551234567", "s.whatsapp.net"),
+    ).Info.MessageSource
+    client = SimpleNamespace(
+        mark_read=AsyncMock(),
+        download_any=AsyncMock(),
+    )
+
+    await ch._send_read_receipt(client, source, "m1")
+
+    client.mark_read.assert_awaited_once_with(
+        "m1",
+        chat=source.Chat,
+        sender=source.Sender,
+        receipt=receipt_type.READ,
+    )
+
+    failing_client = SimpleNamespace(
+        mark_read=AsyncMock(side_effect=RuntimeError("boom")),
+        download_any=AsyncMock(),
+    )
+
+    await ch._send_read_receipt(failing_client, source, "m2")
+
+    failing_client.mark_read.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Send a WhatsApp read receipt (the blue double-check) for each incoming message that the bot processes.

After a message passes the existing dedup check in `_handle_neonize_message`, the channel now calls neonize's `mark_read(..., receipt=ReceiptType.READ)` for that message, so the sender sees their message marked as read.

## Why

Right now the bot silently consumes incoming messages without ever acknowledging them on the WhatsApp side. Senders have no signal that the message was received/seen. Read receipts make the bot behave like a normal WhatsApp client and give users immediate feedback that their message went through.

## How

- New helper `WhatsAppChannel._send_read_receipt(client, info, source, message_id)`.
- It resolves `Chat` and `Sender` JIDs from the message source and calls `client.mark_read(message_id, chat=..., sender=..., receipt=ReceiptType.READ)`.
- It is **best-effort**: if anything fails (missing JID, neonize error, etc.) it is logged at `debug` level and swallowed, so it never blocks or breaks message handling.
- `ReceiptType` is imported lazily inside the helper to avoid adding an import at module load time.

## Notes

- No new dependencies — uses neonize's existing `mark_read` API.
- Respects the bot's own dedup: the receipt is only sent once per message id, right after the message is accepted.
- Does nothing for messages from self / status broadcasts, since those return early before this point.

## Testing

Verified against the installed neonize (`0.3.18.post0`) that `NewAClient.mark_read` has the signature `(*message_ids, chat, sender, receipt, timestamp=None)` and that `ReceiptType.READ` exists, matching this call. Running locally, incoming messages now show the blue double-check on the sender side, and induced failures are logged without interrupting processing.
