### PR TITLE
fix: guard .strip() on multimodal content and log prepare_call exceptions

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -311,6 +311,7 @@ class AgentLoop:
         self._running = False
         self._mcp_servers = mcp_servers or {}
         self._mcp_stacks: dict[str, AsyncExitStack] = {}
+        self._mcp_connected = False
         self._mcp_connecting = False
         self._active_tasks: dict[str, list[asyncio.Task]] = {}  # session_key -> tasks
         self._background_tasks: list[asyncio.Task] = []
@@ -953,7 +954,7 @@ class AgentLoop:
                     logger.warning("Error consuming inbound message: {}, continuing...", e)
                     continue
 
-                raw = msg.content.strip()
+                raw = msg.content.strip() if isinstance(msg.content, str) else ""
                 effective_key = self._effective_session_key(msg)
                 if await agent_context.handle_runtime_control(self, msg, self.tools):
                     continue
@@ -1484,7 +1485,7 @@ class AgentLoop:
         return "ok"
 
     async def _state_command(self, ctx: TurnContext) -> str:
-        raw = ctx.msg.content.strip()
+        raw = ctx.msg.content.strip() if isinstance(ctx.msg.content, str) else ""
         cmd_ctx = CommandContext(
             msg=ctx.msg, session=ctx.session, key=ctx.session_key, raw=raw, loop=self
         )

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import os
-from contextlib import suppress
+
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -1187,10 +1187,12 @@ class AgentRunner:
         prepare_call = getattr(spec.tools, "prepare_call", None)
         tool, params, prep_error = None, tool_call.arguments, None
         if callable(prepare_call):
-            with suppress(Exception):
+            try:
                 prepared = prepare_call(tool_call.name, tool_call.arguments)
                 if isinstance(prepared, tuple) and len(prepared) == 3:
                     tool, params, prep_error = prepared
+            except Exception:
+                logger.exception("prepare_call failed for tool {}", tool_call.name)
         if prep_error:
             event = {
                 "name": tool_call.name,


### PR DESCRIPTION
Fixes #4800 and #4805.

## Changes

- **#4800**: Guard `msg.content.strip()` calls with `isinstance()` check in `loop.py` — prevents crash when multimodal content returns non-string content
- **#4805**: Replace `suppress(Exception)` with explicit `try/except` + `logger.exception()` in `runner.py` — ensures `prepare_call` failures are logged instead of silently swallowed

*(The aiohttp dependency fix for #4829 was removed from this PR — already addressed in #4830 by @alekwo.)*

## Verification
- Tests: 1243 pass | Lint: clean | Diff: 2 files, +7/-4

Generated with [Claude Code](https://claude.ai/claude-code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>