### PR TITLE
fix(heartbeat): rewrite prompt to execute tasks instead of reporting

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1595,7 +1595,7 @@ def _run_gateway(
 
             prompt = (
                 _HEARTBEAT_PREAMBLE
-                + f"Review the following HEARTBEAT.md and report any active tasks:\n\n{content}"
+                + f"You are executing periodic heartbeat tasks. Read the active tasks below, perform each one, and report what you did:\n\n{content}"
             )
 
             # Internal check: funnel all output through the post-run gate so the


### PR DESCRIPTION
Prior to `v0.2.1` (fe2af64e) heartbeat execution was split into two stages: review and execute. After fe2af64e refactored heartbeat from being a service to being a cron job, the two stage system became single stage, but the prompt was not updated to reflect this change.

Currently, agents only list tasks instead of executing them. I would consider this a high priority and low risk PR, so, hopefully, this gets merged soon.

Thanks!