### PR TITLE
fix(providers): standardize oauth_cli_kit error messages across CLI and WebUI

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -2401,7 +2401,7 @@ def _logout_github_copilot() -> None:
     try:
         from nanobot.providers.github_copilot_provider import get_storage
     except ImportError:
-        console.print("[red]GitHub Copilot provider unavailable. Ensure oauth-cli-kit is installed.[/red]")
+        console.print("[red]oauth_cli_kit not installed. Run: pip install oauth-cli-kit[/red]")
         raise typer.Exit(1)
 
     storage = get_storage()

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -1119,7 +1119,9 @@ def login_oauth_provider(query: QueryParams) -> dict[str, Any]:
         try:
             from oauth_cli_kit import get_token, login_oauth_interactive
         except ImportError:
-            raise WebUISettingsError("oauth_cli_kit is not installed", status=500) from None
+            raise WebUISettingsError(
+                "oauth_cli_kit not installed. Run: pip install oauth-cli-kit", status=500
+            ) from None
 
         try:
             proxy = resolve_config_env_vars(load_config()).providers.openai_codex.proxy or None
@@ -1146,7 +1148,9 @@ def login_oauth_provider(query: QueryParams) -> dict[str, Any]:
                 login_github_copilot,
             )
         except ImportError:
-            raise WebUISettingsError("GitHub Copilot OAuth support is unavailable", status=500) from None
+            raise WebUISettingsError(
+                "oauth_cli_kit not installed. Run: pip install oauth-cli-kit", status=500
+            ) from None
 
         token = get_github_copilot_login_status()
         if not token:
@@ -1171,13 +1175,17 @@ def logout_oauth_provider(query: QueryParams) -> dict[str, Any]:
             from oauth_cli_kit.providers import OPENAI_CODEX_PROVIDER
             from oauth_cli_kit.storage import FileTokenStorage
         except ImportError:
-            raise WebUISettingsError("oauth_cli_kit is not installed", status=500) from None
+            raise WebUISettingsError(
+                "oauth_cli_kit not installed. Run: pip install oauth-cli-kit", status=500
+            ) from None
         token_path = FileTokenStorage(token_filename=OPENAI_CODEX_PROVIDER.token_filename).get_token_path()
     elif spec.name == "github_copilot":
         try:
             from nanobot.providers.github_copilot_provider import get_storage
         except ImportError:
-            raise WebUISettingsError("GitHub Copilot OAuth support is unavailable", status=500) from None
+            raise WebUISettingsError(
+                "oauth_cli_kit not installed. Run: pip install oauth-cli-kit", status=500
+            ) from None
         token_path = get_storage().get_token_path()
     else:
         raise WebUISettingsError("OAuth logout is not supported for this provider")

--- a/tests/webui/test_settings_api.py
+++ b/tests/webui/test_settings_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import json
 from types import SimpleNamespace
 
@@ -878,6 +879,42 @@ def test_openai_codex_oauth_login_passes_configured_proxy(
     login_oauth_provider({"provider": ["openai-codex"]})
 
     assert captured == {"get_proxy": proxy, "login_proxy": proxy}
+
+
+def test_openai_codex_oauth_login_reports_missing_oauth_cli_kit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "oauth_cli_kit":
+            raise ImportError("missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(WebUISettingsError) as exc:
+        login_oauth_provider({"provider": ["openai-codex"]})
+
+    assert "oauth_cli_kit not installed. Run: pip install oauth-cli-kit" in str(exc.value)
+
+
+def test_github_copilot_oauth_login_reports_missing_oauth_cli_kit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "nanobot.providers.github_copilot_provider":
+            raise ImportError("missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(WebUISettingsError) as exc:
+        login_oauth_provider({"provider": ["github-copilot"]})
+
+    assert "oauth_cli_kit not installed. Run: pip install oauth-cli-kit" in str(exc.value)
 
 
 def test_provider_models_payload_fetches_openai_compatible_models(


### PR DESCRIPTION
Standardize oauth_cli_kit import error messages across the CLI and WebUI so every code path shows the same message with the install command.

Before:
- CLI Copilot: "GitHub Copilot provider unavailable. Ensure oauth-cli-kit is installed."
- WebUI Codex/Copilot: "oauth_cli_kit is not installed" or "GitHub Copilot OAuth support is unavailable"

After:
- All paths: "oauth_cli_kit not installed. Run: pip install oauth-cli-kit"

Changes are string-only. No behavioral or logic changes.

Closes #4681
