### PR TITLE
fix(pairing): restore durable atomic writes

### DIFF
--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -2,6 +2,7 @@
 
 import base64
 import json
+import os
 import re
 import shutil
 import time
@@ -447,8 +448,17 @@ def _cleanup_tool_result_buckets(root: Path, current_bucket: Path) -> None:
 def _write_text_atomic(path: Path, content: str) -> None:
     tmp = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
     try:
-        tmp.write_text(content, encoding="utf-8")
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
         tmp.replace(path)
+        with suppress(OSError, NotImplementedError):
+            dfd = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(dfd)
+            finally:
+                os.close(dfd)
     finally:
         if tmp.exists():
             tmp.unlink(missing_ok=True)

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1,6 +1,9 @@
+from pathlib import Path
+
 import tiktoken
 
-from nanobot.utils.helpers import split_message, truncate_text_to_tokens
+from nanobot.utils import helpers
+from nanobot.utils.helpers import _write_text_atomic, split_message, truncate_text_to_tokens
 
 
 def test_split_message_no_code_blocks_unchanged():
@@ -31,3 +34,44 @@ def test_truncate_text_to_tokens_non_positive_budget_returns_text():
     text = "anything"
 
     assert truncate_text_to_tokens(text, 0) == text
+
+
+def test_write_text_atomic_fsyncs_file_and_parent_directory(
+    tmp_path: Path, monkeypatch
+) -> None:
+    target = tmp_path / "pairing.json"
+    fsync_calls: list[int] = []
+    closed_fds: list[int] = []
+
+    def fake_fsync(fd: int) -> None:
+        fsync_calls.append(fd)
+
+    monkeypatch.setattr(helpers.os, "fsync", fake_fsync)
+    monkeypatch.setattr(helpers.os, "open", lambda path, flags: 12345)
+    monkeypatch.setattr(helpers.os, "close", lambda fd: closed_fds.append(fd))
+
+    _write_text_atomic(target, '{"approved": {}}')
+
+    assert target.read_text(encoding="utf-8") == '{"approved": {}}'
+    assert len(fsync_calls) == 2
+    assert fsync_calls[0] != 12345
+    assert fsync_calls[1] == 12345
+    assert closed_fds == [12345]
+
+
+def test_write_text_atomic_keeps_file_when_directory_fsync_is_unsupported(
+    tmp_path: Path, monkeypatch
+) -> None:
+    target = tmp_path / "pairing.json"
+    fsync_calls: list[int] = []
+
+    def fake_open(path, flags):
+        raise OSError("directory fsync unsupported")
+
+    monkeypatch.setattr(helpers.os, "fsync", lambda fd: fsync_calls.append(fd))
+    monkeypatch.setattr(helpers.os, "open", fake_open)
+
+    _write_text_atomic(target, '{"pending": {}}')
+
+    assert target.read_text(encoding="utf-8") == '{"pending": {}}'
+    assert len(fsync_calls) == 1


### PR DESCRIPTION
 ## Summary

  Restore crash-durable atomic writes in `_write_text_atomic` by fsyncing the temporary file before replace and best-effort fsyncing the parent directory after replace.

  This fixes a regression where `pairing._save()` was refactored to use the shared helper, but the helper did not preserve the file/directory fsync behavior previously
  added for pairing store durability. Without this, recently approved senders could be lost after a crash or power loss, causing users to be asked to pair again.

  ## Changes

  - Add file `flush()` + `os.fsync()` before atomic replace.
  - Add best-effort parent directory fsync after replace for durable dirent persistence.
  - Keep directory fsync tolerant of unsupported platforms.
  - Add regression tests for file fsync, directory fsync, and unsupported directory fsync behavior.
