### PR TITLE
fix(security): authorize destructive priority commands

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -237,6 +237,11 @@ class AgentLoop:
         self.runtime_events = runtime_events or RuntimeEventBus()
         self.runtime_event_publisher = RuntimeEventPublisher(self.runtime_events)
         self.channels_config = channels_config
+        self.admin_senders = frozenset(
+            str(sender).strip()
+            for sender in (getattr(channels_config, "admin_senders", None) or [])
+            if str(sender).strip()
+        )
         self.restart_mode = restart_mode
         self.provider = provider
         self._provider_snapshot_loader = provider_snapshot_loader
@@ -691,6 +696,20 @@ class AgentLoop:
             await self.bus.publish_outbound(result)
         else:
             logger.warning("Command '{}' matched but dispatch returned None", raw)
+
+    def is_destructive_command_authorized(self, msg: InboundMessage) -> bool:
+        """Return whether *msg* may run process/task destructive commands."""
+        # Direct AgentLoop users (for example the SDK and unit-test harnesses)
+        # do not have channel authorization configuration.  Their caller owns
+        # the process, so retain the existing programmatic behavior.  Loops
+        # created from Config always receive ChannelsConfig and are protected.
+        if self.channels_config is None or msg.channel in {"cli", "system"}:
+            return True
+        return bool(
+            msg.sender_id in self.admin_senders
+            or f"{msg.channel}:{msg.sender_id}" in self.admin_senders
+            or "*" in self.admin_senders
+        )
 
     async def _cancel_active_tasks(self, key: str) -> int:
         """Cancel and await all active tasks and subagents for *key*.

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -144,6 +144,13 @@ async def cmd_stop(ctx: CommandContext) -> OutboundMessage:
     """Cancel all active tasks and subagents for the session."""
     loop = ctx.loop
     msg = ctx.msg
+    if not loop.is_destructive_command_authorized(msg):
+        return OutboundMessage(
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+            content="You are not authorized to stop tasks.",
+            metadata=dict(msg.metadata or {}),
+        )
     total = await loop._cancel_active_tasks(ctx.key)
     # Also drain pending queue to prevent mid-turn injection deadlock
     pending = loop._pending_queues.pop(ctx.key, None)
@@ -164,6 +171,13 @@ async def cmd_stop(ctx: CommandContext) -> OutboundMessage:
 async def cmd_restart(ctx: CommandContext) -> OutboundMessage:
     """Restart the process."""
     msg = ctx.msg
+    if not ctx.loop.is_destructive_command_authorized(msg):
+        return OutboundMessage(
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+            content="You are not authorized to restart nanobot.",
+            metadata=dict(msg.metadata or {}),
+        )
     set_restart_notice_to_env(
         channel=msg.channel,
         chat_id=msg.chat_id,

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -34,6 +34,14 @@ class ChannelsConfig(Base):
     show_reasoning: bool = True  # surface model reasoning when channel implements it
     extract_document_text: bool = True  # extract text from document attachments before sending to the model
     send_max_retries: int = Field(default=3, ge=0, le=10)  # Max delivery attempts (initial send included)
+    admin_senders: list[str] = Field(default_factory=list)
+    """Sender IDs allowed to run destructive priority commands.
+
+    Entries may be bare sender IDs (matching across channels) or
+    ``channel:sender_id`` values for channel-scoped authorization.  An empty
+    list deliberately denies destructive priority commands from chat channels;
+    local CLI/system control remains available to the process owner.
+    """
     transcription_provider: str = "groq"  # Deprecated: use top-level transcription.provider
     transcription_language: str | None = Field(default=None, pattern=r"^[a-z]{2,3}$")  # Deprecated: use top-level transcription.language
 

--- a/tests/cli/test_restart_command.py
+++ b/tests/cli/test_restart_command.py
@@ -36,6 +36,64 @@ def _make_loop():
 class TestRestartCommand:
 
     @pytest.mark.asyncio
+    async def test_restart_is_denied_to_non_admin_chat_sender(self):
+        from nanobot.command.builtin import cmd_restart
+        from nanobot.command.router import CommandContext
+        from nanobot.config.schema import ChannelsConfig
+
+        loop, _bus = _make_loop()
+        loop.channels_config = ChannelsConfig()
+        msg = InboundMessage(channel="telegram", sender_id="user", chat_id="direct", content="/restart")
+        ctx = CommandContext(msg=msg, session=None, key=msg.session_key, raw="/restart", loop=loop)
+
+        with patch("nanobot.command.builtin.os.execv") as mock_execv:
+            out = await cmd_restart(ctx)
+
+        assert "not authorized" in out.content
+        mock_execv.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_restart_allows_channel_scoped_admin_sender(self):
+        from nanobot.command.builtin import cmd_restart
+        from nanobot.command.router import CommandContext
+
+        loop, _bus = _make_loop()
+        loop.admin_senders = frozenset({"telegram:user"})
+        msg = InboundMessage(channel="telegram", sender_id="user", chat_id="direct", content="/restart")
+        ctx = CommandContext(msg=msg, session=None, key=msg.session_key, raw="/restart", loop=loop)
+
+        async def _fast_sleep(_delay: float) -> None:
+            return None
+
+        scheduled: list[asyncio.Task] = []
+        real_create_task = asyncio.create_task
+        with patch("nanobot.command.builtin.asyncio.sleep", _fast_sleep), \
+             patch("nanobot.command.builtin.asyncio.create_task", lambda coro: scheduled.append(real_create_task(coro)) or scheduled[-1]), \
+             patch("nanobot.command.builtin.os.execv") as mock_execv:
+            out = await cmd_restart(ctx)
+            await scheduled[0]
+
+        assert "Restarting" in out.content
+        mock_execv.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_is_denied_to_non_admin_chat_sender(self):
+        from nanobot.command.builtin import cmd_stop
+        from nanobot.command.router import CommandContext
+        from nanobot.config.schema import ChannelsConfig
+
+        loop, _bus = _make_loop()
+        loop.channels_config = ChannelsConfig()
+        msg = InboundMessage(channel="telegram", sender_id="user", chat_id="direct", content="/stop")
+        ctx = CommandContext(msg=msg, session=None, key=msg.session_key, raw="/stop", loop=loop)
+
+        with patch.object(loop, "_cancel_active_tasks", new_callable=AsyncMock) as cancel:
+            out = await cmd_stop(ctx)
+
+        assert "not authorized" in out.content
+        cancel.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_restart_sends_message_and_calls_execv(self):
         from nanobot.command.builtin import cmd_restart
         from nanobot.command.router import CommandContext
@@ -147,6 +205,7 @@ class TestRestartCommand:
         """Verify /restart is handled at the run-loop level, not inside _dispatch."""
         loop, bus = _make_loop()
         loop.restart_mode = "exec"
+        loop.admin_senders = frozenset({"telegram:u1"})
         msg = InboundMessage(channel="telegram", sender_id="u1", chat_id="c1", content="/restart")
 
         async def _fast_sleep(_delay: float) -> None:


### PR DESCRIPTION
## Summary

- Add an explicit `channels.admin_senders` allowlist for destructive priority commands.
- Protect `/restart` and `/stop` from approved-but-non-admin chat users.
- Preserve local CLI/system control paths and support bare or channel-scoped sender IDs.
- Add regression coverage for denied and authorized restart/stop behavior.

## Root cause

Priority commands were dispatched before the session lock and had no authorization check, allowing any sender who passed channel-level access or pairing to restart the entire process or cancel a session.

## Validation

- `uv run pytest -q tests/cli/test_restart_command.py tests/command`
- `uv run pytest -q --maxfail=1`
- `uv run ruff check nanobot/agent/loop.py nanobot/command/builtin.py nanobot/config/schema.py tests/cli/test_restart_command.py`
- `git diff --check`

Closes #4776