### PR TITLE
fix: install timezone data on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "pyyaml>=6.0,<7.0.0",
     "filelock>=3.25.2",
     "packaging>=24.0",
+    "tzdata>=2025.2; sys_platform == 'win32'",
     "defusedxml>=0.7.1,<1.0.0",
     "pypdf>=5.0.0,<6.0.0",
     "python-docx>=1.1.0,<2.0.0",

--- a/tests/channels/test_channel_plugins.py
+++ b/tests/channels/test_channel_plugins.py
@@ -1552,6 +1552,7 @@ def test_optional_dependency_metadata_for_enable():
     ):
         assert not any(dep.startswith(dep_name) for dep in required)
     for dependency in (
+        "tzdata>=2025.2; sys_platform == 'win32'",
         "defusedxml>=0.7.1,<1.0.0",
         "pypdf>=5.0.0,<6.0.0",
         "python-docx>=1.1.0,<2.0.0",


### PR DESCRIPTION
## Summary

- add tzdata to the base installation on Windows so Python zoneinfo can resolve IANA timezone names
- cover the conditional dependency in the project metadata contract test

## Root cause

The WebUI offers IANA names such as Asia/Shanghai, but a default Windows installation had no system timezone database and did not install tzdata. ZoneInfo therefore rejected every timezone, including UTC, and the settings API returned invalid timezone. CI did not expose this because its all-extras install pulled tzdata transitively through the QQ extra.

## Verification

- PASS: default Windows uv sync with no extras installs tzdata; ZoneInfo resolves UTC and Asia/Shanghai with 598 available zones
- PASS: focused dependency metadata and WebUI settings API tests (2 passed)
- PASS: Ruff on the touched test module
- PASS: focused WebUI timezone picker test
- PASS: production WebUI build
- PASS: built wheel metadata contains the Windows-only tzdata requirement
- PASS: real gateway + headless browser flow selects Asia/Shanghai, saves without an error, and preserves it after reload