### PR TITLE
fix(agent): avoid tool compaction echo loops

### DIFF
--- a/nanobot/agent/context_governance.py
+++ b/nanobot/agent/context_governance.py
@@ -427,7 +427,7 @@ class ContextGovernor:
     @staticmethod
     def _summary_for(message: dict[str, Any]) -> str:
         name = message.get("name", "tool")
-        return f"[{name} result omitted from context]"
+        return f"[Prior {name} result compacted to fit context; the tool call already completed.]"
 
     def _legal_history_tail(
         self,

--- a/tests/agent/test_runner_governance.py
+++ b/tests/agent/test_runner_governance.py
@@ -550,7 +550,7 @@ def test_microcompact_overflow_compacts_to_low_watermark(monkeypatch):
     def estimate(_provider, _model, msgs, _tools):
         return sum(
             100 if (content := msg.get("content")) == long_content
-            else 1 if isinstance(content, str) and "omitted from context" in content
+            else 1 if isinstance(content, str) and "compacted to fit context" in content
             else 0
             for msg in msgs
             if msg.get("role") == "tool"
@@ -564,7 +564,7 @@ def test_microcompact_overflow_compacts_to_low_watermark(monkeypatch):
         set(),
     )
     tool_msgs = [m for m in result if m.get("role") == "tool"]
-    compacted = [m for m in tool_msgs if "omitted from context" in str(m.get("content", ""))]
+    compacted = [m for m in tool_msgs if "compacted to fit context" in str(m.get("content", ""))]
     preserved = [m for m in tool_msgs if m.get("content") == long_content]
 
     assert len(compacted) == 8
@@ -609,7 +609,7 @@ def test_microcompact_compacts_newest_when_it_alone_overflows(monkeypatch):
     )
 
     tool_msg = next(m for m in result if m.get("role") == "tool")
-    assert "omitted from context" in tool_msg["content"]
+    assert "compacted to fit context" in tool_msg["content"]
     assert compacted_tool_call_ids == {"c0"}
 
 


### PR DESCRIPTION
## Summary

Fixes future feedback loops where compacted tool-result placeholders can look like tool failures to the model.

## Root Cause

Context governance can compact stale tool results into short placeholders. The old placeholder text looked like a missing tool result:

`[read_file result omitted from context]`

In long review sessions, that wording can lead the model to investigate whether `read_file` or `exec` output was lost even though the tool call had already completed.

## Changes

- Reword compacted tool-result placeholders to explicitly say the prior tool call completed and was compacted only to fit context.
- Update microcompact tests to match the new wording.

No legacy-session migration or hidden-reasoning cleanup is included; old sessions are left as-is.

## Validation

- `uv run --extra dev pytest tests/agent/test_runner_governance.py -q` — 28 passed
- `ruff check nanobot/agent/context_governance.py tests/agent/test_runner_governance.py` — passed
- `git diff --check` — passed