### PR TITLE
fix(loop): propagate leaked CancelledError instead of silently swallowing it

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -945,11 +945,10 @@ class AgentLoop:
                     )
                     continue
                 except asyncio.CancelledError:
-                    # Preserve real task cancellation so shutdown can complete cleanly.
-                    # Only ignore non-task CancelledError signals that may leak from integrations.
-                    if not self._running or asyncio.current_task().cancelling():
-                        raise
-                    continue
+                    # Preserve cancellation at this boundary. MCP/AnyIO cancel scopes
+                    # can leak CancelledError without cancelling this task, and hiding
+                    # that here would leave the loop running after an integration failure.
+                    raise
                 except Exception as e:
                     logger.warning("Error consuming inbound message: {}, continuing...", e)
                     continue

--- a/tests/agent/test_task_cancel.py
+++ b/tests/agent/test_task_cancel.py
@@ -103,6 +103,18 @@ class TestHandleStop:
 
 
 class TestDispatch:
+    @pytest.mark.asyncio
+    async def test_run_propagates_leaked_cancelled_error_from_consume_inbound(self):
+        loop, bus = _make_loop()
+        loop._connect_mcp = AsyncMock()
+        loop.close_mcp = AsyncMock()
+        bus.consume_inbound = AsyncMock(side_effect=asyncio.CancelledError("mcp cancel scope"))
+
+        with pytest.raises(asyncio.CancelledError, match="mcp cancel scope"):
+            await loop.run()
+
+        loop.close_mcp.assert_awaited_once()
+
     def test_exec_tool_not_registered_when_disabled(self):
         from nanobot.agent.tools.shell import ExecToolConfig
         from nanobot.config.schema import ToolsConfig


### PR DESCRIPTION
## Summary

In the agent loop's `consume_inbound()` handler, `CancelledError` is only re-raised when the loop is stopping or the current task is cancelling. Otherwise it is swallowed with `continue`.

That can hide `CancelledError` leaked from MCP/AnyIO cancel scopes while the loop is still marked running, leaving the loop alive after an integration failure.

## Changes

- `nanobot/agent/loop.py`: re-raise `CancelledError` at the consume boundary instead of conditionally ignoring it.
- `tests/agent/test_task_cancel.py`: regression test that a leaked `CancelledError` from `consume_inbound()` propagates out of `loop.run()`.

## Verification

```
python -m pytest tests/agent/test_task_cancel.py -v -k leaked_cancelled
```

## Backwards compatibility

This intentionally changes the loop's handling of non-task `CancelledError` leaks. Real task cancellation and shutdown still propagate as before.

Addresses #4804
