### PR TITLE
fix(runtime): reject non-string web fetch URLs

### DIFF
--- a/nanobot/utils/runtime.py
+++ b/nanobot/utils/runtime.py
@@ -94,7 +94,10 @@ def external_lookup_signature(tool_name: str, arguments: Any) -> str | None:
     if not isinstance(arguments, dict):
         return None
     if tool_name == "web_fetch":
-        url = str(arguments.get("url") or "").strip()
+        raw_url = arguments.get("url")
+        if not isinstance(raw_url, str):
+            return None
+        url = raw_url.strip()
         if url:
             return f"web_fetch:{url.lower()}"
     if tool_name == "web_search":

--- a/tests/utils/test_runtime_external_lookup.py
+++ b/tests/utils/test_runtime_external_lookup.py
@@ -1,0 +1,37 @@
+"""Tests for external lookup throttling helpers."""
+
+from __future__ import annotations
+
+from nanobot.utils.runtime import (
+    external_lookup_signature,
+    repeated_external_lookup_error,
+)
+
+
+def test_web_fetch_signature_ignores_none_url():
+    assert external_lookup_signature("web_fetch", {"url": None}) is None
+
+
+def test_web_fetch_signature_ignores_non_string_url():
+    assert external_lookup_signature("web_fetch", {"url": 123}) is None
+
+
+def test_web_fetch_signature_ignores_empty_url():
+    assert external_lookup_signature("web_fetch", {"url": "   "}) is None
+
+
+def test_web_fetch_non_string_url_does_not_create_cache_entry():
+    counts: dict[str, int] = {}
+
+    assert repeated_external_lookup_error("web_fetch", {"url": 123}, counts) is None
+    assert counts == {}
+
+    assert (
+        repeated_external_lookup_error(
+            "web_fetch",
+            {"url": "https://example.com"},
+            counts,
+        )
+        is None
+    )
+    assert counts == {"web_fetch:https://example.com": 1}

--- a/tests/utils/test_runtime_external_lookup.py
+++ b/tests/utils/test_runtime_external_lookup.py
@@ -8,11 +8,7 @@ from nanobot.utils.runtime import (
 )
 
 
-def test_web_fetch_signature_ignores_none_url():
-    assert external_lookup_signature("web_fetch", {"url": None}) is None
-
-
-def test_web_fetch_signature_ignores_non_string_url():
+def test_web_fetch_signature_ignores_truthy_non_string_url():
     assert external_lookup_signature("web_fetch", {"url": 123}) is None
 
 


### PR DESCRIPTION
## Summary

external_lookup_signature() used str(arguments.get("url") or "") for web_fetch. Truthy non-string values such as 123 were coerced into cache signatures like web_fetch:123, which could interfere with later valid lookups.

None and empty-string URLs already produced no signature on the base branch. This PR targets the actual truthy non-string case.

## Changes

- nanobot/utils/runtime.py: require url to be a string before building a web_fetch signature.
- tests/utils/test_runtime_external_lookup.py: regression coverage for truthy non-string URLs and cache behavior.

## Verification

python -m pytest tests/utils/test_runtime_external_lookup.py -q
3 passed

## Backwards compatibility

String URLs behave the same. Only non-string URL values stop being coerced into signatures.

Fixes #4799
