### PR TITLE
fix(webui): gate bootstrap API token issuance

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -241,7 +241,7 @@ Start the browser workbench:
 nanobot webui
 ```
 
-`nanobot webui` prepares the local WebSocket channel if needed, starts the gateway, and opens `http://127.0.0.1:8765`. First-run WebUI setup binds to `127.0.0.1` by default, so it is not exposed to your LAN. Use `nanobot webui --background` when you want the gateway to keep running without an open terminal.
+`nanobot webui` prepares the local WebSocket channel and WebUI bootstrap secret if needed, starts the gateway, and opens `http://127.0.0.1:8765`. First-run WebUI setup binds to `127.0.0.1` by default, so it is not exposed to your LAN. Use `nanobot webui --background` when you want the gateway to keep running without an open terminal.
 
 ## 6. Test One CLI Message
 

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -221,7 +221,7 @@ All fields go under `channels.websocket` in `config.json`.
 | `token` | string | `""` | Static shared secret. When set, clients must provide `?token=<value>` matching this secret (timing-safe comparison). Issued tokens are also accepted as a fallback. |
 | `websocketRequiresToken` | bool | `true` | When `true` and no static `token` is configured, clients must still present a valid issued token. Set to `false` to allow unauthenticated connections (only safe for local/trusted networks). |
 | `tokenIssuePath` | string | `""` | HTTP path for issuing short-lived tokens. Must differ from `path`. See [Token Issuance](#token-issuance). |
-| `tokenIssueSecret` | string | `""` | Secret required to obtain tokens via the issue endpoint. If empty, any client can obtain tokens (logged as a warning). |
+| `tokenIssueSecret` | string | `""` | Secret required to obtain tokens via the issue endpoint. If empty, any client can obtain WebSocket connection tokens from `tokenIssuePath` (logged as a warning), and `/webui/bootstrap` will not return a WebUI REST API token. |
 | `tokenTtlS` | int | `300` | Time-to-live for issued tokens in seconds (30 – 86,400). |
 
 ### Access Control
@@ -265,6 +265,10 @@ For production deployments where `websocketRequiresToken: true`, use short-lived
 
 3. Client opens WebSocket with `?token=nbwt_aBcDeFg...&client_id=...`.
 4. The token is consumed (single use) and cannot be reused.
+
+The embedded WebUI's `/webui/bootstrap` route also returns a WebSocket token.
+It returns a separate `api_token` for REST routes only after the request proves
+knowledge of `tokenIssueSecret` or the static `token`.
 
 ### Example setup
 

--- a/docs/webui.md
+++ b/docs/webui.md
@@ -17,9 +17,10 @@ nanobot webui
 
 `nanobot webui` creates the config/workspace when needed, checks provider setup,
 offers Quick Start when the model provider is not ready, enables the local
-WebSocket channel after confirmation, starts the gateway, and opens the browser.
-The first-run path binds the WebUI to `127.0.0.1` by default, so it is not
-available from other devices on your LAN.
+WebSocket channel after confirmation, generates a WebUI bootstrap secret when
+one is missing, starts the gateway, and opens the browser. The first-run path
+binds the WebUI to `127.0.0.1` by default, so it is not available from other
+devices on your LAN.
 
 Run it in the background when you do not want to keep a terminal open:
 
@@ -30,8 +31,9 @@ nanobot webui --background
 Manage the background gateway with `nanobot gateway status`, `nanobot gateway
 logs`, `nanobot gateway restart`, and `nanobot gateway stop`.
 
-Manual config still works. Set `tokenIssueSecret` when you intentionally expose
-the WebUI beyond localhost or want a browser password:
+Manual config still works. Set `tokenIssueSecret` for full WebUI access; it is
+required before `/webui/bootstrap` returns a REST API token for session, settings,
+Apps, Skills, and automation routes:
 
 ```json
 {

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -919,11 +919,30 @@ def _host_for_local_browser(host: str) -> str:
     return host
 
 
+def _webui_bootstrap_secret(config: Config) -> str:
+    ws_cfg = _webui_config_dict(config)
+    return str(ws_cfg.get("tokenIssueSecret") or ws_cfg.get("token") or "").strip()
+
+
 def _webui_browser_url(config: Config) -> str:
+    from urllib.parse import quote
+
     ws_cfg = _webui_config_dict(config)
     host = _host_for_local_browser(str(ws_cfg.get("host") or "127.0.0.1"))
     port = int(ws_cfg.get("port") or 8765)
-    return f"http://{host}:{port}"
+    base_url = f"http://{host}:{port}"
+    secret = _webui_bootstrap_secret(config)
+    if not secret:
+        return base_url
+    return f"{base_url}/#/?bootstrapSecret={quote(secret, safe='')}"
+
+
+def _webui_display_url(url: str) -> str:
+    marker = "bootstrapSecret="
+    if marker not in url:
+        return url
+    prefix, _ = url.split(marker, 1)
+    return f"{prefix}{marker}<redacted>"
 
 
 def _ensure_local_webui_channel(config: Config, *, port: int | None, yes: bool) -> bool:
@@ -936,7 +955,8 @@ def _ensure_local_webui_channel(config: Config, *, port: int | None, yes: bool) 
 
     needs_enable = not model.enabled
     needs_port = port is not None and model.port != port
-    if not needs_enable and not needs_port:
+    needs_secret = not model.token_issue_secret.strip() and not model.token.strip()
+    if not needs_enable and not needs_port and not needs_secret:
         return False
 
     target_port = port if port is not None else model.port
@@ -944,11 +964,11 @@ def _ensure_local_webui_channel(config: Config, *, port: int | None, yes: bool) 
     console.print("[bold]Local WebUI setup[/bold]")
     console.print(f"  URL: [cyan]http://127.0.0.1:{target_port}[/cyan]")
     console.print("  Bind: [cyan]127.0.0.1 only[/cyan] (not exposed to your LAN)")
-    console.print("  Auth: localhost bootstrap issues short-lived WebSocket tokens")
+    console.print("  Auth: generated WebUI bootstrap secret stored in config")
     console.print(
         "  LAN access requires an explicit host change plus a WebUI password in config."
     )
-    _confirm_webui_action("Enable the local WebUI channel in this config?", yes=yes)
+    _confirm_webui_action("Update the local WebUI channel in this config?", yes=yes)
 
     if not model.enabled:
         model.enabled = True
@@ -961,6 +981,11 @@ def _ensure_local_webui_channel(config: Config, *, port: int | None, yes: bool) 
         changed = True
     if not model.websocket_requires_token:
         model.websocket_requires_token = True
+        changed = True
+    if needs_secret:
+        import secrets
+
+        model.token_issue_secret = secrets.token_urlsafe(32)
         changed = True
 
     setattr(config.channels, "websocket", model.model_dump(by_alias=True, exclude_none=True))
@@ -1244,7 +1269,7 @@ def webui(
     effective_gateway_port = gateway_port if gateway_port is not None else runtime_config.gateway.port
 
     console.print()
-    console.print(f"WebUI: [cyan]{webui_url}[/cyan]")
+    console.print(f"WebUI: [cyan]{_webui_display_url(webui_url)}[/cyan]")
     console.print(f"Gateway health: [cyan]http://{runtime_config.gateway.host}:{effective_gateway_port}/health[/cyan]")
     if no_open:
         console.print("[dim]Browser opening disabled by --no-open.[/dim]")

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -945,19 +945,20 @@ def _webui_display_url(url: str) -> str:
     return f"{prefix}{marker}<redacted>"
 
 
-def _ensure_local_webui_channel(config: Config, *, port: int | None, yes: bool) -> bool:
+def _ensure_local_webui_channel(config: Config, *, port: int | None, yes: bool) -> tuple[bool, bool]:
     """Enable the local WebUI channel with safe localhost defaults."""
     from nanobot.channels.websocket import WebSocketConfig
 
     current = getattr(config.channels, "websocket", None) or {}
     model = WebSocketConfig.model_validate(current)
     changed = False
+    generated_secret = False
 
     needs_enable = not model.enabled
     needs_port = port is not None and model.port != port
     needs_secret = not model.token_issue_secret.strip() and not model.token.strip()
     if not needs_enable and not needs_port and not needs_secret:
-        return False
+        return False, False
 
     target_port = port if port is not None else model.port
     console.print()
@@ -987,9 +988,10 @@ def _ensure_local_webui_channel(config: Config, *, port: int | None, yes: bool) 
 
         model.token_issue_secret = secrets.token_urlsafe(32)
         changed = True
+        generated_secret = True
 
     setattr(config.channels, "websocket", model.model_dump(by_alias=True, exclude_none=True))
-    return changed
+    return changed, generated_secret
 
 
 def _warn_webui_bind_scope(config: Config) -> None:
@@ -1250,7 +1252,11 @@ def webui(
             setup_config.agents.defaults.workspace = workspace
 
     try:
-        changed_webui = _ensure_local_webui_channel(setup_config, port=port, yes=yes)
+        changed_webui, generated_bootstrap_secret = _ensure_local_webui_channel(
+            setup_config,
+            port=port,
+            yes=yes,
+        )
         _warn_webui_bind_scope(setup_config)
         webui_url = _webui_browser_url(setup_config)
     except ValueError as exc:
@@ -1273,6 +1279,14 @@ def webui(
     console.print(f"Gateway health: [cyan]http://{runtime_config.gateway.host}:{effective_gateway_port}/health[/cyan]")
     if no_open:
         console.print("[dim]Browser opening disabled by --no-open.[/dim]")
+        if generated_bootstrap_secret:
+            console.print(
+                "[yellow]A WebUI bootstrap secret was generated and saved in this config.[/yellow]"
+            )
+            console.print(
+                "[dim]Open the WebUI and enter channels.websocket.tokenIssueSecret from "
+                f"{config_path}, or rerun without --no-open to open the authenticated URL.[/dim]"
+            )
 
     if background:
         config_arg = str(config_path)
@@ -1284,18 +1298,27 @@ def webui(
                 config_path=config_arg,
             )
         )
-        result = runtime.start_background(
-            GatewayStartOptions(
-                port=effective_gateway_port,
-                workspace=workspace_arg,
-                config_path=config_arg,
-            )
+        start_options = GatewayStartOptions(
+            port=effective_gateway_port,
+            workspace=workspace_arg,
+            config_path=config_arg,
         )
-        if not result.ok and result.message != "gateway_already_running":
-            console.print(f"[yellow]Gateway was not started: {result.message}[/yellow]")
+        result = runtime.start_background(start_options)
+        restarted = False
+        restart_attempted = False
+        if not result.ok and result.message == "gateway_already_running" and changed_webui:
+            restart_attempted = True
+            console.print("[yellow]WebUI config changed; restarting the background gateway.[/yellow]")
+            result = runtime.restart(start_options, timeout_s=20)
+            restarted = result.ok
+        if not result.ok and (restart_attempted or result.message != "gateway_already_running"):
+            action = "restarted" if restart_attempted else "started"
+            console.print(f"[yellow]Gateway was not {action}: {result.message}[/yellow]")
             console.print(f"Logs: {result.status.log_path}")
             raise typer.Exit(1)
-        if result.ok:
+        if restarted:
+            console.print("[green]Gateway restarted in the background.[/green]")
+        elif result.ok:
             console.print("[green]Gateway started in the background.[/green]")
         else:
             console.print("[yellow]Gateway is already running in the background.[/yellow]")

--- a/nanobot/webui/gateway_tokens.py
+++ b/nanobot/webui/gateway_tokens.py
@@ -42,12 +42,10 @@ class GatewayTokenStore:
             return False
         return True
 
-    def issue_token(self, ttl_s: int | float, *, api_token: bool = False) -> str:
+    def issue_token(self, ttl_s: int | float) -> str:
         token_value = f"nbwt_{secrets.token_urlsafe(32)}"
         expiry = time.monotonic() + float(ttl_s)
         self.issued_tokens[token_value] = expiry
-        if api_token:
-            self.api_tokens[token_value] = expiry
         return token_value
 
     def issue_api_token(self, ttl_s: int | float) -> str:

--- a/nanobot/webui/gateway_tokens.py
+++ b/nanobot/webui/gateway_tokens.py
@@ -50,6 +50,12 @@ class GatewayTokenStore:
             self.api_tokens[token_value] = expiry
         return token_value
 
+    def issue_api_token(self, ttl_s: int | float) -> str:
+        token_value = f"nbwt_{secrets.token_urlsafe(32)}"
+        expiry = time.monotonic() + float(ttl_s)
+        self.api_tokens[token_value] = expiry
+        return token_value
+
     def take_issued_token_if_valid(self, token_value: str | None) -> bool:
         if not token_value:
             return False

--- a/nanobot/webui/ws_http.py
+++ b/nanobot/webui/ws_http.py
@@ -306,33 +306,40 @@ class GatewayHTTPHandler:
 
     def _handle_bootstrap(self, connection: Any, request: Any) -> Response:
         secret = self.config.token_issue_secret.strip() or self.config.token.strip()
+        api_token_allowed = bool(secret)
         if secret:
             if not _issue_route_secret_matches(request.headers, secret):
                 return _http_error(401, "Unauthorized")
         elif not _is_localhost(connection):
             return _http_error(403, "bootstrap is localhost-only")
 
-        if not self.tokens.can_issue(include_api_token=True):
+        if not self.tokens.can_issue(include_api_token=api_token_allowed):
             return _http_response(
                 json.dumps({"error": "too many outstanding tokens"}).encode("utf-8"),
                 status=429,
                 content_type="application/json; charset=utf-8",
             )
-        token = self.tokens.issue_token(self.config.token_ttl_s, api_token=True)
+        token = self.tokens.issue_token(self.config.token_ttl_s)
+        api_token = (
+            self.tokens.issue_api_token(self.config.token_ttl_s)
+            if api_token_allowed
+            else None
+        )
 
         ws_url = self._bootstrap_ws_url(request)
         expected_path = _normalize_config_path(self.config.path)
-        return _http_json_response(
-            {
-                "token": token,
-                "ws_path": expected_path,
-                "ws_url": ws_url,
-                "expires_in": self.config.token_ttl_s,
-                "model_name": _resolve_bootstrap_model_name(self.runtime_model_name),
-                "runtime_surface": self._runtime_surface,
-                "runtime_capabilities": self._capabilities,
-            }
-        )
+        payload = {
+            "token": token,
+            "ws_path": expected_path,
+            "ws_url": ws_url,
+            "expires_in": self.config.token_ttl_s,
+            "model_name": _resolve_bootstrap_model_name(self.runtime_model_name),
+            "runtime_surface": self._runtime_surface,
+            "runtime_capabilities": self._capabilities,
+        }
+        if api_token is not None:
+            payload["api_token"] = api_token
+        return _http_json_response(payload)
 
     def _bootstrap_ws_url(self, request: Any) -> str:
         headers = getattr(request, "headers", {}) or {}

--- a/tests/channels/test_websocket_channel.py
+++ b/tests/channels/test_websocket_channel.py
@@ -87,6 +87,7 @@ def _basic_handler(bus: Any, **kw: Any) -> GatewayServices:
         "enabled": True, "allowFrom": ["*"],
         "host": "127.0.0.1", "port": _PORT,
         "path": "/ws", "websocketRequiresToken": False,
+        "tokenIssueSecret": kw.get("token_issue_secret", ""),
     })
     return build_gateway_services(
         config=cfg,
@@ -2099,7 +2100,12 @@ async def test_bootstrap_exposes_native_surface(bus: MagicMock) -> None:
             "websocketRequiresToken": True,
         },
         bus,
-        gateway=_basic_handler(bus, runtime_surface="native", runtime_capabilities_overrides={"can_pick_folder": True}),
+        gateway=_basic_handler(
+            bus,
+            token_issue_secret="native-secret",
+            runtime_surface="native",
+            runtime_capabilities_overrides={"can_pick_folder": True},
+        ),
     )
 
     server_task = asyncio.create_task(channel.start())
@@ -2116,6 +2122,8 @@ async def test_bootstrap_exposes_native_surface(bus: MagicMock) -> None:
         assert body["runtime_capabilities"]["can_pick_folder"] is True
         assert body["runtime_capabilities"]["can_restart_engine"] is True
         assert body["token"].startswith("nbwt_")
+        assert body["api_token"].startswith("nbwt_")
+        assert body["api_token"] != body["token"]
     finally:
         await channel.stop()
         await server_task

--- a/tests/channels/test_websocket_http_routes.py
+++ b/tests/channels/test_websocket_http_routes.py
@@ -660,7 +660,7 @@ async def test_nanobot_feature_remote_install_requires_opt_in(
         install_calls=install_calls,
     )
     channel = _ch(bus, session_manager=_seed_session(tmp_path), port=_free_port())
-    token = channel.gateway.tokens.issue_token(300, api_token=True)
+    token = channel.gateway.tokens.issue_api_token(300)
     path = "/api/settings/nanobot-features/enable?name=matrix"
     request = _FakeReq({"Authorization": f"Bearer {token}"}, path=path)
 
@@ -707,7 +707,7 @@ async def test_nanobot_feature_local_install_allowed_by_default(
         install_calls=install_calls,
     )
     channel = _ch(bus, session_manager=_seed_session(tmp_path), port=_free_port())
-    token = channel.gateway.tokens.issue_token(300, api_token=True)
+    token = channel.gateway.tokens.issue_api_token(300)
     request = _FakeReq(
         {"Authorization": f"Bearer {token}", "Host": "127.0.0.1:8765"},
         path="/api/settings/nanobot-features/enable?name=matrix",
@@ -743,7 +743,7 @@ async def test_nanobot_feature_loopback_reverse_proxy_install_requires_opt_in(
         install_calls=install_calls,
     )
     channel = _ch(bus, session_manager=_seed_session(tmp_path), port=_free_port())
-    token = channel.gateway.tokens.issue_token(300, api_token=True)
+    token = channel.gateway.tokens.issue_api_token(300)
     request = _FakeReq(
         {
             "Authorization": f"Bearer {token}",
@@ -795,7 +795,7 @@ async def test_nanobot_feature_remote_enable_without_install_is_allowed(
         install_calls=install_calls,
     )
     channel = _ch(bus, session_manager=_seed_session(tmp_path), port=_free_port())
-    token = channel.gateway.tokens.issue_token(300, api_token=True)
+    token = channel.gateway.tokens.issue_api_token(300)
     request = _FakeReq(
         {"Authorization": f"Bearer {token}"},
         path="/api/settings/nanobot-features/enable?name=matrix",
@@ -829,7 +829,7 @@ async def test_nanobot_feature_remote_disable_does_not_need_install_policy(
     _stub_matrix_feature(monkeypatch, config_path, deps=["matrix-nio>=0.25.2"], installed=False)
 
     channel = _ch(bus, session_manager=_seed_session(tmp_path), port=_free_port())
-    token = channel.gateway.tokens.issue_token(300, api_token=True)
+    token = channel.gateway.tokens.issue_api_token(300)
     request = _FakeReq(
         {"Authorization": f"Bearer {token}"},
         path="/api/settings/nanobot-features/disable?name=matrix",

--- a/tests/channels/test_websocket_http_routes.py
+++ b/tests/channels/test_websocket_http_routes.py
@@ -203,6 +203,7 @@ async def test_bootstrap_returns_token_for_localhost(
         assert resp.status_code == 200
         body = resp.json()
         assert body["token"].startswith("nbwt_")
+        assert "api_token" not in body
         assert body["ws_path"] == "/"
         assert body["ws_url"] == "ws://127.0.0.1:29901/"
         assert body["expires_in"] > 0
@@ -225,9 +226,8 @@ async def test_sessions_routes_require_bearer_token(
         deny = await _http_get("http://127.0.0.1:29902/api/sessions")
         assert deny.status_code == 401
 
-        # Mint a token via bootstrap, then call the API with it.
-        boot = await _http_get("http://127.0.0.1:29902/webui/bootstrap")
-        token = boot.json()["token"]
+        # Directly mint an API token for route-level auth checks.
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
         listing = await _http_get("http://127.0.0.1:29902/api/sessions", headers=auth)
@@ -303,8 +303,7 @@ async def test_session_automations_route_filters_by_webui_session(
         )
         assert deny.status_code == 401
 
-        boot = await _http_get("http://127.0.0.1:29914/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
         resp = await _http_get(
             "http://127.0.0.1:29914/api/sessions/websocket%3Aabc/automations",
@@ -356,8 +355,7 @@ async def test_session_automations_route_ignores_unified_owner(
     server_task = asyncio.create_task(channel.start())
     await asyncio.sleep(0.3)
     try:
-        boot = await _http_get("http://127.0.0.1:29917/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
         resp = await _http_get(
@@ -403,8 +401,7 @@ async def test_session_automations_route_lists_local_triggers(
     server_task = asyncio.create_task(channel.start())
     await asyncio.sleep(0.3)
     try:
-        boot = await _http_get(f"{base_url}/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
         resp = await _http_get(
@@ -469,8 +466,7 @@ async def test_webui_skills_route_requires_token_and_hides_paths(
         deny_detail = await _http_get("http://127.0.0.1:29920/api/webui/skills/workspace-skill")
         assert deny_detail.status_code == 401
 
-        boot = await _http_get("http://127.0.0.1:29920/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         resp = await _http_get(
             "http://127.0.0.1:29920/api/webui/skills",
             headers={"Authorization": f"Bearer {token}"},
@@ -566,8 +562,7 @@ async def test_cli_apps_routes_require_token_and_return_payload(
         deny = await _http_get("http://127.0.0.1:29912/api/settings/cli-apps")
         assert deny.status_code == 401
 
-        boot = await _http_get("http://127.0.0.1:29912/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
         catalog = await _http_get(
@@ -603,8 +598,7 @@ async def test_nanobot_feature_routes_require_token_and_enable(
         deny = await _http_get("http://127.0.0.1:29916/api/settings/nanobot-features")
         assert deny.status_code == 401
 
-        boot = await _http_get("http://127.0.0.1:29916/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
         catalog = await _http_get(
@@ -875,8 +869,7 @@ async def test_cli_apps_catalog_does_not_block_other_webui_http_routes(
     server_task = asyncio.create_task(channel.start())
     await asyncio.sleep(0.3)
     try:
-        boot = await _http_get("http://127.0.0.1:29935/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
         catalog_task = asyncio.create_task(
@@ -917,8 +910,7 @@ async def test_cli_apps_route_supports_installed_only_payload(
     server_task = asyncio.create_task(channel.start())
     await asyncio.sleep(0.3)
     try:
-        boot = await _http_get("http://127.0.0.1:29936/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
         resp = await _http_get(
@@ -1014,8 +1006,7 @@ async def test_mcp_presets_routes_require_token_and_return_payload(
         deny = await _http_get("http://127.0.0.1:29913/api/settings/mcp-presets")
         assert deny.status_code == 401
 
-        boot = await _http_get("http://127.0.0.1:29913/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
         catalog = await _http_get(
@@ -1104,8 +1095,7 @@ async def test_sessions_list_only_returns_websocket_sessions_by_default(
     server_task = asyncio.create_task(channel.start())
     await asyncio.sleep(0.3)
     try:
-        boot = await _http_get("http://127.0.0.1:29906/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
         listing = await _http_get(
@@ -1131,8 +1121,7 @@ async def test_webui_sidebar_state_routes_are_config_dir_scoped(
     server_task = asyncio.create_task(channel.start())
     await asyncio.sleep(0.3)
     try:
-        boot = await _http_get("http://127.0.0.1:29911/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
         initial = await _http_get(
@@ -1183,8 +1172,7 @@ async def test_session_delete_removes_file(
     server_task = asyncio.create_task(channel.start())
     await asyncio.sleep(0.3)
     try:
-        boot = await _http_get("http://127.0.0.1:29903/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
         path = sm._get_session_path("websocket:doomed")
@@ -1267,8 +1255,7 @@ async def test_webui_automations_route_lists_all_jobs_and_allows_user_actions(
         deny = await _http_get(f"{base_url}/api/webui/automations")
         assert deny.status_code == 401, deny.text
 
-        boot = await _http_get(f"{base_url}/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
         resp = await _http_get(
             f"{base_url}/api/webui/automations",
@@ -1480,8 +1467,7 @@ async def test_webui_automations_route_manages_local_triggers(
     server_task = asyncio.create_task(channel.start())
     await asyncio.sleep(0.3)
     try:
-        boot = await _http_get(f"{base_url}/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
         listed = await _http_get(f"{base_url}/api/webui/automations", headers=auth)
@@ -1559,8 +1545,7 @@ async def test_session_delete_blocks_when_bound_automation_exists(
     server_task = asyncio.create_task(channel.start())
     await asyncio.sleep(0.3)
     try:
-        boot = await _http_get("http://127.0.0.1:29915/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
         path = sm._get_session_path("websocket:doomed")
@@ -1605,8 +1590,7 @@ async def test_session_delete_blocks_and_cascades_local_triggers(
     server_task = asyncio.create_task(channel.start())
     await asyncio.sleep(0.3)
     try:
-        boot = await _http_get(f"{base_url}/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
         blocked = await _http_get(
@@ -1655,8 +1639,7 @@ async def test_session_delete_can_cascade_bound_automations(
     server_task = asyncio.create_task(channel.start())
     await asyncio.sleep(0.3)
     try:
-        boot = await _http_get("http://127.0.0.1:29916/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
         path = sm._get_session_path("websocket:doomed")
@@ -1699,8 +1682,7 @@ async def test_session_delete_blocks_origin_automation_when_unified_enabled(
     server_task = asyncio.create_task(channel.start())
     await asyncio.sleep(0.3)
     try:
-        boot = await _http_get("http://127.0.0.1:29918/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
         path = sm._get_session_path("websocket:doomed")
@@ -1732,8 +1714,7 @@ async def test_session_routes_accept_percent_encoded_websocket_keys(
     server_task = asyncio.create_task(channel.start())
     await asyncio.sleep(0.3)
     try:
-        boot = await _http_get("http://127.0.0.1:29910/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
         msgs = await _http_get(
@@ -1794,8 +1775,7 @@ async def test_webui_thread_resigns_assistant_media_urls(
     server_task = asyncio.create_task(channel.start())
     await asyncio.sleep(0.3)
     try:
-        boot = await _http_get("http://127.0.0.1:29914/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
         resp = await _http_get(
             "http://127.0.0.1:29914/api/sessions/websocket:video-replay/webui-thread",
@@ -1833,8 +1813,7 @@ async def test_session_routes_reject_non_websocket_keys(
     server_task = asyncio.create_task(channel.start())
     await asyncio.sleep(0.3)
     try:
-        boot = await _http_get("http://127.0.0.1:29909/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
         # The webui list already hides non-websocket sessions; handcrafted URLs
@@ -1867,8 +1846,7 @@ async def test_session_routes_reject_invalid_key(
     server_task = asyncio.create_task(channel.start())
     await asyncio.sleep(0.3)
     try:
-        boot = await _http_get("http://127.0.0.1:29904/webui/bootstrap")
-        token = boot.json()["token"]
+        token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
         # Invalid characters in the key -> regex match fails -> 404
@@ -2074,6 +2052,8 @@ def test_bootstrap_accepts_static_token_as_secret(bus: MagicMock) -> None:
     assert resp.status_code == 200
     body = json.loads(resp.body)
     assert body["token"].startswith("nbwt_")
+    assert body["api_token"].startswith("nbwt_")
+    assert body["api_token"] != body["token"]
 
 
 def test_bootstrap_ws_url_uses_forwarded_https_host(bus: MagicMock) -> None:
@@ -2091,6 +2071,30 @@ def test_localhost_without_auth_is_valid(bus: MagicMock) -> None:
     channel = _ch(bus, host="127.0.0.1")
     resp = channel.gateway.http._handle_bootstrap(_LOCAL, _NO_HEADERS)
     assert resp.status_code == 200
+    body = json.loads(resp.body)
+    assert body["token"].startswith("nbwt_")
+    assert "api_token" not in body
+    assert not channel.gateway.tokens.check_api_token(
+        _FakeReq({"Authorization": f"Bearer {body['token']}"})
+    )
+
+
+def test_authenticated_bootstrap_returns_distinct_api_token(bus: MagicMock) -> None:
+    channel = _ch(bus, host="127.0.0.1", tokenIssueSecret="s3cret")
+    resp = channel.gateway.http._handle_bootstrap(
+        _LOCAL, _FakeReq({"Authorization": "Bearer s3cret"})
+    )
+    assert resp.status_code == 200
+    body = json.loads(resp.body)
+    assert body["token"].startswith("nbwt_")
+    assert body["api_token"].startswith("nbwt_")
+    assert body["api_token"] != body["token"]
+    assert not channel.gateway.tokens.check_api_token(
+        _FakeReq({"Authorization": f"Bearer {body['token']}"})
+    )
+    assert channel.gateway.tokens.check_api_token(
+        _FakeReq({"Authorization": f"Bearer {body['api_token']}"})
+    )
 
 
 def test_bootstrap_prefers_runtime_model_name(bus: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/channels/test_websocket_media_route.py
+++ b/tests/channels/test_websocket_media_route.py
@@ -517,8 +517,7 @@ async def test_session_messages_exposes_signed_media_urls(
         server_task = asyncio.create_task(channel.start())
         await asyncio.sleep(0.3)
         try:
-            boot = await _http_get("http://127.0.0.1:29925/webui/bootstrap")
-            token = boot.json()["token"]
+            token = channel.gateway.tokens.issue_api_token(300)
             auth = {"Authorization": f"Bearer {token}"}
             resp = await _http_get(
                 "http://127.0.0.1:29925/api/sessions/websocket:media-hydrate/messages",
@@ -562,8 +561,7 @@ async def test_session_messages_skips_vanished_media(
         server_task = asyncio.create_task(channel.start())
         await asyncio.sleep(0.3)
         try:
-            boot = await _http_get("http://127.0.0.1:29926/webui/bootstrap")
-            token = boot.json()["token"]
+            token = channel.gateway.tokens.issue_api_token(300)
             resp = await _http_get(
                 "http://127.0.0.1:29926/api/sessions/websocket:vanished/messages",
                 headers={"Authorization": f"Bearer {token}"},

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1657,7 +1657,7 @@ def test_webui_yes_creates_config_and_enables_local_websocket(
     assert data["agents"]["defaults"]["workspace"] == str(workspace)
     assert seen["templates"] == workspace
     assert seen["gateway_kwargs"] == {"port": 18888, "open_browser_url": None}
-    compact_output = _strip_ansi(result.stdout).replace("\n", " ")
+    compact_output = re.sub(r"\s+", " ", _strip_ansi(result.stdout))
     assert "bootstrap secret was generated" in compact_output
     assert "channels.websocket.tokenIssueSecret" in compact_output
     assert "rerun without --no-open" in compact_output

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1657,6 +1657,10 @@ def test_webui_yes_creates_config_and_enables_local_websocket(
     assert data["agents"]["defaults"]["workspace"] == str(workspace)
     assert seen["templates"] == workspace
     assert seen["gateway_kwargs"] == {"port": 18888, "open_browser_url": None}
+    compact_output = _strip_ansi(result.stdout).replace("\n", " ")
+    assert "bootstrap secret was generated" in compact_output
+    assert "channels.websocket.tokenIssueSecret" in compact_output
+    assert "rerun without --no-open" in compact_output
 
 
 def test_webui_yes_refuses_missing_provider_setup(monkeypatch, tmp_path: Path) -> None:
@@ -1736,6 +1740,80 @@ def test_webui_background_starts_runtime_and_opens_browser(monkeypatch, tmp_path
     assert opened_url.startswith("http://127.0.0.1:8765/#/?bootstrapSecret=")
     assert "bootstrapSecret=<redacted>" in compact_output
     assert "bootstrapSecret=" in opened_url
+
+
+def test_webui_background_restarts_when_config_changes_and_gateway_is_running(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from nanobot.gateway import GatewayStartOptions, GatewayStatus, RuntimeResult
+
+    config_file = tmp_path / "config.json"
+    workspace = tmp_path / "workspace"
+    config_file.write_text("{}")
+    seen: dict[str, object] = {}
+    _patch_webui_provider_ready(monkeypatch)
+    monkeypatch.setattr("nanobot.cli.commands.sync_workspace_templates", lambda _path: None)
+
+    def _status(options: GatewayStartOptions) -> GatewayStatus:
+        return GatewayStatus(
+            running=True,
+            pid=123,
+            state_path=tmp_path / "gateway.json",
+            log_path=tmp_path / "gateway.log",
+            port=options.port,
+            reason="running",
+        )
+
+    class _FakeRuntime:
+        def __init__(self, **kwargs) -> None:
+            seen["runtime_kwargs"] = kwargs
+
+        def start_background(self, options: GatewayStartOptions) -> RuntimeResult:
+            seen["start_options"] = options
+            return RuntimeResult(False, "gateway_already_running", _status(options))
+
+        def restart(self, options: GatewayStartOptions, *, timeout_s: int) -> RuntimeResult:
+            seen["restart_options"] = options
+            seen["restart_timeout"] = timeout_s
+            return RuntimeResult(True, "gateway_started_background", _status(options))
+
+    monkeypatch.setattr("nanobot.gateway.GatewayRuntime", _FakeRuntime)
+    monkeypatch.setattr(
+        "nanobot.cli.commands._open_webui_browser",
+        lambda url: seen.__setitem__("opened_url", url),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "webui",
+            "--config",
+            str(config_file),
+            "--workspace",
+            str(workspace),
+            "--background",
+            "--gateway-port",
+            "18889",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0
+    compact_output = _strip_ansi(result.stdout).replace("\n", " ")
+    assert "WebUI config changed; restarting the background gateway" in compact_output
+    assert "Gateway restarted in the background" in compact_output
+    assert "Gateway is already running" not in compact_output
+    options = seen["restart_options"]
+    assert isinstance(options, GatewayStartOptions)
+    assert options is seen["start_options"]
+    assert seen["restart_timeout"] == 20
+    assert options.port == 18889
+    assert options.config_path == str(config_file.resolve(strict=False))
+    assert options.workspace == str(workspace.resolve(strict=False))
+    opened_url = seen["opened_url"]
+    assert isinstance(opened_url, str)
+    assert opened_url.startswith("http://127.0.0.1:8765/#/?bootstrapSecret=")
 
 
 def _patch_serve_runtime(monkeypatch, config: Config, seen: dict[str, object]) -> None:

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1652,6 +1652,8 @@ def test_webui_yes_creates_config_and_enables_local_websocket(
     assert websocket["host"] == "127.0.0.1"
     assert websocket["port"] == 8899
     assert websocket["websocketRequiresToken"] is True
+    assert isinstance(websocket["tokenIssueSecret"], str)
+    assert len(websocket["tokenIssueSecret"]) >= 32
     assert data["agents"]["defaults"]["workspace"] == str(workspace)
     assert seen["templates"] == workspace
     assert seen["gateway_kwargs"] == {"port": 18888, "open_browser_url": None}
@@ -1729,7 +1731,11 @@ def test_webui_background_starts_runtime_and_opens_browser(monkeypatch, tmp_path
     assert options.port == 18889
     assert options.config_path == str(config_file.resolve(strict=False))
     assert options.workspace == str(workspace.resolve(strict=False))
-    assert seen["opened_url"] == "http://127.0.0.1:8765"
+    opened_url = seen["opened_url"]
+    assert isinstance(opened_url, str)
+    assert opened_url.startswith("http://127.0.0.1:8765/#/?bootstrapSecret=")
+    assert "bootstrapSecret=<redacted>" in compact_output
+    assert "bootstrapSecret=" in opened_url
 
 
 def _patch_serve_runtime(monkeypatch, config: Config, seen: dict[str, object]) -> None:

--- a/tests/webui/test_gateway_webui_smoke.py
+++ b/tests/webui/test_gateway_webui_smoke.py
@@ -15,6 +15,8 @@ import httpx
 import pytest
 import websockets
 
+_BOOTSTRAP_SECRET = "smoke-secret"
+
 
 def _free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
@@ -45,6 +47,7 @@ def _write_smoke_config(path: Path, *, workspace: Path, ws_port: int, gateway_po
                 "host": "127.0.0.1",
                 "port": ws_port,
                 "allowFrom": ["*"],
+                "tokenIssueSecret": _BOOTSTRAP_SECRET,
             }
         },
         "gateway": {
@@ -95,6 +98,17 @@ def _get_json(url: str, *, token: str | None = None) -> dict:
     return response.json()
 
 
+def _get_bootstrap(url: str) -> dict:
+    response = httpx.get(
+        url,
+        headers={"X-Nanobot-Auth": _BOOTSTRAP_SECRET},
+        timeout=5.0,
+        trust_env=False,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
 def _wait_for_bootstrap(base_url: str, process: subprocess.Popen[bytes], log_path: Path) -> dict:
     deadline = time.monotonic() + 20
     last_error: Exception | None = None
@@ -102,7 +116,7 @@ def _wait_for_bootstrap(base_url: str, process: subprocess.Popen[bytes], log_pat
         if process.poll() is not None:
             break
         try:
-            return _get_json(f"{base_url}/webui/bootstrap")
+            return _get_bootstrap(f"{base_url}/webui/bootstrap")
         except (httpx.HTTPError, OSError) as exc:
             last_error = exc
             time.sleep(0.2)
@@ -162,7 +176,7 @@ async def test_gateway_webui_bootstrap_message_and_thread_hydration(tmp_path: Pa
             assert "Current model: `custom/smoke-model`" in answer["text"]
             await _recv_until(ws, "turn_end")
 
-        api_token = _wait_for_bootstrap(base_url, process, log_path)["token"]
+        api_token = _wait_for_bootstrap(base_url, process, log_path)["api_token"]
         sessions = _get_json(f"{base_url}/api/sessions", token=api_token)
         key = f"websocket:{chat_id}"
         assert key in {row["key"] for row in sessions["sessions"]}

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -24,6 +24,7 @@ import { ThemeProvider, useTheme } from "@/hooks/useTheme";
 import { cn } from "@/lib/utils";
 import {
   clearSavedSecret,
+  consumeUrlBootstrapSecret,
   deriveWsUrl,
   fetchBootstrap,
   loadSavedSecret,
@@ -361,14 +362,14 @@ export default function App() {
         current.status === "ready" && current.client === client
           ? {
               ...current,
-              token: boot.token,
+              token: boot.api_token,
               tokenExpiresAt,
               modelName: boot.model_name ?? current.modelName,
               runtimeSurface,
             }
           : current,
       );
-      return { token: boot.token, url };
+      return { token: boot.api_token, url };
     },
     [],
   );
@@ -402,7 +403,7 @@ export default function App() {
           setState({
             status: "ready",
             client,
-            token: boot.token,
+            token: boot.api_token,
             tokenExpiresAt: bootstrapTokenExpiresAt(boot.expires_in),
             modelName: boot.model_name ?? null,
             runtimeSurface,
@@ -441,7 +442,7 @@ export default function App() {
   }, [refreshReadyClient, state]);
 
   useEffect(() => {
-    const saved = loadSavedSecret();
+    const saved = consumeUrlBootstrapSecret() || loadSavedSecret();
     return bootstrapWithSecret(saved);
   }, [bootstrapWithSecret]);
 

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -23,6 +23,7 @@ import { useSkills } from "@/hooks/useSkills";
 import { ThemeProvider, useTheme } from "@/hooks/useTheme";
 import { cn } from "@/lib/utils";
 import {
+  BootstrapAuthRequiredError,
   clearSavedSecret,
   consumeUrlBootstrapSecret,
   deriveWsUrl,
@@ -296,6 +297,12 @@ function normalizeWorkspaceScope(scope: WorkspaceScopePayload): WorkspaceScopePa
   };
 }
 
+function isBootstrapAuthRequired(error: unknown): boolean {
+  if (error instanceof BootstrapAuthRequiredError) return true;
+  const msg = error instanceof Error ? error.message : String(error);
+  return msg.includes("HTTP 401") || msg.includes("HTTP 403");
+}
+
 function HostChrome({
   onToggleSidebar,
   onSidebarPreviewEnter,
@@ -410,11 +417,13 @@ export default function App() {
           });
         } catch (e) {
           if (cancelled) return;
-          const msg = (e as Error).message;
-          if (msg.includes("HTTP 401") || msg.includes("HTTP 403")) {
+          if (isBootstrapAuthRequired(e)) {
             setState({ status: "auth", failed: !!secret });
           } else {
-            setState({ status: "error", message: msg });
+            setState({
+              status: "error",
+              message: e instanceof Error ? e.message : String(e),
+            });
           }
         }
       })();
@@ -432,8 +441,7 @@ export default function App() {
       try {
         await refreshReadyClient(client, state.runtimeSurface);
       } catch (e) {
-        const msg = (e as Error).message;
-        if (msg.includes("HTTP 401") || msg.includes("HTTP 403")) {
+        if (isBootstrapAuthRequired(e)) {
           setState({ status: "auth", failed: !!bootstrapSecretRef.current });
         }
       }

--- a/webui/src/lib/bootstrap.ts
+++ b/webui/src/lib/bootstrap.ts
@@ -2,6 +2,7 @@ import type { BootstrapResponse } from "./types";
 import { fetchWithTimeout } from "./http";
 
 const SECRET_STORAGE_KEY = "nanobot-webui.bootstrap-secret";
+const URL_SECRET_PARAM = "bootstrapSecret";
 
 /** Read a previously saved bootstrap secret from localStorage. */
 export function loadSavedSecret(): string {
@@ -31,6 +32,29 @@ export function clearSavedSecret(): void {
   }
 }
 
+export function consumeUrlBootstrapSecret(): string {
+  if (typeof window === "undefined") return "";
+  const hash = window.location.hash || "";
+  const queryStart = hash.indexOf("?");
+  if (queryStart < 0) return "";
+
+  const path = hash.slice(0, queryStart) || "#/";
+  const query = hash.slice(queryStart + 1);
+  const params = new URLSearchParams(query);
+  const secret = params.get(URL_SECRET_PARAM)?.trim() || "";
+  if (!secret) return "";
+
+  params.delete(URL_SECRET_PARAM);
+  const nextQuery = params.toString();
+  const nextHash = `${path}${nextQuery ? `?${nextQuery}` : ""}`;
+  window.history.replaceState(
+    null,
+    "",
+    `${window.location.pathname}${window.location.search}${nextHash}`,
+  );
+  return secret;
+}
+
 /**
  * Fetch a short-lived token + the WebSocket path from the gateway's
  * ``/webui/bootstrap`` endpoint.
@@ -55,6 +79,9 @@ export async function fetchBootstrap(
   const body = (await res.json()) as BootstrapResponse;
   if (!body.token || !body.ws_path) {
     throw new Error("bootstrap response missing token or ws_path");
+  }
+  if (!body.api_token) {
+    throw new Error("bootstrap response missing api_token");
   }
   return body;
 }

--- a/webui/src/lib/bootstrap.ts
+++ b/webui/src/lib/bootstrap.ts
@@ -4,6 +4,13 @@ import { fetchWithTimeout } from "./http";
 const SECRET_STORAGE_KEY = "nanobot-webui.bootstrap-secret";
 const URL_SECRET_PARAM = "bootstrapSecret";
 
+export class BootstrapAuthRequiredError extends Error {
+  constructor(message = "bootstrap authentication required") {
+    super(message);
+    this.name = "BootstrapAuthRequiredError";
+  }
+}
+
 /** Read a previously saved bootstrap secret from localStorage. */
 export function loadSavedSecret(): string {
   if (typeof window === "undefined") return "";
@@ -74,6 +81,9 @@ export async function fetchBootstrap(
     headers,
   }, timeoutMs);
   if (!res.ok) {
+    if (res.status === 401 || res.status === 403) {
+      throw new BootstrapAuthRequiredError(`bootstrap failed: HTTP ${res.status}`);
+    }
     throw new Error(`bootstrap failed: HTTP ${res.status}`);
   }
   const body = (await res.json()) as BootstrapResponse;
@@ -81,7 +91,9 @@ export async function fetchBootstrap(
     throw new Error("bootstrap response missing token or ws_path");
   }
   if (!body.api_token) {
-    throw new Error("bootstrap response missing api_token");
+    throw new BootstrapAuthRequiredError(
+      "bootstrap authentication required: missing api_token",
+    );
   }
   return body;
 }

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -296,6 +296,7 @@ export interface SidebarStatePayload {
 
 export interface BootstrapResponse {
   token: string;
+  api_token: string;
   ws_path: string;
   ws_url?: string | null;
   expires_in: number;

--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -177,10 +177,12 @@ vi.mock("@/hooks/useTheme", async () => {
 vi.mock("@/lib/bootstrap", () => ({
   fetchBootstrap: vi.fn().mockResolvedValue({
     token: "tok",
+    api_token: "api-tok",
     ws_path: "/",
     expires_in: 300,
   }),
   deriveWsUrl: vi.fn(() => "ws://test"),
+  consumeUrlBootstrapSecret: vi.fn(() => ""),
   loadSavedSecret: vi.fn(() => ""),
   saveSecret: vi.fn(),
   clearSavedSecret: vi.fn(),
@@ -239,6 +241,7 @@ describe("App layout", () => {
     localStorage.removeItem("nanobot-webui.sidebar.session-updates.v1");
     vi.mocked(fetchBootstrap).mockReset().mockResolvedValue({
       token: "tok",
+      api_token: "api-tok",
       ws_path: "/",
       expires_in: 300,
     });
@@ -723,6 +726,7 @@ describe("App layout", () => {
     ];
     vi.mocked(fetchBootstrap).mockResolvedValue({
       token: "tok",
+      api_token: "api-tok",
       ws_path: "/",
       expires_in: 300,
       runtime_surface: "native",
@@ -2147,11 +2151,13 @@ describe("App layout", () => {
     vi.mocked(fetchBootstrap)
       .mockResolvedValueOnce({
         token: "tok-1",
+        api_token: "api-tok-1",
         ws_path: "/",
         expires_in: 30,
       })
       .mockResolvedValueOnce({
         token: "tok-2",
+        api_token: "api-tok-2",
         ws_path: "/",
         expires_in: 300,
       });

--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -175,6 +175,12 @@ vi.mock("@/hooks/useTheme", async () => {
 });
 
 vi.mock("@/lib/bootstrap", () => ({
+  BootstrapAuthRequiredError: class BootstrapAuthRequiredError extends Error {
+    constructor(message = "bootstrap authentication required") {
+      super(message);
+      this.name = "BootstrapAuthRequiredError";
+    }
+  },
   fetchBootstrap: vi.fn().mockResolvedValue({
     token: "tok",
     api_token: "api-tok",
@@ -217,7 +223,11 @@ vi.mock("@/lib/nanobot-client", () => {
   return { NanobotClient: MockClient };
 });
 
-import { deriveWsUrl, fetchBootstrap } from "@/lib/bootstrap";
+import {
+  BootstrapAuthRequiredError,
+  deriveWsUrl,
+  fetchBootstrap,
+} from "@/lib/bootstrap";
 import App from "@/App";
 
 describe("App layout", () => {
@@ -262,6 +272,20 @@ describe("App layout", () => {
   it("shows the auth form without an invalid-password error on first load", async () => {
     vi.mocked(fetchBootstrap).mockRejectedValueOnce(
       new Error("bootstrap failed: HTTP 401"),
+    );
+
+    render(<App />);
+
+    expect(await screen.findByText("Authentication required")).toBeInTheDocument();
+    expect(screen.queryByText("Invalid password. Try again.")).not.toBeInTheDocument();
+    expect(connectSpy).not.toHaveBeenCalled();
+  });
+
+  it("shows the auth form when bootstrap does not issue an API token", async () => {
+    vi.mocked(fetchBootstrap).mockRejectedValueOnce(
+      new BootstrapAuthRequiredError(
+        "bootstrap authentication required: missing api_token",
+      ),
     );
 
     render(<App />);

--- a/webui/src/tests/bootstrap.test.ts
+++ b/webui/src/tests/bootstrap.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { consumeUrlBootstrapSecret, deriveWsUrl, fetchBootstrap } from "@/lib/bootstrap";
+import {
+  BootstrapAuthRequiredError,
+  consumeUrlBootstrapSecret,
+  deriveWsUrl,
+  fetchBootstrap,
+} from "@/lib/bootstrap";
 
 describe("bootstrap helpers", () => {
   afterEach(() => {
@@ -51,7 +56,7 @@ describe("bootstrap helpers", () => {
     await pending;
   });
 
-  it("rejects bootstrap responses without an API token", async () => {
+  it("treats bootstrap responses without an API token as auth-required", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => ({
@@ -60,9 +65,12 @@ describe("bootstrap helpers", () => {
       })),
     );
 
-    await expect(fetchBootstrap()).rejects.toThrow(
-      "bootstrap response missing api_token",
-    );
+    const promise = fetchBootstrap();
+    await expect(promise).rejects.toMatchObject({
+      name: "BootstrapAuthRequiredError",
+      message: "bootstrap authentication required: missing api_token",
+    });
+    await expect(promise).rejects.toBeInstanceOf(BootstrapAuthRequiredError);
   });
 
   it("consumes bootstrap secrets from the URL fragment", () => {

--- a/webui/src/tests/bootstrap.test.ts
+++ b/webui/src/tests/bootstrap.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { deriveWsUrl, fetchBootstrap } from "@/lib/bootstrap";
+import { consumeUrlBootstrapSecret, deriveWsUrl, fetchBootstrap } from "@/lib/bootstrap";
 
 describe("bootstrap helpers", () => {
   afterEach(() => {
@@ -49,5 +49,30 @@ describe("bootstrap helpers", () => {
     await vi.advanceTimersByTimeAsync(25);
 
     await pending;
+  });
+
+  it("rejects bootstrap responses without an API token", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ token: "ws-token", ws_path: "/", expires_in: 300 }),
+      })),
+    );
+
+    await expect(fetchBootstrap()).rejects.toThrow(
+      "bootstrap response missing api_token",
+    );
+  });
+
+  it("consumes bootstrap secrets from the URL fragment", () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/#/settings?bootstrapSecret=s3cret&section=models",
+    );
+
+    expect(consumeUrlBootstrapSecret()).toBe("s3cret");
+    expect(window.location.hash).toBe("#/settings?section=models");
   });
 });


### PR DESCRIPTION
## Summary
- split WebUI bootstrap WebSocket tokens from REST API tokens
- only return a WebUI `api_token` after `/webui/bootstrap` verifies `tokenIssueSecret` or the static `token`
- make `nanobot webui` generate a local bootstrap secret when missing and pass it to the browser through a removable URL fragment
- update frontend bootstrap handling, route tests, smoke tests, and docs

Fixes #4825.

## Verification
- Pre-fix reproduction on current main: direct API without token returned 401; unauthenticated localhost `/webui/bootstrap` returned 200; reusing that token returned 200 from `/api/sessions` and `/api/sessions/<key>/messages` with the seeded canary.
- Post-fix reproduction: unauthenticated localhost bootstrap still returns a WS token, but no `api_token`; using that WS token against `/api/sessions/<key>/messages` returns 401; authenticated bootstrap returns a distinct `api_token` that works.
- `pytest tests/channels/test_websocket_http_routes.py tests/channels/test_websocket_media_route.py tests/channels/test_websocket_channel.py::test_bootstrap_exposes_native_surface tests/webui/test_gateway_webui_smoke.py tests/cli/test_commands.py::test_webui_yes_creates_config_and_enables_local_websocket tests/cli/test_commands.py::test_webui_background_starts_runtime_and_opens_browser -q`
- `ruff check nanobot/webui nanobot/cli/commands.py tests/channels/test_websocket_http_routes.py tests/channels/test_websocket_media_route.py tests/channels/test_websocket_channel.py tests/webui/test_gateway_webui_smoke.py tests/cli/test_commands.py`
- `bun run test -- src/tests/bootstrap.test.ts src/tests/app-layout.test.tsx`
- `bun run build`
- Playwright smoke through the built WebUI: opened `/#/?bootstrapSecret=verify-secret`, confirmed the URL became `#/`, localStorage saved the secret, and the page reached the connected main UI.