### PR TITLE
fix: protect user skills from dream writes

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Iterator
 
+import yaml
 from loguru import logger
 
 from nanobot.session.manager import Session
@@ -584,14 +585,14 @@ class MemoryStore:
         lines = text.splitlines()
         if not lines or lines[0].strip() != "---":
             return False
-        for line in lines[1:]:
-            stripped = line.strip()
-            if stripped == "---":
-                return False
-            key, sep, value = stripped.partition(":")
-            if sep and key.strip() == "dream_managed" and value.strip().lower() == "true":
-                return True
-        return False
+        end_index = next((idx for idx, line in enumerate(lines[1:], start=1) if line.strip() == "---"), None)
+        if end_index is None:
+            return False
+        try:
+            frontmatter = yaml.safe_load("\n".join(lines[1:end_index]))
+        except yaml.YAMLError:
+            return False
+        return isinstance(frontmatter, dict) and frontmatter.get("dream_managed") is True
 
     @staticmethod
     def dream_run_completed(resp: object | None) -> bool:

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -532,20 +532,66 @@ class MemoryStore:
             workspace=workspace,
             allowed_dir=skills_dir,
             extra_write_allowed_files=editable_files,
+            write_guard=self._dream_skill_write_guard,
             file_states=file_states,
         ))
         tools.register(ApplyPatchTool(
             workspace=workspace,
             allowed_dir=skills_dir,
             extra_write_allowed_files=editable_files,
+            write_guard=self._dream_skill_write_guard,
             file_states=file_states,
         ))
         tools.register(WriteFileTool(
             workspace=workspace,
             allowed_dir=skills_dir,
+            write_guard=self._dream_skill_write_guard,
             file_states=file_states,
         ))
         return tools
+
+    def _dream_skill_write_guard(self, path: Path, content: str | None = None) -> str | None:
+        """Allow Dream to write only skills it explicitly owns."""
+        skills_dir = (self.workspace / "skills").resolve(strict=False)
+        try:
+            target = path.resolve(strict=False)
+            rel = target.relative_to(skills_dir)
+        except (OSError, RuntimeError, ValueError):
+            return None
+
+        parts = rel.parts
+        if len(parts) < 2:
+            return "Dream may only modify skill files inside a named skill directory"
+
+        marker_file = skills_dir / parts[0] / "SKILL.md"
+        if marker_file.exists():
+            try:
+                marker_text = marker_file.read_text(encoding="utf-8")
+            except OSError:
+                return f"Dream could not verify ownership for skill {parts[0]!r}"
+            if self._skill_content_is_dream_managed(marker_text):
+                return None
+            return f"Dream may not modify unmarked user skill {parts[0]!r}"
+
+        if parts[-1] == "SKILL.md" and content is not None:
+            if self._skill_content_is_dream_managed(content):
+                return None
+        return "Dream may only create skills whose SKILL.md has dream_managed: true"
+
+    @staticmethod
+    def _skill_content_is_dream_managed(content: str) -> bool:
+        text = content.lstrip("\ufeff")
+        lines = text.splitlines()
+        if not lines or lines[0].strip() != "---":
+            return False
+        for line in lines[1:]:
+            stripped = line.strip()
+            if stripped == "---":
+                return False
+            key, sep, value = stripped.partition(":")
+            if sep and key.strip() == "dream_managed" and value.strip().lower() == "true":
+                return True
+        return False
 
     @staticmethod
     def dream_run_completed(resp: object | None) -> bool:

--- a/nanobot/agent/tools/apply_patch.py
+++ b/nanobot/agent/tools/apply_patch.py
@@ -265,6 +265,9 @@ class ApplyPatchTool(_FsTool):
                     _format_summary(summary) for summary in summaries
                 )
 
+            for path, content in writes.items():
+                self._check_write_guard(path, content)
+
             backups: dict[Path, bytes | None] = {}
             for path in writes:
                 backups[path] = path.read_bytes() if path.exists() else None

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -5,7 +5,7 @@ import mimetypes
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from nanobot.agent.tools.base import Tool, ToolResult, tool_parameters
 from nanobot.agent.tools.file_state import FileStates, _hash_file, current_file_states
@@ -48,6 +48,7 @@ class _FsTool(Tool):
         extra_read_allowed_dirs: list[Path] | None = None,
         extra_write_allowed_dirs: list[Path] | None = None,
         extra_write_allowed_files: list[Path] | None = None,
+        write_guard: Callable[[Path, str | None], str | None] | None = None,
         file_states: FileStates | None = None,
         restrict_to_workspace: bool | None = None,
         sandbox_restricts_workspace: bool = False,
@@ -62,6 +63,7 @@ class _FsTool(Tool):
         ]
         self._extra_write_allowed_dirs = list(extra_write_allowed_dirs or [])
         self._extra_write_allowed_files = list(extra_write_allowed_files or [])
+        self._write_guard = write_guard
         self._restrict_to_workspace = (
             bool(restrict_to_workspace)
             if restrict_to_workspace is not None
@@ -149,6 +151,13 @@ class _FsTool(Tool):
             self._extra_write_allowed_files,
             include_media_dir=False,
         )
+
+    def _check_write_guard(self, path: Path, content: str | None = None) -> None:
+        if self._write_guard is None:
+            return
+        message = self._write_guard(path, content)
+        if message:
+            raise PermissionError(message)
 
     def _resolve(self, path: str) -> Path:
         return self._resolve_read(path)
@@ -487,6 +496,7 @@ class WriteFileTool(_FsTool):
             if content is None:
                 raise ValueError("Unknown content")
             fp = self._resolve_write(path)
+            self._check_write_guard(fp, content)
             fp.parent.mkdir(parents=True, exist_ok=True)
             fp.write_text(content, encoding="utf-8")
             self._file_states.record_write(fp)
@@ -837,6 +847,7 @@ class EditFileTool(_FsTool):
                 return ToolResult.error("Error: expected_replacements must be >= 1.")
 
             fp = self._resolve_write(path)
+            self._check_write_guard(fp, new_text)
 
             # Create-file semantics: old_text='' + file doesn't exist → create
             if not fp.exists():

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -171,12 +171,12 @@ class TestDreamTools:
             "write_file",
             {
                 "path": "skills/demo/SKILL.md",
-                "content": "---\nname: demo\ndescription: Demo skill.\n---\n\nUse when needed.\n",
+                "content": "---\ndream_managed: true\nname: demo\ndescription: Demo skill.\n---\n\nUse when needed.\n",
             },
         )
 
         assert "Successfully wrote" in result
-        assert target.read_text(encoding="utf-8").startswith("---\nname: demo")
+        assert target.read_text(encoding="utf-8").startswith("---\ndream_managed: true")
 
     @pytest.mark.asyncio
     async def test_dream_tools_keep_internal_write_scope_under_full_access(self, store):
@@ -200,7 +200,7 @@ class TestDreamTools:
                         {
                             "path": "skills/scoped/SKILL.md",
                             "action": "add",
-                            "new_text": "---\nname: scoped\n---\n",
+                            "new_text": "---\ndream_managed: true\nname: scoped\n---\n",
                         }
                     ]
                 },
@@ -211,7 +211,7 @@ class TestDreamTools:
         assert "outside allowed directory" in outside_result
         assert not outside_target.exists()
         assert "Patch applied" in skill_result
-        assert skill_target.read_text(encoding="utf-8").startswith("---\nname: scoped")
+        assert skill_target.read_text(encoding="utf-8").startswith("---\ndream_managed: true")
 
     @pytest.mark.asyncio
     async def test_dream_cannot_modify_memory_internal_files(self, store):

--- a/tests/agent/test_memory_store.py
+++ b/tests/agent/test_memory_store.py
@@ -75,6 +75,33 @@ class TestMemoryStoreBasicIO:
         assert skill_file.read_text(encoding="utf-8") == "# Weather\n\nUser-owned skill.\n"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "frontmatter",
+        [
+            "description: |\n  dream_managed: true\n",
+            "metadata:\n  dream_managed: true\n",
+        ],
+    )
+    async def test_dream_write_tools_ignore_nested_or_block_ownership_markers(
+        self,
+        store,
+        frontmatter,
+    ):
+        skill_file = store.workspace / "skills" / "weather" / "SKILL.md"
+        skill_file.parent.mkdir(parents=True)
+        original = f"---\n{frontmatter}---\n# Weather\n\nUser-owned skill.\n"
+        skill_file.write_text(original, encoding="utf-8")
+        tools = store.build_dream_tools()
+
+        write_result = await tools.get("write_file").execute(
+            path="skills/weather/SKILL.md",
+            content="---\ndream_managed: true\n---\n# Weather\n\nOverwritten.\n",
+        )
+
+        assert "unmarked user skill" in write_result
+        assert skill_file.read_text(encoding="utf-8") == original
+
+    @pytest.mark.asyncio
     async def test_dream_write_tools_allow_marked_skill(self, store):
         skill_file = store.workspace / "skills" / "weather" / "SKILL.md"
         skill_file.parent.mkdir(parents=True)

--- a/tests/agent/test_memory_store.py
+++ b/tests/agent/test_memory_store.py
@@ -44,6 +44,88 @@ class TestMemoryStoreBasicIO:
         assert "Long-term Memory" in ctx
         assert "important fact" in ctx
 
+    @pytest.mark.asyncio
+    async def test_dream_write_tools_block_unmarked_user_skill(self, store):
+        skill_file = store.workspace / "skills" / "weather" / "SKILL.md"
+        skill_file.parent.mkdir(parents=True)
+        skill_file.write_text("# Weather\n\nUser-owned skill.\n", encoding="utf-8")
+        tools = store.build_dream_tools()
+
+        write_result = await tools.get("write_file").execute(
+            path="skills/weather/SKILL.md",
+            content="# Weather\n\nOverwritten.\n",
+        )
+        edit_result = await tools.get("edit_file").execute(
+            path="skills/weather/SKILL.md",
+            old_text="User-owned skill.",
+            new_text="Overwritten.",
+        )
+        patch_result = await tools.get("apply_patch").execute(
+            edits=[{
+                "path": "skills/weather/SKILL.md",
+                "action": "replace",
+                "old_text": "User-owned skill.",
+                "new_text": "Overwritten.",
+            }]
+        )
+
+        assert "unmarked user skill" in write_result
+        assert "unmarked user skill" in edit_result
+        assert "unmarked user skill" in patch_result
+        assert skill_file.read_text(encoding="utf-8") == "# Weather\n\nUser-owned skill.\n"
+
+    @pytest.mark.asyncio
+    async def test_dream_write_tools_allow_marked_skill(self, store):
+        skill_file = store.workspace / "skills" / "weather" / "SKILL.md"
+        skill_file.parent.mkdir(parents=True)
+        skill_file.write_text(
+            "---\ndream_managed: true\n---\n# Weather\n\nOriginal.\n",
+            encoding="utf-8",
+        )
+        tools = store.build_dream_tools()
+
+        edit_result = await tools.get("edit_file").execute(
+            path="skills/weather/SKILL.md",
+            old_text="Original.",
+            new_text="Updated.",
+        )
+        patch_result = await tools.get("apply_patch").execute(
+            edits=[{
+                "path": "skills/weather/SKILL.md",
+                "action": "replace",
+                "old_text": "Updated.",
+                "new_text": "Patched.",
+            }]
+        )
+        write_result = await tools.get("write_file").execute(
+            path="skills/weather/notes.md",
+            content="Dream notes.\n",
+        )
+
+        assert "Successfully edited" in edit_result
+        assert "Patch applied" in patch_result
+        assert "Successfully wrote" in write_result
+        assert "Patched." in skill_file.read_text(encoding="utf-8")
+        assert (store.workspace / "skills" / "weather" / "notes.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_dream_can_create_only_marked_skill(self, store):
+        tools = store.build_dream_tools()
+
+        unmarked = await tools.get("write_file").execute(
+            path="skills/new-skill/SKILL.md",
+            content="# New Skill\n",
+        )
+        marked = await tools.get("write_file").execute(
+            path="skills/dream-skill/SKILL.md",
+            content="---\ndream_managed: true\n---\n# Dream Skill\n",
+        )
+
+        assert "dream_managed: true" in unmarked
+        assert "Successfully wrote" in marked
+        assert not (store.workspace / "skills" / "new-skill" / "SKILL.md").exists()
+        assert (store.workspace / "skills" / "dream-skill" / "SKILL.md").exists()
+
 
 class TestHistoryWithCursor:
     def test_append_history_returns_cursor(self, store):


### PR DESCRIPTION
## Summary
- add a Dream-only write guard for workspace skills
- require `dream_managed: true` frontmatter before Dream can modify existing skills
- allow Dream-created skills only when the initial `SKILL.md` carries that marker

Fixes #4075

## Verification
- `uv run pytest tests/agent/test_memory_store.py::TestMemoryStoreBasicIO::test_dream_write_tools_block_unmarked_user_skill tests/agent/test_memory_store.py::TestMemoryStoreBasicIO::test_dream_write_tools_allow_marked_skill tests/agent/test_memory_store.py::TestMemoryStoreBasicIO::test_dream_can_create_only_marked_skill -q`
- `uv run ruff check nanobot/agent/memory.py nanobot/agent/tools/filesystem.py nanobot/agent/tools/apply_patch.py tests/agent/test_memory_store.py`