### PR TITLE
fix: include Feishu SDK in dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ olostep = [
 dev = [
     "pytest>=9.0.0,<10.0.0",
     "pytest-asyncio>=1.3.0,<2.0.0",
+    "lark-oapi>=1.5.0,<2.0.0",
     "aiohttp>=3.9.0,<4.0.0",
     "pytest-cov>=6.0.0,<7.0.0",
     "ruff>=0.1.0",


### PR DESCRIPTION
## Summary

- include `lark-oapi` in the `dev` dependency extra
- keep the documented local development setup aligned with the Feishu test requirements

## Root cause

Several Feishu tests import `lark_oapi` dynamically. `uv sync --extra dev` did not install the SDK, so the documented local test setup failed with `ModuleNotFoundError`, while CI's `--all-extras` setup masked the omission.

## Validation

- `uv sync --extra dev`
- `uv run pytest tests/channels/test_feishu_streaming.py tests/channels/test_feishu_reply.py tests/channels/test_feishu_mentions.py tests/channels/test_feishu_reaction.py -q` - 123 passed
- `uv run ruff check nanobot` - passed
- `uv run pytest -q` - 4667 passed, 34 skipped; 38 unrelated existing failures on Windows (shell, timezone data, and network-isolation expectations)

Closes #4887
