### PR TITLE
fix: contain malformed mcp tool results

### DIFF
--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -461,10 +461,19 @@ class MCPToolWrapper(_MCPWrapperBase):
                 return f"(MCP tool call failed: {type(exc).__name__})"
             else:
                 # Success — extract text and persist any image content as artifacts.
-                rendered = self._render_call_result(result.content, kwargs)
-                if getattr(result, "isError", False):
-                    return ToolResult.error(rendered)
-                return rendered
+                try:
+                    rendered = self._render_call_result(result.content, kwargs)
+                    if getattr(result, "isError", False):
+                        return ToolResult.error(rendered)
+                    return rendered
+                except Exception as exc:
+                    logger.exception(
+                        "MCP tool '{}' failed while rendering result: {}: {}",
+                        self._name,
+                        type(exc).__name__,
+                        exc,
+                    )
+                    return f"(MCP tool call failed: {type(exc).__name__})"
 
         return "(MCP tool call failed)"  # Unreachable, but satisfies type checkers
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -321,6 +321,18 @@ async def test_execute_wraps_mcp_is_error_result() -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_contains_malformed_success_result() -> None:
+    async def call_tool(_name: str, arguments: dict) -> object:
+        return SimpleNamespace(content=None)
+
+    wrapper = _make_wrapper(SimpleNamespace(call_tool=call_tool))
+
+    result = await wrapper.execute()
+
+    assert result == "(MCP tool call failed: TypeError)"
+
+
+@pytest.mark.asyncio
 async def test_execute_preserves_success_text_that_starts_with_error() -> None:
     async def call_tool(_name: str, arguments: dict) -> object:
         return SimpleNamespace(


### PR DESCRIPTION
## Summary
- contain exceptions raised while rendering successful MCP tool-call results
- return a model-visible MCP tool error instead of propagating malformed/empty result crashes
- add regression coverage for a successful MCP response with empty content

Fixes #4652

## Verification
- uv run pytest tests/tools/test_mcp_tool.py::test_execute_contains_malformed_success_result tests/tools/test_mcp_tool.py::test_execute_handles_generic_exception -q
- uv run ruff check nanobot/agent/tools/mcp.py tests/tools/test_mcp_tool.py