### PR TITLE
fix(cli): handle CSI-u Shift+Enter instead of dumping raw escapes

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -309,28 +309,12 @@ def _build_cli_key_bindings() -> KeyBindings:
       * Enter       -> submit the current input (keeps the familiar
                        single-line Enter-to-send feel even though the buffer
                        is multiline-capable).
-      * Alt+Enter   -> insert a newline for multi-line input. Universally
-                       supported, so this is the reliable multiline shortcut.
+      * Alt+Enter   -> insert a newline for multi-line input.
       * Shift+Enter -> insert a newline on terminals that emit the CSI-u
                        (kitty / fixterms) keyboard-protocol encoding for it.
     """
-    # Terminals speaking the CSI-u (kitty / fixterms) keyboard protocol -- e.g.
-    # kitty, Ghostty and WezTerm when it is enabled -- send Shift+Enter as the
-    # escape sequence "\x1b[13;2u". prompt_toolkit 3.0 has no support for that
-    # protocol (no way to negotiate it, no default mapping for the sequence), so
-    # when such a terminal sends it the Vt100Parser fails to recognise the
-    # sequence and dumps the raw bytes ("^[[13;2u") straight into the buffer.
-    #
-    # Register the sequence so it parses as one keypress bound to insert a
-    # newline instead. "\x1b[13;2u" is absent from prompt_toolkit's default
-    # ANSI_SEQUENCES table, so this is a pure addition -- setdefault() overrides
-    # nothing -- carried on Keys.ControlF3, an enum member prompt_toolkit
-    # declares but never wires to a default sequence or binding.
-    #
-    # This is best-effort: without protocol negotiation we can only *react* to a
-    # CSI-u sequence a terminal already emits, not *request* one. Terminals that
-    # collapse Shift+Enter into a plain Enter are indistinguishable and fall back
-    # to Alt+Enter, which is why Alt+Enter stays the primary shortcut.
+    # prompt_toolkit does not recognize CSI-u, so register its Shift+Enter
+    # sequence as a best-effort addition without overriding existing mappings.
     with suppress(Exception):
         from prompt_toolkit.input import ansi_escape_sequences as _aes
 

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -309,8 +309,33 @@ def _build_cli_key_bindings() -> KeyBindings:
       * Enter       -> submit the current input (keeps the familiar
                        single-line Enter-to-send feel even though the buffer
                        is multiline-capable).
-      * Alt+Enter   -> insert a newline for multi-line input.
+      * Alt+Enter   -> insert a newline for multi-line input. Universally
+                       supported, so this is the reliable multiline shortcut.
+      * Shift+Enter -> insert a newline on terminals that emit the CSI-u
+                       (kitty / fixterms) keyboard-protocol encoding for it.
     """
+    # Terminals speaking the CSI-u (kitty / fixterms) keyboard protocol -- e.g.
+    # kitty, Ghostty and WezTerm when it is enabled -- send Shift+Enter as the
+    # escape sequence "\x1b[13;2u". prompt_toolkit 3.0 has no support for that
+    # protocol (no way to negotiate it, no default mapping for the sequence), so
+    # when such a terminal sends it the Vt100Parser fails to recognise the
+    # sequence and dumps the raw bytes ("^[[13;2u") straight into the buffer.
+    #
+    # Register the sequence so it parses as one keypress bound to insert a
+    # newline instead. "\x1b[13;2u" is absent from prompt_toolkit's default
+    # ANSI_SEQUENCES table, so this is a pure addition -- setdefault() overrides
+    # nothing -- carried on Keys.ControlF3, an enum member prompt_toolkit
+    # declares but never wires to a default sequence or binding.
+    #
+    # This is best-effort: without protocol negotiation we can only *react* to a
+    # CSI-u sequence a terminal already emits, not *request* one. Terminals that
+    # collapse Shift+Enter into a plain Enter are indistinguishable and fall back
+    # to Alt+Enter, which is why Alt+Enter stays the primary shortcut.
+    with suppress(Exception):
+        from prompt_toolkit.input import ansi_escape_sequences as _aes
+
+        _aes.ANSI_SEQUENCES.setdefault("\x1b[13;2u", Keys.ControlF3)
+
     kb = KeyBindings()
 
     @kb.add("enter")
@@ -323,6 +348,10 @@ def _build_cli_key_bindings() -> KeyBindings:
 
     # LF-as-Enter terminals send Alt+Enter as ESC + LF rather than ESC + CR.
     @kb.add("escape", Keys.ControlJ)  # Alt+Enter on LF-as-Enter terminals
+    def _(event):
+        event.current_buffer.insert_text("\n")
+
+    @kb.add(Keys.ControlF3)  # Shift+Enter on CSI-u capable terminals
     def _(event):
         event.current_buffer.insert_text("\n")
 

--- a/tests/cli/test_cli_input.py
+++ b/tests/cli/test_cli_input.py
@@ -129,12 +129,7 @@ async def test_alt_enter_inserts_newline_on_lf_terminals():
 
 @pytest.mark.asyncio
 async def test_csi_u_shift_enter_inserts_newline_not_raw_escape():
-    """Terminals speaking the CSI-u (kitty / fixterms) keyboard protocol send
-    Shift+Enter as "\\x1b[13;2u". prompt_toolkit has no support for that protocol
-    and would otherwise dump the raw escape bytes ("^[[13;2u") into the buffer;
-    the binding must instead parse it as one keypress and insert a newline. Only
-    a real PromptSession/parser exercises the ANSI_SEQUENCES registration.
-    """
+    """CSI-u Shift+Enter inserts a newline instead of raw escape bytes."""
     from prompt_toolkit.application import create_app_session
     from prompt_toolkit.input import create_pipe_input
     from prompt_toolkit.output import DummyOutput

--- a/tests/cli/test_cli_input.py
+++ b/tests/cli/test_cli_input.py
@@ -127,6 +127,29 @@ async def test_alt_enter_inserts_newline_on_lf_terminals():
     assert result == "foo\nbar"
 
 
+@pytest.mark.asyncio
+async def test_csi_u_shift_enter_inserts_newline_not_raw_escape():
+    """Terminals speaking the CSI-u (kitty / fixterms) keyboard protocol send
+    Shift+Enter as "\\x1b[13;2u". prompt_toolkit has no support for that protocol
+    and would otherwise dump the raw escape bytes ("^[[13;2u") into the buffer;
+    the binding must instead parse it as one keypress and insert a newline. Only
+    a real PromptSession/parser exercises the ANSI_SEQUENCES registration.
+    """
+    from prompt_toolkit.application import create_app_session
+    from prompt_toolkit.input import create_pipe_input
+    from prompt_toolkit.output import DummyOutput
+
+    with create_pipe_input() as pipe_input:
+        with create_app_session(input=pipe_input, output=DummyOutput()):
+            commands._init_prompt_session()
+            session = commands._PROMPT_SESSION
+            pipe_input.send_text("foo\x1b[13;2ubar\r")
+            result = await session.prompt_async("> ")
+
+    # A newline is inserted and no raw escape bytes leak into the result.
+    assert result == "foo\nbar"
+
+
 def test_thinking_spinner_pause_stops_and_restarts():
     """Pause should stop the active spinner and restart it afterward."""
     spinner = MagicMock()


### PR DESCRIPTION
## Summary

Follow-up to #4614. That PR added multiline input (Enter submits, Alt+Enter inserts a newline) and, during review, its terminal-dependent Shift+Enter path was intentionally dropped in favor of Alt+Enter only. This PR fixes a **regression** that removal left behind on one class of terminals.

Terminals speaking the **CSI-u (kitty / fixterms) keyboard protocol** — kitty, Ghostty, WezTerm, and some embedded terminal panes that default to it — encode **Shift+Enter** as the escape sequence `\x1b[13;2u`. prompt_toolkit 3.0 has no support for that protocol and no default mapping for the sequence, so its `Vt100Parser` fails to recognise it and dumps the **raw bytes (`^[[13;2u`) straight into the prompt buffer**. So on these terminals Shift+Enter now leaks visible escape garbage into the input instead of doing nothing graceful.

Reproduced in a terminal pane that emits CSI-u: pressing Shift+Enter in `nanobot agent` types `^[[13;2u` literally.

## Fix

Register `\x1b[13;2u` and bind it to insert a newline (same as Alt+Enter):

- `\x1b[13;2u` is **absent from prompt_toolkit's default `ANSI_SEQUENCES`**, so `setdefault()` overrides nothing — this is a pure addition, carried on `Keys.ControlF3`, an enum member prompt_toolkit declares but never wires to a default sequence or binding.
- **Best-effort by design.** prompt_toolkit cannot *negotiate* the protocol (there is no equivalent of crossterm's `PushKeyboardEnhancementFlags`), so we only *react* to a CSI-u sequence a terminal already emits. Terminals that collapse Shift+Enter into a plain Enter remain indistinguishable and fall back to **Alt+Enter, which stays the primary/universal shortcut**. Nothing changes for them.
- Scope is deliberately minimal: only the clean-addition CSI-u encoding. The older xterm `modifyOtherKeys` form (`\x1b[27;2;13~`, which prompt_toolkit *does* map by default) is left untouched to avoid overriding a private default.

For reference, this is the layer at which mainstream agents handle Shift+Enter: **[openai/codex](https://github.com/openai/codex)** (Apache-2.0, `codex-rs`) enables the kitty protocol via crossterm — `PushKeyboardEnhancementFlags(DISAMBIGUATE_ESCAPE_CODES | REPORT_EVENT_TYPES | REPORT_ALTERNATE_KEYS)`, gated on `supports_keyboard_enhancement()` — precisely *"so Shift+Enter is distinguishable from Enter."* prompt_toolkit doesn't expose that negotiation, so the passive registration here is the closest prompt_toolkit-native equivalent; the immediate goal is simply to stop dumping raw escapes.

## Testing

- Added `test_csi_u_shift_enter_inserts_newline_not_raw_escape` — drives a real `PromptSession`/parser with `foo\x1b[13;2ubar\r` and asserts the result is `foo\nbar` (newline inserted, no raw escape bytes leaked).
- `pytest tests/cli/test_cli_input.py` — 23 passed. `ruff check` clean.
- Existing Enter-submit, Alt+Enter (ESC+CR and ESC+LF/WSL) behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
