### PR TITLE
feat(hooks): add auto-discovery mechanism for agent hooks

### DIFF
--- a/nanobot/agent/hooks/__init__.py
+++ b/nanobot/agent/hooks/__init__.py
@@ -4,8 +4,14 @@ from nanobot.agent.hooks.file_edit_activity import (
     FileEditActivityHook,
     create_file_edit_activity_hook,
 )
+from nanobot.agent.hooks.sound_hook import (
+    SoundCompletionHook,
+    create_sound_hook,
+)
 
 __all__ = [
     "FileEditActivityHook",
     "create_file_edit_activity_hook",
+    "SoundCompletionHook",
+    "create_sound_hook",
 ]

--- a/nanobot/agent/hooks/discovery.py
+++ b/nanobot/agent/hooks/discovery.py
@@ -1,0 +1,74 @@
+"""Hook auto-discovery: built-in modules + external plugins.
+
+Mirrors the pattern used by ``nanobot/channels/registry.py`` and
+``nanobot/agent/tools/loader.py``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from nanobot.agent.hook import AgentHook, AgentTurnHookFactory
+
+_INTERNAL_SKIP = frozenset({"__init__", "discovery"})
+
+
+def discover_builtin() -> tuple[list[AgentTurnHookFactory], list[AgentHook]]:
+    """Scan ``nanobot/agent/hooks/`` and collect factories and instances."""
+    import nanobot.agent.hooks as pkg
+
+    factories: list[AgentTurnHookFactory] = []
+    instances: list[AgentHook] = []
+    for _importer, name, _ispkg in pkgutil.iter_modules(pkg.__path__):
+        if name in _INTERNAL_SKIP or name.startswith("_"):
+            continue
+        try:
+            mod = importlib.import_module(f".{name}", pkg.__name__)
+        except Exception:
+            logger.exception("Failed to import hook module: {}", name)
+            continue
+        try:
+            f = getattr(mod, "hook_factories", [])
+            factories.extend(f)
+        except Exception:
+            pass
+        try:
+            h = getattr(mod, "hooks", [])
+            instances.extend(h)
+        except Exception:
+            pass
+    return factories, instances
+
+
+def discover_plugins() -> tuple[list[AgentTurnHookFactory], list[AgentHook]]:
+    """Load external hooks registered via ``entry_points(group='nanobot.hooks')``."""
+    from importlib.metadata import entry_points
+
+    factories: list[AgentTurnHookFactory] = []
+    instances: list[AgentHook] = []
+    try:
+        eps = entry_points(group="nanobot.hooks")
+    except Exception:
+        return factories, instances
+    for ep in eps:
+        try:
+            mod = ep.load()
+            f = getattr(mod, "hook_factories", [])
+            factories.extend(f)
+            h = getattr(mod, "hooks", [])
+            instances.extend(h)
+        except Exception:
+            logger.warning("Failed to load hook plugin '{}'", ep.name)
+    return factories, instances
+
+
+def discover_all() -> tuple[list[AgentTurnHookFactory], list[AgentHook]]:
+    """Return all hooks: built-in + plugins."""
+    bf, bi = discover_builtin()
+    pf, pi = discover_plugins()
+    return bf + pf, bi + pi

--- a/nanobot/agent/hooks/file_edit_activity.py
+++ b/nanobot/agent/hooks/file_edit_activity.py
@@ -137,3 +137,6 @@ def create_file_edit_activity_hook(context: AgentTurnHookContext) -> AgentHook |
         on_progress=context.on_progress,
         workspace=context.workspace,
     )
+
+
+hook_factories = [create_file_edit_activity_hook]

--- a/nanobot/agent/hooks/sound_hook.py
+++ b/nanobot/agent/hooks/sound_hook.py
@@ -1,0 +1,139 @@
+"""Agent hook that plays a completion chime from ``~/.nanobot/resource/sound``.
+
+Drop any ``.mp3`` / ``.wav`` / ``.ogg`` / ``.m4a`` / ``.flac`` / ``.aac`` / ``.opus``
+into that folder and it'll be played (fire-and-forget) when each agent run
+finishes. No audio files → no-op. Playback failure is logged at debug level
+and never raised — the hook is decorative.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import os
+import struct
+import sys
+import wave
+from pathlib import Path
+
+from loguru import logger
+
+from nanobot.agent.hook import AgentHook, AgentRunHookContext
+from nanobot.utils.helpers import ensure_dir
+
+_AUDIO_EXTS = {".mp3", ".wav", ".ogg", ".m4a", ".flac", ".aac", ".opus"}
+_DEFAULT_DIR = Path("~/.nanobot/resource/sound")
+_DEFAULT_CHIME = "default_chime.wav"
+_SAMPLE_RATE = 44100
+_POP_DURATION_S = 0.08
+_POP_F_START = 880.0
+_POP_F_END = 220.0
+_POP_DECAY_TAU = 0.020
+
+
+def _player_argv() -> list[str]:
+    """Return the command prefix that hands a file path to the OS player."""
+    if sys.platform == "darwin":
+        return ["afplay"]
+    if sys.platform.startswith("win"):
+        # `start` is a cmd builtin; empty title argument stops `start` eating the path.
+        return ["cmd", "/c", "start", ""]
+    # Linux / WSL / others: xdg-open is the closest thing to a universal handler.
+    return ["xdg-open"]
+
+
+def _synthesize_chime(path: Path) -> None:
+    # ponytail: short percussive pop — downward sweep + exponential decay.
+    total_frames = int(_POP_DURATION_S * _SAMPLE_RATE)
+    samples = []
+    for n in range(total_frames):
+        t = n / _SAMPLE_RATE
+        # Linear pitch sweep A5 → A3; integrate phase so the sweep is monotonic.
+        phase = 2.0 * math.pi * (
+            _POP_F_START * t
+            - (_POP_F_START - _POP_F_END) * t * t / (2 * _POP_DURATION_S)
+        )
+        env = math.exp(-t / _POP_DECAY_TAU)
+        sample = math.sin(phase) * env * 0.9
+        samples.append(int(max(-1.0, min(1.0, sample)) * 32767))
+    with wave.open(str(path), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(_SAMPLE_RATE)
+        wf.writeframes(b"".join(struct.pack("<h", s) for s in samples))
+
+
+def _ensure_default_sound(sound_dir: Path) -> None:
+    ensure_dir(sound_dir)
+    # If the user has already curated this folder, leave it alone — never
+    # synthesize a default chime alongside their picks.
+    try:
+        has_audio = any(
+            p.is_file() and p.suffix.lower() in _AUDIO_EXTS
+            for p in sound_dir.iterdir()
+        )
+    except OSError:
+        has_audio = False
+    if has_audio:
+        return
+    _synthesize_chime(sound_dir / _DEFAULT_CHIME)
+
+
+class SoundCompletionHook(AgentHook):
+    """Play a random audio file from ``sound_dir`` after each agent run.
+
+    Picks the first audio file (sorted) for deterministic behavior. Override
+    ``sound_dir`` in the constructor to point elsewhere.
+
+    On first construction the directory is created (if missing) and a short
+    default chime is synthesized via stdlib so the hook works out-of-the-box
+    without any user setup. User-supplied audio files always win (lex-first).
+    """
+
+    def __init__(self, sound_dir: Path | None = None) -> None:
+        super().__init__()
+        self._sound_dir = (
+            Path(sound_dir).expanduser() if sound_dir else _DEFAULT_DIR.expanduser()
+        )
+        try:
+            _ensure_default_sound(self._sound_dir)
+        except Exception as exc:  # noqa: BLE001 — bootstrap is decorative
+            logger.debug("sound hook: bootstrap failed ({})", exc)
+
+    def _pick(self) -> Path | None:
+        try:
+            entries = [
+                p
+                for p in self._sound_dir.iterdir()
+                if p.is_file() and p.suffix.lower() in _AUDIO_EXTS
+            ]
+        except (FileNotFoundError, NotADirectoryError, PermissionError):
+            return None
+        return sorted(entries)[0] if entries else None
+
+    async def on_finally(self, context: AgentRunHookContext) -> None:
+        path = self._pick()
+        if path is None:
+            return
+        try:
+            await asyncio.create_subprocess_exec(
+                *_player_argv(),
+                str(path),
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+        except FileNotFoundError:
+            logger.debug("sound hook: player not found for {}", sys.platform)
+        except OSError as exc:
+            logger.debug("sound hook: failed to spawn player ({})", exc)
+
+
+def create_sound_hook(sound_dir: Path | None = None) -> SoundCompletionHook | None:
+    """Create a sound hook."""
+    if not os.getenv("NANOBOT_SILENT"):
+        return SoundCompletionHook(sound_dir)
+    return None
+
+
+_hook = create_sound_hook()
+hooks: list[AgentHook] = [_hook] if _hook else []

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -471,6 +471,7 @@ class AgentLoop:
         allowing callers to override or extend the standard config-derived
         parameters (e.g. ``cron_service``, ``session_manager``).
         """
+        from nanobot.agent.hooks.discovery import discover_all
         from nanobot.providers.factory import make_provider
 
         if bus is None:
@@ -485,6 +486,12 @@ class AgentLoop:
             config,
             provider_snapshot_loader,
         )
+        # Auto-discover built-in and plugin hooks; merge with caller-supplied extras.
+        discovered_factories, discovered_hooks = discover_all()
+        extra_factories: list = extra.pop("hook_factories", [])
+        extra_hooks: list = extra.pop("hooks", [])
+        hook_factories = discovered_factories + extra_factories
+        hooks = discovered_hooks + extra_hooks
         return cls(
             bus=bus,
             provider=provider,
@@ -514,6 +521,8 @@ class AgentLoop:
             provider_snapshot_loader=provider_snapshot_loader,
             preset_snapshot_loader=preset_snapshot_loader,
             tool_registry=tool_registry,
+            hook_factories=hook_factories,
+            hooks=hooks,
             **extra,
         )
 

--- a/nanobot/cli/agent.py
+++ b/nanobot/cli/agent.py
@@ -11,7 +11,6 @@ import typer
 from rich.console import Console
 
 from nanobot import __logo__
-from nanobot.agent.hooks import create_file_edit_activity_hook
 from nanobot.agent.loop import AgentLoop
 from nanobot.agent.tools.mcp import MCPProvider
 from nanobot.agent.tools.registry import ToolRegistry
@@ -98,7 +97,6 @@ def agent(
             provider=provider,
             cron_service=cron,
             image_generation_provider_configs=image_gen_provider_configs(runtime_config),
-            hook_factories=[create_file_edit_activity_hook],
             tool_registry=tools,
         )
     except ValueError as exc:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -47,7 +47,6 @@ from rich.text import Text  # noqa: E402
 
 from nanobot import __logo__, __version__  # noqa: E402
 from nanobot import optional_features as feature_support  # noqa: E402
-from nanobot.agent.hooks import create_file_edit_activity_hook  # noqa: E402
 from nanobot.agent.loop import AgentLoop  # noqa: E402
 from nanobot.agent.tools.mcp import MCPProvider  # noqa: E402
 from nanobot.agent.tools.registry import ToolRegistry  # noqa: E402
@@ -360,7 +359,6 @@ def serve(
             runtime_config, bus,
             session_manager=session_manager,
             image_generation_provider_configs=image_gen_provider_configs(runtime_config),
-            hook_factories=[create_file_edit_activity_hook],
             tool_registry=tools,
         )
     except ValueError as exc:

--- a/nanobot/cli/gateway_runtime.py
+++ b/nanobot/cli/gateway_runtime.py
@@ -12,7 +12,6 @@ from loguru import logger
 from rich.console import Console
 
 from nanobot import __logo__, __version__
-from nanobot.agent.hooks import create_file_edit_activity_hook
 from nanobot.agent.loop import AgentLoop
 from nanobot.agent.tools.mcp import MCPProvider
 from nanobot.agent.tools.registry import ToolRegistry
@@ -435,7 +434,6 @@ def _run_gateway(
         provider_signature=provider_snapshot.signature,
         hooks=[TokenUsageHook(timezone_name=config.agents.defaults.timezone)],
         local_trigger_store=trigger_store,
-        hook_factories=[create_file_edit_activity_hook],
         tool_registry=tools,
     )
     def _schedule_webui_background(awaitable: Awaitable[None]) -> None:

--- a/nanobot/nanobot.py
+++ b/nanobot/nanobot.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Any
 
 from nanobot.agent.hook import AgentHook, SDKCaptureHook
-from nanobot.agent.hooks import create_file_edit_activity_hook
 from nanobot.agent.loop import AgentLoop
 from nanobot.agent.tools.mcp import MCPProvider
 from nanobot.agent.tools.registry import ToolRegistry
@@ -134,7 +133,6 @@ class Nanobot:
         loop = AgentLoop.from_config(
             config,
             image_generation_provider_configs=image_gen_provider_configs(config),
-            hook_factories=[create_file_edit_activity_hook],
             tool_registry=tools,
         )
         return cls(loop, config=config, mcp_provider=mcp_provider)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,11 @@ nanobot = "nanobot.cli.commands:app"
 # [project.entry-points."nanobot.tools"]
 # my_plugin = "my_package.plugins:MyTool"
 
+# Third-party hook plugins register here.  Built-in hooks are discovered
+# automatically via pkgutil scanning in nanobot/agent/hooks/discovery.py.
+# [project.entry-points."nanobot.hooks"]
+# my_hook = "my_package:module"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tests/test_nanobot_facade.py
+++ b/tests/test_nanobot_facade.py
@@ -214,7 +214,9 @@ async def test_run_with_hooks(tmp_path):
     result = await bot.run("hi", hooks=[TestHook()])
 
     assert result.content == "done"
-    assert bot._loop._extra_hooks == []
+    # Hook auto-discovery may register built-in hooks at loop construction,
+    # but per-run hooks must not leak into loop state.
+    assert all(not isinstance(h, TestHook) for h in bot._loop._extra_hooks)
     hooks = bot._loop.process_direct.await_args.kwargs["hooks"]
     assert len(hooks) == 2
     assert isinstance(hooks[0], SDKCaptureHook)


### PR DESCRIPTION
Introduce hook registration via pkgutil scanning + entry_points, mirroring the existing pattern used by channels and tools. Adding a custom hook now only requires dropping a .py file into nanobot/agent/hooks/ with a hook_factories or hooks list — no manual wiring needed.

Changes:
- New: nanobot/agent/hooks/discovery.py — pkgutil scan + entry_points loader
- New: nanobot/agent/hooks/sound_hook.py — completion chime hook
- nanobot/agent/loop.py: from_config() auto-discovers and merges hooks
- nanobot/cli/commands.py, nanobot/nanobot.py: remove manual hook wiring
- pyproject.toml: add dotenv dep + nanobot.hooks entry-point docs