### PR TITLE
fix(sandbox): add Red Hat certificate path support for Node

### DIFF
--- a/nanobot/agent/tools/sandbox.py
+++ b/nanobot/agent/tools/sandbox.py
@@ -33,6 +33,9 @@ def _bwrap(command: str, workspace: str, cwd: str) -> str:
         "/lib64",
         "/etc/alternatives",
         "/etc/ssl/certs",
+        "/etc/pki/tls",
+        "/etc/pki/ca-trust",
+        "/etc/crypto-policies",
         "/etc/resolv.conf",
         "/etc/ld.so.cache",
     ]

--- a/nanobot/agent/tools/sandbox.py
+++ b/nanobot/agent/tools/sandbox.py
@@ -33,7 +33,7 @@ def _bwrap(command: str, workspace: str, cwd: str) -> str:
         "/lib64",
         "/etc/alternatives",
         "/etc/ssl/certs",
-        "/etc/pki/tls",
+        "/etc/pki/tls/certs",
         "/etc/pki/ca-trust",
         "/etc/crypto-policies",
         "/etc/resolv.conf",


### PR DESCRIPTION
# **Summary**
Add Red Hat family certificate directory detection to resolve system CA certificates correctly for sandbox.
Include:
/etc/pki/tls
/etc/pki/ca-trust 
/etc/crypto-policies

Fix UNABLE_TO_GET_ISSUER_CERT_LOCALLY errors when running npx on EulerOS/OpenEuler deployments.