### PR TITLE
fix: enforce message outbound policy

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -561,6 +561,7 @@ class AgentLoop:
             return f"channel {channel!r} is not configured"
 
         allow_from = self._channel_list(cfg, "allow_from", "allowFrom")
+        allow_from.extend(self._channel_nested_list(cfg, "dm", "allow_from", "allowFrom"))
         group_allow_from = self._channel_list(cfg, "group_allow_from", "groupAllowFrom")
         if "*" in allow_from or chat_id in allow_from or chat_id in group_allow_from:
             return None
@@ -586,6 +587,16 @@ class AgentLoop:
             if value:
                 return [str(item) for item in value]
         return []
+
+    @classmethod
+    def _channel_nested_list(cls, cfg: Any, section: str, *names: str) -> list[str]:
+        if isinstance(cfg, dict):
+            nested = cfg.get(section)
+        else:
+            nested = getattr(cfg, section, None)
+        if nested is None:
+            return []
+        return cls._channel_list(nested, *names)
 
     async def _connect_mcp(self) -> None:
         """Connect configured MCP servers."""

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -48,6 +48,7 @@ from nanobot.bus.runtime_events import (
 )
 from nanobot.command import CommandContext, CommandRouter, register_builtin_commands
 from nanobot.config.schema import AgentDefaults, ModelPresetConfig
+from nanobot.pairing import is_approved
 from nanobot.providers.base import LLMProvider
 from nanobot.providers.factory import ProviderSnapshot
 from nanobot.security.workspace_access import (
@@ -541,6 +542,50 @@ class AgentLoop:
             registered.append("my")
 
         logger.info("Registered {} tools: {}", len(registered), registered)
+
+        if message_tool := self.tools.get("message"):
+            if isinstance(message_tool, MessageTool):
+                message_tool.set_outbound_authorizer(self._authorize_message_tool_target)
+
+    def _authorize_message_tool_target(
+        self,
+        channel: str,
+        chat_id: str,
+        default_channel: str,
+        default_chat_id: str,
+    ) -> str | None:
+        if channel == default_channel and chat_id == default_chat_id:
+            return None
+        cfg = self._channel_config(channel)
+        if cfg is None:
+            return f"channel {channel!r} is not configured"
+
+        allow_from = self._channel_list(cfg, "allow_from", "allowFrom")
+        group_allow_from = self._channel_list(cfg, "group_allow_from", "groupAllowFrom")
+        if "*" in allow_from or chat_id in allow_from or chat_id in group_allow_from:
+            return None
+        if is_approved(channel, chat_id):
+            return None
+        return f"{channel}:{chat_id} is not in allow_from or group_allow_from"
+
+    def _channel_config(self, channel: str) -> Any | None:
+        cfg = self.channels_config
+        if cfg is None:
+            return None
+        if isinstance(cfg, dict):
+            return cfg.get(channel)
+        return getattr(cfg, channel, None)
+
+    @staticmethod
+    def _channel_list(cfg: Any, *names: str) -> list[str]:
+        for name in names:
+            if isinstance(cfg, dict):
+                value = cfg.get(name)
+            else:
+                value = getattr(cfg, name, None)
+            if value:
+                return [str(item) for item in value]
+        return []
 
     async def _connect_mcp(self) -> None:
         """Connect configured MCP servers."""

--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -11,8 +11,10 @@ from nanobot.agent.tools.context import ContextAware, RequestContext
 from nanobot.agent.tools.path_utils import resolve_workspace_path
 from nanobot.agent.tools.schema import ArraySchema, StringSchema, tool_parameters_schema
 from nanobot.bus.events import OutboundMessage
-from nanobot.config.paths import get_workspace_path
+from nanobot.config.paths import get_media_dir, get_workspace_path
 from nanobot.security.workspace_access import current_tool_workspace
+
+OutboundAuthorizer = Callable[[str, str, str, str], str | None]
 
 
 @tool_parameters(
@@ -56,8 +58,10 @@ class MessageTool(Tool, ContextAware):
         default_message_id: str | None = None,
         workspace: str | Path | None = None,
         restrict_to_workspace: bool = False,
+        outbound_authorizer: OutboundAuthorizer | None = None,
     ):
         self._send_callback = send_callback
+        self._outbound_authorizer = outbound_authorizer
         self._workspace = (
             Path(workspace).expanduser() if workspace is not None else get_workspace_path()
         )
@@ -109,6 +113,10 @@ class MessageTool(Tool, ContextAware):
     def set_send_callback(self, callback: Callable[[OutboundMessage], Awaitable[None]]) -> None:
         """Set the callback for sending messages."""
         self._send_callback = callback
+
+    def set_outbound_authorizer(self, authorizer: OutboundAuthorizer | None) -> None:
+        """Set the authorization hook for proactive/cross-target sends."""
+        self._outbound_authorizer = authorizer
 
     def start_turn(self) -> None:
         """Reset per-turn send tracking."""
@@ -162,7 +170,7 @@ class MessageTool(Tool, ContextAware):
         )
 
     def _resolve_media(self, media: list[str]) -> list[str]:
-        """Resolve local media attachments and enforce workspace restriction when enabled."""
+        """Resolve local media attachments and confine them to trusted roots."""
         resolved: list[str] = []
         access = current_tool_workspace(
             self._workspace,
@@ -172,11 +180,13 @@ class MessageTool(Tool, ContextAware):
         for p in media:
             if p.startswith(("http://", "https://")):
                 resolved.append(p)
-            elif not access.restrict_to_workspace:
-                path = Path(p).expanduser()
-                resolved.append(p if path.is_absolute() else str(workspace / path))
             else:
-                resolved.append(str(resolve_workspace_path(p, workspace, access.allowed_root)))
+                resolved.append(str(resolve_workspace_path(
+                    p,
+                    workspace,
+                    access.allowed_root or workspace,
+                    extra_allowed_dirs=[get_media_dir()],
+                )))
         return resolved
 
     async def execute(
@@ -233,6 +243,16 @@ class MessageTool(Tool, ContextAware):
 
         if not self._send_callback:
             return ToolResult.error("Error: Message sending not configured")
+
+        if self._outbound_authorizer is not None:
+            denial = self._outbound_authorizer(
+                str(channel),
+                str(chat_id),
+                str(default_channel),
+                str(default_chat_id),
+            )
+            if denial:
+                return ToolResult.error(f"Error: outbound target is not authorized: {denial}")
 
         if media:
             try:

--- a/tests/agent/test_loop_tool_context.py
+++ b/tests/agent/test_loop_tool_context.py
@@ -4,9 +4,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from nanobot.agent.loop import AgentLoop
+from nanobot.agent.tools.context import RequestContext
 from nanobot.bus.queue import MessageBus
 from nanobot.providers.base import LLMResponse, ToolCallRequest
-from nanobot.agent.tools.context import RequestContext
 
 
 class _ContextRecordingTool:
@@ -87,3 +87,28 @@ async def test_loop_hook_preserves_metadata_when_resetting_tool_context(tmp_path
         "metadata": metadata,
         "session_key": "slack:C123:111.222",
     }
+
+
+def test_message_tool_authorizer_uses_channel_allowlists(tmp_path: Path) -> None:
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+        channels_config={
+            "telegram": {"allow_from": ["user-1"]},
+            "slack": {"group_allow_from": ["C123"]},
+        },
+    )
+
+    assert loop._authorize_message_tool_target("telegram", "same", "telegram", "same") is None
+    assert loop._authorize_message_tool_target("telegram", "user-1", "cli", "direct") is None
+    assert loop._authorize_message_tool_target("slack", "C123", "cli", "direct") is None
+    assert loop._authorize_message_tool_target("telegram", "user-2", "cli", "direct") == (
+        "telegram:user-2 is not in allow_from or group_allow_from"
+    )
+    assert loop._authorize_message_tool_target("discord", "123", "cli", "direct") == (
+        "channel 'discord' is not configured"
+    )

--- a/tests/agent/test_loop_tool_context.py
+++ b/tests/agent/test_loop_tool_context.py
@@ -99,12 +99,13 @@ def test_message_tool_authorizer_uses_channel_allowlists(tmp_path: Path) -> None
         model="test-model",
         channels_config={
             "telegram": {"allow_from": ["user-1"]},
-            "slack": {"group_allow_from": ["C123"]},
+            "slack": {"dm": {"policy": "allowlist", "allow_from": ["U123"]}, "group_allow_from": ["C123"]},
         },
     )
 
     assert loop._authorize_message_tool_target("telegram", "same", "telegram", "same") is None
     assert loop._authorize_message_tool_target("telegram", "user-1", "cli", "direct") is None
+    assert loop._authorize_message_tool_target("slack", "U123", "cli", "direct") is None
     assert loop._authorize_message_tool_target("slack", "C123", "cli", "direct") is None
     assert loop._authorize_message_tool_target("telegram", "user-2", "cli", "direct") == (
         "telegram:user-2 is not in allow_from or group_allow_from"

--- a/tests/agent/test_workspace_scope.py
+++ b/tests/agent/test_workspace_scope.py
@@ -217,7 +217,7 @@ def test_image_reference_scope_restricted_blocks_outside_and_full_allows(tmp_pat
         reset_workspace_scope(token)
 
 
-def test_message_media_scope_restricted_blocks_outside_and_full_allows(tmp_path: Path) -> None:
+def test_message_media_scope_blocks_outside_even_under_full_scope(tmp_path: Path) -> None:
     project = tmp_path / "project"
     outside = tmp_path / "outside"
     project.mkdir()
@@ -245,7 +245,8 @@ def test_message_media_scope_restricted_blocks_outside_and_full_allows(tmp_path:
     )
     token = bind_workspace_scope(full)
     try:
-        assert tool._resolve_media([str(media)]) == [str(media)]
+        with pytest.raises(PermissionError):
+            tool._resolve_media([str(media)])
     finally:
         reset_workspace_scope(token)
 

--- a/tests/tools/test_message_tool.py
+++ b/tests/tools/test_message_tool.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from nanobot.agent.tools.message import MessageTool
@@ -81,19 +79,23 @@ async def test_message_tool_marks_channel_delivery_only_when_enabled() -> None:
 
 
 @pytest.mark.asyncio
-async def test_message_tool_records_media_deliveries() -> None:
+async def test_message_tool_records_media_deliveries(tmp_path) -> None:
     sent: list[OutboundMessage] = []
 
     async def _send(msg: OutboundMessage) -> None:
         sent.append(msg)
 
-    tool = MessageTool(send_callback=_send)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    generated = workspace / "generated.png"
+    generated.write_text("image", encoding="utf-8")
+    tool = MessageTool(send_callback=_send, workspace=workspace)
 
     await tool.execute(
         content="image",
         channel="websocket",
         chat_id="chat-1",
-        media=["/tmp/generated.png"],
+        media=[str(generated)],
     )
 
     assert sent[0].metadata == {"_record_channel_delivery": True}
@@ -162,6 +164,31 @@ async def test_message_tool_does_not_inherit_metadata_for_cross_target() -> None
     await tool.execute(content="channel reply", channel="slack", chat_id="C999")
 
     assert sent[0].metadata == {}
+
+
+@pytest.mark.asyncio
+async def test_message_tool_blocks_unauthorized_cross_target_send() -> None:
+    sent: list[OutboundMessage] = []
+
+    async def _send(msg: OutboundMessage) -> None:
+        sent.append(msg)
+
+    def _authorize(channel: str, chat_id: str, default_channel: str, default_chat_id: str) -> str | None:
+        if channel == default_channel and chat_id == default_chat_id:
+            return None
+        return "blocked target"
+
+    tool = MessageTool(send_callback=_send, outbound_authorizer=_authorize)
+    from nanobot.agent.tools.context import RequestContext
+
+    tool.set_context(RequestContext(channel="telegram", chat_id="allowed", metadata={}))
+
+    same_target = await tool.execute(content="same")
+    cross_target = await tool.execute(content="cross", channel="telegram", chat_id="other")
+
+    assert same_target == "Message sent to telegram:allowed"
+    assert cross_target == "Error: outbound target is not authorized: blocked target"
+    assert [msg.content for msg in sent] == ["same"]
 
 
 @pytest.mark.asyncio
@@ -256,24 +283,27 @@ async def test_message_tool_allows_workspace_absolute_media_when_restricted(tmp_
 
 
 @pytest.mark.asyncio
-async def test_message_tool_passes_through_absolute_media_paths() -> None:
+async def test_message_tool_rejects_outside_absolute_media_paths_when_unrestricted(tmp_path) -> None:
     sent: list[OutboundMessage] = []
 
     async def _send(msg: OutboundMessage) -> None:
         sent.append(msg)
 
-    tool = MessageTool(send_callback=_send)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "abs_image.png"
+    outside.write_text("image", encoding="utf-8")
+    tool = MessageTool(send_callback=_send, workspace=workspace)
 
-    abs_path = os.path.abspath(os.path.join(os.sep, "tmp", "abs_image.png"))
-
-    await tool.execute(
+    result = await tool.execute(
         content="see attached",
         channel="telegram",
         chat_id="1",
-        media=[abs_path],
+        media=[str(outside)],
     )
 
-    assert sent[0].media == [abs_path]
+    assert result.startswith("Error: media path is not allowed:")
+    assert sent == []
 
 
 @pytest.mark.asyncio
@@ -298,15 +328,20 @@ async def test_message_tool_passes_through_url_media_paths() -> None:
 
 
 @pytest.mark.asyncio
-async def test_message_tool_resolves_mixed_media_paths() -> None:
+async def test_message_tool_resolves_mixed_media_paths(tmp_path, monkeypatch) -> None:
     sent: list[OutboundMessage] = []
 
     async def _send(msg: OutboundMessage) -> None:
         sent.append(msg)
 
-    tool = MessageTool(send_callback=_send)
-
-    abs_path = os.path.abspath(os.path.join(os.sep, "tmp", "absolute.png"))
+    workspace = tmp_path / "workspace"
+    media_root = tmp_path / "media"
+    workspace.mkdir()
+    media_root.mkdir()
+    media_path = media_root / "absolute.png"
+    media_path.write_text("image", encoding="utf-8")
+    monkeypatch.setattr("nanobot.agent.tools.message.get_media_dir", lambda: media_root)
+    tool = MessageTool(send_callback=_send, workspace=workspace)
 
     await tool.execute(
         content="see attached",
@@ -314,16 +349,16 @@ async def test_message_tool_resolves_mixed_media_paths() -> None:
         chat_id="1",
         media=[
             "output/relative.png",
-            abs_path,
+            str(media_path),
             "https://example.com/url.png",
             "http://example.com/http.png",
         ],
     )
 
-    expected_relative = str(get_workspace_path() / "output/relative.png")
+    expected_relative = str((workspace / "output/relative.png").resolve())
     assert sent[0].media == [
         expected_relative,
-        abs_path,
+        str(media_path.resolve()),
         "https://example.com/url.png",
         "http://example.com/http.png",
     ]
@@ -336,7 +371,7 @@ async def test_message_tool_tracks_turn_media_for_same_target(tmp_path) -> None:
     async def _send(msg: OutboundMessage) -> None:
         sent.append(msg)
 
-    tool = MessageTool(send_callback=_send)
+    tool = MessageTool(send_callback=_send, workspace=tmp_path)
     from nanobot.agent.tools.context import RequestContext
 
     tool.set_context(RequestContext(channel="websocket", chat_id="chat-1", metadata={}))
@@ -353,7 +388,7 @@ async def test_message_tool_start_turn_clears_tracked_media(tmp_path) -> None:
     async def _send(msg: OutboundMessage) -> None:
         pass
 
-    tool = MessageTool(send_callback=_send)
+    tool = MessageTool(send_callback=_send, workspace=tmp_path)
     from nanobot.agent.tools.context import RequestContext
 
     tool.set_context(RequestContext(channel="websocket", chat_id="chat-1", metadata={}))
@@ -370,7 +405,7 @@ async def test_message_tool_cross_target_does_not_track_turn_media(tmp_path) -> 
     async def _send(msg: OutboundMessage) -> None:
         pass
 
-    tool = MessageTool(send_callback=_send)
+    tool = MessageTool(send_callback=_send, workspace=tmp_path)
     from nanobot.agent.tools.context import RequestContext
 
     tool.set_context(RequestContext(channel="websocket", chat_id="chat-1", metadata={}))
@@ -392,7 +427,7 @@ async def test_message_tool_rejects_wrong_explicit_ws_chat_id(tmp_path) -> None:
     async def _send(msg: OutboundMessage) -> None:
         sent.append(msg)
 
-    tool = MessageTool(send_callback=_send)
+    tool = MessageTool(send_callback=_send, workspace=tmp_path)
     from nanobot.agent.tools.context import RequestContext
 
     conv = "550e8400-e29b-41d4-a716-446655440000"
@@ -416,7 +451,7 @@ async def test_message_tool_allows_ws_explicit_when_matches_context(tmp_path) ->
     async def _send(msg: OutboundMessage) -> None:
         sent.append(msg)
 
-    tool = MessageTool(send_callback=_send)
+    tool = MessageTool(send_callback=_send, workspace=tmp_path)
     from nanobot.agent.tools.context import RequestContext
 
     conv = "550e8400-e29b-41d4-a716-446655440000"
@@ -441,7 +476,7 @@ async def test_message_tool_cli_context_may_target_other_ws_chat(tmp_path) -> No
     async def _send(msg: OutboundMessage) -> None:
         sent.append(msg)
 
-    tool = MessageTool(send_callback=_send)
+    tool = MessageTool(send_callback=_send, workspace=tmp_path)
     from nanobot.agent.tools.context import RequestContext
 
     target = "550e8400-e29b-41d4-a716-446655440000"

--- a/tests/tools/test_message_tool_suppress.py
+++ b/tests/tools/test_message_tool_suppress.py
@@ -66,6 +66,7 @@ class TestMessageToolSuppressLogic:
         mt = loop.tools.get("message")
         if isinstance(mt, MessageTool):
             mt.set_send_callback(AsyncMock(side_effect=lambda m: sent.append(m)))
+            mt.set_outbound_authorizer(lambda *_args: None)
 
         msg = InboundMessage(channel="feishu", sender_id="user1", chat_id="chat123", content="Send email")
         result = await loop._process_message(msg)


### PR DESCRIPTION
## Summary
- add an authorization hook before `message` tool outbound dispatch
- wire AgentLoop to enforce channel `allow_from` / `group_allow_from` for cross-target sends
- confine local media attachments to workspace/media roots even when workspace restriction is disabled

Fixes #4076

## Verification
- `uv run pytest tests/tools/test_message_tool.py::test_message_tool_blocks_unauthorized_cross_target_send tests/tools/test_message_tool.py::test_message_tool_rejects_outside_absolute_media_paths_when_unrestricted tests/tools/test_message_tool.py::test_message_tool_resolves_mixed_media_paths tests/tools/test_message_tool.py::test_message_tool_records_media_deliveries tests/tools/test_message_tool.py::test_message_tool_tracks_turn_media_for_same_target tests/tools/test_message_tool.py::test_message_tool_allows_ws_explicit_when_matches_context tests/agent/test_loop_tool_context.py::test_message_tool_authorizer_uses_channel_allowlists -q`
- `uv run ruff check nanobot/agent/tools/message.py nanobot/agent/loop.py tests/tools/test_message_tool.py tests/agent/test_loop_tool_context.py`