### PR TITLE
[security] fix(mcp): prevent enabledTools name collisions

### DIFF
--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -894,10 +894,32 @@ async def connect_mcp_servers(
                         for wrapped_name, raw_names in sorted(ambiguous_wrapped_names.items())
                     ),
                 )
+            ambiguous_allowed_raw_names = {
+                wrapped_name: [raw_name for raw_name in raw_names if raw_name in enabled_tools]
+                for wrapped_name, raw_names in ambiguous_wrapped_names.items()
+            }
+            ambiguous_allowed_raw_names = {
+                wrapped_name: raw_names
+                for wrapped_name, raw_names in ambiguous_allowed_raw_names.items()
+                if len(raw_names) > 1
+            }
+            if ambiguous_allowed_raw_names:
+                logger.warning(
+                    "MCP server '{}': enabledTools lists multiple raw MCP names that all "
+                    "sanitize to the same wrapped name; skipping ambiguous entries: {}",
+                    name,
+                    "; ".join(
+                        f"{wrapped_name} -> {', '.join(raw_names)}"
+                        for wrapped_name, raw_names in sorted(ambiguous_allowed_raw_names.items())
+                    ),
+                )
 
             for tool_def in tools.tools:
                 wrapped_name = _sanitize_name(f"mcp_{name}_{tool_def.name}")
-                raw_name_allowed = tool_def.name in enabled_tools
+                raw_name_allowed = (
+                    tool_def.name in enabled_tools
+                    and wrapped_name not in ambiguous_allowed_raw_names
+                )
                 stable_wrapped_name = f"mcp_{name}_{tool_def.name}"
                 wrapped_name_allowed = (
                     wrapped_name in enabled_tools

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -6,6 +6,7 @@ import os
 import re
 import shutil
 import urllib.parse
+from collections import defaultdict
 from collections.abc import Awaitable, Callable
 from contextlib import AsyncExitStack, suppress
 from typing import Any, Mapping
@@ -874,18 +875,50 @@ async def connect_mcp_servers(
             registered_count = 0
             matched_enabled_tools: set[str] = set()
             available_raw_names = [tool_def.name for tool_def in tools.tools]
-            available_wrapped_names = [_sanitize_name(f"mcp_{name}_{tool_def.name}") for tool_def in tools.tools]
+            wrapped_to_raw: dict[str, list[str]] = defaultdict(list)
+            for tool_def in tools.tools:
+                wrapped_to_raw[_sanitize_name(f"mcp_{name}_{tool_def.name}")].append(tool_def.name)
+            available_wrapped_names = list(wrapped_to_raw)
+            ambiguous_wrapped_names = {
+                wrapped_name: raw_names
+                for wrapped_name, raw_names in wrapped_to_raw.items()
+                if len(raw_names) > 1
+            }
+            if ambiguous_wrapped_names:
+                logger.warning(
+                    "MCP server '{}': ambiguous sanitized tool names detected; wrapped-name "
+                    "enabledTools entries will not match these tools: {}",
+                    name,
+                    "; ".join(
+                        f"{wrapped_name} -> {', '.join(raw_names)}"
+                        for wrapped_name, raw_names in sorted(ambiguous_wrapped_names.items())
+                    ),
+                )
+
             for tool_def in tools.tools:
                 wrapped_name = _sanitize_name(f"mcp_{name}_{tool_def.name}")
-                if (
-                    not allow_all_tools
-                    and tool_def.name not in enabled_tools
-                    and wrapped_name not in enabled_tools
-                ):
+                raw_name_allowed = tool_def.name in enabled_tools
+                stable_wrapped_name = f"mcp_{name}_{tool_def.name}"
+                wrapped_name_allowed = (
+                    wrapped_name in enabled_tools
+                    and wrapped_name == stable_wrapped_name
+                    and wrapped_name not in ambiguous_wrapped_names
+                )
+                if not allow_all_tools and not raw_name_allowed and not wrapped_name_allowed:
                     logger.debug(
                         "MCP: skipping tool '{}' from server '{}' (not in enabledTools)",
                         wrapped_name,
                         name,
+                    )
+                    continue
+                if allow_all_tools and wrapped_name in ambiguous_wrapped_names:
+                    logger.warning(
+                        "MCP: skipping ambiguous tool '{}' from server '{}' because raw MCP names "
+                        "{} all sanitize to '{}'",
+                        tool_def.name,
+                        name,
+                        ", ".join(ambiguous_wrapped_names[wrapped_name]),
+                        wrapped_name,
                     )
                     continue
                 wrapper = MCPToolWrapper(session, name, tool_def, tool_timeout=cfg.tool_timeout)
@@ -893,9 +926,9 @@ async def connect_mcp_servers(
                 logger.debug("MCP: registered tool '{}' from server '{}'", wrapper.name, name)
                 registered_count += 1
                 if enabled_tools:
-                    if tool_def.name in enabled_tools:
+                    if raw_name_allowed:
                         matched_enabled_tools.add(tool_def.name)
-                    if wrapped_name in enabled_tools:
+                    if wrapped_name_allowed:
                         matched_enabled_tools.add(wrapped_name)
 
             if enabled_tools and not allow_all_tools:

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -604,6 +604,31 @@ async def test_connect_mcp_servers_enabled_tools_raw_name_can_select_collision_u
 
 
 @pytest.mark.asyncio
+async def test_connect_mcp_servers_enabled_tools_rejects_multiple_colliding_raw_names(
+    fake_mcp_runtime: dict[str, object | None], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_mcp_runtime["session"] = _make_fake_session(["demo.read", "demo/read"])
+    registry = ToolRegistry()
+    warnings: list[str] = []
+
+    def _warning(message: str, *args: object) -> None:
+        warnings.append(message.format(*args))
+
+    monkeypatch.setattr("nanobot.agent.tools.mcp.logger.warning", _warning)
+
+    stacks = await connect_mcp_servers(
+        {"test": MCPServerConfig(command="fake", enabled_tools=["demo.read", "demo/read"])},
+        registry,
+    )
+    for stack in stacks.values():
+        await stack.aclose()
+
+    assert registry.tool_names == []
+    assert any("enabledTools lists multiple raw MCP names" in warning for warning in warnings)
+    assert any("enabledTools entries not found: demo.read, demo/read" in warning for warning in warnings)
+
+
+@pytest.mark.asyncio
 async def test_connect_mcp_servers_enabled_tools_empty_list_registers_none(
     fake_mcp_runtime: dict[str, object | None],
 ) -> None:

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -513,6 +513,97 @@ async def test_connect_mcp_servers_enabled_tools_supports_wrapped_names(
 
 
 @pytest.mark.asyncio
+async def test_connect_mcp_servers_enabled_tools_rejects_sanitized_wrapped_name_for_raw_tool(
+    fake_mcp_runtime: dict[str, object | None], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_mcp_runtime["session"] = _make_fake_session(["demo/read"])
+    registry = ToolRegistry()
+    warnings: list[str] = []
+
+    def _warning(message: str, *args: object) -> None:
+        warnings.append(message.format(*args))
+
+    monkeypatch.setattr("nanobot.agent.tools.mcp.logger.warning", _warning)
+
+    stacks = await connect_mcp_servers(
+        {"test": MCPServerConfig(command="fake", enabled_tools=["mcp_test_demo_read"])},
+        registry,
+    )
+    for stack in stacks.values():
+        await stack.aclose()
+
+    assert registry.tool_names == []
+    assert any("enabledTools entries not found: mcp_test_demo_read" in warning for warning in warnings)
+
+
+@pytest.mark.asyncio
+async def test_connect_mcp_servers_enabled_tools_rejects_ambiguous_wrapped_names(
+    fake_mcp_runtime: dict[str, object | None], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_mcp_runtime["session"] = _make_fake_session(["demo.read", "demo/read"])
+    registry = ToolRegistry()
+    warnings: list[str] = []
+
+    def _warning(message: str, *args: object) -> None:
+        warnings.append(message.format(*args))
+
+    monkeypatch.setattr("nanobot.agent.tools.mcp.logger.warning", _warning)
+
+    stacks = await connect_mcp_servers(
+        {"test": MCPServerConfig(command="fake", enabled_tools=["mcp_test_demo_read"])},
+        registry,
+    )
+    for stack in stacks.values():
+        await stack.aclose()
+
+    assert registry.tool_names == []
+    assert any("ambiguous sanitized tool names" in warning for warning in warnings)
+    assert any("enabledTools entries not found: mcp_test_demo_read" in warning for warning in warnings)
+
+
+@pytest.mark.asyncio
+async def test_connect_mcp_servers_enabled_tools_all_skips_ambiguous_wrapped_names(
+    fake_mcp_runtime: dict[str, object | None], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_mcp_runtime["session"] = _make_fake_session(["demo.read", "demo/read", "safe"])
+    registry = ToolRegistry()
+    warnings: list[str] = []
+
+    def _warning(message: str, *args: object) -> None:
+        warnings.append(message.format(*args))
+
+    monkeypatch.setattr("nanobot.agent.tools.mcp.logger.warning", _warning)
+
+    stacks = await connect_mcp_servers(
+        {"test": MCPServerConfig(command="fake", enabled_tools=["*"])},
+        registry,
+    )
+    for stack in stacks.values():
+        await stack.aclose()
+
+    assert registry.tool_names == ["mcp_test_safe"]
+    assert any("skipping ambiguous tool 'demo.read'" in warning for warning in warnings)
+    assert any("skipping ambiguous tool 'demo/read'" in warning for warning in warnings)
+
+
+@pytest.mark.asyncio
+async def test_connect_mcp_servers_enabled_tools_raw_name_can_select_collision_uniquely(
+    fake_mcp_runtime: dict[str, object | None],
+) -> None:
+    fake_mcp_runtime["session"] = _make_fake_session(["demo.read", "demo/read"])
+    registry = ToolRegistry()
+    stacks = await connect_mcp_servers(
+        {"test": MCPServerConfig(command="fake", enabled_tools=["demo.read"])},
+        registry,
+    )
+    for stack in stacks.values():
+        await stack.aclose()
+
+    assert registry.tool_names == ["mcp_test_demo_read"]
+    assert getattr(registry.get("mcp_test_demo_read"), "_original_name", None) == "demo.read"
+
+
+@pytest.mark.asyncio
 async def test_connect_mcp_servers_enabled_tools_empty_list_registers_none(
     fake_mcp_runtime: dict[str, object | None],
 ) -> None:
@@ -1257,7 +1348,7 @@ async def test_connect_mcp_servers_sanitizes_resource_names(
 
 
 @pytest.mark.asyncio
-async def test_connect_mcp_servers_enabled_tools_matches_sanitized_name(
+async def test_connect_mcp_servers_enabled_tools_rejects_sanitized_name_for_lossy_raw_name(
     fake_mcp_runtime: dict[str, object | None],
 ) -> None:
     fake_mcp_runtime["session"] = _make_fake_session_with_capabilities(
@@ -1271,7 +1362,7 @@ async def test_connect_mcp_servers_enabled_tools_matches_sanitized_name(
     for stack in stacks.values():
         await stack.aclose()
 
-    assert registry.tool_names == ["mcp_test_My_Tool"]
+    assert registry.tool_names == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
This PR hardens the MCP `enabledTools` capability boundary so lossy sanitized wrapped names cannot authorize a different raw MCP tool.

- Fixes a model-visible MCP tool identity confusion path where raw names such as `demo.read`, `demo/read`, `demo read`, and `demo__read` normalize to the same wrapped name.
- Keeps exact raw MCP tool names as the unambiguous allowlist identity for lossy names.
- Preserves wrapped-name compatibility for stable names that do not change during sanitization.
- Adds focused regression coverage and a Docker stdio-MCP proof that the previous colliding wrapped-name path now registers no tool.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| MCP `enabledTools` wrapped-name collision | A mutable or malicious MCP server could cause an unapproved raw tool to inherit approval from a colliding model-visible wrapped name. In credential-bearing MCP deployments, this can bypass the operator's intended least-privilege tool boundary. | Medium; potentially higher in credential-bearing/action-bearing MCP deployments |

## Before this PR
- `enabledTools` accepted either raw MCP tool names or sanitized wrapped names such as `mcp_test_demo_read`.
- The wrapped names were generated through `_sanitize_name(...)`, which is lossy and many-to-one.
- A raw tool named `demo/read` could be registered when the operator allowlisted only `mcp_test_demo_read`, even though that wrapped name could have been produced by a different raw tool such as `demo.read`.
- Ambiguous wrapped names could also collide when all MCP tools were enabled, risking duplicate model-visible tool identities.

## After this PR
- Exact raw MCP names remain supported as the precise allowlist identity.
- Wrapped-name `enabledTools` entries only match when the wrapped name is stable and does not depend on lossy sanitization.
- Ambiguous wrapped-name groups are detected before registration.
- Ambiguous tools are skipped when all tools are enabled so duplicate model-visible MCP names do not silently overwrite each other.
- Regression tests lock in rejection for sanitized wrapped-name authorization and ambiguous wrapped-name groups.

## Why this matters
`enabledTools` is a least-privilege boundary for model-callable MCP tools. When that boundary uses lossy generated names as identities, a tool with a different raw MCP name can be registered under an approved model-visible name.

This matters most for MCP servers that carry credentials or side effects, such as repository, API, browser, database, or cloud integrations. A compromised, malicious, or mutable MCP endpoint should not be able to change raw tool names and inherit an operator's prior approval for a different capability.

## How this differs from related issue/PR
This is adjacent to the merged MCP `enabledTools` fix in [#4436](https://github.com/HKUDS/nanobot/pull/4436), `fix(tools): gate MCP resource and prompt registration behind enabledTools`, which merged on 2026-06-25 and fixed [#4435](https://github.com/HKUDS/nanobot/issues/4435).

| Merged PR | Boundary covered | What it fixed | Why this PR is still needed |
|-----------|------------------|---------------|-----------------------------|
| [#4436](https://github.com/HKUDS/nanobot/pull/4436) | MCP resource/prompt registration under `enabledTools` | When a server used `enabledTools: []` or a specific tool list, ordinary tools were filtered but MCP resources and prompts were still registered and exposed. #4436 now registers resources/prompts only when the server is effectively allow-all (`["*"]`). | #4436 did not change the identity used for ordinary MCP tool allowlisting. A raw tool can still be authorized through a lossy sanitized wrapped name unless the tool-name boundary is hardened. |
| This PR | MCP ordinary tool identity under `enabledTools` | A wrapped/model-visible name such as `mcp_test_demo_read` could authorize a different raw MCP tool such as `demo/read` because `_sanitize_name(...)` is many-to-one. | It closes the sibling tool-identity path so `enabledTools` cannot be bypassed by raw-name collisions after resources/prompts are already gated. |

In short:
- [#4436](https://github.com/HKUDS/nanobot/pull/4436) made `enabledTools` apply consistently across MCP capability *types* by blocking resources/prompts whenever the operator configured a restricted tool set.
- This PR makes `enabledTools` apply safely within the ordinary MCP *tool* type by ensuring an approved wrapped name cannot identify multiple or lossy raw MCP tool names.
- The vulnerable code path here is the tool registration allowlist check in `connect_mcp_servers(...)`, not the resource/prompt registration path fixed by #4436.
- Both fixes are needed because they protect adjacent layers of the same MCP least-privilege boundary: capability type coverage first, then capability identity correctness.

## Attack flow
```text
Operator allowlists a wrapped MCP tool name such as mcp_test_demo_read
    -> MCP server advertises a different raw tool such as demo/read
        -> Nanobot sanitizes the raw name to the same wrapped name
            -> enabledTools wrapped-name check treats it as approved
                -> the model-visible tool calls the unapproved raw MCP capability
```

## Affected code

| Issue | Files |
|-------|-------|
| MCP wrapped-name identity collision | `nanobot/agent/tools/mcp.py`, `tests/tools/test_mcp_tool.py` |

## Root cause
Issue 1: MCP `enabledTools` wrapped-name collision
- `_sanitize_name(...)` intentionally converts provider-incompatible characters to underscores and collapses runs.
- The result is not a stable authorization identity because multiple raw names can map to the same wrapped name.
- `connect_mcp_servers(...)` previously accepted the wrapped name directly in `enabledTools` without proving that it uniquely and reversibly identified the raw MCP tool.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| MCP `enabledTools` wrapped-name collision | 4.2 Medium | `CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:N` |

Rationale:
- The attacker condition is a malicious, compromised, or mutable configured MCP server, or an actor able to influence that server's advertised tool list.
- The direct bug is a capability-boundary bypass, not default unauthenticated code execution.
- Impact can be higher in deployments where the affected MCP server has credential-bearing or action-bearing tools, but this PR keeps the universal claim bounded to the authorization boundary failure.

## Safe reproduction steps
1. Configure an MCP server named `test` with `enabledTools: ["mcp_test_demo_read"]`.
2. Have that MCP server advertise only the raw tool name `demo/read`.
3. On vulnerable code, connect the MCP server and inspect the registered tool.
4. Observe that `mcp_test_demo_read` is registered even though the backing raw name is `demo/read`.
5. Execute `mcp_test_demo_read` and observe the raw MCP call goes to `demo/read`.

## Expected vulnerable behavior
On vulnerable code, the Docker stdio-MCP proof showed:

```text
enabledTools= ['mcp_test_demo_read']
registered_tool_names= ['mcp_test_demo_read']
registered_original_name= demo/read
execute_result= COLLIDING_TOOL_EXECUTED
expected_unapproved_raw_name= demo/read
```

After this PR, the same safe proof registers no tool:

```text
enabledTools= ['mcp_test_demo_read']
registered_tool_names= []
collision_blocked= true
```

## Changes in this PR
- Builds a wrapped-name to raw-name map before applying `enabledTools`.
- Detects ambiguous wrapped names generated by lossy sanitization.
- Allows wrapped-name matching only when the wrapped name is stable and unambiguous.
- Requires exact raw-name allowlisting for raw MCP names that need lossy sanitization.
- Skips ambiguous wrapped-name groups under wildcard allow-all to avoid duplicate model-visible registrations.
- Adds tests for sanitized wrapped-name rejection, ambiguous wrapped-name rejection, wildcard ambiguity handling, and exact raw-name compatibility.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| MCP registration hardening | `nanobot/agent/tools/mcp.py` | Tightens `enabledTools` matching around raw names, wrapped names, and ambiguous sanitized names. |
| Regression tests | `tests/tools/test_mcp_tool.py` | Adds focused tests for lossy wrapped-name rejection and collision handling. |

## Maintainer impact
- Existing exact raw-name `enabledTools` entries continue to work.
- Existing wrapped-name entries for stable tool names such as `demo` continue to work.
- Wrapped-name entries for raw MCP names that require sanitization now fail closed and should be changed to the exact raw MCP tool name.
- Ambiguous MCP tool name groups are skipped rather than silently producing duplicate model-visible identities.

## Fix rationale
The raw MCP tool name is the only precise identity available from the server. A sanitized model-visible wrapper is useful for provider compatibility, but it is not safe as an authorization identity when sanitization changes the name or when multiple raw names normalize to the same wrapper.

Failing closed in those cases preserves least privilege and makes unsafe configuration visible through warnings instead of silently registering the wrong capability.

## Type of change
- [x] Security hardening / bug fix
- [x] Regression tests
- [ ] Documentation-only change
- [ ] Refactor with no behavior change

## Test plan
The following commands were run successfully:

```bash
uv run --extra dev python -m pytest tests/tools/test_mcp_tool.py -q
# 68 passed
```

```bash
uv run --extra dev python -m ruff check nanobot/agent/tools/mcp.py tests/tools/test_mcp_tool.py
# All checks passed
```

```bash
git diff --check
# passed with no output
```

Docker stdio-MCP fixed-behavior proof:

```bash
docker run --rm \
  -v /path/to/nanobot:/repo \
  -v /path/to/mcp_collision_server.py:/tmp/mcp_collision_server.py:ro \
  -v /path/to/repro_mcp_enabledtools_collision_fixed.py:/tmp/repro_mcp_enabledtools_collision_fixed.py:ro \
  -w /repo \
  ghcr.io/astral-sh/uv:python3.12-bookworm-slim \
  uv run --extra dev python /tmp/repro_mcp_enabledtools_collision_fixed.py
# registered_tool_names= []
# collision_blocked= true
```

Docker focused test run:

```bash
docker run --rm \
  -v /path/to/nanobot:/repo \
  -w /repo \
  ghcr.io/astral-sh/uv:python3.12-bookworm-slim \
  uv run --extra dev python -m pytest tests/tools/test_mcp_tool.py -q
# 68 passed
```

## Disclosure notes
This PR is intentionally bounded to MCP `enabledTools` identity handling. It does not claim default unauthenticated takeover, arbitrary host file read, secret theft, or RCE. The impact is an MCP capability-boundary bypass that becomes more serious when the configured MCP server has credential-bearing or action-bearing tools.

