### PR TITLE
fix(cli): print response text when streaming fails in interactive mode

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1485,6 +1485,17 @@ def agent(
                                 )
                             continue
                         if isinstance(event, StreamedResponseEvent):
+                            if msg.content and renderer and not renderer.streamed:
+                                await renderer.close()
+                                print_kwargs: dict[str, Any] = {}
+                                if renderer.header_printed:
+                                    print_kwargs["show_header"] = False
+                                _print_agent_response(
+                                    msg.content,
+                                    render_markdown=markdown,
+                                    metadata=msg.metadata,
+                                    **print_kwargs,
+                                )
                             turn_done.set()
                             continue
 


### PR DESCRIPTION
## Summary

In interactive mode, the final `StreamedResponseEvent` handler silently dropped `msg.content`, so the complete answer was lost whenever streaming was requested but no `StreamDeltaEvent`s actually arrived (e.g. a provider returned a complete response without invoking the stream callback, or the fallback provider recovered content). In that case `renderer.streamed` stays `False`, the buffered path in `on_end` prints nothing, and the user sees no answer.

When a `StreamedResponseEvent` arrives with content and the renderer never streamed, close the renderer and print the final response directly. This mirrors the existing non-interactive run-once fallback at `nanobot/cli/commands.py:1420-1430`.

## Changes

- `nanobot/cli/commands.py`: in the interactive `_consume_outbound` handler, when a `StreamedResponseEvent` carries content and `renderer` is present but `renderer.streamed` is `False`, call `renderer.close()` and print the content via `_print_agent_response` (suppressing the header if the renderer already printed one) before signaling turn completion.

## Notes

- Scope is intentionally minimal: it reuses the exact pattern already used in the run-once path.
- `StreamRenderer.close()` is idempotent, so the subsequent post-turn cleanup calling `close()` again is harmless.
- Follow-up (separate PR, intentionally not included here to keep this fix small): extract the duplicated "renderer didn't stream -> print final response" block (now at `commands.py:1420-1430` and `commands.py:1488-1498`) into a small helper to keep the two code paths from drifting.