### PR TITLE
fix(webui): sync package-lock.json to resolve docker build failure

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-tooltip": "^1.1.6",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "diff": "^9.0.0",
         "i18next": "^26.0.6",
         "lucide-react": "^0.469.0",
         "react": "^18.3.1",
@@ -3227,6 +3228,15 @@
       "version": "1.2.2",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dlv": {
       "version": "1.1.3",


### PR DESCRIPTION
### What does this PR do?

This PR updates the `webui/package-lock.json` file to sync it with the current `webui/package.json`.

### Why is this necessary?

Currently, building the Docker image from a fresh clone fails at the `webui-builder` stage (`Step 5/23 : RUN npm ci`).

Because `npm ci` requires absolute synchronization between `package.json` and the lockfile, the build crashes complaining about a missing dependency (`diff@9.0.0`) in the lockfile. It appears `package.json` was updated previously, but the newly generated lockfile was accidentally omitted. This PR restores that synchronization so the Docker build completes successfully.

**Error encountered during `docker build -t nanobot .**`:

```text
Step 5/23 : RUN npm ci
npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
npm error
npm error Missing: diff@9.0.0 from lock file

```

### Changes Made

* Navigated to the `webui/` directory and ran `npm install` to freshly resolve the dependency tree.
* Committed the updated `package-lock.json` so that `npm ci` can execute successfully in the Dockerfile.

### Testing

* [x] Verified `docker build -t nanobot .` completes successfully from scratch.
* [x] Verified no unintended package upgrades occurred outside of resolving the missing dependencies.
