### PR TITLE
fix(gateway): resolve config path for state refresh

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1307,13 +1307,16 @@ def _run_gateway(
     session_manager = SessionManager(config.workspace_path)
 
     # Self-heal the gateway state file with the current PID after any restart.
+    from nanobot.config.loader import get_config_path
     from nanobot.gateway.runtime import GatewayRuntime, GatewayRuntimePaths
+
+    config_path = str(get_config_path().resolve(strict=False))
     GatewayRuntime.refresh_state_pid(
         paths=GatewayRuntimePaths.for_instance(
             workspace=str(config.workspace_path)
             if not is_default_workspace(config.workspace_path)
             else None,
-            config_path=config.config_path,
+            config_path=config_path,
         )
     )
 


### PR DESCRIPTION
## Summary
- fix the main-branch CI regression from gateway state PID refresh
- read the active runtime config path from the config loader instead of a non-existent Config.config_path field
- keep the gateway state self-heal behavior from #4547 without changing the Config schema

## Root Cause
#4547 added early gateway state refresh in _run_gateway(), but it accessed config.config_path. Config does not define that field, so foreground gateway startup crashed before channels/health could start. That cascaded into all gateway-related CI failures on main.

## Validation
- python -m pytest tests/cli/test_commands.py::test_gateway_uses_workspace_directory_for_cron_store tests/cli/test_commands.py::test_gateway_unbound_agent_cron_is_skipped tests/cli/test_commands.py::test_gateway_bound_cron_runs_as_session_turn tests/cli/test_commands.py::test_gateway_local_trigger_queue_submits_agent_turns tests/cli/test_commands.py::test_gateway_workspace_override_does_not_migrate_legacy_cron tests/cli/test_commands.py::test_gateway_custom_config_workspace_does_not_migrate_legacy_cron tests/cli/test_commands.py::test_gateway_health_endpoint_binds_and_serves_expected_responses tests/cli/test_commands.py::test_gateway_shutdown_lets_agent_task_own_mcp_cleanup tests/cli/test_commands.py::test_gateway_shutdown_event_exits_forever_runtime_tasks tests/webui/test_gateway_webui_smoke.py::test_gateway_webui_bootstrap_message_and_thread_hydration -q
- python -m pytest tests/cli/test_commands.py -q
- python -m ruff check nanobot/cli/commands.py