### PR TITLE
docs: update recent changes through July 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ Highlights:
 
 ## Recent Updates
 
-- **2026-07-12** Explicit `/goal` activation, lifecycle-safe runtime context, safer workspace access changes.
-- **2026-07-11** Syntax-highlighted file previews and diffs, queued prompts, safer targeted edits.
-- **2026-07-10** Isolated model runtime routing, sturdier subprocess cleanup, broader multiline CLI support.
-- **2026-07-09** Live file-edit diff progress, tighter localhost bootstrap tokens, Matrix image fixes.
-- **2026-07-08** Safer WebUI/API bootstrap, non-interactive onboard refresh, responsive prompt rail.
+- **2026-07-12** Explicit `/goal` activation, safer runtime and workspace access.
+- **2026-07-11** Syntax-highlighted previews and diffs, queued prompts, safer edits.
+- **2026-07-10** Stable model routing, multiline CLI input, new automation guide.
+- **2026-07-09** Live file-edit diffs, safer localhost setup, Matrix image fixes.
+- **2026-07-08** Safer WebUI/API setup, onboard refresh, responsive prompt rail.
 
 For older updates, see the [release archive](./docs/release-archive.md) or [GitHub releases](https://github.com/HKUDS/nanobot/releases).
 

--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ Highlights:
 
 ## Recent Updates
 
-- **2026-06-21** Python SDK runtime controls, optional Keenable key, cleaner run hooks.
-- **2026-06-20** Telegram rich messages, safer SDK concurrency, smoother Quick Start.
-- **2026-06-19** Firecrawl app, OpenAI image edits, safer session deletion.
-- **2026-06-18** Feishu recovery, Keenable search, Mistral polish, workspace-aware git.
-- **2026-06-17** Default idle auto-compact, clearer `/dream`, macOS installer fixes.
+- **2026-07-12** Explicit `/goal` activation, lifecycle-safe runtime context, safer workspace access changes.
+- **2026-07-11** Syntax-highlighted file previews and diffs, queued prompts, safer targeted edits.
+- **2026-07-10** Isolated model runtime routing, sturdier subprocess cleanup, broader multiline CLI support.
+- **2026-07-09** Live file-edit diff progress, tighter localhost bootstrap tokens, Matrix image fixes.
+- **2026-07-08** Safer WebUI/API bootstrap, non-interactive onboard refresh, responsive prompt rail.
 
 For older updates, see the [release archive](./docs/release-archive.md) or [GitHub releases](https://github.com/HKUDS/nanobot/releases).
 

--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ Highlights:
 
 ## Recent Updates
 
-- **2026-07-12** Explicit `/goal` activation, lifecycle-safe runtime context, safer workspace access changes.
-- **2026-07-11** Syntax-highlighted file previews and diffs, queued prompts, safer targeted edits.
-- **2026-07-10** Isolated model runtime routing, sturdier subprocess cleanup, broader multiline CLI support.
-- **2026-07-09** Live file-edit diff progress, tighter localhost bootstrap tokens, Matrix image fixes.
-- **2026-07-08** Safer WebUI/API bootstrap, non-interactive onboard refresh, responsive prompt rail.
+- **2026-07-12** Safer workspace scope restoration and access reduction, lifecycle-bound runtime context.
+- **2026-07-11** Explicit `/goal` activation, persistent runtime context, request metadata, cleaner MCP ownership.
+- **2026-07-10** Syntax-highlighted file previews and diffs, queued prompts, isolated model runtime routing.
+- **2026-07-09** Tighter localhost bootstrap tokens, Matrix image fixes, fuller file-preview access handling.
+- **2026-07-08** Live file-edit diff progress, safer WebUI bootstrap, non-interactive onboard refresh.
 
 For older updates, see the [release archive](./docs/release-archive.md) or [GitHub releases](https://github.com/HKUDS/nanobot/releases).
 

--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ Highlights:
 
 ## Recent Updates
 
-- **2026-07-12** Safer workspace scope restoration and access reduction, lifecycle-bound runtime context.
-- **2026-07-11** Explicit `/goal` activation, persistent runtime context, request metadata, cleaner MCP ownership.
-- **2026-07-10** Syntax-highlighted file previews and diffs, queued prompts, isolated model runtime routing.
-- **2026-07-09** Tighter localhost bootstrap tokens, Matrix image fixes, fuller file-preview access handling.
-- **2026-07-08** Live file-edit diff progress, safer WebUI bootstrap, non-interactive onboard refresh.
+- **2026-07-12** Explicit `/goal` activation, lifecycle-safe runtime context, safer workspace access changes.
+- **2026-07-11** Syntax-highlighted file previews and diffs, queued prompts, safer targeted edits.
+- **2026-07-10** Isolated model runtime routing, sturdier subprocess cleanup, broader multiline CLI support.
+- **2026-07-09** Live file-edit diff progress, tighter localhost bootstrap tokens, Matrix image fixes.
+- **2026-07-08** Safer WebUI/API bootstrap, non-interactive onboard refresh, responsive prompt rail.
 
 For older updates, see the [release archive](./docs/release-archive.md) or [GitHub releases](https://github.com/HKUDS/nanobot/releases).
 

--- a/docs/release-archive.md
+++ b/docs/release-archive.md
@@ -6,26 +6,23 @@ For tagged releases, see [GitHub Releases](https://github.com/HKUDS/nanobot/rele
 
 ## Highlights
 
-- **2026-07-12** 🔒 Safer workspace scope restoration and access reduction, lifecycle-bound runtime context.
-- **2026-07-11** 🎯 Explicit `/goal` activation, persistent runtime context, request metadata, cleaner MCP and Dream ownership.
-- **2026-07-10** 📝 Syntax-highlighted file previews and diffs, queued prompts, isolated model runtime routing, quieter Dream commits.
-- **2026-07-09** 🔐 Tighter localhost bootstrap tokens, Matrix image fixes, fuller file-preview access handling, MCP reconnect coverage.
-- **2026-07-08** 🛠️ Live file-edit diff progress, safer WebUI bootstrap, non-interactive onboard refresh, configurable Docker extras.
-- **2026-07-07** 🛡️ Sturdier subprocess cleanup, responsive prompt rails, safer API setup and web fetches, broader CLI multiline input.
-- **2026-07-06** 💬 Reliable slash-command lifecycles, refreshed gateway state paths, Feishu new-session dividers.
-- **2026-07-05** 📱 Mobile WebUI containment, bounded MCP tool names, safer proxied fetches, clearer Serper and OAuth errors.
-- **2026-07-04** 💬 Sturdier Mattermost streaming, narrow-screen WebUI fixes, safer Windows gateway shutdown.
-- **2026-07-03** 🧙 Safe WebUI first-run launcher, optional plugin controls, canonical OpenCode, Claude Sonnet 4.6, resilient MCP reconnects.
-- **2026-07-02** 🛡️ Guarded file-edit targets, DNS-pinned web fetches, durable pairing writes, recoverable local-trigger audits.
-- **2026-07-01** ⌨️ CLI multiline input, pending local triggers, `$skill` shortcuts, typed channel events, structured tool errors.
-- **2026-06-30** ⏰ Workspace Dream prompts, session-bound local triggers, Copilot Enterprise endpoints, explicit restart modes.
-- **2026-06-29** 🌐 Per-provider proxies, WhatsApp read receipts, redacted MCP credentials, context replay scaled to model windows.
-- **2026-06-28** 🔄 Refreshed OAuth provider defaults, reliable Weixin streaming, sturdier WebUI reconnects, malformed tool-call protection.
-- **2026-06-27** 🪟 Self-healing gateway state, PowerShell-first Windows exec, authenticated non-local APIs, safer session migration.
-- **2026-06-26** 🖼️ MCP image artifacts, collision-safe sessions, a Neonize-based WhatsApp backend, leaner Docker images.
-- **2026-06-25** 🔒 Hardened shell allowlists, non-login exec defaults, opt-in Telegram rich messages, restored code-block copying.
-- **2026-06-24** 🎛️ OpenCode Zen/Go, configurable thinking styles and subagent failure handling, MiMo voice input, steadier reasoning streams.
-- **2026-06-23** 🌙 Kimi Coding Plan, safer Anthropic tool-call IDs, Mattermost file and mobile fixes, iOS WebUI input polish.
+- **2026-07-12** 🎯 Explicit `/goal` activation, lifecycle-safe runtime context, safer workspace access changes.
+- **2026-07-11** 🛠️ Syntax-highlighted file previews and diffs, queued prompts, safer targeted edits, quieter Dream commits.
+- **2026-07-10** 🧠 Isolated model runtime routing, sturdier subprocess cleanup, broader multiline CLI support, a new automation guide.
+- **2026-07-09** 📝 Live file-edit diff progress, tighter localhost bootstrap tokens, Matrix image fixes, configurable Docker extras.
+- **2026-07-08** 🔐 Safer WebUI/API bootstrap, non-interactive onboard refresh, responsive prompt rail, expanded chat app guides.
+- **2026-07-07** ⌨️ CLI multiline input, metadata-driven slash commands, DNS-pinned SSRF-safe web fetches.
+- **2026-07-06** 💬 Mattermost channel, Serper search, canonical OpenCode, safer Windows shells, mobile WebUI polish.
+- **2026-07-04** 🔌 Resilient MCP reconnects, durable pairing writes, safer Copilot refresh, Windows shutdown fixes.
+- **2026-07-03** 🧙 Safe WebUI first-run launcher, optional plugin controls, Claude Sonnet 4.6 default, workspace Dream prompts.
+- **2026-07-02** ⏰ Session-bound local triggers with recovery, audit records, deferred delivery, and WebUI pending state.
+- **2026-07-01** 🛡️ API keys for non-local binds, `$skill` shortcuts, structured tool errors, typed channel events.
+- **2026-06-30** 🌐 Per-provider proxies, Copilot Enterprise endpoints, WhatsApp read receipts, safer Weixin delivery and MCP logs.
+- **2026-06-29** 🧠 Context replay that scales with model windows, with obsolete max-message limits removed.
+- **2026-06-28** 🖼️ MCP image artifacts, sturdier WebUI reconnect and stop behavior, malformed tool-call protection.
+- **2026-06-27** 🔒 Collision-safe sessions, hardened shell allowlists, non-login exec defaults, a Neonize-based WhatsApp backend.
+- **2026-06-25** 🎛️ Configurable provider thinking styles and subagent failure handling, MiMo voice input, opt-in Telegram rich messages.
+- **2026-06-24** 🌙 Kimi Coding and OpenCode Zen/Go providers, normalized reasoning streams, safer Anthropic tool-call IDs.
 - **2026-06-22** 🚀 Released **v0.2.2** — **The Durability Release** makes nanobot sturdier for daily agent work: segmented WebUI transcripts, first-class Python SDK runtime controls, automation management, richer search/STT providers, and stronger gateway/session/provider reliability. Please see [release notes](https://github.com/HKUDS/nanobot/releases/tag/v0.2.2) for details.
 - **2026-06-21** 🧰 Python SDK runtime controls, optional Keenable key, cleaner run hooks.
 - **2026-06-20** 💬 Telegram rich messages, safer SDK concurrency, smoother Quick Start.

--- a/docs/release-archive.md
+++ b/docs/release-archive.md
@@ -6,23 +6,23 @@ For tagged releases, see [GitHub Releases](https://github.com/HKUDS/nanobot/rele
 
 ## Highlights
 
-- **2026-07-12** 🎯 Explicit `/goal` activation, lifecycle-safe runtime context, safer workspace access changes.
-- **2026-07-11** 🛠️ Syntax-highlighted file previews and diffs, queued prompts, safer targeted edits, quieter Dream commits.
-- **2026-07-10** 🧠 Isolated model runtime routing, sturdier subprocess cleanup, broader multiline CLI support, a new automation guide.
-- **2026-07-09** 📝 Live file-edit diff progress, tighter localhost bootstrap tokens, Matrix image fixes, configurable Docker extras.
-- **2026-07-08** 🔐 Safer WebUI/API bootstrap, non-interactive onboard refresh, responsive prompt rail, expanded chat app guides.
-- **2026-07-07** ⌨️ CLI multiline input, metadata-driven slash commands, DNS-pinned SSRF-safe web fetches.
-- **2026-07-06** 💬 Mattermost channel, Serper search, canonical OpenCode, safer Windows shells, mobile WebUI polish.
-- **2026-07-04** 🔌 Resilient MCP reconnects, durable pairing writes, safer Copilot refresh, Windows shutdown fixes.
-- **2026-07-03** 🧙 Safe WebUI first-run launcher, optional plugin controls, Claude Sonnet 4.6 default, workspace Dream prompts.
-- **2026-07-02** ⏰ Session-bound local triggers with recovery, audit records, deferred delivery, and WebUI pending state.
-- **2026-07-01** 🛡️ API keys for non-local binds, `$skill` shortcuts, structured tool errors, typed channel events.
-- **2026-06-30** 🌐 Per-provider proxies, Copilot Enterprise endpoints, WhatsApp read receipts, safer Weixin delivery and MCP logs.
-- **2026-06-29** 🧠 Context replay that scales with model windows, with obsolete max-message limits removed.
-- **2026-06-28** 🖼️ MCP image artifacts, sturdier WebUI reconnect and stop behavior, malformed tool-call protection.
-- **2026-06-27** 🔒 Collision-safe sessions, hardened shell allowlists, non-login exec defaults, a Neonize-based WhatsApp backend.
-- **2026-06-25** 🎛️ Configurable provider thinking styles and subagent failure handling, MiMo voice input, opt-in Telegram rich messages.
-- **2026-06-24** 🌙 Kimi Coding and OpenCode Zen/Go providers, normalized reasoning streams, safer Anthropic tool-call IDs.
+- **2026-07-12** 🎯 Explicit `/goal` activation, safer runtime and workspace access.
+- **2026-07-11** 🛠️ Syntax-highlighted previews and diffs, queued prompts, safer edits.
+- **2026-07-10** 🧠 Stable model routing, multiline CLI input, new automation guide.
+- **2026-07-09** 📝 Live file-edit diffs, safer localhost setup, Matrix image fixes.
+- **2026-07-08** 🔐 Safer WebUI/API setup, onboard refresh, responsive prompt rail.
+- **2026-07-07** ⌨️ CLI multiline input, steadier slash commands, safer web fetching.
+- **2026-07-06** 💬 Mattermost channel, Serper search, safer Windows shells.
+- **2026-07-04** 🔌 MCP reconnects, safer Copilot refresh, Windows shutdown fixes.
+- **2026-07-03** 🧙 Guided WebUI setup, plugin controls, Claude Sonnet 4.6 default.
+- **2026-07-02** ⏰ Local triggers with recovery, audit history, WebUI pending status.
+- **2026-07-01** 🛡️ API keys for remote binds, `$skill` shortcuts, clearer tool errors.
+- **2026-06-30** 🌐 Provider proxies, Copilot Enterprise, steadier WhatsApp and Weixin.
+- **2026-06-29** 🧠 Context replay scaled to model windows, without fixed message caps.
+- **2026-06-28** 🖼️ MCP images, steadier WebUI reconnects, safer tool calls.
+- **2026-06-27** 🔒 Collision-safe sessions, safer shells, Neonize WhatsApp.
+- **2026-06-25** 🎛️ Thinking controls, MiMo voice input, opt-in Telegram rich messages.
+- **2026-06-24** 🌙 Kimi Coding and OpenCode, steadier reasoning and Anthropic tool calls.
 - **2026-06-22** 🚀 Released **v0.2.2** — **The Durability Release** makes nanobot sturdier for daily agent work: segmented WebUI transcripts, first-class Python SDK runtime controls, automation management, richer search/STT providers, and stronger gateway/session/provider reliability. Please see [release notes](https://github.com/HKUDS/nanobot/releases/tag/v0.2.2) for details.
 - **2026-06-21** 🧰 Python SDK runtime controls, optional Keenable key, cleaner run hooks.
 - **2026-06-20** 💬 Telegram rich messages, safer SDK concurrency, smoother Quick Start.

--- a/docs/release-archive.md
+++ b/docs/release-archive.md
@@ -6,23 +6,26 @@ For tagged releases, see [GitHub Releases](https://github.com/HKUDS/nanobot/rele
 
 ## Highlights
 
-- **2026-07-12** 🎯 Explicit `/goal` activation, lifecycle-safe runtime context, safer workspace access changes.
-- **2026-07-11** 🛠️ Syntax-highlighted file previews and diffs, queued prompts, safer targeted edits, quieter Dream commits.
-- **2026-07-10** 🧠 Isolated model runtime routing, sturdier subprocess cleanup, broader multiline CLI support, a new automation guide.
-- **2026-07-09** 📝 Live file-edit diff progress, tighter localhost bootstrap tokens, Matrix image fixes, configurable Docker extras.
-- **2026-07-08** 🔐 Safer WebUI/API bootstrap, non-interactive onboard refresh, responsive prompt rail, expanded chat app guides.
-- **2026-07-07** ⌨️ CLI multiline input, metadata-driven slash commands, DNS-pinned SSRF-safe web fetches.
-- **2026-07-06** 💬 Mattermost channel, Serper search, canonical OpenCode, safer Windows shells, mobile WebUI polish.
-- **2026-07-04** 🔌 Resilient MCP reconnects, durable pairing writes, safer Copilot refresh, Windows shutdown fixes.
-- **2026-07-03** 🧙 Safe WebUI first-run launcher, optional plugin controls, Claude Sonnet 4.6 default, workspace Dream prompts.
-- **2026-07-02** ⏰ Session-bound local triggers with recovery, audit records, deferred delivery, and WebUI pending state.
-- **2026-07-01** 🛡️ API keys for non-local binds, `$skill` shortcuts, structured tool errors, typed channel events.
-- **2026-06-30** 🌐 Per-provider proxies, Copilot Enterprise endpoints, WhatsApp read receipts, safer Weixin delivery and MCP logs.
-- **2026-06-29** 🧠 Context replay that scales with model windows, with obsolete max-message limits removed.
-- **2026-06-28** 🖼️ MCP image artifacts, sturdier WebUI reconnect and stop behavior, malformed tool-call protection.
-- **2026-06-27** 🔒 Collision-safe sessions, hardened shell allowlists, non-login exec defaults, a Neonize-based WhatsApp backend.
-- **2026-06-25** 🎛️ Configurable provider thinking styles and subagent failure handling, MiMo voice input, opt-in Telegram rich messages.
-- **2026-06-24** 🌙 Kimi Coding and OpenCode Zen/Go providers, normalized reasoning streams, safer Anthropic tool-call IDs.
+- **2026-07-12** 🔒 Safer workspace scope restoration and access reduction, lifecycle-bound runtime context.
+- **2026-07-11** 🎯 Explicit `/goal` activation, persistent runtime context, request metadata, cleaner MCP and Dream ownership.
+- **2026-07-10** 📝 Syntax-highlighted file previews and diffs, queued prompts, isolated model runtime routing, quieter Dream commits.
+- **2026-07-09** 🔐 Tighter localhost bootstrap tokens, Matrix image fixes, fuller file-preview access handling, MCP reconnect coverage.
+- **2026-07-08** 🛠️ Live file-edit diff progress, safer WebUI bootstrap, non-interactive onboard refresh, configurable Docker extras.
+- **2026-07-07** 🛡️ Sturdier subprocess cleanup, responsive prompt rails, safer API setup and web fetches, broader CLI multiline input.
+- **2026-07-06** 💬 Reliable slash-command lifecycles, refreshed gateway state paths, Feishu new-session dividers.
+- **2026-07-05** 📱 Mobile WebUI containment, bounded MCP tool names, safer proxied fetches, clearer Serper and OAuth errors.
+- **2026-07-04** 💬 Sturdier Mattermost streaming, narrow-screen WebUI fixes, safer Windows gateway shutdown.
+- **2026-07-03** 🧙 Safe WebUI first-run launcher, optional plugin controls, canonical OpenCode, Claude Sonnet 4.6, resilient MCP reconnects.
+- **2026-07-02** 🛡️ Guarded file-edit targets, DNS-pinned web fetches, durable pairing writes, recoverable local-trigger audits.
+- **2026-07-01** ⌨️ CLI multiline input, pending local triggers, `$skill` shortcuts, typed channel events, structured tool errors.
+- **2026-06-30** ⏰ Workspace Dream prompts, session-bound local triggers, Copilot Enterprise endpoints, explicit restart modes.
+- **2026-06-29** 🌐 Per-provider proxies, WhatsApp read receipts, redacted MCP credentials, context replay scaled to model windows.
+- **2026-06-28** 🔄 Refreshed OAuth provider defaults, reliable Weixin streaming, sturdier WebUI reconnects, malformed tool-call protection.
+- **2026-06-27** 🪟 Self-healing gateway state, PowerShell-first Windows exec, authenticated non-local APIs, safer session migration.
+- **2026-06-26** 🖼️ MCP image artifacts, collision-safe sessions, a Neonize-based WhatsApp backend, leaner Docker images.
+- **2026-06-25** 🔒 Hardened shell allowlists, non-login exec defaults, opt-in Telegram rich messages, restored code-block copying.
+- **2026-06-24** 🎛️ OpenCode Zen/Go, configurable thinking styles and subagent failure handling, MiMo voice input, steadier reasoning streams.
+- **2026-06-23** 🌙 Kimi Coding Plan, safer Anthropic tool-call IDs, Mattermost file and mobile fixes, iOS WebUI input polish.
 - **2026-06-22** 🚀 Released **v0.2.2** — **The Durability Release** makes nanobot sturdier for daily agent work: segmented WebUI transcripts, first-class Python SDK runtime controls, automation management, richer search/STT providers, and stronger gateway/session/provider reliability. Please see [release notes](https://github.com/HKUDS/nanobot/releases/tag/v0.2.2) for details.
 - **2026-06-21** 🧰 Python SDK runtime controls, optional Keenable key, cleaner run hooks.
 - **2026-06-20** 💬 Telegram rich messages, safer SDK concurrency, smoother Quick Start.

--- a/docs/release-archive.md
+++ b/docs/release-archive.md
@@ -6,6 +6,23 @@ For tagged releases, see [GitHub Releases](https://github.com/HKUDS/nanobot/rele
 
 ## Highlights
 
+- **2026-07-12** 🎯 Explicit `/goal` activation, lifecycle-safe runtime context, safer workspace access changes.
+- **2026-07-11** 🛠️ Syntax-highlighted file previews and diffs, queued prompts, safer targeted edits, quieter Dream commits.
+- **2026-07-10** 🧠 Isolated model runtime routing, sturdier subprocess cleanup, broader multiline CLI support, a new automation guide.
+- **2026-07-09** 📝 Live file-edit diff progress, tighter localhost bootstrap tokens, Matrix image fixes, configurable Docker extras.
+- **2026-07-08** 🔐 Safer WebUI/API bootstrap, non-interactive onboard refresh, responsive prompt rail, expanded chat app guides.
+- **2026-07-07** ⌨️ CLI multiline input, metadata-driven slash commands, DNS-pinned SSRF-safe web fetches.
+- **2026-07-06** 💬 Mattermost channel, Serper search, canonical OpenCode, safer Windows shells, mobile WebUI polish.
+- **2026-07-04** 🔌 Resilient MCP reconnects, durable pairing writes, safer Copilot refresh, Windows shutdown fixes.
+- **2026-07-03** 🧙 Safe WebUI first-run launcher, optional plugin controls, Claude Sonnet 4.6 default, workspace Dream prompts.
+- **2026-07-02** ⏰ Session-bound local triggers with recovery, audit records, deferred delivery, and WebUI pending state.
+- **2026-07-01** 🛡️ API keys for non-local binds, `$skill` shortcuts, structured tool errors, typed channel events.
+- **2026-06-30** 🌐 Per-provider proxies, Copilot Enterprise endpoints, WhatsApp read receipts, safer Weixin delivery and MCP logs.
+- **2026-06-29** 🧠 Context replay that scales with model windows, with obsolete max-message limits removed.
+- **2026-06-28** 🖼️ MCP image artifacts, sturdier WebUI reconnect and stop behavior, malformed tool-call protection.
+- **2026-06-27** 🔒 Collision-safe sessions, hardened shell allowlists, non-login exec defaults, a Neonize-based WhatsApp backend.
+- **2026-06-25** 🎛️ Configurable provider thinking styles and subagent failure handling, MiMo voice input, opt-in Telegram rich messages.
+- **2026-06-24** 🌙 Kimi Coding and OpenCode Zen/Go providers, normalized reasoning streams, safer Anthropic tool-call IDs.
 - **2026-06-22** 🚀 Released **v0.2.2** — **The Durability Release** makes nanobot sturdier for daily agent work: segmented WebUI transcripts, first-class Python SDK runtime controls, automation management, richer search/STT providers, and stronger gateway/session/provider reliability. Please see [release notes](https://github.com/HKUDS/nanobot/releases/tag/v0.2.2) for details.
 - **2026-06-21** 🧰 Python SDK runtime controls, optional Keenable key, cleaner run hooks.
 - **2026-06-20** 💬 Telegram rich messages, safer SDK concurrency, smoother Quick Start.


### PR DESCRIPTION
## Summary

- refresh the README's five recent updates with highlights through July 12
- backfill the release archive with 17 meaningful update days from June 24 through July 12
- keep the project homepage concise while preserving the fuller history in `docs/release-archive.md`

The summaries are grouped by the date changes landed on `main`. June 23 is intentionally omitted because its only two commits adjust existing v0.2.2 release-news copy; June 26 and July 5 are omitted because no commits landed on those dates.

## Verification

- `git diff --check`
- fixed the cutoff at main commit `45d1caba` (the final July 12 commit)
- audited every date from 2026-06-23 through 2026-07-12 by committer date
- confirmed the archive contains exactly the 17 dates with meaningful landed changes

Documentation-only change; no runtime tests were needed.