### PR TITLE
refactor: make retention planning explicit

### DIFF
--- a/nanobot/agent/autocompact.py
+++ b/nanobot/agent/autocompact.py
@@ -47,7 +47,7 @@ class AutoCompact:
             metadata={},
             last_consolidated=0,
         )
-        result = probe.retain_recent_legal_suffix(
+        result = probe.plan_recent_legal_suffix(
             self._RECENT_SUFFIX_MESSAGES,
             extend_to_user=True,
         )

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -1016,8 +1016,8 @@ class Consolidator:
                 metadata={},
                 last_consolidated=0,
             )
-            result = probe.retain_recent_legal_suffix(max_suffix, extend_to_user=True)
-            messages_to_keep = probe.messages
+            result = probe.plan_recent_legal_suffix(max_suffix, extend_to_user=True)
+            messages_to_keep = result.retained
             messages_to_remove = result.dropped[result.already_consolidated_count:]
 
             if not messages_to_remove and not messages_to_keep:

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -112,8 +112,10 @@ def _metadata_title(metadata: Any) -> str:
 
 @dataclass
 class RetentionResult:
+    retained: list[dict[str, Any]]
     dropped: list[dict]
     already_consolidated_count: int
+    new_last_consolidated: int
 
 
 @dataclass
@@ -290,30 +292,27 @@ class Session:
         self.updated_at = datetime.now()
         self.metadata.pop("_last_summary", None)
 
-    def retain_recent_legal_suffix(
+    def plan_recent_legal_suffix(
         self,
         max_messages: int,
         *,
         extend_to_user: bool = False,
     ) -> RetentionResult:
-        """Keep a legal recent suffix, optionally extending it back to a user turn.
-
-        Returns a RetentionResult with dropped messages and how many of those
-        were in the already-consolidated prefix. This method mutates
-        self.messages and self.last_consolidated in place.
-        """
+        """Plan a legal recent suffix without mutating the session."""
         if max_messages <= 0:
             dropped = list(self.messages)
-            lc = self.last_consolidated
-            self.clear()
             return RetentionResult(
+                retained=[],
                 dropped=dropped,
-                already_consolidated_count=min(lc, len(dropped)),
+                already_consolidated_count=min(self.last_consolidated, len(dropped)),
+                new_last_consolidated=0,
             )
         if len(self.messages) <= max_messages:
             return RetentionResult(
+                retained=list(self.messages),
                 dropped=[],
                 already_consolidated_count=0,
+                new_last_consolidated=self.last_consolidated,
             )
 
         original = list(self.messages)
@@ -377,13 +376,27 @@ class Session:
             if i < before_lc and id(m) in retained_ids
         )
 
-        self.messages = retained
-        self.last_consolidated = new_lc
-        self.updated_at = datetime.now()
         return RetentionResult(
+            retained=retained,
             dropped=dropped,
             already_consolidated_count=already_consolidated,
+            new_last_consolidated=new_lc,
         )
+
+    def retain_recent_legal_suffix(
+        self,
+        max_messages: int,
+        *,
+        extend_to_user: bool = False,
+    ) -> RetentionResult:
+        """Keep a legal recent suffix, optionally extending it back to a user turn."""
+        result = self.plan_recent_legal_suffix(max_messages, extend_to_user=extend_to_user)
+        self.messages = result.retained
+        self.last_consolidated = result.new_last_consolidated
+        self.updated_at = datetime.now()
+        if max_messages <= 0:
+            self.metadata.pop("_last_summary", None)
+        return result
 
     def enforce_file_cap(
         self,
@@ -394,13 +407,16 @@ class Session:
         if limit <= 0 or len(self.messages) <= limit:
             return
 
-        result = self.retain_recent_legal_suffix(limit)
+        result = self.plan_recent_legal_suffix(limit)
         if not result.dropped:
             return
 
         archive_chunk = result.dropped[result.already_consolidated_count:]
         if archive_chunk and on_archive:
             on_archive(archive_chunk)
+        self.messages = result.retained
+        self.last_consolidated = result.new_last_consolidated
+        self.updated_at = datetime.now()
         logger.info(
             "Session file cap hit for {}: dropped {}, raw-archived {}, kept {}",
             self.key,

--- a/tests/agent/test_auto_compact.py
+++ b/tests/agent/test_auto_compact.py
@@ -102,11 +102,11 @@ def _make_fake_compact(
             metadata={},
             last_consolidated=0,
         )
-        result = probe.retain_recent_legal_suffix(
+        result = probe.plan_recent_legal_suffix(
             max_suffix,
             extend_to_user=True,
         )
-        kept = probe.messages
+        kept = result.retained
         archive_msgs = result.dropped[result.already_consolidated_count:]
 
         if not archive_msgs and not kept:

--- a/tests/agent/test_session_manager_history.py
+++ b/tests/agent/test_session_manager_history.py
@@ -691,6 +691,25 @@ def test_retain_recent_legal_suffix_returns_dropped_messages():
     assert [m["content"] for m in result.dropped] == [f"msg{i}" for i in range(6)]
     assert len(session.messages) == 4
     assert result.already_consolidated_count == 0
+    assert [m["content"] for m in result.retained] == [f"msg{i}" for i in range(6, 10)]
+    assert result.new_last_consolidated == 0
+
+
+def test_plan_recent_legal_suffix_is_pure_and_explicit():
+    """Retention planning exposes retained/dropped/cursor fields without mutating."""
+    session = Session(key="test:plan-retention")
+    for i in range(8):
+        session.messages.append({"role": "user", "content": f"msg{i}"})
+    session.last_consolidated = 5
+
+    result = session.plan_recent_legal_suffix(4)
+
+    assert [m["content"] for m in result.retained] == [f"msg{i}" for i in range(4, 8)]
+    assert [m["content"] for m in result.dropped] == [f"msg{i}" for i in range(4)]
+    assert result.already_consolidated_count == 4
+    assert result.new_last_consolidated == 1
+    assert [m["content"] for m in session.messages] == [f"msg{i}" for i in range(8)]
+    assert session.last_consolidated == 5
 
 
 def test_retain_recent_legal_suffix_returns_empty_when_no_drop():


### PR DESCRIPTION
## Summary
- add a pure session retention-plan helper with retained, dropped, consolidated count, and new cursor fields
- make retain/file-cap/idle-compaction callers apply the plan explicitly
- cover plan purity and explicit cursor/archive semantics in tests

Fixes #4136

## Verification
- uv run pytest tests/agent/test_session_manager_history.py::test_retain_recent_legal_suffix_returns_dropped_messages tests/agent/test_session_manager_history.py::test_plan_recent_legal_suffix_is_pure_and_explicit tests/agent/test_session_manager_history.py::test_retain_recent_legal_suffix_returns_empty_when_no_drop tests/agent/test_session_manager_history.py::test_retain_recent_legal_suffix_returns_all_on_zero tests/agent/test_auto_compact.py::TestAgentLoopTTLParam::test_session_enforce_file_cap_skips_archive_when_dropped_prefix_already_consolidated tests/agent/test_auto_compact.py::TestAgentLoopTTLParam::test_session_enforce_file_cap_archives_only_unconsolidated_dropped_prefix tests/agent/test_consolidator.py::TestCompactIdleSession::test_archives_prefix_keeps_suffix -q
- uv run ruff check nanobot/session/manager.py nanobot/agent/autocompact.py nanobot/agent/memory.py tests/agent/test_auto_compact.py tests/agent/test_session_manager_history.py