### PR TITLE
test: add scripted agent runner harness

### DIFF
--- a/tests/agent/harness.py
+++ b/tests/agent/harness.py
@@ -1,0 +1,156 @@
+"""Scripted test harness helpers for agent runner tests."""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Iterable, Sequence
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
+
+from nanobot.providers.base import GenerationSettings, LLMResponse, ToolCallRequest
+
+
+def tool_call(
+    name: str,
+    arguments: dict[str, Any] | None = None,
+    *,
+    id: str | None = None,
+) -> ToolCallRequest:
+    """Build a stable tool call for scripted runner tests."""
+    return ToolCallRequest(
+        id=id or f"{name}_call",
+        name=name,
+        arguments=arguments or {},
+    )
+
+
+@dataclass(slots=True)
+class ProviderRequest:
+    """A provider request captured by ``ScriptedProvider``."""
+
+    messages: list[dict[str, Any]]
+    tools: list[dict[str, Any]] | None
+    kwargs: dict[str, Any]
+
+
+@dataclass(slots=True)
+class ToolExecution:
+    """A tool invocation captured by ``ScriptedTools``."""
+
+    name: str
+    arguments: dict[str, Any]
+
+
+class ScriptedTools:
+    """Minimal tool registry double for scripted runner tests."""
+
+    def __init__(
+        self,
+        results: Iterable[Any],
+        *,
+        definitions: Sequence[dict[str, Any]] | None = None,
+    ) -> None:
+        self._results = deque(results)
+        self._definitions = list(definitions or [])
+        self.calls: list[ToolExecution] = []
+
+    def get_definitions(self) -> list[dict[str, Any]]:
+        return deepcopy(self._definitions)
+
+    async def execute(self, name: str, arguments: dict[str, Any]) -> Any:
+        self.calls.append(ToolExecution(name=name, arguments=deepcopy(arguments)))
+        if not self._results:
+            raise AssertionError(f"ScriptedTools received unexpected call to {name}")
+        result = self._results.popleft()
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+
+class ScriptedProvider:
+    """Minimal provider double that returns pre-planned LLM responses.
+
+    The harness records every request so tests can assert the exact transcript
+    the runner sends back to the model after tool calls, injections, and
+    context governance.
+    """
+
+    supports_progress_deltas = False
+
+    def __init__(
+        self,
+        responses: Iterable[LLMResponse],
+        *,
+        default_model: str = "test-model",
+        stream_chunks: Sequence[Sequence[str] | None] | None = None,
+    ) -> None:
+        self._responses = deque(responses)
+        self._stream_chunks = deque(stream_chunks or [])
+        self._default_model = default_model
+        self.generation = GenerationSettings()
+        self.requests: list[ProviderRequest] = []
+
+    def get_default_model(self) -> str:
+        return self._default_model
+
+    def estimate_prompt_tokens(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        model: str | None = None,
+    ) -> tuple[int, str]:
+        return (0, "scripted")
+
+    async def chat_with_retry(self, **kwargs: Any) -> LLMResponse:
+        self._record(kwargs)
+        return self._next_response()
+
+    async def chat_stream_with_retry(
+        self,
+        *,
+        on_content_delta=None,
+        on_thinking_delta=None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        self._record(kwargs)
+        response = self._next_response()
+        if response.reasoning_content and on_thinking_delta is not None:
+            await on_thinking_delta(response.reasoning_content)
+        if on_content_delta is not None:
+            chunks = self._stream_chunks.popleft() if self._stream_chunks else None
+            for chunk in chunks if chunks is not None else [response.content or ""]:
+                await on_content_delta(chunk)
+        return response
+
+    def _record(self, kwargs: dict[str, Any]) -> None:
+        self.requests.append(
+            ProviderRequest(
+                messages=deepcopy(kwargs.get("messages", [])),
+                tools=deepcopy(kwargs.get("tools")),
+                kwargs={k: v for k, v in kwargs.items() if k not in {"messages", "tools"}},
+            ),
+        )
+
+    def _next_response(self) -> LLMResponse:
+        if not self._responses:
+            raise AssertionError("ScriptedProvider received more requests than responses")
+        return self._responses.popleft()
+
+
+def assert_tool_results_are_paired(messages: Sequence[dict[str, Any]]) -> None:
+    """Assert every tool result references a prior assistant tool call."""
+    declared: set[str] = set()
+    orphans: list[str] = []
+    for message in messages:
+        if message.get("role") == "assistant":
+            for call in message.get("tool_calls") or []:
+                if isinstance(call, dict):
+                    call_id = call.get("id")
+                    if isinstance(call_id, str):
+                        declared.add(call_id)
+        if message.get("role") == "tool":
+            call_id = message.get("tool_call_id")
+            if isinstance(call_id, str) and call_id not in declared:
+                orphans.append(call_id)
+    assert orphans == [], f"orphan tool_call_ids: {orphans}"

--- a/tests/agent/test_runner_harness.py
+++ b/tests/agent/test_runner_harness.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 import pytest
 
-from nanobot.agent.runner import AgentRunSpec, AgentRunner
-from nanobot.config.schema import AgentDefaults
-from nanobot.providers.base import LLMResponse
-from tests.agent.harness import (
+from agent.harness import (
     ScriptedProvider,
     ScriptedTools,
     assert_tool_results_are_paired,
     tool_call,
 )
+from nanobot.agent.runner import AgentRunner, AgentRunSpec
+from nanobot.config.schema import AgentDefaults
+from nanobot.providers.base import LLMResponse
 
 _MAX_TOOL_RESULT_CHARS = AgentDefaults().max_tool_result_chars
 

--- a/tests/agent/test_runner_harness.py
+++ b/tests/agent/test_runner_harness.py
@@ -1,0 +1,132 @@
+"""Tests that exercise the reusable scripted agent harness."""
+
+from __future__ import annotations
+
+import pytest
+
+from nanobot.agent.runner import AgentRunSpec, AgentRunner
+from nanobot.config.schema import AgentDefaults
+from nanobot.providers.base import LLMResponse
+from tests.agent.harness import (
+    ScriptedProvider,
+    ScriptedTools,
+    assert_tool_results_are_paired,
+    tool_call,
+)
+
+_MAX_TOOL_RESULT_CHARS = AgentDefaults().max_tool_result_chars
+
+
+@pytest.mark.asyncio
+async def test_scripted_provider_drives_tool_loop_transcript() -> None:
+    provider = ScriptedProvider([
+        LLMResponse(
+            content="I will inspect the file.",
+            tool_calls=[tool_call("read_file", {"path": "README.md"}, id="read_1")],
+            reasoning_content="Need to inspect first.",
+            usage={"prompt_tokens": 7, "completion_tokens": 3},
+        ),
+        LLMResponse(
+            content="README says hello.",
+            usage={"prompt_tokens": 11, "completion_tokens": 5},
+        ),
+    ])
+    tools = ScriptedTools(
+        ["hello from README"],
+        definitions=[{"type": "function", "function": {"name": "read_file"}}],
+    )
+
+    result = await AgentRunner(provider).run(
+        AgentRunSpec(
+            initial_messages=[{"role": "user", "content": "Summarize README.md"}],
+            tools=tools,
+            model="test-model",
+            max_iterations=3,
+            max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        ),
+    )
+
+    assert result.final_content == "README says hello."
+    assert result.tools_used == ["read_file"]
+    assert result.usage == {
+        "prompt_tokens": 18,
+        "completion_tokens": 8,
+        "total_tokens": 26,
+        "provider_tokens": 26,
+    }
+    assert tools.calls[0].name == "read_file"
+    assert tools.calls[0].arguments == {"path": "README.md"}
+    assert len(provider.requests) == 2
+
+    second_request = provider.requests[1]
+    assert_tool_results_are_paired(second_request.messages)
+    assert second_request.messages == [
+        {"role": "user", "content": "Summarize README.md"},
+        {
+            "role": "assistant",
+            "content": "I will inspect the file.",
+            "tool_calls": [
+                {
+                    "id": "read_1",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": '{"path": "README.md"}',
+                    },
+                },
+            ],
+            "reasoning_content": "Need to inspect first.",
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "read_1",
+            "name": "read_file",
+            "content": "hello from README",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_scripted_harness_covers_multi_tool_transcript_pairing() -> None:
+    provider = ScriptedProvider([
+        LLMResponse(
+            content="I need both files.",
+            tool_calls=[
+                tool_call("read_file", {"path": "pyproject.toml"}, id="read_pyproject"),
+                tool_call("read_file", {"path": "README.md"}, id="read_readme"),
+            ],
+        ),
+        LLMResponse(content="Both files were inspected."),
+    ])
+    tools = ScriptedTools(["pyproject content", "readme content"])
+
+    result = await AgentRunner(provider).run(
+        AgentRunSpec(
+            initial_messages=[{"role": "user", "content": "Inspect project files"}],
+            tools=tools,
+            model="test-model",
+            max_iterations=3,
+            max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        ),
+    )
+
+    assert result.final_content == "Both files were inspected."
+    assert [call.arguments["path"] for call in tools.calls] == [
+        "pyproject.toml",
+        "README.md",
+    ]
+    assert_tool_results_are_paired(result.messages)
+    assert provider.requests[1].messages[-2:] == [
+        {
+            "role": "tool",
+            "tool_call_id": "read_pyproject",
+            "name": "read_file",
+            "content": "pyproject content",
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "read_readme",
+            "name": "read_file",
+            "content": "readme content",
+        },
+    ]


### PR DESCRIPTION
## Summary
- add a reusable scripted provider harness for agent runner tests
- capture provider requests so runner tests can assert the exact transcript sent back to the model
- cover a full tool-loop script: model tool call, tool result insertion, final model response, and usage accumulation

## Validation
- `uv run --extra dev pytest tests/agent/test_runner_harness.py tests/agent/test_runner_core.py -q`
- `uv run --extra dev ruff check tests/agent/harness.py tests/agent/test_runner_harness.py --select F`