### PR TITLE
fix(install): skip wizard without an interactive terminal

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -269,7 +269,15 @@ if [ "${NANOBOT_SKIP_WIZARD:-}" = "1" ]; then
   exit 0
 fi
 
-info "Starting setup wizard..."
-run_nanobot onboard --wizard
+if [ -t 0 ]; then
+  info "Starting setup wizard..."
+  run_nanobot onboard --wizard
+elif : 2>/dev/null < /dev/tty; then
+  info "Starting setup wizard..."
+  run_nanobot onboard --wizard < /dev/tty
+else
+  info "Skipping setup wizard because no interactive terminal is available."
+  info "Run this later: $(nanobot_try_command) onboard --wizard"
+fi
 
 info "Done. Try: $(nanobot_try_command) agent -m \"Hello!\""


### PR DESCRIPTION
Fixes #4599

## Summary
- Run the setup wizard normally when stdin is already interactive.
- Use `/dev/tty` for the wizard when `install.sh` itself was read from a pipe, such as `curl ... | sh`.
- Skip the wizard with a manual follow-up command when no interactive terminal is available.

## Root Cause
`curl ... | sh` leaves fd 0 connected to the script pipe, so `prompt_toolkit` sees non-terminal input and raises `EOFError` when the installer starts `nanobot onboard --wizard`.

## Validation
- `sh -n scripts/install.sh`
- Direct `sh scripts/install.sh` smoke with fake `python3`/`uv` and noninteractive stdin: exit 0, skipped wizard, and the fake `uv` log contained only install plus `--version`, not `onboard --wizard`.
