### PR TITLE
Add Dockerfile arg to override optional Python dependencies to install at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,15 +17,16 @@ WORKDIR /app
 
 # Install Python dependencies first (cached layer). Hatch reads the custom build
 # hook from hatch_build.py even for this metadata-only install.
+ARG NANOBOT_EXTRAS=whatsapp
 COPY pyproject.toml README.md LICENSE THIRD_PARTY_NOTICES.md hatch_build.py ./
 RUN mkdir -p nanobot && touch nanobot/__init__.py && \
-    NANOBOT_SKIP_WEBUI_BUILD=1 uv pip install --system --no-cache ".[whatsapp]" && \
+    NANOBOT_SKIP_WEBUI_BUILD=1 uv pip install --system --no-cache ".[$NANOBOT_EXTRAS]" && \
     rm -rf nanobot
 
 # Copy the full source and install
 COPY nanobot/ nanobot/
 COPY --from=webui-builder /app/nanobot/web/dist/ nanobot/web/dist/
-RUN NANOBOT_SKIP_WEBUI_BUILD=1 uv pip install --system --no-cache ".[whatsapp]"
+RUN NANOBOT_SKIP_WEBUI_BUILD=1 uv pip install --system --no-cache ".[$NANOBOT_EXTRAS]"
 
 # Create non-root user and config directory
 RUN useradd -m -u 1000 -s /bin/bash nanobot && \


### PR DESCRIPTION
Introduce a new `ARG` called `NANOBOT_EXTRAS` to the `Dockerfile` (defaulted to its current `whatsapp` setting) to allow users to override what optional Python dependencies to install at Docker build time.

One use case for this is to allow users to upgrade and rebuild their existing, containerised nanobot installation with support for the optional packages they need based on their individual preferences, such as use of a different channel (e.g. Telegram) by default.

```sh
docker build --build-arg NANOBOT_EXTRAS=telegram .
```