### PR TITLE
fix(matrix): preserve mxc markdown image sources

### DIFF
--- a/nanobot/channels/matrix.py
+++ b/nanobot/channels/matrix.py
@@ -18,7 +18,7 @@ from nanobot.security.workspace_policy import is_path_within
 try:
     import aiohttp
     import nh3
-    from mistune import create_markdown
+    from mistune import HTMLRenderer, create_markdown
     from nio import (
         AsyncClient,
         AsyncClientConfig,
@@ -77,7 +77,7 @@ class _MediaTooLargeError(Exception):
     """Raised when an inbound Matrix media download exceeds the configured cap."""
 
 MATRIX_MARKDOWN = create_markdown(
-    escape=True,
+    renderer=HTMLRenderer(escape=True, allow_harmful_protocols=("mxc://",)),
     plugins=["table", "strikethrough", "url", "superscript", "subscript"],
 )
 


### PR DESCRIPTION
## Summary
- allow Mistune's HTML renderer to preserve Matrix `mxc://` image sources
- keep the existing nh3 sanitization policy so non-`mxc://` image sources are still stripped

## Context
`mistune==3.3.3` now rewrites `mxc://` image sources to `#harmful-link`, which broke `test_send_keeps_only_mxc_image_sources` across unrelated PRs.

## Tests
- `uv run --extra dev --extra matrix pytest tests/channels/test_matrix_channel.py::test_send_keeps_only_mxc_image_sources -q`
- `uv run --extra dev --extra matrix pytest tests/channels/test_matrix_channel.py -q`
- `uv run --extra dev --extra matrix ruff check nanobot/channels/matrix.py`