### PR TITLE
fix: limit long MCP-derived tool names

### DIFF
--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -1,6 +1,7 @@
 """MCP client: connects to MCP servers and wraps their tools as native nanobot tools."""
 
 import asyncio
+import hashlib
 import json
 import os
 import re
@@ -120,6 +121,25 @@ def _filter_malformed_mcp_progress_notifications(read_stream: Any, server_name: 
 def _sanitize_name(name: str) -> str:
     """Sanitize an MCP-derived name for model API compatibility."""
     return _SANITIZE_RE.sub("_", re.sub(r"[^a-zA-Z0-9_-]", "_", name))
+
+
+_MAX_TOOL_NAME_LENGTH = 64
+_HASH_LENGTH = 8
+
+
+def _limit_tool_name(name: str, max_length: int = _MAX_TOOL_NAME_LENGTH) -> str:
+    """Limit a tool name while keeping short names unchanged."""
+    if len(name) <= max_length:
+        return name
+
+    digest = hashlib.sha1(name.encode("utf-8")).hexdigest()[:_HASH_LENGTH]
+    prefix_length = max_length - _HASH_LENGTH - 1
+    return f"{name[:prefix_length]}_{digest}"
+
+
+def _sanitize_mcp_tool_name(name: str) -> str:
+    """Sanitize and limit an MCP-derived tool name."""
+    return _limit_tool_name(_sanitize_name(name))
 
 
 def _is_transient(exc: BaseException) -> bool:
@@ -389,7 +409,7 @@ class MCPToolWrapper(_MCPWrapperBase):
     def __init__(self, session, server_name: str, tool_def, tool_timeout: int = 30):
         self._set_mcp_connection(session, server_name)
         self._original_name = tool_def.name
-        self._name = _sanitize_name(f"mcp_{server_name}_{tool_def.name}")
+        self._name = _sanitize_mcp_tool_name(f"mcp_{server_name}_{tool_def.name}")
         self._description = tool_def.description or tool_def.name
         raw_schema = tool_def.inputSchema or {"type": "object", "properties": {}}
         self._parameters = _normalize_schema_for_openai(raw_schema)
@@ -548,7 +568,7 @@ class MCPResourceWrapper(_MCPWrapperBase):
     def __init__(self, session, server_name: str, resource_def, resource_timeout: int = 30):
         self._set_mcp_connection(session, server_name)
         self._uri = resource_def.uri
-        self._name = _sanitize_name(f"mcp_{server_name}_resource_{resource_def.name}")
+        self._name = _sanitize_mcp_tool_name(f"mcp_{server_name}_resource_{resource_def.name}")
         desc = resource_def.description or resource_def.name
         self._description = f"[MCP Resource] {desc}\nURI: {self._uri}"
         self._parameters: dict[str, Any] = {
@@ -649,7 +669,7 @@ class MCPPromptWrapper(_MCPWrapperBase):
     def __init__(self, session, server_name: str, prompt_def, prompt_timeout: int = 30):
         self._set_mcp_connection(session, server_name)
         self._prompt_name = prompt_def.name
-        self._name = _sanitize_name(f"mcp_{server_name}_prompt_{prompt_def.name}")
+        self._name = _sanitize_mcp_tool_name(f"mcp_{server_name}_prompt_{prompt_def.name}")
         desc = prompt_def.description or prompt_def.name
         self._description = (
             f"[MCP Prompt] {desc}\n"

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -913,9 +913,9 @@ async def connect_mcp_servers(
             registered_count = 0
             matched_enabled_tools: set[str] = set()
             available_raw_names = [tool_def.name for tool_def in tools.tools]
-            available_wrapped_names = [_sanitize_name(f"mcp_{name}_{tool_def.name}") for tool_def in tools.tools]
+            available_wrapped_names = [_sanitize_mcp_tool_name(f"mcp_{name}_{tool_def.name}") for tool_def in tools.tools]
             for tool_def in tools.tools:
-                wrapped_name = _sanitize_name(f"mcp_{name}_{tool_def.name}")
+                wrapped_name = _sanitize_mcp_tool_name(f"mcp_{name}_{tool_def.name}")
                 if (
                     not allow_all_tools
                     and tool_def.name not in enabled_tools
@@ -1294,11 +1294,10 @@ def _attach_reconnect_handlers(
         )
 
     for server_name in server_names:
-        prefix = _tool_prefix(server_name)
         for tool_name in list(registry.tool_names):
-            if not tool_name.startswith(prefix):
-                continue
             tool = registry.get(tool_name)
+            if not _tool_belongs_to_server(tool, tool_name, server_name):
+                continue
             if isinstance(tool, _MCPWrapperBase):
                 tool.set_reconnect_handler(reconnect)
 
@@ -1351,11 +1350,17 @@ def _tool_prefix(server_name: str) -> str:
     return _sanitize_name(f"mcp_{server_name}_")
 
 
+def _tool_belongs_to_server(tool: Tool | None, tool_name: str, server_name: str) -> bool:
+    if isinstance(tool, _MCPWrapperBase):
+        return getattr(tool, "_server_name", None) == server_name
+    return tool_name.startswith(_tool_prefix(server_name))
+
+
 def _unregister_server_tools(state: Any, registry: ToolRegistry, server_name: str) -> int:
-    prefix = _tool_prefix(server_name)
     removed = 0
     for tool_name in list(registry.tool_names):
-        if tool_name.startswith(prefix):
+        tool = registry.get(tool_name)
+        if _tool_belongs_to_server(tool, tool_name, server_name):
             registry.unregister(tool_name)
             removed += 1
     return removed

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -16,6 +16,7 @@ from nanobot.agent.tools.mcp import (
     MCPResourceWrapper,
     MCPToolWrapper,
     _normalize_windows_stdio_command,
+    _sanitize_mcp_tool_name,
     _sanitize_name,
     connect_mcp_servers,
 )
@@ -1319,3 +1320,15 @@ async def test_connect_mcp_servers_enabled_tools_matches_sanitized_name(
 )
 def test_redact_url_strips_credentials_and_query(url: str, expected: str) -> None:
     assert mcp_mod._redact_url(url) == expected
+
+def test_mcp_tool_name_keeps_short_name():
+    name = _sanitize_mcp_tool_name("mcp_myserver_resource_myres")
+    assert name == "mcp_myserver_resource_myres"
+
+
+def test_mcp_tool_name_limits_long_name():
+    long_name = "mcp_" + "a" * 100
+    name = _sanitize_mcp_tool_name(long_name)
+
+    assert len(name) <= 64
+    assert name.startswith("mcp_")

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1332,3 +1332,35 @@ def test_mcp_tool_name_limits_long_name():
 
     assert len(name) <= 64
     assert name.startswith("mcp_")
+
+
+def test_long_server_name_tools_are_matched_by_server_name() -> None:
+    server_name = "very-long-server-name-" * 4
+    tool_def = SimpleNamespace(
+        name="search",
+        description="search tool",
+        inputSchema={"type": "object", "properties": {}},
+    )
+    other_tool_def = SimpleNamespace(
+        name="search",
+        description="other search tool",
+        inputSchema={"type": "object", "properties": {}},
+    )
+    wrapper = MCPToolWrapper(SimpleNamespace(call_tool=None), server_name, tool_def)
+    other_wrapper = MCPToolWrapper(SimpleNamespace(call_tool=None), "other", other_tool_def)
+    registry = ToolRegistry()
+    registry.register(wrapper)
+    registry.register(other_wrapper)
+
+    assert len(wrapper.name) == 64
+    assert not wrapper.name.startswith(mcp_mod._tool_prefix(server_name))
+
+    mcp_mod._attach_reconnect_handlers(SimpleNamespace(), registry, {server_name})
+    assert wrapper._reconnect is not None
+    assert other_wrapper._reconnect is None
+
+    removed = mcp_mod._unregister_server_tools(SimpleNamespace(), registry, server_name)
+
+    assert removed == 1
+    assert wrapper.name not in registry.tool_names
+    assert other_wrapper.name in registry.tool_names

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -546,6 +546,26 @@ async def test_connect_mcp_servers_enabled_tools_supports_wrapped_names(
 
 
 @pytest.mark.asyncio
+async def test_connect_mcp_servers_enabled_tools_supports_limited_wrapped_names(
+    fake_mcp_runtime: dict[str, object | None],
+) -> None:
+    long_tool_name = "tool-" + "very-long-name-" * 8
+    wrapped_name = _sanitize_mcp_tool_name(f"mcp_test_{long_tool_name}")
+    assert len(wrapped_name) == 64
+
+    fake_mcp_runtime["session"] = _make_fake_session([long_tool_name, "other"])
+    registry = ToolRegistry()
+    stacks = await connect_mcp_servers(
+        {"test": MCPServerConfig(command="fake", enabled_tools=[wrapped_name])},
+        registry,
+    )
+    for stack in stacks.values():
+        await stack.aclose()
+
+    assert registry.tool_names == [wrapped_name]
+
+
+@pytest.mark.asyncio
 async def test_connect_mcp_servers_enabled_tools_empty_list_registers_none(
     fake_mcp_runtime: dict[str, object | None],
 ) -> None:


### PR DESCRIPTION
## What

Limit MCP-derived tool/function names when they exceed the API name length constraint.

## Why

Long MCP server/tool/resource/prompt names may generate function names longer than the model API allows, causing errors such as:

'ERROR | - | LLM returned error: Error: {'message': "Invalid 'tools[50].function.name': string too long. Expected a string with maximum length 128, but got a string with length 147 instead.", 'type': 'invalid_request_error', 'param':'

## How

- Keep `_sanitize_name()` focused on character sanitization.
- Add a separate MCP tool name limiting helper.
- Preserve existing short names unchanged.
- Only truncate and append a hash when names exceed the length limit.

## Test

- `pytest tests/tools/test_mcp_tool.py`
- `pytest tests/agent/test_mcp_transient_retry.py`
- `pytest tests/agent/test_mcp_connection.py`