### PR TITLE
feat: support canonical opencode provider

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -232,7 +232,7 @@ Tracing covers the providers that go through nanobot's OpenAI-compatible client 
 > - **MiniMax thinking mode**: `providers.minimaxAnthropic` is the config block for `reasoningEffort` / thinking mode. MiniMax exposes that capability through its Anthropic-compatible endpoint, so nanobot keeps it as a separate provider instead of guessing MiniMax-specific thinking parameters on the generic OpenAI-compatible `minimax` endpoint. It uses the same `MINIMAX_API_KEY`. Default Anthropic-compatible base URL: `https://api.minimax.io/anthropic`; for mainland China use `https://api.minimaxi.com/anthropic`.
 > - **Kimi Coding Plan**: Use `providers.kimiCoding` with `provider: "kimi_coding"` for Kimi's dedicated Anthropic Messages API endpoint. The endpoint requires a Claude-compatible `User-Agent`; nanobot sends `claude-code/0.1.0` by default, and you can override it with `extraHeaders.User-Agent` if your account requires a different value.
 > - **VolcEngine / BytePlus Coding Plan**: Subscription endpoints are configured through dedicated providers `volcengineCodingPlan` or `byteplusCodingPlan`, separate from the pay-per-use `volcengine` / `byteplus` providers.
-> - **OpenCode Zen / Go**: `providers.opencodeZen` and `providers.opencodeGo` use the same `OPENCODE_API_KEY`, but route to different OpenCode gateways. These providers use OpenCode's OpenAI-compatible `chat/completions` endpoints; choose model IDs from that endpoint family.
+> - **OpenCode Zen / Go**: `providers.opencode` (canonical Zen), the legacy-compatible `providers.opencodeZen`, and `providers.opencodeGo` use the same `OPENCODE_API_KEY`, but route to different OpenCode gateways. These providers use OpenCode's OpenAI-compatible `chat/completions` endpoints; choose model IDs from that endpoint family.
 > - **Zhipu Coding Plan**: If you're on Zhipu's coding plan, set `"apiBase": "https://open.bigmodel.cn/api/coding/paas/v4"` in your zhipu provider config.
 > - **Alibaba Cloud BaiLian**: If you're using Alibaba Cloud BaiLian's OpenAI-compatible endpoint, set `"apiBase": "https://dashscope.aliyuncs.com/compatible-mode/v1"` in your dashscope provider config.
 > - **StepFun Step Plan**: If you're on StepFun's Step Plan subscription, set `"apiBase": "https://api.stepfun.ai/step_plan/v1"` in your stepfun provider config. Supported models include `step-3.5-flash`, `step-3.5-flash-2603`, and `step-router-v1`.
@@ -246,7 +246,8 @@ Tracing covers the providers that go through nanobot's OpenAI-compatible client 
 |----------|---------|-------------|
 | `custom` | Any OpenAI-compatible endpoint | — |
 | `openrouter` | LLM gateway for hosted model families + Voice transcription (STT models) | [openrouter.ai](https://openrouter.ai) |
-| `opencode_zen` | LLM gateway (OpenCode Zen coding-agent models) | [opencode.ai/docs/zen](https://opencode.ai/docs/zen/) |
+| `opencode` | LLM gateway (OpenCode Zen coding-agent models) | [opencode.ai/docs/zen](https://opencode.ai/docs/zen/) |
+| `opencode_zen` | LLM gateway (legacy alias for OpenCode Zen) | [opencode.ai/docs/zen](https://opencode.ai/docs/zen/) |
 | `opencode_go` | LLM gateway (OpenCode Go low-cost coding models) | [opencode.ai/docs/go](https://opencode.ai/docs/go/) |
 | `huggingface` | LLM (Hugging Face Inference Providers) | [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens) |
 | `skywork` | LLM (Skywork / APIFree API gateway) | [apifree.ai](https://www.apifree.ai) |
@@ -764,6 +765,7 @@ variable, but use separate provider keys and default base URLs:
 
 | Provider | Default API base | Model prefix accepted by nanobot |
 |----------|------------------|-----------------------------------|
+| `opencode` | `https://opencode.ai/zen/v1` | `opencode/<model-id>` |
 | `opencode_zen` | `https://opencode.ai/zen/v1` | `opencode/<model-id>` |
 | `opencode_go` | `https://opencode.ai/zen/go/v1` | `opencode-go/<model-id>` |
 
@@ -772,13 +774,13 @@ OpenCode Zen:
 ```json
 {
   "providers": {
-    "opencodeZen": {
+    "opencode": {
       "apiKey": "${OPENCODE_API_KEY}"
     }
   },
   "modelPresets": {
     "opencodeZen": {
-      "provider": "opencode_zen",
+      "provider": "opencode",
       "model": "opencode/deepseek-v4-pro"
     }
   },
@@ -789,6 +791,8 @@ OpenCode Zen:
   }
 }
 ```
+
+`providers.opencodeZen` / `provider: "opencode_zen"` still work as compatibility aliases for existing configs.
 
 OpenCode Go:
 

--- a/nanobot/cli/onboard.py
+++ b/nanobot/cli/onboard.py
@@ -1590,10 +1590,9 @@ def _get_quick_start_provider_info() -> dict[str, _QuickStartProviderInfo]:
 
 def _get_quick_start_provider_choices() -> dict[str, str]:
     """Return Quick Start provider display choices."""
-    choices = {
-        info.display_name: provider_name
-        for provider_name, info in _get_quick_start_provider_info().items()
-    }
+    choices: dict[str, str] = {}
+    for provider_name, info in _get_quick_start_provider_info().items():
+        choices.setdefault(info.display_name, provider_name)
     choices[_QUICK_START_CUSTOM_PROVIDER_CHOICE] = "custom"
     return choices
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -260,6 +260,7 @@ class ProvidersConfig(Base):
     github_copilot: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # Github Copilot (OAuth)
     qianfan: ProviderConfig = Field(default_factory=ProviderConfig)  # Qianfan (百度千帆)
     nvidia: ProviderConfig = Field(default_factory=ProviderConfig)  # NVIDIA NIM (nvapi- keys)
+    opencode: ProviderConfig = Field(default_factory=ProviderConfig)  # OpenCode Zen (canonical provider id)
     opencode_zen: ProviderConfig = Field(default_factory=ProviderConfig)  # OpenCode Zen (curated coding models)
     opencode_go: ProviderConfig = Field(default_factory=ProviderConfig)  # OpenCode Go (low-cost coding models)
 

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -179,7 +179,20 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         gateway_reasoning_style="reasoning_effort",
     ),
     # OpenCode Zen: OpenAI-compatible chat-completions gateway for coding models.
-    # OpenCode's own config uses "opencode/<model>"; send the bare model upstream.
+    # models.dev/OpenCode use provider id "opencode" and model ids like
+    # "opencode/<model>"; send the bare model upstream.
+    ProviderSpec(
+        name="opencode",
+        keywords=("opencode/", "opencode", "opencode-zen", "opencode_zen"),
+        env_key="OPENCODE_API_KEY",
+        display_name="OpenCode Zen",
+        backend="openai_compat",
+        is_gateway=True,
+        detect_by_base_keyword="opencode.ai/zen",
+        default_api_base="https://opencode.ai/zen/v1",
+        strip_model_prefixes=("opencode", "opencode_zen", "opencode-zen"),
+    ),
+    # Compatibility alias for configs that already used providers.opencodeZen.
     ProviderSpec(
         name="opencode_zen",
         keywords=("opencode/", "opencode_zen", "opencode-zen"),

--- a/tests/agent/test_onboard_logic.py
+++ b/tests/agent/test_onboard_logic.py
@@ -975,15 +975,20 @@ class TestMainMenuUpdate:
 
         choices = onboard_wizard._get_quick_start_provider_choices()
         selected_provider_names = set(choices.values())
-        expected_provider_names = {
-            spec.name
-            for spec in PROVIDERS
-            if spec.name != "custom" and not spec.is_oauth and not spec.is_transcription_only
-        }
+        expected_provider_names = set()
+        seen_display_names: set[str] = set()
+        for spec in PROVIDERS:
+            if spec.name == "custom" or spec.is_oauth or spec.is_transcription_only:
+                continue
+            if spec.display_name in seen_display_names:
+                continue
+            seen_display_names.add(spec.display_name)
+            expected_provider_names.add(spec.name)
         expected_provider_names.add("custom")
 
         assert selected_provider_names == expected_provider_names
         assert "assemblyai" not in selected_provider_names
+        assert choices["OpenCode Zen"] == "opencode"
         assert choices[onboard_wizard._QUICK_START_CUSTOM_PROVIDER_CHOICE] == "custom"
 
     def test_quick_start_provider_choice_skips_advanced_prompts(self, monkeypatch):

--- a/tests/providers/test_opencode_provider.py
+++ b/tests/providers/test_opencode_provider.py
@@ -8,6 +8,7 @@ from nanobot.providers.registry import PROVIDERS, find_by_name
 def test_opencode_config_fields_exist() -> None:
     config = ProvidersConfig()
 
+    assert hasattr(config, "opencode")
     assert hasattr(config, "opencode_zen")
     assert hasattr(config, "opencode_go")
 
@@ -15,7 +16,7 @@ def test_opencode_config_fields_exist() -> None:
 def test_opencode_specs_use_openai_compatible_gateways() -> None:
     specs = {spec.name: spec for spec in PROVIDERS}
 
-    zen = specs["opencode_zen"]
+    zen = specs["opencode"]
     assert zen.backend == "openai_compat"
     assert zen.env_key == "OPENCODE_API_KEY"
     assert zen.display_name == "OpenCode Zen"
@@ -23,6 +24,10 @@ def test_opencode_specs_use_openai_compatible_gateways() -> None:
     assert zen.detect_by_base_keyword == "opencode.ai/zen"
     assert zen.default_api_base == "https://opencode.ai/zen/v1"
     assert "opencode" in zen.strip_model_prefixes
+
+    zen_compat = specs["opencode_zen"]
+    assert zen_compat.env_key == "OPENCODE_API_KEY"
+    assert zen_compat.default_api_base == zen.default_api_base
 
     go = specs["opencode_go"]
     assert go.backend == "openai_compat"
@@ -35,6 +40,10 @@ def test_opencode_specs_use_openai_compatible_gateways() -> None:
 
 
 def test_find_by_name_opencode_providers() -> None:
+    canonical = find_by_name("opencode")
+    assert canonical is not None
+    assert canonical.name == "opencode"
+
     zen = find_by_name("opencode_zen")
     assert zen is not None
     assert zen.name == "opencode_zen"
@@ -47,14 +56,25 @@ def test_find_by_name_opencode_providers() -> None:
 def test_opencode_forced_providers_use_default_api_base() -> None:
     zen_config = Config.model_validate(
         {
+            "providers": {"opencode": {"apiKey": "opencode-key"}},
+            "agents": {"defaults": {"provider": "opencode", "model": "opencode/o3"}},
+        }
+    )
+
+    assert zen_config.get_provider_name() == "opencode"
+    assert zen_config.get_api_key() == "opencode-key"
+    assert zen_config.get_api_base() == "https://opencode.ai/zen/v1"
+
+    legacy_zen_config = Config.model_validate(
+        {
             "providers": {"opencodeZen": {"apiKey": "opencode-key"}},
             "agents": {"defaults": {"provider": "opencode_zen", "model": "opencode/o3"}},
         }
     )
 
-    assert zen_config.get_provider_name() == "opencode_zen"
-    assert zen_config.get_api_key() == "opencode-key"
-    assert zen_config.get_api_base() == "https://opencode.ai/zen/v1"
+    assert legacy_zen_config.get_provider_name() == "opencode_zen"
+    assert legacy_zen_config.get_api_key() == "opencode-key"
+    assert legacy_zen_config.get_api_base() == "https://opencode.ai/zen/v1"
 
     go_config = Config.model_validate(
         {
@@ -72,7 +92,7 @@ def test_opencode_prefixes_are_stripped_before_request() -> None:
     zen_provider = OpenAICompatProvider(
         api_key=None,
         default_model="opencode/o3",
-        spec=find_by_name("opencode_zen"),
+        spec=find_by_name("opencode"),
     )
     zen_kwargs = zen_provider._build_kwargs(
         messages=[{"role": "user", "content": "hi"}],


### PR DESCRIPTION
## Summary
- add canonical OpenCode Zen provider support as opencode / providers.opencode
- keep the existing opencode_zen / providers.opencodeZen compatibility alias
- keep OpenCode Go as opencode-go / opencode_go
- document and test that Zen and Go both use OPENCODE_API_KEY
- also fixed stale model/providers in tests


## Research
- OpenCode docs list Zen and Go as separate provider choices, but both ask users for an OpenCode API key.
- models.dev advertises provider ids opencode and opencode-go, both with env OPENCODE_API_KEY.
- models.dev API bases are https://opencode.ai/zen/v1 and https://opencode.ai/zen/go/v1.

## Verification
- uv run pytest tests/providers/test_opencode_provider.py -q
- uv run ruff check nanobot/providers/registry.py nanobot/config/schema.py tests/providers/test_opencode_provider.py