### PR TITLE
fix(mcp): contain malformed tool results

### DIFF
--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -418,7 +418,9 @@ class MCPToolWrapper(_MCPWrapperBase):
                 logger.warning(
                     "MCP tool '{}' timed out after {}s", self._name, self._tool_timeout
                 )
-                return f"(MCP tool call timed out after {self._tool_timeout}s)"
+                return ToolResult.error(
+                    f"(MCP tool call timed out after {self._tool_timeout}s)"
+                )
             except asyncio.CancelledError:
                 # MCP SDK's anyio cancel scopes can leak CancelledError on timeout/failure.
                 # Re-raise only if our task was externally cancelled (e.g. /stop).
@@ -426,7 +428,7 @@ class MCPToolWrapper(_MCPWrapperBase):
                 if task is not None and task.cancelling() > 0:
                     raise
                 logger.warning("MCP tool '{}' was cancelled by server/SDK", self._name)
-                return "(MCP tool call was cancelled)"
+                return ToolResult.error("(MCP tool call was cancelled)")
             except Exception as exc:
                 if await self._refresh_session_after_termination(
                     exc,
@@ -451,20 +453,35 @@ class MCPToolWrapper(_MCPWrapperBase):
                         self._name,
                         type(exc).__name__,
                     )
-                    return f"(MCP tool call failed after retry: {type(exc).__name__})"
+                    return ToolResult.error(
+                        f"(MCP tool call failed after retry: {type(exc).__name__})"
+                    )
                 logger.exception(
                     "MCP tool '{}' failed: {}: {}",
                     self._name,
                     type(exc).__name__,
                     exc,
                 )
-                return f"(MCP tool call failed: {type(exc).__name__})"
+                return ToolResult.error(
+                    f"(MCP tool call failed: {type(exc).__name__})"
+                )
             else:
                 # Success — extract text and persist any image content as artifacts.
-                rendered = self._render_call_result(result.content, kwargs)
-                if getattr(result, "isError", False):
-                    return ToolResult.error(rendered)
-                return rendered
+                try:
+                    rendered = self._render_call_result(result.content, kwargs)
+                    if getattr(result, "isError", False):
+                        return ToolResult.error(rendered)
+                    return rendered
+                except Exception as exc:
+                    logger.exception(
+                        "MCP tool '{}' failed while rendering result: {}: {}",
+                        self._name,
+                        type(exc).__name__,
+                        exc,
+                    )
+                    return ToolResult.error(
+                        f"(MCP tool returned malformed content: {type(exc).__name__})"
+                    )
 
         return "(MCP tool call failed)"  # Unreachable, but satisfies type checkers
 

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -129,6 +129,8 @@ def _is_transient(exc: BaseException) -> bool:
 
 def _is_session_terminated(exc: BaseException) -> bool:
     """Return True when the MCP SDK reports a dead client session."""
+    if _is_transient(exc):
+        return True
     messages = [str(exc)]
     error = getattr(exc, "error", None)
     if error is not None:

--- a/tests/agent/test_mcp_transient_retry.py
+++ b/tests/agent/test_mcp_transient_retry.py
@@ -16,6 +16,7 @@ from nanobot.agent.tools.mcp import (
     _is_session_terminated,
     _is_transient,
 )
+from nanobot.agent.tools.registry import is_tool_error_result
 
 # ---------------------------------------------------------------------------
 # _is_transient helper
@@ -134,6 +135,7 @@ async def test_tool_fails_after_retry_exhausted():
 
     assert "failed after retry" in output
     assert "ClosedResourceError" in output
+    assert is_tool_error_result(wrapper.name, output)
     assert session.call_tool.call_count == 2
 
 
@@ -237,12 +239,10 @@ async def test_tool_retry_on_end_of_stream():
 
 
 @pytest.mark.asyncio
-async def test_tool_reconnects_when_transient_retry_reveals_terminated_session():
-    """Tool should reconnect if a stale session reports termination after transient retry."""
+async def test_tool_reconnects_on_transient_failure():
+    """Tool should reconnect when a stale session reports a transient stream failure."""
     old_session = AsyncMock()
-    old_session.call_tool = AsyncMock(
-        side_effect=[_FakeClosedResourceError("closed"), _session_terminated_error()]
-    )
+    old_session.call_tool = AsyncMock(side_effect=_FakeClosedResourceError("closed"))
     new_session = AsyncMock()
     new_session.call_tool = AsyncMock(return_value=_make_tool_result("fresh"))
 
@@ -257,12 +257,13 @@ async def test_tool_reconnects_when_transient_retry_reveals_terminated_session()
 
     wrapper.set_reconnect_handler(reconnect)
 
-    with patch("nanobot.agent.tools.mcp.asyncio.sleep", new_callable=AsyncMock):
+    with patch("nanobot.agent.tools.mcp.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
         output = await wrapper.execute(foo="bar")
 
     assert output == "fresh"
-    assert old_session.call_tool.call_count == 2
+    assert old_session.call_tool.call_count == 1
     assert new_session.call_tool.call_count == 1
+    mock_sleep.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -478,6 +478,61 @@ async def test_execute_handles_generic_exception() -> None:
     assert is_tool_error_result(wrapper.name, result)
 
 
+@pytest.mark.asyncio
+async def test_execute_reconnects_on_transient_failure() -> None:
+    class ClosedResourceError(Exception):
+        pass
+
+    reconnects = 0
+
+    async def stale_call_tool(_name: str, arguments: dict) -> object:
+        raise ClosedResourceError("stream closed")
+
+    async def fresh_call_tool(_name: str, arguments: dict) -> object:
+        return SimpleNamespace(content=[_FakeTextContent("ok")])
+
+    wrapper = _make_wrapper(SimpleNamespace(call_tool=stale_call_tool))
+
+    async def reconnect(_server_name: str, _tool_name: str, _stale_tool: object) -> object:
+        nonlocal reconnects
+        reconnects += 1
+        return SimpleNamespace(_session=SimpleNamespace(call_tool=fresh_call_tool))
+
+    wrapper.set_reconnect_handler(reconnect)
+
+    result = await wrapper.execute()
+
+    assert result == "ok"
+    assert reconnects == 1
+
+
+@pytest.mark.asyncio
+async def test_execute_marks_transient_retry_failure_as_tool_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ClosedResourceError(Exception):
+        pass
+
+    calls = 0
+
+    async def call_tool(_name: str, arguments: dict) -> object:
+        nonlocal calls
+        calls += 1
+        raise ClosedResourceError("closed")
+
+    async def fast_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(mcp_mod.asyncio, "sleep", fast_sleep)
+    wrapper = _make_wrapper(SimpleNamespace(call_tool=call_tool))
+
+    result = await wrapper.execute()
+
+    assert calls == 2
+    assert result == "(MCP tool call failed after retry: ClosedResourceError)"
+    assert is_tool_error_result(wrapper.name, result)
+
+
 def _make_tool_def(name: str) -> SimpleNamespace:
     return SimpleNamespace(
         name=name,

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -321,6 +321,35 @@ async def test_execute_wraps_mcp_is_error_result() -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_contains_malformed_success_result() -> None:
+    async def call_tool(_name: str, arguments: dict) -> object:
+        return SimpleNamespace(content=None)
+
+    wrapper = _make_wrapper(SimpleNamespace(call_tool=call_tool))
+
+    result = await wrapper.execute()
+
+    assert result == "(MCP tool returned malformed content: TypeError)"
+    assert is_tool_error_result(wrapper.name, result)
+
+
+@pytest.mark.asyncio
+async def test_registry_adds_retry_hint_to_malformed_mcp_result() -> None:
+    async def call_tool(_name: str, arguments: dict) -> object:
+        return SimpleNamespace(content=None)
+
+    wrapper = _make_wrapper(SimpleNamespace(call_tool=call_tool))
+    registry = ToolRegistry()
+    registry.register(wrapper)
+
+    result = await registry.execute(wrapper.name, {})
+
+    assert is_tool_error_result(wrapper.name, result)
+    assert "MCP tool returned malformed content" in result
+    assert "Analyze the error above and try a different approach" in result
+
+
+@pytest.mark.asyncio
 async def test_execute_preserves_success_text_that_starts_with_error() -> None:
     async def call_tool(_name: str, arguments: dict) -> object:
         return SimpleNamespace(
@@ -401,6 +430,7 @@ async def test_execute_returns_timeout_message() -> None:
     result = await wrapper.execute()
 
     assert result == "(MCP tool call timed out after 0.01s)"
+    assert is_tool_error_result(wrapper.name, result)
 
 
 @pytest.mark.asyncio
@@ -413,6 +443,7 @@ async def test_execute_handles_server_cancelled_error() -> None:
     result = await wrapper.execute()
 
     assert result == "(MCP tool call was cancelled)"
+    assert is_tool_error_result(wrapper.name, result)
 
 
 @pytest.mark.asyncio
@@ -444,6 +475,7 @@ async def test_execute_handles_generic_exception() -> None:
     result = await wrapper.execute()
 
     assert result == "(MCP tool call failed: RuntimeError)"
+    assert is_tool_error_result(wrapper.name, result)
 
 
 def _make_tool_def(name: str) -> SimpleNamespace:

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -478,61 +478,6 @@ async def test_execute_handles_generic_exception() -> None:
     assert is_tool_error_result(wrapper.name, result)
 
 
-@pytest.mark.asyncio
-async def test_execute_reconnects_on_transient_failure() -> None:
-    class ClosedResourceError(Exception):
-        pass
-
-    reconnects = 0
-
-    async def stale_call_tool(_name: str, arguments: dict) -> object:
-        raise ClosedResourceError("stream closed")
-
-    async def fresh_call_tool(_name: str, arguments: dict) -> object:
-        return SimpleNamespace(content=[_FakeTextContent("ok")])
-
-    wrapper = _make_wrapper(SimpleNamespace(call_tool=stale_call_tool))
-
-    async def reconnect(_server_name: str, _tool_name: str, _stale_tool: object) -> object:
-        nonlocal reconnects
-        reconnects += 1
-        return SimpleNamespace(_session=SimpleNamespace(call_tool=fresh_call_tool))
-
-    wrapper.set_reconnect_handler(reconnect)
-
-    result = await wrapper.execute()
-
-    assert result == "ok"
-    assert reconnects == 1
-
-
-@pytest.mark.asyncio
-async def test_execute_marks_transient_retry_failure_as_tool_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    class ClosedResourceError(Exception):
-        pass
-
-    calls = 0
-
-    async def call_tool(_name: str, arguments: dict) -> object:
-        nonlocal calls
-        calls += 1
-        raise ClosedResourceError("closed")
-
-    async def fast_sleep(_delay: float) -> None:
-        return None
-
-    monkeypatch.setattr(mcp_mod.asyncio, "sleep", fast_sleep)
-    wrapper = _make_wrapper(SimpleNamespace(call_tool=call_tool))
-
-    result = await wrapper.execute()
-
-    assert calls == 2
-    assert result == "(MCP tool call failed after retry: ClosedResourceError)"
-    assert is_tool_error_result(wrapper.name, result)
-
-
 def _make_tool_def(name: str) -> SimpleNamespace:
     return SimpleNamespace(
         name=name,


### PR DESCRIPTION
fix #4652

## Summary 

- contain exceptions raised while rendering malformed MCP tool results
- mark MCP timeouts, internal cancellations, retry failures, and execution exceptions as structured tool errors. This is the main difference from PR #4660 . 

## Changes

- wrap MCP result rendering in a local exception boundary
- convert malformed responses to `ToolResult.error`
- convert timeout, server-side cancellation, transient retry failure, and generic MCP exceptions to `ToolResult.error`
- continue propagating genuine external `CancelledError` signals
- add regression coverage for malformed empty content and registry-level correction hints