### PR TITLE
fix(config): serialize model presets as camelCase

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -401,6 +401,7 @@ class Config(BaseSettings):
     model_presets: dict[str, ModelPresetConfig] = Field(
         default_factory=dict,
         validation_alias=AliasChoices("modelPresets", "model_presets"),
+        serialization_alias="modelPresets",
     )
 
     def __init__(self, **values: Any) -> None:

--- a/tests/config/test_model_presets.py
+++ b/tests/config/test_model_presets.py
@@ -219,6 +219,23 @@ def test_model_presets_accepts_camel_case_root_key() -> None:
     assert config.model_presets["fast"].provider == "openai"
 
 
+def test_model_presets_serializes_with_camel_case_root_key() -> None:
+    config = Config.model_validate({
+        "model_presets": {
+            "fast": {
+                "model": "openai/gpt-4.1",
+                "provider": "openai",
+            }
+        },
+    })
+
+    dumped = config.model_dump(mode="json", by_alias=True)
+
+    assert "modelPresets" in dumped
+    assert "model_presets" not in dumped
+    assert dumped["modelPresets"]["fast"]["model"] == "openai/gpt-4.1"
+
+
 def test_resolve_preset_can_target_named_preset_without_activating() -> None:
     config = Config.model_validate({
         "model_presets": {


### PR DESCRIPTION
Serialize `model_presets` as `modelPresets` while keeping both forms valid when loading config. The **modelPresets** fields of the current configuration file will now be in line with the names of the "Quick Start" fields in the document.

A screenshot of the document：
<img width="1432" height="1146" alt="e8bfc9bb-525a-4b28-a44b-693e14965897" src="https://github.com/user-attachments/assets/627130bb-8cd3-49a9-81c5-0bce2f26548f" />

https://nanobot.wiki/cn/docs/0.2.2/getting-started/quick-start
