### PR TITLE
fix(exec): block relative symlink workspace escapes

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -666,12 +666,22 @@ class ExecTool(Tool):
     def _relative_path_escape_error(cls, command: str, cwd_path: Path) -> str | None:
         """Block existing relative path operands that resolve outside the workspace."""
         try:
-            tokens = shlex.split(command, posix=not _IS_WINDOWS)
+            lexer = shlex.shlex(command, posix=not _IS_WINDOWS, punctuation_chars=True)
+            lexer.whitespace_split = True
+            tokens = list(lexer)
         except ValueError:
             return None
 
         media_path = get_media_dir().resolve()
         for idx, token in enumerate(tokens):
+            if (
+                token.isdigit()
+                and idx + 1 < len(tokens)
+                and tokens[idx + 1].startswith((">", "<"))
+            ):
+                continue
+            if idx > 0 and tokens[idx - 1] in {"<<", "<<<"}:
+                continue
             relative_path = cls._relative_path_token(token, idx)
             if relative_path is None:
                 continue

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import re
+import shlex
 import shutil
 import sys
 from contextlib import suppress
@@ -630,6 +631,10 @@ class ExecTool(Tool):
 
             cwd_path = Path(cwd).resolve()
 
+            relative_escape = self._relative_path_escape_error(cmd, cwd_path)
+            if relative_escape:
+                return relative_escape
+
             for raw in self._extract_absolute_paths(cmd):
                 try:
                     expanded = os.path.expandvars(raw.strip())
@@ -655,6 +660,61 @@ class ExecTool(Tool):
                         + _WORKSPACE_BOUNDARY_NOTE
                     )
 
+        return None
+
+    @classmethod
+    def _relative_path_escape_error(cls, command: str, cwd_path: Path) -> str | None:
+        """Block existing relative path operands that resolve outside the workspace."""
+        try:
+            tokens = shlex.split(command, posix=not _IS_WINDOWS)
+        except ValueError:
+            return None
+
+        media_path = get_media_dir().resolve()
+        for idx, token in enumerate(tokens):
+            relative_path = cls._relative_path_token(token, idx)
+            if relative_path is None:
+                continue
+            try:
+                candidate = (cwd_path / os.path.expandvars(relative_path)).expanduser()
+                if not candidate.exists() and not candidate.is_symlink():
+                    continue
+                resolved = candidate.resolve()
+            except Exception:
+                continue
+            if not (is_path_within(resolved, cwd_path) or is_path_within(resolved, media_path)):
+                return (
+                    "Error: Command blocked by safety guard (path outside working dir)"
+                    + _WORKSPACE_BOUNDARY_NOTE
+                )
+        return None
+
+    @staticmethod
+    def _relative_path_token(token: str, index: int) -> str | None:
+        if not token or "\0" in token:
+            return None
+        if token in {"&&", "||", ";", "|", "(", ")", "{", "}"}:
+            return None
+        if re.match(r"^[A-Za-z][A-Za-z0-9+.-]*://", token):
+            return None
+        if token.startswith("-"):
+            return None
+        if re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", token):
+            return None
+
+        redirect = re.match(r"^(?:\d*)?(?:>>?|<<?|<>|>\||&>)(.+)$", token)
+        if redirect:
+            token = redirect.group(1)
+            if not token or token.startswith("&"):
+                return None
+        elif token.startswith((">", "<")) or re.match(r"^\d+[<>]", token):
+            return None
+
+        path = Path(os.path.expandvars(token)).expanduser()
+        if path.is_absolute():
+            return None
+        if index > 0 or token.startswith((".", "~")) or "/" in token or "\\" in token:
+            return token
         return None
 
     @classmethod

--- a/tests/tools/test_exec_security.py
+++ b/tests/tools/test_exec_security.py
@@ -238,6 +238,60 @@ async def test_exec_allows_working_dir_equal_to_workspace(tmp_path):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("command", ["cat link.txt", "cat <link.txt", "cat 0<link.txt"])
+async def test_exec_restricted_workspace_blocks_relative_symlink_escape(tmp_path, command):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.txt"
+    secret.write_text("sentinel-secret", encoding="utf-8")
+    link = workspace / "link.txt"
+    try:
+        link.symlink_to(secret)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+
+    tool = ExecTool(working_dir=str(workspace), restrict_to_workspace=True, timeout=5)
+    result = await tool.execute(command=command)
+
+    assert "path outside working dir" in result
+    assert "sentinel-secret" not in result
+
+
+def test_exec_guard_blocks_relative_symlink_redirect_target(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    target = outside / "target.txt"
+    target.write_text("outside", encoding="utf-8")
+    link = workspace / "link.txt"
+    try:
+        link.symlink_to(target)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+
+    tool = ExecTool(working_dir=str(workspace), restrict_to_workspace=True)
+    error = tool._guard_command("echo pwn >link.txt", str(workspace))
+
+    assert error is not None
+    assert "path outside working dir" in error
+    assert target.read_text(encoding="utf-8") == "outside"
+
+
+def test_exec_guard_allows_relative_workspace_file(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "inside.txt").write_text("ok", encoding="utf-8")
+
+    tool = ExecTool(working_dir=str(workspace), restrict_to_workspace=True)
+    error = tool._guard_command("cat inside.txt", str(workspace))
+
+    assert error is None
+
+
+@pytest.mark.asyncio
 async def test_exec_ignores_workspace_check_when_not_restricted(tmp_path):
     """Without restrict_to_workspace, the LLM may still choose any working_dir."""
     workspace = tmp_path / "workspace"

--- a/tests/tools/test_exec_security.py
+++ b/tests/tools/test_exec_security.py
@@ -9,7 +9,11 @@ from unittest.mock import patch
 import pytest
 
 from nanobot.agent.tools.shell import ExecTool
-from nanobot.security.workspace_access import bind_workspace_scope, build_workspace_scope, reset_workspace_scope
+from nanobot.security.workspace_access import (
+    bind_workspace_scope,
+    build_workspace_scope,
+    reset_workspace_scope,
+)
 
 
 def _fake_resolve_private(hostname, port, family=0, type_=0):
@@ -238,7 +242,16 @@ async def test_exec_allows_working_dir_equal_to_workspace(tmp_path):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("command", ["cat link.txt", "cat <link.txt", "cat 0<link.txt"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cat link.txt",
+        "cat <link.txt",
+        "cat 0<link.txt",
+        "cat link.txt; echo ok",
+        "cat link.txt|wc -c",
+    ],
+)
 async def test_exec_restricted_workspace_blocks_relative_symlink_escape(tmp_path, command):
     workspace = tmp_path / "workspace"
     workspace.mkdir()


### PR DESCRIPTION
## Summary
- block restricted exec commands from following existing relative path operands through symlinks outside the workspace
- keep existing absolute-path, media-dir, URL, and deny/allow guard behavior intact
- add regression coverage for `cat link.txt` escaping through a workspace symlink

Closes #4072.

## Tests
- uv run --extra dev pytest tests/tools/test_exec_security.py tests/tools/test_tool_validation.py -q
- uv run --extra dev pytest tests/tools/test_exec_security.py tests/tools/test_exec_env.py tests/tools/test_exec_platform.py tests/tools/test_exec_session_tools.py -q
- uv run --extra dev ruff check nanobot/agent/tools/shell.py tests/tools/test_exec_security.py --select F