### PR TITLE
fix(webui): show generic tool arguments in activity

### DIFF
--- a/webui/src/components/thread/AgentActivityCluster.tsx
+++ b/webui/src/components/thread/AgentActivityCluster.tsx
@@ -986,7 +986,7 @@ function describeTraceLine(line: string): TraceDescription {
     };
   }
   if (name) {
-    return { kind: "tool", label: "Using", detail: name };
+    return { kind: "tool", label: "Using", detail: genericToolTraceDetail(name, args) };
   }
   if (/done|complete|success/i.test(trimmed)) {
     return { kind: "done", label: "Done", detail: trimmed };
@@ -1146,6 +1146,35 @@ function formatTraceUrl(url: URL): string {
   const host = displayHost(url.hostname);
   const path = url.pathname && url.pathname !== "/" ? url.pathname : "";
   return `${host}${path}`;
+}
+
+function genericToolTraceDetail(name: string, args: string): string {
+  const preview = previewGenericToolArgs(args);
+  return preview ? `${name} ${preview}` : name;
+}
+
+function previewGenericToolArgs(args: string): string {
+  const compactArgs = args.trim();
+  if (!compactArgs) return "";
+  try {
+    return previewGenericArgsObject(JSON.parse(compactArgs) as unknown);
+  } catch {
+    return compactArgs.replace(/^["']|["']$/g, "");
+  }
+}
+
+function previewGenericArgsObject(argsObject: unknown): string {
+  if (!argsObject || typeof argsObject !== "object" || Array.isArray(argsObject)) {
+    return previewScalar(argsObject) ?? "";
+  }
+  const record = argsObject as Record<string, unknown>;
+  const entries: string[] = [];
+  for (const key of ["query", "glob", "pattern", "path", "file_path", "url", "name", "id", "title"]) {
+    const preview = previewScalar(record[key]);
+    if (preview) entries.push(`${key}: ${preview}`);
+    if (entries.length >= 2) return entries.join(" · ");
+  }
+  return entries.join(" · ");
 }
 
 function previewTraceDetail(args: string, fallback: string): string {

--- a/webui/src/tests/agent-activity-cluster.test.tsx
+++ b/webui/src/tests/agent-activity-cluster.test.tsx
@@ -767,6 +767,31 @@ describe("AgentActivityCluster", () => {
     expect(screen.getByText("url: http://localhost:3000/dashboard")).toBeInTheDocument();
   });
 
+  it("shows readable argument previews for generic tool traces", () => {
+    render(
+      <AgentActivityCluster
+        messages={[{
+          id: "t-generic-tools",
+          role: "tool",
+          kind: "trace",
+          content: 'grep({"pattern":"dream_cursor"})',
+          traces: [
+            'find_files({"query":"thread","glob":"*.tsx"})',
+            'list_dir({"path":"memory"})',
+            'grep({"pattern":"dream_cursor"})',
+          ],
+          createdAt: 1,
+        }]}
+        isTurnStreaming
+        hasBodyBelow={false}
+      />,
+    );
+
+    expect(screen.getByText("find_files query: thread · glob: *.tsx")).toBeInTheDocument();
+    expect(screen.getByText("list_dir path: memory")).toBeInTheDocument();
+    expect(screen.getByText("grep pattern: dream_cursor")).toBeInTheDocument();
+  });
+
   it("summarizes long shell traces instead of dumping scripts", () => {
     const command = [
       "cat << 'EOF' | bash",


### PR DESCRIPTION
## Summary
- render readable key/value previews for generic WebUI tool activity rows
- keep the fix scoped to the existing frontend trace renderer; no backend or websocket protocol changes
- avoid dumping arbitrary JSON objects by previewing only common scalar argument keys such as `query`, `glob`, `pattern`, and `path`
- add a focused regression test for `find_files`, `list_dir`, and `grep` traces

## Verification
- `bun run test -- src/tests/agent-activity-cluster.test.tsx`
- `bun run build`
