### PR TITLE
fix(heartbeat): make response evaluation more configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2029,6 +2029,10 @@ The heartbeat job is backed by the same cron service as user-created reminders. 
 | `gateway.heartbeat.keepRecentMessages` | `8` | Number of recent heartbeat-session messages to retain after each run. |
 | `gateway.restartMode` | `auto` | Restart strategy for `/restart`: `auto` uses `spawn` on Windows foreground runs and `exec` elsewhere. Use `exit` with Windows service wrappers such as WinSW or nssm so the service manager owns the restart. |
 
+### Custom heartbeat evaluator prompt
+
+The notification gate runs on a built-in system prompt. Advanced users can override it, but you rarely need to — it's strongly advised to first read the evaluator code and the default `evaluator.md`. To override, drop your prompt at `<workspace>/prompts/evaluator.md`. It must still instruct the model to call the `evaluate_notification` tool; otherwise the gate fails closed and stays silent.
+
 
 ## Subagent Concurrency
 

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -29,6 +29,12 @@ from nanobot.utils.helpers import (
     truncate_text_to_tokens,
 )
 from nanobot.utils.prompt_templates import render_template
+from nanobot.utils.workspace_prompts import (
+    WORKSPACE_PROMPT_MAX_CHARS,
+    has_workspace_prompt_override,
+    load_workspace_prompt_override,
+    workspace_prompt_file,
+)
 
 if TYPE_CHECKING:
     from nanobot.utils.llm_runtime import LLMRuntime
@@ -492,14 +498,10 @@ class MemoryStore:
 
     @property
     def dream_prompt_file(self) -> Path:
-        return self.workspace / "prompts" / "dream.md"
+        return workspace_prompt_file(self.workspace, "dream")
 
     def has_dream_prompt_override(self) -> bool:
-        with suppress(OSError):
-            return self.dream_prompt_file.is_file() and bool(
-                self.dream_prompt_file.read_text(encoding="utf-8").strip()
-            )
-        return False
+        return has_workspace_prompt_override(self.dream_prompt_file)
 
     @staticmethod
     def default_dream_prompt() -> str:
@@ -512,20 +514,19 @@ class MemoryStore:
         )
 
     def _dream_template(self) -> str:
-        with suppress(OSError):
-            text = self.dream_prompt_file.read_text(encoding="utf-8")
-            if text.strip():
-                text = text.rstrip()
-                if len(text) > _DREAM_PROMPT_MAX_CHARS:
-                    if not self._dream_prompt_oversize_logged:
-                        self._dream_prompt_oversize_logged = True
-                        logger.warning(
-                            "workspace Dream prompt exceeds {} chars ({}); truncating. "
-                            "Further occurrences suppressed.",
-                            _DREAM_PROMPT_MAX_CHARS, len(text),
-                        )
-                    return truncate_text(text, _DREAM_PROMPT_MAX_CHARS)
-                return text
+        text, original_chars = load_workspace_prompt_override(self.dream_prompt_file)
+        if text is not None:
+            if (
+                original_chars > WORKSPACE_PROMPT_MAX_CHARS
+                and not self._dream_prompt_oversize_logged
+            ):
+                self._dream_prompt_oversize_logged = True
+                logger.warning(
+                    "workspace Dream prompt exceeds {} chars ({}); truncating. "
+                    "Further occurrences suppressed.",
+                    WORKSPACE_PROMPT_MAX_CHARS, original_chars,
+                )
+            return text
         return self.default_dream_prompt()
 
     def build_dream_prompt(self, *, max_entries: int = 20) -> tuple[str, int] | None:
@@ -734,7 +735,6 @@ class MemoryStore:
 # that catches any new caller that forgot to set its own cap.
 _RAW_ARCHIVE_MAX_CHARS = 16_000       # fallback dump (LLM failed)
 _ARCHIVE_SUMMARY_MAX_CHARS = 8_000    # LLM-produced consolidation summary
-_DREAM_PROMPT_MAX_CHARS = 32_000      # workspace-local Dream prompt override
 _HISTORY_ENTRY_HARD_CAP = 64_000      # emergency cap in append_history
 
 

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1860,15 +1860,15 @@ def _run_gateway(
                 if isinstance(message_tool, MessageTool) and suppress_token is not None:
                     message_tool.reset_suppress_delivery(suppress_token)
 
-            if not resp or not resp.content:
-                return
-
-            response = resp.content
-
             # Keep a small tail of heartbeat history so the loop stays bounded.
             session = agent.sessions.get_or_create("heartbeat")
             session.retain_recent_legal_suffix(hb_cfg.keep_recent_messages)
             agent.sessions.save(session)
+
+            if not resp or not resp.content:
+                return
+
+            response = resp.content
 
             evaluator_prompt = resolve_evaluator_prompt(config.workspace_path)
 

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -77,7 +77,7 @@ from nanobot.cli.stream import StreamRenderer, ThinkingSpinner  # noqa: E402
 from nanobot.config.paths import get_workspace_path, is_default_workspace  # noqa: E402
 from nanobot.config.schema import Config  # noqa: E402
 from nanobot.security.network import is_loopback_host  # noqa: E402
-from nanobot.utils.evaluator import evaluate_response  # noqa: E402
+from nanobot.utils.evaluator import evaluate_response, resolve_evaluator_prompt  # noqa: E402
 from nanobot.utils.helpers import sync_workspace_templates  # noqa: E402
 from nanobot.utils.restart import (  # noqa: E402
     consume_restart_notice_from_env,
@@ -1859,21 +1859,29 @@ def _run_gateway(
             finally:
                 if isinstance(message_tool, MessageTool) and suppress_token is not None:
                     message_tool.reset_suppress_delivery(suppress_token)
-            response = resp.content if resp else ""
+
+            if not resp or not resp.content:
+                return
+
+            response = resp.content
 
             # Keep a small tail of heartbeat history so the loop stays bounded.
             session = agent.sessions.get_or_create("heartbeat")
             session.retain_recent_legal_suffix(hb_cfg.keep_recent_messages)
             agent.sessions.save(session)
 
-            if not response:
-                return None
+            evaluator_prompt = resolve_evaluator_prompt(config.workspace_path)
 
             # Fail closed: stay silent on evaluator failure instead of notifying.
             should_notify = await evaluate_response(
-                response, prompt, agent.provider, agent.model,
+                response=response,
+                task_context=prompt,
+                provider=agent.provider,
+                model=agent.model,
+                evaluator_prompt=evaluator_prompt,
                 default_notify=False,
             )
+
             if should_notify:
                 logger.info("Heartbeat: completed, delivering response")
                 await _deliver_to_channel(

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -144,6 +144,14 @@ BUILTIN_COMMAND_SPECS: tuple[BuiltinCommandSpec, ...] = (
         accepts_args=True,
     ),
     BuiltinCommandSpec(
+        "/evaluator-prompt",
+        "Heartbeat evaluator",
+        "Customize the heartbeat notification gate prompt for this workspace.",
+        "file-text",
+        "[init]",
+        accepts_args=True,
+    ),
+    BuiltinCommandSpec(
         "/skill",
         "List skills",
         "List all enabled skills available to the agent.",
@@ -505,6 +513,64 @@ async def cmd_dream_prompt(ctx: CommandContext) -> OutboundMessage:
             "Dream memory instructions: nanobot default\n\n"
             f"- Editable file: `{display_path}`\n"
             "- Run `/dream-prompt init` to create an editable copy."
+        )
+
+    return OutboundMessage(
+        channel=ctx.msg.channel,
+        chat_id=ctx.msg.chat_id,
+        content=content,
+        metadata={**dict(ctx.msg.metadata or {}), "render_as": "text"},
+    )
+
+
+async def cmd_evaluator_prompt(ctx: CommandContext) -> OutboundMessage:
+    """Show or set up the workspace heartbeat evaluator prompt."""
+    from nanobot.utils.evaluator import (
+        default_evaluator_prompt,
+        evaluator_prompt_file,
+        has_evaluator_prompt_override,
+    )
+
+    workspace = ctx.loop.context.memory.workspace
+    path = evaluator_prompt_file(workspace)
+    display_path = path.relative_to(workspace).as_posix()
+    args = ctx.args.strip().lower()
+
+    if args == "init":
+        try:
+            prompt_exists_with_content = path.exists() and (
+                not path.is_file() or bool(path.read_text(encoding="utf-8").strip())
+            )
+        except OSError:
+            prompt_exists_with_content = True
+        if prompt_exists_with_content:
+            content = (
+                f"Heartbeat evaluator prompt already exists at `{display_path}`.\n\n"
+                "Edit that file, or delete/empty it to return to nanobot's default."
+            )
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(default_evaluator_prompt() + "\n", encoding="utf-8")
+            content = (
+                f"Created heartbeat evaluator prompt at `{display_path}`.\n\n"
+                "Edit that file to control when the heartbeat notification gate speaks. "
+                "It must still instruct the model to call the `evaluate_notification` tool, "
+                "otherwise the gate fails closed and stays silent. "
+                "Delete or empty it to return to nanobot's default."
+            )
+    elif args:
+        content = "Usage: /evaluator-prompt [init]"
+    elif has_evaluator_prompt_override(workspace):
+        content = (
+            "Heartbeat evaluator prompt: custom for this workspace\n\n"
+            f"- Path: `{display_path}`\n"
+            "- Delete or empty this file to return to nanobot's default."
+        )
+    else:
+        content = (
+            "Heartbeat evaluator prompt: nanobot default\n\n"
+            f"- Editable file: `{display_path}`\n"
+            "- Run `/evaluator-prompt init` to create an editable copy."
         )
 
     return OutboundMessage(
@@ -954,6 +1020,8 @@ def register_builtin_commands(router: CommandRouter) -> None:
     router.prefix("/dream-restore ", cmd_dream_restore)
     router.exact("/dream-prompt", cmd_dream_prompt)
     router.prefix("/dream-prompt ", cmd_dream_prompt)
+    router.exact("/evaluator-prompt", cmd_evaluator_prompt)
+    router.prefix("/evaluator-prompt ", cmd_evaluator_prompt)
     router.exact("/skill", cmd_skill)
     router.exact("/help", cmd_help)
     router.exact("/pairing", cmd_pairing)

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -17,6 +17,7 @@ from nanobot.bus.events import OutboundMessage
 from nanobot.command.router import CommandContext, CommandRouter
 from nanobot.utils.helpers import build_status_content
 from nanobot.utils.restart import set_restart_notice_to_env
+from nanobot.utils.workspace_prompts import initialize_workspace_prompt
 
 # WebUI protocol contract for how a slash command participates in turn state:
 # - side_channel: returns control text without starting or ending an agent turn.
@@ -480,20 +481,12 @@ async def cmd_dream_prompt(ctx: CommandContext) -> OutboundMessage:
     args = ctx.args.strip().lower()
 
     if args == "init":
-        try:
-            prompt_exists_with_content = path.exists() and (
-                not path.is_file() or bool(path.read_text(encoding="utf-8").strip())
-            )
-        except OSError:
-            prompt_exists_with_content = True
-        if prompt_exists_with_content:
+        if not initialize_workspace_prompt(path, store.default_dream_prompt()):
             content = (
                 f"Dream memory instructions already exist at `{display_path}`.\n\n"
                 "Edit that file, or delete/empty it to return to nanobot's default."
             )
         else:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(store.default_dream_prompt() + "\n", encoding="utf-8")
             content = (
                 f"Created Dream memory instructions at `{display_path}`.\n\n"
                 "Edit that file to teach Dream how to organize memory. "
@@ -537,20 +530,12 @@ async def cmd_evaluator_prompt(ctx: CommandContext) -> OutboundMessage:
     args = ctx.args.strip().lower()
 
     if args == "init":
-        try:
-            prompt_exists_with_content = path.exists() and (
-                not path.is_file() or bool(path.read_text(encoding="utf-8").strip())
-            )
-        except OSError:
-            prompt_exists_with_content = True
-        if prompt_exists_with_content:
+        if not initialize_workspace_prompt(path, default_evaluator_prompt()):
             content = (
                 f"Heartbeat evaluator prompt already exists at `{display_path}`.\n\n"
                 "Edit that file, or delete/empty it to return to nanobot's default."
             )
         else:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(default_evaluator_prompt() + "\n", encoding="utf-8")
             content = (
                 f"Created heartbeat evaluator prompt at `{display_path}`.\n\n"
                 "Edit that file to control when the heartbeat notification gate speaks. "

--- a/nanobot/templates/prompts/README.md
+++ b/nanobot/templates/prompts/README.md
@@ -1,11 +1,25 @@
-# Dream Memory Instructions
+# Prompt Overrides
 
-This folder is for plain-language instructions that tell Dream how to organize memory in this workspace.
+This folder holds plain-language prompt overrides for this workspace.
 
-Most users do not need to edit anything here. To guide Dream differently for this workspace, run:
+## Dream memory
+
+`dream.md` tells Dream how to organize memory in this workspace. Most users do not need to touch it. To create an editable copy, run:
 
 ```text
 /dream-prompt init
 ```
 
 That creates `prompts/dream.md`. Edit it in plain Markdown. Delete or empty it to return to nanobot's default memory behavior.
+
+## Heartbeat evaluator
+
+`evaluator.md` overrides the system prompt for the heartbeat notification gate — the model that decides whether a heartbeat result is worth delivering. This is an advanced override; you rarely need it. Before editing, read the evaluator code and the default `evaluator.md`.
+
+To create an editable copy, run:
+
+```text
+/evaluator-prompt init
+```
+
+That creates `prompts/evaluator.md`. It must still instruct the model to call the `evaluate_notification` tool; otherwise the gate fails closed and stays silent. Delete or empty the file to return to the built-in prompt.

--- a/nanobot/utils/evaluator.py
+++ b/nanobot/utils/evaluator.py
@@ -6,14 +6,57 @@ LLM call to decide whether the result warrants notifying the user.
 
 from __future__ import annotations
 
+from contextlib import suppress
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from loguru import logger
 
+from nanobot.utils.helpers import truncate_text
 from nanobot.utils.prompt_templates import render_template
 
 if TYPE_CHECKING:
     from nanobot.providers.base import LLMProvider
+
+# Cap for a workspace-local heartbeat evaluator prompt override.
+EVALUATOR_PROMPT_MAX_CHARS = 32_000
+
+
+def evaluator_prompt_file(workspace: Path) -> Path:
+    """Path to the workspace-local heartbeat evaluator prompt override."""
+    return workspace / "prompts" / "evaluator.md"
+
+
+def has_evaluator_prompt_override(workspace: Path) -> bool:
+    """True when the workspace defines a non-empty evaluator prompt override."""
+    with suppress(OSError):
+        path = evaluator_prompt_file(workspace)
+        return path.is_file() and bool(path.read_text(encoding="utf-8").strip())
+    return False
+
+
+def default_evaluator_prompt() -> str:
+    """The built-in heartbeat notification-gate system prompt."""
+    return render_template("agent/evaluator.md", part="system", strip=True)
+
+
+def resolve_evaluator_prompt(workspace: Path) -> str:
+    """Return the active evaluator prompt: workspace override or built-in default.
+
+    Oversized overrides are truncated so a runaway file cannot blow up the
+    evaluator call.
+    """
+    with suppress(OSError):
+        text = evaluator_prompt_file(workspace).read_text(encoding="utf-8").rstrip()
+        if text:
+            if len(text) > EVALUATOR_PROMPT_MAX_CHARS:
+                logger.warning(
+                    "Workspace heartbeat evaluator prompt exceeds {} chars ({}); truncating.",
+                    EVALUATOR_PROMPT_MAX_CHARS, len(text),
+                )
+                return truncate_text(text, EVALUATOR_PROMPT_MAX_CHARS)
+            return text
+    return default_evaluator_prompt()
 
 _EVALUATE_TOOL = [
     {
@@ -44,17 +87,19 @@ async def evaluate_response(
     task_context: str,
     provider: LLMProvider,
     model: str,
-    default_notify: bool = True,
+    evaluator_prompt: str,
+    default_notify: bool = False,
 ) -> bool:
     """Decide whether a heartbeat result should be delivered to the user.
 
     On any failure, falls back to ``default_notify``. Heartbeat passes
     ``False`` to fail closed.
     """
+
     try:
         llm_response = await provider.chat_with_retry(
             messages=[
-                {"role": "system", "content": render_template("agent/evaluator.md", part="system")},
+                {"role": "system", "content": evaluator_prompt},
                 {"role": "user", "content": render_template(
                     "agent/evaluator.md",
                     part="user",
@@ -64,7 +109,7 @@ async def evaluate_response(
             ],
             tools=_EVALUATE_TOOL,
             model=model,
-            max_tokens=256,
+            max_tokens=4096,
             temperature=0.0,
         )
 

--- a/nanobot/utils/evaluator.py
+++ b/nanobot/utils/evaluator.py
@@ -6,33 +6,34 @@ LLM call to decide whether the result warrants notifying the user.
 
 from __future__ import annotations
 
-from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from nanobot.utils.helpers import truncate_text
 from nanobot.utils.prompt_templates import render_template
+from nanobot.utils.workspace_prompts import (
+    WORKSPACE_PROMPT_MAX_CHARS,
+    has_workspace_prompt_override,
+    load_workspace_prompt_override,
+    workspace_prompt_file,
+)
 
 if TYPE_CHECKING:
     from nanobot.providers.base import LLMProvider
 
 # Cap for a workspace-local heartbeat evaluator prompt override.
-EVALUATOR_PROMPT_MAX_CHARS = 32_000
+EVALUATOR_PROMPT_MAX_CHARS = WORKSPACE_PROMPT_MAX_CHARS
 
 
 def evaluator_prompt_file(workspace: Path) -> Path:
     """Path to the workspace-local heartbeat evaluator prompt override."""
-    return workspace / "prompts" / "evaluator.md"
+    return workspace_prompt_file(workspace, "evaluator")
 
 
 def has_evaluator_prompt_override(workspace: Path) -> bool:
     """True when the workspace defines a non-empty evaluator prompt override."""
-    with suppress(OSError):
-        path = evaluator_prompt_file(workspace)
-        return path.is_file() and bool(path.read_text(encoding="utf-8").strip())
-    return False
+    return has_workspace_prompt_override(evaluator_prompt_file(workspace))
 
 
 def default_evaluator_prompt() -> str:
@@ -46,16 +47,14 @@ def resolve_evaluator_prompt(workspace: Path) -> str:
     Oversized overrides are truncated so a runaway file cannot blow up the
     evaluator call.
     """
-    with suppress(OSError):
-        text = evaluator_prompt_file(workspace).read_text(encoding="utf-8").rstrip()
-        if text:
-            if len(text) > EVALUATOR_PROMPT_MAX_CHARS:
-                logger.warning(
-                    "Workspace heartbeat evaluator prompt exceeds {} chars ({}); truncating.",
-                    EVALUATOR_PROMPT_MAX_CHARS, len(text),
-                )
-                return truncate_text(text, EVALUATOR_PROMPT_MAX_CHARS)
-            return text
+    text, original_chars = load_workspace_prompt_override(evaluator_prompt_file(workspace))
+    if text is not None:
+        if original_chars > EVALUATOR_PROMPT_MAX_CHARS:
+            logger.warning(
+                "Workspace heartbeat evaluator prompt exceeds {} chars ({}); truncating.",
+                EVALUATOR_PROMPT_MAX_CHARS, original_chars,
+            )
+        return text
     return default_evaluator_prompt()
 
 _EVALUATE_TOOL = [

--- a/nanobot/utils/workspace_prompts.py
+++ b/nanobot/utils/workspace_prompts.py
@@ -1,0 +1,58 @@
+"""Shared file handling for workspace-local prompt overrides."""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from pathlib import Path
+
+from nanobot.utils.helpers import truncate_text
+
+WORKSPACE_PROMPT_MAX_CHARS = 32_000
+
+
+def workspace_prompt_file(workspace: Path, name: str) -> Path:
+    """Return the conventional path for a named workspace prompt override."""
+    return workspace / "prompts" / f"{name}.md"
+
+
+def load_workspace_prompt_override(
+    path: Path,
+    *,
+    max_chars: int = WORKSPACE_PROMPT_MAX_CHARS,
+) -> tuple[str | None, int]:
+    """Load and cap a non-empty UTF-8 prompt override.
+
+    Returns the loaded text and its original length. Missing, unreadable, and
+    empty files return ``(None, 0)`` so callers can fall back to their default.
+    """
+    with suppress(OSError):
+        text = path.read_text(encoding="utf-8").rstrip()
+        if text:
+            original_chars = len(text)
+            return truncate_text(text, max_chars), original_chars
+    return None, 0
+
+
+def has_workspace_prompt_override(path: Path) -> bool:
+    """Return whether a path contains a non-empty workspace prompt override."""
+    text, _original_chars = load_workspace_prompt_override(path)
+    return text is not None
+
+
+def initialize_workspace_prompt(path: Path, default_prompt: str) -> bool:
+    """Create a default prompt copy when the target is missing or empty.
+
+    Returns ``False`` without overwriting a non-empty file, non-file path, or
+    path whose current state cannot be read safely.
+    """
+    try:
+        if path.exists() and (
+            not path.is_file() or bool(path.read_text(encoding="utf-8").strip())
+        ):
+            return False
+    except OSError:
+        return False
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(default_prompt + "\n", encoding="utf-8")
+    return True

--- a/nanobot/utils/workspace_prompts.py
+++ b/nanobot/utils/workspace_prompts.py
@@ -25,7 +25,7 @@ def load_workspace_prompt_override(
     Returns the loaded text and its original length. Missing, unreadable, and
     empty files return ``(None, 0)`` so callers can fall back to their default.
     """
-    with suppress(OSError):
+    with suppress(OSError, UnicodeDecodeError):
         text = path.read_text(encoding="utf-8").rstrip()
         if text:
             original_chars = len(text)
@@ -50,7 +50,7 @@ def initialize_workspace_prompt(path: Path, default_prompt: str) -> bool:
             not path.is_file() or bool(path.read_text(encoding="utf-8").strip())
         ):
             return False
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return False
 
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/agent/test_evaluator.py
+++ b/tests/agent/test_evaluator.py
@@ -31,17 +31,26 @@ def _eval_tool_call(should_notify: bool, reason: str = "") -> LLMResponse:
     )
 
 
+_EVAL_PROMPT = "You are a notification gate. Call evaluate_notification."
+
+
 @pytest.mark.asyncio
 async def test_should_notify_true() -> None:
     provider = DummyProvider([_eval_tool_call(True, "user asked to be reminded")])
-    result = await evaluate_response("Task completed with results", "check emails", provider, "m")
+    result = await evaluate_response(
+        "Task completed with results", "check emails", provider, "m",
+        evaluator_prompt=_EVAL_PROMPT,
+    )
     assert result is True
 
 
 @pytest.mark.asyncio
 async def test_should_notify_false() -> None:
     provider = DummyProvider([_eval_tool_call(False, "routine check, nothing new")])
-    result = await evaluate_response("All clear, no updates", "check status", provider, "m")
+    result = await evaluate_response(
+        "All clear, no updates", "check status", provider, "m",
+        evaluator_prompt=_EVAL_PROMPT,
+    )
     assert result is False
 
 
@@ -52,14 +61,20 @@ async def test_fallback_on_error() -> None:
             raise RuntimeError("provider down")
 
     provider = FailingProvider([])
-    result = await evaluate_response("some response", "some task", provider, "m")
+    result = await evaluate_response(
+        "some response", "some task", provider, "m",
+        evaluator_prompt=_EVAL_PROMPT, default_notify=True,
+    )
     assert result is True
 
 
 @pytest.mark.asyncio
 async def test_no_tool_call_fallback() -> None:
     provider = DummyProvider([LLMResponse(content="I think you should notify", tool_calls=[])])
-    result = await evaluate_response("some response", "some task", provider, "m")
+    result = await evaluate_response(
+        "some response", "some task", provider, "m",
+        evaluator_prompt=_EVAL_PROMPT, default_notify=True,
+    )
     assert result is True
 
 
@@ -70,12 +85,18 @@ async def test_fail_closed_on_error() -> None:
             raise RuntimeError("provider down")
 
     provider = FailingProvider([])
-    result = await evaluate_response("some", "task", provider, "m", default_notify=False)
+    result = await evaluate_response(
+        "some", "task", provider, "m",
+        evaluator_prompt=_EVAL_PROMPT, default_notify=False,
+    )
     assert result is False
 
 
 @pytest.mark.asyncio
 async def test_fail_closed_on_no_tool_call() -> None:
     provider = DummyProvider([LLMResponse(content="text only", tool_calls=[])])
-    result = await evaluate_response("some", "task", provider, "m", default_notify=False)
+    result = await evaluate_response(
+        "some", "task", provider, "m",
+        evaluator_prompt=_EVAL_PROMPT, default_notify=False,
+    )
     assert result is False

--- a/tests/agent/test_evaluator.py
+++ b/tests/agent/test_evaluator.py
@@ -1,7 +1,13 @@
 import pytest
 
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
-from nanobot.utils.evaluator import evaluate_response
+from nanobot.utils.evaluator import (
+    EVALUATOR_PROMPT_MAX_CHARS,
+    default_evaluator_prompt,
+    evaluate_response,
+    evaluator_prompt_file,
+    resolve_evaluator_prompt,
+)
 
 
 class DummyProvider(LLMProvider):
@@ -32,6 +38,33 @@ def _eval_tool_call(should_notify: bool, reason: str = "") -> LLMResponse:
 
 
 _EVAL_PROMPT = "You are a notification gate. Call evaluate_notification."
+
+
+def test_resolve_evaluator_prompt_uses_workspace_override(tmp_path) -> None:
+    path = evaluator_prompt_file(tmp_path)
+    path.parent.mkdir()
+    path.write_text("Custom evaluator prompt.\n", encoding="utf-8")
+
+    assert resolve_evaluator_prompt(tmp_path) == "Custom evaluator prompt."
+
+
+def test_resolve_evaluator_prompt_uses_default_for_empty_override(tmp_path) -> None:
+    path = evaluator_prompt_file(tmp_path)
+    path.parent.mkdir()
+    path.write_text("  \n", encoding="utf-8")
+
+    assert resolve_evaluator_prompt(tmp_path) == default_evaluator_prompt()
+
+
+def test_resolve_evaluator_prompt_caps_workspace_override(tmp_path) -> None:
+    path = evaluator_prompt_file(tmp_path)
+    path.parent.mkdir()
+    path.write_text("x" * (EVALUATOR_PROMPT_MAX_CHARS + 1), encoding="utf-8")
+
+    prompt = resolve_evaluator_prompt(tmp_path)
+
+    assert prompt.startswith("x" * EVALUATOR_PROMPT_MAX_CHARS)
+    assert prompt.endswith("... (truncated)")
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_evaluator.py
+++ b/tests/agent/test_evaluator.py
@@ -56,6 +56,14 @@ def test_resolve_evaluator_prompt_uses_default_for_empty_override(tmp_path) -> N
     assert resolve_evaluator_prompt(tmp_path) == default_evaluator_prompt()
 
 
+def test_resolve_evaluator_prompt_uses_default_for_undecodable_override(tmp_path) -> None:
+    path = evaluator_prompt_file(tmp_path)
+    path.parent.mkdir()
+    path.write_bytes("Custom evaluator prompt.".encode("utf-16"))
+
+    assert resolve_evaluator_prompt(tmp_path) == default_evaluator_prompt()
+
+
 def test_resolve_evaluator_prompt_caps_workspace_override(tmp_path) -> None:
     path = evaluator_prompt_file(tmp_path)
     path.parent.mkdir()

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1705,6 +1705,109 @@ def _patch_cli_command_runtime(
         monkeypatch.setattr("nanobot.config.paths.get_cron_dir", get_cron_dir)
 
 
+def test_heartbeat_empty_response_still_retains_recent_messages(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    config_file = _write_instance_config(tmp_path)
+    config = Config()
+    config.agents.defaults.workspace = str(tmp_path / "workspace")
+    config.agents.defaults.dream.enabled = True
+    config.workspace_path.mkdir(parents=True)
+    (config.workspace_path / "HEARTBEAT.md").write_text(
+        "## Active Tasks\n\n- Check repository health\n",
+        encoding="utf-8",
+    )
+
+    provider = _fake_provider()
+    bus = MagicMock()
+    bus.publish_outbound = AsyncMock()
+    seen: dict[str, object] = {}
+
+    class _FakeSession:
+        def retain_recent_legal_suffix(self, limit: int) -> None:
+            seen["retained_limit"] = limit
+
+    class _FakeSessionManager:
+        def __init__(self, _workspace: Path) -> None:
+            self.session = _FakeSession()
+            seen["heartbeat_session"] = self.session
+
+        def get_or_create(self, key: str) -> _FakeSession:
+            seen["session_key"] = key
+            return self.session
+
+        def save(self, session: _FakeSession) -> None:
+            seen["saved_session"] = session
+
+        def list_sessions(self) -> list[dict[str, str]]:
+            return [{"key": "telegram:u1"}]
+
+    class _FakeCron:
+        def __init__(self, _store_path: Path) -> None:
+            self.on_job = None
+            seen["cron"] = self
+
+        def status(self) -> dict[str, int]:
+            return {"jobs": 0}
+
+        def register_system_job(self, _job: CronJob) -> None:
+            raise _StopGatewayError("stop")
+
+    class _FakeAgentLoop:
+        @classmethod
+        def from_config(cls, config, bus=None, **extra):
+            return cls(**extra)
+
+        def __init__(self, *args, **kwargs) -> None:
+            self.model = "test-model"
+            self.provider = kwargs.get("provider", object())
+            self.sessions = kwargs["session_manager"]
+            self.tools = {}
+
+        async def process_direct(self, *_args, **_kwargs):
+            return SimpleNamespace(content="")
+
+        async def close_mcp(self) -> None:
+            return None
+
+        async def run(self) -> None:
+            return None
+
+        def stop(self) -> None:
+            return None
+
+    class _FakeChannelManager:
+        def __init__(self, *_args, **_kwargs) -> None:
+            self.enabled_channels = ["telegram"]
+
+    async def _unexpected_evaluator(*_args, **_kwargs) -> bool:
+        raise AssertionError("empty heartbeat response must not be evaluated")
+
+    _patch_cli_command_runtime(
+        monkeypatch,
+        config,
+        make_provider=lambda _config: provider,
+        message_bus=lambda: bus,
+        session_manager=_FakeSessionManager,
+        cron_service=_FakeCron,
+    )
+    monkeypatch.setattr("nanobot.cli.commands.AgentLoop", _FakeAgentLoop)
+    monkeypatch.setattr("nanobot.channels.manager.ChannelManager", _FakeChannelManager)
+    monkeypatch.setattr("nanobot.cli.commands.read_webui_sidebar_state", lambda: {})
+    monkeypatch.setattr("nanobot.cli.commands.evaluate_response", _unexpected_evaluator)
+
+    result = runner.invoke(app, ["gateway", "--config", str(config_file)])
+
+    assert isinstance(result.exception, _StopGatewayError)
+    cron = seen["cron"]
+    response = asyncio.run(cron.on_job(CronJob(id="heartbeat", name="heartbeat")))
+
+    assert response is None
+    assert seen["session_key"] == "heartbeat"
+    assert seen["retained_limit"] == config.gateway.heartbeat.keep_recent_messages
+    assert seen["saved_session"] is seen["heartbeat_session"]
+
+
 def test_webui_yes_creates_config_and_enables_local_websocket(
     monkeypatch,
     tmp_path: Path,

--- a/tests/command/test_builtin_evaluator_prompt.py
+++ b/tests/command/test_builtin_evaluator_prompt.py
@@ -60,6 +60,23 @@ async def test_evaluator_prompt_init_does_not_overwrite_existing_prompt(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_evaluator_prompt_handles_undecodable_existing_prompt(tmp_path) -> None:
+    prompt_file = tmp_path / "prompts" / "evaluator.md"
+    prompt_file.parent.mkdir()
+    original = "custom".encode("utf-16")
+    prompt_file.write_bytes(original)
+
+    status = await cmd_evaluator_prompt(_make_ctx(tmp_path))
+    init = await cmd_evaluator_prompt(
+        _make_ctx(tmp_path, "/evaluator-prompt init", "init")
+    )
+
+    assert "Heartbeat evaluator prompt: nanobot default" in status.content
+    assert "already exists" in init.content
+    assert prompt_file.read_bytes() == original
+
+
+@pytest.mark.asyncio
 async def test_evaluator_prompt_init_recreates_empty_prompt(tmp_path) -> None:
     prompt_file = tmp_path / "prompts" / "evaluator.md"
     prompt_file.parent.mkdir()

--- a/tests/command/test_builtin_evaluator_prompt.py
+++ b/tests/command/test_builtin_evaluator_prompt.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nanobot.bus.events import InboundMessage
+from nanobot.command.builtin import (
+    build_help_text,
+    builtin_command_palette,
+    cmd_evaluator_prompt,
+)
+from nanobot.command.router import CommandContext
+from nanobot.utils.evaluator import default_evaluator_prompt
+
+
+def _make_ctx(tmp_path, raw: str = "/evaluator-prompt", args: str = "") -> CommandContext:
+    msg = InboundMessage(channel="cli", sender_id="u1", chat_id="direct", content=raw)
+    loop = SimpleNamespace(context=SimpleNamespace(memory=SimpleNamespace(workspace=tmp_path)))
+    return CommandContext(msg=msg, session=None, key=msg.session_key, raw=raw, args=args, loop=loop)
+
+
+@pytest.mark.asyncio
+async def test_evaluator_prompt_reports_default_prompt(tmp_path) -> None:
+    out = await cmd_evaluator_prompt(_make_ctx(tmp_path))
+
+    assert "Heartbeat evaluator prompt: nanobot default" in out.content
+    assert "prompts/evaluator.md" in out.content
+    assert str(tmp_path) not in out.content
+    assert "/evaluator-prompt init" in out.content
+
+
+@pytest.mark.asyncio
+async def test_evaluator_prompt_init_copies_default_prompt(tmp_path) -> None:
+    ctx = _make_ctx(tmp_path, "/evaluator-prompt init", "init")
+
+    out = await cmd_evaluator_prompt(ctx)
+
+    prompt_file = tmp_path / "prompts" / "evaluator.md"
+    assert "Created heartbeat evaluator prompt" in out.content
+    assert "prompts/evaluator.md" in out.content
+    assert str(tmp_path) not in out.content
+    assert "evaluate_notification" in out.content
+    assert prompt_file.read_text(encoding="utf-8") == default_evaluator_prompt() + "\n"
+
+
+@pytest.mark.asyncio
+async def test_evaluator_prompt_init_does_not_overwrite_existing_prompt(tmp_path) -> None:
+    prompt_file = tmp_path / "prompts" / "evaluator.md"
+    prompt_file.parent.mkdir()
+    prompt_file.write_text("custom", encoding="utf-8")
+    ctx = _make_ctx(tmp_path, "/evaluator-prompt init", "init")
+
+    out = await cmd_evaluator_prompt(ctx)
+
+    assert "already exists" in out.content
+    assert "prompts/evaluator.md" in out.content
+    assert str(tmp_path) not in out.content
+    assert prompt_file.read_text(encoding="utf-8") == "custom"
+
+
+@pytest.mark.asyncio
+async def test_evaluator_prompt_init_recreates_empty_prompt(tmp_path) -> None:
+    prompt_file = tmp_path / "prompts" / "evaluator.md"
+    prompt_file.parent.mkdir()
+    prompt_file.write_text("  \n", encoding="utf-8")
+    ctx = _make_ctx(tmp_path, "/evaluator-prompt init", "init")
+
+    out = await cmd_evaluator_prompt(ctx)
+
+    assert "Created heartbeat evaluator prompt" in out.content
+    assert prompt_file.read_text(encoding="utf-8") == default_evaluator_prompt() + "\n"
+
+
+@pytest.mark.asyncio
+async def test_evaluator_prompt_reports_override(tmp_path) -> None:
+    prompt_file = tmp_path / "prompts" / "evaluator.md"
+    prompt_file.parent.mkdir()
+    prompt_file.write_text("custom", encoding="utf-8")
+
+    out = await cmd_evaluator_prompt(_make_ctx(tmp_path))
+
+    assert "Heartbeat evaluator prompt: custom for this workspace" in out.content
+    assert "prompts/evaluator.md" in out.content
+
+
+@pytest.mark.asyncio
+async def test_evaluator_prompt_rejects_unknown_args(tmp_path) -> None:
+    out = await cmd_evaluator_prompt(_make_ctx(tmp_path, "/evaluator-prompt nope", "nope"))
+
+    assert out.content == "Usage: /evaluator-prompt [init]"
+
+
+def test_evaluator_prompt_command_in_help_and_palette() -> None:
+    palette = builtin_command_palette()
+    entry = next(item for item in palette if item["command"] == "/evaluator-prompt")
+
+    assert entry["arg_hint"] == "[init]"
+    assert entry["lifecycle"] == "side_channel"
+    assert entry["accepts_args"] is True
+    assert "/evaluator-prompt [init]" in build_help_text()


### PR DESCRIPTION
This one is a bit bigger and aimed at other regressions caused by heartbeat migration to cron (as outlined in #4896)
Main changes:
 - Heartbeat evaluation can be disabled, with AI response being always sent
 - Evaluator has a bit of a stricter prompt ("MUST" instead of plain "Call", smaller models failed here)
 - Evaluator token cap lifted to 16k (again, smaller reasoning models just can't fit their reasoning into 256 reasoning + output + tool tokens.)
 - Custom prompt for evaluator. Just seemed as an easy feature to add, but it can be removed, if you don't like it. I didn't really find any place where that would be *really* useful.
 
 I was intending to use strip_regex to make the model print the task that it picked, something like: `[Tell user about something]: This is something that I've found!`, and then strip `^[.*?]`, or something along those lines. Given that the task list is provided to the evaluator, it would make it easier for the it to decide if the response is just the model yapping, or something that the user might actually want to see.

Custom `HEARTBEAT-EVALUATOR.md` would fine-tune that behavior, since smaller models tend to make some weird choices and assumptions.