### PR TITLE
fix(dream): ground memory audit records in the real git diff

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -41,6 +41,14 @@ class MemoryStore:
     """Pure file I/O for memory files: MEMORY.md, history.jsonl, SOUL.md, USER.md."""
 
     _DEFAULT_MAX_HISTORY = 1000
+    # Durable files whose real working-tree delta grounds Dream commit messages
+    # and the cursor-advance gate. Deliberately excludes memory/.dream_cursor so
+    # that advancing the cursor itself is never mistaken for a productive edit.
+    _DREAM_CONTENT_PATHS = ("SOUL.md", "USER.md", "memory/MEMORY.md")
+    # Per-file cap when embedding current contents into the Dream prompt. The
+    # durable files are tiny in practice (~5 KB total), but a runaway file must
+    # not unbounded the prompt.
+    _DREAM_FILE_EMBED_CAP = 8000
     _INTERNAL_HISTORY_SESSION_PREFIXES = ("cron:", "dream:")
     _INTERNAL_HISTORY_SESSION_KEYS = {"heartbeat"}
     _LEGACY_ENTRY_START_RE = re.compile(r"^\[(\d{4}-\d{2}-\d{2}[^\]]*)\]\s*")
@@ -485,6 +493,11 @@ class MemoryStore:
         """Build the Dream prompt with unprocessed history context.
 
         Returns ``(prompt, last_cursor)`` or ``None`` if nothing to process.
+
+        The current contents of the durable memory files (SOUL.md, USER.md,
+        memory/MEMORY.md) are embedded so the model edits the real files rather
+        than a stale mental model — eliminating a class of failed/out-of-bounds
+        edits that previously produced hallucinated audit records.
         """
         from nanobot.agent.skills import BUILTIN_SKILLS_DIR
 
@@ -502,8 +515,45 @@ class MemoryStore:
         template = render_template(
             "agent/dream.md", strip=True, skill_creator_path=skill_creator_path,
         )
-        prompt = f"{template}\n\n## Conversation History\n{history_text}"
+        files_section = self._render_current_memory_files()
+        prompt = (
+            f"{template}\n\n{files_section}\n\n"
+            f"## Conversation History\n{history_text}"
+        )
         return (prompt, batch[-1]["cursor"])
+
+    def _render_current_memory_files(self) -> str:
+        """Render the durable memory files' current contents for the Dream prompt.
+
+        Missing files render as ``(empty)``; oversized files are capped. The
+        section is the ground truth the model must edit against.
+        """
+        files = [
+            ("SOUL.md", self.soul_file),
+            ("USER.md", self.user_file),
+            ("memory/MEMORY.md", self.memory_file),
+        ]
+        blocks = []
+        for label, path in files:
+            try:
+                content = path.read_text(encoding="utf-8") if path.exists() else ""
+            except OSError:
+                content = ""
+            if len(content) > self._DREAM_FILE_EMBED_CAP:
+                content = truncate_text(content, self._DREAM_FILE_EMBED_CAP) + "\n...[truncated]"
+            blocks.append(f"### {label}\n{content}" if content.strip() else f"### {label}\n(empty)")
+        return "## Current Memory Files\n" + "\n\n".join(blocks)
+
+    def dream_content_diff(self) -> str:
+        """Structured summary of uncommitted changes to the durable memory files.
+
+        Returns "" when git is unavailable or no content file changed. This is
+        the ground-truth input for diff-grounded Dream commit messages and for
+        gating cursor advance on real edits (never on LLM self-report).
+        """
+        if not self._git.is_initialized():
+            return ""
+        return self._git.summarize_working_tree(list(self._DREAM_CONTENT_PATHS))
 
     def build_dream_tools(self):
         """Build the restricted tool registry used by Dream runs."""
@@ -596,12 +646,22 @@ class MemoryStore:
         return f"dream:{datetime.now():%Y%m%d-%H%M%S}"
 
     @staticmethod
-    def build_dream_commit_message(prefix: str, resp: object | None) -> str:
-        """Build a Dream auto-commit message, appending the LLM summary if present."""
-        msg = prefix
-        if resp is not None and getattr(resp, "content", None):
-            msg = f"{msg}\n\n{resp.content.strip()}"
-        return msg
+    def build_dream_commit_message(prefix: str, diff_body: str) -> str:
+        """Build a Dream commit message grounded in the real working-tree diff.
+
+        *diff_body* is a structured, machine-derived summary of the actual file
+        changes (see :meth:`dream_content_diff` /
+        :meth:`GitStore.summarize_working_tree`). The LLM narrative is
+        deliberately excluded so the audit record (``/dream-log``) reflects the
+        filesystem's truth, not the model's self-report.
+
+        An empty *diff_body* yields the bare *prefix*, which ``auto_commit``
+        turns into a no-op when there is nothing to stage.
+        """
+        diff_body = (diff_body or "").strip()
+        if not diff_body:
+            return prefix
+        return f"{prefix}\n\n{diff_body}"
 
     @staticmethod
     def prune_dream_sessions(sessions_dir: Path, *, keep: int = 10) -> None:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1017,6 +1017,7 @@ def _run_gateway(
 
             store = agent.context.memory
             resp = None
+            diff_body = ""
             try:
                 result = store.build_dream_prompt()
                 if result is None:
@@ -1031,9 +1032,20 @@ def _run_gateway(
                     tools=store.build_dream_tools(),
                     on_progress=_silent,
                 )
-                if MemoryStore.dream_run_completed(resp):
+                # Ground truth: the real file delta, not the LLM's self-report.
+                diff_body = store.dream_content_diff()
+                productive = bool(diff_body) or (
+                    not store.git.is_initialized()
+                    and MemoryStore.dream_run_completed(resp)
+                )
+                if productive:
                     store.set_last_dream_cursor(last_cursor)
                     logger.info("Dream cron job completed, cursor advanced to {}", last_cursor)
+                elif MemoryStore.dream_run_completed(resp):
+                    logger.info(
+                        "Dream cron job completed with no memory changes; "
+                        "cursor not advanced",
+                    )
                 else:
                     logger.warning(
                         "Dream cron job did not complete; cursor remains at {}",
@@ -1051,7 +1063,7 @@ def _run_gateway(
                 )
                 if store.git.is_initialized():
                     msg = build_dream_commit_message(
-                        "dream: periodic memory consolidation", resp,
+                        "dream: periodic memory consolidation", diff_body,
                     )
                     sha = store.git.auto_commit(msg)
                     if sha:

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -352,6 +352,7 @@ async def cmd_dream(ctx: CommandContext) -> OutboundMessage:
         store = loop.context.memory
         content = ""
         resp = None
+        diff_body = ""
         t0 = time.monotonic()
         try:
             result = store.build_dream_prompt()
@@ -372,9 +373,17 @@ async def cmd_dream(ctx: CommandContext) -> OutboundMessage:
                 on_progress=_silent,
             )
             elapsed = time.monotonic() - t0
-            if MemoryStore.dream_run_completed(resp):
+            # Ground truth: the real file delta, not the LLM's self-report.
+            diff_body = store.dream_content_diff()
+            productive = bool(diff_body) or (
+                not store.git.is_initialized()
+                and MemoryStore.dream_run_completed(resp)
+            )
+            if productive:
                 store.set_last_dream_cursor(last_cursor)
                 content = f"Dream completed in {elapsed:.1f}s."
+            elif MemoryStore.dream_run_completed(resp):
+                content = f"Dream completed in {elapsed:.1f}s; no memory changes."
             else:
                 content = (
                     f"Dream did not complete after {elapsed:.1f}s; "
@@ -392,7 +401,7 @@ async def cmd_dream(ctx: CommandContext) -> OutboundMessage:
                 timezone_name=getattr(loop.context, "timezone", None),
             )
             if store.git.is_initialized():
-                commit_msg = build_dream_commit_message("dream: manual run", resp)
+                commit_msg = build_dream_commit_message("dream: manual run", diff_body)
                 sha = store.git.auto_commit(commit_msg)
                 if sha:
                     content += f" (commit {sha})"

--- a/nanobot/templates/agent/dream.md
+++ b/nanobot/templates/agent/dream.md
@@ -99,7 +99,10 @@ For [SKILL] entries:
 - Skills are instruction sets with concrete values, commands, and examples. MEMORY.md keeps strategic context and high-level facts only.
 
 ## Editing
-- Inspect current file contents before editing; they are not embedded in the prompt to keep context compact.
+- Current contents of SOUL.md, USER.md, and memory/MEMORY.md are embedded in this prompt under "Current Memory Files". Edit those files directly; do not rely on a remembered version of a file.
 - Batch changes into as few calls as possible. Surgical edits only.
+
+## Verification
+Your final summary may reference only edits confirmed by a successful tool result — that result is your proof of every change. Do not narrate edits you did not make. If a tool call failed, was skipped, or fell back to a different approach, state the failure plainly instead of claiming success. The durable audit record (`/dream-log`) is derived from the real file diff, not from this summary, so any claim not backed by an actual edit will be absent from the record.
 
 Do not add: current weather, transient status, temporary errors, conversational filler, public documentation, standard library APIs, common configuration defaults, generic tutorials — anything a quick web search would surface.

--- a/nanobot/utils/gitstore.py
+++ b/nanobot/utils/gitstore.py
@@ -354,11 +354,20 @@ class GitStore:
                     if head_text is None:
                         head_text = ""
                     wt_path = self._workspace / path
-                    wt_text = (
-                        wt_path.read_text(encoding="utf-8", errors="replace")
-                        if wt_path.exists()
-                        else ""
-                    )
+                    try:
+                        wt_text = (
+                            wt_path.read_text(encoding="utf-8")
+                            if wt_path.exists()
+                            else ""
+                        )
+                    except UnicodeDecodeError:
+                        # Non-UTF-8 (binary/corrupt) working-tree file: record
+                        # the change without a unified diff, which would
+                        # otherwise be polluted with replacement characters and
+                        # misrepresent the audit record.
+                        changed += 1
+                        summary_lines.append(f"{path}: binary or non-UTF-8 file changed")
+                        continue
                     if head_text == wt_text:
                         continue
                     changed += 1
@@ -392,7 +401,8 @@ class GitStore:
             f"{total_added} insertion{'s' if total_added != 1 else ''}(+), "
             f"{total_removed} deletion{'s' if total_removed != 1 else ''}(-)"
         )
-        body += f"\n\n```diff\n{diff_text}\n```"
+        if diff_lines:
+            body += f"\n\n```diff\n{diff_text}\n```"
         return body
 
     @staticmethod

--- a/nanobot/utils/gitstore.py
+++ b/nanobot/utils/gitstore.py
@@ -10,6 +10,11 @@ from pathlib import Path
 
 from loguru import logger
 
+# Cap on the unified-diff block embedded in Dream commit messages. Memory files
+# are tiny in practice, but a pathological rewrite must not blow up the audit
+# record. The structured per-file summary is always emitted in full regardless.
+_WORKING_TREE_DIFF_MAX_CHARS = 6000
+
 
 @dataclass
 class CommitInfo:
@@ -298,6 +303,109 @@ class GitStore:
         except Exception:
             logger.exception("Git diff_commits failed")
             return ""
+
+    def summarize_working_tree(self, paths: list[str]) -> str:
+        """Structured summary of working-tree changes vs HEAD for *paths*.
+
+        Pure filesystem/git ground truth — never LLM narrative — suitable as a
+        truthful audit record. Returns "" when the repo is not initialized or
+        none of *paths* differ from HEAD.
+
+        Format::
+
+            SOUL.md: +3 -1
+            memory/MEMORY.md: +12 -8
+
+            2 files changed, 15 insertions(+), 9 deletions(-)
+
+            ```diff
+            --- SOUL.md
+            +++ SOUL.md
+            @@ ...
+            - old
+            + new
+            ```
+        """
+        if not self.is_initialized():
+            return ""
+
+        try:
+            import difflib
+
+            from dulwich.repo import Repo
+        except ImportError:
+            return ""
+
+        summary_lines: list[str] = []
+        diff_lines: list[str] = []
+        total_added = 0
+        total_removed = 0
+        changed = 0
+
+        try:
+            with Repo(str(self._workspace)) as repo:
+                head_tree = self._head_tree(repo)
+                for path in paths:
+                    head_text = (
+                        self._read_blob_from_tree(repo, head_tree, path)
+                        if head_tree is not None
+                        else None
+                    )
+                    if head_text is None:
+                        head_text = ""
+                    wt_path = self._workspace / path
+                    wt_text = (
+                        wt_path.read_text(encoding="utf-8", errors="replace")
+                        if wt_path.exists()
+                        else ""
+                    )
+                    if head_text == wt_text:
+                        continue
+                    changed += 1
+                    hunks = list(difflib.unified_diff(
+                        head_text.splitlines(),
+                        wt_text.splitlines(),
+                        fromfile=path,
+                        tofile=path,
+                        lineterm="",
+                    ))
+                    added = sum(1 for line in hunks if line.startswith("+") and not line.startswith("+++"))
+                    removed = sum(1 for line in hunks if line.startswith("-") and not line.startswith("---"))
+                    total_added += added
+                    total_removed += removed
+                    summary_lines.append(f"{path}: +{added} -{removed}")
+                    diff_lines.extend(hunks)
+        except Exception:
+            logger.exception("Git summarize_working_tree failed")
+            return ""
+
+        if changed == 0:
+            return ""
+
+        diff_text = "\n".join(diff_lines)
+        if len(diff_text) > _WORKING_TREE_DIFF_MAX_CHARS:
+            diff_text = diff_text[:_WORKING_TREE_DIFF_MAX_CHARS] + "\n...[diff truncated]"
+
+        body = "\n".join(summary_lines)
+        body += (
+            f"\n{changed} file{'s' if changed != 1 else ''} changed, "
+            f"{total_added} insertion{'s' if total_added != 1 else ''}(+), "
+            f"{total_removed} deletion{'s' if total_removed != 1 else ''}(-)"
+        )
+        body += f"\n\n```diff\n{diff_text}\n```"
+        return body
+
+    @staticmethod
+    def _head_tree(repo) -> object | None:
+        """Return the tree object at HEAD, or None if there are no commits."""
+        try:
+            head = repo.refs[b"HEAD"]
+        except KeyError:
+            return None
+        commit = repo[head]
+        if commit.type_name != b"commit":
+            return None
+        return repo[commit.tree]
 
     def find_commit(self, short_sha: str, max_entries: int = 20) -> CommitInfo | None:
         """Find a commit by short SHA prefix match."""

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -61,6 +61,29 @@ class TestBuildDreamPrompt:
         prompt, _ = result
         assert "skill-creator" in prompt
 
+    def test_prompt_embeds_current_memory_file_contents(self, store):
+        """Dream must see the real current file contents (Tier 4) so it edits the
+        files, not a stale mental model."""
+        store.append_history("hello")
+        result = store.build_dream_prompt()
+        assert result is not None
+        prompt, _ = result
+        assert "## Current Memory Files" in prompt
+        assert "### SOUL.md" in prompt
+        assert "### USER.md" in prompt
+        assert "### memory/MEMORY.md" in prompt
+        # Real current contents are embedded verbatim.
+        assert "Project X active" in prompt
+        assert "Helpful" in prompt
+
+    def test_prompt_renders_missing_files_as_empty(self, tmp_path):
+        store = MemoryStore(tmp_path)  # no durable files written
+        store.append_history("hello")
+        result = store.build_dream_prompt()
+        assert result is not None
+        prompt, _ = result
+        assert "(empty)" in prompt
+
     def test_truncates_long_entries(self, store):
         long_content = "x" * 2000
         store.append_history(long_content)
@@ -524,48 +547,95 @@ class TestEphemeralHooks:
         spy.before_iteration.assert_called()
 
 class TestDreamCommitMessage:
-    async def test_commit_includes_response_summary(self, tmp_path):
-        """Git auto-commit after Dream should include the LLM response in the body."""
-        import subprocess
-        from unittest.mock import AsyncMock, MagicMock
+    def test_commit_message_reflects_real_diff_not_narrative(self, tmp_path):
+        """The Dream commit message must mirror the real git diff and ignore the
+        LLM's narrative, so ``/dream-log`` can never lie.
 
-        from nanobot.agent.memory import MemoryStore
+        Regression for the hallucinated-commit bug: commit ``a72ca2a`` claimed a
+        "Medical Research" section that never reached the diff.
+        """
+        import subprocess
 
         store = MemoryStore(tmp_path)
         store.write_soul("# Soul")
         store.write_memory("# Memory")
-        store.append_history("user discussed project goals")
-
-        provider = MagicMock()
-        provider.get_default_model.return_value = "test-model"
-        provider.supports_tools = True
-        provider.generation = MagicMock(max_tokens=4096)
-        provider.chat_with_retry = AsyncMock(return_value=MagicMock(
-            content="Identified 2 new facts about project goals",
-            finish_reason="stop",
-            tool_calls=[],
-            usage={},
-        ))
-
         store.git.init()
         store.git.auto_commit("initial state")
 
-        # Simulate what the cron handler does: produce a resp with content,
-        # build the commit message via the actual function, then commit.
-        resp_content = "Identified 2 new facts about project goals"
-        resp = MagicMock(content=resp_content)
-        msg = MemoryStore.build_dream_commit_message(
-            "dream: periodic memory consolidation", resp,
-        )
+        # A real edit to a tracked content file.
+        store.write_memory("# Memory\n- DMSO research notes")
 
-        # Write a change so auto_commit has something to commit
-        store.write_memory("# Memory\n- Updated by Dream")
+        # A lying narrative the old code would have appended verbatim.
+        lying = "Added a Medical Research section (Mastic Gum, DMSO) to MEMORY.md"
+        diff_body = store.dream_content_diff()
+        assert diff_body, "real edit must be detected"
+        assert "DMSO research notes" in diff_body
+        assert lying not in diff_body
+
+        msg = MemoryStore.build_dream_commit_message(
+            "dream: periodic memory consolidation", diff_body,
+        )
+        assert lying not in msg
+        assert "DMSO research notes" in msg
+
         sha = store.git.auto_commit(msg)
         assert sha is not None
-
         log = subprocess.check_output(
             ["git", "log", "-1", "--format=%B"],
             cwd=str(tmp_path), text=True,
         ).strip()
         assert "dream: periodic memory consolidation" in log
-        assert "Identified 2 new facts" in log
+        assert "DMSO research notes" in log
+        assert lying not in log
+
+    def test_commit_message_is_bare_prefix_when_no_changes(self, tmp_path):
+        """A no-op Dream run yields only the prefix — never a narrated summary."""
+        store = MemoryStore(tmp_path)
+        store.write_soul("# Soul")
+        store.write_memory("# Memory")
+        store.git.init()
+        store.git.auto_commit("initial state")
+
+        # No edits at all.
+        assert store.dream_content_diff() == ""
+        msg = MemoryStore.build_dream_commit_message(
+            "dream: manual run", store.dream_content_diff(),
+        )
+        assert msg == "dream: manual run"
+
+    def test_build_commit_message_ignores_none_and_empty_body(self):
+        assert MemoryStore.build_dream_commit_message("dream: x", "") == "dream: x"
+        assert MemoryStore.build_dream_commit_message("dream: x", None) == "dream: x"
+        assert MemoryStore.build_dream_commit_message("dream: x", "  ") == "dream: x"
+        assert (
+            MemoryStore.build_dream_commit_message("dream: x", "SOUL.md: +1 -0")
+            == "dream: x\n\nSOUL.md: +1 -0"
+        )
+
+
+class TestDreamContentDiff:
+    """The ground-truth signal that gates cursor advance and commit messages."""
+
+    def test_empty_when_git_not_initialized(self, store):
+        assert store.dream_content_diff() == ""
+
+    def test_empty_when_no_tracked_changes(self, store):
+        store.git.init()
+        store.git.auto_commit("initial")
+        assert store.dream_content_diff() == ""
+
+    def test_reflects_real_content_edits(self, store):
+        store.git.init()
+        store.git.auto_commit("initial")
+        store.write_memory("# Memory\n- DMSO research notes")
+        diff = store.dream_content_diff()
+        assert diff
+        assert "memory/MEMORY.md" in diff
+        assert "DMSO research notes" in diff
+
+    def test_ignores_cursor_only_changes(self, store):
+        """Advancing the cursor must not count as a productive content edit."""
+        store.git.init()
+        store.git.auto_commit("initial")
+        store.set_last_dream_cursor(99)  # only memory/.dream_cursor changes
+        assert store.dream_content_diff() == ""

--- a/tests/command/test_builtin_dream.py
+++ b/tests/command/test_builtin_dream.py
@@ -12,10 +12,17 @@ from nanobot.utils.gitstore import CommitInfo
 
 
 class _FakeStore:
-    def __init__(self, git, last_dream_cursor: int = 1, dream_prompt_result=None):
+    def __init__(
+        self,
+        git,
+        last_dream_cursor: int = 1,
+        dream_prompt_result=None,
+        content_diff: str = "",
+    ):
         self.git = git
         self._last_dream_cursor = last_dream_cursor
         self._dream_prompt_result = dream_prompt_result
+        self._content_diff = content_diff
         self.compact_history_called = False
 
     def get_last_dream_cursor(self) -> int:
@@ -29,6 +36,9 @@ class _FakeStore:
 
     def set_last_dream_cursor(self, value: int) -> None:
         self._last_dream_cursor = value
+
+    def dream_content_diff(self) -> str:
+        return self._content_diff
 
     def compact_history(self) -> None:
         self.compact_history_called = True
@@ -142,6 +152,74 @@ async def test_dream_internal_run_silences_progress(tmp_path) -> None:
 
     assert len(calls) == 1
     assert callable(calls[0][1]["on_progress"])
+
+
+def _build_runnable_dream(
+    tmp_path,
+    *,
+    initialized: bool,
+    content_diff: str,
+    stop_reason: str = "completed",
+) -> tuple[CommandContext, _FakeStore]:
+    """Build a /dream ctx whose run is driven by a canned stop reason + diff."""
+    msg = InboundMessage(channel="cli", sender_id="u1", chat_id="direct", content="/dream")
+    store = _FakeStore(
+        _FakeGit(initialized=initialized),
+        last_dream_cursor=5,
+        dream_prompt_result=("dream prompt", 42),
+        content_diff=content_diff,
+    )
+
+    async def process_direct(*args, **kwargs):
+        return OutboundMessage(
+            channel="cli",
+            chat_id="direct",
+            content="done",
+            metadata={"_stop_reason": stop_reason},
+        )
+
+    bus = _FakeBus()
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    loop = SimpleNamespace(
+        bus=bus,
+        context=SimpleNamespace(memory=store, timezone="UTC"),
+        sessions=SimpleNamespace(sessions_dir=sessions_dir),
+        process_direct=process_direct,
+    )
+    ctx = CommandContext(msg=msg, session=None, key=msg.session_key, raw="/dream", args="", loop=loop)
+    return ctx, store
+
+
+@pytest.mark.asyncio
+async def test_dream_advances_cursor_when_diff_nonempty(tmp_path) -> None:
+    """A real file delta => productive run => cursor advances (Tier 3)."""
+    ctx, store = _build_runnable_dream(tmp_path, initialized=True, content_diff="SOUL.md: +1 -0")
+    await cmd_dream(ctx)
+    await asyncio.sleep(0)
+    assert store._last_dream_cursor == 42
+
+
+@pytest.mark.asyncio
+async def test_dream_keeps_cursor_on_completed_noop(tmp_path) -> None:
+    """Completed run with no file changes must NOT advance the cursor, so the
+    history batch is reconsidered next run instead of silently swallowed."""
+    ctx, store = _build_runnable_dream(tmp_path, initialized=True, content_diff="")
+    await cmd_dream(ctx)
+    await asyncio.sleep(0)
+    assert store._last_dream_cursor == 5  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_dream_non_git_falls_back_to_completion_gate(tmp_path) -> None:
+    """Without git there is no diff signal; productivity falls back to the
+    completion check so non-git workspaces keep working."""
+    ctx, store = _build_runnable_dream(
+        tmp_path, initialized=False, content_diff="", stop_reason="completed",
+    )
+    await cmd_dream(ctx)
+    await asyncio.sleep(0)
+    assert store._last_dream_cursor == 42  # advanced via completion fallback
 
 
 @pytest.mark.asyncio

--- a/tests/utils/test_gitstore.py
+++ b/tests/utils/test_gitstore.py
@@ -135,6 +135,13 @@ class TestSummarizeWorkingTree:
         assert summary  # a removal is still a change
         assert "deletion" in summary
 
+    def test_non_utf8_file_marked_binary_without_replacement_chars(self, git, tmp_path):
+        # Invalid UTF-8 must not leak replacement chars into the audit record.
+        (tmp_path / "MEMORY.md").write_bytes(b"\x89PNG\r\n\x1a\n\xff\xfe\x00\x01")
+        summary = git.summarize_working_tree(["MEMORY.md"])
+        assert "MEMORY.md: binary or non-UTF-8 file changed" in summary
+        assert "\ufffd" not in summary  # no U+FFFD replacement chars leaked
+
 
 class TestNestedRepoProtection:
     """Regression tests for GitHub issue #2980: nested repo protection."""

--- a/tests/utils/test_gitstore.py
+++ b/tests/utils/test_gitstore.py
@@ -98,6 +98,44 @@ class TestLineAges:
         assert age_by_line["- keep"] == 30
 
 
+class TestSummarizeWorkingTree:
+    """Ground-truth diff summary used to keep Dream audit records honest."""
+
+    def test_empty_when_not_initialized(self, tmp_path):
+        git = GitStore(tmp_path, tracked_files=["MEMORY.md"])
+        assert git.summarize_working_tree(["MEMORY.md"]) == ""
+
+    def test_empty_when_no_changes(self, git):
+        assert git.summarize_working_tree(["MEMORY.md", "SOUL.md"]) == ""
+
+    def test_summarizes_real_change(self, git, tmp_path):
+        (tmp_path / "MEMORY.md").write_text("# Memory\n- new fact\n", encoding="utf-8")
+        summary = git.summarize_working_tree(["MEMORY.md"])
+        assert "MEMORY.md: +2 -0" in summary
+        assert "new fact" in summary
+        assert "1 file changed, 2 insertions(+), 0 deletions(-)" in summary
+
+    def test_only_reports_requested_paths(self, git, tmp_path):
+        # MEMORY.md changes, but we only ask about the unchanged SOUL.md.
+        (tmp_path / "MEMORY.md").write_text("changed\n", encoding="utf-8")
+        assert git.summarize_working_tree(["SOUL.md"]) == ""
+
+    def test_counts_additions_and_removals(self, git, tmp_path):
+        (tmp_path / "MEMORY.md").write_text("# M\n- keep\n- new\n", encoding="utf-8")
+        summary = git.summarize_working_tree(["MEMORY.md"])
+        assert "MEMORY.md: +3 -0" in summary
+
+    def test_detects_deletion(self, git, tmp_path):
+        # File removed from the working tree (must have content first; the
+        # fixture's tracked files start empty, so an empty-file delete is a no-op).
+        (tmp_path / "MEMORY.md").write_text("has content\n", encoding="utf-8")
+        git.auto_commit("add content")
+        (tmp_path / "MEMORY.md").unlink()
+        summary = git.summarize_working_tree(["MEMORY.md"])
+        assert summary  # a removal is still a change
+        assert "deletion" in summary
+
+
 class TestNestedRepoProtection:
     """Regression tests for GitHub issue #2980: nested repo protection."""
 


### PR DESCRIPTION
## Problem

A Dream consolidation run could produce a `/dream-log` record that does **not** match the actual file changes. The commit message — which doubles as the user-facing audit log — was the model's own narrative, appended verbatim with no reconciliation against the real diff.

Observed failure: a "periodic memory consolidation" commit claimed to add a "Medical Research" section (DMSO, Mastic Gum) to `memory/MEMORY.md`, but the real diff contained no such section — only a `USER.md` addition and a `[durable]`-tag prune. A user trusting `/dream-log` would never re-read the files, so the record wasn't just incomplete; it was actively misleading.

## Why this became possible

Dream was simplified in `d1a94dae`, which replaced a heavyweight two-phase class with a single `process_direct` call. That refactor was a reasonable complexity reduction, but it quietly removed a structural guarantee the old design had for free.

**The old two-phase design separated analysis from edits:**
- **Phase 1** produced a constrained, *pre-edit* analysis artifact (one tagged line per finding: `[FILE] …`, `[FILE-REMOVE] …`, `[SKILL] …`). That artifact became the commit message.
- **Phase 2** consumed the Phase 1 output and performed the edits — and crucially it **embedded the current file contents** ("Edit directly — file contents provided below, no `read_file` needed").

Because the narrative (Phase 1) was produced *before* and *independently of* the edits (Phase 2), it could describe intent without being able to misrepresent outcome.

**The single-phase collapse changed the semantics of the narrative.** Each individual choice in the refactor was locally motivated, but together they let the model's after-the-fact self-report become the durable record:

| Choice (post-refactor) | Reasonable local motivation | What it actually enabled |
|---|---|---|
| `build_dream_commit_message` appends `resp.content` | "Restore" the rich audit narrative Phase 1 used to provide | `resp.content` is a single-turn self-report, not a pre-edit analysis — it can drift from what really happened |
| `dream_run_completed` checks only the stop reason | Crash-safety: don't advance the cursor on a crashed run | Cannot tell a productive run from a silent-edit-failure / no-op run |
| File contents omitted ("to keep context compact") | Token economy for a background task | A regression — old Phase 2 *did* embed them; the model now edits a remembered/stale file and lost edits go unnoticed |

The hallucination is an **emergent property of removing the structural separation** — not any single careless line. With no edit verification and no embedded ground truth, the model's narrative could drift from reality, and that drift became the auditable record.

## Fix

Re-derive the old guarantees **mechanically**, without reviving the heavyweight class. Three layers, each independently sufficient for a different property:

**1. Diff-grounded audit record (corrective).** The commit message is now derived from the real `git diff` of the tracked memory files, never from the model's words.
- `GitStore.summarize_working_tree()` (`nanobot/utils/gitstore.py`): a structured, machine-derived summary — per-file `+N/-M`, totals, and a capped unified diff — computed from the working tree vs HEAD.
- `MemoryStore.build_dream_commit_message(prefix, diff_body)`: takes the diff body instead of `resp`; an empty diff yields only the prefix.

**2. Cursor-advance gate (data retention).** The dream cursor now advances only when there is a non-empty content diff. A no-op or failed-edit run no longer silently swallows its history batch — it is reconsidered next run. Since the diff is already computed for (1), this is nearly free.
- `MemoryStore.dream_content_diff()`: the ground-truth delta over `SOUL.md`/`USER.md`/`memory/MEMORY.md` only — deliberately excludes `memory/.dream_cursor` so that advancing the cursor itself is never mistaken for a productive edit.

**3. Embed current file contents (preventive).** `build_dream_prompt` now embeds the live contents of the three durable files (with a per-file cap), restoring the property old Phase 2 had. The model edits the real files, eliminating the stale-mental-model and lost-edit failure classes at the source. `dream.md` is updated to document this and to add a chain-of-verification guardrail: the summary may only cite edits confirmed by a successful tool result.

Non-git workspaces (no audit log to protect) fall back to the original completion check, so nothing breaks there.

## Why all three layers

Layer 1 guarantees the audit log can **never** lie — even if an edit silently fails, the message reflects only what landed. Layer 3 reduces the *rate* of such failures by anchoring edits to reality. Layer 2 closes the related retention hole (history being swallowed on no-ops). Together they restore, mechanically, the integrity the two-phase architecture used to provide structurally.

## Testing

- Regression: `test_commit_message_reflects_real_diff_not_narrative` feeds a deliberately fabricated `resp.content` and asserts the real diff reaches the commit log while the fabrication never does.
- `summarize_working_tree`: additions, removals, deletions, path-scoping, and the no-change case.
- `dream_content_diff`: real-edit detection, no-change, and isolation from cursor-only writes.
- Cursor-gate behavior across both the `/dream` command and the cron path (advance on diff, hold on no-op, non-git fallback).
- Prompt embedding of current file contents (present, missing, capped).

All existing dream/gitstore/command suites pass; `ruff` clean.

## Scope

Deliberately surgical — only the hallucination path. A separate `chore(dream)` cleanup can remove the now-dead line-age annotation machinery orphaned by the same refactor (`line_ages()`, `_compute_line_ages()`, the `LineAge` dataclass, and the deprecated `annotate_line_ages` config field) — all fully inert (no production callers, no writer of the old `← Nd` markers), so they're left out of scope here.
