### PR TITLE
fix(api): avoid retaining idle session locks

### DIFF
--- a/nanobot/api/server.py
+++ b/nanobot/api/server.py
@@ -12,6 +12,7 @@ import hmac
 import json as _json
 import time
 import uuid
+import weakref
 from typing import Any
 
 from aiohttp import web
@@ -90,6 +91,16 @@ def _response_text(value: Any) -> str:
     if hasattr(value, "content"):
         return str(getattr(value, "content") or "")
     return str(value)
+
+
+def _get_session_lock(app: web.Application, session_key: str) -> asyncio.Lock:
+    session_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = app["session_locks"]
+    session_lock = session_locks.get(session_key)
+    if session_lock is None:
+        session_lock = asyncio.Lock()
+        session_locks[session_key] = session_lock
+    return session_lock
+
 
 # ---------------------------------------------------------------------------
 # SSE helpers
@@ -238,12 +249,14 @@ async def handle_chat_completions(request: web.Request) -> web.Response:
         return _error_json(400, f"Only configured model '{model_name}' is available")
 
     session_key = f"api:{session_id}" if session_id else API_SESSION_KEY
-    session_locks: dict[str, asyncio.Lock] = request.app["session_locks"]
-    session_lock = session_locks.setdefault(session_key, asyncio.Lock())
+    session_lock = _get_session_lock(request.app, session_key)
 
     logger.info(
         "API request session_key={} media={} text={} stream={}",
-        session_key, len(media_paths), text[:80], stream,
+        session_key,
+        len(media_paths),
+        text[:80],
+        stream,
     )
     # -- streaming path --
     if stream:
@@ -360,7 +373,9 @@ async def handle_chat_completions(request: web.Request) -> web.Response:
         return _error_json(500, "Internal server error", err_type="server_error")
 
     return web.json_response(
-        _chat_completion_response(response_text, model_name, getattr(agent_loop, "_last_usage", None))
+        _chat_completion_response(
+            response_text, model_name, getattr(agent_loop, "_last_usage", None)
+        )
     )
 
 
@@ -410,7 +425,7 @@ def create_app(
     app["agent_loop"] = agent_loop
     app["model_name"] = model_name
     app["request_timeout"] = request_timeout
-    app["session_locks"] = {}  # per-user locks, keyed by session_key
+    app["session_locks"] = weakref.WeakValueDictionary()
 
     @web.middleware
     async def auth_middleware(request: web.Request, handler) -> web.StreamResponse:
@@ -422,7 +437,7 @@ def create_app(
         auth = request.headers.get("Authorization", "")
         if not auth.startswith("Bearer "):
             return _error_json(401, "Missing Authorization header. Use: Bearer <api_key>")
-        if not hmac.compare_digest(auth[len("Bearer "):], api_key):
+        if not hmac.compare_digest(auth[len("Bearer ") :], api_key):
             return _error_json(401, "Invalid API key")
         return await handler(request)
 

--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 import json
 from unittest.mock import AsyncMock, MagicMock
 
@@ -132,7 +133,9 @@ async def test_api_key_protects_api_routes_but_not_health(aiohttp_client, mock_a
 
 @pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")
 @pytest.mark.asyncio
-async def test_api_routes_allow_requests_without_configured_api_key(aiohttp_client, mock_agent) -> None:
+async def test_api_routes_allow_requests_without_configured_api_key(
+    aiohttp_client, mock_agent
+) -> None:
     app = create_app(mock_agent, model_name="test-model")
     client = await aiohttp_client(app)
 
@@ -187,7 +190,7 @@ async def test_model_mismatch_returns_400() -> None:
         "agent_loop": _make_mock_agent(),
         "model_name": "test-model",
         "request_timeout": 10.0,
-        "session_lock": asyncio.Lock(),
+        "session_locks": {},
     }
 
     resp = await handle_chat_completions(request)
@@ -211,7 +214,7 @@ async def test_single_user_message_required() -> None:
         "agent_loop": _make_mock_agent(),
         "model_name": "test-model",
         "request_timeout": 10.0,
-        "session_lock": asyncio.Lock(),
+        "session_locks": {},
     }
 
     resp = await handle_chat_completions(request)
@@ -232,7 +235,7 @@ async def test_single_user_message_must_have_user_role() -> None:
         "agent_loop": _make_mock_agent(),
         "model_name": "test-model",
         "request_timeout": 10.0,
-        "session_lock": asyncio.Lock(),
+        "session_locks": {},
     }
 
     resp = await handle_chat_completions(request)
@@ -344,6 +347,72 @@ async def test_fixed_session_requests_are_serialized(aiohttp_client) -> None:
 
 @pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")
 @pytest.mark.asyncio
+async def test_custom_session_requests_are_serialized(aiohttp_client) -> None:
+    active = 0
+    max_active = 0
+    seen_sessions: list[str] = []
+
+    async def slow_process(content, session_key="", channel="", chat_id="", **kwargs):
+        nonlocal active, max_active
+        seen_sessions.append(session_key)
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.05)
+        active -= 1
+        return content
+
+    agent = MagicMock()
+    agent.process_direct = slow_process
+    agent._connect_mcp = AsyncMock()
+    agent.close_mcp = AsyncMock()
+    agent._last_usage = {}
+
+    app = create_app(agent, model_name="m", api_key=API_KEY)
+    client = await aiohttp_client(app)
+
+    async def send():
+        resp = await client.post(
+            "/v1/chat/completions",
+            headers=AUTH_HEADERS,
+            json={
+                "messages": [{"role": "user", "content": "hello"}],
+                "session_id": "same-session",
+            },
+        )
+        assert resp.status == 200
+        await resp.json()
+
+    await asyncio.gather(send(), send())
+
+    assert max_active == 1
+    assert seen_sessions == ["api:same-session", "api:same-session"]
+
+
+@pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")
+@pytest.mark.asyncio
+async def test_idle_custom_session_locks_do_not_accumulate(aiohttp_client) -> None:
+    agent = _make_mock_agent("ok")
+    app = create_app(agent, model_name="m", api_key=API_KEY)
+    client = await aiohttp_client(app)
+
+    for index in range(20):
+        resp = await client.post(
+            "/v1/chat/completions",
+            headers=AUTH_HEADERS,
+            json={
+                "messages": [{"role": "user", "content": "hello"}],
+                "session_id": f"session-{index}",
+            },
+        )
+        assert resp.status == 200
+        await resp.json()
+
+    gc.collect()
+    assert len(app["session_locks"]) == 0
+
+
+@pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")
+@pytest.mark.asyncio
 async def test_models_endpoint(aiohttp_client, app) -> None:
     client = await aiohttp_client(app)
     resp = await client.get("/v1/models", headers=AUTH_HEADERS)
@@ -406,7 +475,10 @@ async def test_multimodal_remote_image_url_returns_400(aiohttp_client, mock_agen
                     "role": "user",
                     "content": [
                         {"type": "text", "text": "describe this"},
-                        {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "https://example.com/image.png"},
+                        },
                     ],
                 }
             ]
@@ -519,7 +591,15 @@ async def test_process_direct_accepts_media() -> None:
 
     captured_msg = None
 
-    async def fake_process(msg, *, session_key="", on_progress=None, on_stream=None, on_stream_end=None, ephemeral=False):
+    async def fake_process(
+        msg,
+        *,
+        session_key="",
+        on_progress=None,
+        on_stream=None,
+        on_stream_end=None,
+        ephemeral=False,
+    ):
         nonlocal captured_msg
         captured_msg = msg
         return None


### PR DESCRIPTION
## Summary

Fixes #4883.

API session locks created for custom `session_id` values were stored indefinitely, causing the lock registry to grow over time.

This replaces the lock store with a `WeakValueDictionary`, allowing idle locks to be garbage-collected while preserving serialization for concurrent requests sharing the same session.

## Changes

* Add `_get_session_lock()` for lock retrieval and creation.
* Store session locks in `WeakValueDictionary`.
* Add regression tests for lock cleanup and same-session serialization.

## Validation

```bash
uv run --extra dev ruff check nanobot/api/server.py tests/test_openai_api.py
uv run --extra dev ruff format --check nanobot/api/server.py tests/test_openai_api.py
uv run --extra dev python -m pytest tests/test_openai_api.py -q
```