### PR TITLE
fix: omit temperature for sonnet 5

### DIFF
--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -545,10 +545,12 @@ class AnthropicProvider(LLMProvider):
         max_tokens = max(1, max_tokens)
         thinking_enabled = bool(reasoning_effort) and reasoning_effort.lower() != "none"
 
-        # Several Anthropic models (opus-4-7, opus-4-8, fable) deprecated the
+        # Several Anthropic models (opus-4-7, opus-4-8, sonnet-5, fable) deprecated the
         # `temperature` parameter — the API returns 400 if it is present.
         _model_lower = model_name.lower()
-        omit_temperature = any(m in _model_lower for m in ("opus-4-7", "opus-4-8", "fable"))
+        omit_temperature = any(
+            m in _model_lower for m in ("opus-4-7", "opus-4-8", "sonnet-5", "fable")
+        )
 
         kwargs: dict[str, Any] = {
             "model": model_name,

--- a/tests/providers/test_anthropic_thinking.py
+++ b/tests/providers/test_anthropic_thinking.py
@@ -115,6 +115,24 @@ def test_fable_omits_temperature_none() -> None:
     assert "temperature" not in kw
 
 
+def test_sonnet_5_omits_temperature_adaptive() -> None:
+    kw = _build(_make_provider("claude-sonnet-5"), "adaptive")
+    assert "temperature" not in kw
+    assert kw["thinking"] == {"type": "adaptive"}
+
+
+def test_sonnet_5_omits_temperature_enabled() -> None:
+    kw = _build(_make_provider("claude-sonnet-5"), "high", max_tokens=4096)
+    assert "temperature" not in kw
+    assert kw["thinking"]["type"] == "enabled"
+
+
+def test_sonnet_5_omits_temperature_none() -> None:
+    kw = _build(_make_provider("anthropic/claude-sonnet-5"), None)
+    assert "temperature" not in kw
+    assert "thinking" not in kw
+
+
 def test_ordinary_model_sends_temperature() -> None:
     kw = _build(_make_provider("claude-sonnet-4-6"), None)
     assert kw["temperature"] == 0.7


### PR DESCRIPTION
## Summary
- omit Anthropic temperature for model names containing sonnet-5
- add regression coverage for adaptive, enabled, and non-thinking calls

Fixes #4683

## Verification
- uv run pytest tests/providers/test_anthropic_thinking.py -q
- uv run ruff check nanobot/providers/anthropic_provider.py tests/providers/test_anthropic_thinking.py