### PR TITLE
fix(memory): use .get() for role key to prevent KeyError on malformed messages

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -706,7 +706,7 @@ class MemoryStore:
             tools = f" [tools: {', '.join(message['tools_used'])}]" if message.get("tools_used") else ""
             lines.append(
                 f"[{message.get('timestamp', '?')[:16]}] "
-                f"{message['role'].upper()}{tools}: {content}"
+                f"{message.get('role', 'unknown').upper()}{tools}: {content}"
             )
         return "\n".join(lines)
 

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -110,6 +110,11 @@ class TestConsolidatorSummarize:
 
         assert formatted == f"[2026-07-27] USER: [image: {path}]"
 
+    def test_format_messages_defaults_missing_role(self):
+        formatted = MemoryStore._format_messages([{"content": "hello"}])
+
+        assert formatted == "[?] UNKNOWN: hello"
+
     async def test_archive_excludes_model_only_runtime_context(
         self, consolidator, mock_provider, runtime
     ):


### PR DESCRIPTION
## Summary

`MemoryStore._format_messages()` reads `message['role']` directly. A malformed history entry missing `role` raises `KeyError` during archive formatting.

Nearby fields already use defensive `.get()` access.

## Changes

- `nanobot/agent/memory.py`: use `message.get('role', 'unknown').upper()` when formatting archived messages.

## Verification

```
python -m pytest tests/agent/test_memory_store.py -q
```

## Backwards compatibility

Valid messages with a role field are unchanged. Missing-role entries format as `UNKNOWN` instead of crashing.

Fixes #4801
