### PR TITLE
feat(webui): notify when a background chat finishes

### DIFF
--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -44,6 +44,7 @@ import type {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { fetchSettings, fetchWorkspaces } from "@/lib/api";
+import { showTurnCompleteNotification } from "@/lib/notifications";
 import {
   createRuntimeHost,
   getHostApi,
@@ -1242,8 +1243,31 @@ function Shell({
     });
   }, [client, onModelNameChange]);
 
+  const notifyTurnCompleted = useCallback((chatId: string) => {
+    if (
+      document.visibilityState === "visible"
+      && document.hasFocus()
+      && view === "chat"
+      && activeChatIdRef.current === chatId
+    ) {
+      return;
+    }
+    const session = sessions.find((candidate) => candidate.chatId === chatId);
+    const chatTitle = session
+      ? displayTitle(session, sidebarState.title_overrides, t("chat.newChat"))
+      : t("app.brand");
+    showTurnCompleteNotification({
+      chatId,
+      title: t("notifications.turnComplete.title", { defaultValue: "Nanobot finished" }),
+      body: t("notifications.turnComplete.body", {
+        defaultValue: "{{title}} is ready for your reply.",
+        title: chatTitle,
+      }),
+    });
+  }, [sessions, sidebarState.title_overrides, t, view]);
+
   useEffect(() => {
-    return client.onRunStatus((chatId, startedAt) => {
+    return client.onRunStatus((chatId, startedAt, completed) => {
       if (startedAt != null) {
         const nextRunning = new Set(runningChatIdsRef.current);
         nextRunning.add(chatId);
@@ -1258,7 +1282,9 @@ function Shell({
         return;
       }
 
-      if (!runningChatIdsRef.current.has(chatId)) return;
+      const wasRunning = runningChatIdsRef.current.has(chatId);
+      if (!wasRunning && !completed) return;
+      if (completed) notifyTurnCompleted(chatId);
       const nextRunning = new Set(runningChatIdsRef.current);
       nextRunning.delete(chatId);
       runningChatIdsRef.current = nextRunning;
@@ -1273,7 +1299,7 @@ function Shell({
         return next;
       });
     });
-  }, [client]);
+  }, [client, notifyTurnCompleted]);
 
   useEffect(() => {
     return client.onStatus((status) => {

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -110,6 +110,13 @@ import { getHostApi } from "@/lib/runtime";
 import { notifyMcpPresetsChanged } from "@/lib/mcp-preset-events";
 import { fmtDateTime, relativeTime } from "@/lib/format";
 import {
+  getBrowserNotificationPermission,
+  getTurnNotificationsEnabled,
+  requestTurnNotificationsPermission,
+  setTurnNotificationsEnabled,
+  showTestNotification,
+} from "@/lib/notifications";
+import {
   logoFallbackUrls,
   providerBrand,
   providerDisplayLabel,
@@ -2172,6 +2179,39 @@ function AppearanceSettings({
 }) {
   const { t } = useTranslation();
   const tx = (key: string, fallback: string) => t(key, { defaultValue: fallback });
+  const [turnNotificationsEnabled, setTurnNotificationsEnabledState] = useState(
+    () => getTurnNotificationsEnabled(),
+  );
+  const [notificationPermission, setNotificationPermission] = useState(
+    () => getBrowserNotificationPermission(),
+  );
+  const notificationUnavailable = notificationPermission === "unsupported";
+  const notificationDenied = notificationPermission === "denied";
+  const turnNotificationsActive = turnNotificationsEnabled && notificationPermission === "granted";
+  const handleTurnNotificationsChange = async (enabled: boolean) => {
+    if (!enabled) {
+      setTurnNotificationsEnabled(false);
+      setTurnNotificationsEnabledState(false);
+      setNotificationPermission(getBrowserNotificationPermission());
+      return;
+    }
+    const permission = await requestTurnNotificationsPermission();
+    setNotificationPermission(permission);
+    const allowed = permission === "granted";
+    setTurnNotificationsEnabled(allowed);
+    setTurnNotificationsEnabledState(allowed);
+    if (allowed) {
+      showTestNotification(
+        tx("notifications.test.title", "Nanobot notifications enabled"),
+        tx("notifications.test.body", "You will be notified when a background chat finishes."),
+      );
+    }
+  };
+  const notificationHelp = notificationUnavailable
+    ? tx("settings.help.turnNotificationsUnsupported", "Desktop notifications are not supported in this browser.")
+    : notificationDenied
+      ? tx("settings.help.turnNotificationsDenied", "Notifications are blocked in browser settings.")
+      : tx("settings.help.turnNotifications", "Show a desktop notification when a background chat finishes.");
   return (
     <div className="space-y-7">
       <section>
@@ -2267,6 +2307,19 @@ function AppearanceSettings({
               onChange={(brandLogos) => onChangeLocalPrefs((prev) => ({ ...prev, brandLogos }))}
               ariaLabel={tx("settings.rows.brandLogos", "Brand logos")}
               label={localPrefs.brandLogos ? tx("settings.values.on", "On") : tx("settings.values.off", "Off")}
+            />
+          </SettingsRow>
+          <SettingsRow
+            title={tx("settings.rows.turnNotifications", "Turn notifications")}
+            description={notificationHelp}
+          >
+            <ToggleButton
+              checked={turnNotificationsActive}
+              onChange={(enabled) => {
+                void handleTurnNotificationsChange(enabled);
+              }}
+              ariaLabel={tx("settings.rows.turnNotifications", "Turn notifications")}
+              label={turnNotificationsActive ? tx("settings.values.on", "On") : tx("settings.values.off", "Off")}
             />
           </SettingsRow>
         </SettingsGroup>

--- a/webui/src/lib/nanobot-client.ts
+++ b/webui/src/lib/nanobot-client.ts
@@ -72,7 +72,7 @@ type SessionUpdateHandler = (
   scope?: SessionUpdateScope,
   workspaceScope?: WorkspaceScopePayload,
 ) => void;
-type RunStatusHandler = (chatId: string, startedAt: number | null) => void;
+type RunStatusHandler = (chatId: string, startedAt: number | null, completed?: boolean) => void;
 
 /** Structured errors surfaced to the UI.
  *
@@ -229,10 +229,8 @@ export class NanobotClient {
 
   private recordGoalStatusForRunStrip(chatId: string, ev: InboundEvent): void {
     if (ev.event === "turn_end") {
-      if (this.runStartedAtByChatId.has(chatId)) {
-        this.runStartedAtByChatId.delete(chatId);
-        this.emitRunStatus(chatId, null);
-      }
+      this.runStartedAtByChatId.delete(chatId);
+      this.emitRunStatus(chatId, null, true);
       return;
     }
     if (ev.event !== "goal_status") return;
@@ -242,7 +240,7 @@ export class NanobotClient {
       if (previous !== ev.started_at) this.emitRunStatus(chatId, ev.started_at);
     } else if (this.runStartedAtByChatId.has(chatId)) {
       this.runStartedAtByChatId.delete(chatId);
-      this.emitRunStatus(chatId, null);
+      this.emitRunStatus(chatId, null, true);
     }
   }
 
@@ -545,9 +543,10 @@ export class NanobotClient {
     }
   }
 
-  private emitRunStatus(chatId: string, startedAt: number | null): void {
+  private emitRunStatus(chatId: string, startedAt: number | null, completed = false): void {
     for (const handler of this.runStatusHandlers) {
-      handler(chatId, startedAt);
+      if (completed) handler(chatId, startedAt, true);
+      else handler(chatId, startedAt);
     }
   }
 

--- a/webui/src/lib/notifications.ts
+++ b/webui/src/lib/notifications.ts
@@ -1,0 +1,73 @@
+const TURN_NOTIFICATIONS_KEY = "nanobot-webui.turn-notifications.v1";
+
+export type BrowserNotificationPermission = NotificationPermission | "unsupported";
+
+export function getTurnNotificationsEnabled(): boolean {
+  try {
+    return window.localStorage.getItem(TURN_NOTIFICATIONS_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function setTurnNotificationsEnabled(enabled: boolean): void {
+  try {
+    if (enabled) {
+      window.localStorage.setItem(TURN_NOTIFICATIONS_KEY, "1");
+    } else {
+      window.localStorage.removeItem(TURN_NOTIFICATIONS_KEY);
+    }
+  } catch {
+    // ignore storage errors (private mode, etc.)
+  }
+}
+
+export function getBrowserNotificationPermission(): BrowserNotificationPermission {
+  if (typeof window === "undefined" || !("Notification" in window)) return "unsupported";
+  return window.Notification.permission;
+}
+
+export async function requestTurnNotificationsPermission(): Promise<BrowserNotificationPermission> {
+  if (typeof window === "undefined" || !("Notification" in window)) return "unsupported";
+  if (window.Notification.permission !== "default") return window.Notification.permission;
+  return window.Notification.requestPermission();
+}
+
+export function showTurnCompleteNotification({
+  chatId,
+  title,
+  body,
+}: {
+  chatId: string;
+  title: string;
+  body: string;
+}): boolean {
+  if (!getTurnNotificationsEnabled()) return false;
+  if (getBrowserNotificationPermission() !== "granted") return false;
+  try {
+    const options: NotificationOptions & { renotify?: boolean } = {
+      body,
+      icon: "/brand/nanobot_icon.png",
+      renotify: true,
+      tag: `nanobot-turn-${chatId}`,
+    };
+    new window.Notification(title, options);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function showTestNotification(title: string, body: string): boolean {
+  if (getBrowserNotificationPermission() !== "granted") return false;
+  try {
+    new window.Notification(title, {
+      body,
+      icon: "/brand/nanobot_icon.png",
+      tag: "nanobot-test-notification",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -12,7 +12,7 @@ const getSessionAutomationsSpy = vi.fn<(key: string) => Promise<SessionAutomatio
 const toggleThemeSpy = vi.fn();
 const updateUrlSpy = vi.fn();
 const attachSpy = vi.fn();
-const runStatusHandlers = new Set<(chatId: string, startedAt: number | null) => void>();
+const runStatusHandlers = new Set<(chatId: string, startedAt: number | null, completed?: boolean) => void>();
 const sessionUpdateHandlers = new Set<(chatId: string, scope?: string) => void>();
 let mockSessions: ChatSummary[] = [];
 const HERO_GREETING_PATTERN =
@@ -199,7 +199,7 @@ vi.mock("@/lib/nanobot-client", () => {
       sessionUpdateHandlers.add(handler);
       return () => sessionUpdateHandlers.delete(handler);
     };
-    onRunStatus = (handler: (chatId: string, startedAt: number | null) => void) => {
+    onRunStatus = (handler: (chatId: string, startedAt: number | null, completed?: boolean) => void) => {
       runStatusHandlers.add(handler);
       return () => runStatusHandlers.delete(handler);
     };
@@ -237,6 +237,7 @@ describe("App layout", () => {
     localStorage.removeItem("nanobot-webui.sidebar");
     localStorage.removeItem("nanobot-webui.sidebar.completed-runs.v1");
     localStorage.removeItem("nanobot-webui.sidebar.session-updates.v1");
+    localStorage.removeItem("nanobot-webui.turn-notifications.v1");
     vi.mocked(fetchBootstrap).mockReset().mockResolvedValue({
       token: "tok",
       ws_path: "/",
@@ -1127,7 +1128,7 @@ describe("App layout", () => {
     expect(within(sidebar).getByTitle("Agent running")).toBeInTheDocument();
 
     act(() => {
-      for (const handler of runStatusHandlers) handler("chat-a", null);
+      for (const handler of runStatusHandlers) handler("chat-a", null, true);
     });
     expect(within(sidebar).queryByTitle("Agent running")).not.toBeInTheDocument();
     expect(within(sidebar).getByTitle("New activity")).toBeInTheDocument();
@@ -1179,7 +1180,7 @@ describe("App layout", () => {
     expect(within(sidebar).getByTitle("Agent running")).toBeInTheDocument();
 
     act(() => {
-      for (const handler of runStatusHandlers) handler("chat-a", null);
+      for (const handler of runStatusHandlers) handler("chat-a", null, true);
     });
     expect(within(sidebar).queryByTitle("Agent running")).not.toBeInTheDocument();
     expect(within(sidebar).queryByTitle("New activity")).not.toBeInTheDocument();
@@ -1188,6 +1189,100 @@ describe("App layout", () => {
       fireEvent.click(within(sidebar).getByRole("button", { name: /^Other chat$/ }));
     });
     expect(within(sidebar).queryByTitle("New activity")).not.toBeInTheDocument();
+  });
+
+  it("shows a desktop notification when an inactive session finishes", async () => {
+    const notifications: Array<{ title: string; options?: NotificationOptions }> = [];
+    class FakeNotification {
+      static permission: NotificationPermission = "granted";
+      static requestPermission = vi.fn(async () => FakeNotification.permission);
+
+      constructor(title: string, options?: NotificationOptions) {
+        notifications.push({ title, options });
+      }
+    }
+    Object.defineProperty(window, "Notification", {
+      configurable: true,
+      value: FakeNotification,
+    });
+    localStorage.setItem("nanobot-webui.turn-notifications.v1", "1");
+    mockSessions = [
+      {
+        key: "websocket:chat-a",
+        channel: "websocket",
+        chatId: "chat-a",
+        createdAt: "2026-04-16T10:00:00Z",
+        updatedAt: "2026-04-16T10:00:00Z",
+        preview: "Background work",
+      },
+    ];
+
+    render(<App />);
+
+    await waitFor(() => expect(connectSpy).toHaveBeenCalled());
+    act(() => {
+      for (const handler of runStatusHandlers) handler("chat-a", 12_345);
+      for (const handler of runStatusHandlers) handler("chat-a", null, true);
+    });
+
+    expect(notifications).toEqual([
+      {
+        title: "Nanobot finished",
+        options: {
+          body: "Background work is ready for your reply.",
+          icon: "/brand/nanobot_icon.png",
+          renotify: true,
+          tag: "nanobot-turn-chat-a",
+        },
+      },
+    ]);
+  });
+
+  it("shows a desktop notification when the active session finishes without focus", async () => {
+    const notifications: Array<{ title: string; options?: NotificationOptions }> = [];
+    class FakeNotification {
+      static permission: NotificationPermission = "granted";
+      static requestPermission = vi.fn(async () => FakeNotification.permission);
+
+      constructor(title: string, options?: NotificationOptions) {
+        notifications.push({ title, options });
+      }
+    }
+    Object.defineProperty(window, "Notification", {
+      configurable: true,
+      value: FakeNotification,
+    });
+    const hasFocusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    localStorage.setItem("nanobot-webui.turn-notifications.v1", "1");
+    mockSessions = [
+      {
+        key: "websocket:chat-a",
+        channel: "websocket",
+        chatId: "chat-a",
+        createdAt: "2026-04-16T10:00:00Z",
+        updatedAt: "2026-04-16T10:00:00Z",
+        preview: "Active work",
+      },
+    ];
+
+    try {
+      render(<App />);
+
+      await waitFor(() => expect(connectSpy).toHaveBeenCalled());
+      const sidebar = screen.getByRole("navigation", { name: "Sidebar navigation" });
+      await act(async () => {
+        fireEvent.click(within(sidebar).getByRole("button", { name: /^Active work$/ }));
+      });
+
+      act(() => {
+        for (const handler of runStatusHandlers) handler("chat-a", 12_345);
+        for (const handler of runStatusHandlers) handler("chat-a", null, true);
+      });
+
+      expect(notifications).toHaveLength(1);
+    } finally {
+      hasFocusSpy.mockRestore();
+    }
   });
 
   it("marks inactive sessions when a thread update arrives", async () => {

--- a/webui/src/tests/nanobot-client.test.ts
+++ b/webui/src/tests/nanobot-client.test.ts
@@ -235,7 +235,13 @@ describe("NanobotClient", () => {
       chat_id: "chat-strip",
     });
     expect(client.getRunStartedAt("chat-strip")).toBeNull();
-    expect(handler).toHaveBeenLastCalledWith("chat-strip", null);
+    expect(handler).toHaveBeenLastCalledWith("chat-strip", null, true);
+
+    lastSocket().fakeMessage({
+      event: "turn_end",
+      chat_id: "chat-missed-running",
+    });
+    expect(handler).toHaveBeenLastCalledWith("chat-missed-running", null, true);
   });
 
   it("notifies run status subscribers and replays running chats", () => {
@@ -265,8 +271,8 @@ describe("NanobotClient", () => {
       chat_id: "chat-status",
       status: "idle",
     });
-    expect(handler).toHaveBeenCalledWith("chat-status", null);
-    expect(lateHandler).toHaveBeenCalledWith("chat-status", null);
+    expect(handler).toHaveBeenCalledWith("chat-status", null, true);
+    expect(lateHandler).toHaveBeenCalledWith("chat-status", null, true);
   });
 
   it("records goal_state per chat_id without an onChat subscriber", () => {

--- a/webui/src/tests/setup.ts
+++ b/webui/src/tests/setup.ts
@@ -27,7 +27,11 @@ function createTestStorage(): Storage {
   };
 }
 
-if (typeof window !== "undefined" && typeof localStorage.setItem !== "function") {
+if (
+  typeof window !== "undefined" &&
+  (typeof globalThis.localStorage === "undefined" ||
+    typeof globalThis.localStorage.setItem !== "function")
+) {
   const storage = createTestStorage();
   Object.defineProperty(window, "localStorage", {
     value: storage,


### PR DESCRIPTION
## Summary

Adds **opt-in desktop notifications** that fire when an agent turn completes in a chat that is **not** the currently focused, active conversation — so you can kick off background work, switch tabs, and get pinged when a reply is ready.

## What changed

- **`webui/src/lib/notifications.ts`** (new): thin wrapper over the browser `Notification` API. Gated by a `localStorage` preference **and** the granted permission, with graceful fallbacks when notifications are `unsupported`/`denied`. Notifications are tagged per `chatId` so repeated completions of the same chat re-alert rather than stack.
- **`nanobot-client.ts`**: `emitRunStatus` now carries a `completed` flag, and `turn_end` always reports completion. This surfaces runs that started *before* the client attached (missed-`running` case). The start-emit call signature is left as 2-arg to preserve existing subscriber contracts.
- **`App.tsx`**: on completion, suppresses the notification when the finished chat is visible, focused **and** active; otherwise shows one titled with the chat's display title.
- **`SettingsView.tsx`**: new "Turn notifications" toggle under Appearance that requests permission on enable, reflects `denied`/`unsupported` state in its help text, and fires a confirmation notification when granted.
- **`tests/setup.ts`**: hardened the test `localStorage` shim to install when the global is absent.

## Notes on correctness

- On **disconnect** the client emits `null` *without* `completed`, so no false "finished" notifications when the socket drops.
- On **(re)subscribe** the server only replays `goal_status: running` (never `turn_end`), so reconnecting does not spuriously notify for already-finished chats.
- New strings use i18n `defaultValue` fallbacks (English), consistent with how not-yet-translated UI strings are staged in this codebase (avoids breaking the locale key-parity test).

## Testing

- `bun run lint` — clean
- `tsc -p tsconfig.build.json --noEmit` — clean
- `vitest run` — **436 passed**, including two new App-layout tests (inactive session finishes; active session finishes without focus) and a client test for the missed-`running` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)