### PR TITLE
chore(codex): identify failing request stage

### DIFF
--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -6,6 +6,8 @@ import asyncio
 import hashlib
 import json
 from collections.abc import Awaitable, Callable
+from secrets import token_hex
+from time import monotonic
 from typing import Any
 
 import httpx
@@ -75,10 +77,17 @@ class OpenAICodexProvider(LLMProvider):
         if tools:
             body["tools"] = convert_tools(tools)
 
+        attempt_id = token_hex(4)
+        stage = "oauth_token"
+        stage_started_at = monotonic()
+        tls_verify: bool | None = None
         try:
             token = await asyncio.to_thread(get_codex_token, proxy=self.proxy)
             headers = _build_headers(token.account_id, token.access)
 
+            stage = "codex_request"
+            stage_started_at = monotonic()
+            tls_verify = True
             try:
                 content, tool_calls, finish_reason, usage, reasoning_content = await _request_codex(
                     DEFAULT_CODEX_URL, headers, body, verify=True,
@@ -90,7 +99,13 @@ class OpenAICodexProvider(LLMProvider):
             except Exception as e:
                 if "CERTIFICATE_VERIFY_FAILED" not in str(e):
                     raise
-                logger.warning("SSL verification failed for Codex API; retrying with verify=False")
+                logger.warning(
+                    "SSL verification failed for Codex API: attempt_id={}; "
+                    "retrying with verify=False",
+                    attempt_id,
+                )
+                stage_started_at = monotonic()
+                tls_verify = False
                 content, tool_calls, finish_reason, usage, reasoning_content = await _request_codex(
                     DEFAULT_CODEX_URL, headers, body, verify=False,
                     proxy=self.proxy,
@@ -108,9 +123,17 @@ class OpenAICodexProvider(LLMProvider):
         except Exception as e:
             response = _codex_error_response(e)
             exc_type = "CodexHTTPError" if isinstance(e, _CodexHTTPError) else type(e).__name__
+            elapsed_ms = max(0, round((monotonic() - stage_started_at) * 1000))
             logger.warning(
-                "Codex API request failed: type={} kind={} retryable={} status={} "
+                "Codex API request failed: attempt_id={} stage={} elapsed_ms={} model={} "
+                "proxy_enabled={} tls_verify={} type={} kind={} retryable={} status={} "
                 "error_type={} error_code={} retry_after={} summary={}",
+                attempt_id,
+                stage,
+                elapsed_ms,
+                body["model"],
+                self.proxy is not None,
+                tls_verify,
                 exc_type,
                 response.error_kind,
                 response.error_should_retry,

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -6,8 +6,6 @@ import asyncio
 import hashlib
 import json
 from collections.abc import Awaitable, Callable
-from secrets import token_hex
-from time import monotonic
 from typing import Any
 
 import httpx
@@ -77,17 +75,12 @@ class OpenAICodexProvider(LLMProvider):
         if tools:
             body["tools"] = convert_tools(tools)
 
-        attempt_id = token_hex(4)
         stage = "oauth_token"
-        stage_started_at = monotonic()
-        tls_verify: bool | None = None
         try:
             token = await asyncio.to_thread(get_codex_token, proxy=self.proxy)
             headers = _build_headers(token.account_id, token.access)
 
             stage = "codex_request"
-            stage_started_at = monotonic()
-            tls_verify = True
             try:
                 content, tool_calls, finish_reason, usage, reasoning_content = await _request_codex(
                     DEFAULT_CODEX_URL, headers, body, verify=True,
@@ -99,13 +92,7 @@ class OpenAICodexProvider(LLMProvider):
             except Exception as e:
                 if "CERTIFICATE_VERIFY_FAILED" not in str(e):
                     raise
-                logger.warning(
-                    "SSL verification failed for Codex API: attempt_id={}; "
-                    "retrying with verify=False",
-                    attempt_id,
-                )
-                stage_started_at = monotonic()
-                tls_verify = False
+                logger.warning("SSL verification failed for Codex API; retrying with verify=False")
                 content, tool_calls, finish_reason, usage, reasoning_content = await _request_codex(
                     DEFAULT_CODEX_URL, headers, body, verify=False,
                     proxy=self.proxy,
@@ -123,17 +110,10 @@ class OpenAICodexProvider(LLMProvider):
         except Exception as e:
             response = _codex_error_response(e)
             exc_type = "CodexHTTPError" if isinstance(e, _CodexHTTPError) else type(e).__name__
-            elapsed_ms = max(0, round((monotonic() - stage_started_at) * 1000))
             logger.warning(
-                "Codex API request failed: attempt_id={} stage={} elapsed_ms={} model={} "
-                "proxy_enabled={} tls_verify={} type={} kind={} retryable={} status={} "
+                "Codex API request failed: stage={} type={} kind={} retryable={} status={} "
                 "error_type={} error_code={} retry_after={} summary={}",
-                attempt_id,
                 stage,
-                elapsed_ms,
-                body["model"],
-                self.proxy is not None,
-                tls_verify,
                 exc_type,
                 response.error_kind,
                 response.error_should_retry,

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -20,6 +20,12 @@ from nanobot.providers.openai_codex_provider import (
 )
 from nanobot.providers.registry import find_by_name
 
+_CODEX_DIAGNOSTIC_FORMAT = (
+    "Codex API request failed: attempt_id={} stage={} elapsed_ms={} model={} "
+    "proxy_enabled={} tls_verify={} type={} kind={} retryable={} status={} "
+    "error_type={} error_code={} retry_after={} summary={}"
+)
+
 
 def _mock_codex_token(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_token(**_kwargs):
@@ -29,6 +35,15 @@ def _mock_codex_token(monkeypatch: pytest.MonkeyPatch) -> None:
         "nanobot.providers.openai_codex_provider.get_codex_token",
         fake_token,
     )
+
+
+def _mock_codex_diagnostic_context(
+    monkeypatch: pytest.MonkeyPatch,
+    *monotonic_values: float,
+) -> None:
+    clock = iter(monotonic_values)
+    monkeypatch.setattr("nanobot.providers.openai_codex_provider.token_hex", lambda _size: "deadbeef")
+    monkeypatch.setattr("nanobot.providers.openai_codex_provider.monotonic", lambda: next(clock))
 
 
 def test_codex_default_model_matches_curated_flagship() -> None:
@@ -277,8 +292,91 @@ async def test_codex_provider_passes_proxy_to_oauth_and_response_request(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_codex_remote_protocol_error_identifies_oauth_stage(monkeypatch) -> None:
+    log_capture = _capture_codex_warnings(monkeypatch)
+    _mock_codex_diagnostic_context(monkeypatch, 10.0, 10.25)
+    proxy = "http://PRIVATE_PROXY_CREDENTIAL@127.0.0.1:7890"
+
+    def fake_token(**_kwargs):
+        raise httpx.RemoteProtocolError("Server disconnected without sending a response.")
+
+    monkeypatch.setattr("nanobot.providers.openai_codex_provider.get_codex_token", fake_token)
+
+    provider = OpenAICodexProvider(proxy=proxy)
+    response = await provider.chat([{"role": "user", "content": "PRIVATE PROMPT"}])
+
+    assert response.error_kind == "connection"
+    assert response.error_should_retry is True
+    assert log_capture.calls == [
+        (
+            _CODEX_DIAGNOSTIC_FORMAT,
+            (
+                "deadbeef",
+                "oauth_token",
+                250,
+                "gpt-5.6-sol",
+                True,
+                None,
+                "RemoteProtocolError",
+                "connection",
+                True,
+                None,
+                None,
+                None,
+                None,
+                "RemoteProtocolError connection",
+            ),
+        )
+    ]
+    assert "PRIVATE_PROXY_CREDENTIAL" not in repr(log_capture.calls)
+    assert "PRIVATE PROMPT" not in repr(log_capture.calls)
+
+
+@pytest.mark.asyncio
+async def test_codex_remote_protocol_error_identifies_request_stage(monkeypatch) -> None:
+    log_capture = _capture_codex_warnings(monkeypatch)
+    _mock_codex_diagnostic_context(monkeypatch, 10.0, 20.0, 20.25)
+    _mock_codex_token(monkeypatch)
+
+    async def fake_request(*args: Any, **kwargs: Any):
+        raise httpx.RemoteProtocolError("Server disconnected without sending a response.")
+
+    monkeypatch.setattr("nanobot.providers.openai_codex_provider._request_codex", fake_request)
+
+    provider = OpenAICodexProvider(proxy="http://PRIVATE_PROXY_CREDENTIAL@127.0.0.1:7890")
+    response = await provider.chat([{"role": "user", "content": "PRIVATE PROMPT"}])
+
+    assert response.error_kind == "connection"
+    assert response.error_should_retry is True
+    assert log_capture.calls == [
+        (
+            _CODEX_DIAGNOSTIC_FORMAT,
+            (
+                "deadbeef",
+                "codex_request",
+                250,
+                "gpt-5.6-sol",
+                True,
+                True,
+                "RemoteProtocolError",
+                "connection",
+                True,
+                None,
+                None,
+                None,
+                None,
+                "RemoteProtocolError connection",
+            ),
+        )
+    ]
+    assert "PRIVATE_PROXY_CREDENTIAL" not in repr(log_capture.calls)
+    assert "PRIVATE PROMPT" not in repr(log_capture.calls)
+
+
+@pytest.mark.asyncio
 async def test_codex_timeout_error_writes_diagnostic_log(monkeypatch) -> None:
     log_capture = _capture_codex_warnings(monkeypatch)
+    _mock_codex_diagnostic_context(monkeypatch, 10.0, 20.0, 20.125)
     _mock_codex_token(monkeypatch)
 
     async def fake_request(*args: Any, **kwargs: Any):
@@ -294,9 +392,14 @@ async def test_codex_timeout_error_writes_diagnostic_log(monkeypatch) -> None:
     )
     assert log_capture.calls == [
         (
-            "Codex API request failed: type={} kind={} retryable={} status={} "
-            "error_type={} error_code={} retry_after={} summary={}",
+            _CODEX_DIAGNOSTIC_FORMAT,
             (
+                "deadbeef",
+                "codex_request",
+                125,
+                "gpt-5.6-sol",
+                False,
+                True,
                 "ReadTimeout",
                 "timeout",
                 True,
@@ -396,6 +499,7 @@ async def test_codex_http_error_preserves_status_and_retry_after(monkeypatch) ->
 @pytest.mark.asyncio
 async def test_codex_http_diagnostic_log_omits_raw_body(monkeypatch) -> None:
     log_capture = _capture_codex_warnings(monkeypatch)
+    _mock_codex_diagnostic_context(monkeypatch, 10.0, 20.0, 20.125)
     _mock_codex_token(monkeypatch)
 
     async def fake_request(*args: Any, **kwargs: Any):
@@ -414,9 +518,14 @@ async def test_codex_http_diagnostic_log_omits_raw_body(monkeypatch) -> None:
     assert response.content == "Error calling Codex (CodexHTTPError): HTTP 500: Codex API request failed"
     assert log_capture.calls == [
         (
-            "Codex API request failed: type={} kind={} retryable={} status={} "
-            "error_type={} error_code={} retry_after={} summary={}",
+            _CODEX_DIAGNOSTIC_FORMAT,
             (
+                "deadbeef",
+                "codex_request",
+                125,
+                "gpt-5.6-sol",
+                False,
+                True,
                 "CodexHTTPError",
                 "http",
                 True,

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -20,12 +20,6 @@ from nanobot.providers.openai_codex_provider import (
 )
 from nanobot.providers.registry import find_by_name
 
-_CODEX_DIAGNOSTIC_FORMAT = (
-    "Codex API request failed: attempt_id={} stage={} elapsed_ms={} model={} "
-    "proxy_enabled={} tls_verify={} type={} kind={} retryable={} status={} "
-    "error_type={} error_code={} retry_after={} summary={}"
-)
-
 
 def _mock_codex_token(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_token(**_kwargs):
@@ -35,15 +29,6 @@ def _mock_codex_token(monkeypatch: pytest.MonkeyPatch) -> None:
         "nanobot.providers.openai_codex_provider.get_codex_token",
         fake_token,
     )
-
-
-def _mock_codex_diagnostic_context(
-    monkeypatch: pytest.MonkeyPatch,
-    *monotonic_values: float,
-) -> None:
-    clock = iter(monotonic_values)
-    monkeypatch.setattr("nanobot.providers.openai_codex_provider.token_hex", lambda _size: "deadbeef")
-    monkeypatch.setattr("nanobot.providers.openai_codex_provider.monotonic", lambda: next(clock))
 
 
 def test_codex_default_model_matches_curated_flagship() -> None:
@@ -292,91 +277,8 @@ async def test_codex_provider_passes_proxy_to_oauth_and_response_request(monkeyp
 
 
 @pytest.mark.asyncio
-async def test_codex_remote_protocol_error_identifies_oauth_stage(monkeypatch) -> None:
-    log_capture = _capture_codex_warnings(monkeypatch)
-    _mock_codex_diagnostic_context(monkeypatch, 10.0, 10.25)
-    proxy = "http://PRIVATE_PROXY_CREDENTIAL@127.0.0.1:7890"
-
-    def fake_token(**_kwargs):
-        raise httpx.RemoteProtocolError("Server disconnected without sending a response.")
-
-    monkeypatch.setattr("nanobot.providers.openai_codex_provider.get_codex_token", fake_token)
-
-    provider = OpenAICodexProvider(proxy=proxy)
-    response = await provider.chat([{"role": "user", "content": "PRIVATE PROMPT"}])
-
-    assert response.error_kind == "connection"
-    assert response.error_should_retry is True
-    assert log_capture.calls == [
-        (
-            _CODEX_DIAGNOSTIC_FORMAT,
-            (
-                "deadbeef",
-                "oauth_token",
-                250,
-                "gpt-5.6-sol",
-                True,
-                None,
-                "RemoteProtocolError",
-                "connection",
-                True,
-                None,
-                None,
-                None,
-                None,
-                "RemoteProtocolError connection",
-            ),
-        )
-    ]
-    assert "PRIVATE_PROXY_CREDENTIAL" not in repr(log_capture.calls)
-    assert "PRIVATE PROMPT" not in repr(log_capture.calls)
-
-
-@pytest.mark.asyncio
-async def test_codex_remote_protocol_error_identifies_request_stage(monkeypatch) -> None:
-    log_capture = _capture_codex_warnings(monkeypatch)
-    _mock_codex_diagnostic_context(monkeypatch, 10.0, 20.0, 20.25)
-    _mock_codex_token(monkeypatch)
-
-    async def fake_request(*args: Any, **kwargs: Any):
-        raise httpx.RemoteProtocolError("Server disconnected without sending a response.")
-
-    monkeypatch.setattr("nanobot.providers.openai_codex_provider._request_codex", fake_request)
-
-    provider = OpenAICodexProvider(proxy="http://PRIVATE_PROXY_CREDENTIAL@127.0.0.1:7890")
-    response = await provider.chat([{"role": "user", "content": "PRIVATE PROMPT"}])
-
-    assert response.error_kind == "connection"
-    assert response.error_should_retry is True
-    assert log_capture.calls == [
-        (
-            _CODEX_DIAGNOSTIC_FORMAT,
-            (
-                "deadbeef",
-                "codex_request",
-                250,
-                "gpt-5.6-sol",
-                True,
-                True,
-                "RemoteProtocolError",
-                "connection",
-                True,
-                None,
-                None,
-                None,
-                None,
-                "RemoteProtocolError connection",
-            ),
-        )
-    ]
-    assert "PRIVATE_PROXY_CREDENTIAL" not in repr(log_capture.calls)
-    assert "PRIVATE PROMPT" not in repr(log_capture.calls)
-
-
-@pytest.mark.asyncio
 async def test_codex_timeout_error_writes_diagnostic_log(monkeypatch) -> None:
     log_capture = _capture_codex_warnings(monkeypatch)
-    _mock_codex_diagnostic_context(monkeypatch, 10.0, 20.0, 20.125)
     _mock_codex_token(monkeypatch)
 
     async def fake_request(*args: Any, **kwargs: Any):
@@ -392,14 +294,10 @@ async def test_codex_timeout_error_writes_diagnostic_log(monkeypatch) -> None:
     )
     assert log_capture.calls == [
         (
-            _CODEX_DIAGNOSTIC_FORMAT,
+            "Codex API request failed: stage={} type={} kind={} retryable={} status={} "
+            "error_type={} error_code={} retry_after={} summary={}",
             (
-                "deadbeef",
                 "codex_request",
-                125,
-                "gpt-5.6-sol",
-                False,
-                True,
                 "ReadTimeout",
                 "timeout",
                 True,
@@ -499,7 +397,6 @@ async def test_codex_http_error_preserves_status_and_retry_after(monkeypatch) ->
 @pytest.mark.asyncio
 async def test_codex_http_diagnostic_log_omits_raw_body(monkeypatch) -> None:
     log_capture = _capture_codex_warnings(monkeypatch)
-    _mock_codex_diagnostic_context(monkeypatch, 10.0, 20.0, 20.125)
     _mock_codex_token(monkeypatch)
 
     async def fake_request(*args: Any, **kwargs: Any):
@@ -518,14 +415,10 @@ async def test_codex_http_diagnostic_log_omits_raw_body(monkeypatch) -> None:
     assert response.content == "Error calling Codex (CodexHTTPError): HTTP 500: Codex API request failed"
     assert log_capture.calls == [
         (
-            _CODEX_DIAGNOSTIC_FORMAT,
+            "Codex API request failed: stage={} type={} kind={} retryable={} status={} "
+            "error_type={} error_code={} retry_after={} summary={}",
             (
-                "deadbeef",
                 "codex_request",
-                125,
-                "gpt-5.6-sol",
-                False,
-                True,
                 "CodexHTTPError",
                 "http",
                 True,


### PR DESCRIPTION
## Summary

- add a stage field to the existing Codex failure warning
- distinguish OAuth token acquisition failures from Codex Responses API failures
- preserve existing request, retry, fallback, and redaction behavior

## Testing

- uv run python -m pytest tests/providers/test_openai_codex_provider.py -q
- uv run python -m ruff check nanobot/providers/openai_codex_provider.py tests/providers/test_openai_codex_provider.py