### PR TITLE
fix(transcription): resolve API key env placeholders

### DIFF
--- a/nanobot/audio/transcription.py
+++ b/nanobot/audio/transcription.py
@@ -9,6 +9,7 @@ HTTP details; those live in ``nanobot.providers.transcription``.
 from __future__ import annotations
 
 import os
+import re
 from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -81,10 +82,28 @@ def _provider_default_api_base(provider: str) -> str | None:
     return spec.default_api_base if spec else None
 
 
+_ENV_REF_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def _resolve_env_placeholders(value: str) -> str:
+    missing = False
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal missing
+        resolved = os.environ.get(match.group(1))
+        if resolved is None:
+            missing = True
+            return ""
+        return resolved
+
+    resolved = _ENV_REF_PATTERN.sub(replace, value)
+    return "" if missing else resolved
+
+
 def _resolve_transcription_api_key(provider: str, provider_cfg: Any) -> str:
     api_key = getattr(provider_cfg, "api_key", None) if provider_cfg else None
     if api_key:
-        return api_key
+        return _resolve_env_placeholders(api_key)
 
     spec = find_by_name(provider)
     if provider == "siliconflow":
@@ -93,7 +112,7 @@ def _resolve_transcription_api_key(provider: str, provider_cfg: Any) -> str:
             return env_key
 
     env_key = spec.env_key if spec else ""
-    return os.environ.get(env_key) if env_key else ""
+    return (os.environ.get(env_key) or "") if env_key else ""
 
 
 def _resolve_transcription_api_base(provider: str, provider_cfg: Any) -> str:

--- a/tests/providers/test_transcription.py
+++ b/tests/providers/test_transcription.py
@@ -132,6 +132,73 @@ def test_resolver_supports_siliconflow_transcription_provider() -> None:
     assert resolved.api_base == "https://api.siliconflow.cn/v1"
 
 
+def test_resolver_expands_selected_api_key_placeholder() -> None:
+    config = Config()
+    config.transcription.provider = "groq"
+    config.providers.groq.api_key = "${GROQ_TRANSCRIPTION_KEY}"
+
+    with patch.dict(
+        os.environ,
+        {"GROQ_TRANSCRIPTION_KEY": "gsk-from-env"},
+        clear=True,
+    ):
+        resolved = resolve_transcription_config(config)
+
+    assert resolved.api_key == "gsk-from-env"
+    assert resolved.configured is True
+    assert config.providers.groq.api_key == "${GROQ_TRANSCRIPTION_KEY}"
+
+
+def test_resolver_missing_explicit_placeholder_does_not_use_fallback() -> None:
+    config = Config()
+    config.transcription.provider = "groq"
+    config.providers.groq.api_key = "${MISSING_GROQ_TRANSCRIPTION_KEY}"
+
+    with patch.dict(os.environ, {"GROQ_API_KEY": "gsk-fallback"}, clear=True):
+        resolved = resolve_transcription_config(config)
+
+    assert resolved.api_key == ""
+    assert resolved.configured is False
+
+
+def test_resolver_missing_placeholder_empties_composite_key() -> None:
+    config = Config()
+    config.transcription.provider = "groq"
+    config.providers.groq.api_key = "prefix-${PRESENT_KEY}-${MISSING_KEY}"
+
+    with patch.dict(
+        os.environ,
+        {"PRESENT_KEY": "present", "GROQ_API_KEY": "gsk-fallback"},
+        clear=True,
+    ):
+        resolved = resolve_transcription_config(config)
+
+    assert resolved.api_key == ""
+
+
+def test_resolver_ignores_unrelated_missing_placeholder() -> None:
+    config = Config()
+    config.transcription.provider = "groq"
+    config.providers.groq.api_key = "gsk-test"
+    config.providers.openai.api_key = "${MISSING_OPENAI_TRANSCRIPTION_KEY}"
+
+    with patch.dict(os.environ, clear=True):
+        resolved = resolve_transcription_config(config)
+
+    assert resolved.api_key == "gsk-test"
+    assert config.providers.openai.api_key == "${MISSING_OPENAI_TRANSCRIPTION_KEY}"
+
+
+def test_resolver_uses_registry_api_key_fallback_for_empty_key() -> None:
+    config = Config()
+    config.transcription.provider = "groq"
+
+    with patch.dict(os.environ, {"GROQ_API_KEY": "gsk-fallback"}, clear=True):
+        resolved = resolve_transcription_config(config)
+
+    assert resolved.api_key == "gsk-fallback"
+
+
 def test_resolver_defaults_siliconflow_transcription_api_base() -> None:
     config = Config()
     config.transcription.provider = "siliconflow"

--- a/tests/webui/test_transcription_ws.py
+++ b/tests/webui/test_transcription_ws.py
@@ -42,6 +42,33 @@ async def test_webui_transcribe_audio_rejects_unconfigured_provider(
 
 
 @pytest.mark.asyncio
+async def test_webui_transcribe_audio_rejects_missing_api_key_placeholder(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config()
+    config.transcription.provider = "groq"
+    config.providers.groq.api_key = "${MISSING_GROQ_TRANSCRIPTION_KEY}"
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+    monkeypatch.delenv("MISSING_GROQ_TRANSCRIPTION_KEY", raising=False)
+    monkeypatch.setenv("GROQ_API_KEY", "gsk-fallback")
+
+    event, payload = await webui_transcription_event({
+        "request_id": "voice-1",
+        "data_url": _audio_data_url(),
+    })
+
+    assert event == "transcription_error"
+    assert payload == {
+        "request_id": "voice-1",
+        "detail": "not_configured",
+        "provider": "groq",
+    }
+
+
+@pytest.mark.asyncio
 async def test_webui_transcribe_audio_rejects_unsupported_mime(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
  ## Summary

  - Resolve `${ENV_VAR}` placeholders only for the selected transcription provider's explicit API key.
  - Treat a missing referenced variable as an unconfigured transcription provider without falling back to `GROQ_API_KEY`.
  - Preserve existing empty-key fallback and the WebUI `not_configured` error contract.
  - Leave `api_base` and WebUI production code unchanged.

  ## Tests

  - `ruff check nanobot/audio/transcription.py tests/providers/test_transcription.py tests/webui/test_transcription_ws.py`
  - `env PYTHONPATH=. pytest -q tests/providers/test_transcription.py tests/webui/test_transcription_ws.py tests/webui/test_settings_api.py`
    - `130 passed`