### PR TITLE
test: add memory lifecycle harness

### DIFF
--- a/tests/agent/memory_harness.py
+++ b/tests/agent/memory_harness.py
@@ -1,0 +1,86 @@
+"""Scripted helpers for memory lifecycle tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from nanobot.agent.memory import Consolidator, MemoryStore
+from nanobot.session.manager import Session, SessionManager
+
+
+class ScriptedMemoryProvider:
+    """Tiny provider stub that returns queued text responses."""
+
+    def __init__(self, *responses: str | BaseException) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+        self.generation = SimpleNamespace(max_tokens=128)
+
+    async def chat_with_retry(self, **kwargs: Any) -> SimpleNamespace:
+        self.calls.append(kwargs)
+        if not self._responses:
+            raise AssertionError("ScriptedMemoryProvider has no response queued")
+        response = self._responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return SimpleNamespace(content=response, finish_reason="stop")
+
+
+@dataclass
+class MemoryLifecycleHarness:
+    """Drive a small memory flow from session turns to durable files."""
+
+    workspace: Path
+    model: str = "test-model"
+    store: MemoryStore = field(init=False)
+    sessions: SessionManager = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.store = MemoryStore(self.workspace)
+        self.sessions = SessionManager(self.workspace)
+        self.store.write_soul("# Soul\n- Helpful")
+        self.store.write_user("# User\n")
+        self.store.write_memory("# Memory\n")
+
+    def session(self, key: str = "cli:memory") -> Session:
+        return self.sessions.get_or_create(key)
+
+    def add_turn(self, session: Session, user: str, assistant: str) -> None:
+        session.add_message("user", user)
+        session.add_message("assistant", assistant)
+        self.sessions.save(session)
+
+    async def archive_session(
+        self,
+        session: Session,
+        *,
+        summary: str | BaseException,
+        end_idx: int | None = None,
+    ) -> str | None:
+        provider = ScriptedMemoryProvider(summary)
+        consolidator = Consolidator(
+            store=self.store,
+            provider=provider,
+            model=self.model,
+            sessions=self.sessions,
+            context_window_tokens=4096,
+            build_messages=lambda **_kwargs: [],
+            get_tool_definitions=lambda: [],
+            max_completion_tokens=128,
+        )
+        end_idx = len(session.messages) if end_idx is None else end_idx
+        result = await consolidator.archive(session.messages[:end_idx])
+        session.last_consolidated = end_idx
+        self.sessions.save(session)
+        return result
+
+    def init_git_snapshot(self) -> None:
+        assert self.store.git.init() is True
+
+    def commit_memory_change(self, message: str) -> str:
+        sha = self.store.git.auto_commit(message)
+        assert sha is not None
+        return sha

--- a/tests/agent/test_memory_lifecycle_harness.py
+++ b/tests/agent/test_memory_lifecycle_harness.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from tests.agent.memory_harness import MemoryLifecycleHarness
+from agent.memory_harness import MemoryLifecycleHarness
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_memory_lifecycle_harness.py
+++ b/tests/agent/test_memory_lifecycle_harness.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.agent.memory_harness import MemoryLifecycleHarness
+
+
+@pytest.mark.asyncio
+async def test_memory_lifecycle_harness_archives_then_versions_memory(tmp_path):
+    harness = MemoryLifecycleHarness(tmp_path)
+    session = harness.session()
+    harness.add_turn(
+        session,
+        "Please keep PR summaries short and concrete.",
+        "Got it. I will keep PR summaries short and concrete.",
+    )
+
+    summary = await harness.archive_session(
+        session,
+        summary="- User prefers short, concrete PR summaries.",
+    )
+
+    entries = harness.store.read_unprocessed_history(since_cursor=0)
+    assert summary == "- User prefers short, concrete PR summaries."
+    assert session.last_consolidated == 2
+    assert [entry["cursor"] for entry in entries] == [1]
+    assert entries[0]["content"] == summary
+
+    harness.init_git_snapshot()
+    harness.store.write_user("# User\n- Prefers short, concrete PR summaries.\n")
+    sha = harness.commit_memory_change(
+        "memory: record user PR summary preference\n\n"
+        "Source: archived session summary cursor 1"
+    )
+
+    assert len(sha) == 8
+    assert "short, concrete PR summaries" in harness.store.read_user()
+    commits = harness.store.git.log(max_entries=2)
+    assert commits[0].sha == sha
+    assert commits[0].message.startswith("memory: record user PR summary preference")
+    assert "cursor 1" in commits[0].message
+
+
+@pytest.mark.asyncio
+async def test_memory_lifecycle_harness_raw_archives_failed_summary(tmp_path):
+    harness = MemoryLifecycleHarness(tmp_path)
+    session = harness.session()
+    harness.add_turn(session, "Remember that I use pytest.", "Noted.")
+
+    summary = await harness.archive_session(
+        session,
+        summary=RuntimeError("provider unavailable"),
+    )
+
+    entries = harness.store.read_unprocessed_history(since_cursor=0)
+    assert summary is None
+    assert session.last_consolidated == 2
+    assert [entry["cursor"] for entry in entries] == [1]
+    assert entries[0]["content"].startswith("[RAW] 2 messages")
+    assert "Remember that I use pytest." in entries[0]["content"]


### PR DESCRIPTION
## Summary
- add a scripted memory lifecycle harness for tests that drive session turns, Consolidator archive, history.jsonl, and GitStore together
- cover the happy path from archived session summary to versioned durable memory updates
- cover degraded consolidation falling back to raw history breadcrumbs while still advancing the archived session boundary

## Tests
- uv run --extra dev pytest tests/agent/test_memory_lifecycle_harness.py tests/agent/test_consolidator.py tests/agent/test_memory_store.py -q
- uv run --extra dev ruff check tests/agent/memory_harness.py tests/agent/test_memory_lifecycle_harness.py --select F,E,I