### PR TITLE
fix(codex): align OAuth defaults and setup docs

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -287,9 +287,13 @@ remain accepted as no-op compatibility aliases.
 | Command | Description |
 |---|---|
 | `nanobot provider login openai-codex` | Authenticate OpenAI Codex provider |
+| `nanobot provider login openai-codex --set-main` | Authenticate Codex and select its current default model |
+| `nanobot provider login openai-codex --set-main --model openai-codex/gpt-5.6-sol` | Authenticate Codex and select a specific model |
 | `nanobot provider login github-copilot` | Authenticate GitHub Copilot provider |
 | `nanobot provider logout openai-codex` | Remove OpenAI Codex OAuth state |
 | `nanobot provider logout github-copilot` | Remove GitHub Copilot OAuth state |
+
+Add `--config <path>` when the selected provider/model should be written to a non-default config file. Passing `--model` also selects the provider as the active provider.
 
 See [`providers.md`](./providers.md#oauth-providers) for when OAuth providers need explicit provider/model selection.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -286,14 +286,10 @@ remain accepted as no-op compatibility aliases.
 
 | Command | Description |
 |---|---|
-| `nanobot provider login openai-codex` | Authenticate OpenAI Codex provider |
 | `nanobot provider login openai-codex --set-main` | Authenticate Codex and select its current default model |
-| `nanobot provider login openai-codex --set-main --model openai-codex/gpt-5.6-sol` | Authenticate Codex and select a specific model |
-| `nanobot provider login github-copilot` | Authenticate GitHub Copilot provider |
+| `nanobot provider login github-copilot --set-main` | Authenticate GitHub Copilot and select its current default model |
 | `nanobot provider logout openai-codex` | Remove OpenAI Codex OAuth state |
 | `nanobot provider logout github-copilot` | Remove GitHub Copilot OAuth state |
-
-Add `--config <path>` when the selected provider/model should be written to a non-default config file. Passing `--model` also selects the provider as the active provider.
 
 See [`providers.md`](./providers.md#oauth-providers) for when OAuth providers need explicit provider/model selection.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -662,14 +662,7 @@ nanobot agent -m "Reply with one short sentence."
 
 Codex uses OAuth instead of API keys. Requires a ChatGPT Plus or Pro account. `nanobot provider login` stores the OAuth session outside config. A `providers.openai_codex` block is optional and is only needed for provider-specific settings such as a proxy.
 
-**1. Login:**
-```bash
-nanobot provider login openai-codex
-```
-
-If the machine running nanobot cannot open a graphical browser, copy the printed URL into a real browser. For remote SSH login, open the URL locally, then paste the final `http://localhost:1455/auth/callback?...` redirect URL back into the terminal when prompted.
-
-**2. Optional proxy** (merge into `~/.nanobot/config.json` if Codex OAuth or Codex API traffic must use a proxy):
+**1. Optional proxy** (configure this before login if Codex OAuth or API traffic must use a proxy):
 
 ```json
 {
@@ -683,13 +676,28 @@ If the machine running nanobot cannot open a graphical browser, copy the printed
 
 The proxy applies to Codex OAuth token refresh, interactive token exchange, and Codex Responses API requests. It does not affect other providers; configure `proxy` separately on each supported provider that needs it.
 
-**3. Set model** (merge into `~/.nanobot/config.json`):
+**2. Login and select Codex:**
+
+```bash
+nanobot provider login openai-codex --set-main
+```
+
+This authenticates Codex and makes the current flagship model, `openai-codex/gpt-5.6-sol`, the active agent model. To choose another model from the Codex catalog, pass it explicitly:
+
+```bash
+nanobot provider login openai-codex --set-main --model openai-codex/gpt-5.6-sol
+```
+
+Omit `--set-main` when you only want to refresh the OAuth session without changing the active model. If the machine running nanobot cannot open a graphical browser, copy the printed URL into a real browser. For remote SSH login, open the URL locally, then paste the final `http://localhost:1455/auth/callback?...` redirect URL back into the terminal when prompted.
+
+**3. Named preset alternative** (merge into `~/.nanobot/config.json` when you prefer preset-based model switching):
+
 ```json
 {
   "modelPresets": {
     "codex": {
       "provider": "openai_codex",
-      "model": "gpt-5.1-codex",
+      "model": "openai-codex/gpt-5.6-sol",
       "reasoningEffort": "high"
     }
   },
@@ -701,7 +709,15 @@ The proxy applies to Codex OAuth token refresh, interactive token exchange, and 
 }
 ```
 
-Use `reasoningEffort` in the preset to send a Codex reasoning effort such as `"low"`, `"medium"`, `"high"`, or another value supported by the selected model. When `provider` is explicitly `openai_codex`, the model name does not need the `openai-codex/` prefix.
+Use `reasoningEffort` in the preset to send a Codex reasoning effort such as `"low"`, `"medium"`, `"high"`, or another value supported by the selected model.
+
+The similar-looking names have different roles:
+
+- `openai-codex` is the CLI login name and the canonical model prefix.
+- `openai_codex` is the provider ID used in config.
+- `openai/...` selects the direct OpenAI API provider; do not use that prefix with Codex OAuth.
+
+When `provider` is explicitly `openai_codex`, the model prefix is optional, so `gpt-5.6-sol` also works. The examples keep the `openai-codex/` prefix to make the route unambiguous.
 
 **4. Chat:**
 ```bash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -660,14 +660,14 @@ nanobot agent -m "Reply with one short sentence."
 <details>
 <summary><b>OpenAI Codex (OAuth)</b></summary>
 
-Codex uses OAuth instead of API keys. Requires a ChatGPT Plus or Pro account. `nanobot provider login` stores the OAuth session outside config. A `providers.openai_codex` block is optional and is only needed for provider-specific settings such as a proxy.
+Codex uses OAuth instead of API keys. Requires a ChatGPT Plus or Pro account. `nanobot provider login` stores the OAuth session outside config. A `providers.openaiCodex` block is optional and is only needed for provider-specific settings such as a proxy.
 
 **1. Optional proxy** (configure this before login if Codex OAuth or API traffic must use a proxy):
 
 ```json
 {
   "providers": {
-    "openai_codex": {
+    "openaiCodex": {
       "proxy": "http://127.0.0.1:7890"
     }
   }
@@ -714,8 +714,11 @@ Use `reasoningEffort` in the preset to send a Codex reasoning effort such as `"l
 The similar-looking names have different roles:
 
 - `openai-codex` is the CLI login name and the canonical model prefix.
-- `openai_codex` is the provider ID used in config.
+- `openaiCodex` is the settings key under `providers`, for example `providers.openaiCodex.proxy`.
+- `openai_codex` is the provider ID used as a `modelPresets.<name>.provider` value.
 - `openai/...` selects the direct OpenAI API provider; do not use that prefix with Codex OAuth.
+
+Do not keep both `openaiCodex` and `openai_codex` as keys under `providers`; they are aliases for the same built-in provider and duplicate entries are rejected.
 
 When `provider` is explicitly `openai_codex`, the model prefix is optional, so `gpt-5.6-sol` also works. The examples keep the `openai-codex/` prefix to make the route unambiguous.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -298,7 +298,7 @@ Tracing covers the providers that go through nanobot's OpenAI-compatible client 
 | `ovms` | LLM (local, OpenVINO Model Server) | [docs.openvino.ai](https://docs.openvino.ai/2026/model-server/ovms_docs_llm_quickstart.html) |
 | `vllm` | LLM (local, any OpenAI-compatible server) | — |
 | `nvidia` | LLM (NVIDIA NIM) | [build.nvidia.com](https://build.nvidia.com/) |
-| `openai_codex` | LLM (Codex, OAuth) | `nanobot provider login openai-codex` |
+| `openai_codex` | LLM (Codex, OAuth) | `nanobot provider login openai-codex --set-main` |
 | `github_copilot` | LLM (GitHub Copilot, OAuth) | `nanobot provider login github-copilot` |
 | `qianfan` | LLM (Baidu Qianfan) | [cloud.baidu.com](https://cloud.baidu.com/doc/qianfan/s/Hmh4suq26) |
 
@@ -660,80 +660,19 @@ nanobot agent -m "Reply with one short sentence."
 <details>
 <summary><b>OpenAI Codex (OAuth)</b></summary>
 
-Codex uses OAuth instead of API keys. Requires a ChatGPT Plus or Pro account. `nanobot provider login` stores the OAuth session outside config. A `providers.openaiCodex` block is optional and is only needed for provider-specific settings such as a proxy.
-
-**1. Optional proxy** (configure this before login if Codex OAuth or API traffic must use a proxy):
-
-```json
-{
-  "providers": {
-    "openaiCodex": {
-      "proxy": "http://127.0.0.1:7890"
-    }
-  }
-}
-```
-
-The proxy applies to Codex OAuth token refresh, interactive token exchange, and Codex Responses API requests. It does not affect other providers; configure `proxy` separately on each supported provider that needs it.
-
-**2. Login and select Codex:**
+Codex uses OAuth instead of API keys and requires a ChatGPT Plus or Pro account. Authenticate it and make the current flagship model the active agent model with one command:
 
 ```bash
 nanobot provider login openai-codex --set-main
 ```
 
-This authenticates Codex and makes the current flagship model, `openai-codex/gpt-5.6-sol`, the active agent model. To choose another model from the Codex catalog, pass it explicitly:
+Then run:
 
-```bash
-nanobot provider login openai-codex --set-main --model openai-codex/gpt-5.6-sol
-```
-
-Omit `--set-main` when you only want to refresh the OAuth session without changing the active model. If the machine running nanobot cannot open a graphical browser, copy the printed URL into a real browser. For remote SSH login, open the URL locally, then paste the final `http://localhost:1455/auth/callback?...` redirect URL back into the terminal when prompted.
-
-**3. Named preset alternative** (merge into `~/.nanobot/config.json` when you prefer preset-based model switching):
-
-```json
-{
-  "modelPresets": {
-    "codex": {
-      "provider": "openai_codex",
-      "model": "openai-codex/gpt-5.6-sol",
-      "reasoningEffort": "high"
-    }
-  },
-  "agents": {
-    "defaults": {
-      "modelPreset": "codex"
-    }
-  }
-}
-```
-
-Use `reasoningEffort` in the preset to send a Codex reasoning effort such as `"low"`, `"medium"`, `"high"`, or another value supported by the selected model.
-
-The similar-looking names have different roles:
-
-- `openai-codex` is the CLI login name and the canonical model prefix.
-- `openaiCodex` is the settings key under `providers`, for example `providers.openaiCodex.proxy`.
-- `openai_codex` is the provider ID used as a `modelPresets.<name>.provider` value.
-- `openai/...` selects the direct OpenAI API provider; do not use that prefix with Codex OAuth.
-
-Do not keep both `openaiCodex` and `openai_codex` as keys under `providers`; they are aliases for the same built-in provider and duplicate entries are rejected.
-
-When `provider` is explicitly `openai_codex`, the model prefix is optional, so `gpt-5.6-sol` also works. The examples keep the `openai-codex/` prefix to make the route unambiguous.
-
-**4. Chat:**
 ```bash
 nanobot agent -m "Hello!"
-
-# Target a specific workspace/config locally
-nanobot agent -c ~/.nanobot-telegram/config.json -m "Hello!"
-
-# One-off workspace override on top of that config
-nanobot agent -c ~/.nanobot-telegram/config.json -w /tmp/nanobot-telegram-test -m "Hello!"
 ```
 
-> Docker users: use `docker run -it` for interactive OAuth login.
+For proxy, remote/headless login, model-name, or config-key errors, see [`troubleshooting.md`](./troubleshooting.md#provider-and-model-problems).
 
 </details>
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -418,41 +418,19 @@ See [`configuration.md#providers`](./configuration.md#providers) for Bedrock-spe
 
 Some providers do not use API keys in `config.json`.
 
+For OpenAI Codex:
+
 ```bash
-# Choose one OAuth provider:
 nanobot provider login openai-codex --set-main
+```
+
+For GitHub Copilot:
+
+```bash
 nanobot provider login github-copilot --set-main
 ```
 
-`--set-main` authenticates the provider and selects its current default model. Add `--model <model-id>` to choose a model explicitly, or omit `--set-main` when you only want to refresh the OAuth session. If you configure manually, select the OAuth provider and model explicitly in a preset; OAuth providers are not valid automatic fallbacks.
-
-For OpenAI Codex, add `providers.openaiCodex.proxy` before running the login command when OAuth/token refresh or Codex API requests must use a proxy:
-
-```json
-{
-  "providers": {
-    "openaiCodex": {
-      "proxy": "http://127.0.0.1:7890"
-    }
-  },
-  "modelPresets": {
-    "codex": {
-      "provider": "openai_codex",
-      "model": "openai-codex/gpt-5.6-sol",
-      "reasoningEffort": "high"
-    }
-  },
-  "agents": {
-    "defaults": {
-      "modelPreset": "codex"
-    }
-  }
-}
-```
-
-For Codex, `openai-codex` is the CLI login name and canonical model prefix, `openaiCodex` is the settings key under `providers`, and `openai_codex` is the provider ID used in a model preset. Do not keep both spellings as keys under `providers`, and do not use an `openai/...` model with `provider: "openai_codex"`; that prefix belongs to the direct OpenAI API provider. With the provider set explicitly, a bare Codex model such as `gpt-5.6-sol` is also accepted.
-
-If you run the login command on a remote/headless machine and open the authorization URL in a local browser, paste the final `http://localhost:1455/auth/callback?...` redirect URL back into the terminal when prompted. See [`configuration.md#providers`](./configuration.md#providers) for the full OAuth provider notes.
+Each command authenticates the selected provider and makes its current default model active. OAuth providers are not valid automatic fallbacks. See [`troubleshooting.md`](./troubleshooting.md#provider-and-model-problems) for proxy, headless-login, model-name, and config-key errors.
 
 ## Provider Resolution
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -426,12 +426,12 @@ nanobot provider login github-copilot --set-main
 
 `--set-main` authenticates the provider and selects its current default model. Add `--model <model-id>` to choose a model explicitly, or omit `--set-main` when you only want to refresh the OAuth session. If you configure manually, select the OAuth provider and model explicitly in a preset; OAuth providers are not valid automatic fallbacks.
 
-For OpenAI Codex, add `providers.openai_codex.proxy` before running the login command when OAuth/token refresh or Codex API requests must use a proxy:
+For OpenAI Codex, add `providers.openaiCodex.proxy` before running the login command when OAuth/token refresh or Codex API requests must use a proxy:
 
 ```json
 {
   "providers": {
-    "openai_codex": {
+    "openaiCodex": {
       "proxy": "http://127.0.0.1:7890"
     }
   },
@@ -450,7 +450,7 @@ For OpenAI Codex, add `providers.openai_codex.proxy` before running the login co
 }
 ```
 
-For Codex, `openai-codex` is the CLI login name and canonical model prefix, while `openai_codex` is the config provider ID. Do not use an `openai/...` model with `provider: "openai_codex"`; that prefix belongs to the direct OpenAI API provider. With the provider set explicitly, a bare Codex model such as `gpt-5.6-sol` is also accepted.
+For Codex, `openai-codex` is the CLI login name and canonical model prefix, `openaiCodex` is the settings key under `providers`, and `openai_codex` is the provider ID used in a model preset. Do not keep both spellings as keys under `providers`, and do not use an `openai/...` model with `provider: "openai_codex"`; that prefix belongs to the direct OpenAI API provider. With the provider set explicitly, a bare Codex model such as `gpt-5.6-sol` is also accepted.
 
 If you run the login command on a remote/headless machine and open the authorization URL in a local browser, paste the final `http://localhost:1455/auth/callback?...` redirect URL back into the terminal when prompted. See [`configuration.md#providers`](./configuration.md#providers) for the full OAuth provider notes.
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -419,13 +419,14 @@ See [`configuration.md#providers`](./configuration.md#providers) for Bedrock-spe
 Some providers do not use API keys in `config.json`.
 
 ```bash
-nanobot provider login openai-codex
-nanobot provider login github-copilot
+# Choose one OAuth provider:
+nanobot provider login openai-codex --set-main
+nanobot provider login github-copilot --set-main
 ```
 
-Then explicitly select the provider and model in a preset. OAuth providers are not valid automatic fallbacks.
+`--set-main` authenticates the provider and selects its current default model. Add `--model <model-id>` to choose a model explicitly, or omit `--set-main` when you only want to refresh the OAuth session. If you configure manually, select the OAuth provider and model explicitly in a preset; OAuth providers are not valid automatic fallbacks.
 
-For OpenAI Codex, add `providers.openai_codex.proxy` only when Codex OAuth/token refresh or Codex API requests must use a proxy:
+For OpenAI Codex, add `providers.openai_codex.proxy` before running the login command when OAuth/token refresh or Codex API requests must use a proxy:
 
 ```json
 {
@@ -437,7 +438,7 @@ For OpenAI Codex, add `providers.openai_codex.proxy` only when Codex OAuth/token
   "modelPresets": {
     "codex": {
       "provider": "openai_codex",
-      "model": "gpt-5.1-codex",
+      "model": "openai-codex/gpt-5.6-sol",
       "reasoningEffort": "high"
     }
   },
@@ -448,6 +449,8 @@ For OpenAI Codex, add `providers.openai_codex.proxy` only when Codex OAuth/token
   }
 }
 ```
+
+For Codex, `openai-codex` is the CLI login name and canonical model prefix, while `openai_codex` is the config provider ID. Do not use an `openai/...` model with `provider: "openai_codex"`; that prefix belongs to the direct OpenAI API provider. With the provider set explicitly, a bare Codex model such as `gpt-5.6-sol` is also accepted.
 
 If you run the login command on a remote/headless machine and open the authorization URL in a local browser, paste the final `http://localhost:1455/auth/callback?...` redirect URL back into the terminal when prompted. See [`configuration.md#providers`](./configuration.md#providers) for the full OAuth provider notes.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -136,6 +136,7 @@ If you need a known-good snippet instead of diagnosis, use [`provider-cookbook.m
 | Local model connection refused | Ollama, vLLM, LM Studio, or another local server is not running, or `apiBase` points to the wrong port. |
 | Bedrock validation error | Check AWS region, credentials, model access, model ID, and whether the model supports Converse. |
 | OAuth provider fails | Run `nanobot provider login openai-codex` or `nanobot provider login github-copilot`, then select the provider explicitly. |
+| Codex says a model is not supported with a ChatGPT account | Use provider `openai_codex` with a Codex model such as `openai-codex/gpt-5.6-sol`. Do not use the direct-API `openai/...` prefix with Codex OAuth. |
 
 ## Langfuse Problems
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -137,6 +137,7 @@ If you need a known-good snippet instead of diagnosis, use [`provider-cookbook.m
 | Bedrock validation error | Check AWS region, credentials, model access, model ID, and whether the model supports Converse. |
 | OAuth provider fails | Run `nanobot provider login openai-codex` or `nanobot provider login github-copilot`, then select the provider explicitly. |
 | Codex says a model is not supported with a ChatGPT account | Use provider `openai_codex` with a Codex model such as `openai-codex/gpt-5.6-sol`. Do not use the direct-API `openai/...` prefix with Codex OAuth. |
+| Config says `providers.openai_codex` conflicts with the built-in provider | Under `providers`, keep only the canonical `openaiCodex` settings key and remove a duplicate `openai_codex` key. A model preset's `provider` value remains `openai_codex`. |
 
 ## Langfuse Problems
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -135,7 +135,10 @@ If you need a known-good snippet instead of diagnosis, use [`provider-cookbook.m
 | Provider cannot be inferred | Pin `modelPresets.<name>.provider` in the active preset instead of using `"auto"`. For legacy direct configs, pin `agents.defaults.provider`. |
 | Local model connection refused | Ollama, vLLM, LM Studio, or another local server is not running, or `apiBase` points to the wrong port. |
 | Bedrock validation error | Check AWS region, credentials, model access, model ID, and whether the model supports Converse. |
-| OAuth provider fails | Run `nanobot provider login openai-codex` or `nanobot provider login github-copilot`, then select the provider explicitly. |
+| OAuth provider fails | Run `nanobot provider login openai-codex --set-main` or `nanobot provider login github-copilot --set-main`. |
+| Codex OAuth needs a proxy | Set `providers.openaiCodex.proxy` before running the login command. The proxy applies to login, token refresh, and Codex API requests. |
+| Codex login runs on a remote/headless machine | Open the printed URL in a local browser, then paste the final `http://localhost:1455/auth/callback?...` URL back into the terminal. |
+| Codex login runs in Docker | Start the container with `docker run -it` so the OAuth flow has an interactive terminal. |
 | Codex says a model is not supported with a ChatGPT account | Use provider `openai_codex` with a Codex model such as `openai-codex/gpt-5.6-sol`. Do not use the direct-API `openai/...` prefix with Codex OAuth. |
 | Config says `providers.openai_codex` conflicts with the built-in provider | Under `providers`, keep only the canonical `openaiCodex` settings key and remove a duplicate `openai_codex` key. A model preset's `provider` value remains `openai_codex`. |
 

--- a/docs/webui.md
+++ b/docs/webui.md
@@ -205,12 +205,6 @@ the relevant control.
 Browser-only display preferences, such as file edit display mode, take effect
 immediately for the current browser and do not change gateway configuration.
 
-To use OpenAI Codex, open **Settings → Providers**, select **OpenAI Codex**, and
-complete OAuth sign-in. Then open **Settings → Models**, create or edit a model
-configuration, choose **OpenAI Codex** as the provider, and select a model from
-the built-in catalog. Both OAuth sign-in and an active Codex model configuration
-are required; no API key is stored in `config.json`.
-
 ## LAN Access
 
 To open the WebUI from another device on the same network, bind the WebSocket

--- a/docs/webui.md
+++ b/docs/webui.md
@@ -205,6 +205,12 @@ the relevant control.
 Browser-only display preferences, such as file edit display mode, take effect
 immediately for the current browser and do not change gateway configuration.
 
+To use OpenAI Codex, open **Settings → Providers**, select **OpenAI Codex**, and
+complete OAuth sign-in. Then open **Settings → Models**, create or edit a model
+configuration, choose **OpenAI Codex** as the provider, and select a model from
+the built-in catalog. Both OAuth sign-in and an active Codex model configuration
+are required; no API key is stored in `config.json`.
+
 ## LAN Access
 
 To open the WebUI from another device on the same network, bind the WebSocket

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -2646,7 +2646,7 @@ _PROVIDER_DISPLAY: dict[str, str] = {
 }
 
 _OAUTH_PROVIDER_DEFAULT_MODELS: dict[str, str] = {
-    "openai_codex": "openai-codex/gpt-5.4-mini",
+    "openai_codex": "openai-codex/gpt-5.6-sol",
     "github_copilot": "github-copilot/gpt-5.4-mini",
 }
 

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -35,7 +35,7 @@ class OpenAICodexProvider(LLMProvider):
 
     def __init__(
         self,
-        default_model: str = "openai-codex/gpt-5.1-codex",
+        default_model: str = "openai-codex/gpt-5.6-sol",
         proxy: str | None = None,
     ):
         super().__init__(api_key=None, api_base=None)

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -450,9 +450,19 @@ def test_config_matches_github_copilot_codex_with_hyphen_prefix():
 
 def test_config_matches_openai_codex_with_hyphen_prefix():
     config = Config()
-    config.agents.defaults.model = "openai-codex/gpt-5.1-codex"
+    config.agents.defaults.model = "openai-codex/gpt-5.6-sol"
 
     assert config.get_provider_name() == "openai_codex"
+
+
+def test_openai_codex_oauth_default_matches_curated_flagship():
+    spec = find_by_name("openai_codex")
+
+    assert spec is not None
+    assert spec.builtin_models
+    assert cli_commands._OAUTH_PROVIDER_DEFAULT_MODELS["openai_codex"] == (
+        spec.builtin_models[0].id
+    )
 
 
 def test_config_dump_excludes_oauth_provider_blocks():
@@ -605,7 +615,7 @@ def test_provider_login_can_set_openai_codex_as_main_provider(tmp_path):
 
     saved = Config.model_validate(json.loads(config_path.read_text(encoding="utf-8")))
     assert saved.agents.defaults.provider == "openai_codex"
-    assert saved.agents.defaults.model == "openai-codex/gpt-5.4-mini"
+    assert saved.agents.defaults.model == "openai-codex/gpt-5.6-sol"
     assert saved.agents.defaults.model_preset is None
     assert make_provider(saved).__class__.__name__ == "OpenAICodexProvider"
 
@@ -1071,8 +1081,8 @@ async def test_github_copilot_provider_refreshes_client_api_key_before_chat():
 
 
 def test_openai_codex_strip_prefix_supports_hyphen_and_underscore():
-    assert _strip_model_prefix("openai-codex/gpt-5.1-codex") == "gpt-5.1-codex"
-    assert _strip_model_prefix("openai_codex/gpt-5.1-codex") == "gpt-5.1-codex"
+    assert _strip_model_prefix("openai-codex/gpt-5.6-sol") == "gpt-5.6-sol"
+    assert _strip_model_prefix("openai_codex/gpt-5.6-sol") == "gpt-5.6-sol"
 
 
 def test_make_provider_passes_extra_headers_to_custom_provider():

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -18,6 +18,7 @@ from nanobot.providers.openai_codex_provider import (
     _request_codex,
     _should_retry_status,
 )
+from nanobot.providers.registry import find_by_name
 
 
 def _mock_codex_token(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -28,6 +29,14 @@ def _mock_codex_token(monkeypatch: pytest.MonkeyPatch) -> None:
         "nanobot.providers.openai_codex_provider.get_codex_token",
         fake_token,
     )
+
+
+def test_codex_default_model_matches_curated_flagship() -> None:
+    spec = find_by_name("openai_codex")
+
+    assert spec is not None
+    assert spec.builtin_models
+    assert OpenAICodexProvider().get_default_model() == spec.builtin_models[0].id
 
 
 class _WarningCaptureLogger:

--- a/tests/webui/test_settings_api.py
+++ b/tests/webui/test_settings_api.py
@@ -1220,7 +1220,7 @@ def test_create_model_configuration_accepts_configured_oauth_provider(
         {
             "label": ["Codex"],
             "provider": ["openai_codex"],
-            "model": ["openai-codex/gpt-5.1-codex"],
+            "model": ["openai-codex/gpt-5.6-sol"],
         }
     )
 


### PR DESCRIPTION
## Summary

- make `openai-codex/gpt-5.6-sol` the Codex provider and OAuth `--set-main` default, matching the first curated flagship model
- document the recommended one-command login flow, proxy-before-login ordering, Codex provider/model naming, WebUI setup, and the `openai/...` prefix pitfall
- add regression coverage that keeps the runtime and CLI defaults aligned with the curated Codex catalog

## Testing

- `python -m pytest tests/providers/test_openai_codex_provider.py tests/cli/test_commands.py tests/webui/test_settings_api.py -q` (`199 passed, 1 skipped`)
- `ruff check nanobot/cli/commands.py nanobot/providers/openai_codex_provider.py tests/cli/test_commands.py tests/providers/test_openai_codex_provider.py tests/webui/test_settings_api.py`
- `git diff --check`

Closes #1304