### PR TITLE
fix(agent): add wall-clock timeout for streaming LLM requests

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -185,7 +185,7 @@ These variables are process-level switches. Set them in the same terminal, servi
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `NANOBOT_MAX_CONCURRENT_REQUESTS` | `3` | Maximum concurrently running inbound agent requests. Must be an integer; set `0` or a negative value for unlimited. |
-| `NANOBOT_LLM_TIMEOUT_S` | `300` | Wall-clock timeout, in seconds, around ordinary LLM requests. Set `0` to disable. Sustained-goal turns bypass this wall-clock cap. |
+| `NANOBOT_LLM_TIMEOUT_S` | `300` | Wall-clock timeout, in seconds. Ordinary requests use this value; streaming requests use the greater of 300 seconds or twice this value. Set `0` to disable. Sustained-goal turns bypass this wall-clock cap. |
 | `NANOBOT_STREAM_IDLE_TIMEOUT_S` | `90` | Streaming idle timeout, in seconds, used by streaming providers. Invalid or non-positive values are ignored; values above `3600` are clamped. |
 | `NANOBOT_OPENAI_COMPAT_TIMEOUT_S` | `120` | HTTP request timeout, in seconds, for OpenAI-compatible providers. Invalid or non-positive values are ignored. |
 | `NANOBOT_WORKSPACE_SANDBOX_ENFORCED` | unset | Marks that an external workspace sandbox is already enforced. Truthy values (`1`, `true`, `yes`, `on`, `enabled`) use `NANOBOT_WORKSPACE_SANDBOX_PROVIDER` as the label; any other non-false value is treated as the provider name. |

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -824,16 +824,17 @@ class AgentRunner:
             )
         except asyncio.TimeoutError:
             if outer_timeout_s is None:
-                return LLMResponse(
+                response = LLMResponse(
                     content="Error calling LLM: stream stalled",
                     finish_reason="error",
                     error_kind="timeout",
                 )
-            return LLMResponse(
-                content=f"Error calling LLM: timed out after {outer_timeout_s:g}s",
-                finish_reason="error",
-                error_kind="timeout",
-            )
+            else:
+                response = LLMResponse(
+                    content=f"Error calling LLM: timed out after {outer_timeout_s:g}s",
+                    finish_reason="error",
+                    error_kind="timeout",
+                )
         if progress_state and progress_state.get("reasoning_open"):
             await hook.emit_reasoning_end()
         dropped, all_dropped, original_finish_reason = (

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -806,11 +806,17 @@ class AgentRunner:
         else:
             coro = spec.runtime.provider.chat_with_retry(**kwargs)
 
-        # Streaming requests already have provider-level idle timeouts
-        # (NANOBOT_STREAM_IDLE_TIMEOUT_S). Do not also apply the outer wall-clock
-        # LLM timeout here, or healthy long reasoning streams can be killed just
-        # because total elapsed time exceeded NANOBOT_LLM_TIMEOUT_S.
-        outer_timeout_s = None if (wants_streaming or wants_progress_streaming) else timeout_s
+        # Streaming requests also have provider-level idle timeouts
+        # (NANOBOT_STREAM_IDLE_TIMEOUT_S), but a stream that keeps producing
+        # very slow deltas can still run forever. Use a more generous wall-clock
+        # timeout for streaming while preserving NANOBOT_LLM_TIMEOUT_S=0 as an
+        # opt-out for all LLM wall-clock timeouts.
+        is_streaming_request = wants_streaming or wants_progress_streaming
+        outer_timeout_s = (
+            max(300.0, timeout_s * 2)
+            if is_streaming_request and timeout_s is not None
+            else timeout_s
+        )
         try:
             response = (
                 await coro if outer_timeout_s is None

--- a/tests/agent/test_runner_core.py
+++ b/tests/agent/test_runner_core.py
@@ -189,7 +189,7 @@ async def test_runner_times_out_hung_llm_request():
 
 
 @pytest.mark.asyncio
-async def test_runner_does_not_apply_outer_wall_timeout_to_streaming_requests():
+async def test_runner_applies_outer_wall_timeout_to_streaming_requests():
     from nanobot.agent.hook import AgentHook, AgentHookContext
     from nanobot.agent.runner import AgentRunner
 
@@ -216,8 +216,13 @@ async def test_runner_does_not_apply_outer_wall_timeout_to_streaming_requests():
             streamed.append(delta)
 
     runner = AgentRunner()
-    wait_for = AsyncMock(side_effect=AssertionError("streaming path must not use wait_for"))
-    with patch("nanobot.agent.runner.asyncio.wait_for", wait_for):
+    wait_for_calls: list[float] = []
+
+    async def fake_wait_for(coro, *, timeout):
+        wait_for_calls.append(timeout)
+        return await coro
+
+    with patch("nanobot.agent.runner.asyncio.wait_for", fake_wait_for):
         result = await runner.run(make_run_spec(provider,
             initial_messages=[{"role": "user", "content": "think for a while"}],
             tools=tools,
@@ -232,7 +237,47 @@ async def test_runner_does_not_apply_outer_wall_timeout_to_streaming_requests():
     assert result.final_content == "still alive"
     assert streamed == ["still ", "alive"]
     provider.chat_with_retry.assert_not_awaited()
-    wait_for.assert_not_awaited()
+    assert wait_for_calls == [300.0]
+
+
+@pytest.mark.asyncio
+async def test_runner_times_out_never_ending_streaming_request():
+    from nanobot.agent.hook import AgentHook
+    from nanobot.agent.runner import AgentRunner
+
+    provider = MagicMock(spec=LLMProvider)
+
+    async def chat_stream_with_retry(*, on_content_delta, **kwargs):
+        await asyncio.sleep(3600)
+
+    provider.chat_stream_with_retry = chat_stream_with_retry
+    provider.chat_with_retry = AsyncMock()
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+
+    class StreamingHook(AgentHook):
+        def wants_streaming(self) -> bool:
+            return True
+
+    async def fake_wait_for(coro, *, timeout):
+        coro.close()
+        raise asyncio.TimeoutError
+
+    runner = AgentRunner()
+    with patch("nanobot.agent.runner.asyncio.wait_for", fake_wait_for):
+        result = await runner.run(make_run_spec(provider,
+            initial_messages=[{"role": "user", "content": "think forever"}],
+            tools=tools,
+            model="test-model",
+            max_iterations=1,
+            max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+            hook=StreamingHook(),
+            llm_timeout_s=200,
+        ))
+
+    assert result.stop_reason == "error"
+    assert result.final_content == "Error calling LLM: timed out after 400s"
+    provider.chat_with_retry.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_runner_core.py
+++ b/tests/agent/test_runner_core.py
@@ -281,6 +281,65 @@ async def test_runner_times_out_never_ending_streaming_request():
 
 
 @pytest.mark.asyncio
+async def test_runner_closes_progress_reasoning_on_streaming_wall_timeout():
+    from nanobot.agent.hook import AgentHook
+    from nanobot.agent.runner import AgentRunner
+
+    provider = MagicMock(spec=LLMProvider)
+    provider.supports_progress_deltas = True
+    events: list[tuple[str, str | None]] = []
+
+    async def chat_stream_with_retry(*, on_content_delta, **kwargs):
+        try:
+            await on_content_delta("<think>working...</think>")
+            await asyncio.sleep(3600)
+        finally:
+            events.append(("provider_cancelled", None))
+
+    provider.chat_stream_with_retry = chat_stream_with_retry
+    provider.chat_with_retry = AsyncMock()
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+
+    class ProgressReasoningHook(AgentHook):
+        async def emit_reasoning(self, reasoning_content: str | None) -> None:
+            if reasoning_content:
+                events.append(("reasoning", reasoning_content))
+
+        async def emit_reasoning_end(self) -> None:
+            events.append(("reasoning_end", None))
+
+    real_wait_for = asyncio.wait_for
+
+    async def fake_wait_for(coro, *, timeout):
+        assert timeout == 300.0
+        return await real_wait_for(coro, timeout=0.01)
+
+    runner = AgentRunner()
+    with patch("nanobot.agent.runner.asyncio.wait_for", fake_wait_for):
+        result = await runner.run(make_run_spec(provider,
+            initial_messages=[{"role": "user", "content": "think forever"}],
+            tools=tools,
+            model="test-model",
+            max_iterations=1,
+            max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+            hook=ProgressReasoningHook(),
+            progress_callback=AsyncMock(),
+            stream_progress_deltas=True,
+            llm_timeout_s=1,
+        ))
+
+    assert result.stop_reason == "error"
+    assert result.final_content == "Error calling LLM: timed out after 300s"
+    assert events == [
+        ("reasoning", "working..."),
+        ("provider_cancelled", None),
+        ("reasoning_end", None),
+    ]
+    provider.chat_with_retry.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_runner_replaces_empty_tool_result_with_marker():
     from nanobot.agent.runner import AgentRunner
 


### PR DESCRIPTION
## Summary
- Fixes #4795
- apply a finite wall-clock timeout to streaming and progress-streaming LLM requests
- preserve timeout opt-out behavior when `NANOBOT_LLM_TIMEOUT_S=0`
- update runner tests for streaming timeout wrapping and timeout errors

## Tests
- `uv run pytest tests/agent/test_runner_core.py -q`
- `uv run ruff check nanobot/agent/runner.py tests/agent/test_runner_core.py`