### PR TITLE
fix(memory): replace WeakValueDictionary with plain dict for consolidation locks

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -7,7 +7,6 @@ import json
 import os
 import re
 import threading
-import weakref
 from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
@@ -760,13 +759,15 @@ class Consolidator:
         self.unified_session = unified_session
         self._build_messages = build_messages
         self._get_tool_definitions = get_tool_definitions
-        self._locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
-            weakref.WeakValueDictionary()
-        )
+        self._locks: dict[str, asyncio.Lock] = {}
 
     def get_lock(self, session_key: str) -> asyncio.Lock:
         """Return the shared consolidation lock for one session."""
-        return self._locks.setdefault(session_key, asyncio.Lock())
+        lock = self._locks.get(session_key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[session_key] = lock
+        return lock
 
     def pick_consolidation_boundary(
         self,

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -76,8 +76,8 @@ def _tool_round(call_id: str) -> list[dict]:
     ]
 
 
-def test_get_lock_keeps_same_lock_after_gc(consolidator):
-    """Per-session locks must stay strongly referenced by the consolidator."""
+def test_get_lock_persists_lock_reference(consolidator):
+    """Per-session locks persist across GC cycles so the same lock is always returned for a given session key."""
     lock = consolidator.get_lock("cli:lock")
     lock_ref = weakref.ref(lock)
     assert consolidator.get_lock("cli:lock") is lock

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -1,5 +1,7 @@
 """Tests for the lightweight Consolidator — append-only to HISTORY.md."""
 
+import gc
+import weakref
 from dataclasses import replace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -72,6 +74,18 @@ def _tool_round(call_id: str) -> list[dict]:
         },
         {"role": "tool", "tool_call_id": call_id, "name": "x", "content": "ok"},
     ]
+
+
+def test_get_lock_keeps_same_lock_after_gc(consolidator):
+    """Per-session locks must stay strongly referenced by the consolidator."""
+    lock = consolidator.get_lock("cli:lock")
+    lock_ref = weakref.ref(lock)
+    assert consolidator.get_lock("cli:lock") is lock
+
+    del lock
+    gc.collect()
+
+    assert consolidator.get_lock("cli:lock") is lock_ref()
 
 
 class TestConsolidatorSummarize:


### PR DESCRIPTION
## Summary

Consolidator stored per-session `asyncio.Lock` objects in `weakref.WeakValueDictionary`. If no strong references remain when GC runs, the lock can be collected. The next `get_lock()` call creates a new lock for the same session key, so two concurrent consolidations can hold different locks and interleave session writes.

## Changes

- `nanobot/agent/memory.py`: replace `WeakValueDictionary` with a plain `dict[str, asyncio.Lock]` in `Consolidator`.
- `tests/agent/test_consolidator.py`: regression test that drops local references, runs `gc.collect()`, and checks the same lock is still returned.

## Verification

```
python -m pytest tests/agent/test_consolidator.py -v -k test_get_lock
# 1 passed
```

## Backwards compatibility

No public API change. Lock lifetime is now tied to the consolidator instance instead of weak GC of idle lock objects.

Closes #4789
