### PR TITLE
fix(command): stop silently discards pending queue messages

### DIFF
--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -179,12 +179,13 @@ async def cmd_stop(ctx: CommandContext) -> OutboundMessage:
     # Also drain pending queue to prevent mid-turn injection deadlock
     pending = loop._pending_queues.pop(ctx.key, None)
     if pending is not None:
-        while not pending.empty():
+        while True:
             try:
-                pending.get_nowait()
-                total += 1
-            except Exception:
+                item = pending.get_nowait()
+            except asyncio.QueueEmpty:
                 break
+            await loop.bus.publish_inbound(item)
+            total += 1
     content = f"Stopped {total} task(s)." if total else "No active task to stop."
     return OutboundMessage(
         channel=msg.channel, chat_id=msg.chat_id, content=content,

--- a/tests/command/test_stop_pending_queue.py
+++ b/tests/command/test_stop_pending_queue.py
@@ -5,7 +5,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from nanobot.bus.events import OutboundMessage
+import nanobot.agent.loop  # noqa: F401
+from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.command.builtin import cmd_stop
 from nanobot.command.router import CommandContext
 
@@ -16,10 +17,23 @@ async def test_cmd_stop_drains_pending_queue():
     mock_loop = MagicMock()
     mock_loop._cancel_active_tasks = AsyncMock(return_value=1)
     mock_loop._pending_queues = {}
+    mock_loop.bus.publish_inbound = AsyncMock()
 
     pending = asyncio.Queue()
-    await pending.put("msg1")
-    await pending.put("msg2")
+    msg1 = InboundMessage(
+        channel="websocket",
+        sender_id="user",
+        chat_id="test-chat",
+        content="msg1",
+    )
+    msg2 = InboundMessage(
+        channel="websocket",
+        sender_id="user",
+        chat_id="test-chat",
+        content="msg2",
+    )
+    await pending.put(msg1)
+    await pending.put(msg2)
     mock_loop._pending_queues["test-session"] = pending
 
     ctx = CommandContext(
@@ -35,6 +49,10 @@ async def test_cmd_stop_drains_pending_queue():
     assert isinstance(result, OutboundMessage)
     assert "Stopped 3 task(s)" in result.content  # 1 cancelled + 2 drained
     assert "test-session" not in mock_loop._pending_queues
+    assert [call.args[0] for call in mock_loop.bus.publish_inbound.await_args_list] == [
+        msg1,
+        msg2,
+    ]
 
 
 @pytest.mark.asyncio
@@ -43,6 +61,7 @@ async def test_cmd_stop_with_empty_pending_queue():
     mock_loop = MagicMock()
     mock_loop._cancel_active_tasks = AsyncMock(return_value=2)
     mock_loop._pending_queues = {}
+    mock_loop.bus.publish_inbound = AsyncMock()
 
     pending = asyncio.Queue()
     mock_loop._pending_queues["test-session"] = pending
@@ -59,6 +78,7 @@ async def test_cmd_stop_with_empty_pending_queue():
 
     assert "Stopped 2 task(s)" in result.content
     assert "test-session" not in mock_loop._pending_queues
+    mock_loop.bus.publish_inbound.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -67,6 +87,7 @@ async def test_cmd_stop_no_pending_queue():
     mock_loop = MagicMock()
     mock_loop._cancel_active_tasks = AsyncMock(return_value=0)
     mock_loop._pending_queues = {}
+    mock_loop.bus.publish_inbound = AsyncMock()
 
     ctx = CommandContext(
         msg=MagicMock(channel="websocket", chat_id="test-chat", metadata={}),
@@ -79,3 +100,4 @@ async def test_cmd_stop_no_pending_queue():
     result = await cmd_stop(ctx)
 
     assert "No active task to stop" in result.content
+    mock_loop.bus.publish_inbound.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Fixes #4792
- Re-publish drained pending queue messages when `/stop` cancels an active turn
- Update `/stop` pending queue tests to assert FIFO re-publication and queue cleanup

## Tests
- `uv run pytest tests/command/test_stop_pending_queue.py -v`
- `uv run ruff check nanobot/command/builtin.py tests/command/test_stop_pending_queue.py`