### PR TITLE
fix(install): skip wizard when stdin is not a TTY

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -269,6 +269,14 @@ if [ "${NANOBOT_SKIP_WIZARD:-}" = "1" ]; then
   exit 0
 fi
 
+if ! tty -s; then
+  info "Input is not a terminal (stdin is a pipe or redirected)."
+  info "The setup wizard needs an interactive terminal."
+  info "Install completed. Start the wizard manually with:"
+  info "  $(nanobot_try_command) onboard --wizard"
+  exit 0
+fi
+
 info "Starting setup wizard..."
 run_nanobot onboard --wizard
 


### PR DESCRIPTION
## Problem

When nanobot is installed via `curl -fsSL ...install.sh | sh`, stdin is a pipe rather than a terminal. The setup wizard uses prompt_toolkit select prompts, which require an interactive terminal. When stdin is not a TTY, `prompt_toolkit` raises `EOFError` and the wizard crashes immediately after showing the menu, discarding the configuration.

Reported in #4599.

## Root cause

`scripts/install.sh` runs `run_nanobot onboard --wizard` unconditionally (unless `NANOBOT_SKIP_WIZARD=1` is set). There is no check for whether stdin is actually a terminal. The `curl | sh` pattern pipes the script body into `sh`, so fd 0 is the pipe, not a TTY. prompt_toolkit detects this and throws `EOFError` at the first interactive prompt.

The traceback in the issue confirms this:

```
Warning: Input is not a terminal (fd=0).
...
  File ".../prompt_toolkit/application/application.py", line 746, in _run_async
    result = await f
EOFError
Configuration discarded. No changes were saved.
```

## Fix

Add a `tty -s` check before launching the wizard. If stdin is not a terminal, skip the wizard and print a message directing the user to run `nanobot onboard --wizard` manually in their terminal:

```
Input is not a terminal (stdin is a pipe or redirected).
The setup wizard needs an interactive terminal.
Install completed. Start the wizard manually with:
  nanobot onboard --wizard
```

This is a 6-line addition to `scripts/install.sh`, placed after the existing `NANOBOT_SKIP_WIZARD` guard and before `run_nanobot onboard --wizard`.

## Testing

- `sh -n scripts/install.sh` passes (syntax check)
- Simulated non-TTY stdin (`echo "" | sh ...`): the guard triggers, wizard is skipped, message is printed, script exits 0
- `NANOBOT_SKIP_WIZARD=1` path still works as before
- Interactive TTY path is unchanged (the `tty -s` check passes silently)

Closes #4599
