### PR TITLE
fix(dream): ignore line-ending-only memory diffs

### DIFF
--- a/nanobot/utils/gitstore.py
+++ b/nanobot/utils/gitstore.py
@@ -356,7 +356,7 @@ class GitStore:
                     wt_path = self._workspace / path
                     try:
                         wt_text = (
-                            wt_path.read_text(encoding="utf-8")
+                            wt_path.read_bytes().decode("utf-8")
                             if wt_path.exists()
                             else ""
                         )
@@ -368,12 +368,12 @@ class GitStore:
                         changed += 1
                         summary_lines.append(f"{path}: binary or non-UTF-8 file changed")
                         continue
-                    # Git blobs preserve line endings while read_text() normalizes
-                    # them. Compare the same logical lines used by the diff.
+                    # Treat CRLF and LF as equivalent without hiding other
+                    # newline changes, such as a missing final newline.
+                    if head_text.replace("\r\n", "\n") == wt_text.replace("\r\n", "\n"):
+                        continue
                     head_lines = head_text.splitlines()
                     wt_lines = wt_text.splitlines()
-                    if head_lines == wt_lines:
-                        continue
                     changed += 1
                     hunks = list(difflib.unified_diff(
                         head_lines,

--- a/nanobot/utils/gitstore.py
+++ b/nanobot/utils/gitstore.py
@@ -368,12 +368,16 @@ class GitStore:
                         changed += 1
                         summary_lines.append(f"{path}: binary or non-UTF-8 file changed")
                         continue
-                    if head_text == wt_text:
+                    # Git blobs preserve line endings while read_text() normalizes
+                    # them. Compare the same logical lines used by the diff.
+                    head_lines = head_text.splitlines()
+                    wt_lines = wt_text.splitlines()
+                    if head_lines == wt_lines:
                         continue
                     changed += 1
                     hunks = list(difflib.unified_diff(
-                        head_text.splitlines(),
-                        wt_text.splitlines(),
+                        head_lines,
+                        wt_lines,
                         fromfile=path,
                         tofile=path,
                         lineterm="",

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -666,6 +666,37 @@ class TestDreamContentDiff:
         store.git.auto_commit("initial")
         assert store.dream_content_diff() == ""
 
+    def test_ignores_platform_line_ending_normalization(self, store, monkeypatch):
+        import subprocess
+
+        system_config = store.workspace / "system.gitconfig"
+        global_config = store.workspace / "global.gitconfig"
+        system_config.touch()
+        global_config.touch()
+        subprocess.run(
+            [
+                "git", "config", "--file", str(system_config),
+                "core.autocrlf", "false",
+            ],
+            check=True,
+            capture_output=True,
+        )
+        monkeypatch.delenv("GIT_CONFIG_NOSYSTEM", raising=False)
+        monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(system_config))
+        monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
+
+        store.soul_file.write_bytes(b"# Soul\r\n- Helpful")
+        store.memory_file.write_bytes(b"# Memory\r\n- Project X active")
+        store.git.init()
+
+        status = subprocess.check_output(
+            ["git", "status", "--porcelain", "--", "SOUL.md", "memory/MEMORY.md"],
+            cwd=store.workspace,
+            text=True,
+        )
+        assert status == ""
+        assert store.dream_content_diff() == ""
+
     def test_reflects_real_content_edits(self, store):
         store.git.init()
         store.git.auto_commit("initial")

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -697,6 +697,22 @@ class TestDreamContentDiff:
         assert status == ""
         assert store.dream_content_diff() == ""
 
+    @pytest.mark.parametrize(
+        ("before", "after", "changed"),
+        [
+            (b"# Memory\r\n", b"# Memory\n", False),
+            (b"# Memory\n", b"# Memory", True),
+            (b"# Memory\r", b"# Memory\n", True),
+        ],
+    )
+    def test_only_ignores_crlf_lf_changes(self, store, before, after, changed):
+        store.memory_file.write_bytes(before)
+        store.git.init()
+
+        store.memory_file.write_bytes(after)
+
+        assert bool(store.dream_content_diff()) is changed
+
     def test_reflects_real_content_edits(self, store):
         store.git.init()
         store.git.auto_commit("initial")


### PR DESCRIPTION
## Summary

- compare Dream memory content using the same logical lines used to render its unified diff
- ignore CRLF/LF representation differences when Git reports the tracked files as unchanged
- add a regression test with CRLF blobs and a clean native Git working tree

## Root cause

Git blobs preserve their original line endings, while Python's `read_text()` applies universal-newline normalization. The implementation compared those raw strings first, then generated its diff from `splitlines()`. A CRLF/LF-only mismatch therefore counted as a changed file even though the resulting diff contained zero additions and zero deletions.

This caused no-op Dream runs to be treated as productive and produced summaries such as `SOUL.md: +0 -0`.

Fixes #4882

## Validation

- `python -m pytest tests/agent/test_dream.py tests/utils/test_gitstore.py -q` (`57 passed`)
- `ruff check nanobot/utils/gitstore.py tests/agent/test_dream.py`
- `git diff --check`