### PR TITLE
feat(exec): add RTK command rewriter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,6 +62,7 @@ If you are not sure where a setting belongs, start from the task you are trying 
 | Enable web search or fetch | `tools.web.search.*`, `tools.web.fetch.*`, optional `tools.ssrfWhitelist` | Ask a question that requires current web information, then inspect logs if needed | [Web Tools](#web-tools), [Security](#security) |
 | Enable image generation | `tools.imageGeneration.enabled`, `tools.imageGeneration.provider`, `tools.imageGeneration.model`, matching provider credentials | Enable Image Generation in the WebUI and send one image request | [Image Generation](#image-generation) |
 | Add external tools through MCP | `tools.mcpServers.<name>` | Start `nanobot gateway --verbose` and check startup/tool logs | [MCP](#mcp-model-context-protocol) |
+| Compress noisy shell command output with RTK | `tools.exec.rtk.enabled`, optional `tools.exec.rtk.path` | Run a failing test or git command through `exec` and check that RTK rewrites it | [Security](#security) |
 | Tighten tool and network safety | `tools.restrictToWorkspace`, `tools.exec.sandbox`, `tools.ssrfWhitelist`, `channels.*.allowFrom` | Run the same workflow through the channel or CLI you plan to expose | [Security](#security), [Pairing](#pairing) |
 | Tune request timeouts or process concurrency | `NANOBOT_LLM_TIMEOUT_S`, `NANOBOT_STREAM_IDLE_TIMEOUT_S`, `NANOBOT_MAX_CONCURRENT_REQUESTS` | Start nanobot from the same environment and inspect startup/runtime logs | [Runtime Environment Variables](#runtime-environment-variables) |
 | Run multiple isolated bots | separate `--config` and `--workspace` paths, plus distinct `gateway.port` or channel ports when processes run together | Use the same explicit paths with `nanobot status`, `agent`, `webui`, `gateway`, and `serve` | [Multiple Instances](./multiple-instances.md), [CLI Reference](./cli-reference.md) |
@@ -1955,9 +1956,43 @@ For API keys, tokens, and other secrets, see [Environment Variables for Secrets]
 | `tools.exec.timeout` | `60` | Default hard timeout in seconds for shell commands. Config values may exceed the per-call tool cap; set `0` to disable the hard timeout for trusted long-running commands. |
 | `tools.exec.pathPrepend` | `""` | Extra directories to prepend to `PATH` when running shell commands. Use this when configured tools should win executable lookup precedence, such as a Python virtual environment's `bin` or `Scripts` directory. |
 | `tools.exec.pathAppend` | `""` | Extra directories to append to `PATH` when running shell commands (e.g. `/usr/sbin` for `ufw`). |
+| `tools.exec.rtk.enabled` | `false` | Enable optional [RTK](https://github.com/rtk-ai/rtk) command rewriting for shell commands. RTK can wrap noisy developer commands such as test and git invocations so their output is summarized for the model. |
+| `tools.exec.rtk.path` | `"rtk"` | RTK executable path or command name. If the binary is not found, nanobot runs the original command. |
+| `tools.exec.rtk.rewriteTimeoutMs` | `2000` | Maximum time to wait for `rtk rewrite <command>`. On timeout or rewrite failure, nanobot runs the original command. |
+| `tools.exec.rtk.teeDir` | `".nanobot/rtk-tee"` | Directory for RTK tee files containing full command output. Relative paths are resolved under the active workspace. Set to `""` to leave RTK's default behavior unchanged. |
 | `tools.webuiAllowRemotePackageInstall` | `false` | When `false`, the WebUI can install missing optional packages only from a browser opened on the same machine as nanobot. Set to `true` only when a trusted remote admin is allowed to install Python packages into this nanobot environment. |
 | `tools.ssrfWhitelist` | `[]` | CIDR ranges exempted from the shared SSRF guard used by web fetches and HTTP/SSE MCP connections. Prefer exact host CIDRs such as `192.168.1.50/32`; broad ranges increase SSRF exposure. |
 | `channels.*.allowFrom` | omitted | Access control per channel. Omit to use pairing-only mode; set `["*"]` to allow everyone; or list specific user IDs. See [Pairing](#pairing) for details. |
+
+### RTK command rewriting
+
+RTK integration is opt-in and only applies to the built-in shell `exec` tool. Install RTK separately so the configured binary is available to the nanobot process, then enable it in `config.json`:
+
+```json
+{
+  "tools": {
+    "exec": {
+      "rtk": {
+        "enabled": true,
+        "path": "rtk",
+        "rewriteTimeoutMs": 2000,
+        "teeDir": ".nanobot/rtk-tee"
+      }
+    }
+  }
+}
+```
+
+When enabled, nanobot asks RTK whether a command should be rewritten before execution:
+
+1. nanobot applies its existing guard to the original command;
+2. nanobot runs `rtk rewrite <command>`;
+3. if RTK returns a different command, nanobot applies the same guard to the rewritten command;
+4. nanobot then applies any configured shell sandbox wrapper and executes the final command.
+
+This means RTK cannot be used to bypass `denyPatterns`, workspace checks, SSRF checks, or `tools.exec.sandbox`. RTK is also fail-open: if RTK is missing, returns no rewrite, exits with an unsupported-command status, or times out, nanobot runs the original command.
+
+By default, nanobot sets `RTK_TEE_DIR` to `.nanobot/rtk-tee` under the active workspace so full command output stays reachable from workspace-scoped tools. The normal `exec` response still contains RTK's summarized output.
 
 **Docker security**: The official Docker image runs as a non-root user (`nanobot`, UID 1000) with bubblewrap pre-installed. When using `docker-compose.yml`, the container drops all Linux capabilities except `SYS_ADMIN` (required for bwrap's namespace isolation).
 

--- a/nanobot/agent/tools/command_rewriters.py
+++ b/nanobot/agent/tools/command_rewriters.py
@@ -1,0 +1,167 @@
+"""Command rewriters for shell execution."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+from contextlib import suppress
+from pathlib import Path
+
+from loguru import logger
+from pydantic import Field
+
+from nanobot.config_base import Base
+
+
+class RTKCommandRewriterConfig(Base):
+    """RTK command rewrite configuration for exec."""
+
+    enabled: bool = False
+    path: str = "rtk"
+    rewrite_timeout_ms: int = Field(default=2000, ge=1, le=60_000)
+    tee_dir: str = ".nanobot/rtk-tee"
+
+
+class RTKCommandRewriter:
+    """Use ``rtk rewrite`` to wrap noisy developer commands."""
+
+    _REWRITE_EXIT_CODES = {0, 3}
+
+    def __init__(
+        self,
+        config: RTKCommandRewriterConfig,
+        *,
+        path_prepend: str = "",
+        path_append: str = "",
+    ) -> None:
+        self.config = config
+        self.path_prepend = path_prepend
+        self.path_append = path_append
+
+    async def rewrite(
+        self,
+        command: str,
+        *,
+        cwd: str,
+        env: dict[str, str],
+        workspace_root: str | None,
+    ) -> str:
+        if not self.config.enabled:
+            return command
+
+        executable = self._resolve_binary()
+        if not executable:
+            logger.debug("RTK command rewriter enabled but '{}' was not found", self.config.path)
+            return command
+
+        self._apply_tee_dir(env, cwd=cwd, workspace_root=workspace_root)
+
+        try:
+            returncode, stdout, stderr = await self._run_rewrite(executable, command, cwd, env)
+        except asyncio.TimeoutError:
+            logger.debug("RTK rewrite timed out after {}ms", self.config.rewrite_timeout_ms)
+            return command
+        except OSError as exc:
+            logger.debug("RTK rewrite failed to start: {}", exc)
+            return command
+
+        if returncode not in self._REWRITE_EXIT_CODES:
+            if stderr:
+                logger.debug(
+                    "RTK rewrite exited with {}: {}",
+                    returncode,
+                    stderr.decode("utf-8", errors="replace").strip()[:500],
+                )
+            return command
+
+        rewritten = stdout.decode("utf-8", errors="replace").strip()
+        if not rewritten or rewritten == command.strip():
+            return command
+        return rewritten
+
+    def _resolve_binary(self) -> str | None:
+        binary = (self.config.path or "rtk").strip() or "rtk"
+        if os.sep in binary or (os.altsep and os.altsep in binary):
+            return str(Path(binary).expanduser())
+
+        path = self._compose_search_path(os.environ.get("PATH", ""))
+        return shutil.which(binary, path=path)
+
+    def _compose_search_path(self, current_path: str) -> str:
+        parts = []
+        if self.path_prepend:
+            parts.append(self.path_prepend)
+        if current_path:
+            parts.append(current_path)
+        if self.path_append:
+            parts.append(self.path_append)
+        return os.pathsep.join(parts)
+
+    def _apply_tee_dir(
+        self,
+        env: dict[str, str],
+        *,
+        cwd: str,
+        workspace_root: str | None,
+    ) -> None:
+        raw = self.config.tee_dir.strip()
+        if not raw:
+            return
+
+        tee_dir = Path(raw).expanduser()
+        if not tee_dir.is_absolute():
+            tee_dir = Path(workspace_root or cwd).expanduser() / tee_dir
+
+        try:
+            tee_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            logger.debug("Could not create RTK tee dir '{}': {}", tee_dir, exc)
+            return
+        env["RTK_TEE_DIR"] = str(tee_dir)
+
+    async def _run_rewrite(
+        self,
+        executable: str,
+        command: str,
+        cwd: str,
+        env: dict[str, str],
+    ) -> tuple[int, bytes, bytes]:
+        process = await asyncio.create_subprocess_exec(
+            executable,
+            "rewrite",
+            command,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=cwd,
+            env=env,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(),
+                timeout=self.config.rewrite_timeout_ms / 1000,
+            )
+        except asyncio.TimeoutError:
+            process.kill()
+            with suppress(Exception):
+                await process.wait()
+            raise
+        return process.returncode or 0, stdout, stderr
+
+
+def filter_rtk_hook_warnings(text: str) -> str:
+    """Remove RTK's hook-install reminder from auto-wrapped output."""
+    if "[rtk]" not in text or "No hook installed" not in text:
+        return text
+
+    lines = text.splitlines()
+    filtered = [
+        line
+        for line in lines
+        if not (line.lstrip().startswith("[rtk]") and "No hook installed" in line)
+    ]
+    if not filtered:
+        return ""
+    suffix = "\n" if text.endswith(("\n", "\r\n")) else ""
+    return "\n".join(filtered) + suffix

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -16,6 +16,11 @@ from loguru import logger
 from pydantic import Field
 
 from nanobot.agent.tools.base import Tool, ToolResult, tool_parameters
+from nanobot.agent.tools.command_rewriters import (
+    RTKCommandRewriter,
+    RTKCommandRewriterConfig,
+    filter_rtk_hook_warnings,
+)
 from nanobot.agent.tools.context import current_request_session_key
 from nanobot.agent.tools.exec_session import (
     DEFAULT_EXEC_SESSION_MANAGER,
@@ -61,6 +66,7 @@ class ExecToolConfig(Base):
     allowed_env_keys: list[str] = Field(default_factory=list)
     allow_patterns: list[str] = Field(default_factory=list)
     deny_patterns: list[str] = Field(default_factory=list)
+    rtk: RTKCommandRewriterConfig = Field(default_factory=RTKCommandRewriterConfig)
 
 
 @dataclass(slots=True)
@@ -164,6 +170,7 @@ class ExecTool(Tool):
             allowed_env_keys=cfg.allowed_env_keys,
             allow_patterns=cfg.allow_patterns,
             deny_patterns=cfg.deny_patterns,
+            rtk=cfg.rtk,
         )
 
     def __init__(
@@ -179,6 +186,7 @@ class ExecTool(Tool):
         path_prepend: str = "",
         path_append: str = "",
         allowed_env_keys: list[str] | None = None,
+        rtk: RTKCommandRewriterConfig | dict[str, Any] | None = None,
         session_manager: Any | None = None,
     ):
         self.timeout = timeout
@@ -211,6 +219,12 @@ class ExecTool(Tool):
         self.path_prepend = path_prepend
         self.path_append = path_append
         self.allowed_env_keys = allowed_env_keys or []
+        self.rtk = RTKCommandRewriterConfig.model_validate(rtk or {})
+        self._rtk_rewriter = RTKCommandRewriter(
+            self.rtk,
+            path_prepend=path_prepend,
+            path_append=path_append,
+        )
         self._session_manager = session_manager or DEFAULT_EXEC_SESSION_MANAGER
 
     @property
@@ -276,7 +290,7 @@ class ExecTool(Tool):
         if max_output_chars is None:
             max_output_chars = max_output_tokens
 
-        prepared = self._prepare_command(command, working_dir, timeout, shell, login)
+        prepared = await self._prepare_command(command, working_dir, timeout, shell, login)
         if isinstance(prepared, str):
             return prepared
 
@@ -307,10 +321,16 @@ class ExecTool(Tool):
             output_parts = []
 
             if stdout:
-                output_parts.append(stdout.decode("utf-8", errors="replace"))
+                stdout_text = stdout.decode("utf-8", errors="replace")
+                if self.rtk.enabled:
+                    stdout_text = filter_rtk_hook_warnings(stdout_text)
+                if stdout_text:
+                    output_parts.append(stdout_text)
 
             if stderr:
                 stderr_text = stderr.decode("utf-8", errors="replace")
+                if self.rtk.enabled:
+                    stderr_text = filter_rtk_hook_warnings(stderr_text)
                 if stderr_text.strip():
                     output_parts.append(f"STDERR:\n{stderr_text}")
 
@@ -374,7 +394,7 @@ class ExecTool(Tool):
             return self.timeout
         return None
 
-    def _prepare_command(
+    async def _prepare_command(
         self,
         command: str,
         working_dir: str | None = None,
@@ -419,6 +439,26 @@ class ExecTool(Tool):
         if guard_error:
             return guard_error
 
+        effective_timeout = self._resolve_timeout(timeout)
+        env = self._build_env()
+
+        rewritten_command = await self._rtk_rewriter.rewrite(
+            command,
+            cwd=cwd,
+            env=env,
+            workspace_root=workspace_root,
+        )
+        if rewritten_command != command:
+            rewrite_guard_error = self._guard_command(
+                rewritten_command,
+                cwd,
+                restrict_to_workspace=access.restrict_to_workspace,
+                workspace_root=workspace_root,
+            )
+            if rewrite_guard_error:
+                return rewrite_guard_error
+            command = rewritten_command
+
         if self.sandbox:
             if _IS_WINDOWS:
                 logger.warning(
@@ -429,9 +469,6 @@ class ExecTool(Tool):
                 workspace = workspace_root or cwd
                 command = wrap_command(self.sandbox, command, workspace, cwd)
                 cwd = str(Path(workspace).resolve())
-
-        effective_timeout = self._resolve_timeout(timeout)
-        env = self._build_env()
 
         if self.path_prepend or self.path_append:
             if _IS_WINDOWS:

--- a/tests/tools/test_exec_rtk.py
+++ b/tests/tools/test_exec_rtk.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nanobot.agent.tools.command_rewriters import (
+    RTKCommandRewriter,
+    RTKCommandRewriterConfig,
+    filter_rtk_hook_warnings,
+)
+from nanobot.agent.tools.shell import ExecTool, ExecToolConfig
+
+
+def _mock_process(stdout: bytes = b"ok\n", stderr: bytes = b"", returncode: int = 0):
+    process = AsyncMock()
+    process.communicate.return_value = (stdout, stderr)
+    process.returncode = returncode
+    return process
+
+
+@pytest.mark.asyncio
+async def test_exec_rtk_rewrites_command_and_sets_workspace_tee_dir(tmp_path):
+    captured: dict[str, object] = {}
+
+    async def fake_run_rewrite(self, executable, command, cwd, env):
+        captured["rewrite_executable"] = executable
+        captured["rewrite_command"] = command
+        captured["rewrite_cwd"] = cwd
+        captured["rewrite_env"] = dict(env)
+        return 3, b"rtk pytest tests -q\n", b""
+
+    async def capture_spawn(command, cwd, env, shell_program=None, login=False, *, stdin=None):
+        captured["spawn_command"] = command
+        captured["spawn_cwd"] = cwd
+        captured["spawn_env"] = dict(env)
+        return _mock_process()
+
+    with (
+        patch.object(RTKCommandRewriter, "_resolve_binary", return_value="rtk"),
+        patch.object(RTKCommandRewriter, "_run_rewrite", fake_run_rewrite),
+        patch.object(ExecTool, "_spawn", side_effect=capture_spawn),
+    ):
+        tool = ExecTool(
+            working_dir=str(tmp_path),
+            rtk=RTKCommandRewriterConfig(enabled=True),
+        )
+        result = await tool.execute(command="pytest tests -q")
+
+    tee_dir = tmp_path / ".nanobot" / "rtk-tee"
+    assert "ok" in result
+    assert captured["rewrite_executable"] == "rtk"
+    assert captured["rewrite_command"] == "pytest tests -q"
+    assert captured["spawn_command"] == "rtk pytest tests -q"
+    assert captured["spawn_env"]["RTK_TEE_DIR"] == str(tee_dir)
+    assert tee_dir.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_exec_rtk_fail_opens_when_rewrite_is_unsupported(tmp_path):
+    captured: dict[str, object] = {}
+
+    async def fake_run_rewrite(self, executable, command, cwd, env):
+        return 1, b"", b"unsupported"
+
+    async def capture_spawn(command, cwd, env, shell_program=None, login=False, *, stdin=None):
+        captured["spawn_command"] = command
+        return _mock_process()
+
+    with (
+        patch.object(RTKCommandRewriter, "_resolve_binary", return_value="rtk"),
+        patch.object(RTKCommandRewriter, "_run_rewrite", fake_run_rewrite),
+        patch.object(ExecTool, "_spawn", side_effect=capture_spawn),
+    ):
+        tool = ExecTool(
+            working_dir=str(tmp_path),
+            rtk=RTKCommandRewriterConfig(enabled=True),
+        )
+        result = await tool.execute(command="echo hello")
+
+    assert "ok" in result
+    assert captured["spawn_command"] == "echo hello"
+
+
+@pytest.mark.asyncio
+async def test_exec_rtk_does_not_wrap_same_command_again(tmp_path):
+    captured: dict[str, object] = {}
+
+    async def fake_run_rewrite(self, executable, command, cwd, env):
+        return 3, b"rtk pytest tests -q\n", b""
+
+    async def capture_spawn(command, cwd, env, shell_program=None, login=False, *, stdin=None):
+        captured["spawn_command"] = command
+        return _mock_process()
+
+    with (
+        patch.object(RTKCommandRewriter, "_resolve_binary", return_value="rtk"),
+        patch.object(RTKCommandRewriter, "_run_rewrite", fake_run_rewrite),
+        patch.object(ExecTool, "_spawn", side_effect=capture_spawn),
+    ):
+        tool = ExecTool(
+            working_dir=str(tmp_path),
+            rtk=RTKCommandRewriterConfig(enabled=True),
+        )
+        result = await tool.execute(command="rtk pytest tests -q")
+
+    assert "ok" in result
+    assert captured["spawn_command"] == "rtk pytest tests -q"
+
+
+@pytest.mark.asyncio
+async def test_exec_rtk_rewritten_command_must_pass_guard(tmp_path):
+    async def fake_run_rewrite(self, executable, command, cwd, env):
+        return 3, b"rm -rf build\n", b""
+
+    with (
+        patch.object(RTKCommandRewriter, "_resolve_binary", return_value="rtk"),
+        patch.object(RTKCommandRewriter, "_run_rewrite", fake_run_rewrite),
+        patch.object(ExecTool, "_spawn", new_callable=AsyncMock) as mock_spawn,
+    ):
+        tool = ExecTool(
+            working_dir=str(tmp_path),
+            rtk=RTKCommandRewriterConfig(enabled=True),
+        )
+        result = await tool.execute(command="pytest tests -q")
+
+    assert "deny pattern filter" in result
+    mock_spawn.assert_not_called()
+
+
+def test_exec_config_accepts_rtk_camel_case_aliases():
+    config = ExecToolConfig(rtk={"enabled": True, "rewriteTimeoutMs": 1234})
+
+    assert config.rtk.enabled is True
+    assert config.rtk.rewrite_timeout_ms == 1234
+
+
+def test_rtk_hook_warning_filter_removes_only_warning_line():
+    text = "[rtk] /!\\ No hook installed - run `rtk init -g`\nreal output\n"
+
+    assert filter_rtk_hook_warnings(text) == "real output\n"

--- a/tests/tools/test_tool_loader.py
+++ b/tests/tools/test_tool_loader.py
@@ -239,6 +239,7 @@ def test_exec_tool_enabled():
 
 
 def test_exec_tool_create():
+    from nanobot.agent.tools.command_rewriters import RTKCommandRewriterConfig
     from nanobot.agent.tools.shell import ExecTool
     mock_config = MagicMock()
     mock_config.exec.enable = True
@@ -249,11 +250,13 @@ def test_exec_tool_create():
     mock_config.exec.allowed_env_keys = []
     mock_config.exec.allow_patterns = []
     mock_config.exec.deny_patterns = []
+    mock_config.exec.rtk = RTKCommandRewriterConfig()
     mock_config.restrict_to_workspace = False
     ctx = ToolContext(config=mock_config, workspace="/tmp")
     tool = ExecTool.create(ctx)
     assert isinstance(tool, ExecTool)
     assert tool.path_prepend == "/venv/bin"
+    assert tool.rtk.enabled is False
 
 
 def test_web_tools_config_cls():
@@ -357,6 +360,7 @@ def test_mcp_wrappers_not_discoverable():
 
 def test_loader_registers_same_tools_as_old_hardcoded():
     """Verify the loader produces the same tool set as the old _register_default_tools."""
+    from nanobot.agent.tools.command_rewriters import RTKCommandRewriterConfig
     from nanobot.agent.tools.loader import ToolLoader
     from nanobot.agent.tools.registry import ToolRegistry
 
@@ -369,6 +373,7 @@ def test_loader_registers_same_tools_as_old_hardcoded():
     mock_config.exec.allowed_env_keys = []
     mock_config.exec.allow_patterns = []
     mock_config.exec.deny_patterns = []
+    mock_config.exec.rtk = RTKCommandRewriterConfig()
     mock_config.restrict_to_workspace = False
     mock_config.web.enable = True
     mock_config.web.search = MagicMock()


### PR DESCRIPTION
## Summary
- add an opt-in tools.exec.rtk config and RTK command rewriter for exec
- run rtk rewrite before sandbox wrapping, then re-run the existing exec guard on rewritten commands
- set RTK_TEE_DIR under the workspace and filter RTK hook reminder noise from one-shot exec output

## Testing
- ruff check nanobot/agent/tools/command_rewriters.py nanobot/agent/tools/shell.py tests/tools/test_exec_rtk.py tests/tools/test_tool_loader.py
- python -m pytest tests/tools/test_exec_rtk.py tests/tools/test_exec_platform.py tests/tools/test_tool_loader.py -q
- python -m pytest tests/tools/test_exec_security.py tests/tools/test_exec_env.py tests/tools/test_exec_session_tools.py -q
- python -m pytest tests/tools -q