### PR TITLE
fix(runner): narrow BaseException catch to Exception in tool execution

### DIFF
--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -1190,7 +1190,7 @@ class AgentRunner:
                 result = await spec.tools.execute(tool_call.name, params)
         except asyncio.CancelledError:
             raise
-        except BaseException as exc:
+        except Exception as exc:
             await hook.on_execute_tool_error(context, tool_call, tool, params, exc)
             event = {
                 "name": tool_call.name,

--- a/tests/agent/test_runner_errors.py
+++ b/tests/agent/test_runner_errors.py
@@ -3,6 +3,7 @@ session message isolation, and tool result preservation."""
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -43,6 +44,39 @@ async def test_runner_returns_structured_tool_error():
     assert result.tool_events == [
         {"name": "list_dir", "status": "error", "detail": "boom"}
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("control_error", [KeyboardInterrupt, SystemExit])
+async def test_runner_propagates_tool_control_flow_exceptions(control_error: type[BaseException]):
+    from nanobot.agent.runner import AgentRunner
+
+    provider = MagicMock(spec=LLMProvider)
+
+    async def execute(_name, _args):
+        raise control_error("stop")
+
+    tools = SimpleNamespace(
+        get_definitions=lambda: [],
+        execute=execute,
+    )
+    runner = AgentRunner()
+    spec = make_run_spec(
+        provider,
+        initial_messages=[],
+        tools=tools,
+        model="test-model",
+        max_iterations=1,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    )
+
+    with pytest.raises(control_error):
+        await runner._run_tool(
+            spec,
+            ToolCallRequest(id="call_1", name="list_dir", arguments={}),
+            external_lookup_counts={},
+            workspace_violation_counts={},
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

In `AgentRunner._run_tool()`, tool execution caught `BaseException`. That includes control-flow signals such as `KeyboardInterrupt` and `SystemExit`, which then get converted into conversational tool error payloads instead of propagating.

`asyncio.CancelledError` is already handled by a separate `except` clause and re-raised.

## Changes

- `nanobot/agent/runner.py`: narrow the tool-execution catch from `BaseException` to `Exception`.
- `tests/agent/test_runner_errors.py`: parametrized regression test that `KeyboardInterrupt` and `SystemExit` from tool execute propagate through `_run_tool`.

## Verification

```
python -m pytest tests/agent/test_runner_errors.py -v
# 11 passed
```

## Backwards compatibility

Normal tool failures still become structured error payloads. Only non-`Exception` control-flow signals stop being swallowed by the tool catch path.

Fixes #4788
