### PR TITLE
fix(shell): reap zombie processes on all subprocess exit paths

### DIFF
--- a/nanobot/agent/tools/exec_session.py
+++ b/nanobot/agent/tools/exec_session.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import time
 import uuid
 from contextlib import suppress

--- a/nanobot/agent/tools/exec_session.py
+++ b/nanobot/agent/tools/exec_session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 import uuid
 from contextlib import suppress
@@ -148,6 +149,9 @@ class _ExecSession:
                     asyncio.gather(self._stdout_task, self._stderr_task),
                     timeout=2.0,
                 )
+            # Safety-net reap after normal exit.
+            from nanobot.agent.tools.shell import _reap_pid
+            _reap_pid(self.process.pid)
         elif yield_time_ms > 0:
             await self._wait_for_buffered_output()
 
@@ -171,8 +175,14 @@ class _ExecSession:
         if self.process.returncode is not None:
             return
         self.process.kill()
-        with suppress(asyncio.TimeoutError):
-            await asyncio.wait_for(self.process.wait(), timeout=5.0)
+        try:
+            with suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(self.process.wait(), timeout=5.0)
+        finally:
+            # Safety-net waitpid — prevent zombie if asyncio's child watcher
+            # did not reap the process (common in containers).
+            from nanobot.agent.tools.shell import _reap_pid
+            _reap_pid(self.process.pid)
 
     async def _wait_for_buffered_output(self) -> None:
         deadline = time.monotonic() + OUTPUT_DRAIN_GRACE_S

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -41,6 +41,24 @@ from nanobot.security.workspace_policy import is_path_within
 _IS_WINDOWS = sys.platform == "win32"
 
 
+def _reap_pid(pid: int) -> None:
+    """Best-effort ``waitpid`` to reap a child and prevent zombies.
+
+    Call this after killing or after normal completion of any subprocess
+    as a safety net — asyncio's child-watcher *should* have reaped it,
+    but in containers / edge-cases it sometimes doesn't.
+    """
+    if _IS_WINDOWS:
+        return
+    try:
+        os.waitpid(pid, os.WNOHANG)
+    except (ProcessLookupError, ChildProcessError):
+        # Already reaped, or not our child — both are fine.
+        pass
+    except OSError as exc:
+        logger.debug("_reap_pid({}): {}", pid, exc)
+
+
 # Policy note appended to recoverable workspace-boundary guard errors.
 _WORKSPACE_BOUNDARY_NOTE = (
     "\n\nNote: this is a hard policy boundary, not a transient failure. "
@@ -283,6 +301,7 @@ class ExecTool(Tool):
         if yield_time_ms is not None:
             return await self._execute_session(prepared, yield_time_ms, max_output_chars)
 
+        process: asyncio.subprocess.Process | None = None
         try:
             process = await self._spawn(
                 prepared.command,
@@ -303,6 +322,11 @@ class ExecTool(Tool):
             except asyncio.CancelledError:
                 await self._kill_process(process)
                 raise
+
+            # Safety-net reap: asyncio *should* have reaped the child via
+            # communicate(), but in containers the child-watcher sometimes
+            # misses it, leaving a zombie.
+            _reap_pid(process.pid)
 
             output_parts = []
 
@@ -330,6 +354,10 @@ class ExecTool(Tool):
             return result
 
         except Exception as e:
+            # Kill and reap the child if it was spawned but an unexpected
+            # error prevented communicate() from completing.
+            if process is not None:
+                await self._kill_process(process)
             return ToolResult.error(f"Error executing command: {str(e)}")
 
     async def _execute_session(
@@ -604,11 +632,7 @@ class ExecTool(Tool):
             with suppress(asyncio.TimeoutError):
                 await asyncio.wait_for(process.wait(), timeout=5.0)
         finally:
-            if not _IS_WINDOWS:
-                try:
-                    os.waitpid(process.pid, os.WNOHANG)
-                except (ProcessLookupError, ChildProcessError) as e:
-                    logger.debug("Process already reaped or not found: {}", e)
+            _reap_pid(process.pid)
 
     def _build_env(self) -> dict[str, str]:
         """Build a minimal environment for subprocess execution.

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -632,9 +632,18 @@ class ExecTool(Tool):
 
     @staticmethod
     async def _kill_process(process: asyncio.subprocess.Process) -> None:
-        """Kill a subprocess and reap it to prevent zombies."""
-        process.kill()
+        """Kill a subprocess and reap it to prevent zombies.
+
+        Safe to call when the process has already exited (e.g. generic
+        exception handlers after a successful ``communicate()``): skips
+        ``kill()`` and only runs the safety-net reap.
+        """
+        if process.returncode is not None:
+            _reap_pid(process.pid)
+            return
         try:
+            with suppress(ProcessLookupError):
+                process.kill()
             with suppress(asyncio.TimeoutError):
                 await asyncio.wait_for(process.wait(), timeout=5.0)
         finally:

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -47,11 +47,17 @@ def _reap_pid(pid: int) -> None:
     Call this after killing or after normal completion of any subprocess
     as a safety net — asyncio's child-watcher *should* have reaped it,
     but in containers / edge-cases it sometimes doesn't.
+
+    Uses ``os`` capability checks rather than ``_IS_WINDOWS`` so this is
+    safe when tests patch the platform flag while still running on Windows
+    (``os.waitpid`` / ``os.WNOHANG`` do not exist there).
     """
-    if _IS_WINDOWS:
+    waitpid = getattr(os, "waitpid", None)
+    wnohang = getattr(os, "WNOHANG", None)
+    if waitpid is None or wnohang is None:
         return
     try:
-        os.waitpid(pid, os.WNOHANG)
+        waitpid(pid, wnohang)
     except (ProcessLookupError, ChildProcessError):
         # Already reaped, or not our child — both are fine.
         pass

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -200,7 +200,6 @@ app = typer.Typer(
 )
 
 console = Console()
-_IS_WINDOWS = sys.platform == "win32"
 EXIT_COMMANDS = {"exit", "quit", "/exit", "/quit", ":q"}
 _REASONING_SENTENCE_ENDINGS = (".", "!", "?", "。", "！", "？")
 _REASONING_FLUSH_CHARS = 60
@@ -1626,29 +1625,6 @@ def _run_gateway(
     else:
         console.print("[yellow]✗[/yellow] Heartbeat: disabled")
 
-    async def _zombie_reaper() -> None:
-        """Periodically reap zombie child processes.
-
-        asyncio's child-watcher *should* reap all children, but inside
-        Docker containers the pidfd / SIGCHLD mechanism can miss exits.
-        This task runs every 30 s and calls ``os.waitpid(-1, WNOHANG)``
-        in a loop to collect any zombies that slipped through.
-        """
-        _INTERVAL = 30
-        while True:
-            await asyncio.sleep(_INTERVAL)
-            reaped = 0
-            while True:
-                try:
-                    pid, _ = os.waitpid(-1, os.WNOHANG)
-                    if pid == 0:
-                        break  # no more zombie children
-                    reaped += 1
-                except ChildProcessError:
-                    break  # no child processes at all
-            if reaped:
-                logger.info("Zombie reaper: reaped {} defunct child process(es)", reaped)
-
     async def _health_server(host: str, health_port: int):
         """Lightweight HTTP health endpoint on the gateway port."""
         import json as _json
@@ -1774,11 +1750,6 @@ def _run_gateway(
                     name="nanobot-local-triggers",
                 ),
             ]
-            if not _IS_WINDOWS:
-                tasks.append(asyncio.create_task(
-                    _zombie_reaper(),
-                    name="nanobot-zombie-reaper",
-                ))
             if health_server_enabled:
                 tasks.append(asyncio.create_task(
                     _health_server(config.gateway.host, port),

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -200,6 +200,7 @@ app = typer.Typer(
 )
 
 console = Console()
+_IS_WINDOWS = sys.platform == "win32"
 EXIT_COMMANDS = {"exit", "quit", "/exit", "/quit", ":q"}
 _REASONING_SENTENCE_ENDINGS = (".", "!", "?", "。", "！", "？")
 _REASONING_FLUSH_CHARS = 60
@@ -1625,6 +1626,29 @@ def _run_gateway(
     else:
         console.print("[yellow]✗[/yellow] Heartbeat: disabled")
 
+    async def _zombie_reaper() -> None:
+        """Periodically reap zombie child processes.
+
+        asyncio's child-watcher *should* reap all children, but inside
+        Docker containers the pidfd / SIGCHLD mechanism can miss exits.
+        This task runs every 30 s and calls ``os.waitpid(-1, WNOHANG)``
+        in a loop to collect any zombies that slipped through.
+        """
+        _INTERVAL = 30
+        while True:
+            await asyncio.sleep(_INTERVAL)
+            reaped = 0
+            while True:
+                try:
+                    pid, _ = os.waitpid(-1, os.WNOHANG)
+                    if pid == 0:
+                        break  # no more zombie children
+                    reaped += 1
+                except ChildProcessError:
+                    break  # no child processes at all
+            if reaped:
+                logger.info("Zombie reaper: reaped {} defunct child process(es)", reaped)
+
     async def _health_server(host: str, health_port: int):
         """Lightweight HTTP health endpoint on the gateway port."""
         import json as _json
@@ -1750,6 +1774,11 @@ def _run_gateway(
                     name="nanobot-local-triggers",
                 ),
             ]
+            if not _IS_WINDOWS:
+                tasks.append(asyncio.create_task(
+                    _zombie_reaper(),
+                    name="nanobot-zombie-reaper",
+                ))
             if health_server_enabled:
                 tasks.append(asyncio.create_task(
                     _health_server(config.gateway.host, port),

--- a/tests/tools/test_shell_reap.py
+++ b/tests/tools/test_shell_reap.py
@@ -1,0 +1,255 @@
+"""Tests for subprocess zombie reaping in ExecTool / exec sessions."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nanobot.agent.tools.exec_session import _ExecSession
+from nanobot.agent.tools.shell import ExecTool, _reap_pid
+
+
+def test_reap_pid_noops_without_waitpid():
+    """On platforms (or test stubs) without waitpid, reaping is a no-op."""
+    with patch("nanobot.agent.tools.shell.os") as mock_os:
+        mock_os.waitpid = None
+        mock_os.WNOHANG = None
+        _reap_pid(12345)
+
+
+def test_reap_pid_calls_waitpid_wnohang():
+    with patch("nanobot.agent.tools.shell.os") as mock_os:
+        mock_os.waitpid = MagicMock(return_value=(12345, 0))
+        mock_os.WNOHANG = 1
+        _reap_pid(12345)
+        mock_os.waitpid.assert_called_once_with(12345, 1)
+
+
+def test_reap_pid_swallows_already_reaped_errors():
+    with patch("nanobot.agent.tools.shell.os") as mock_os:
+        mock_os.WNOHANG = 1
+        mock_os.waitpid = MagicMock(side_effect=ChildProcessError("no child"))
+        _reap_pid(99)
+
+        mock_os.waitpid = MagicMock(side_effect=ProcessLookupError("gone"))
+        _reap_pid(99)
+
+
+@pytest.mark.asyncio
+async def test_kill_process_skips_kill_when_already_exited():
+    """Already-dead processes must not raise ProcessLookupError from kill()."""
+    process = AsyncMock()
+    process.pid = 4242
+    process.returncode = 0
+    process.kill = MagicMock(side_effect=ProcessLookupError("already dead"))
+
+    with patch("nanobot.agent.tools.shell._reap_pid") as reap:
+        await ExecTool._kill_process(process)
+
+    process.kill.assert_not_called()
+    process.wait.assert_not_called()
+    reap.assert_called_once_with(4242)
+
+
+@pytest.mark.asyncio
+async def test_kill_process_kills_and_reaps_live_process():
+    process = AsyncMock()
+    process.pid = 77
+    process.returncode = None
+    process.kill = MagicMock()
+    process.wait = AsyncMock(return_value=0)
+
+    with patch("nanobot.agent.tools.shell._reap_pid") as reap:
+        await ExecTool._kill_process(process)
+
+    process.kill.assert_called_once()
+    process.wait.assert_awaited()
+    reap.assert_called_once_with(77)
+
+
+@pytest.mark.asyncio
+async def test_kill_process_reaps_even_if_kill_races_exit():
+    """If the child exits between returncode check and kill(), still reap."""
+    process = AsyncMock()
+    process.pid = 88
+    process.returncode = None
+    process.kill = MagicMock(side_effect=ProcessLookupError("raced exit"))
+    process.wait = AsyncMock(return_value=0)
+
+    with patch("nanobot.agent.tools.shell._reap_pid") as reap:
+        await ExecTool._kill_process(process)
+
+    process.kill.assert_called_once()
+    reap.assert_called_once_with(88)
+
+
+@pytest.mark.asyncio
+async def test_execute_reaps_after_normal_completion():
+    mock_proc = AsyncMock()
+    mock_proc.pid = 1001
+    mock_proc.communicate.return_value = (b"ok\n", b"")
+    mock_proc.returncode = 0
+
+    with (
+        patch.object(ExecTool, "_spawn", return_value=mock_proc),
+        patch.object(ExecTool, "_guard_command", return_value=None),
+        patch("nanobot.agent.tools.shell._reap_pid") as reap,
+    ):
+        tool = ExecTool()
+        result = await tool.execute(command="echo ok")
+
+    assert "ok" in result
+    assert "Exit code: 0" in result
+    reap.assert_called_with(1001)
+
+
+@pytest.mark.asyncio
+async def test_execute_timeout_kills_and_reaps():
+    mock_proc = AsyncMock()
+    mock_proc.pid = 1002
+    mock_proc.returncode = None
+    mock_proc.communicate.side_effect = asyncio.TimeoutError()
+    mock_proc.kill = MagicMock()
+    mock_proc.wait = AsyncMock(return_value=-9)
+
+    with (
+        patch.object(ExecTool, "_spawn", return_value=mock_proc),
+        patch.object(ExecTool, "_guard_command", return_value=None),
+        patch("nanobot.agent.tools.shell._reap_pid") as reap,
+    ):
+        tool = ExecTool(timeout=1)
+        result = await tool.execute(command="sleep 99", timeout=1)
+
+    assert "timed out" in result.lower()
+    mock_proc.kill.assert_called_once()
+    reap.assert_called_with(1002)
+
+
+@pytest.mark.asyncio
+async def test_execute_exception_after_success_does_not_raise_on_dead_process():
+    """Generic except must return ToolResult.error, not ProcessLookupError."""
+    mock_proc = AsyncMock()
+    mock_proc.pid = 1003
+    mock_proc.communicate = AsyncMock(return_value=(b"out\n", b""))
+    mock_proc.returncode = 0
+    mock_proc.kill = MagicMock(side_effect=ProcessLookupError("already dead"))
+
+    with (
+        patch.object(ExecTool, "_spawn", return_value=mock_proc),
+        patch.object(ExecTool, "_guard_command", return_value=None),
+        patch("nanobot.agent.tools.shell._reap_pid") as reap,
+        patch(
+            "nanobot.agent.tools.shell.clamp_session_int",
+            side_effect=RuntimeError("boom after exit"),
+        ),
+    ):
+        tool = ExecTool()
+        result = await tool.execute(command="echo out")
+
+    assert "Error executing command" in result
+    assert "boom after exit" in result
+    mock_proc.kill.assert_not_called()
+    assert reap.called
+
+
+@pytest.mark.asyncio
+async def test_execute_exception_during_communicate_kills_live_process():
+    mock_proc = AsyncMock()
+    mock_proc.pid = 1004
+    mock_proc.returncode = None
+    mock_proc.communicate.side_effect = OSError("pipe broken")
+    mock_proc.kill = MagicMock()
+    mock_proc.wait = AsyncMock(return_value=-1)
+
+    with (
+        patch.object(ExecTool, "_spawn", return_value=mock_proc),
+        patch.object(ExecTool, "_guard_command", return_value=None),
+        patch("nanobot.agent.tools.shell._reap_pid") as reap,
+    ):
+        tool = ExecTool()
+        result = await tool.execute(command="broken")
+
+    assert "Error executing command" in result
+    assert "pipe broken" in result
+    mock_proc.kill.assert_called_once()
+    reap.assert_called_with(1004)
+
+
+def _mock_session_process(*, pid: int, returncode: int | None):
+    process = AsyncMock()
+    process.pid = pid
+    process.returncode = returncode
+    process.kill = MagicMock()
+    process.wait = AsyncMock(return_value=returncode if returncode is not None else -9)
+    # Constructor starts stream readers; closed streams exit immediately.
+    process.stdout = None
+    process.stderr = None
+    process.stdin = None
+    return process
+
+
+@pytest.mark.asyncio
+async def test_exec_session_kill_reaps():
+    process = _mock_session_process(pid=2001, returncode=None)
+    session = _ExecSession(
+        session_id="abc",
+        process=process,
+        command="sleep 1",
+        cwd="/tmp",
+        timeout=30,
+        owner_session_key=None,
+    )
+    try:
+        with patch("nanobot.agent.tools.shell._reap_pid") as reap:
+            await session.kill()
+        process.kill.assert_called_once()
+        reap.assert_called_once_with(2001)
+    finally:
+        await asyncio.gather(session._stdout_task, session._stderr_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_exec_session_poll_reaps_after_exit():
+    process = _mock_session_process(pid=2002, returncode=0)
+    session = _ExecSession(
+        session_id="def",
+        process=process,
+        command="echo hi",
+        cwd="/tmp",
+        timeout=30,
+        owner_session_key=None,
+    )
+    try:
+        with patch("nanobot.agent.tools.shell._reap_pid") as reap:
+            poll = await session.poll(yield_time_ms=0, max_output_chars=1000)
+        assert poll.done is True
+        assert poll.exit_code == 0
+        reap.assert_called_once_with(2002)
+    finally:
+        await asyncio.gather(session._stdout_task, session._stderr_task, return_exceptions=True)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="zombie reaping is a Unix waitpid concern")
+@pytest.mark.asyncio
+async def test_real_timeout_leaves_no_zombie(tmp_path):
+    """Integration: timed-out sleep should not leave a defunct child of this process."""
+    import os
+
+    tool = ExecTool(working_dir=str(tmp_path), timeout=1)
+    result = await tool.execute(command="sleep 30", timeout=1)
+    assert "timed out" in result.lower()
+
+    await asyncio.sleep(0.05)
+    reaped = []
+    while True:
+        try:
+            pid, status = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            break
+        if pid == 0:
+            break
+        reaped.append((pid, status))
+    assert reaped == [], f"unreaped children left as zombies: {reaped}"


### PR DESCRIPTION
## Summary
- Reap zombie child processes on **all** subprocess exit paths, not only timeout/cancel in `_kill_process()`.
- Add shared `_reap_pid()` helper (`os.waitpid(WNOHANG)` with capability checks) and use it as a safety net after normal exit, kill, and unexpected exceptions.
- Harden `_kill_process()` for already-exited processes (skip `kill()`, still reap) so generic exception handlers cannot raise `ProcessLookupError`.
- Cover reaping via unit/integration tests in `tests/tools/test_shell_reap.py`.

**Design note:** intentionally **no** gateway-wide `waitpid(-1)` reaper. A global reaper can race asyncio's child watcher for just-exited `create_subprocess_exec` children and replace the real exit code with `255`. Reaping is limited to PIDs we explicitly own after their corresponding `wait` / `communicate` / kill paths.

## Context
The earlier fix (`dbcc7cb5`) only covered the one-shot timeout path. Zombies still accumulated via:
- `_ExecSession.kill()` (SIGKILL + `wait(5s)` with no `waitpid` fallback on timeout)
- `ExecTool.execute()` generic exception handler leaking the subprocess
- Normal completion paths relying solely on asyncio's child-watcher

## Test plan
- [x] Unit tests for `_reap_pid`, `_kill_process`, execute timeout/exception/normal paths, and session kill/poll reaps (`pytest tests/tools/test_shell_reap.py`)
- [x] Integration: timed-out `sleep` leaves no unreaped child (`test_real_timeout_leaves_no_zombie`)
- [x] Run commands via `exec` that exit normally; confirm no zombies (`ps -eo stat,pid,ppid,cmd | grep Z` or equivalent)
- [x] Cancel / timeout a long-running exec; confirm child is killed and reaped
- [x] In Docker (if available), run a burst of short execs and verify no defunct children accumulate over a few minutes

### Manual Docker verification (2026-07-09, `nanobot-maya`)
Deployed image includes full fix (capability-checked `_reap_pid`, hardened `_kill_process`, no gateway-wide reaper). Results inside the running container:
- ~20+ min live agent workload with many real `exec` tool calls: **0 zombies**
- Timeout: `sleep 60` with 2s limit → timed out in ~2.01s, no leftover sleep, **0 zombies**
- Cancel: mid-flight `task.cancel()` on `sleep 120` → no leftover sleep, **0 zombies**
- Burst: 60 short normal execs (`echo`/`true`): **0 zombies**