### PR TITLE
Fix missing aiohttp slack dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ qq = [
     "qq-botpy>=1.2.0,<2.0.0",
 ]
 slack = [
+    "aiohttp>=3.9.0,<4.0.0",
     "slack-sdk>=3.39.0,<4.0.0",
     "slackify-markdown>=0.2.0,<1.0.0",
 ]

--- a/tests/channels/test_channel_plugins.py
+++ b/tests/channels/test_channel_plugins.py
@@ -1103,6 +1103,7 @@ def test_optional_dependency_metadata_for_enable():
     assert deps["napcat"] == ["aiohttp>=3.9.0,<4.0.0"]
     assert deps["qq"] == ["aiohttp>=3.9.0,<4.0.0", "qq-botpy>=1.2.0,<2.0.0"]
     assert deps["slack"] == [
+        "aiohttp>=3.9.0,<4.0.0",
         "slack-sdk>=3.39.0,<4.0.0",
         "slackify-markdown>=0.2.0,<1.0.0",
     ]


### PR DESCRIPTION
Added `"aiohttp>=3.9.0,<4.0.0"` to the dependencies for **slack**

fixes #4829 