### PR TITLE
docs(readme): clarify LangSmith integration status

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@
 - **2026-03-16** 🚀 Released **v0.1.4.post5** — a refinement-focused release with stronger reliability and channel support, and a more dependable day-to-day experience. Please see [release notes](https://github.com/HKUDS/nanobot/releases/tag/v0.1.4.post5) for details.
 - **2026-03-15** 🧩 DingTalk rich media, smarter built-in skills, and cleaner model compatibility.
 - **2026-03-14** 💬 Channel plugins, Feishu replies, and steadier MCP, QQ, and media handling.
-- **2026-03-13** 🌐 Multi-provider web search, LangSmith, and broader reliability improvements.
+- **2026-03-13** 🌐 Multi-provider web search and broader reliability improvements. (Note: LangSmith integration is being updated, see [#2493](https://github.com/HKUDS/nanobot/issues/2493))
 - **2026-03-12** 🚀 VolcEngine support, Telegram reply context, `/restart`, and sturdier memory.
 - **2026-03-11** 🔌 WeCom, Ollama, cleaner discovery, and safer tool behavior.
 - **2026-03-10** 🧠 Token-based memory, shared retries, and cleaner gateway and Telegram behavior.


### PR DESCRIPTION
Relates to #2493

## Problem

README.md mentions "LangSmith" as a working feature from the 2026-03-13 update:

> **2026-03-13** 🌐 Multi-provider web search, LangSmith, and broader reliability improvements.

However, users report that LangSmith integration no longer works after recent updates (specifically, after `litellm_provider.py` was removed). See #2493 for details.

This creates confusion for users who try LangSmith based on the README claim.

## Changes

- Updated the 2026-03-13 changelog entry to remove the outdated LangSmith mention
- Added a note directing users to #2493 for current LangSmith integration status
- No code changes, documentation only

## Side effect analysis

- Default values: Unchanged (documentation only)
- Backward compatibility: ✅ No impact on existing configurations
- Downstream consumers: ✅ No impact (changelog update only)
- Security boundaries: ✅ No impact (documentation only)

## Tests

- Documentation only, no code changes
- Preview: Markdown link renders correctly

---

This is a minimal documentation update to help users understand the current state of LangSmith integration and avoid confusion. Once #2493 or #3140 is resolved, this note can be removed or updated accordingly.
