### PR TITLE
fix(webui): bind landing first message to created chat

### DIFF
--- a/webui/src/components/thread/ThreadShell.tsx
+++ b/webui/src/components/thread/ThreadShell.tsx
@@ -339,6 +339,7 @@ export function ThreadShell({
   const filePreviewWidthRef = useRef(FILE_PREVIEW_DEFAULT_WIDTH);
   const filePreviewCloseTimerRef = useRef<number | null>(null);
   const pendingFirstRef = useRef<PendingFirstMessage | null>(null);
+  const [pendingFirstTargetChatId, setPendingFirstTargetChatId] = useState<string | null>(null);
   const viewportRef = useRef<ThreadViewportHandle | null>(null);
   const messageCacheRef = useRef<Map<string, UIMessage[]>>(new Map());
   /** Last chatId we associated with the in-memory thread (for cache-on-switch). */
@@ -555,15 +556,22 @@ export function ThreadShell({
     messageCacheRef.current.set(chatId, projectWebuiThreadMessages(messages));
   }, [chatId, loading, messages]);
 
+  // The landing composer queues the first message while `new_chat` is in flight.
+  // Only the chat created for that send may consume it; selecting another chat
+  // while creation is pending must not leak the message there.
   useEffect(() => {
-    if (!chatId) return;
+    if (!chatId || pendingFirstTargetChatId !== chatId) return;
     const pending = pendingFirstRef.current;
-    if (!pending) return;
+    if (!pending) {
+      setPendingFirstTargetChatId(null);
+      return;
+    }
     pendingFirstRef.current = null;
+    setPendingFirstTargetChatId(null);
     setScrollToLatestUserPromptSignal((value) => value + 1);
     send(pending.content, pending.images, pending.options);
     setBooting(false);
-  }, [chatId, send]);
+  }, [chatId, pendingFirstTargetChatId, send]);
 
   useEffect(() => {
     let cancelled = false;
@@ -585,11 +593,15 @@ export function ThreadShell({
       if (booting) return;
       setBooting(true);
       pendingFirstRef.current = { content, images, options: withWorkspaceScope(options) };
+      setPendingFirstTargetChatId(null);
       const newId = await onCreateChat?.(workspaceScope);
       if (!newId) {
         pendingFirstRef.current = null;
+        setPendingFirstTargetChatId(null);
         setBooting(false);
+        return;
       }
+      setPendingFirstTargetChatId(newId);
     },
     [booting, onCreateChat, withWorkspaceScope, workspaceScope],
   );

--- a/webui/src/tests/thread-shell.test.tsx
+++ b/webui/src/tests/thread-shell.test.tsx
@@ -507,6 +507,71 @@ describe("ThreadShell", () => {
     expect(onNewChat).not.toHaveBeenCalled();
   });
 
+  it("binds a pending landing message to the chat created for it", async () => {
+    const client = makeClient();
+    let resolveCreate: ((chatId: string) => void) | null = null;
+    const onCreateChat = vi.fn(() => new Promise<string>((resolve) => {
+      resolveCreate = resolve;
+    }));
+
+    const { rerender } = render(
+      wrap(
+        client,
+        <ThreadShell
+          session={null}
+          title="nanobot"
+          onToggleSidebar={() => {}}
+          onCreateChat={onCreateChat}
+        />,
+      ),
+    );
+
+    fireEvent.change(screen.getByLabelText("Message input"), {
+      target: { value: "must not leak" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() => expect(onCreateChat).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      rerender(
+        wrap(
+          client,
+          <ThreadShell
+            session={session("existing-chat")}
+            title="Existing chat"
+            onToggleSidebar={() => {}}
+            onCreateChat={onCreateChat}
+          />,
+        ),
+      );
+    });
+
+    await act(async () => {
+      resolveCreate?.("chat-new");
+    });
+
+    expect(client.sendMessage).not.toHaveBeenCalled();
+
+    await act(async () => {
+      rerender(
+        wrap(
+          client,
+          <ThreadShell
+            session={session("chat-new")}
+            title="New chat"
+            onToggleSidebar={() => {}}
+            onCreateChat={onCreateChat}
+          />,
+        ),
+      );
+    });
+
+    await waitFor(() =>
+      expectSendMessageWithTurn(client, "chat-new", "must not leak"),
+    );
+  });
+
   it("keeps the first landing message when new chat history is still empty", async () => {
     const client = makeClient();
     const onCreateChat = vi.fn().mockResolvedValue("chat-new");


### PR DESCRIPTION
## Summary                                                                                                                                                   
                                                                                                                                                              
 Fixes #4835.                                                                                                                                                 
                                                                                                                                                              
 - Track the chat id returned by `onCreateChat` for a queued landing-page first message.                                                                      
 - Only consume the queued first message when that exact chat becomes active.                                                                                 
 - Add a regression test for selecting an existing chat while chat creation is still pending.                                                                 
                                                                                                                                                              
 ## Problem / Root Cause                                                                                                                                      
                                                                                                                                                              
 The blank landing composer queues the first message while `new_chat` is in flight. `ThreadShell` previously consumed `pendingFirstRef` as soon as any        
 `chatId` became active.                                                                                                                                      
                                                                                                                                                              
 If the user selected an existing chat before the newly created chat became active, that existing chat could consume the queued landing message.              
                                                                                                                                                              
 ## Scope                                                                                                                                                     
                                                                                                                                                              
 - Files changed: `webui/src/components/thread/ThreadShell.tsx`, `webui/src/tests/thread-shell.test.tsx`.                                                     
 - No WebSocket protocol changes.                                                                                                                             
 - No backend/session/storage changes.                                                                                                                        
 - No routing or API changes.                                                                                                                                 
                                                                                                                                                              
 ## Validation                                                                                                                                                
                                                                                                                                                              
 - `cd webui && bun run lint`                                                                                                                                 
 - `cd webui && bun run test -- src/tests/thread-shell.test.tsx`                                                                                              
 - `cd webui && bun run build`         