### PR TITLE
fix(loop): guard .strip() on msg.content against list-form multimodal data

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1002,7 +1002,7 @@ class AgentLoop:
                     logger.warning("Error consuming inbound message: {}, continuing...", e)
                     continue
 
-                raw = msg.content.strip()
+                raw = msg.content.strip() if isinstance(msg.content, str) else ""
                 effective_key = self._effective_session_key(msg)
                 if await agent_context.handle_runtime_control(self, msg, self.tools):
                     continue
@@ -1546,7 +1546,7 @@ class AgentLoop:
         return "ok"
 
     async def _state_command(self, ctx: TurnContext) -> str:
-        raw = ctx.msg.content.strip()
+        raw = ctx.msg.content.strip() if isinstance(ctx.msg.content, str) else ""
         _, automation_metadata = automation_history_overrides(ctx.msg.metadata)
         is_user_turn = (
             ctx.original_user_text is not None


### PR DESCRIPTION
## Summary

`msg.content` can be either a string or a list of multimodal content blocks. Two command-dispatch paths still call `.strip()` unconditionally. When a channel delivers list-form content, that raises `AttributeError` and the message is dropped.

Nearby code already guards with `isinstance(..., str)`.

## Changes

- `nanobot/agent/loop.py`: guard `.strip()` in the inbound consume path and `_state_command()` so non-string content becomes an empty command string instead of crashing.

## Verification

```
python -m pytest tests/agent/test_task_cancel.py tests/agent/test_loop_save_turn.py -q
```

## Backwards compatibility

String messages behave the same. Only non-string content avoids the `.strip()` crash.

Fixes #4800
