### PR TITLE
fix(runner): log suppressed prepare_call exceptions instead of silently swallowing them

### DIFF
--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -1190,10 +1190,11 @@ class AgentRunner:
                 prepared = prepare_call(tool_call.name, tool_call.arguments)
                 if isinstance(prepared, tuple) and len(prepared) == 3:
                     tool, params, prep_error = prepared
-            except Exception:
+            except Exception as exc:
                 logger.opt(exception=True).warning(
-                    "prepare_call failed for tool {} -- running unprepared",
+                    "prepare_call failed for tool {} -- running unprepared: {}",
                     tool_call.name,
+                    exc,
                 )
         if prep_error:
             event = {

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -1191,7 +1191,7 @@ class AgentRunner:
                 if isinstance(prepared, tuple) and len(prepared) == 3:
                     tool, params, prep_error = prepared
             except Exception:
-                logger.warning(
+                logger.opt(exception=True).warning(
                     "prepare_call failed for tool {} -- running unprepared",
                     tool_call.name,
                 )

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import inspect
 import os
-from contextlib import suppress
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -1187,10 +1186,15 @@ class AgentRunner:
         prepare_call = getattr(spec.tools, "prepare_call", None)
         tool, params, prep_error = None, tool_call.arguments, None
         if callable(prepare_call):
-            with suppress(Exception):
+            try:
                 prepared = prepare_call(tool_call.name, tool_call.arguments)
                 if isinstance(prepared, tuple) and len(prepared) == 3:
                     tool, params, prep_error = prepared
+            except Exception:
+                logger.warning(
+                    "prepare_call failed for tool {} -- running unprepared",
+                    tool_call.name,
+                )
         if prep_error:
             event = {
                 "name": tool_call.name,


### PR DESCRIPTION
## Summary

`AgentRunner._run_tool()` wrapped `prepare_call()` in `suppress(Exception)`. If preparation failed, the exception was swallowed and the tool continued with raw arguments, with no operator-visible signal.

## Changes

- `nanobot/agent/runner.py`: replace silent suppression with try/except that logs the exception at WARNING with traceback details, then continues unprepared as before.

## Verification

```
python -m pytest tests/agent/test_runner_errors.py tests/agent/test_runner_tool_execution.py -q
```

## Backwards compatibility

Runtime behavior is unchanged: preparation failures still fall back to unprepared execution. The only change is diagnostic logging.

Fixes #4805
