### PR TITLE
Share channel markdown helpers

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -25,6 +25,11 @@ from nanobot.bus.events import OutboundMessage
 from nanobot.bus.outbound_events import ProgressEvent
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
+from nanobot.channels.markdown import (
+    parse_pipe_table_rows,
+    protect_fenced_code_blocks,
+    strip_basic_inline_markdown,
+)
 from nanobot.command.router import normalize_command_text
 from nanobot.config.paths import get_media_dir
 from nanobot.config.schema import Base
@@ -1044,15 +1049,6 @@ class FeishuChannel(BaseChannel):
 
     _HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 
-    _CODE_BLOCK_RE = re.compile(r"(```[\s\S]*?```)", re.MULTILINE)
-
-    # Markdown formatting patterns that should be stripped from plain-text
-    # surfaces like table cells and heading text.
-    _MD_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
-    _MD_BOLD_UNDERSCORE_RE = re.compile(r"__(.+?)__")
-    _MD_ITALIC_RE = re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)")
-    _MD_STRIKE_RE = re.compile(r"~~(.+?)~~")
-
     @classmethod
     def _strip_md_formatting(cls, text: str) -> str:
         """Strip markdown formatting markers from text for plain display.
@@ -1060,37 +1056,31 @@ class FeishuChannel(BaseChannel):
         Feishu table cells do not support markdown rendering, so we remove
         the formatting markers to keep the text readable.
         """
-        # Remove bold markers
-        text = cls._MD_BOLD_RE.sub(r"\1", text)
-        text = cls._MD_BOLD_UNDERSCORE_RE.sub(r"\1", text)
-        # Remove italic markers
-        text = cls._MD_ITALIC_RE.sub(r"\1", text)
-        # Remove strikethrough markers
-        text = cls._MD_STRIKE_RE.sub(r"\1", text)
-        return text
+        text = strip_basic_inline_markdown(text)
+        return re.sub(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)", r"\1", text)
 
     @classmethod
     def _parse_md_table(cls, table_text: str) -> dict | None:
         """Parse a markdown table into a Feishu table element."""
         lines = [_line.strip() for _line in table_text.strip().split("\n") if _line.strip()]
-        if len(lines) < 3:
+        rows, has_separator = parse_pipe_table_rows(lines)
+        if len(lines) < 3 or not rows or not has_separator:
             return None
+        rows = [[cls._strip_md_formatting(cell) for cell in row] for row in rows]
 
-        def split(_line: str) -> list[str]:
-            return [c.strip() for c in _line.strip("|").split("|")]
-
-        headers = [cls._strip_md_formatting(h) for h in split(lines[0])]
-        rows = [[cls._strip_md_formatting(c) for c in split(_line)] for _line in lines[2:]]
+        headers = rows[0]
+        body_rows = rows[1:]
         columns = [
             {"tag": "column", "name": f"c{i}", "display_name": h, "width": "auto"}
             for i, h in enumerate(headers)
         ]
         return {
             "tag": "table",
-            "page_size": len(rows) + 1,
+            "page_size": len(body_rows) + 1,
             "columns": columns,
             "rows": [
-                {f"c{i}": r[i] if i < len(r) else "" for i in range(len(headers))} for r in rows
+                {f"c{i}": row[i] if i < len(row) else "" for i in range(len(headers))}
+                for row in body_rows
             ],
         }
 
@@ -1142,11 +1132,11 @@ class FeishuChannel(BaseChannel):
 
     def _split_headings(self, content: str) -> list[dict]:
         """Split content by headings, converting headings to div elements."""
-        protected = content
-        code_blocks = []
-        for m in self._CODE_BLOCK_RE.finditer(content):
-            code_blocks.append(m.group(1))
-            protected = protected.replace(m.group(1), f"\x00CODE{len(code_blocks) - 1}\x00", 1)
+        protected, code_blocks = protect_fenced_code_blocks(
+            content,
+            lambda i: f"\x00CODE{i}\x00",
+            include_fence=True,
+        )
 
         elements = []
         last_end = 0

--- a/nanobot/channels/markdown.py
+++ b/nanobot/channels/markdown.py
@@ -1,0 +1,104 @@
+"""Shared Markdown helpers for chat channel renderers."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Callable
+
+_BASIC_INLINE_STRIP_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\*\*(.+?)\*\*"), r"\1"),
+    (re.compile(r"__(.+?)__"), r"\1"),
+    (re.compile(r"~~(.+?)~~"), r"\1"),
+    (re.compile(r"`([^`]+)`"), r"\1"),
+)
+
+_PIPE_TABLE_LINE_RE = re.compile(r"^\s*\|.+\|")
+_TABLE_SEPARATOR_RE = re.compile(r"^:?-+:?$")
+_FENCED_CODE_BLOCK_RE = re.compile(r"```[\w]*\n?([\s\S]*?)```")
+
+
+def strip_basic_inline_markdown(text: str) -> str:
+    """Strip common inline Markdown markers for plain-text surfaces."""
+    for pattern, repl in _BASIC_INLINE_STRIP_PATTERNS:
+        text = pattern.sub(repl, text)
+    return text.strip()
+
+
+def display_width(text: str) -> int:
+    """Return a monospace display width that accounts for wide CJK glyphs."""
+    return sum(2 if unicodedata.east_asian_width(char) in ("W", "F") else 1 for char in text)
+
+
+def parse_pipe_table_rows(table_lines: list[str]) -> tuple[list[list[str]], bool]:
+    """Parse Markdown pipe-table lines into rows and report whether a separator exists."""
+    rows: list[list[str]] = []
+    has_separator = False
+    for line in table_lines:
+        cells = [strip_basic_inline_markdown(cell) for cell in line.strip().strip("|").split("|")]
+        if all(_TABLE_SEPARATOR_RE.match(cell) for cell in cells if cell):
+            has_separator = True
+            continue
+        rows.append(cells)
+    return rows, has_separator
+
+
+def render_pipe_table_box(table_lines: list[str]) -> str:
+    """Render a Markdown pipe-table as compact aligned plain text."""
+    rows, has_separator = parse_pipe_table_rows(table_lines)
+    if not rows or not has_separator:
+        return "\n".join(table_lines)
+
+    column_count = max(len(row) for row in rows)
+    for row in rows:
+        row.extend([""] * (column_count - len(row)))
+    widths = [
+        max(display_width(row[column_index]) for row in rows)
+        for column_index in range(column_count)
+    ]
+
+    def render_row(cells: list[str]) -> str:
+        return "  ".join(
+            f"{cell}{' ' * (width - display_width(cell))}"
+            for cell, width in zip(cells, widths)
+        )
+
+    output = [render_row(rows[0])]
+    output.append("  ".join("\u2500" * width for width in widths))
+    for row in rows[1:]:
+        output.append(render_row(row))
+    return "\n".join(output)
+
+
+def replace_pipe_tables(text: str, replace: Callable[[list[str]], str]) -> str:
+    """Replace contiguous Markdown pipe-table lines using *replace*."""
+    lines = text.split("\n")
+    rebuilt: list[str] = []
+    index = 0
+    while index < len(lines):
+        if _PIPE_TABLE_LINE_RE.match(lines[index]):
+            table_lines: list[str] = []
+            while index < len(lines) and _PIPE_TABLE_LINE_RE.match(lines[index]):
+                table_lines.append(lines[index])
+                index += 1
+            rebuilt.append(replace(table_lines))
+        else:
+            rebuilt.append(lines[index])
+            index += 1
+    return "\n".join(rebuilt)
+
+
+def protect_fenced_code_blocks(
+    text: str,
+    make_token: Callable[[int], str],
+    *,
+    include_fence: bool = False,
+) -> tuple[str, list[str]]:
+    """Replace fenced code blocks with tokens and return protected payloads."""
+    protected: list[str] = []
+
+    def save(match: re.Match[str]) -> str:
+        protected.append(match.group(0) if include_fence else match.group(1))
+        return make_token(len(protected) - 1)
+
+    return _FENCED_CODE_BLOCK_RE.sub(save, text), protected

--- a/nanobot/channels/signal.py
+++ b/nanobot/channels/signal.py
@@ -6,7 +6,6 @@ import asyncio
 import json
 import re
 import shutil
-import unicodedata
 from collections import deque
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
@@ -21,6 +20,11 @@ from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.outbound_events import ProgressEvent
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
+from nanobot.channels.markdown import (
+    protect_fenced_code_blocks,
+    render_pipe_table_box,
+    replace_pipe_tables,
+)
 from nanobot.config.paths import get_media_dir
 from nanobot.config.schema import Base
 from nanobot.pairing import is_approved
@@ -34,7 +38,6 @@ class _Run:
     opaque: bool = False  # code / table content — skip further pattern processing
 
 
-_SIG_CODE_BLOCK_RE = re.compile(r"```(?:\w+)?\n?([\s\S]*?)```")
 _SIG_INLINE_CODE_RE = re.compile(r"`([^`\n]+)`")
 _SIG_HEADER_RE = re.compile(r"^#{1,6}\s+(.+)$", re.MULTILINE)
 _SIG_BLOCKQUOTE_RE = re.compile(r"^>\s*(.*)$", re.MULTILINE)
@@ -48,61 +51,14 @@ _SIG_ITALIC_RE = re.compile(
 _SIG_STRIKE_RE = re.compile(r"~~(.+?)~~|(?<![~\w])~([^~\n]+)~(?![~\w])", re.DOTALL)
 _SIG_TOKEN_RE = re.compile(r"\x00C(\d+)\x00")
 
-# Patterns used to strip inline markdown when rendering table cells as plain
-# text. Defined separately from the styling regexes above because the cell
-# stripper needs a fixed, narrow subset (no single-asterisk italic, no
-# single-tilde strikethrough) and benefits from each pattern's group 1 being
-# the content directly.
-_SIG_CELL_STRIP_PATTERNS: tuple[tuple[re.Pattern, str], ...] = (
-    (re.compile(r"\*\*(.+?)\*\*"), r"\1"),
-    (re.compile(r"__(.+?)__"), r"\1"),
-    (re.compile(r"~~(.+?)~~"), r"\1"),
-    (re.compile(r"`([^`]+)`"), r"\1"),
-)
-
-
 def _utf16_len(s: str) -> int:
     """UTF-16 code-unit length, matching Signal BodyRange semantics."""
     return len(s.encode("utf-16-le")) // 2
 
 
-def _sig_strip_cell(s: str) -> str:
-    """Strip inline markdown from a table cell for plain-text rendering."""
-    for pattern, repl in _SIG_CELL_STRIP_PATTERNS:
-        s = pattern.sub(repl, s)
-    return s.strip()
-
-
 def _sig_render_table(table_lines: list[str]) -> str:
     """Render a markdown pipe-table as fixed-width plain text."""
-
-    def dw(s: str) -> int:
-        return sum(2 if unicodedata.east_asian_width(c) in ("W", "F") else 1 for c in s)
-
-    rows: list[list[str]] = []
-    has_sep = False
-    for line in table_lines:
-        cells = [_sig_strip_cell(c) for c in line.strip().strip("|").split("|")]
-        if all(re.match(r"^:?-+:?$", c) for c in cells if c):
-            has_sep = True
-            continue
-        rows.append(cells)
-    if not rows or not has_sep:
-        return "\n".join(table_lines)
-
-    ncols = max(len(r) for r in rows)
-    for r in rows:
-        r.extend([""] * (ncols - len(r)))
-    widths = [max(dw(r[c]) for r in rows) for c in range(ncols)]
-
-    def dr(cells: list[str]) -> str:
-        return "  ".join(f"{c}{' ' * (w - dw(c))}" for c, w in zip(cells, widths))
-
-    out = [dr(rows[0])]
-    out.append("  ".join("─" * w for w in widths))
-    for row in rows[1:]:
-        out.append(dr(row))
-    return "\n".join(out)
+    return render_pipe_table_box(table_lines)
 
 
 def _markdown_to_signal(text: str) -> tuple[str, list[str]]:
@@ -116,34 +72,18 @@ def _markdown_to_signal(text: str) -> tuple[str, list[str]]:
 
     # Phase 1 (text-level): extract code blocks and tables with placeholder tokens
     # so they're protected from inline-style processing.
-    protected: list[str] = []
-
-    def save_code(m: re.Match) -> str:
-        protected.append(m.group(1))
-        return f"\x00C{len(protected) - 1}\x00"
-
-    text = _SIG_CODE_BLOCK_RE.sub(save_code, text)
+    text, protected = protect_fenced_code_blocks(text, lambda i: f"\x00C{i}\x00")
 
     # Detect and render pipe-tables line by line.
-    lines = text.split("\n")
-    rebuilt: list[str] = []
-    i = 0
-    while i < len(lines):
-        if re.match(r"^\s*\|.+\|", lines[i]):
-            tbl: list[str] = []
-            while i < len(lines) and re.match(r"^\s*\|.+\|", lines[i]):
-                tbl.append(lines[i])
-                i += 1
-            rendered = _sig_render_table(tbl)
-            if rendered != "\n".join(tbl):
-                protected.append(rendered)
-                rebuilt.append(f"\x00C{len(protected) - 1}\x00")
-            else:
-                rebuilt.extend(tbl)
-        else:
-            rebuilt.append(lines[i])
-            i += 1
-    text = "\n".join(rebuilt)
+    def save_table(table_lines: list[str]) -> str:
+        table_text = "\n".join(table_lines)
+        rendered = _sig_render_table(table_lines)
+        if rendered == table_text:
+            return table_text
+        protected.append(rendered)
+        return f"\x00C{len(protected) - 1}\x00"
+
+    text = replace_pipe_tables(text, save_table)
 
     # Phase 2 (run-based): process inline patterns.
     runs: list[_Run] = [_Run(text)]

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import re
 import time
-import unicodedata
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
@@ -29,6 +28,12 @@ from nanobot.bus.events import OutboundMessage
 from nanobot.bus.outbound_events import ProgressEvent
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
+from nanobot.channels.markdown import (
+    protect_fenced_code_blocks,
+    render_pipe_table_box,
+    replace_pipe_tables,
+    strip_basic_inline_markdown,
+)
 from nanobot.command.builtin import build_help_text
 from nanobot.config.paths import get_media_dir
 from nanobot.config.schema import Base
@@ -129,11 +134,7 @@ def _tool_hint_to_telegram_blockquote(text: str) -> str:
 
 def _strip_md(s: str) -> str:
     """Strip markdown inline formatting from text."""
-    s = re.sub(r'\*\*(.+?)\*\*', r'\1', s)
-    s = re.sub(r'__(.+?)__', r'\1', s)
-    s = re.sub(r'~~(.+?)~~', r'\1', s)
-    s = re.sub(r'`([^`]+)`', r'\1', s)
-    return s.strip()
+    return strip_basic_inline_markdown(s)
 
 
 def _strip_md_block(text: str) -> str:
@@ -166,34 +167,7 @@ def _strip_md_block(text: str) -> str:
 
 def _render_table_box(table_lines: list[str]) -> str:
     """Convert markdown pipe-table to compact aligned text for <pre> display."""
-
-    def dw(s: str) -> int:
-        return sum(2 if unicodedata.east_asian_width(c) in ('W', 'F') else 1 for c in s)
-
-    rows: list[list[str]] = []
-    has_sep = False
-    for line in table_lines:
-        cells = [_strip_md(c) for c in line.strip().strip('|').split('|')]
-        if all(re.match(r'^:?-+:?$', c) for c in cells if c):
-            has_sep = True
-            continue
-        rows.append(cells)
-    if not rows or not has_sep:
-        return '\n'.join(table_lines)
-
-    ncols = max(len(r) for r in rows)
-    for r in rows:
-        r.extend([''] * (ncols - len(r)))
-    widths = [max(dw(r[c]) for r in rows) for c in range(ncols)]
-
-    def dr(cells: list[str]) -> str:
-        return '  '.join(f'{c}{" " * (w - dw(c))}' for c, w in zip(cells, widths))
-
-    out = [dr(rows[0])]
-    out.append('  '.join('─' * w for w in widths))
-    for row in rows[1:]:
-        out.append(dr(row))
-    return '\n'.join(out)
+    return render_pipe_table_box(table_lines)
 
 
 def _markdown_to_telegram_html(text: str) -> str:
@@ -204,33 +178,18 @@ def _markdown_to_telegram_html(text: str) -> str:
         return ""
 
     # 1. Extract and protect code blocks (preserve content from other processing)
-    code_blocks: list[str] = []
-    def save_code_block(m: re.Match) -> str:
-        code_blocks.append(m.group(1))
-        return f"\x00CB{len(code_blocks) - 1}\x00"
-
-    text = re.sub(r'```[\w]*\n?([\s\S]*?)```', save_code_block, text)
+    text, code_blocks = protect_fenced_code_blocks(text, lambda i: f"\x00CB{i}\x00")
 
     # 1.5. Convert markdown tables to box-drawing (reuse code_block placeholders)
-    lines = text.split('\n')
-    rebuilt: list[str] = []
-    li = 0
-    while li < len(lines):
-        if re.match(r'^\s*\|.+\|', lines[li]):
-            tbl: list[str] = []
-            while li < len(lines) and re.match(r'^\s*\|.+\|', lines[li]):
-                tbl.append(lines[li])
-                li += 1
-            box = _render_table_box(tbl)
-            if box != '\n'.join(tbl):
-                code_blocks.append(box)
-                rebuilt.append(f"\x00CB{len(code_blocks) - 1}\x00")
-            else:
-                rebuilt.extend(tbl)
-        else:
-            rebuilt.append(lines[li])
-            li += 1
-    text = '\n'.join(rebuilt)
+    def save_table(table_lines: list[str]) -> str:
+        table_text = "\n".join(table_lines)
+        box = _render_table_box(table_lines)
+        if box == table_text:
+            return table_text
+        code_blocks.append(box)
+        return f"\x00CB{len(code_blocks) - 1}\x00"
+
+    text = replace_pipe_tables(text, save_table)
 
     # 2. Extract and protect inline code
     inline_codes: list[str] = []


### PR DESCRIPTION
## Summary

- Add shared Markdown helper utilities for channel renderers.
- Reuse shared code block protection, pipe-table scanning/parsing, table box rendering, and basic inline Markdown stripping.
- Keep Telegram, Signal, and Feishu platform-specific output logic in their channel modules.

Fixes HKUDS/nanobot#4810

## Validation

- `ruff check nanobot/channels/markdown.py nanobot/channels/telegram.py nanobot/channels/signal.py nanobot/channels/feishu.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/channels/test_signal_markdown.py tests/channels/test_telegram_channel.py tests/channels/test_feishu_markdown_rendering.py tests/channels/test_feishu_table_split.py -q`
