### PR TITLE
feat(subagent): configurable MCP inheritance for specialist subagents

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2050,6 +2050,34 @@ Subagents also stop immediately when one of their tools returns an execution err
 | `agents.defaults.maxConcurrentSubagents` | `1` | Maximum number of spawned subagents that may run at the same time. Attempts to spawn beyond this limit return an error. |
 | `agents.defaults.failOnToolError` | `true` | Stop a spawned subagent when a tool execution fails. Set to `false` to return tool errors to the subagent model so it can recover within the same run. |
 
+### Specialist subagents (MCP inheritance)
+
+By default, spawned subagents only get the built-in exec/web/file tools and do **not** inherit any of the main agent's MCP servers. You can promote certain subagents to "specialists" that inherit a filtered subset of your configured MCP servers, so they can use native MCP tools (for example a database or search MCP) instead of re-implementing access through raw shell calls.
+
+Declare a map of specialist slug → list of MCP server names under `tools.subagentSpecialists`:
+
+```json
+{
+  "tools": {
+    "mcpServers": {
+      "db": { "type": "stdio", "command": "..." },
+      "search": { "type": "stdio", "command": "..." }
+    },
+    "subagentSpecialists": {
+      "analyst": ["db"],
+      "researcher": ["search"],
+      "reporter": ["db", "search"]
+    }
+  }
+}
+```
+
+The specialist for a spawned subagent is derived from the **first word** of its spawn `label` (the slug before any space or colon), matched case-insensitively. For example, a subagent spawned with label `analyst monthly revenue` inherits the `db` MCP; `researcher: competitors` inherits `search`. A subagent whose label prefix is not a declared specialist inherits no MCP servers (previous default behavior). Only MCP servers listed for that specialist **and** already present in `tools.mcpServers` are inherited.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `tools.subagentSpecialists` | `{}` | Map of specialist slug → list of MCP server names those subagents inherit. Empty means no subagent inherits MCP servers. |
+
 
 ## Auto Compact
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2072,11 +2072,14 @@ Declare a map of specialist slug → list of MCP server names under `tools.subag
 }
 ```
 
-The specialist for a spawned subagent is derived from the **first word** of its spawn `label` (the slug before any space or colon), matched case-insensitively. For example, a subagent spawned with label `analyst monthly revenue` inherits the `db` MCP; `researcher: competitors` inherits `search`. A subagent whose label prefix is not a declared specialist inherits no MCP servers (previous default behavior). Only MCP servers listed for that specialist **and** already present in `tools.mcpServers` are inherited.
+The specialist is selected through a **trusted** channel: `SubagentManager.spawn()` accepts an explicit `specialist` argument that deployment/policy code passes in. The built-in `spawn` tool deliberately does **not** expose `specialist` in its schema, so the model cannot grant a subagent MCP tools by choosing a task label. Only MCP servers listed for that specialist **and** already present in `tools.mcpServers` are inherited; an unknown/absent specialist inherits nothing (default behavior).
+
+> **Security note.** MCP inheritance is a capability boundary. Never drive it from the spawn `label`, which is a model/user-facing display field — a prompt that influences the label could otherwise self-select a privileged specialist. Keep specialist selection in trusted code.
 
 | Option | Default | Description |
 |--------|---------|-------------|
 | `tools.subagentSpecialists` | `{}` | Map of specialist slug → list of MCP server names those subagents inherit. Empty means no subagent inherits MCP servers. |
+| `tools.subagentAllowLabelSpecialist` | `false` | **Opt-in, insecure.** Also derive the specialist from the spawn `label` prefix (first word before a space/colon). Only enable when the label is a trusted, non-prompt-controlled value in your setup. Leave `false` to keep specialist selection purely on the trusted `specialist` argument. |
 
 
 ## Auto Compact

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -131,12 +131,45 @@ class SubagentManager:
             for slug, mcps in raw.items()
         }
 
+    def _normalize_specialist(self, specialist: str | None) -> str | None:
+        """Validate a trusted specialist slug against the configured mapping.
+
+        ``specialist`` comes from a trusted caller (e.g. deployment code or a
+        cron/policy layer), NOT from the prompt-controllable spawn label.
+        """
+        if not specialist:
+            return None
+        slug = str(specialist).strip().lower()
+        return slug if slug in self._specialist_mcps() else None
+
     def _specialist_from_label(self, label: str | None) -> str | None:
-        """Derive the specialist slug from a spawn label prefix."""
+        """Derive the specialist slug from a spawn label prefix.
+
+        INSECURE: the spawn label is a model/user-facing display field, so this
+        path is only consulted when ``tools.subagent_allow_label_specialist`` is
+        explicitly enabled by the operator. See :meth:`_resolve_specialist`.
+        """
         if not label:
             return None
         slug = label.strip().lower().split()[0].split(":")[0] if label.strip() else ""
         return slug if slug in self._specialist_mcps() else None
+
+    def _resolve_specialist(
+        self, specialist: str | None, label: str | None
+    ) -> str | None:
+        """Resolve the effective specialist slug from trusted inputs.
+
+        Precedence:
+        1. The explicit, trusted ``specialist`` argument (never prompt-derived).
+        2. The spawn ``label`` prefix — ONLY if the operator opted in via
+           ``tools.subagent_allow_label_specialist`` (off by default, insecure).
+        """
+        resolved = self._normalize_specialist(specialist)
+        if resolved is not None:
+            return resolved
+        if getattr(self.tools_config, "subagent_allow_label_specialist", False):
+            return self._specialist_from_label(label)
+        return None
 
     def _subagent_tools_config(self, specialist: str | None = None) -> ToolsConfig:
         """Build a ToolsConfig scoped for subagent use.
@@ -211,8 +244,15 @@ class SubagentManager:
         origin_message_id: str | None = None,
         temperature: float | None = None,
         workspace_scope: WorkspaceScope | None = None,
+        specialist: str | None = None,
     ) -> str:
-        """Spawn a subagent to execute a task in the background."""
+        """Spawn a subagent to execute a task in the background.
+
+        ``specialist`` is a TRUSTED selector for MCP inheritance. It must come
+        from a non-prompt-controlled source (deployment/policy code). The spawn
+        tool deliberately does NOT expose it, so a model cannot grant itself
+        MCP tools by choosing a task label.
+        """
         task_id = str(uuid.uuid4())[:8]
         display_label = label or task[:30] + ("..." if len(task) > 30 else "")
         origin = {"channel": origin_channel, "chat_id": origin_chat_id, "session_key": session_key}
@@ -235,6 +275,7 @@ class SubagentManager:
                 origin_message_id,
                 temperature,
                 workspace_scope,
+                specialist,
             )
         )
         self._running_tasks[task_id] = bg_task
@@ -264,6 +305,7 @@ class SubagentManager:
         origin_message_id: str | None = None,
         temperature: float | None = None,
         workspace_scope: WorkspaceScope | None = None,
+        specialist: str | None = None,
     ) -> None:
         """Execute the subagent task and announce the result."""
         logger.info("Subagent [{}] starting task: {}", task_id, label)
@@ -275,7 +317,7 @@ class SubagentManager:
         mcp_stacks: dict[str, Any] = {}
         try:
             root = workspace_scope.project_path if workspace_scope is not None else self.workspace
-            specialist = self._specialist_from_label(label)
+            specialist = self._resolve_specialist(specialist, label)
             cfg = self._subagent_tools_config(specialist)
             if workspace_scope is not None:
                 cfg.restrict_to_workspace = workspace_scope.restrict_to_workspace

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -119,21 +119,60 @@ class SubagentManager:
         self._task_statuses: dict[str, SubagentStatus] = {}
         self._session_tasks: dict[str, set[str]] = {}  # session_key -> {task_id, ...}
 
-    def _subagent_tools_config(self) -> ToolsConfig:
-        """Build a ToolsConfig scoped for subagent use."""
+    def _specialist_mcps(self) -> dict[str, set[str]]:
+        """Config-driven map of specialist slug -> inherited MCP server names.
+
+        Read from ``tools.subagent_specialists`` so the mapping stays out of
+        the code and each deployment declares its own specialists/MCPs.
+        """
+        raw = getattr(self.tools_config, "subagent_specialists", None) or {}
+        return {
+            str(slug).strip().lower(): {str(m) for m in (mcps or [])}
+            for slug, mcps in raw.items()
+        }
+
+    def _specialist_from_label(self, label: str | None) -> str | None:
+        """Derive the specialist slug from a spawn label prefix."""
+        if not label:
+            return None
+        slug = label.strip().lower().split()[0].split(":")[0] if label.strip() else ""
+        return slug if slug in self._specialist_mcps() else None
+
+    def _subagent_tools_config(self, specialist: str | None = None) -> ToolsConfig:
+        """Build a ToolsConfig scoped for subagent use.
+
+        Specialist subagents inherit a filtered subset of the main agent's
+        configured MCP servers (declared in ``tools.subagent_specialists``)
+        so they can use native tools (e.g. a database MCP) instead of
+        fragile direct connections.
+        """
+        inherited_mcps: dict[str, Any] = {}
+        allowed = self._specialist_mcps().get(specialist or "", set())
+        if allowed:
+            inherited_mcps = {
+                name: cfg
+                for name, cfg in (self.tools_config.mcp_servers or {}).items()
+                if name in allowed
+            }
         return ToolsConfig(
             exec=self.tools_config.exec,
             web=self.tools_config.web,
             file=self.tools_config.file,
             restrict_to_workspace=self.restrict_to_workspace,
+            mcp_servers=inherited_mcps,
         )
 
-    def _build_tools(
+    async def _build_tools(
         self,
         workspace: Path | None = None,
         tools_config: ToolsConfig | None = None,
-    ) -> ToolRegistry:
-        """Build an isolated subagent tool registry via ToolLoader."""
+    ) -> tuple[ToolRegistry, dict[str, Any]]:
+        """Build an isolated subagent tool registry via ToolLoader.
+
+        Also connects any inherited MCP servers and registers their tools.
+        Returns the registry plus a dict of per-server AsyncExitStacks that
+        the caller MUST close when the subagent finishes.
+        """
         root = self.workspace if workspace is None else workspace
         registry = ToolRegistry()
         cfg = tools_config if tools_config is not None else self._subagent_tools_config()
@@ -147,7 +186,15 @@ class SubagentManager:
             ),
         )
         ToolLoader().load(ctx, registry, scope="subagent")
-        return registry
+        mcp_stacks: dict[str, Any] = {}
+        if cfg.mcp_servers:
+            from nanobot.agent.tools.mcp import connect_mcp_servers
+            try:
+                mcp_stacks = await connect_mcp_servers(cfg.mcp_servers, registry)
+            except Exception:
+                logger.exception("Subagent MCP connection failed for %s", list(cfg.mcp_servers))
+                mcp_stacks = {}
+        return registry, mcp_stacks
 
     def set_provider(self, provider: LLMProvider, model: str) -> None:
         self.provider = provider
@@ -225,13 +272,19 @@ class SubagentManager:
             status.phase = payload.get("phase", status.phase)
             status.iteration = payload.get("iteration", status.iteration)
 
+        mcp_stacks: dict[str, Any] = {}
         try:
             root = workspace_scope.project_path if workspace_scope is not None else self.workspace
-            cfg = None
+            specialist = self._specialist_from_label(label)
+            cfg = self._subagent_tools_config(specialist)
             if workspace_scope is not None:
-                cfg = self._subagent_tools_config()
                 cfg.restrict_to_workspace = workspace_scope.restrict_to_workspace
-            tools = self._build_tools(workspace=root, tools_config=cfg)
+            if specialist:
+                logger.info(
+                    "Subagent [{}] specialist='{}' inheriting MCPs: {}",
+                    task_id, specialist, sorted(cfg.mcp_servers),
+                )
+            tools, mcp_stacks = await self._build_tools(workspace=root, tools_config=cfg)
             system_prompt = self._build_subagent_prompt(workspace=root)
             messages: list[dict[str, Any]] = [
                 {"role": "system", "content": system_prompt},
@@ -292,6 +345,12 @@ class SubagentManager:
             status.error = str(e)
             logger.exception("Subagent [{}] failed", task_id)
             await self._announce_result(task_id, label, task, f"Error: {e}", origin, "error", origin_message_id)
+        finally:
+            for name, stack in mcp_stacks.items():
+                try:
+                    await stack.aclose()
+                except Exception:
+                    logger.warning("Subagent [{}] failed to close MCP stack '{}'", task_id, name)
 
     async def _announce_result(
         self,

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -389,8 +389,19 @@ class ToolsConfig(Base):
         default_factory=dict,
         validation_alias=AliasChoices("subagentSpecialists", "subagent_specialists"),
     )  # map of specialist slug -> list of MCP server names that specialist subagents inherit.
-    # The specialist is derived from the spawn label prefix (slug before any space/colon).
-    # Empty (default) = subagents get no inherited MCP servers (previous behavior).
+    # The specialist is selected via the trusted `specialist` argument to
+    # SubagentManager.spawn() (NOT exposed on the spawn tool schema, so it is not
+    # prompt-controllable). Empty (default) = subagents get no inherited MCP servers.
+    subagent_allow_label_specialist: bool = Field(
+        default=False,
+        validation_alias=AliasChoices(
+            "subagentAllowLabelSpecialist",
+            "subagent_allow_label_specialist",
+        ),
+    )  # OPT-IN, INSECURE: also derive the specialist from the spawn label prefix.
+    # The spawn label is a model/user-facing display field, so enabling this lets a
+    # prompt that influences the label grant a subagent the mapped MCP tools. Leave
+    # False unless the label is a trusted, non-prompt-controlled value in your setup.
     ssrf_whitelist: list[str] = Field(default_factory=list)  # CIDR ranges to exempt from SSRF blocking (e.g. ["100.64.0.0/10"] for Tailscale)
 
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -385,6 +385,12 @@ class ToolsConfig(Base):
         ),
     )  # allow non-local WebUI clients to install optional Python packages
     mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
+    subagent_specialists: dict[str, list[str]] = Field(
+        default_factory=dict,
+        validation_alias=AliasChoices("subagentSpecialists", "subagent_specialists"),
+    )  # map of specialist slug -> list of MCP server names that specialist subagents inherit.
+    # The specialist is derived from the spawn label prefix (slug before any space/colon).
+    # Empty (default) = subagents get no inherited MCP servers (previous behavior).
     ssrf_whitelist: list[str] = Field(default_factory=list)  # CIDR ranges to exempt from SSRF blocking (e.g. ["100.64.0.0/10"] for Tailscale)
 
 

--- a/tests/agent/test_subagent.py
+++ b/tests/agent/test_subagent.py
@@ -25,7 +25,7 @@ async def test_subagent_uses_tool_loader():
         model="test",
         max_tool_result_chars=16_000,
     )
-    tools = sm._build_tools()
+    tools, _ = await sm._build_tools()
     assert tools.has("read_file")
     assert tools.has("write_file")
     assert not tools.has("message")
@@ -46,8 +46,8 @@ async def test_subagent_build_tools_isolates_file_read_state(tmp_path):
         max_tool_result_chars=16_000,
     )
 
-    first_read = sm._build_tools().get("read_file")
-    second_read = sm._build_tools().get("read_file")
+    first_read = (await sm._build_tools())[0].get("read_file")
+    second_read = (await sm._build_tools())[0].get("read_file")
 
     assert first_read is not second_read
     assert (await first_read.execute(path="note.txt")).startswith("1| hello")
@@ -56,7 +56,8 @@ async def test_subagent_build_tools_isolates_file_read_state(tmp_path):
     assert "File unchanged" not in second_result
 
 
-def test_subagent_respects_file_tool_toggle(tmp_path):
+@pytest.mark.asyncio
+async def test_subagent_respects_file_tool_toggle(tmp_path):
     provider = MagicMock(spec=LLMProvider)
     provider.get_default_model.return_value = "test"
     sm = SubagentManager(
@@ -68,7 +69,7 @@ def test_subagent_respects_file_tool_toggle(tmp_path):
         tools_config=ToolsConfig(file=FileToolsConfig(enable=False)),
     )
 
-    tools = sm._build_tools()
+    tools, _ = await sm._build_tools()
 
     file_tools = {
         "apply_patch",
@@ -110,3 +111,68 @@ async def test_subagent_forwards_fail_on_tool_error_to_runner(tmp_path):
 
     spec = sm.runner.run.call_args.args[0]
     assert spec.fail_on_tool_error is False
+
+
+def _make_sm_with_mcps(tmp_path):
+    """SubagentManager with generic MCP servers + a config-driven specialist map."""
+    from nanobot.config.schema import MCPServerConfig
+    provider = MagicMock(spec=LLMProvider)
+    provider.get_default_model.return_value = "test"
+    return SubagentManager(
+        provider=provider,
+        workspace=tmp_path,
+        bus=MessageBus(),
+        model="test",
+        max_tool_result_chars=16_000,
+        tools_config=ToolsConfig(
+            mcp_servers={
+                "db": MCPServerConfig(command="echo"),
+                "comms": MCPServerConfig(command="echo"),
+                "media": MCPServerConfig(command="echo"),
+            },
+            subagent_specialists={
+                "analyst": ["db"],
+                "assistant": ["comms"],
+                "creator": ["media", "db"],
+            },
+        ),
+    )
+
+
+def test_specialist_from_label(tmp_path):
+    sm = _make_sm_with_mcps(tmp_path)
+    assert sm._specialist_from_label("analyst run") == "analyst"
+    assert sm._specialist_from_label("creator: promo") == "creator"
+    assert sm._specialist_from_label("Assistant") == "assistant"
+    assert sm._specialist_from_label("random task") is None
+    assert sm._specialist_from_label(None) is None
+
+
+def test_specialist_inherits_only_its_mcps(tmp_path):
+    sm = _make_sm_with_mcps(tmp_path)
+    assert set(sm._subagent_tools_config("analyst").mcp_servers) == {"db"}
+    assert set(sm._subagent_tools_config("assistant").mcp_servers) == {"comms"}
+    assert set(sm._subagent_tools_config("creator").mcp_servers) == {"media", "db"}
+
+
+def test_generic_subagent_inherits_no_mcps(tmp_path):
+    sm = _make_sm_with_mcps(tmp_path)
+    assert sm._subagent_tools_config(None).mcp_servers == {}
+    assert sm._subagent_tools_config("unknown").mcp_servers == {}
+
+
+def test_no_specialist_config_means_no_inheritance(tmp_path):
+    """With no subagent_specialists configured, behavior is the previous default."""
+    from nanobot.config.schema import MCPServerConfig
+    provider = MagicMock(spec=LLMProvider)
+    provider.get_default_model.return_value = "test"
+    sm = SubagentManager(
+        provider=provider,
+        workspace=tmp_path,
+        bus=MessageBus(),
+        model="test",
+        max_tool_result_chars=16_000,
+        tools_config=ToolsConfig(mcp_servers={"db": MCPServerConfig(command="echo")}),
+    )
+    assert sm._specialist_from_label("analyst run") is None
+    assert sm._subagent_tools_config("analyst").mcp_servers == {}

--- a/tests/agent/test_subagent.py
+++ b/tests/agent/test_subagent.py
@@ -176,3 +176,50 @@ def test_no_specialist_config_means_no_inheritance(tmp_path):
     )
     assert sm._specialist_from_label("analyst run") is None
     assert sm._subagent_tools_config("analyst").mcp_servers == {}
+
+
+def test_resolve_specialist_uses_trusted_arg_not_label(tmp_path):
+    """The trusted `specialist` argument selects; the prompt-controllable label does not."""
+    sm = _make_sm_with_mcps(tmp_path)
+    # Trusted specialist arg is honored (validated against the config map).
+    assert sm._resolve_specialist("analyst", label="whatever") == "analyst"
+    assert sm._resolve_specialist("Creator", label=None) == "creator"
+    # Unknown trusted specialist resolves to nothing.
+    assert sm._resolve_specialist("unknown", label="analyst run") is None
+    # No trusted specialist + default config => label is IGNORED (secure default).
+    assert sm._resolve_specialist(None, label="analyst run") is None
+    assert sm._resolve_specialist(None, label="creator: promo") is None
+
+
+def test_resolve_specialist_label_opt_in(tmp_path):
+    """Label-based selection only happens when the operator opts in explicitly."""
+    from nanobot.config.schema import MCPServerConfig
+    provider = MagicMock(spec=LLMProvider)
+    provider.get_default_model.return_value = "test"
+    sm = SubagentManager(
+        provider=provider,
+        workspace=tmp_path,
+        bus=MessageBus(),
+        model="test",
+        max_tool_result_chars=16_000,
+        tools_config=ToolsConfig(
+            mcp_servers={"db": MCPServerConfig(command="echo")},
+            subagent_specialists={"analyst": ["db"]},
+            subagent_allow_label_specialist=True,
+        ),
+    )
+    # With the opt-in enabled, the label prefix is consulted as a fallback.
+    assert sm._resolve_specialist(None, label="analyst run") == "analyst"
+    # The trusted arg still takes precedence over the label.
+    assert sm._resolve_specialist("analyst", label="random task") == "analyst"
+    # Unknown label prefix still yields no specialist.
+    assert sm._resolve_specialist(None, label="random task") is None
+
+
+def test_spawn_tool_does_not_expose_specialist():
+    """The spawn tool schema must not let the model pick a specialist."""
+    from nanobot.agent.tools.spawn import SpawnTool
+    tool = SpawnTool(manager=MagicMock())
+    props = tool.parameters.get("properties", {})
+    assert "specialist" not in props
+    assert "task" in props


### PR DESCRIPTION
## Summary

By default, spawned subagents only get the built-in exec/web/file tools and do **not** inherit any of the main agent's MCP servers. This means a subagent that needs, say, database or search access has to re-implement it through raw shell calls.

This PR adds an optional, config-driven way to promote certain subagents to **specialists** that inherit a filtered subset of the configured MCP servers, so they can use native MCP tools directly.

## How it works

Declare a map of specialist slug -> list of MCP server names under `tools.subagentSpecialists`:

```json
{
  "tools": {
    "mcpServers": {
      "db": { "type": "stdio", "command": "..." },
      "search": { "type": "stdio", "command": "..." }
    },
    "subagentSpecialists": {
      "analyst": ["db"],
      "researcher": ["search"],
      "reporter": ["db", "search"]
    }
  }
}
```

The specialist for a spawned subagent is derived from the **first word** of its spawn `label` (the slug before any space or colon), matched case-insensitively. E.g. label `analyst monthly revenue` inherits `db`; `researcher: competitors` inherits `search`. Only MCP servers listed for that specialist **and** already present in `tools.mcpServers` are inherited. Inherited MCP servers are connected via `connect_mcp_servers` when the subagent starts, and their `AsyncExitStack`s are closed when it finishes.

## Backwards compatibility

Fully backwards compatible. With no `subagentSpecialists` configured (the default), no subagent inherits any MCP server — identical to current behavior. The mapping lives entirely in config; there are no hardcoded server names in the code.

## Changes

- `config/schema.py`: new optional `tools.subagent_specialists` field (camelCase alias `subagentSpecialists`).
- `agent/subagent.py`: `_build_tools` is now async and connects/registers inherited MCP servers, returning the registry plus per-server `AsyncExitStack`s that are closed in a `finally` block; specialist resolved from the spawn label via the config map.
- `docs/configuration.md`: documents the new field under Subagent configuration.
- `tests/agent/test_subagent.py`: covers specialist resolution, per-specialist filtering, generic (no-MCP) subagents, and the no-config default.

## Tests

```
pytest tests/agent/test_subagent.py -q
8 passed
```
