### PR TITLE
feat(long_task): gate sustained-goal behind opt-in flag (default off)

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -148,6 +148,9 @@ class TurnContext:
     hook_factories: list[AgentTurnHookFactory] = field(default_factory=list)
     tools: ToolRegistry | None = None
 
+    # Whether the sustained-goal feature is opted in (tools.long_task.enable).
+    long_task_enabled: bool = False
+
     turn_wall_started_at: float = field(default_factory=time.time)
     visible_run_started_at: float | None = None
     turn_latency_ms: int | None = None
@@ -1360,6 +1363,9 @@ class AgentLoop:
             hooks=list(hooks or []),
             hook_factories=list(hook_factories or []),
             tools=tools,
+            long_task_enabled=bool(
+                getattr(getattr(self.tools_config, "long_task", None), "enable", False)
+            ),
         )
 
         while ctx.state is not TurnState.DONE:

--- a/nanobot/agent/tools/long_task.py
+++ b/nanobot/agent/tools/long_task.py
@@ -30,6 +30,11 @@ from nanobot.session.goal_state import (
     parse_goal_state,
 )
 
+# Re-export so ``from nanobot.agent.tools.long_task import LongTaskToolConfig``
+# keeps working; the class itself lives in a dependency-light module to avoid
+# import cycles during pydantic model_rebuild of ToolsConfig.
+from nanobot.agent.tools.long_task_config import LongTaskToolConfig
+
 if TYPE_CHECKING:
     from nanobot.session.manager import SessionManager
 

--- a/nanobot/agent/tools/long_task.py
+++ b/nanobot/agent/tools/long_task.py
@@ -38,6 +38,30 @@ def _iso_now() -> str:
     return datetime.now().isoformat()
 
 
+def _goal_feature_enabled(ctx: Any) -> bool:
+    """Whether the sustained-goal feature (long_task/complete_goal + auto
+    continuation) is active. Disabled by default; enable via config flag
+    ``tools.long_task.enable = true`` or ``long_task_enable = true``.
+    """
+    config = getattr(ctx, "config", None)
+    if config is None:
+        return False
+    lt = getattr(config, "long_task", None)
+    if lt is not None:
+        flag = getattr(lt, "enable", None)
+        if flag is not None:
+            return bool(flag)
+    tools = getattr(config, "tools", None)
+    if isinstance(tools, dict):
+        lt = tools.get("long_task")
+        if isinstance(lt, dict) and "enable" in lt:
+            return bool(lt["enable"])
+    flag = getattr(config, "long_task_enable", None)
+    if flag is not None:
+        return bool(flag)
+    return False
+
+
 class _GoalToolsMixin:
     """Shared routing context + Session lookup."""
 
@@ -118,6 +142,8 @@ class LongTaskTool(Tool, _GoalToolsMixin):
 
     @classmethod
     def enabled(cls, ctx: Any) -> bool:
+        if not _goal_feature_enabled(ctx):
+            return False
         return getattr(ctx, "sessions", None) is not None
 
     @property
@@ -200,6 +226,8 @@ class CompleteGoalTool(Tool, _GoalToolsMixin):
 
     @classmethod
     def enabled(cls, ctx: Any) -> bool:
+        if not _goal_feature_enabled(ctx):
+            return False
         return getattr(ctx, "sessions", None) is not None
 
     @property

--- a/nanobot/agent/tools/long_task_config.py
+++ b/nanobot/agent/tools/long_task_config.py
@@ -1,0 +1,22 @@
+"""Config for the sustained-goal tools (``long_task`` / ``complete_goal``).
+
+Kept in a dependency-light module (only ``config_base``) so that
+``ToolsConfig`` can resolve its field type via ``model_rebuild()`` without
+triggering the heavier import cycle of ``long_task.py`` (which pulls in
+session/bus modules).
+"""
+from __future__ import annotations
+
+from nanobot.config_base import Base
+
+
+class LongTaskToolConfig(Base):
+    """Feature flag for the sustained-goal behavior.
+
+    Disabled by default: the sustained-goal auto-continuation can keep the agent
+    working on a background goal during long main-thread tasks, blocking user
+    interaction, and is not fully reliable yet. Opt in with
+    ``tools.long_task.enable = true``.
+    """
+
+    enable: bool = False

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from nanobot.agent.tools.cli_apps import CliAppsToolConfig
     from nanobot.agent.tools.filesystem import FileToolsConfig
     from nanobot.agent.tools.image_generation import ImageGenerationToolConfig
+    from nanobot.agent.tools.long_task_config import LongTaskToolConfig
     from nanobot.agent.tools.self import MyToolConfig
     from nanobot.agent.tools.shell import ExecToolConfig
     from nanobot.agent.tools.web import WebToolsConfig
@@ -365,6 +366,7 @@ class ToolsConfig(Base):
     file: FileToolsConfig = Field(default_factory=lambda: _lazy_default("nanobot.agent.tools.filesystem", "FileToolsConfig"))
     cli_apps: CliAppsToolConfig = Field(default_factory=lambda: _lazy_default("nanobot.agent.tools.cli_apps", "CliAppsToolConfig"))
     my: MyToolConfig = Field(default_factory=lambda: _lazy_default("nanobot.agent.tools.self", "MyToolConfig"))
+    long_task: LongTaskToolConfig = Field(default_factory=lambda: _lazy_default("nanobot.agent.tools.long_task_config", "LongTaskToolConfig"))
     image_generation: ImageGenerationToolConfig = Field(
         default_factory=lambda: _lazy_default("nanobot.agent.tools.image_generation", "ImageGenerationToolConfig"),
     )
@@ -611,6 +613,7 @@ def _resolve_tool_config_refs() -> None:
     from nanobot.agent.tools.cli_apps import CliAppsToolConfig
     from nanobot.agent.tools.filesystem import FileToolsConfig
     from nanobot.agent.tools.image_generation import ImageGenerationToolConfig
+    from nanobot.agent.tools.long_task_config import LongTaskToolConfig
     from nanobot.agent.tools.self import MyToolConfig
     from nanobot.agent.tools.shell import ExecToolConfig
     from nanobot.agent.tools.web import WebFetchConfig, WebSearchConfig, WebToolsConfig
@@ -624,6 +627,7 @@ def _resolve_tool_config_refs() -> None:
     mod.WebSearchConfig = WebSearchConfig  # type: ignore[attr-defined]
     mod.WebFetchConfig = WebFetchConfig  # type: ignore[attr-defined]
     mod.MyToolConfig = MyToolConfig  # type: ignore[attr-defined]
+    mod.LongTaskToolConfig = LongTaskToolConfig  # type: ignore[attr-defined]
     mod.ImageGenerationToolConfig = ImageGenerationToolConfig  # type: ignore[attr-defined]
 
     ToolsConfig.model_rebuild()

--- a/nanobot/session/turn_continuation.py
+++ b/nanobot/session/turn_continuation.py
@@ -99,9 +99,32 @@ def should_finalize_on_max_iterations(
     )
 
 
+def _goal_feature_enabled(ctx: Any) -> bool:
+    """Mirror of long_task._goal_feature_enabled; disabled by default."""
+    config = getattr(ctx, "config", None)
+    if config is None:
+        return False
+    lt = getattr(config, "long_task", None)
+    if lt is not None:
+        flag = getattr(lt, "enable", None)
+        if flag is not None:
+            return bool(flag)
+    tools = getattr(config, "tools", None)
+    if isinstance(tools, dict):
+        lt = tools.get("long_task")
+        if isinstance(lt, dict) and "enable" in lt:
+            return bool(lt["enable"])
+    flag = getattr(config, "long_task_enable", None)
+    if flag is not None:
+        return bool(flag)
+    return False
+
+
 async def maybe_continue_turn(ctx: Any) -> bool:
     """Queue an internal continuation for *ctx* when policy allows it."""
     if ctx.session is None or ctx.pending_queue is None:
+        return False
+    if not _goal_feature_enabled(ctx):
         return False
     if not _continuation_available(
         stop_reason=ctx.stop_reason,

--- a/nanobot/session/turn_continuation.py
+++ b/nanobot/session/turn_continuation.py
@@ -100,7 +100,15 @@ def should_finalize_on_max_iterations(
 
 
 def _goal_feature_enabled(ctx: Any) -> bool:
-    """Mirror of long_task._goal_feature_enabled; disabled by default."""
+    """Mirror of long_task._goal_feature_enabled; disabled by default.
+
+    Prefers a resolved ``ctx.long_task_enabled`` flag (set on the loop's
+    TurnContext from ``tools.long_task.enable``); otherwise falls back to reading
+    ``ctx.config`` for callers that pass a raw config-bearing context.
+    """
+    resolved = getattr(ctx, "long_task_enabled", None)
+    if resolved is not None:
+        return bool(resolved)
     config = getattr(ctx, "config", None)
     if config is None:
         return False

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -48,12 +48,21 @@ def _mk_loop() -> AgentLoop:
     return loop
 
 
-def _make_full_loop(tmp_path: Path) -> AgentLoop:
+def _make_full_loop(tmp_path: Path, *, sustained_goal: bool = False) -> AgentLoop:
+    from nanobot.config.schema import ToolsConfig
+
     provider = MagicMock()
     provider.get_default_model.return_value = "test-model"
     provider.generation = SimpleNamespace(max_tokens=4096)
     provider.chat_with_retry = AsyncMock(return_value=LLMResponse(content="Test title"))
-    loop = AgentLoop(bus=MessageBus(), provider=provider, workspace=tmp_path, model="test-model")
+    tools_config = ToolsConfig(long_task={"enable": True}) if sustained_goal else None
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+        tools_config=tools_config,
+    )
     WebuiTurnCoordinator(
         bus=loop.bus,
         sessions=loop.sessions,
@@ -732,7 +741,7 @@ async def test_process_message_does_not_duplicate_early_persisted_user_message(t
 async def test_internal_continuation_queues_turn_without_fake_user_history(
     tmp_path: Path,
 ) -> None:
-    loop = _make_full_loop(tmp_path)
+    loop = _make_full_loop(tmp_path, sustained_goal=True)
     loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=False)  # type: ignore[method-assign]
     session = loop.sessions.get_or_create("feishu:c-auto")
     session.metadata[GOAL_STATE_KEY] = {
@@ -804,7 +813,7 @@ async def test_internal_continuation_queues_turn_without_fake_user_history(
 async def test_internal_continuation_preserves_streaming_route_metadata(
     tmp_path: Path,
 ) -> None:
-    loop = _make_full_loop(tmp_path)
+    loop = _make_full_loop(tmp_path, sustained_goal=True)
     loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=False)  # type: ignore[method-assign]
     session = loop.sessions.get_or_create("feishu:c-stream")
     session.metadata[GOAL_STATE_KEY] = {
@@ -882,7 +891,7 @@ async def test_internal_continuation_preserves_streaming_route_metadata(
 async def test_websocket_internal_continuation_keeps_single_visible_run(
     tmp_path: Path,
 ) -> None:
-    loop = _make_full_loop(tmp_path)
+    loop = _make_full_loop(tmp_path, sustained_goal=True)
     loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=False)  # type: ignore[method-assign]
     session = loop.sessions.get_or_create("websocket:c-auto")
     session.metadata[GOAL_STATE_KEY] = {

--- a/tests/agent/tools/test_long_task.py
+++ b/tests/agent/tools/test_long_task.py
@@ -211,11 +211,31 @@ async def test_long_task_skips_ws_publish_without_bus(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_long_task_and_complete_goal_registered(tmp_path):
+async def test_long_task_and_complete_goal_not_registered_by_default(tmp_path):
+    """The sustained-goal tools are gated off by default (opt-in flag)."""
     bus = MessageBus()
     provider = MagicMock()
     provider.get_default_model.return_value = "test-model"
     loop = AgentLoop(bus=bus, provider=provider, workspace=tmp_path, model="test-model")
+
+    assert loop.tools.get("long_task") is None
+    assert loop.tools.get("complete_goal") is None
+
+
+@pytest.mark.asyncio
+async def test_long_task_and_complete_goal_registered(tmp_path):
+    from nanobot.config.schema import ToolsConfig
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    loop = AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+        tools_config=ToolsConfig(long_task={"enable": True}),
+    )
 
     lt = loop.tools.get("long_task")
     cg = loop.tools.get("complete_goal")

--- a/tests/session/test_turn_continuation.py
+++ b/tests/session/test_turn_continuation.py
@@ -8,7 +8,13 @@ from types import SimpleNamespace
 import pytest
 
 from nanobot.bus.events import InboundMessage
+from nanobot.config.schema import ToolsConfig
 from nanobot.session.goal_state import GOAL_STATE_KEY
+
+
+def _goal_enabled_config():
+    """Config with the sustained-goal feature opted in (flag off by default)."""
+    return ToolsConfig(long_task={"enable": True})
 from nanobot.session.turn_continuation import (
     INTERNAL_CONTINUATION_KIND_META,
     INTERNAL_CONTINUATION_META,
@@ -59,6 +65,7 @@ async def test_maybe_continue_turn_queues_internal_message():
         all_messages=messages,
         suppress_response=False,
         visible_run_started_at=1234.5,
+        config=_goal_enabled_config(),
     )
 
     assert await maybe_continue_turn(ctx) is True


### PR DESCRIPTION
## Summary

The sustained-goal feature (long_task/complete_goal tools + automatic turn continuation) makes the agent keep working on a background goal during long-running tasks in the main thread. In practice this blocks user interaction: while a long task is running the agent stays busy pursuing the goal and the user cannot interject.

The feature is also not fully reliable yet and would benefit from deeper review before being on by default.

This PR gates the whole feature behind an opt-in config flag (tools.long_task.enable, default false). Behavior is unchanged for anyone who explicitly enables it; for everyone else the goal tools and auto-continuation are simply not active.

## Changes

- Add _goal_feature_enabled(ctx) helper that reads tools.long_task.enable (also accepts config.long_task.enable / long_task_enable), defaulting to false.
- LongTaskTool.enabled / CompleteGoalTool.enabled return False when the flag is off.
- maybe_continue_turn short-circuits when the flag is off, so no automatic continuation is queued.

## Notes

Opt-in rather than removal so existing users who rely on it can keep it via a one-line config change while the reliability/UX issues are investigated.