### PR TITLE
fix(loop): add regression test for zero context window token budget

### DIFF
--- a/tests/agent/test_loop_consolidation_tokens.py
+++ b/tests/agent/test_loop_consolidation_tokens.py
@@ -30,6 +30,12 @@ def _make_loop(tmp_path, *, estimated_tokens: int, context_window_tokens: int) -
     return loop
 
 
+def test_replay_token_budget_is_zero_when_context_window_disabled(tmp_path) -> None:
+    loop = _make_loop(tmp_path, estimated_tokens=0, context_window_tokens=0)
+
+    assert loop._replay_token_budget() == 0
+
+
 @pytest.mark.asyncio
 async def test_prompt_below_threshold_does_not_consolidate(tmp_path) -> None:
     loop = _make_loop(tmp_path, estimated_tokens=100, context_window_tokens=200)


### PR DESCRIPTION
When `context_window_tokens` is set to 0 (to disable context window budgeting), the fallback calculation `max(128, context_window_tokens // 2)` used to produce a spurious 128-token budget.

An early guard was already added in `_replay_token_budget()` that returns 0 when `context_window_tokens <= 0`. This PR adds explicit regression test coverage to prevent the bug from returning.

Closes #4802
