### PR TITLE
fix: separate file edit progress ids

### DIFF
--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -461,6 +461,7 @@ class AgentRunner:
                     response.tool_calls,
                     external_lookup_counts,
                     workspace_violation_counts,
+                    response.file_edit_progress_ids,
                 )
                 tool_events.extend(new_events)
                 tools_used.extend(
@@ -861,7 +862,10 @@ class AgentRunner:
             if live_file_edits is not None:
                 await live_file_edits.flush()
                 if response.should_execute_tools:
-                    live_file_edits.apply_final_call_ids(response.tool_calls)
+                    response.file_edit_progress_ids = [
+                        live_file_edits.progress_id_for(tool_call)
+                        for tool_call in response.tool_calls
+                    ]
                 await live_file_edits.error_unmatched(
                     response.tool_calls if response.should_execute_tools else [],
                     "Tool call did not complete.",
@@ -1131,14 +1135,21 @@ class AgentRunner:
         tool_calls: list[ToolCallRequest],
         external_lookup_counts: dict[str, int],
         workspace_violation_counts: dict[str, int],
+        file_edit_progress_ids: list[str | None] | None = None,
     ) -> tuple[list[Any], list[dict[str, str]], BaseException | None]:
         batches = self._partition_tool_batches(spec, tool_calls)
+        progress_id_by_call = {
+            id(tool_call): file_edit_progress_ids[idx]
+            for idx, tool_call in enumerate(tool_calls)
+            if file_edit_progress_ids and idx < len(file_edit_progress_ids)
+        }
         tool_results: list[tuple[Any, dict[str, str], BaseException | None]] = []
         for batch in batches:
             if spec.concurrent_tools and len(batch) > 1:
                 batch_results = await asyncio.gather(*(
                     self._run_tool(
                         spec, tool_call, external_lookup_counts, workspace_violation_counts,
+                        progress_id_by_call.get(id(tool_call)),
                     )
                     for tool_call in batch
                 ))
@@ -1148,6 +1159,7 @@ class AgentRunner:
                 for tool_call in batch:
                     result = await self._run_tool(
                         spec, tool_call, external_lookup_counts, workspace_violation_counts,
+                        progress_id_by_call.get(id(tool_call)),
                     )
                     tool_results.append(result)
                     batch_results.append(result)
@@ -1168,6 +1180,7 @@ class AgentRunner:
         tool_call: ToolCallRequest,
         external_lookup_counts: dict[str, int],
         workspace_violation_counts: dict[str, int],
+        file_edit_progress_id: str | None = None,
     ) -> tuple[Any, dict[str, str], BaseException | None]:
         hint = "\n\n[Analyze the error above and try a different approach.]"
         lookup_error = repeated_external_lookup_error(
@@ -1221,6 +1234,7 @@ class AgentRunner:
                 tool=tool,
                 workspace=spec.workspace,
                 params=params if isinstance(params, dict) else None,
+                progress_id=file_edit_progress_id,
             )
             if progress_callback is not None
             else None

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -163,6 +163,7 @@ class LLMResponse:
     error_code: str | None = None  # Provider/code semantic, e.g. rate_limit_exceeded.
     error_retry_after_s: float | None = None
     error_should_retry: bool | None = None
+    file_edit_progress_ids: list[str | None] = field(default_factory=list)
 
     @property
     def has_tool_calls(self) -> bool:

--- a/nanobot/utils/file_edit_events.py
+++ b/nanobot/utils/file_edit_events.py
@@ -41,6 +41,7 @@ class FileEditTracker:
     path: Path
     display_path: str
     before: FileSnapshot
+    progress_id: str | None = None
 
 
 def is_file_edit_tool(tool_name: str | None) -> bool:
@@ -151,6 +152,7 @@ def prepare_file_edit_tracker(
     tool: Any,
     workspace: Path | None,
     params: dict[str, Any] | None,
+    progress_id: str | None = None,
 ) -> FileEditTracker | None:
     trackers = prepare_file_edit_trackers(
         call_id=call_id,
@@ -158,6 +160,7 @@ def prepare_file_edit_tracker(
         tool=tool,
         workspace=workspace,
         params=params,
+        progress_id=progress_id,
     )
     return trackers[0] if trackers else None
 
@@ -169,6 +172,7 @@ def prepare_file_edit_trackers(
     tool: Any,
     workspace: Path | None,
     params: dict[str, Any] | None,
+    progress_id: str | None = None,
 ) -> list[FileEditTracker]:
     if not is_file_edit_tool(tool_name):
         return []
@@ -190,6 +194,7 @@ def prepare_file_edit_trackers(
             path=path,
             display_path=display_file_edit_path(path, workspace),
             before=before,
+            progress_id=progress_id,
         ))
     return trackers
 
@@ -350,6 +355,7 @@ def build_file_edit_pending_event(
     return {
         "version": 1,
         "call_id": str(call_id or ""),
+        "progress_id": str(call_id or ""),
         "tool": tool_name,
         "path": "",
         "phase": "start",
@@ -421,6 +427,7 @@ class StreamingFileEditTracker:
                 tool=tool,
                 workspace=self._workspace,
                 params={"path": state.path},
+                progress_id=state.call_id or state.key,
             )
             if state.tracker is None:
                 return
@@ -474,6 +481,7 @@ class StreamingFileEditTracker:
                     path=path,
                     display_path=display_file_edit_path(path, self._workspace),
                     before=read_file_snapshot(path),
+                    progress_id=state.call_id or state.key,
                 )
                 file_state = _StreamingPatchFileState(tracker=tracker)
                 state.patch_files[raw_path] = file_state
@@ -525,20 +533,16 @@ class StreamingFileEditTracker:
         if events:
             await self._emit(events)
 
+    def progress_id_for(self, tool_call: Any) -> str | None:
+        """Return the UI correlation key for a final file-edit tool call."""
+        name = getattr(tool_call, "name", None)
+        if not is_file_edit_tool(name):
+            return None
+        return self.canonical_call_id_for(tool_call)
+
     def apply_final_call_ids(self, final_tool_calls: list[Any]) -> None:
-        """Keep final start/end events keyed to any earlier streamed placeholder."""
-        used_canonicals: set[str] = set()
-        for tool_call in final_tool_calls:
-            name = getattr(tool_call, "name", None)
-            if not is_file_edit_tool(name):
-                continue
-            canonical = self.canonical_call_id_for(tool_call)
-            if canonical and canonical not in used_canonicals:
-                try:
-                    tool_call.id = canonical
-                    used_canonicals.add(canonical)
-                except (AttributeError, TypeError):
-                    pass
+        """Deprecated compatibility hook; provider tool-call IDs stay immutable."""
+        return None
 
     def canonical_call_id_for(self, tool_call: Any) -> str | None:
         for state in self._states.values():
@@ -933,6 +937,8 @@ def _event_payload(
         "approximate": bool(approximate),
         "status": status,
     }
+    if tracker.progress_id:
+        payload["progress_id"] = tracker.progress_id
     if binary:
         payload["binary"] = True
     if operation:

--- a/tests/utils/test_file_edit_events.py
+++ b/tests/utils/test_file_edit_events.py
@@ -176,6 +176,7 @@ def test_streaming_write_file_tracker_emits_live_line_counts(tmp_path: Path) -> 
     assert events[0] == {
         "version": 1,
         "call_id": "call-live",
+        "progress_id": "call-live",
         "tool": "write_file",
         "path": "notes.md",
         "absolute_path": (tmp_path / "notes.md").resolve().as_posix(),
@@ -268,6 +269,7 @@ def test_streaming_write_file_tracker_emits_pending_before_path(tmp_path: Path) 
     assert events[0] == {
         "version": 1,
         "call_id": "call-live",
+        "progress_id": "call-live",
         "tool": "write_file",
         "path": "",
         "phase": "start",
@@ -372,6 +374,7 @@ def test_streaming_edit_file_tracker_emits_live_line_counts(tmp_path: Path) -> N
     assert events[0] == {
         "version": 1,
         "call_id": "call-edit",
+        "progress_id": "call-edit",
         "tool": "edit_file",
         "path": "notes.md",
         "absolute_path": (tmp_path / "notes.md").resolve().as_posix(),
@@ -388,7 +391,7 @@ def test_streaming_edit_file_tracker_emits_live_line_counts(tmp_path: Path) -> N
     assert events[-1]["deleted"] == 2
 
 
-def test_streaming_tracker_applies_canonical_call_id_to_final_tool(tmp_path: Path) -> None:
+def test_streaming_tracker_exposes_progress_id_without_mutating_final_tool(tmp_path: Path) -> None:
     events: list[dict] = []
 
     async def emit(batch: list[dict]) -> None:
@@ -406,8 +409,9 @@ def test_streaming_tracker_applies_canonical_call_id_to_final_tool(tmp_path: Pat
             name="write_file",
             arguments={"path": "matched.md", "content": "one\n"},
         )
+        assert tracker.progress_id_for(final) == "idx:0"
         tracker.apply_final_call_ids([final])
-        assert final.id == "idx:0"
+        assert final.id == "provider-final-id"
 
     asyncio.run(run())
 
@@ -442,7 +446,8 @@ def test_streaming_tracker_does_not_remap_non_file_edit_final_tool(tmp_path: Pat
         )
         tracker.apply_final_call_ids([read_final, write_final])
         assert read_final.id == "read-unique"
-        assert write_final.id == "idx:1"
+        assert write_final.id == "write-final"
+        assert tracker.progress_id_for(write_final) == "idx:1"
 
     asyncio.run(run())
 

--- a/webui/src/components/thread/AgentActivityCluster.tsx
+++ b/webui/src/components/thread/AgentActivityCluster.tsx
@@ -1523,8 +1523,9 @@ function fileActivityManySummaryKey(editing: boolean, failed: boolean, deleted: 
 }
 
 function fileEditCallKey(edit: UIFileEdit): string {
-  if (edit.call_id && edit.path) return `${edit.call_id}|${edit.tool}|${edit.path}`;
-  if (edit.call_id) return `${edit.call_id}|${edit.tool}`;
+  const id = edit.progress_id || edit.call_id;
+  if (id && edit.path) return `${id}|${edit.tool}|${edit.path}`;
+  if (id) return `${id}|${edit.tool}`;
   return `${edit.tool}|${edit.path}`;
 }
 

--- a/webui/src/hooks/useNanobotStream.ts
+++ b/webui/src/hooks/useNanobotStream.ts
@@ -271,10 +271,15 @@ function absorbCompleteAssistantMessage(
   ];
 }
 
-function fileEditKey(edit: Pick<UIFileEdit, "call_id" | "tool" | "path">): string {
-  if (edit.call_id && edit.path) return `${edit.call_id}|${edit.tool}|${edit.path}`;
-  if (edit.call_id) return `${edit.call_id}|${edit.tool}`;
+function fileEditKey(edit: Pick<UIFileEdit, "call_id" | "progress_id" | "tool" | "path">): string {
+  const id = edit.progress_id || edit.call_id;
+  if (id && edit.path) return `${id}|${edit.tool}|${edit.path}`;
+  if (id) return `${id}|${edit.tool}`;
   return `${edit.tool}|${edit.path}`;
+}
+
+function fileEditProgressKey(edit: Pick<UIFileEdit, "call_id" | "progress_id" | "tool">): string {
+  return `${edit.progress_id || edit.call_id}|${edit.tool}`;
 }
 
 function fileEditToolEventKey(edit: Pick<UIFileEdit, "call_id" | "tool" | "path">): string {
@@ -375,9 +380,9 @@ function mergeFileEdits(existing: UIFileEdit[] | undefined, incoming: UIFileEdit
     const key = fileEditKey(edit);
     let existingIndex = indexByKey.get(key);
     if (existingIndex === undefined && edit.path) {
-      const eventKey = fileEditToolEventKey(edit);
+      const eventKey = fileEditProgressKey(edit);
       const pendingIndex = next.findIndex((existing) =>
-        !existing.path && existing.pending && fileEditToolEventKey(existing) === eventKey,
+        !existing.path && existing.pending && fileEditProgressKey(existing) === eventKey,
       );
       if (pendingIndex >= 0) existingIndex = pendingIndex;
     }
@@ -401,6 +406,7 @@ function findFileEditTraceIndex(
 ): number | null {
   const incomingKeys = new Set(incoming.map(fileEditKey));
   const incomingToolEventKeys = new Set(incoming.map(fileEditToolEventKey));
+  const incomingProgressKeys = new Set(incoming.map(fileEditProgressKey));
   for (let i = prev.length - 1; i >= 0; i -= 1) {
     const candidate = prev[i];
     if (candidate.role === "user") break;
@@ -412,7 +418,7 @@ function findFileEditTraceIndex(
         || (
           !existing.path
           && existing.pending
-          && incomingToolEventKeys.has(fileEditToolEventKey(existing))
+          && incomingProgressKeys.has(fileEditProgressKey(existing))
         )
       ) return i;
     }

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -213,6 +213,7 @@ export interface ToolProgressEvent {
 export interface UIFileEdit {
   version?: number;
   call_id: string;
+  progress_id?: string;
   tool: string;
   path: string;
   absolute_path?: string;

--- a/webui/src/tests/useNanobotStream.test.tsx
+++ b/webui/src/tests/useNanobotStream.test.tsx
@@ -704,6 +704,61 @@ describe("useNanobotStream", () => {
     }]);
   });
 
+  it("upgrades streamed file_edit placeholders by progress_id", () => {
+    const fake = fakeClient();
+    const { result } = renderHook(() => useNanobotStream("chat-file-edit-progress-id", EMPTY_MESSAGES), {
+      wrapper: wrap(fake.client),
+    });
+
+    act(() => {
+      fake.emit("chat-file-edit-progress-id", {
+        event: "file_edit",
+        chat_id: "chat-file-edit-progress-id",
+        edits: [{
+          call_id: "idx:0",
+          progress_id: "idx:0",
+          tool: "write_file",
+          path: "",
+          phase: "start",
+          added: 1,
+          deleted: 0,
+          approximate: true,
+          status: "editing",
+          pending: true,
+        }],
+      });
+      fake.emit("chat-file-edit-progress-id", {
+        event: "file_edit",
+        chat_id: "chat-file-edit-progress-id",
+        edits: [{
+          call_id: "provider-final-id",
+          progress_id: "idx:0",
+          tool: "write_file",
+          path: "foo.txt",
+          phase: "end",
+          added: 12,
+          deleted: 0,
+          approximate: false,
+          status: "done",
+        }],
+      });
+    });
+
+    const fileEditMessages = result.current.messages.filter((message) => message.fileEdits?.length);
+    expect(fileEditMessages).toHaveLength(1);
+    expect(fileEditMessages[0].fileEdits).toEqual([{
+      call_id: "provider-final-id",
+      progress_id: "idx:0",
+      tool: "write_file",
+      path: "foo.txt",
+      phase: "end",
+      added: 12,
+      deleted: 0,
+      approximate: false,
+      status: "done",
+    }]);
+  });
+
   it("merges file_edit updates after interleaved progress events", () => {
     const fake = fakeClient();
     const { result } = renderHook(() => useNanobotStream("chat-file-edit-progress", EMPTY_MESSAGES), {


### PR DESCRIPTION
## Summary
- keep provider tool_call IDs immutable after final response parsing
- add a separate file-edit progress_id used only to correlate streamed placeholders with final file-edit events
- update WebUI file-edit merging to prefer progress_id for file-edit event coalescing while keeping call_id for provider/tool trace correlation

Fixes #4603

## Verification
- uv run pytest tests/utils/test_file_edit_events.py -q
- uv run ruff check nanobot/utils/file_edit_events.py nanobot/agent/runner.py nanobot/providers/base.py tests/utils/test_file_edit_events.py
- cd webui && bun run build

## Notes
- Targeted Vitest command `bun run test -- useNanobotStream` currently fails before collecting tests in this environment because `localStorage` is undefined in `src/tests/setup.ts`.