### PR TITLE
fix: pin validated dns for ssrf checks

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1596,18 +1596,21 @@ nanobot uses a shared SSRF guard for built-in web fetches and HTTP/SSE MCP conne
 
 Keep whitelist entries as narrow as possible, such as a single host CIDR (`192.168.1.50/32`). The whitelist is global for the shared SSRF guard; it is not limited to one tool or one MCP server.
 
+HTTP/SSE MCP connections use the same process-wide proxy environment behavior as `web_fetch`: proxied targets use the configured proxy, and URLs excluded by `NO_PROXY` remain DNS-pinned direct connections.
+
 > [!TIP]
-> Use `proxy` in `tools.web` to route all web requests (search + fetch) through a proxy:
+> Use `proxy` in `tools.web` to route web requests through a proxy:
 > ```json
 > { "tools": { "web": { "proxy": "http://127.0.0.1:7890" } } }
 > ```
+> `web_fetch` applies DNS pinning for direct connections. When an explicit `tools.web.proxy` or a process-wide proxy environment variable applies to the target URL, nanobot still validates the requested URL locally, but DNS resolution for the outbound fetch happens at the proxy; configure only trusted proxies. URLs excluded by `NO_PROXY` keep the DNS-pinned direct path unless `tools.web.proxy` is configured.
 
 ### `tools.web`
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enable` | boolean | `true` | Enable or disable all built-in web tools (`web_search` + `web_fetch`) |
-| `proxy` | string or null | `null` | Proxy for all web requests, for example `http://127.0.0.1:7890` |
+| `proxy` | string or null | `null` | Proxy for web requests, for example `http://127.0.0.1:7890`. `web_fetch` DNS pinning applies only to direct connections; proxied fetches rely on the configured proxy as the trusted network exit. |
 | `userAgent` | string or null | `null` | User-Agent header for all web requests. If null, a browser one will be used |
 
 ### Web Search

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -24,6 +24,8 @@ from nanobot.bus.events import (
 )
 from nanobot.security.network import (
     PinnedDNSAsyncTransport,
+    env_proxy_applies_to_url,
+    httpx_env_proxy_mounts,
     resolve_url_target,
     validate_url_target,
 )
@@ -159,21 +161,24 @@ async def _probe_http_url(url: str, timeout: float = 3.0) -> bool:
     port = parsed.port
     if not port:
         port = 443 if parsed.scheme == "https" else 80
-    ok, _, resolved_ips = resolve_url_target(url, allow_loopback=True)
+    ok, _, resolved_ips = resolve_url_target(url)
     if not ok:
         return False
-    try:
-        target_host = resolved_ips[0] if resolved_ips else host
-        reader, writer = await asyncio.wait_for(
-            asyncio.open_connection(target_host, port),
-            timeout=timeout,
-        )
-        writer.close()
-        with suppress(OSError, asyncio.TimeoutError):
-            await asyncio.wait_for(writer.wait_closed(), timeout=0.2)
+    if env_proxy_applies_to_url(url):
         return True
-    except (OSError, asyncio.TimeoutError):
-        return False
+    for target_host in resolved_ips or (host,):
+        try:
+            _reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(target_host, port),
+                timeout=timeout,
+            )
+            writer.close()
+            with suppress(OSError, asyncio.TimeoutError):
+                await asyncio.wait_for(writer.wait_closed(), timeout=0.2)
+            return True
+        except (OSError, asyncio.TimeoutError):
+            continue
+    return False
 
 
 def _redact_url(url: str) -> str:
@@ -195,9 +200,17 @@ def _redact_url(url: str) -> str:
         return "<redacted-url>"
 
 
+def _pinned_transport_kwargs() -> dict[str, object]:
+    kwargs: dict[str, object] = {"transport": PinnedDNSAsyncTransport()}
+    mounts = httpx_env_proxy_mounts()
+    if mounts:
+        kwargs["mounts"] = mounts
+    return kwargs
+
+
 async def _validate_mcp_request_url(request: httpx.Request) -> None:
     """Validate each outgoing MCP HTTP request, including redirect targets."""
-    ok, error = validate_url_target(str(request.url), allow_loopback=True)
+    ok, error = validate_url_target(str(request.url))
     if not ok:
         raise httpx.RequestError(
             f"Blocked unsafe MCP URL {_redact_url(str(request.url))} ({error})",
@@ -864,7 +877,7 @@ async def connect_mcp_servers(
                         follow_redirects=True,
                         timeout=timeout,
                         auth=auth,
-                        transport=PinnedDNSAsyncTransport(allow_loopback=True),
+                        **_pinned_transport_kwargs(),
                     )
 
                 read, write = await server_stack.enter_async_context(
@@ -882,7 +895,7 @@ async def connect_mcp_servers(
                         event_hooks={"request": [_validate_mcp_request_url]},
                         follow_redirects=True,
                         timeout=httpx.Timeout(30.0, connect=10.0),
-                        transport=PinnedDNSAsyncTransport(allow_loopback=True),
+                        **_pinned_transport_kwargs(),
                     )
                 )
                 read, write, _ = await server_stack.enter_async_context(

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -22,7 +22,12 @@ from nanobot.bus.events import (
     RUNTIME_CONTROL_MCP_RELOAD,
     InboundMessage,
 )
-from nanobot.security.network import validate_url_target
+from nanobot.security.network import (
+    PinnedDNSAsyncTransport,
+    pin_resolved_url_dns,
+    resolve_url_target,
+    validate_url_target,
+)
 
 # Transient connection errors that warrant a single retry.
 # These typically happen when an MCP server restarts or a network
@@ -153,11 +158,15 @@ async def _probe_http_url(url: str, timeout: float = 3.0) -> bool:
     port = parsed.port
     if not port:
         port = 443 if parsed.scheme == "https" else 80
+    ok, _, resolved_ips = resolve_url_target(url)
+    if not ok:
+        return False
     try:
-        reader, writer = await asyncio.wait_for(
-            asyncio.open_connection(host, port),
-            timeout=timeout,
-        )
+        with pin_resolved_url_dns(url, resolved_ips):
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(host, port),
+                timeout=timeout,
+            )
         writer.close()
         with suppress(OSError, asyncio.TimeoutError):
             await asyncio.wait_for(writer.wait_closed(), timeout=0.2)
@@ -837,6 +846,7 @@ async def connect_mcp_servers(
                         follow_redirects=True,
                         timeout=timeout,
                         auth=auth,
+                        transport=PinnedDNSAsyncTransport(),
                     )
 
                 read, write = await server_stack.enter_async_context(
@@ -854,6 +864,7 @@ async def connect_mcp_servers(
                         event_hooks={"request": [_validate_mcp_request_url]},
                         follow_redirects=True,
                         timeout=httpx.Timeout(30.0, connect=10.0),
+                        transport=PinnedDNSAsyncTransport(),
                     )
                 )
                 read, write, _ = await server_stack.enter_async_context(

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -158,7 +158,7 @@ async def _probe_http_url(url: str, timeout: float = 3.0) -> bool:
     port = parsed.port
     if not port:
         port = 443 if parsed.scheme == "https" else 80
-    ok, _, resolved_ips = resolve_url_target(url)
+    ok, _, resolved_ips = resolve_url_target(url, allow_loopback=True)
     if not ok:
         return False
     try:
@@ -196,7 +196,7 @@ def _redact_url(url: str) -> str:
 
 async def _validate_mcp_request_url(request: httpx.Request) -> None:
     """Validate each outgoing MCP HTTP request, including redirect targets."""
-    ok, error = validate_url_target(str(request.url))
+    ok, error = validate_url_target(str(request.url), allow_loopback=True)
     if not ok:
         raise httpx.RequestError(
             f"Blocked unsafe MCP URL {_redact_url(str(request.url))} ({error})",
@@ -846,7 +846,7 @@ async def connect_mcp_servers(
                         follow_redirects=True,
                         timeout=timeout,
                         auth=auth,
-                        transport=PinnedDNSAsyncTransport(),
+                        transport=PinnedDNSAsyncTransport(allow_loopback=True),
                     )
 
                 read, write = await server_stack.enter_async_context(
@@ -864,7 +864,7 @@ async def connect_mcp_servers(
                         event_hooks={"request": [_validate_mcp_request_url]},
                         follow_redirects=True,
                         timeout=httpx.Timeout(30.0, connect=10.0),
-                        transport=PinnedDNSAsyncTransport(),
+                        transport=PinnedDNSAsyncTransport(allow_loopback=True),
                     )
                 )
                 read, write, _ = await server_stack.enter_async_context(

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -24,7 +24,6 @@ from nanobot.bus.events import (
 )
 from nanobot.security.network import (
     PinnedDNSAsyncTransport,
-    pin_resolved_url_dns,
     resolve_url_target,
     validate_url_target,
 )
@@ -164,11 +163,11 @@ async def _probe_http_url(url: str, timeout: float = 3.0) -> bool:
     if not ok:
         return False
     try:
-        with pin_resolved_url_dns(url, resolved_ips):
-            reader, writer = await asyncio.wait_for(
-                asyncio.open_connection(host, port),
-                timeout=timeout,
-            )
+        target_host = resolved_ips[0] if resolved_ips else host
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(target_host, port),
+            timeout=timeout,
+        )
         writer.close()
         with suppress(OSError, asyncio.TimeoutError):
             await asyncio.wait_for(writer.wait_closed(), timeout=0.2)

--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -124,6 +124,26 @@ def _pinned_dns_transport() -> httpx.AsyncBaseTransport:
     return PinnedDNSAsyncTransport()
 
 
+def _fetch_client_kwargs(proxy: str | None, timeout: float) -> dict[str, Any]:
+    from nanobot.security.network import httpx_env_proxy_mounts
+
+    kwargs: dict[str, Any] = {"timeout": timeout}
+    if proxy:
+        kwargs["proxy"] = proxy
+    else:
+        kwargs["transport"] = _pinned_dns_transport()
+        mounts = httpx_env_proxy_mounts()
+        if mounts:
+            kwargs["mounts"] = mounts
+    return kwargs
+
+
+def _unsafe_url_request_error(exc: BaseException) -> str | None:
+    from nanobot.security.network import UnsafeURLRequestError
+
+    return str(exc) if isinstance(exc, UnsafeURLRequestError) else None
+
+
 async def _get_with_safe_redirects(
     client: httpx.AsyncClient,
     url: str,
@@ -136,7 +156,13 @@ async def _get_with_safe_redirects(
         if not is_valid:
             return None, f"Redirect blocked: {error_msg}"
 
-        response = await client.get(current_url, headers=headers, follow_redirects=False)
+        try:
+            response = await client.get(current_url, headers=headers, follow_redirects=False)
+        except httpx.RequestError as exc:
+            unsafe_error = _unsafe_url_request_error(exc)
+            if unsafe_error is not None:
+                return None, f"Redirect blocked: {unsafe_error}"
+            raise
         is_redirect = 300 <= response.status_code < 400
         if not is_redirect:
             return response, None
@@ -175,7 +201,13 @@ async def _stream_with_safe_redirects(
             headers=headers,
             follow_redirects=False,
         )
-        response = await stream.__aenter__()
+        try:
+            response = await stream.__aenter__()
+        except httpx.RequestError as exc:
+            unsafe_error = _unsafe_url_request_error(exc)
+            if unsafe_error is not None:
+                return None, None, f"Redirect blocked: {unsafe_error}"
+            raise
         is_redirect = 300 <= response.status_code < 400
         if not is_redirect:
             return response, stream, None
@@ -921,17 +953,11 @@ class WebFetchTool(Tool):
         is_valid, error_msg = _validate_url_safe(url)
         if not is_valid:
             return json.dumps({"error": f"URL validation failed: {error_msg}", "url": url}, ensure_ascii=False)
-        if self.proxy:
-            return json.dumps({
-                "error": "web_fetch proxy is incompatible with DNS-pinned SSRF protection",
-                "url": url,
-            }, ensure_ascii=False)
 
         # Detect and fetch images directly to avoid Jina's textual image captioning
         try:
             async with httpx.AsyncClient(
-                transport=_pinned_dns_transport(),
-                timeout=15.0,
+                **_fetch_client_kwargs(self.proxy, 15.0),
             ) as client:
                 r, stream, redirect_error = await _stream_with_safe_redirects(
                     client,
@@ -953,6 +979,9 @@ class WebFetchTool(Tool):
                     if stream is not None:
                         await stream.__aexit__(None, None, None)
         except Exception as e:
+            unsafe_error = _unsafe_url_request_error(e)
+            if unsafe_error is not None:
+                return json.dumps({"error": f"URL validation failed: {unsafe_error}", "url": url}, ensure_ascii=False)
             logger.debug("Pre-fetch image detection failed for {}: {}", url, e)
 
         result = None
@@ -1002,8 +1031,7 @@ class WebFetchTool(Tool):
         """Local fallback using readability-lxml."""
         try:
             async with httpx.AsyncClient(
-                timeout=30.0,
-                transport=_pinned_dns_transport(),
+                **_fetch_client_kwargs(self.proxy, 30.0),
             ) as client:
                 r, redirect_error = await _get_with_safe_redirects(
                     client,

--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -118,6 +118,12 @@ def _resolve_url_safe(url: str) -> tuple[bool, str, tuple[str, ...]]:
     return resolve_url_target(url)
 
 
+def _pinned_dns_transport(proxy: str | None = None) -> httpx.AsyncBaseTransport:
+    from nanobot.security.network import PinnedDNSAsyncTransport
+
+    return PinnedDNSAsyncTransport(proxy=proxy)
+
+
 async def _get_with_safe_redirects(
     client: httpx.AsyncClient,
     url: str,
@@ -126,14 +132,11 @@ async def _get_with_safe_redirects(
     """GET a URL while validating every redirect target before requesting it."""
     current_url = url
     for _ in range(MAX_REDIRECTS + 1):
-        is_valid, error_msg, resolved_ips = _resolve_url_safe(current_url)
+        is_valid, error_msg, _ = _resolve_url_safe(current_url)
         if not is_valid:
             return None, f"Redirect blocked: {error_msg}"
 
-        from nanobot.security.network import pin_resolved_url_dns
-
-        with pin_resolved_url_dns(current_url, resolved_ips):
-            response = await client.get(current_url, headers=headers, follow_redirects=False)
+        response = await client.get(current_url, headers=headers, follow_redirects=False)
         is_redirect = 300 <= response.status_code < 400
         if not is_redirect:
             return response, None
@@ -162,11 +165,9 @@ async def _stream_with_safe_redirects(
     """Open a streamed response while validating every redirect target first."""
     current_url = url
     for _ in range(MAX_REDIRECTS + 1):
-        is_valid, error_msg, resolved_ips = _resolve_url_safe(current_url)
+        is_valid, error_msg, _ = _resolve_url_safe(current_url)
         if not is_valid:
             return None, None, f"Redirect blocked: {error_msg}"
-
-        from nanobot.security.network import pin_resolved_url_dns
 
         stream = client.stream(
             "GET",
@@ -174,8 +175,7 @@ async def _stream_with_safe_redirects(
             headers=headers,
             follow_redirects=False,
         )
-        with pin_resolved_url_dns(current_url, resolved_ips):
-            response = await stream.__aenter__()
+        response = await stream.__aenter__()
         is_redirect = 300 <= response.status_code < 400
         if not is_redirect:
             return response, stream, None
@@ -924,7 +924,10 @@ class WebFetchTool(Tool):
 
         # Detect and fetch images directly to avoid Jina's textual image captioning
         try:
-            async with httpx.AsyncClient(proxy=self.proxy, timeout=15.0) as client:
+            async with httpx.AsyncClient(
+                transport=_pinned_dns_transport(self.proxy),
+                timeout=15.0,
+            ) as client:
                 r, stream, redirect_error = await _stream_with_safe_redirects(
                     client,
                     url,
@@ -995,7 +998,7 @@ class WebFetchTool(Tool):
         try:
             async with httpx.AsyncClient(
                 timeout=30.0,
-                proxy=self.proxy,
+                transport=_pinned_dns_transport(self.proxy),
             ) as client:
                 r, redirect_error = await _get_with_safe_redirects(
                     client,

--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -111,6 +111,13 @@ def _validate_url_safe(url: str) -> tuple[bool, str]:
     return validate_url_target(url)
 
 
+def _resolve_url_safe(url: str) -> tuple[bool, str, tuple[str, ...]]:
+    """Validate URL and return the resolved IPs to pin during the request."""
+    from nanobot.security.network import resolve_url_target
+
+    return resolve_url_target(url)
+
+
 async def _get_with_safe_redirects(
     client: httpx.AsyncClient,
     url: str,
@@ -119,11 +126,14 @@ async def _get_with_safe_redirects(
     """GET a URL while validating every redirect target before requesting it."""
     current_url = url
     for _ in range(MAX_REDIRECTS + 1):
-        is_valid, error_msg = _validate_url_safe(current_url)
+        is_valid, error_msg, resolved_ips = _resolve_url_safe(current_url)
         if not is_valid:
             return None, f"Redirect blocked: {error_msg}"
 
-        response = await client.get(current_url, headers=headers, follow_redirects=False)
+        from nanobot.security.network import pin_resolved_url_dns
+
+        with pin_resolved_url_dns(current_url, resolved_ips):
+            response = await client.get(current_url, headers=headers, follow_redirects=False)
         is_redirect = 300 <= response.status_code < 400
         if not is_redirect:
             return response, None
@@ -152,9 +162,11 @@ async def _stream_with_safe_redirects(
     """Open a streamed response while validating every redirect target first."""
     current_url = url
     for _ in range(MAX_REDIRECTS + 1):
-        is_valid, error_msg = _validate_url_safe(current_url)
+        is_valid, error_msg, resolved_ips = _resolve_url_safe(current_url)
         if not is_valid:
             return None, None, f"Redirect blocked: {error_msg}"
+
+        from nanobot.security.network import pin_resolved_url_dns
 
         stream = client.stream(
             "GET",
@@ -162,7 +174,8 @@ async def _stream_with_safe_redirects(
             headers=headers,
             follow_redirects=False,
         )
-        response = await stream.__aenter__()
+        with pin_resolved_url_dns(current_url, resolved_ips):
+            response = await stream.__aenter__()
         is_redirect = 300 <= response.status_code < 400
         if not is_redirect:
             return response, stream, None

--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -118,10 +118,10 @@ def _resolve_url_safe(url: str) -> tuple[bool, str, tuple[str, ...]]:
     return resolve_url_target(url)
 
 
-def _pinned_dns_transport(proxy: str | None = None) -> httpx.AsyncBaseTransport:
+def _pinned_dns_transport() -> httpx.AsyncBaseTransport:
     from nanobot.security.network import PinnedDNSAsyncTransport
 
-    return PinnedDNSAsyncTransport(proxy=proxy)
+    return PinnedDNSAsyncTransport()
 
 
 async def _get_with_safe_redirects(
@@ -921,11 +921,16 @@ class WebFetchTool(Tool):
         is_valid, error_msg = _validate_url_safe(url)
         if not is_valid:
             return json.dumps({"error": f"URL validation failed: {error_msg}", "url": url}, ensure_ascii=False)
+        if self.proxy:
+            return json.dumps({
+                "error": "web_fetch proxy is incompatible with DNS-pinned SSRF protection",
+                "url": url,
+            }, ensure_ascii=False)
 
         # Detect and fetch images directly to avoid Jina's textual image captioning
         try:
             async with httpx.AsyncClient(
-                transport=_pinned_dns_transport(self.proxy),
+                transport=_pinned_dns_transport(),
                 timeout=15.0,
             ) as client:
                 r, stream, redirect_error = await _stream_with_safe_redirects(
@@ -998,7 +1003,7 @@ class WebFetchTool(Tool):
         try:
             async with httpx.AsyncClient(
                 timeout=30.0,
-                transport=_pinned_dns_transport(self.proxy),
+                transport=_pinned_dns_transport(),
             ) as client:
                 r, redirect_error = await _get_with_safe_redirects(
                     client,

--- a/nanobot/security/network.py
+++ b/nanobot/security/network.py
@@ -149,12 +149,13 @@ def pin_resolved_url_dns(url: str, resolved_ips: tuple[str, ...]):
 class PinnedDNSAsyncTransport(httpx.AsyncBaseTransport):
     """HTTPX transport that pins each request to the IPs validated for its URL."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, allow_loopback: bool = False) -> None:
+        self._allow_loopback = allow_loopback
         self._inner = httpx.AsyncHTTPTransport()
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         url = str(request.url)
-        ok, error, resolved_ips = resolve_url_target(url)
+        ok, error, resolved_ips = resolve_url_target(url, allow_loopback=self._allow_loopback)
         if not ok:
             raise httpx.RequestError(error, request=request)
         with pin_resolved_url_dns(url, resolved_ips):

--- a/nanobot/security/network.py
+++ b/nanobot/security/network.py
@@ -8,6 +8,7 @@ import re
 import socket
 from contextlib import contextmanager, suppress
 from urllib.parse import urlparse
+from urllib.request import getproxies, proxy_bypass
 
 import httpx
 
@@ -25,7 +26,6 @@ _BLOCKED_NETWORKS = [
 ]
 
 _URL_RE = re.compile(r"https?://[^\s\"'`;|<>]+", re.IGNORECASE)
-
 _allowed_networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
 
 
@@ -113,6 +113,66 @@ def validate_url_target(url: str, *, allow_loopback: bool = False) -> tuple[bool
     return ok, error
 
 
+def env_proxy_applies_to_url(url: str) -> bool:
+    """Return True when process proxy settings would proxy this URL."""
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return False
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return False
+
+    proxies = getproxies()
+    proxy_url = proxies.get(parsed.scheme) or proxies.get("all")
+    if not proxy_url:
+        return False
+
+    host = parsed.hostname
+    if parsed.port is not None:
+        host = f"[{host}]:{parsed.port}" if ":" in host else f"{host}:{parsed.port}"
+    return not proxy_bypass(host)
+
+
+def httpx_env_proxy_mounts() -> dict[str, httpx.AsyncBaseTransport | None]:
+    """Build HTTPX proxy mounts while leaving direct routes to the base transport."""
+    proxies = getproxies()
+    mounts: dict[str, httpx.AsyncBaseTransport | None] = {}
+    for scheme in ("http", "https", "all"):
+        proxy_url = proxies.get(scheme)
+        if proxy_url:
+            if "://" not in proxy_url:
+                proxy_url = f"http://{proxy_url}"
+            mounts[f"{scheme}://"] = httpx.AsyncHTTPTransport(proxy=httpx.Proxy(proxy_url))
+
+    if not mounts:
+        return {}
+
+    no_proxy = proxies.get("no", "")
+    if no_proxy == "*":
+        return {}
+    for entry in no_proxy.split(","):
+        pattern = _no_proxy_mount_pattern(entry.strip())
+        if pattern:
+            mounts[pattern] = None
+    return mounts
+
+
+def _no_proxy_mount_pattern(hostname: str) -> str | None:
+    if not hostname:
+        return None
+    if "://" in hostname:
+        return hostname
+
+    unbracketed = hostname.strip("[]")
+    with suppress(ValueError):
+        addr = ipaddress.ip_address(unbracketed)
+        return f"all://[{addr}]" if addr.version == 6 else f"all://{addr}"
+
+    if hostname.lower() == "localhost":
+        return "all://localhost"
+    return f"all://*{hostname}"
+
+
 @contextmanager
 def pin_resolved_url_dns(url: str, resolved_ips: tuple[str, ...]):
     """Pin DNS lookups for the URL hostname to previously validated IPs.
@@ -152,6 +212,10 @@ def pin_resolved_url_dns(url: str, resolved_ips: tuple[str, ...]):
         socket.getaddrinfo = original_getaddrinfo
 
 
+class UnsafeURLRequestError(httpx.RequestError):
+    """Raised when an outgoing request is rejected by URL safety validation."""
+
+
 class PinnedDNSAsyncTransport(httpx.AsyncBaseTransport):
     """HTTPX transport that pins each request to the IPs validated for its URL."""
 
@@ -170,7 +234,7 @@ class PinnedDNSAsyncTransport(httpx.AsyncBaseTransport):
         url = str(request.url)
         ok, error, resolved_ips = resolve_url_target(url, allow_loopback=self._allow_loopback)
         if not ok:
-            raise httpx.RequestError(error, request=request)
+            raise UnsafeURLRequestError(error, request=request)
         async with self._resolver_lock:
             with pin_resolved_url_dns(url, resolved_ips):
                 return await self._inner.handle_async_request(request)

--- a/nanobot/security/network.py
+++ b/nanobot/security/network.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import ipaddress
 import re
 import socket
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from urllib.parse import urlparse
+
+import httpx
 
 _BLOCKED_NETWORKS = [
     ipaddress.ip_network("0.0.0.0/8"),
@@ -58,7 +60,7 @@ def _is_private(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     return any(normalized in net for net in _BLOCKED_NETWORKS)
 
 
-def validate_url_target(url: str, *, allow_loopback: bool = False) -> tuple[bool, str]:
+def resolve_url_target(url: str, *, allow_loopback: bool = False) -> tuple[bool, str, tuple[str, ...]]:
     """Validate a URL is safe to fetch: scheme, hostname, and resolved IPs.
 
     ``allow_loopback`` is intentionally narrow: it only permits literal
@@ -66,26 +68,27 @@ def validate_url_target(url: str, *, allow_loopback: bool = False) -> tuple[bool
     loopback. It does not allow RFC1918, link-local, metadata, or public DNS
     names that happen to resolve to loopback.
 
-    Returns (ok, error_message).  When ok is True, error_message is empty.
+    Returns (ok, error_message, resolved_ips).  When ok is True,
+    resolved_ips contains the public IPs that were validated for this URL.
     """
     try:
         p = urlparse(url)
     except Exception as e:
-        return False, str(e)
+        return False, str(e), ()
 
     if p.scheme not in ("http", "https"):
-        return False, f"Only http/https allowed, got '{p.scheme or 'none'}'"
+        return False, f"Only http/https allowed, got '{p.scheme or 'none'}'", ()
     if not p.netloc:
-        return False, "Missing domain"
+        return False, "Missing domain", ()
 
     hostname = p.hostname
     if not hostname:
-        return False, "Missing hostname"
+        return False, "Missing hostname", ()
 
     try:
         infos = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
     except socket.gaierror:
-        return False, f"Cannot resolve hostname: {hostname}"
+        return False, f"Cannot resolve hostname: {hostname}", ()
 
     addrs: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
     for info in infos:
@@ -95,12 +98,70 @@ def validate_url_target(url: str, *, allow_loopback: bool = False) -> tuple[bool
             continue
         addrs.append(addr)
     if allow_loopback and _is_allowed_loopback_target(hostname, addrs):
-        return True, ""
+        return True, "", tuple(dict.fromkeys(str(_normalize_addr(addr)) for addr in addrs))
     for addr in addrs:
         if _is_private(addr):
-            return False, f"Blocked: {hostname} resolves to private/internal address {addr}"
+            return False, f"Blocked: {hostname} resolves to private/internal address {addr}", ()
 
-    return True, ""
+    return True, "", tuple(dict.fromkeys(str(_normalize_addr(addr)) for addr in addrs))
+
+
+def validate_url_target(url: str, *, allow_loopback: bool = False) -> tuple[bool, str]:
+    """Validate a URL is safe to fetch: scheme, hostname, and resolved IPs."""
+    ok, error, _ = resolve_url_target(url, allow_loopback=allow_loopback)
+    return ok, error
+
+
+@contextmanager
+def pin_resolved_url_dns(url: str, resolved_ips: tuple[str, ...]):
+    """Pin DNS lookups for the URL hostname to previously validated IPs."""
+    try:
+        hostname = urlparse(url).hostname
+    except Exception:
+        hostname = None
+    if not hostname or not resolved_ips:
+        yield
+        return
+
+    pinned_host = hostname.rstrip(".").lower()
+    original_getaddrinfo = socket.getaddrinfo
+
+    def _getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):  # noqa: A002
+        if str(host).rstrip(".").lower() != pinned_host:
+            return original_getaddrinfo(host, port, family, type, proto, flags)
+        infos = []
+        for ip in resolved_ips:
+            addr = ipaddress.ip_address(ip)
+            addr_family = socket.AF_INET6 if addr.version == 6 else socket.AF_INET
+            if family not in (0, socket.AF_UNSPEC, addr_family):
+                continue
+            sockaddr = (ip, port or 0, 0, 0) if addr_family == socket.AF_INET6 else (ip, port or 0)
+            infos.append((addr_family, type or socket.SOCK_STREAM, proto, "", sockaddr))
+        return infos
+
+    socket.getaddrinfo = _getaddrinfo
+    try:
+        yield
+    finally:
+        socket.getaddrinfo = original_getaddrinfo
+
+
+class PinnedDNSAsyncTransport(httpx.AsyncBaseTransport):
+    """HTTPX transport that pins each request to the IPs validated for its URL."""
+
+    def __init__(self) -> None:
+        self._inner = httpx.AsyncHTTPTransport()
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        ok, error, resolved_ips = resolve_url_target(url)
+        if not ok:
+            raise httpx.RequestError(error, request=request)
+        with pin_resolved_url_dns(url, resolved_ips):
+            return await self._inner.handle_async_request(request)
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
 
 
 def validate_resolved_url(url: str) -> tuple[bool, str]:

--- a/nanobot/security/network.py
+++ b/nanobot/security/network.py
@@ -161,11 +161,10 @@ class PinnedDNSAsyncTransport(httpx.AsyncBaseTransport):
         self,
         *,
         allow_loopback: bool = False,
-        proxy: httpx.ProxyTypes | None = None,
         inner: httpx.AsyncBaseTransport | None = None,
     ) -> None:
         self._allow_loopback = allow_loopback
-        self._inner = inner or httpx.AsyncHTTPTransport(proxy=proxy)
+        self._inner = inner or httpx.AsyncHTTPTransport()
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         url = str(request.url)

--- a/nanobot/security/network.py
+++ b/nanobot/security/network.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import ipaddress
 import re
 import socket
@@ -114,7 +115,12 @@ def validate_url_target(url: str, *, allow_loopback: bool = False) -> tuple[bool
 
 @contextmanager
 def pin_resolved_url_dns(url: str, resolved_ips: tuple[str, ...]):
-    """Pin DNS lookups for the URL hostname to previously validated IPs."""
+    """Pin DNS lookups for the URL hostname to previously validated IPs.
+
+    This temporarily overrides process-global resolver state. Do not use it
+    directly across awaits unless the caller serializes access; prefer
+    PinnedDNSAsyncTransport for HTTP requests.
+    """
     try:
         hostname = urlparse(url).hostname
     except Exception:
@@ -149,17 +155,26 @@ def pin_resolved_url_dns(url: str, resolved_ips: tuple[str, ...]):
 class PinnedDNSAsyncTransport(httpx.AsyncBaseTransport):
     """HTTPX transport that pins each request to the IPs validated for its URL."""
 
-    def __init__(self, *, allow_loopback: bool = False) -> None:
+    _resolver_lock = asyncio.Lock()
+
+    def __init__(
+        self,
+        *,
+        allow_loopback: bool = False,
+        proxy: httpx.ProxyTypes | None = None,
+        inner: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
         self._allow_loopback = allow_loopback
-        self._inner = httpx.AsyncHTTPTransport()
+        self._inner = inner or httpx.AsyncHTTPTransport(proxy=proxy)
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         url = str(request.url)
         ok, error, resolved_ips = resolve_url_target(url, allow_loopback=self._allow_loopback)
         if not ok:
             raise httpx.RequestError(error, request=request)
-        with pin_resolved_url_dns(url, resolved_ips):
-            return await self._inner.handle_async_request(request)
+        async with self._resolver_lock:
+            with pin_resolved_url_dns(url, resolved_ips):
+                return await self._inner.handle_async_request(request)
 
     async def aclose(self) -> None:
         await self._inner.aclose()

--- a/tests/security/test_security_network.py
+++ b/tests/security/test_security_network.py
@@ -11,10 +11,20 @@ import pytest
 from nanobot.security.network import (
     configure_ssrf_whitelist,
     contains_internal_url,
+    env_proxy_applies_to_url,
+    httpx_env_proxy_mounts,
     pin_resolved_url_dns,
     resolve_url_target,
     validate_url_target,
 )
+
+_PROXY_ENV_VARS = ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy")
+
+
+@pytest.fixture(autouse=True)
+def _clear_proxy_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (*_PROXY_ENV_VARS, "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(name, raising=False)
 
 
 def _fake_resolve(host: str, results: list[str]):
@@ -182,6 +192,18 @@ def test_allows_normal_https():
     with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve("github.com", ["140.82.121.3"])):
         ok, err = validate_url_target("https://github.com/HKUDS/nanobot")
         assert ok
+
+
+def test_env_proxy_helpers_respect_no_proxy(monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
+    monkeypatch.setenv("NO_PROXY", "localhost,127.0.0.1,::1")
+
+    assert env_proxy_applies_to_url("https://example.com/page")
+    assert not env_proxy_applies_to_url("http://localhost:8765/mcp")
+
+    mounts = httpx_env_proxy_mounts()
+    assert any(transport is None for transport in mounts.values())
+    assert any(transport is not None for transport in mounts.values())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/security/test_security_network.py
+++ b/tests/security/test_security_network.py
@@ -11,6 +11,8 @@ import pytest
 from nanobot.security.network import (
     configure_ssrf_whitelist,
     contains_internal_url,
+    pin_resolved_url_dns,
+    resolve_url_target,
     validate_url_target,
 )
 
@@ -155,6 +157,25 @@ def test_allows_public_ip():
     with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve("example.com", ["93.184.216.34"])):
         ok, err = validate_url_target("http://example.com/page")
         assert ok, f"Should allow public IP, got: {err}"
+
+
+def test_resolve_url_target_returns_validated_public_ips():
+    with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve("example.com", ["93.184.216.34"])):
+        ok, err, resolved_ips = resolve_url_target("http://example.com/page")
+
+    assert ok, err
+    assert resolved_ips == ("93.184.216.34",)
+
+
+def test_pin_resolved_url_dns_prevents_second_resolution_rebind():
+    def _rebinding_resolver(hostname, port, family=0, type_=0):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("169.254.169.254", 0))]
+
+    with patch("nanobot.security.network.socket.getaddrinfo", _rebinding_resolver):
+        with pin_resolved_url_dns("http://example.com/page", ("93.184.216.34",)):
+            infos = socket.getaddrinfo("example.com", 80, socket.AF_UNSPEC, socket.SOCK_STREAM)
+
+    assert infos[0][4][0] == "93.184.216.34"
 
 
 def test_allows_normal_https():

--- a/tests/tools/test_mcp_probe.py
+++ b/tests/tools/test_mcp_probe.py
@@ -9,6 +9,16 @@ import pytest
 
 from nanobot.agent.tools.mcp import _probe_http_url, connect_mcp_servers
 from nanobot.agent.tools.registry import ToolRegistry
+from nanobot.security.network import configure_ssrf_whitelist
+
+_PROXY_ENV_VARS = ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy")
+
+
+@pytest.fixture(autouse=True)
+def _clear_proxy_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (*_PROXY_ENV_VARS, "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(name, raising=False)
+
 
 # ---------------------------------------------------------------------------
 # _probe_http_url unit tests
@@ -23,9 +33,11 @@ async def test_probe_returns_true_for_open_port(tmp_path):
 
     server = await asyncio.start_server(_close_connection, "127.0.0.1", 0)
     port = server.sockets[0].getsockname()[1]
+    configure_ssrf_whitelist(["127.0.0.1/32"])
     try:
         assert await _probe_http_url(f"http://127.0.0.1:{port}/mcp") is True
     finally:
+        configure_ssrf_whitelist([])
         server.close()
         await server.wait_closed()
 
@@ -49,6 +61,55 @@ async def test_probe_rejects_public_name_resolving_to_loopback():
 
     with patch("nanobot.security.network.socket.getaddrinfo", _resolver):
         assert await _probe_http_url("http://example.com:8765/mcp") is False
+
+
+@pytest.mark.asyncio
+async def test_probe_skips_direct_tcp_when_global_proxy_env_is_set(monkeypatch):
+    def _resolver(hostname, port, family=0, type_=0):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+
+    async def _open_connection(*args, **kwargs):
+        raise AssertionError("global proxy env should skip direct TCP probe")
+
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
+    monkeypatch.setenv("NO_PROXY", "localhost,127.0.0.1,::1")
+    monkeypatch.setattr("nanobot.agent.tools.mcp.asyncio.open_connection", _open_connection)
+
+    with patch("nanobot.security.network.socket.getaddrinfo", _resolver):
+        assert await _probe_http_url("https://mcp.example.com/mcp") is True
+
+
+@pytest.mark.asyncio
+async def test_probe_tries_next_validated_ip_when_first_is_unreachable(monkeypatch):
+    attempts: list[tuple[str, int]] = []
+
+    class FakeWriter:
+        def close(self):
+            return None
+
+        async def wait_closed(self):
+            return None
+
+    def _resolver(hostname, port, family=0, type_=0):
+        return [
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.35", 0)),
+        ]
+
+    async def _open_connection(host: str, port: int):
+        attempts.append((host, port))
+        if host == "93.184.216.34":
+            raise OSError("first address unreachable")
+        return object(), FakeWriter()
+
+    monkeypatch.setattr("nanobot.security.network.socket.getaddrinfo", _resolver)
+    monkeypatch.setattr("nanobot.agent.tools.mcp.asyncio.open_connection", _open_connection)
+
+    assert await _probe_http_url("http://mcp.example:8765/mcp") is True
+    assert attempts == [
+        ("93.184.216.34", 8765),
+        ("93.184.216.35", 8765),
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_mcp_probe.py
+++ b/tests/tools/test_mcp_probe.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import socket
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -39,6 +40,15 @@ async def test_probe_returns_false_for_closed_port():
 async def test_probe_uses_default_port_for_http():
     """When no port in URL, should default to 80 (will fail -> False)."""
     assert await _probe_http_url("http://unreachable-host.test/mcp") is False
+
+
+@pytest.mark.asyncio
+async def test_probe_rejects_public_name_resolving_to_loopback():
+    def _resolver(hostname, port, family=0, type_=0):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 0))]
+
+    with patch("nanobot.security.network.socket.getaddrinfo", _resolver):
+        assert await _probe_http_url("http://example.com:8765/mcp") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -751,6 +751,7 @@ async def test_connect_mcp_servers_http_clients_reject_unsafe_redirect_targets(
 
     monkeypatch.setattr(mcp_mod, "validate_url_target", _validate)
     monkeypatch.setattr(mcp_mod, "_probe_http_url", _reachable)
+    monkeypatch.setattr(mcp_mod, "PinnedDNSAsyncTransport", lambda: httpx.MockTransport(_handler))
     monkeypatch.setattr(mcp_mod.httpx, "AsyncClient", _async_client_with_mock_transport)
     monkeypatch.setattr(sys.modules["mcp.client.sse"], "sse_client", _fake_sse_client)
     monkeypatch.setattr(

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -659,8 +659,8 @@ async def test_connect_mcp_servers_logs_stdio_pollution_hint(
 @pytest.mark.parametrize(
     "config",
     [
-        MCPServerConfig(url="http://127.0.0.1:9/sse"),
-        MCPServerConfig(type="streamableHttp", url="http://127.0.0.1:9/mcp"),
+        MCPServerConfig(url="http://169.254.169.254/sse"),
+        MCPServerConfig(type="streamableHttp", url="http://169.254.169.254/mcp"),
     ],
 )
 async def test_connect_mcp_servers_rejects_unsafe_http_urls_before_probe(
@@ -709,7 +709,7 @@ async def test_connect_mcp_servers_http_clients_reject_unsafe_redirect_targets(
     sent_urls: list[str] = []
     used_transports: list[str] = []
 
-    def _validate(url: str) -> tuple[bool, str]:
+    def _validate(url: str, **_kwargs: object) -> tuple[bool, str]:
         checked_urls.append(url)
         if url == "http://127.0.0.1/private":
             return False, "loopback blocked"
@@ -751,7 +751,11 @@ async def test_connect_mcp_servers_http_clients_reject_unsafe_redirect_targets(
 
     monkeypatch.setattr(mcp_mod, "validate_url_target", _validate)
     monkeypatch.setattr(mcp_mod, "_probe_http_url", _reachable)
-    monkeypatch.setattr(mcp_mod, "PinnedDNSAsyncTransport", lambda: httpx.MockTransport(_handler))
+    monkeypatch.setattr(
+        mcp_mod,
+        "PinnedDNSAsyncTransport",
+        lambda **_kwargs: httpx.MockTransport(_handler),
+    )
     monkeypatch.setattr(mcp_mod.httpx, "AsyncClient", _async_client_with_mock_transport)
     monkeypatch.setattr(sys.modules["mcp.client.sse"], "sse_client", _fake_sse_client)
     monkeypatch.setattr(

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -22,6 +22,8 @@ from nanobot.agent.tools.mcp import (
 from nanobot.agent.tools.registry import ToolRegistry, is_tool_error_result
 from nanobot.config.schema import MCPServerConfig
 
+_PROXY_ENV_VARS = ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy")
+
 
 class _FakeTextContent:
     def __init__(self, text: str) -> None:
@@ -47,6 +49,12 @@ class _FakeImageContent:
 @pytest.fixture
 def fake_mcp_runtime() -> dict[str, object | None]:
     return {"session": None}
+
+
+@pytest.fixture(autouse=True)
+def _clear_proxy_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (*_PROXY_ENV_VARS, "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(name, raising=False)
 
 
 @pytest.fixture(autouse=True)
@@ -691,6 +699,8 @@ async def test_connect_mcp_servers_logs_stdio_pollution_hint(
 @pytest.mark.parametrize(
     "config",
     [
+        MCPServerConfig(url="http://127.0.0.1:9/sse"),
+        MCPServerConfig(type="streamableHttp", url="http://127.0.0.1:9/mcp"),
         MCPServerConfig(url="http://169.254.169.254/sse"),
         MCPServerConfig(type="streamableHttp", url="http://169.254.169.254/mcp"),
     ],
@@ -719,6 +729,93 @@ async def test_connect_mcp_servers_rejects_unsafe_http_urls_before_probe(
     assert registry.tool_names == []
     assert attempted_connections == []
     assert any("blocked unsafe URL" in warning for warning in warnings)
+
+
+@pytest.mark.asyncio
+async def test_validate_mcp_request_url_rejects_loopback_without_whitelist() -> None:
+    from nanobot.security.network import configure_ssrf_whitelist
+
+    configure_ssrf_whitelist([])
+    request = httpx.Request("GET", "http://127.0.0.1/private")
+
+    with pytest.raises(httpx.RequestError, match="Blocked unsafe MCP URL"):
+        await mcp_mod._validate_mcp_request_url(request)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "config",
+    [
+        MCPServerConfig(type="sse", url="https://mcp.example.com/sse"),
+        MCPServerConfig(type="streamableHttp", url="https://mcp.example.com/mcp"),
+    ],
+)
+async def test_connect_mcp_servers_env_proxy_adds_proxy_mounts_and_keeps_pinned_transport(
+    config: MCPServerConfig,
+    fake_mcp_runtime: dict[str, object | None],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_mcp_runtime["session"] = _make_fake_session(["demo"])
+    client_kwargs: list[dict[str, object]] = []
+
+    async def _reachable(_url: str) -> bool:
+        return True
+
+    def _validate(_url: str) -> tuple[bool, str]:
+        return True, ""
+
+    class FakeAsyncClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            client_kwargs.append(kwargs)
+
+        async def __aenter__(self) -> object:
+            return self
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> bool:
+            return False
+
+    @asynccontextmanager
+    async def _capturing_sse_client(_url: str, httpx_client_factory=None):
+        assert httpx_client_factory is not None
+        async with httpx_client_factory():
+            pass
+        yield object(), object()
+
+    @asynccontextmanager
+    async def _capturing_streamable_http_client(_url: str, http_client=None):
+        assert http_client is not None
+        yield object(), object(), object()
+
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
+    monkeypatch.setenv("NO_PROXY", "localhost,127.0.0.1,::1")
+    monkeypatch.setattr(mcp_mod, "validate_url_target", _validate)
+    monkeypatch.setattr(mcp_mod, "_probe_http_url", _reachable)
+    monkeypatch.setattr(mcp_mod.httpx, "AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(sys.modules["mcp.client.sse"], "sse_client", _capturing_sse_client)
+    monkeypatch.setattr(
+        sys.modules["mcp.client.streamable_http"],
+        "streamable_http_client",
+        _capturing_streamable_http_client,
+    )
+
+    registry = ToolRegistry()
+    stacks = await connect_mcp_servers({"remote": config}, registry)
+    for stack in stacks.values():
+        await stack.aclose()
+
+    assert client_kwargs
+    assert all("transport" in kwargs for kwargs in client_kwargs)
+    assert all("mounts" in kwargs for kwargs in client_kwargs)
+
+
+def test_mcp_http_clients_no_proxy_env_keeps_pinned_direct_route(monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
+    monkeypatch.setenv("NO_PROXY", "mcp.example.com")
+
+    kwargs = mcp_mod._pinned_transport_kwargs()
+
+    assert "transport" in kwargs
+    assert any(transport is None for transport in kwargs["mounts"].values())
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_web_fetch_security.py
+++ b/tests/tools/test_web_fetch_security.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import socket
 from unittest.mock import patch
@@ -12,6 +13,7 @@ import pytest
 from nanobot.agent.tools import web as web_module
 from nanobot.agent.tools.web import WebFetchTool, _get_with_safe_redirects
 from nanobot.config.schema import WebFetchConfig
+from nanobot.security.network import PinnedDNSAsyncTransport
 from nanobot.security.workspace_access import (
     bind_workspace_scope,
     build_workspace_scope,
@@ -98,27 +100,51 @@ async def test_web_fetch_result_contains_untrusted_flag():
 
 
 @pytest.mark.asyncio
-async def test_safe_redirect_request_pins_validated_dns(monkeypatch):
-    calls: list[str] = []
+async def test_safe_redirect_requests_use_independent_pinned_dns_concurrently(monkeypatch):
+    public_ips = {
+        "a.example": "93.184.216.34",
+        "b.example": "93.184.216.35",
+    }
+    calls: dict[str, int] = {host: 0 for host in public_ips}
+    seen: dict[str, str] = {}
 
-    def _rebinding_resolver(hostname, port, family=0, type_=0):
-        calls.append(hostname)
-        ip = "93.184.216.34" if len(calls) == 1 else "169.254.169.254"
+    def _rebinding_resolver(hostname, port, family=0, type_=0, proto=0, flags=0):
+        host = str(hostname).rstrip(".").lower()
+        calls[host] += 1
+        ip = public_ips[host] if calls[host] <= 2 else "169.254.169.254"
         return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (ip, 0))]
 
-    class FakeClient:
-        async def get(self, url, headers=None, follow_redirects=False):
-            infos = socket.getaddrinfo("attacker.example", 443, socket.AF_UNSPEC, socket.SOCK_STREAM)
-            assert infos[0][4][0] == "93.184.216.34"
-            return httpx.Response(200, request=httpx.Request("GET", url))
+    class ResolvingTransport(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            await asyncio.sleep(0)
+            infos = socket.getaddrinfo(
+                request.url.host,
+                request.url.port or 443,
+                socket.AF_UNSPEC,
+                socket.SOCK_STREAM,
+            )
+            seen[str(request.url)] = infos[0][4][0]
+            return httpx.Response(200, request=request)
+
+    async def _fetch(url: str) -> tuple[httpx.Response | None, str | None]:
+        async with httpx.AsyncClient(
+            transport=PinnedDNSAsyncTransport(inner=ResolvingTransport())
+        ) as client:
+            return await _get_with_safe_redirects(client, url)
 
     monkeypatch.setattr("nanobot.security.network.socket.getaddrinfo", _rebinding_resolver)
 
-    response, error = await _get_with_safe_redirects(FakeClient(), "https://attacker.example/")
+    results = await asyncio.gather(
+        _fetch("https://a.example/"),
+        _fetch("https://b.example/"),
+    )
 
-    assert error is None
-    assert response is not None
-    assert calls == ["attacker.example"]
+    assert all(error is None and response is not None for response, error in results)
+    assert seen == {
+        "https://a.example/": "93.184.216.34",
+        "https://b.example/": "93.184.216.35",
+    }
+    assert calls == {"a.example": 2, "b.example": 2}
 
 
 @pytest.mark.asyncio
@@ -318,6 +344,7 @@ async def test_web_fetch_blocks_private_redirect_before_returning_image(monkeypa
     class TransportAsyncClient(real_async_client):
         def __init__(self, *args, **kwargs):
             kwargs.pop("proxy", None)
+            kwargs.pop("transport", None)
             super().__init__(*args, transport=transport, **kwargs)
 
     monkeypatch.setattr("nanobot.agent.tools.web.httpx.AsyncClient", TransportAsyncClient)

--- a/tests/tools/test_web_fetch_security.py
+++ b/tests/tools/test_web_fetch_security.py
@@ -148,6 +148,19 @@ async def test_safe_redirect_requests_use_independent_pinned_dns_concurrently(mo
 
 
 @pytest.mark.asyncio
+async def test_web_fetch_rejects_proxy_because_upstream_dns_cannot_be_pinned():
+    tool = WebFetchTool(proxy="http://proxy.example:8080")
+
+    with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve_public):
+        result = await tool.execute(url="https://example.com/page")
+
+    data = json.loads(result)
+    assert "error" in data
+    assert "proxy" in data["error"].lower()
+    assert "dns-pinned" in data["error"].lower()
+
+
+@pytest.mark.asyncio
 async def test_web_fetch_can_skip_jina_and_use_custom_user_agent(monkeypatch):
     tool = WebFetchTool(
         config=WebFetchConfig(use_jina_reader=False),

--- a/tests/tools/test_web_fetch_security.py
+++ b/tests/tools/test_web_fetch_security.py
@@ -10,7 +10,7 @@ import httpx
 import pytest
 
 from nanobot.agent.tools import web as web_module
-from nanobot.agent.tools.web import WebFetchTool
+from nanobot.agent.tools.web import WebFetchTool, _get_with_safe_redirects
 from nanobot.config.schema import WebFetchConfig
 from nanobot.security.workspace_access import (
     bind_workspace_scope,
@@ -95,6 +95,30 @@ async def test_web_fetch_result_contains_untrusted_flag():
     data = json.loads(result)
     assert data.get("untrusted") is True
     assert "[External content" in data.get("text", "")
+
+
+@pytest.mark.asyncio
+async def test_safe_redirect_request_pins_validated_dns(monkeypatch):
+    calls: list[str] = []
+
+    def _rebinding_resolver(hostname, port, family=0, type_=0):
+        calls.append(hostname)
+        ip = "93.184.216.34" if len(calls) == 1 else "169.254.169.254"
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (ip, 0))]
+
+    class FakeClient:
+        async def get(self, url, headers=None, follow_redirects=False):
+            infos = socket.getaddrinfo("attacker.example", 443, socket.AF_UNSPEC, socket.SOCK_STREAM)
+            assert infos[0][4][0] == "93.184.216.34"
+            return httpx.Response(200, request=httpx.Request("GET", url))
+
+    monkeypatch.setattr("nanobot.security.network.socket.getaddrinfo", _rebinding_resolver)
+
+    response, error = await _get_with_safe_redirects(FakeClient(), "https://attacker.example/")
+
+    assert error is None
+    assert response is not None
+    assert calls == ["attacker.example"]
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_web_fetch_security.py
+++ b/tests/tools/test_web_fetch_security.py
@@ -21,6 +21,13 @@ from nanobot.security.workspace_access import (
 )
 
 _REAL_GETADDRINFO = socket.getaddrinfo
+_PROXY_ENV_VARS = ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy")
+
+
+@pytest.fixture(autouse=True)
+def _clear_proxy_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (*_PROXY_ENV_VARS, "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(name, raising=False)
 
 
 def _fake_resolve_private(hostname, port, family=0, type_=0):
@@ -29,6 +36,49 @@ def _fake_resolve_private(hostname, port, family=0, type_=0):
 
 def _fake_resolve_public(hostname, port, family=0, type_=0):
     return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+
+
+def _patch_web_fetch_fake_client(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    client_kwargs: list[dict] = []
+
+    class FakeStreamResponse:
+        status_code = 200
+        headers = {"content-type": "text/html"}
+        url = "https://example.com/page"
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeJinaResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"data": {"title": "Example", "content": "Hello", "url": "https://example.com/page"}}
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            client_kwargs.append(kwargs)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def stream(self, method, url, headers=None, **kwargs):
+            return FakeStreamResponse()
+
+        async def get(self, url, headers=None, **kwargs):
+            return FakeJinaResponse()
+
+    monkeypatch.setattr(web_module.httpx, "AsyncClient", FakeClient)
+    return client_kwargs
 
 
 @pytest.mark.asyncio
@@ -148,16 +198,80 @@ async def test_safe_redirect_requests_use_independent_pinned_dns_concurrently(mo
 
 
 @pytest.mark.asyncio
-async def test_web_fetch_rejects_proxy_because_upstream_dns_cannot_be_pinned():
-    tool = WebFetchTool(proxy="http://proxy.example:8080")
+async def test_web_fetch_proxy_remains_supported(monkeypatch):
+    tool = WebFetchTool(proxy="http://config-proxy.example:7890")
+    client_kwargs = _patch_web_fetch_fake_client(monkeypatch)
+
+    monkeypatch.setenv("HTTPS_PROXY", "http://env-proxy.example:8080")
+    monkeypatch.setenv("NO_PROXY", "example.com")
 
     with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve_public):
         result = await tool.execute(url="https://example.com/page")
 
     data = json.loads(result)
+    assert data["extractor"] == "jina"
+    assert all(kwargs["proxy"] == "http://config-proxy.example:7890" for kwargs in client_kwargs)
+    assert all("mounts" not in kwargs for kwargs in client_kwargs)
+    assert all("transport" not in kwargs for kwargs in client_kwargs)
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_env_proxy_adds_proxy_mounts_and_keeps_pinned_transport(monkeypatch):
+    tool = WebFetchTool()
+    client_kwargs = _patch_web_fetch_fake_client(monkeypatch)
+
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
+    monkeypatch.setenv("NO_PROXY", "localhost,127.0.0.1,::1")
+
+    with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve_public):
+        result = await tool.execute(url="https://example.com/page")
+
+    data = json.loads(result)
+    assert data["extractor"] == "jina"
+    fetch_kwargs = [kwargs for kwargs in client_kwargs if kwargs.get("timeout") == 15.0]
+    assert fetch_kwargs
+    assert all("transport" in kwargs for kwargs in fetch_kwargs)
+    assert all("mounts" in kwargs for kwargs in fetch_kwargs)
+
+
+def test_web_fetch_no_proxy_env_keeps_pinned_direct_route(monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
+    monkeypatch.setenv("NO_PROXY", "example.com")
+
+    kwargs = web_module._fetch_client_kwargs(None, 15.0)
+
+    assert "transport" in kwargs
+    assert any(transport is None for transport in kwargs["mounts"].values())
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_does_not_fallback_after_pinned_dns_rebind_rejection(monkeypatch):
+    calls = {"evil.example": 0}
+
+    def _rebinding_resolver(hostname, port, family=0, type_=0, proto=0, flags=0):
+        host = str(hostname).rstrip(".").lower()
+        calls[host] += 1
+        ip = "93.184.216.34" if calls[host] <= 2 else "169.254.169.254"
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (ip, 0))]
+
+    tool = WebFetchTool()
+
+    async def _unexpected_jina(*args, **kwargs):
+        raise AssertionError("Jina fallback should not run after an SSRF rejection")
+
+    async def _unexpected_readability(*args, **kwargs):
+        raise AssertionError("Readability fallback should not run after an SSRF rejection")
+
+    monkeypatch.setattr(tool, "_fetch_jina", _unexpected_jina)
+    monkeypatch.setattr(tool, "_fetch_readability", _unexpected_readability)
+
+    with patch("nanobot.security.network.socket.getaddrinfo", _rebinding_resolver):
+        result = await tool.execute(url="http://evil.example/page")
+
+    data = json.loads(result)
     assert "error" in data
-    assert "proxy" in data["error"].lower()
-    assert "dns-pinned" in data["error"].lower()
+    assert "blocked" in data["error"].lower()
+    assert calls["evil.example"] == 3
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- return validated resolved IPs from SSRF URL validation while preserving the existing validate_url_target API
- pin web_fetch DNS lookups to the validated IPs while opening each request/redirect
- use pinned DNS for MCP HTTP probes and MCP HTTP client transports

Fixes #4611

## Verification
- uv run pytest tests/security/test_security_network.py tests/tools/test_web_fetch_security.py -q
- uv run pytest tests/tools/test_mcp_tool.py -q
- uv run ruff check nanobot/security/network.py nanobot/agent/tools/web.py nanobot/agent/tools/mcp.py tests/security/test_security_network.py tests/tools/test_web_fetch_security.py tests/tools/test_mcp_tool.py