### PR TITLE
Feature: non-interactive config refresh with 'nanobot onboard --refresh'

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,6 +8,7 @@ Use this page when you know what you want to run and need the command shape. For
 |---|---|---|
 | Check the install | `nanobot --version` | If this fails, try `python -m nanobot --version` |
 | Create or refresh config | `nanobot onboard` | Creates `~/.nanobot/config.json` and `~/.nanobot/workspace/` |
+| Refresh config non-interactively | `nanobot onboard --refresh` | Preserves existing values and adds missing default fields without prompting |
 | Use guided setup | `nanobot onboard --wizard` | Best when you prefer prompts over hand-editing JSON |
 | Open the browser workbench | `nanobot webui` | Prepares local WebUI settings, starts the gateway, and opens the browser |
 | Check config without calling a model | `nanobot status` | Summarizes the selected config, workspace, active model, and providers |
@@ -58,6 +59,7 @@ with `--background`, use `nanobot gateway stop`.
 | Command | Description |
 |---|---|
 | `nanobot onboard` | Initialize or refresh the default config and workspace |
+| `nanobot onboard --refresh` | Refresh an existing config without prompting, preserving existing values |
 | `nanobot onboard --wizard` | Use the interactive setup wizard |
 | `nanobot onboard --config <path> --workspace <path>` | Initialize or refresh a specific instance |
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -115,7 +115,7 @@ Initialization creates:
 | `~/.nanobot/config.json` | Main settings file for providers, models, channels, tools, gateway, and API |
 | `~/.nanobot/workspace/` | Agent workspace for memory, sessions, heartbeat tasks, skills, and artifacts |
 
-If you already have a config, `nanobot onboard` can refresh missing default fields without overwriting your existing values.
+If you already have a config, `nanobot onboard` can refresh missing default fields without overwriting your existing values. Use `nanobot onboard --refresh` to do the same refresh without an interactive prompt.
 
 ## 3. Configure a Provider
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -111,10 +111,10 @@ Common config mistakes:
 To refresh missing defaults without overwriting existing settings, run:
 
 ```bash
-nanobot onboard
+nanobot onboard --refresh
 ```
 
-When prompted about overwriting the config, choose the option that keeps current values and merges missing defaults.
+For an interactive choice between resetting and refreshing, run `nanobot onboard` and choose the option that keeps current values and merges missing defaults.
 
 ## Provider and Model Problems
 

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -597,11 +597,7 @@ def onboard(
     workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace directory"),
     config: str | None = typer.Option(None, "--config", "-c", help="Path to config file"),
     wizard: bool = typer.Option(False, "--wizard", help="Use interactive wizard"),
-    refresh: bool = typer.Option(
-        False,
-        "--refresh",
-        help="Refresh config, preserving existing settings without prompting",
-    ),
+    non_interactive_refresh: bool = typer.Option(False, "--refresh", help="Refresh config, preserving existing settings without prompting"),
 ):
     """Initialize nanobot configuration and workspace."""
     from nanobot.config.loader import get_config_path, load_config, save_config, set_config_path
@@ -623,25 +619,24 @@ def onboard(
     if config_path.exists():
         if wizard:
             config = _apply_workspace_override(load_config(config_path))
-        elif refresh:
-            config = _apply_workspace_override(load_config(config_path))
-            save_config(config, config_path)
-            console.print(
-                f"[green]✓[/green] Config refreshed at {config_path} (existing values preserved)"
-            )
         else:
-            console.print(f"[yellow]Config already exists at {config_path}[/yellow]")
-            console.print(
-                "  [bold]y[/bold] = overwrite with defaults (existing values will be lost)"
-            )
-            console.print(
-                "  [bold]N[/bold] = refresh config, keeping existing values and adding new fields"
-            )
-            if typer.confirm("Overwrite?"):
-                config = _apply_workspace_override(Config())
-                save_config(config, config_path)
-                console.print(f"[green]✓[/green] Config reset to defaults at {config_path}")
-            else:
+            should_refresh = non_interactive_refresh
+            if not non_interactive_refresh:
+                console.print(f"[yellow]Config already exists at {config_path}[/yellow]")
+                console.print(
+                    "  [bold]y[/bold] = overwrite with defaults (existing values will be lost)"
+                )
+                console.print(
+                    "  [bold]N[/bold] = refresh config, keeping existing values and adding new fields"
+                )
+                if typer.confirm("Overwrite?"):
+                    config = _apply_workspace_override(Config())
+                    save_config(config, config_path)
+                    console.print(f"[green]✓[/green] Config reset to defaults at {config_path}")
+                else:
+                    should_refresh = True
+
+            if should_refresh:
                 config = _apply_workspace_override(load_config(config_path))
                 save_config(config, config_path)
                 console.print(

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -597,6 +597,11 @@ def onboard(
     workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace directory"),
     config: str | None = typer.Option(None, "--config", "-c", help="Path to config file"),
     wizard: bool = typer.Option(False, "--wizard", help="Use interactive wizard"),
+    refresh: bool = typer.Option(
+        False,
+        "--refresh",
+        help="Refresh config, preserving existing settings without prompting",
+    ),
 ):
     """Initialize nanobot configuration and workspace."""
     from nanobot.config.loader import get_config_path, load_config, save_config, set_config_path
@@ -618,6 +623,12 @@ def onboard(
     if config_path.exists():
         if wizard:
             config = _apply_workspace_override(load_config(config_path))
+        elif refresh:
+            config = _apply_workspace_override(load_config(config_path))
+            save_config(config, config_path)
+            console.print(
+                f"[green]✓[/green] Config refreshed at {config_path} (existing values preserved)"
+            )
         else:
             console.print(f"[yellow]Config already exists at {config_path}[/yellow]")
             console.print(

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -218,6 +218,20 @@ def test_onboard_existing_config_refresh(mock_paths):
     assert (workspace_dir / "AGENTS.md").exists()
 
 
+def test_onboard_existing_config_refresh_non_interactive(mock_paths):
+    """Config exists, user specifies --refresh — should refresh non-interactively (no prompt)."""
+    config_file, workspace_dir, _ = mock_paths
+    config_file.write_text('{"existing": true}')
+
+    result = runner.invoke(app, ["onboard", "--refresh"])
+
+    assert result.exit_code == 0
+    assert "Config already exists" not in result.stdout
+    assert "existing values preserved" in result.stdout
+    assert workspace_dir.exists()
+    assert (workspace_dir / "AGENTS.md").exists()
+
+
 def test_onboard_existing_config_overwrite(mock_paths):
     """Config exists, user confirms overwrite — should reset to defaults."""
     config_file, workspace_dir, _ = mock_paths
@@ -261,6 +275,7 @@ def test_onboard_help_shows_workspace_and_config_options():
     assert "--config" in stripped_output
     assert "-c" in stripped_output
     assert "--wizard" in stripped_output
+    assert "--refresh" in stripped_output
     assert "--dir" not in stripped_output
 
 


### PR DESCRIPTION
addresses #4851 

## Problem / Motivation
Currently, the only way to refresh the config file with new settings is to run nanobot onboard and then respond to the prompt to preserve existing settings.

This is not feasible for systems configured to update themselves automatically or semi-automatically.

## Proposed Solution
Add an optional --refresh parameter for the onboard command, and handle the refresh non-interactively if specified.