### PR TITLE
fix(mcp): isolate reconnect cancel scopes to prevent gateway crash

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1189,9 +1189,14 @@ class AgentLoop:
         if self._background_tasks:
             await asyncio.gather(*self._background_tasks, return_exceptions=True)
             self._background_tasks.clear()
-        for name, stack in self._mcp_stacks.items():
+        for name, stack in list(self._mcp_stacks.items()):
             try:
                 await stack.aclose()
+            except asyncio.CancelledError:
+                task = asyncio.current_task()
+                if task is not None and task.cancelling() > 0:
+                    raise
+                logger.debug("MCP server '{}' cleanup cancelled by SDK (can be ignored)", name)
             except (RuntimeError, BaseExceptionGroup):
                 logger.debug("MCP server '{}' cleanup error (can be ignored)", name)
         self._mcp_stacks.clear()

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -7,8 +7,8 @@ import os
 import re
 import shutil
 import urllib.parse
-from collections.abc import Awaitable, Callable
-from contextlib import AsyncExitStack, suppress
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from typing import Any, Mapping
 from weakref import WeakKeyDictionary
 
@@ -168,6 +168,19 @@ def _is_session_terminated(exc: BaseException) -> bool:
     )
 
 
+def _is_mcp_cancel_scope_cancellation(exc: asyncio.CancelledError) -> bool:
+    """Return True when ``exc`` was injected by an anyio cancel scope."""
+    return str(exc).startswith("Cancelled via cancel scope")
+
+
+def _clear_task_cancellation(task: asyncio.Task[Any] | None) -> None:
+    """Acknowledge all pending asyncio cancellation requests on ``task``."""
+    if task is None:
+        return
+    while task.cancelling() > 0:
+        task.uncancel()
+
+
 async def _probe_http_url(url: str, timeout: float = 3.0) -> bool:
     """Quick TCP probe to check if an HTTP MCP server is reachable.
 
@@ -198,7 +211,99 @@ async def _probe_http_url(url: str, timeout: float = 3.0) -> bool:
             return True
         except (OSError, asyncio.TimeoutError):
             continue
+        except asyncio.CancelledError as exc:
+            # Swallow MCP SDK anyio cancel-scope leaks during probing so reconnect
+            # can proceed; re-raise genuine external cancellation.
+            if not _is_mcp_cancel_scope_cancellation(exc):
+                raise
+            _clear_task_cancellation(asyncio.current_task())
+            logger.debug(
+                "MCP URL probe for {} cancelled by SDK cancel scope, retrying",
+                _redact_url(url),
+            )
     return False
+
+
+async def _force_close_async_gen(agen: AsyncGenerator[Any, Any]) -> None:
+    """Close an async generator, swallowing every possible cleanup error.
+
+    MCP SDK transports use anyio task groups whose teardown can raise
+    ``RuntimeError`` / ``BaseExceptionGroup`` / ``CancelledError``.  We must
+    ensure the generator object reaches a closed state so Python's GC
+    finalizer does not try to close it again and crash the event loop.
+    """
+    with suppress(BaseException):
+        await agen.aclose()
+
+
+@asynccontextmanager
+async def _safe_streamable_http_client(*args: Any, **kwargs: Any) -> AsyncGenerator[
+    tuple[Any, Any, Callable[[], str | None]],
+    None,
+]:
+    """Wrap ``streamable_http_client`` to isolate anyio cleanup leaks.
+
+    The MCP SDK's ``streamable_http_client`` creates an anyio cancel scope
+    bound to the task that enters it.  If the AsyncExitStack is later closed
+    from a different task (e.g. nanobot's reconnect path), the cancel scope
+    teardown cancels the original host task and leaks ``CancelledError`` into
+    unrelated awaits.  We avoid that by running the transport context in a
+    dedicated worker task so the cancel scope is never bound to the caller.
+    """
+    from mcp.client.streamable_http import streamable_http_client
+
+    cm = streamable_http_client(*args, **kwargs)
+    loop = asyncio.get_running_loop()
+    enter_future: asyncio.Future[Any] = loop.create_future()
+    exit_event = asyncio.Event()
+
+    async def _suppress_exit_cm() -> None:
+        with suppress(BaseException):
+            await cm.__aexit__(None, None, None)
+
+    async def _worker() -> None:
+        try:
+            result = await cm.__aenter__()
+        except BaseException as exc:
+            if not enter_future.done():
+                enter_future.set_exception(exc)
+            return
+
+        if enter_future.done():
+            await _suppress_exit_cm()
+            return
+
+        enter_future.set_result(result)
+        try:
+            await exit_event.wait()
+        except BaseException:
+            pass
+        finally:
+            await _suppress_exit_cm()
+
+    worker = asyncio.create_task(_worker())
+    try:
+        done, _ = await asyncio.wait(
+            {enter_future, worker},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if worker in done:
+            await worker
+            if not enter_future.done():
+                raise RuntimeError("streamable_http_client worker exited unexpectedly")
+        result = enter_future.result()
+    except BaseException:
+        worker.cancel()
+        with suppress(BaseException):
+            await worker
+        raise
+
+    try:
+        yield result
+    finally:
+        exit_event.set()
+        with suppress(BaseException):
+            await worker
 
 
 def _redact_url(url: str) -> str:
@@ -812,19 +917,19 @@ class MCPPromptWrapper(_MCPWrapperBase):
                 return "\n".join(parts) or "(no output)"
 
 
-async def connect_mcp_servers(
+async def _connect_mcp_servers_impl(
     mcp_servers: dict, registry: ToolRegistry
 ) -> dict[str, AsyncExitStack]:
-    """Connect to configured MCP servers and register their tools, resources, prompts.
+    """Implementation of ``connect_mcp_servers``.
 
-    Returns a dict mapping server name -> its dedicated AsyncExitStack.
-    Each server gets its own stack to prevent cancel scope conflicts
-    when multiple MCP servers are configured.
+    This runs inside a dedicated transient task so that any anyio cancel
+    scopes entered by the MCP SDK are bound to that task.  Once the task
+    completes, the live AsyncExitStacks are handed back to the caller; later
+    cleanup from a different task can no longer cancel the caller.
     """
     from mcp import ClientSession, StdioServerParameters
     from mcp.client.sse import sse_client
     from mcp.client.stdio import stdio_client
-    from mcp.client.streamable_http import streamable_http_client
 
     async def connect_single_server(name: str, cfg) -> tuple[str, AsyncExitStack | None]:
         server_stack = AsyncExitStack()
@@ -913,7 +1018,7 @@ async def connect_mcp_servers(
                     )
                 )
                 read, write, _ = await server_stack.enter_async_context(
-                    streamable_http_client(cfg.url, http_client=http_client)
+                    _safe_streamable_http_client(cfg.url, http_client=http_client)
                 )
             else:
                 logger.warning("MCP server '{}': unknown transport type '{}'", name, transport_type)
@@ -1057,6 +1162,26 @@ async def connect_mcp_servers(
             server_stacks[result[0]] = result[1]
 
     return server_stacks
+
+
+async def connect_mcp_servers(
+    mcp_servers: dict, registry: ToolRegistry
+) -> dict[str, AsyncExitStack]:
+    """Connect to configured MCP servers and register their tools, resources, prompts.
+
+    Returns a dict mapping server name -> its dedicated AsyncExitStack.
+    The actual connection work runs in a dedicated transient task so that the
+    MCP SDK's anyio cancel scopes are bound to that task, not the caller.
+    """
+    task = asyncio.create_task(_connect_mcp_servers_impl(mcp_servers, registry))
+    try:
+        return await task
+    except asyncio.CancelledError:
+        if not task.done():
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+        raise
 
 
 def session_extra(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
@@ -1384,5 +1509,10 @@ async def _close_server(state: Any, server_name: str) -> None:
         return
     try:
         await stack.aclose()
+    except asyncio.CancelledError:
+        task = asyncio.current_task()
+        if task is not None and task.cancelling() > 0:
+            raise
+        logger.debug("MCP server '{}' cleanup cancelled by SDK (can be ignored)", server_name)
     except (RuntimeError, BaseExceptionGroup):
         logger.debug("MCP server '{}' cleanup error (can be ignored)", server_name)

--- a/nanobot/webui/mcp_presets_api.py
+++ b/nanobot/webui/mcp_presets_api.py
@@ -904,8 +904,16 @@ def _test_timeout(cfg: MCPServerConfig) -> int:
 
 async def _close_mcp_stacks(stacks: Mapping[str, Any]) -> None:
     for stack in stacks.values():
-        with suppress(Exception):
+        try:
             await stack.aclose()
+        except asyncio.CancelledError:
+            task = asyncio.current_task()
+            if task is not None and task.cancelling() > 0:
+                raise
+        except (RuntimeError, BaseExceptionGroup):
+            pass
+        except Exception:
+            pass
 
 
 async def mcp_presets_test_action(query: QueryParams) -> dict[str, Any]:

--- a/tests/agent/test_mcp_reconnect_crash.py
+++ b/tests/agent/test_mcp_reconnect_crash.py
@@ -1,0 +1,227 @@
+"""Reproduction test for HKUDS/nanobot#4302.
+
+This test starts a real FastMCP streamable-http server in a child process,
+lets its idle timeout kill the session, and then exercises nanobot's MCP
+reconnect path.  The bug being reproduced is a gateway crash caused by
+improper cleanup of the old ``streamable_http_client`` async generator during
+reconnect / shutdown.
+
+Run:
+
+    pytest tests/agent/test_mcp_reconnect_crash.py -v
+"""
+
+import asyncio
+import multiprocessing
+import socket
+import time
+from contextlib import suppress
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.agent.tools import mcp as mcp_module
+from nanobot.agent.tools.mcp import MCPToolWrapper
+from nanobot.bus.queue import MessageBus
+from nanobot.config.schema import MCPServerConfig
+from nanobot.security import network as security_network
+
+_IDLE_TIMEOUT_SECONDS = 5
+_TOOL_TIMEOUT_SECONDS = 10
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _run_mcp_server(port: int, ready_event: multiprocessing.Event) -> None:
+    """FastMCP server target for ``multiprocessing.Process``.
+
+    The server exposes a single ``greet`` tool and terminates idle sessions
+    after ``_IDLE_TIMEOUT_SECONDS``.
+    """
+    from mcp.server.fastmcp import FastMCP
+    from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
+    mcp = FastMCP("IdleTimeoutDemo", json_response=True, port=port)
+
+    @mcp.tool()
+    def greet(name: str = "World") -> str:  # noqa: N802
+        """Greet someone."""
+        return f"Hello, {name}!"
+
+    mcp._session_manager = StreamableHTTPSessionManager(
+        app=mcp._mcp_server,
+        json_response=mcp.settings.json_response,
+        stateless=mcp.settings.stateless_http,
+        security_settings=mcp.settings.transport_security,
+        session_idle_timeout=_IDLE_TIMEOUT_SECONDS,
+    )
+
+    ready_event.set()
+    mcp.run(transport="streamable-http")
+
+
+async def _wait_for_server(url: str, timeout: float = 10.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            async with httpx.AsyncClient(timeout=2.0) as client:
+                response = await client.get(
+                    url,
+                    headers={"Accept": "text/event-stream"},
+                )
+                if response.status_code < 500:
+                    return True
+        except Exception:
+            await asyncio.sleep(0.1)
+    return False
+
+
+@pytest.fixture(scope="module")
+def mcp_server_url():
+    """Start the idle-timeout MCP server and yield its URL."""
+    ctx = multiprocessing.get_context("spawn")
+    port = _free_port()
+    ready_event = ctx.Event()
+    process = ctx.Process(
+        target=_run_mcp_server,
+        args=(port, ready_event),
+        daemon=True,
+    )
+    process.start()
+    ready_event.wait(timeout=10.0)
+
+    url = f"http://127.0.0.1:{port}/mcp"
+    if not asyncio.run(_wait_for_server(url, timeout=10.0)):
+        process.terminate()
+        process.join(timeout=5.0)
+        pytest.skip(f"MCP repro server failed to start on {url}")
+
+    yield url
+
+    process.terminate()
+    process.join(timeout=5.0)
+    if process.is_alive():
+        process.kill()
+        process.join(timeout=2.0)
+
+
+def _make_loop(tmp_path, *, mcp_servers: dict) -> AgentLoop:
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.generation.max_tokens = 4096
+    return AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+        mcp_servers=mcp_servers,
+    )
+
+
+@pytest.fixture(autouse=True)
+def allow_loopback_mcp_urls(monkeypatch: pytest.MonkeyPatch):
+    """The repro server runs on 127.0.0.1; allow nanobot to talk to it."""
+    monkeypatch.setattr(
+        mcp_module,
+        "validate_url_target",
+        lambda url, *, allow_loopback=False: (True, ""),
+    )
+    monkeypatch.setattr(
+        mcp_module,
+        "resolve_url_target",
+        lambda url, *, allow_loopback=False: (True, "", ("127.0.0.1",)),
+    )
+    monkeypatch.setattr(
+        security_network,
+        "resolve_url_target",
+        lambda url, *, allow_loopback=False: (True, "", ("127.0.0.1",)),
+    )
+    monkeypatch.setattr(
+        mcp_module,
+        "env_proxy_applies_to_url",
+        lambda url: False,
+    )
+    monkeypatch.setattr(
+        mcp_module,
+        "httpx_env_proxy_mounts",
+        lambda: {},
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_reconnect_after_session_timeout(tmp_path, mcp_server_url):
+    """Reconnect to a real MCP server after its idle timeout kills the session."""
+    cfg = MCPServerConfig(
+        type="streamableHttp",
+        url=mcp_server_url,
+        tool_timeout=_TOOL_TIMEOUT_SECONDS,
+        enabled_tools=["*"],
+    )
+    loop = _make_loop(tmp_path, mcp_servers={"repro": cfg})
+
+    await loop._connect_mcp()
+    assert "repro" in loop._mcp_stacks
+
+    tool = loop.tools.get("mcp_repro_greet")
+    assert isinstance(tool, MCPToolWrapper)
+
+    output = await tool.execute(name="first")
+    assert "Hello, first" in output
+
+    # Wait for the server-side idle timeout to terminate the session.
+    await asyncio.sleep(_IDLE_TIMEOUT_SECONDS + 1)
+
+    output = await tool.execute(name="second")
+    assert "Hello, second" in output
+
+    await loop.close_mcp()
+
+
+@pytest.mark.asyncio
+async def test_mcp_reconnect_during_shutdown_does_not_crash(tmp_path, mcp_server_url):
+    """Simulate the production crash: shutdown while reconnect is in flight."""
+    cfg = MCPServerConfig(
+        type="streamableHttp",
+        url=mcp_server_url,
+        tool_timeout=_TOOL_TIMEOUT_SECONDS,
+        enabled_tools=["*"],
+    )
+    loop = _make_loop(tmp_path, mcp_servers={"repro": cfg})
+
+    await loop._connect_mcp()
+    tool = loop.tools.get("mcp_repro_greet")
+    assert isinstance(tool, MCPToolWrapper)
+
+    await tool.execute(name="first")
+    await asyncio.sleep(_IDLE_TIMEOUT_SECONDS + 1)
+
+    call_task = asyncio.create_task(tool.execute(name="second"))
+    loop.stop()
+
+    unhandled: list[BaseException] = []
+
+    def capture_unhandled(_loop, context):
+        exc = context.get("exception")
+        if exc is not None:
+            unhandled.append(exc)
+
+    asyncio.get_running_loop().set_exception_handler(capture_unhandled)
+
+    try:
+        await asyncio.wait_for(asyncio.shield(call_task), timeout=15)
+    except asyncio.CancelledError:
+        unhandled.append(asyncio.CancelledError("main task cancelled by leaked MCP cancel scope"))
+    except Exception as exc:
+        unhandled.append(exc)
+
+    with suppress(Exception):
+        await loop.close_mcp()
+
+    assert not unhandled, f"Unhandled exception leaked during reconnect/shutdown: {unhandled[0]}"


### PR DESCRIPTION
##  Yes, I know it's not the most elgant way to fix this, but it's working for better or worse. At least the test is usable for later researchers.

  When an MCP streamable-http server's idle timeout kills the session, nanobot's reconnect path closes the old transport stack and opens a new one. The old  stack contains the MCP SDK's anyio cancel scopes, which are bound to the task that originally entered them. Closing the stack from a different task  (reconnect / shutdown) cancels that original task and leaks `CancelledError` into unrelated awaits, crashing the gateway.

  Reproduced by the new test `tests/agent/test_mcp_reconnect_crash.py::test_mcp_reconnect_during_shutdown_does_not_crash`.

  ## Changes
  
  - Run MCP connection setup in a dedicated transient `asyncio.Task` so anyio cancel scopes are bound to a task that is done by the time cleanup runs.
  - Keep the worker-task wrapper around `streamable_http_client` for extra isolation.
  - Harden `_probe_http_url`, `_close_server`, `AgentLoop.close_mcp`, and `_close_mcp_stacks` to swallow SDK-injected cancel-scope leaks while still
  propagating genuine task cancellations.
  
  ## Verification
  
  ```bash
  uv run pytest tests/agent/test_mcp_reconnect_crash.py -v
  # 2 passed
  
  uv run pytest tests/agent/test_mcp_connection.py tests/agent/test_mcp_transient_retry.py -v
  # 39 passed
  
  uv run ruff check nanobot/agent/tools/mcp.py nanobot/agent/loop.py nanobot/webui/mcp_presets_api.py
  # All checks passed
 ```

  Fixes HKUDS/nanobot#4302
