### PR TITLE
fix(security): default restrict_to_workspace to True (#4796)

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -368,7 +368,7 @@ class ToolsConfig(Base):
     image_generation: ImageGenerationToolConfig = Field(
         default_factory=lambda: _lazy_default("nanobot.agent.tools.image_generation", "ImageGenerationToolConfig"),
     )
-    restrict_to_workspace: bool = False  # policy intent: keep tool access inside workspace when possible
+    restrict_to_workspace: bool = True  # policy intent: keep tool access inside workspace when possible
     webui_allow_local_service_access: bool = Field(
         default=True,
         validation_alias=AliasChoices(

--- a/nanobot/security/workspace_access.py
+++ b/nanobot/security/workspace_access.py
@@ -352,7 +352,7 @@ def current_workspace_scope() -> WorkspaceScope | None:
 def current_tool_workspace(
     default_workspace: str | Path | None,
     *,
-    restrict_to_workspace: bool = False,
+    restrict_to_workspace: bool = True,
     sandbox_restricts_workspace: bool = False,
 ) -> ToolWorkspace:
     """Return the workspace/access policy for the current tool call."""


### PR DESCRIPTION
Fixes #4796.

### Summary
This PR updates the default value of `restrict_to_workspace` from `False` to `True` in the configuration schema and the workspace access logic.

### Motivation
By defaulting to `False`, tool operations (read, write, edit, exec) were inherently unconfined, allowing the LLM agent to access any files on the host filesystem that the gateway process could reach. This changes the default behavior to enforce the principle of least privilege. Users who specifically need full filesystem access can still explicitly opt-in by configuring it to `False`.

### Changes
- Updated `restrict_to_workspace: bool = True` in `nanobot/config/schema.py`
- Updated the default `restrict_to_workspace` parameter to `True` in `nanobot/security/workspace_access.py`
