### PR TITLE
fix(plugins): polish optional feature controls

### DIFF
--- a/docs/chat-apps.md
+++ b/docs/chat-apps.md
@@ -335,9 +335,7 @@ nanobot gateway
 Requires the WhatsApp optional dependencies:
 
 ```bash
-pip install "nanobot-ai[whatsapp]"
-# Source checkout:
-python -m pip install -e ".[whatsapp]"
+nanobot plugins enable whatsapp
 ```
 
 **1. Link device with QR**

--- a/docs/openai-api.md
+++ b/docs/openai-api.md
@@ -3,7 +3,7 @@
 nanobot can expose a minimal OpenAI-compatible endpoint for local integrations:
 
 ```bash
-python -m pip install "nanobot-ai[api]"
+nanobot plugins enable api
 nanobot agent -m "Hello!"
 nanobot serve
 ```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -329,7 +329,7 @@ nanobot --version
 If you use WhatsApp from a source checkout, keep the optional dependencies installed:
 
 ```bash
-python -m pip install -e ".[whatsapp]"
+nanobot plugins enable whatsapp
 ```
 
 ## First-Run Troubleshooting

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -141,7 +141,11 @@ class ChannelManager:
             if _channel_config_enabled(name, section):
                 enabled_names.add(name)
 
-        for name, cls in discover_enabled(enabled_names, _names=names).items():
+        for name, cls in discover_enabled(
+            enabled_names,
+            _names=names,
+            warn_import_errors=True,
+        ).items():
             section = section_for(name)
             if section is None:
                 continue

--- a/nanobot/channels/registry.py
+++ b/nanobot/channels/registry.py
@@ -58,6 +58,7 @@ def discover_enabled(
     *,
     _names: list[str] | None = None,
     _include_all_external: bool = False,
+    warn_import_errors: bool = False,
 ) -> dict[str, type[BaseChannel]]:
     """Return channels whose module names are in *enabled_names*.
 
@@ -73,7 +74,11 @@ def discover_enabled(
         try:
             result[modname] = load_channel_class(modname)
         except ImportError as e:
-            logger.debug("Skipping built-in channel '{}': {}", modname, e)
+            message = "Enabled built-in channel '{}' is not available: {}"
+            if warn_import_errors:
+                logger.warning(message, modname, e)
+            else:
+                logger.debug(message, modname, e)
 
     external = discover_plugins(None if _include_all_external else enabled_names)
     shadowed = set(external) & set(names)

--- a/nanobot/channels/whatsapp.py
+++ b/nanobot/channels/whatsapp.py
@@ -72,7 +72,7 @@ def _load_neonize() -> _NeonizeAPI:
         from neonize.utils.jid import build_jid
     except ImportError as exc:
         raise RuntimeError(
-            'WhatsApp dependencies not installed. Run: pip install "nanobot-ai[whatsapp]"'
+            "WhatsApp dependencies not installed. Run: nanobot plugins enable whatsapp"
         ) from exc
 
     _NEONIZE_API = _NeonizeAPI(

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -848,7 +848,7 @@ def serve(
     try:
         from aiohttp import web  # noqa: F401
     except ImportError:
-        console.print("[red]aiohttp is required. Install with: pip install 'nanobot-ai[api]'[/red]")
+        console.print("[red]aiohttp is required. Install with: nanobot plugins enable api[/red]")
         raise typer.Exit(1)
 
     from nanobot.api.server import create_app

--- a/nanobot/webui/nanobot_features_api.py
+++ b/nanobot/webui/nanobot_features_api.py
@@ -31,6 +31,10 @@ def nanobot_features_action(
         return enable_optional_feature(name, allow_install=allow_install)
     if action == "disable":
         if name == "websocket":
-            raise OptionalFeatureError("Channel 'websocket' cannot be disabled from WebUI", status=400)
+            raise OptionalFeatureError(
+                "The WebUI websocket channel cannot be disabled from WebUI. "
+                "Use `nanobot plugins disable websocket` from a terminal if you need to disable it.",
+                status=400,
+            )
         return disable_optional_feature(name)
     raise OptionalFeatureError(f"unknown feature action '{action}'", status=404)

--- a/tests/channels/test_channel_plugins.py
+++ b/tests/channels/test_channel_plugins.py
@@ -231,6 +231,23 @@ def test_discover_enabled_imports_only_enabled_builtins():
     assert loaded == ["enabled"]
 
 
+def test_discover_enabled_warns_for_enabled_builtin_import_errors():
+    from nanobot.channels.registry import discover_enabled
+
+    with (
+        patch("nanobot.channels.registry.load_channel_class", side_effect=ImportError("missing sdk")),
+        patch(_EP_TARGET, return_value=[]),
+        patch("nanobot.channels.registry.logger.warning") as warning,
+    ):
+        result = discover_enabled({"matrix"}, _names=["matrix"], warn_import_errors=True)
+
+    assert result == {}
+    warning.assert_called_once()
+    assert warning.call_args.args[0] == "Enabled built-in channel '{}' is not available: {}"
+    assert warning.call_args.args[1] == "matrix"
+    assert "missing sdk" in str(warning.call_args.args[2])
+
+
 def test_discover_all_builtin_shadows_plugin():
     from nanobot.channels.registry import discover_all
 
@@ -300,7 +317,7 @@ def test_manager_loads_websocket_from_default_config():
 
     seen_enabled: set[str] = set()
 
-    def _discover_enabled(enabled_names: set[str], _names=None):
+    def _discover_enabled(enabled_names: set[str], _names=None, warn_import_errors: bool = False):
         seen_enabled.update(enabled_names)
         return {"websocket": _FakeWebSocket} if "websocket" in enabled_names else {}
 
@@ -320,7 +337,7 @@ def test_manager_respects_explicitly_disabled_websocket_config():
 
     seen_enabled: set[str] = set()
 
-    def _discover_enabled(enabled_names: set[str], _names=None):
+    def _discover_enabled(enabled_names: set[str], _names=None, warn_import_errors: bool = False):
         seen_enabled.update(enabled_names)
         return {}
 

--- a/tests/channels/test_websocket_http_routes.py
+++ b/tests/channels/test_websocket_http_routes.py
@@ -631,7 +631,8 @@ async def test_nanobot_feature_routes_require_token_and_enable(
             headers=auth,
         )
         assert disabled_websocket.status_code == 400
-        assert disabled_websocket.text == "Channel 'websocket' cannot be disabled from WebUI"
+        assert "cannot be disabled from WebUI" in disabled_websocket.text
+        assert "websocket" not in json.loads(config_path.read_text(encoding="utf-8"))["channels"]
 
         disabled = await _http_get(
             "http://127.0.0.1:29916/api/settings/nanobot-features/disable?name=matrix",

--- a/webui/src/tests/settings-view.test.tsx
+++ b/webui/src/tests/settings-view.test.tsx
@@ -424,7 +424,7 @@ describe("SettingsView Apps catalog", () => {
   });
 
   it("does not offer to disable the websocket channel", async () => {
-    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url === "/api/settings") return jsonResponse(settingsPayload());
       if (url === "/api/settings/cli-apps") return jsonResponse({ apps: [], installed_count: 0 });
@@ -446,7 +446,8 @@ describe("SettingsView Apps catalog", () => {
         });
       }
       return { ok: false, status: 404, json: async () => ({}) } as Response;
-    }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
 
     renderSettingsView();
 
@@ -454,6 +455,10 @@ describe("SettingsView Apps catalog", () => {
     expect(screen.getByText("Required for WebUI")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Disable" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Required for WebUI" })).toBeDisabled();
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/api/settings/nanobot-features/disable?name=websocket",
+      expect.anything(),
+    );
   });
 
   it("publishes the latest settings payload to the shell", async () => {


### PR DESCRIPTION
## Summary

Polishes the optional feature controls added in #4396 so the new WebUI/CLI feature discovery path is safer and easier to recover from.

## Changes

- Warn at normal log level when an explicitly enabled built-in channel cannot be imported because its optional dependencies are missing.
- Keep `discover_all()` quiet for catalog discovery, while runtime channel initialization passes `warn_import_errors=True`.
- Prevent the WebUI from disabling its own `websocket` channel.
  - CLI still supports `nanobot plugins disable websocket` for advanced/manual recovery workflows.
  - WebUI route returns a clear 400 if called directly.
  - Apps catalog shows WebSocket as enabled instead of exposing the danger action.
- Update stale optional dependency guidance to the new `nanobot plugins enable ...` flow for API and WhatsApp setup.

## Verification

- `PYTHONPATH="$PWD" pytest tests/channels/test_channel_plugins.py tests/channels/test_websocket_http_routes.py -q`
- `PYTHONPATH="$PWD" pytest tests/channels/test_channel_plugins.py tests/channels/test_websocket_http_routes.py tests/config/test_config_migration.py tests/cli_apps/test_service.py tests/providers/test_azure_openai_provider.py tests/test_msteams.py -q`
- `ruff check nanobot/channels/registry.py nanobot/channels/manager.py nanobot/webui/nanobot_features_api.py nanobot/channels/whatsapp.py nanobot/cli/commands.py tests/channels/test_channel_plugins.py tests/channels/test_websocket_http_routes.py`
- `cd webui && bun run test -- src/tests/settings-view.test.tsx src/tests/api.test.ts src/tests/i18n.test.tsx`
- `cd webui && bun run lint`
- `cd webui && bun run build`
