### PR TITLE
feat(cli): support multiline input via Alt+Enter

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -77,6 +77,8 @@ Default paths:
 | `nanobot agent --no-markdown` | Print plain text instead of Rich-rendered Markdown |
 | `nanobot agent --logs` | Show runtime logs while chatting |
 
+In interactive mode, `Enter` sends the current message. Press `Alt+Enter` to add a newline before sending.
+
 Interactive mode exits with `exit`, `quit`, `/exit`, `/quit`, `:q`, or `Ctrl+D`.
 
 ## Gateway

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -278,6 +278,8 @@ Then update ~/.nanobot/config.json to add a model preset named "primary" for my 
 Tell me exactly what changed and whether I need to run /restart.
 ```
 
+In interactive mode, `Enter` sends the current message. Press `Alt+Enter` to add a newline before sending.
+
 Exit interactive mode with `exit`, `quit`, `/exit`, `/quit`, `:q`, or `Ctrl+D`.
 
 ## 7. Choose Your Next Step

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -308,11 +308,19 @@ def _build_cli_key_bindings() -> KeyBindings:
     # the case prompt_toolkit itself calls out) send for a plain Enter
     # keypress. Aliasing to ControlJ made Enter stop submitting there, since
     # our handler shadowed prompt_toolkit's own "treat \n as \r" fallback.
+    #
+    # "\x1b[27;2;13~" (the older xterm modifyOtherKeys / rxvt encoding of
+    # Shift+Enter) is already registered by prompt_toolkit by default -- as
+    # Keys.ControlM, i.e. plain Enter/submit. A plain setdefault() would be a
+    # no-op against that existing entry, silently leaving this Shift+Enter
+    # variant behaving like a submit instead of inserting a newline. Assign
+    # directly to override it, since inserting a newline is the whole point
+    # of a Shift+Enter binding here.
     with suppress(Exception):
         from prompt_toolkit.input import ansi_escape_sequences as _aes
 
         for _seq in ("\x1b[13;2u", "\x1b[27;2;13~"):
-            _aes.ANSI_SEQUENCES.setdefault(_seq, Keys.ControlF3)
+            _aes.ANSI_SEQUENCES[_seq] = Keys.ControlF3
 
     kb = KeyBindings()
 

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -291,9 +291,7 @@ def _build_cli_key_bindings() -> KeyBindings:
       * Enter       -> submit the current input (keeps the familiar
                        single-line Enter-to-send feel even though the buffer
                        is multiline-capable).
-      * Alt+Enter   -> insert a newline. Universally supported across
-                       terminal emulators, so this is the reliable way to
-                       compose multi-line input.
+      * Alt+Enter   -> insert a newline for multi-line input.
     """
     kb = KeyBindings()
 
@@ -305,11 +303,7 @@ def _build_cli_key_bindings() -> KeyBindings:
     def _(event):
         event.current_buffer.insert_text("\n")
 
-    # On the same LF-as-Enter terminals (WSL) we preserve plain Enter for,
-    # Alt+Enter arrives as ESC + LF ("\x1b\x0a" = Escape + ControlJ) rather than
-    # ESC + CR, so the "escape","enter" binding above never matches: Escape is
-    # swallowed and the bare LF triggers prompt_toolkit's default submit. Bind
-    # ESC + ControlJ too so Alt+Enter reliably inserts a newline there as well.
+    # LF-as-Enter terminals send Alt+Enter as ESC + LF rather than ESC + CR.
     @kb.add("escape", Keys.ControlJ)  # Alt+Enter on LF-as-Enter terminals
     def _(event):
         event.current_buffer.insert_text("\n")

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -42,6 +42,8 @@ from prompt_toolkit import PromptSession, print_formatted_text  # noqa: E402
 from prompt_toolkit.application import run_in_terminal  # noqa: E402
 from prompt_toolkit.formatted_text import ANSI, HTML  # noqa: E402
 from prompt_toolkit.history import FileHistory  # noqa: E402
+from prompt_toolkit.key_binding import KeyBindings  # noqa: E402
+from prompt_toolkit.keys import Keys  # noqa: E402
 from prompt_toolkit.patch_stdout import patch_stdout  # noqa: E402
 from rich.console import Console  # noqa: E402
 from rich.markdown import Markdown  # noqa: E402
@@ -282,6 +284,49 @@ def _restore_terminal() -> None:
         termios.tcsetattr(sys.stdin.fileno(), termios.TCSADRAIN, _SAVED_TERM_ATTRS)
 
 
+def _build_cli_key_bindings() -> KeyBindings:
+    """Key bindings for the interactive prompt.
+
+    Behaviour:
+      * Enter       -> submit the current input (keeps the familiar
+                       single-line Enter-to-send feel even though the buffer
+                       is multiline-capable).
+      * Alt+Enter   -> insert a newline. Universally supported across
+                       terminal emulators, so this is the reliable way to
+                       compose multi-line input.
+      * Shift+Enter -> insert a newline *if* the terminal sends a dedicated
+                       sequence for it (kitty / iTerm2 with the CSI-u /
+                       fixterms keyboard protocol). Plain terminals collapse
+                       Shift+Enter into Enter and cannot be distinguished, in
+                       which case Alt+Enter is the fallback.
+    """
+    # prompt_toolkit has no symbolic Keys.ShiftEnter and @kb.add() rejects raw
+    # escape strings, so register the CSI-u Shift+Enter sequences against a
+    # spare key symbol (ControlJ) and bind that. Terminals that never emit
+    # these sequences simply won't trigger the binding.
+    with suppress(Exception):
+        from prompt_toolkit.input import ansi_escape_sequences as _aes
+
+        for _seq in ("\x1b[13;2u", "\x1b[27;2;13~"):
+            _aes.ANSI_SEQUENCES.setdefault(_seq, Keys.ControlJ)
+
+    kb = KeyBindings()
+
+    @kb.add("enter")
+    def _(event):
+        event.current_buffer.validate_and_handle()
+
+    @kb.add("escape", "enter")  # Alt+Enter / Meta+Enter
+    def _(event):
+        event.current_buffer.insert_text("\n")
+
+    @kb.add(Keys.ControlJ)  # Shift+Enter on CSI-u capable terminals
+    def _(event):
+        event.current_buffer.insert_text("\n")
+
+    return kb
+
+
 def _init_prompt_session() -> None:
     """Create the prompt_toolkit session with persistent file history."""
     global _PROMPT_SESSION, _SAVED_TERM_ATTRS
@@ -300,7 +345,11 @@ def _init_prompt_session() -> None:
     _PROMPT_SESSION = PromptSession(
         history=SafeFileHistory(str(history_file)),
         enable_open_in_editor=False,
-        multiline=False,  # Enter submits (single line mode)
+        # Multiline-capable buffer; Enter still submits via the custom key
+        # bindings, while Shift+Enter (supported terminals) or Alt+Enter adds
+        # a newline.
+        multiline=True,
+        key_bindings=_build_cli_key_bindings(),
     )
 
 

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -328,7 +328,16 @@ def _build_cli_key_bindings() -> KeyBindings:
     def _(event):
         event.current_buffer.validate_and_handle()
 
-    @kb.add("escape", "enter")  # Alt+Enter / Meta+Enter
+    @kb.add("escape", "enter")  # Alt+Enter / Meta+Enter (ESC + CR, "\x1b\r")
+    def _(event):
+        event.current_buffer.insert_text("\n")
+
+    # On the same LF-as-Enter terminals (WSL) we preserve plain Enter for,
+    # Alt+Enter arrives as ESC + LF ("\x1b\x0a" = Escape + ControlJ) rather than
+    # ESC + CR, so the "escape","enter" binding above never matches: Escape is
+    # swallowed and the bare LF triggers prompt_toolkit's default submit. Bind
+    # ESC + ControlJ too so Alt+Enter reliably inserts a newline there as well.
+    @kb.add("escape", Keys.ControlJ)  # Alt+Enter on LF-as-Enter terminals
     def _(event):
         event.current_buffer.insert_text("\n")
 

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -294,34 +294,7 @@ def _build_cli_key_bindings() -> KeyBindings:
       * Alt+Enter   -> insert a newline. Universally supported across
                        terminal emulators, so this is the reliable way to
                        compose multi-line input.
-      * Shift+Enter -> insert a newline *if* the terminal sends a dedicated
-                       sequence for it (kitty / iTerm2 with the CSI-u /
-                       fixterms keyboard protocol). Plain terminals collapse
-                       Shift+Enter into Enter and cannot be distinguished, in
-                       which case Alt+Enter is the fallback.
     """
-    # prompt_toolkit has no symbolic Keys.ShiftEnter and @kb.add() rejects raw
-    # escape strings, so register the CSI-u Shift+Enter sequences against
-    # Keys.ControlF3 -- an enum member prompt_toolkit declares but never wires
-    # to a default ANSI sequence or key binding, unlike e.g. Keys.ControlJ,
-    # which is also the literal LF byte ("\x0a") that some terminals (WSL is
-    # the case prompt_toolkit itself calls out) send for a plain Enter
-    # keypress. Aliasing to ControlJ made Enter stop submitting there, since
-    # our handler shadowed prompt_toolkit's own "treat \n as \r" fallback.
-    #
-    # "\x1b[27;2;13~" (the older xterm modifyOtherKeys / rxvt encoding of
-    # Shift+Enter) is already registered by prompt_toolkit by default -- as
-    # Keys.ControlM, i.e. plain Enter/submit. A plain setdefault() would be a
-    # no-op against that existing entry, silently leaving this Shift+Enter
-    # variant behaving like a submit instead of inserting a newline. Assign
-    # directly to override it, since inserting a newline is the whole point
-    # of a Shift+Enter binding here.
-    with suppress(Exception):
-        from prompt_toolkit.input import ansi_escape_sequences as _aes
-
-        for _seq in ("\x1b[13;2u", "\x1b[27;2;13~"):
-            _aes.ANSI_SEQUENCES[_seq] = Keys.ControlF3
-
     kb = KeyBindings()
 
     @kb.add("enter")
@@ -338,10 +311,6 @@ def _build_cli_key_bindings() -> KeyBindings:
     # swallowed and the bare LF triggers prompt_toolkit's default submit. Bind
     # ESC + ControlJ too so Alt+Enter reliably inserts a newline there as well.
     @kb.add("escape", Keys.ControlJ)  # Alt+Enter on LF-as-Enter terminals
-    def _(event):
-        event.current_buffer.insert_text("\n")
-
-    @kb.add(Keys.ControlF3)  # Shift+Enter on CSI-u capable terminals
     def _(event):
         event.current_buffer.insert_text("\n")
 
@@ -367,8 +336,7 @@ def _init_prompt_session() -> None:
         history=SafeFileHistory(str(history_file)),
         enable_open_in_editor=False,
         # Multiline-capable buffer; Enter still submits via the custom key
-        # bindings, while Shift+Enter (supported terminals) or Alt+Enter adds
-        # a newline.
+        # bindings, while Alt+Enter adds a newline.
         multiline=True,
         key_bindings=_build_cli_key_bindings(),
     )

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -301,14 +301,18 @@ def _build_cli_key_bindings() -> KeyBindings:
                        which case Alt+Enter is the fallback.
     """
     # prompt_toolkit has no symbolic Keys.ShiftEnter and @kb.add() rejects raw
-    # escape strings, so register the CSI-u Shift+Enter sequences against a
-    # spare key symbol (ControlJ) and bind that. Terminals that never emit
-    # these sequences simply won't trigger the binding.
+    # escape strings, so register the CSI-u Shift+Enter sequences against
+    # Keys.ControlF3 -- an enum member prompt_toolkit declares but never wires
+    # to a default ANSI sequence or key binding, unlike e.g. Keys.ControlJ,
+    # which is also the literal LF byte ("\x0a") that some terminals (WSL is
+    # the case prompt_toolkit itself calls out) send for a plain Enter
+    # keypress. Aliasing to ControlJ made Enter stop submitting there, since
+    # our handler shadowed prompt_toolkit's own "treat \n as \r" fallback.
     with suppress(Exception):
         from prompt_toolkit.input import ansi_escape_sequences as _aes
 
         for _seq in ("\x1b[13;2u", "\x1b[27;2;13~"):
-            _aes.ANSI_SEQUENCES.setdefault(_seq, Keys.ControlJ)
+            _aes.ANSI_SEQUENCES.setdefault(_seq, Keys.ControlF3)
 
     kb = KeyBindings()
 
@@ -320,7 +324,7 @@ def _build_cli_key_bindings() -> KeyBindings:
     def _(event):
         event.current_buffer.insert_text("\n")
 
-    @kb.add(Keys.ControlJ)  # Shift+Enter on CSI-u capable terminals
+    @kb.add(Keys.ControlF3)  # Shift+Enter on CSI-u capable terminals
     def _(event):
         event.current_buffer.insert_text("\n")
 

--- a/tests/cli/test_cli_input.py
+++ b/tests/cli/test_cli_input.py
@@ -88,11 +88,34 @@ def test_cli_key_bindings_enter_submits_and_alt_enter_newlines():
     alt_enter.call(MagicMock(current_buffer=buf))
     buf.insert_text.assert_called_once_with("\n")
 
-    # ControlJ (mapped Shift+Enter on CSI-u terminals) -> newline
-    ctrl_j = bound[(Keys.ControlJ.value,)]
+    # ControlF3 (synthetic carrier for the Shift+Enter CSI-u sequence) -> newline.
+    # Not ControlJ: that's also the literal LF byte some terminals (e.g. WSL)
+    # send for a plain Enter keypress, so binding it would break submit there.
+    shift_enter = bound[(Keys.ControlF3.value,)]
     buf = MagicMock()
-    ctrl_j.call(MagicMock(current_buffer=buf))
+    shift_enter.call(MagicMock(current_buffer=buf))
     buf.insert_text.assert_called_once_with("\n")
+
+
+@pytest.mark.asyncio
+async def test_raw_lf_enter_still_submits_like_wsl_terminals():
+    """A raw LF byte (\\x0a) is what some terminals -- e.g. WSL -- send for a
+    plain Enter keypress. It must submit the buffer, not insert a newline;
+    a mock buffer can't catch a key binding shadowing prompt_toolkit's own
+    default \\n-as-\\r handling, so this drives a real PromptSession/parser.
+    """
+    from prompt_toolkit.application import create_app_session
+    from prompt_toolkit.input import create_pipe_input
+    from prompt_toolkit.output import DummyOutput
+
+    with create_pipe_input() as pipe_input:
+        with create_app_session(input=pipe_input, output=DummyOutput()):
+            commands._init_prompt_session()
+            session = commands._PROMPT_SESSION
+            pipe_input.send_text("hello\x0aworld\r")
+            result = await session.prompt_async("> ")
+
+    assert result == "hello"
 
 
 def test_thinking_spinner_pause_stops_and_restarts():

--- a/tests/cli/test_cli_input.py
+++ b/tests/cli/test_cli_input.py
@@ -112,13 +112,7 @@ async def test_raw_lf_enter_still_submits_like_wsl_terminals():
 
 @pytest.mark.asyncio
 async def test_alt_enter_inserts_newline_on_lf_terminals():
-    """On LF-as-Enter terminals (WSL), Alt+Enter arrives as ESC + LF
-    ("\\x1b\\x0a" = Escape + ControlJ) rather than the ESC + CR that the
-    "escape","enter" binding matches. Without a dedicated ESC + ControlJ
-    binding the Escape is swallowed and the bare LF submits, so the documented
-    Alt+Enter newline fallback breaks on exactly the terminal path plain Enter
-    is preserved for. Drive a real PromptSession to prove it inserts a newline.
-    """
+    """LF-as-Enter terminals send Alt+Enter as ESC + LF, which needs its own binding."""
     from prompt_toolkit.application import create_app_session
     from prompt_toolkit.input import create_pipe_input
     from prompt_toolkit.output import DummyOutput

--- a/tests/cli/test_cli_input.py
+++ b/tests/cli/test_cli_input.py
@@ -46,8 +46,8 @@ def test_init_prompt_session_creates_session():
     # Ensure global is None before test
     commands._PROMPT_SESSION = None
 
-    with patch("nanobot.cli.commands.PromptSession") as MockSession, \
-         patch("nanobot.cli.commands.FileHistory") as MockHistory, \
+    with patch("nanobot.cli.commands.PromptSession") as mock_session_cls, \
+         patch("nanobot.cli.commands.FileHistory"), \
          patch("pathlib.Path.home") as mock_home:
 
         mock_home.return_value = MagicMock()
@@ -55,17 +55,17 @@ def test_init_prompt_session_creates_session():
         commands._init_prompt_session()
 
         assert commands._PROMPT_SESSION is not None
-        MockSession.assert_called_once()
-        _, kwargs = MockSession.call_args
-        # Buffer is multiline-capable so Shift+Enter / Alt+Enter can insert
-        # newlines; Enter-to-submit is restored via custom key bindings.
+        mock_session_cls.assert_called_once()
+        _, kwargs = mock_session_cls.call_args
+        # Buffer is multiline-capable so Alt+Enter can insert newlines;
+        # Enter-to-submit is restored via custom key bindings.
         assert kwargs["multiline"] is True
         assert kwargs["enable_open_in_editor"] is False
         assert kwargs.get("key_bindings") is not None
 
 
 def test_cli_key_bindings_enter_submits_and_alt_enter_newlines():
-    """Enter submits the buffer; Alt+Enter and Shift+Enter insert a newline."""
+    """Enter submits the buffer; Alt+Enter inserts a newline."""
     from prompt_toolkit.keys import Keys
 
     kb = commands._build_cli_key_bindings()
@@ -88,14 +88,6 @@ def test_cli_key_bindings_enter_submits_and_alt_enter_newlines():
     alt_enter.call(MagicMock(current_buffer=buf))
     buf.insert_text.assert_called_once_with("\n")
 
-    # ControlF3 (synthetic carrier for the Shift+Enter CSI-u sequence) -> newline.
-    # Not ControlJ: that's also the literal LF byte some terminals (e.g. WSL)
-    # send for a plain Enter keypress, so binding it would break submit there.
-    shift_enter = bound[(Keys.ControlF3.value,)]
-    buf = MagicMock()
-    shift_enter.call(MagicMock(current_buffer=buf))
-    buf.insert_text.assert_called_once_with("\n")
-
 
 @pytest.mark.asyncio
 async def test_raw_lf_enter_still_submits_like_wsl_terminals():
@@ -116,28 +108,6 @@ async def test_raw_lf_enter_still_submits_like_wsl_terminals():
             result = await session.prompt_async("> ")
 
     assert result == "hello"
-
-
-@pytest.mark.asyncio
-async def test_xterm_modifyotherkeys_shift_enter_inserts_newline():
-    """"\\x1b[27;2;13~" (the older xterm modifyOtherKeys/rxvt encoding of
-    Shift+Enter) is registered by prompt_toolkit *by default* as plain
-    Enter/submit, so a `setdefault()`-based override would silently no-op
-    against it. This must actually insert a newline like the kitty CSI-u
-    encoding does, which only a real PromptSession/parser can confirm.
-    """
-    from prompt_toolkit.application import create_app_session
-    from prompt_toolkit.input import create_pipe_input
-    from prompt_toolkit.output import DummyOutput
-
-    with create_pipe_input() as pipe_input:
-        with create_app_session(input=pipe_input, output=DummyOutput()):
-            commands._init_prompt_session()
-            session = commands._PROMPT_SESSION
-            pipe_input.send_text("foo\x1b[27;2;13~bar\r")
-            result = await session.prompt_async("> ")
-
-    assert result == "foo\nbar"
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_cli_input.py
+++ b/tests/cli/test_cli_input.py
@@ -140,6 +140,29 @@ async def test_xterm_modifyotherkeys_shift_enter_inserts_newline():
     assert result == "foo\nbar"
 
 
+@pytest.mark.asyncio
+async def test_alt_enter_inserts_newline_on_lf_terminals():
+    """On LF-as-Enter terminals (WSL), Alt+Enter arrives as ESC + LF
+    ("\\x1b\\x0a" = Escape + ControlJ) rather than the ESC + CR that the
+    "escape","enter" binding matches. Without a dedicated ESC + ControlJ
+    binding the Escape is swallowed and the bare LF submits, so the documented
+    Alt+Enter newline fallback breaks on exactly the terminal path plain Enter
+    is preserved for. Drive a real PromptSession to prove it inserts a newline.
+    """
+    from prompt_toolkit.application import create_app_session
+    from prompt_toolkit.input import create_pipe_input
+    from prompt_toolkit.output import DummyOutput
+
+    with create_pipe_input() as pipe_input:
+        with create_app_session(input=pipe_input, output=DummyOutput()):
+            commands._init_prompt_session()
+            session = commands._PROMPT_SESSION
+            pipe_input.send_text("foo\x1b\x0abar\r")
+            result = await session.prompt_async("> ")
+
+    assert result == "foo\nbar"
+
+
 def test_thinking_spinner_pause_stops_and_restarts():
     """Pause should stop the active spinner and restart it afterward."""
     spinner = MagicMock()

--- a/tests/cli/test_cli_input.py
+++ b/tests/cli/test_cli_input.py
@@ -1,4 +1,3 @@
-import asyncio
 from contextlib import nullcontext
 from io import StringIO
 from unittest.mock import AsyncMock, MagicMock, call, patch
@@ -26,7 +25,7 @@ async def test_read_interactive_input_async_returns_input(mock_prompt_session):
     mock_prompt_session.prompt_async.return_value = "hello world"
 
     result = await commands._read_interactive_input_async()
-    
+
     assert result == "hello world"
     mock_prompt_session.prompt_async.assert_called_once()
     args, _ = mock_prompt_session.prompt_async.call_args
@@ -46,20 +45,54 @@ def test_init_prompt_session_creates_session():
     """Test that _init_prompt_session initializes the global session."""
     # Ensure global is None before test
     commands._PROMPT_SESSION = None
-    
+
     with patch("nanobot.cli.commands.PromptSession") as MockSession, \
          patch("nanobot.cli.commands.FileHistory") as MockHistory, \
          patch("pathlib.Path.home") as mock_home:
-        
+
         mock_home.return_value = MagicMock()
-        
+
         commands._init_prompt_session()
-        
+
         assert commands._PROMPT_SESSION is not None
         MockSession.assert_called_once()
         _, kwargs = MockSession.call_args
-        assert kwargs["multiline"] is False
+        # Buffer is multiline-capable so Shift+Enter / Alt+Enter can insert
+        # newlines; Enter-to-submit is restored via custom key bindings.
+        assert kwargs["multiline"] is True
         assert kwargs["enable_open_in_editor"] is False
+        assert kwargs.get("key_bindings") is not None
+
+
+def test_cli_key_bindings_enter_submits_and_alt_enter_newlines():
+    """Enter submits the buffer; Alt+Enter and Shift+Enter insert a newline."""
+    from prompt_toolkit.keys import Keys
+
+    kb = commands._build_cli_key_bindings()
+
+    def _keys(binding):
+        return tuple(getattr(k, "value", k) for k in binding.keys)
+
+    bound = {_keys(b): b for b in kb.bindings}
+
+    # Enter -> submit
+    enter = bound[(Keys.Enter.value,)]
+    buf = MagicMock()
+    enter.call(MagicMock(current_buffer=buf))
+    buf.validate_and_handle.assert_called_once()
+    buf.insert_text.assert_not_called()
+
+    # Alt+Enter (escape, enter) -> newline
+    alt_enter = bound[(Keys.Escape.value, Keys.Enter.value)]
+    buf = MagicMock()
+    alt_enter.call(MagicMock(current_buffer=buf))
+    buf.insert_text.assert_called_once_with("\n")
+
+    # ControlJ (mapped Shift+Enter on CSI-u terminals) -> newline
+    ctrl_j = bound[(Keys.ControlJ.value,)]
+    buf = MagicMock()
+    ctrl_j.call(MagicMock(current_buffer=buf))
+    buf.insert_text.assert_called_once_with("\n")
 
 
 def test_thinking_spinner_pause_stops_and_restarts():

--- a/tests/cli/test_cli_input.py
+++ b/tests/cli/test_cli_input.py
@@ -118,6 +118,28 @@ async def test_raw_lf_enter_still_submits_like_wsl_terminals():
     assert result == "hello"
 
 
+@pytest.mark.asyncio
+async def test_xterm_modifyotherkeys_shift_enter_inserts_newline():
+    """"\\x1b[27;2;13~" (the older xterm modifyOtherKeys/rxvt encoding of
+    Shift+Enter) is registered by prompt_toolkit *by default* as plain
+    Enter/submit, so a `setdefault()`-based override would silently no-op
+    against it. This must actually insert a newline like the kitty CSI-u
+    encoding does, which only a real PromptSession/parser can confirm.
+    """
+    from prompt_toolkit.application import create_app_session
+    from prompt_toolkit.input import create_pipe_input
+    from prompt_toolkit.output import DummyOutput
+
+    with create_pipe_input() as pipe_input:
+        with create_app_session(input=pipe_input, output=DummyOutput()):
+            commands._init_prompt_session()
+            session = commands._PROMPT_SESSION
+            pipe_input.send_text("foo\x1b[27;2;13~bar\r")
+            result = await session.prompt_async("> ")
+
+    assert result == "foo\nbar"
+
+
 def test_thinking_spinner_pause_stops_and_restarts():
     """Pause should stop the active spinner and restart it afterward."""
     spinner = MagicMock()


### PR DESCRIPTION
## Problem

The interactive CLI prompt used a single-line buffer (`multiline=False`), so there was no way to compose a multi-line message before submitting -- every Enter press sent immediately.

## Fix

Switch to a multiline-capable `PromptSession` buffer with custom key bindings:

- **Enter** still submits (unchanged feel).
- **Alt+Enter** inserts a newline.
- **Alt+Enter** is handled for both common terminal encodings: ESC + CR and ESC + LF on LF-as-Enter terminals such as WSL.

`Shift+Enter` is intentionally not part of this PR because many terminals collapse it into plain Enter and do not send a distinguishable sequence.

## Testing

- `tests/cli/test_cli_input.py`: unit tests for the key-binding handlers, plus real `PromptSession`/parser regression coverage for raw LF-as-Enter and Alt+Enter on LF-as-Enter terminals.
- Maintainer edit verified real `PromptSession` behavior for plain CR Enter, plain LF Enter, ESC+CR Alt+Enter, and ESC+LF Alt+Enter.
- CI reran after the maintainer edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
