### PR TITLE
fix(agent): guard .strip() on list-form msg.content — crash on multimodal messages

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -960,7 +960,7 @@ class AgentLoop:
                     logger.warning("Error consuming inbound message: {}, continuing...", e)
                     continue
 
-                raw = msg.content.strip()
+                raw = msg.content.strip() if isinstance(msg.content, str) else ""
                 effective_key = self._effective_session_key(msg)
                 if await agent_context.handle_runtime_control(self, msg, self.tools):
                     continue
@@ -1496,7 +1496,7 @@ class AgentLoop:
         return "ok"
 
     async def _state_command(self, ctx: TurnContext) -> str:
-        raw = ctx.msg.content.strip()
+        raw = ctx.msg.content.strip() if isinstance(ctx.msg.content, str) else ""
         cmd_ctx = CommandContext(
             msg=ctx.msg, session=ctx.session, key=ctx.session_key, raw=raw, loop=self
         )


### PR DESCRIPTION
## Summary

`msg.content` may be a `list[dict]` (multimodal content blocks) as well as a `str`. Two code paths in `AgentLoop` called `.strip()` unconditionally:

1. `_consume_inbound` at `loop.py:963`
2. `_state_command` at `loop.py:1499`

When a channel delivers a multimodal message (list-form content), `.strip()` raises `AttributeError` and the message is silently dropped.

## Fix

Guard with `isinstance`:

```python
raw = msg.content.strip() if isinstance(msg.content, str) else 
```

This pattern is already used at `_persist_user_message_early` (`loop.py:640`) for the same purpose.

## Testing

- 5 input variants (list / str / None / empty string / int) verified
- All 1254 agent tests pass (no regression)
- `ruff check` passes

Closes #4800