### PR TITLE
fix(providers): update Anthropic default model to claude-sonnet-4-6

### DIFF
--- a/docs/my-tool.md
+++ b/docs/my-tool.md
@@ -39,7 +39,7 @@ Without parameters, returns a key config overview:
 my(action="check")
 # → max_iterations: 40
 #   context_window_tokens: 200000
-#   model: 'anthropic/claude-sonnet-4-20250514'
+#   model: 'anthropic/claude-sonnet-4-6'
 #   workspace: PosixPath('/tmp/workspace')
 #   provider_retry_mode: 'standard'
 #   max_tool_result_chars: 16000

--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -58,7 +58,7 @@ class AnthropicProvider(LLMProvider):
         self,
         api_key: str | None = None,
         api_base: str | None = None,
-        default_model: str = "claude-sonnet-4-20250514",
+        default_model: str = "claude-sonnet-4-6",
         extra_headers: dict[str, str] | None = None,
     ):
         super().__init__(api_key, api_base)

--- a/nanobot/skills/my/references/examples.md
+++ b/nanobot/skills/my/references/examples.md
@@ -23,7 +23,7 @@ Concrete scenarios showing when and how to use the my tool effectively.
 ### "What model are you running?"
 ```
 → my(action="check", key="model")
-  → 'anthropic/claude-sonnet-4-20250514'
+  → 'anthropic/claude-sonnet-4-6'
 → my(action="check", key="model_preset")
   → 'deep'
 ```
@@ -49,7 +49,7 @@ Concrete scenarios showing when and how to use the my tool effectively.
 ### Switching to a raw model when no preset exists
 ```
 → my(action="set", key="model", value="anthropic/claude-haiku-4-5-20251001")
-  → "Set model = 'anthropic/claude-haiku-4-5-20251001' (was 'anthropic/claude-sonnet-4-20250514')"
+  → "Set model = 'anthropic/claude-haiku-4-5-20251001' (was 'anthropic/claude-sonnet-4-6')"
 → "Switched to a faster model for these batch tasks."
 ```
 

--- a/tests/agent/tools/test_self_tool.py
+++ b/tests/agent/tools/test_self_tool.py
@@ -18,7 +18,7 @@ from nanobot.agent.tools.self import MyTool
 def _make_mock_loop(**overrides):
     """Build a lightweight mock AgentLoop with the attributes MyTool reads."""
     loop = MagicMock()
-    loop.model = "anthropic/claude-sonnet-4-20250514"
+    loop.model = "anthropic/claude-sonnet-4-6"
     loop.max_iterations = 40
     loop.context_window_tokens = 65_536
     loop.workspace = Path("/tmp/workspace")


### PR DESCRIPTION
Update the stale default model from claude-sonnet-4-20250514 to claude-sonnet-4-6 across the codebase:

- AnthropicProvider.__init__ default_model parameter
- docs/my-tool.md example output
- skills/my/references/examples.md model references
- tests/agent/tools/test_self_tool.py mock setup

Fixes #4675