### PR TITLE
fix(providers): add Anthropic OAuth with env-var-aware login/logout

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -2233,14 +2233,21 @@ _LOGIN_HANDLERS: dict[str, Callable[[], None]] = {}
 _LOGOUT_HANDLERS: dict[str, Callable[[], None]] = {}
 
 _PROVIDER_DISPLAY: dict[str, str] = {
+    "anthropic_oauth": "Anthropic OAuth",
     "openai_codex": "OpenAI Codex",
     "github_copilot": "GitHub Copilot",
 }
 
 _OAUTH_PROVIDER_DEFAULT_MODELS: dict[str, str] = {
+    "anthropic_oauth": "anthropic-oauth/claude-sonnet-4-6",
     "openai_codex": "openai-codex/gpt-5.4-mini",
     "github_copilot": "github-copilot/gpt-5.4-mini",
 }
+
+_CLAUDE_CODE_OAUTH_ENV_WARNING = (
+    "Note: CLAUDE_CODE_OAUTH_TOKEN environment variable is still set. "
+    "Unset it (e.g. `unset CLAUDE_CODE_OAUTH_TOKEN`) to fully log out."
+)
 
 
 def _register_login(name: str):
@@ -2304,7 +2311,10 @@ def _set_oauth_provider_as_main(
 
 @provider_app.command("login")
 def provider_login(
-    provider: str = typer.Argument(..., help="OAuth provider (e.g. 'openai-codex', 'github-copilot')"),
+    provider: str = typer.Argument(
+        ...,
+        help="OAuth provider (e.g. 'anthropic-oauth', 'openai-codex', 'github-copilot')",
+    ),
     set_main: bool = typer.Option(
         False,
         "--set-main",
@@ -2335,7 +2345,10 @@ def provider_login(
 
 @provider_app.command("logout")
 def provider_logout(
-    provider: str = typer.Argument(..., help="OAuth provider (e.g. 'openai-codex', 'github-copilot')"),
+    provider: str = typer.Argument(
+        ...,
+        help="OAuth provider (e.g. 'anthropic-oauth', 'openai-codex', 'github-copilot')",
+    ),
 ):
     """Log out from an OAuth provider."""
     spec = _resolve_oauth_provider(provider)
@@ -2347,6 +2360,41 @@ def provider_logout(
 
     console.print(f"{__logo__} OAuth Logout - {spec.label}\n")
     handler()
+
+
+@_register_login("anthropic_oauth")
+def _login_anthropic_oauth() -> None:
+    try:
+        from nanobot.providers.anthropic_provider import (
+            CLAUDE_CODE_OAUTH_TOKEN_ENV,
+            login_anthropic_oauth,
+        )
+    except ImportError:
+        console.print("[red]Anthropic OAuth support is unavailable. Ensure oauth-cli-kit is installed.[/red]")
+        raise typer.Exit(1)
+
+    login_anthropic_oauth()
+    if os.environ.get(CLAUDE_CODE_OAUTH_TOKEN_ENV):
+        console.print("[green]Using CLAUDE_CODE_OAUTH_TOKEN from environment (no file stored)[/green]")
+        return
+    console.print("[green]✓ Authenticated with Anthropic OAuth[/green]")
+
+
+@_register_logout("anthropic_oauth")
+def _logout_anthropic_oauth() -> None:
+    """Clear local OAuth credentials for Anthropic OAuth."""
+    try:
+        from nanobot.providers.anthropic_provider import (
+            CLAUDE_CODE_OAUTH_TOKEN_ENV,
+            get_anthropic_oauth_storage_path,
+        )
+    except ImportError:
+        console.print("[red]Anthropic OAuth support is unavailable. Ensure oauth-cli-kit is installed.[/red]")
+        raise typer.Exit(1)
+
+    _delete_oauth_files(get_anthropic_oauth_storage_path(), _PROVIDER_DISPLAY["anthropic_oauth"])
+    if os.environ.get(CLAUDE_CODE_OAUTH_TOKEN_ENV):
+        console.print(f"[yellow]! {_CLAUDE_CODE_OAUTH_ENV_WARNING}[/yellow]")
 
 
 @_register_login("openai_codex")

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -256,6 +256,7 @@ class ProvidersConfig(Base):
     volcengine_coding_plan: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine Coding Plan
     byteplus: ProviderConfig = Field(default_factory=ProviderConfig)  # BytePlus (VolcEngine international)
     byteplus_coding_plan: ProviderConfig = Field(default_factory=ProviderConfig)  # BytePlus Coding Plan
+    anthropic_oauth: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # Anthropic OAuth
     openai_codex: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # OpenAI Codex (OAuth)
     github_copilot: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # Github Copilot (OAuth)
     qianfan: ProviderConfig = Field(default_factory=ProviderConfig)  # Qianfan (百度千帆)

--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import os
 import re
 import secrets
 import string
 from collections import deque
 from collections.abc import Awaitable, Callable
+from contextlib import suppress
+from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 from loguru import logger
@@ -23,6 +27,8 @@ from nanobot.providers.base import (
 )
 
 _ALNUM = string.ascii_letters + string.digits
+CLAUDE_CODE_OAUTH_TOKEN_ENV = "CLAUDE_CODE_OAUTH_TOKEN"
+ANTHROPIC_OAUTH_TOKEN_FILENAME = "anthropic-oauth.json"
 
 
 def _gen_tool_id() -> str:
@@ -45,6 +51,39 @@ def _sanitize_tool_id(tid: str) -> str:
     safe_prefix = re.sub(r"[^a-zA-Z0-9_-]", "_", tid)[:48].strip("_") or "toolu"
     digest = hashlib.sha1(tid.encode()).hexdigest()[:8]
     return f"{safe_prefix}_{digest}"
+
+
+def get_anthropic_oauth_storage_path() -> Path:
+    """Return the local storage path used for Anthropic OAuth tokens."""
+    from oauth_cli_kit.storage import FileTokenStorage
+
+    return FileTokenStorage(token_filename=ANTHROPIC_OAUTH_TOKEN_FILENAME).get_token_path()
+
+
+def get_anthropic_oauth_login_status() -> Any | None:
+    """Return Anthropic OAuth status, preferring Claude Code's env token."""
+    env_token = os.environ.get(CLAUDE_CODE_OAUTH_TOKEN_ENV)
+    if env_token:
+        return SimpleNamespace(access=env_token, account_id="environment", expires=None)
+
+    token = None
+    with suppress(Exception):
+        from oauth_cli_kit.storage import FileTokenStorage
+
+        token = FileTokenStorage(token_filename=ANTHROPIC_OAUTH_TOKEN_FILENAME).load()
+    if token and getattr(token, "access", None):
+        return token
+    return None
+
+
+def login_anthropic_oauth() -> Any | None:
+    """Log in to Anthropic OAuth unless Claude Code's env token is already set."""
+    if os.environ.get(CLAUDE_CODE_OAUTH_TOKEN_ENV):
+        return None
+
+    from oauth_cli_kit import login_oauth_interactive
+
+    return login_oauth_interactive()
 
 
 class AnthropicProvider(LLMProvider):

--- a/nanobot/providers/factory.py
+++ b/nanobot/providers/factory.py
@@ -103,8 +103,14 @@ def _make_provider_core(
     elif backend == "anthropic":
         from nanobot.providers.anthropic_provider import AnthropicProvider
 
+        api_key = p.api_key if p else None
+        if spec and spec.name == "anthropic_oauth":
+            from nanobot.providers.anthropic_provider import get_anthropic_oauth_login_status
+
+            token = get_anthropic_oauth_login_status()
+            api_key = getattr(token, "access", None) if token else None
         provider = AnthropicProvider(
-            api_key=p.api_key if p else None,
+            api_key=api_key,
             api_base=config.get_api_base(model, preset=resolved),
             default_model=model,
             extra_headers=_provider_extra_headers(spec, p),

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -342,6 +342,16 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         backend="openai_compat",
         supports_max_completion_tokens=True,
     ),
+    # Anthropic OAuth: Claude Code-compatible OAuth token
+    ProviderSpec(
+        name="anthropic_oauth",
+        keywords=("anthropic-oauth", "anthropic_oauth"),
+        env_key="",
+        display_name="Anthropic OAuth",
+        backend="anthropic",
+        is_oauth=True,
+        supports_prompt_caching=True,
+    ),
     # OpenAI Codex: OAuth-based, dedicated provider
     ProviderSpec(
         name="openai_codex",

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -98,6 +98,10 @@ _IMAGE_GENERATION_ASPECT_RATIOS = {
 _CONTEXT_WINDOW_TOKEN_OPTIONS = {65_536, 200_000, 262_144}
 _MODEL_CONFIGURATION_SLUG_RE = re.compile(r"[^a-z0-9_-]+")
 _ENV_REF_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+_CLAUDE_CODE_OAUTH_ENV_WARNING = (
+    "Note: CLAUDE_CODE_OAUTH_TOKEN environment variable is still set. "
+    "Unset it (e.g. `unset CLAUDE_CODE_OAUTH_TOKEN`) to fully log out."
+)
 
 class WebUISettingsError(ValueError):
     """User-facing settings validation failure."""
@@ -228,6 +232,24 @@ def _provider_requires_api_base(spec: Any) -> bool:
 def _oauth_provider_status(spec: Any) -> dict[str, Any]:
     if not getattr(spec, "is_oauth", False):
         return {"configured": False, "account": None, "expires_at": None, "login_supported": False}
+
+    if spec.name == "anthropic_oauth":
+        try:
+            from nanobot.providers.anthropic_provider import get_anthropic_oauth_login_status
+        except ImportError:
+            return {
+                "configured": False,
+                "account": None,
+                "expires_at": None,
+                "login_supported": False,
+            }
+        token = get_anthropic_oauth_login_status()
+        return {
+            "configured": bool(token and getattr(token, "access", None)),
+            "account": getattr(token, "account_id", None) if token else None,
+            "expires_at": getattr(token, "expires", None) if token else None,
+            "login_supported": True,
+        }
 
     if spec.name == "openai_codex":
         try:
@@ -1139,6 +1161,15 @@ def login_oauth_provider(query: QueryParams) -> dict[str, Any]:
             raise WebUISettingsError("OAuth login failed", status=401)
         return settings_payload()
 
+    if spec.name == "anthropic_oauth":
+        try:
+            from nanobot.providers.anthropic_provider import login_anthropic_oauth
+        except ImportError:
+            raise WebUISettingsError("Anthropic OAuth support is unavailable", status=500) from None
+
+        login_anthropic_oauth()
+        return settings_payload()
+
     if spec.name == "github_copilot":
         try:
             from nanobot.providers.github_copilot_provider import (
@@ -1173,6 +1204,15 @@ def logout_oauth_provider(query: QueryParams) -> dict[str, Any]:
         except ImportError:
             raise WebUISettingsError("oauth_cli_kit is not installed", status=500) from None
         token_path = FileTokenStorage(token_filename=OPENAI_CODEX_PROVIDER.token_filename).get_token_path()
+    elif spec.name == "anthropic_oauth":
+        try:
+            from nanobot.providers.anthropic_provider import (
+                CLAUDE_CODE_OAUTH_TOKEN_ENV,
+                get_anthropic_oauth_storage_path,
+            )
+        except ImportError:
+            raise WebUISettingsError("Anthropic OAuth support is unavailable", status=500) from None
+        token_path = get_anthropic_oauth_storage_path()
     elif spec.name == "github_copilot":
         try:
             from nanobot.providers.github_copilot_provider import get_storage
@@ -1185,7 +1225,10 @@ def logout_oauth_provider(query: QueryParams) -> dict[str, Any]:
     for path in (token_path, token_path.with_suffix(".lock")):
         with suppress(FileNotFoundError):
             path.unlink()
-    return settings_payload()
+    payload = settings_payload()
+    if spec.name == "anthropic_oauth" and os.environ.get(CLAUDE_CODE_OAUTH_TOKEN_ENV):
+        payload["warning"] = _CLAUDE_CODE_OAUTH_ENV_WARNING
+    return payload
 
 
 def update_network_safety_settings(query: QueryParams) -> dict[str, Any]:

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -464,6 +464,25 @@ def test_provider_logout_github_copilot_succeeds_when_no_local_oauth_file(monkey
     assert "No local OAuth credentials found for GitHub Copilot" in result.stdout
 
 
+def test_provider_logout_anthropic_oauth_warns_when_env_token_set(tmp_path, monkeypatch):
+    token_path = tmp_path / "auth" / "anthropic-oauth.json"
+    token_path.parent.mkdir(parents=True, exist_ok=True)
+    token_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "env-token")
+    monkeypatch.setattr(
+        "nanobot.providers.anthropic_provider.get_anthropic_oauth_storage_path",
+        lambda: token_path,
+    )
+
+    result = runner.invoke(app, ["provider", "logout", "anthropic-oauth"])
+
+    assert result.exit_code == 0
+    assert not token_path.exists()
+    assert "Logged out from Anthropic OAuth" in result.stdout
+    assert "CLAUDE_CODE_OAUTH_TOKEN environment variable is still set" in result.stdout
+    assert "unset CLAUDE_CODE_OAUTH_TOKEN" in result.stdout
+
+
 def test_provider_logout_rejects_unknown_provider():
     result = runner.invoke(app, ["provider", "logout", "not-a-real-provider"])
 
@@ -493,6 +512,48 @@ def test_provider_login_rejects_unknown_provider():
 
     assert result.exit_code == 1
     assert "Unknown OAuth provider" in result.stdout
+
+
+def test_provider_login_anthropic_oauth_uses_env_token_message(monkeypatch):
+    called = False
+
+    def fake_login() -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "env-token")
+    monkeypatch.setattr(
+        "nanobot.providers.anthropic_provider.login_anthropic_oauth",
+        fake_login,
+    )
+
+    result = runner.invoke(app, ["provider", "login", "anthropic-oauth"])
+
+    assert result.exit_code == 0
+    assert called is True
+    assert "Using CLAUDE_CODE_OAUTH_TOKEN from environment (no file stored)" in result.stdout
+    assert "Authenticated with Anthropic OAuth" not in result.stdout
+
+
+def test_provider_login_anthropic_oauth_without_env_token_shows_success(monkeypatch):
+    called = False
+
+    def fake_login() -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "nanobot.providers.anthropic_provider.login_anthropic_oauth",
+        fake_login,
+    )
+
+    result = runner.invoke(app, ["provider", "login", "anthropic-oauth"])
+
+    assert result.exit_code == 0
+    assert called is True
+    assert "Authenticated with Anthropic OAuth" in result.stdout
+    assert "CLAUDE_CODE_OAUTH_TOKEN from environment" not in result.stdout
 
 
 def test_provider_login_can_set_openai_codex_as_main_provider(tmp_path):

--- a/tests/webui/test_settings_api.py
+++ b/tests/webui/test_settings_api.py
@@ -15,6 +15,7 @@ from nanobot.webui.settings_api import (
     _oauth_provider_status,
     create_model_configuration,
     login_oauth_provider,
+    logout_oauth_provider,
     provider_models_payload,
     settings_payload,
     settings_usage_payload,
@@ -878,6 +879,26 @@ def test_openai_codex_oauth_login_passes_configured_proxy(
     login_oauth_provider({"provider": ["openai-codex"]})
 
     assert captured == {"get_proxy": proxy, "login_proxy": proxy}
+
+
+def test_anthropic_oauth_logout_warns_when_env_token_set(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token_path = tmp_path / "auth" / "anthropic-oauth.json"
+    token_path.parent.mkdir(parents=True, exist_ok=True)
+    token_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "env-token")
+    monkeypatch.setattr(
+        "nanobot.providers.anthropic_provider.get_anthropic_oauth_storage_path",
+        lambda: token_path,
+    )
+
+    payload = logout_oauth_provider({"provider": ["anthropic-oauth"]})
+
+    assert not token_path.exists()
+    assert "CLAUDE_CODE_OAUTH_TOKEN environment variable is still set" in payload["warning"]
+    assert "unset CLAUDE_CODE_OAUTH_TOKEN" in payload["warning"]
 
 
 def test_provider_models_payload_fetches_openai_compatible_models(


### PR DESCRIPTION
Add Anthropic OAuth provider integration with env-var-aware login/logout behavior.

The provider reads the `CLAUDE_CODE_OAUTH_TOKEN` environment variable (set by Claude Code) in addition to the file-based OAuth token storage. Two UX issues that arise from this dual-source model are addressed here:

**Logout warns when env var remains set** (Bug 1):
After deleting the local token file, the CLI and WebUI logout paths now check whether `CLAUDE_CODE_OAUTH_TOKEN` is still in the environment. If it is, a warning is shown noting that the env var must be unset manually (since the subprocess cannot modify the parent shell's environment).

**Login shows a distinct message when env var is present** (Bug 2):
When `CLAUDE_CODE_OAUTH_TOKEN` is already set, `login_anthropic_oauth()` returns immediately without prompting or writing to disk. The CLI handler now detects this and prints "Using CLAUDE_CODE_OAUTH_TOKEN from environment (no file stored)" instead of the misleading "Authenticated with Anthropic OAuth" message.

Additional wiring:
- ProviderSpec registered in `registry.py` with `is_oauth=True`
- Factory resolves the OAuth token as the API key for the Anthropic backend
- Config schema entry added (`exclude=True`, matching other OAuth providers)
- WebUI settings API: `_oauth_provider_status`, `login_oauth_provider`, and `logout_oauth_provider` all handle `anthropic_oauth`

Fixes #4674
