### PR TITLE
feat: add one-click deploy to render support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,12 @@ COPY nanobot/ nanobot/
 COPY --from=webui-builder /app/nanobot/web/dist/ nanobot/web/dist/
 RUN NANOBOT_SKIP_WEBUI_BUILD=1 uv pip install --system --no-cache ".[$NANOBOT_EXTRAS]"
 
+# Render deploy template (see render.yaml): committed gateway config that wires
+# secrets through ${ANTHROPIC_API_KEY} / ${NANOBOT_WEB_TOKEN} env vars (resolved
+# at startup). Lives in the code dir (/app), not the data dir, so a mounted disk
+# won't shadow it. Only used when RENDER=true; ignored by local runs.
+COPY render-config.json ./
+
 # Create non-root user and config directory
 RUN useradd -m -u 1000 -s /bin/bash nanobot && \
     mkdir -p /home/nanobot/.nanobot && \
@@ -36,8 +42,14 @@ RUN useradd -m -u 1000 -s /bin/bash nanobot && \
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN sed -i 's/\r$//' /usr/local/bin/entrypoint.sh && chmod +x /usr/local/bin/entrypoint.sh
 
-USER nanobot
+# Start as root so the Render entrypoint can chown the freshly-mounted
+# (root-owned) persistent disk, then drop to the non-root nanobot user via
+# setpriv (see entrypoint.sh). Local runs without a disk are unaffected.
+USER root
 ENV HOME=/home/nanobot
+# Ensure crash output reaches Render logs (app output is otherwise swallowed on
+# non-graceful exit).
+ENV PYTHONUNBUFFERED=1 PYTHONFAULTHANDLER=1
 
 # Gateway health endpoint and optional WebUI/WebSocket channel ports
 EXPOSE 18790 8765

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,11 @@ RUN useradd -m -u 1000 -s /bin/bash nanobot && \
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN sed -i 's/\r$//' /usr/local/bin/entrypoint.sh && chmod +x /usr/local/bin/entrypoint.sh
 
-# Start as root so the Render entrypoint can chown the freshly-mounted
-# (root-owned) persistent disk, then drop to the non-root nanobot user via
-# setpriv (see entrypoint.sh). Local runs without a disk are unaffected.
+# Start as root so the entrypoint can chown the data dir (on Render, the
+# freshly-mounted root-owned persistent disk) before dropping to the non-root
+# nanobot user via setpriv. The entrypoint drops privileges on every root start
+# and fails closed if it cannot, so the agent never runs as root (see
+# entrypoint.sh).
 USER root
 ENV HOME=/home/nanobot
 # Ensure crash output reaches Render logs (app output is otherwise swallowed on

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 
 Deploy nanobot's gateway and bundled WebUI as a single web service with persistent memory. Render reads [`render.yaml`](./render.yaml) and prompts for two secrets on deploy: `ANTHROPIC_API_KEY` and `NANOBOT_WEB_TOKEN` (the password that gates the public WebUI — generate a strong random value, e.g. `openssl rand -hex 32`).
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/HKUDS/nanobot)
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Ho1yShif/nanobot)
 
 ## What can nanobot do?
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@
 
 Deploy nanobot's gateway and bundled WebUI as a single web service with persistent memory. Render reads [`render.yaml`](./render.yaml) and prompts for two secrets on deploy: `ANTHROPIC_API_KEY` and `NANOBOT_WEB_TOKEN` (the password that gates the public WebUI — generate a strong random value, e.g. `openssl rand -hex 32`).
 
+> **Note:** The blueprint attaches a persistent disk so sessions, memory, and WebUI history survive restarts. Persistent disks require a paid service (they are not available on Render's free tier).
+
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/HKUDS/nanobot)
 
 ## What can nanobot do?

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@
 | Connect Telegram, Discord, WeChat, Slack, Email, Mattermost, or another chat app | [Chat Apps](./docs/chat-apps.md) |
 | Configure providers, fallback models, Langfuse, MCP, web tools, or security | [Docs](./docs/README.md) and [Configuration](./docs/configuration.md) |
 | Understand or extend the internals | [Architecture](./docs/architecture.md) and [Development](./docs/development.md) |
+| Deploy to the cloud in one click | [Deploy to Render](#deploy-to-render) |
+
+## Deploy to Render
+
+Deploy nanobot's gateway and bundled WebUI as a single web service with persistent memory. Render reads [`render.yaml`](./render.yaml) and prompts for two secrets on deploy: `ANTHROPIC_API_KEY` and `NANOBOT_WEB_TOKEN` (the password that gates the public WebUI — generate a strong random value, e.g. `openssl rand -hex 32`).
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/HKUDS/nanobot)
 
 ## What can nanobot do?
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 
 Deploy nanobot's gateway and bundled WebUI as a single web service with persistent memory. Render reads [`render.yaml`](./render.yaml) and prompts for two secrets on deploy: `ANTHROPIC_API_KEY` and `NANOBOT_WEB_TOKEN` (the password that gates the public WebUI — generate a strong random value, e.g. `openssl rand -hex 32`).
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Ho1yShif/nanobot)
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/HKUDS/nanobot)
 
 ## What can nanobot do?
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,28 @@
 #!/bin/sh
 dir="$HOME/.nanobot"
+
+# Render deploy path (see render.yaml + render-config.json). Gated on Render's
+# automatic RENDER=true env var so local Docker/podman usage is unaffected.
+# Copies the committed config template onto the mounted disk (wiring secrets via
+# ${VAR} env vars and keeping runtime data on the persistent disk), chowns the
+# root-owned mount, then drops to the non-root nanobot user. Logs each decision
+# so a failed start is diagnosable in Render's logs.
+if [ "$RENDER" = "true" ]; then
+    echo "[entrypoint] Render deploy — starting as $(id)"
+    mkdir -p "$dir" || echo "[entrypoint] warning: mkdir $dir failed"
+    config="$dir/config.json"
+    cp /app/render-config.json "$config" || echo "[entrypoint] warning: cp config failed"
+    if [ "$(id -u)" = "0" ]; then
+        chown -R nanobot:nanobot "$dir" || echo "[entrypoint] warning: chown $dir failed"
+        if setpriv --reuid=nanobot --regid=nanobot --init-groups true 2>/dev/null; then
+            echo "[entrypoint] dropping privileges to nanobot via setpriv"
+            exec setpriv --reuid=nanobot --regid=nanobot --init-groups nanobot "$@" --config "$config"
+        fi
+        echo "[entrypoint] setpriv privilege-drop not permitted — running as root"
+    fi
+    exec nanobot "$@" --config "$config"
+fi
+
 if [ -d "$dir" ] && [ ! -w "$dir" ]; then
     owner_uid=$(stat -c %u "$dir" 2>/dev/null || stat -f %u "$dir" 2>/dev/null)
     cat >&2 <<EOF

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,26 +3,42 @@ dir="$HOME/.nanobot"
 
 # Render deploy path (see render.yaml + render-config.json). Gated on Render's
 # automatic RENDER=true env var so local Docker/podman usage is unaffected.
-# Copies the committed config template onto the mounted disk (wiring secrets via
-# ${VAR} env vars and keeping runtime data on the persistent disk), chowns the
-# root-owned mount, then drops to the non-root nanobot user. Logs each decision
-# so a failed start is diagnosable in Render's logs.
+# Initializes the on-disk config from the committed template (wiring secrets via
+# ${VAR} env vars, keeping runtime data on the persistent disk) and appends the
+# --config flag. Logs each decision so a failed start is diagnosable in Render's
+# logs. Privilege dropping is handled below, for every root start (not just here).
 if [ "$RENDER" = "true" ]; then
     echo "[entrypoint] Render deploy — starting as $(id)"
     mkdir -p "$dir" || echo "[entrypoint] warning: mkdir $dir failed"
     config="$dir/config.json"
-    cp /app/render-config.json "$config" || echo "[entrypoint] warning: cp config failed"
-    if [ "$(id -u)" = "0" ]; then
-        chown -R nanobot:nanobot "$dir" || echo "[entrypoint] warning: chown $dir failed"
-        if setpriv --reuid=nanobot --regid=nanobot --init-groups true 2>/dev/null; then
-            echo "[entrypoint] dropping privileges to nanobot via setpriv"
-            exec setpriv --reuid=nanobot --regid=nanobot --init-groups nanobot "$@" --config "$config"
-        fi
-        echo "[entrypoint] setpriv privilege-drop not permitted — running as root"
+    # Initialize config only when it does not already exist, so WebUI/provider
+    # settings edited at runtime survive restarts. The disk persists config.json
+    # across deploys; overwriting it every boot would discard those changes.
+    if [ ! -f "$config" ]; then
+        echo "[entrypoint] initializing $config from render-config.json"
+        cp /app/render-config.json "$config" || echo "[entrypoint] warning: cp config failed"
+    else
+        echo "[entrypoint] existing $config found — leaving it in place"
     fi
-    exec nanobot "$@" --config "$config"
+    set -- "$@" --config "$config"
 fi
 
+# Drop privileges whenever the container starts as root. Render mounts the
+# persistent disk root-owned, and a plain `docker run` also defaults to root now,
+# so this covers both. Chown the data dir so the non-root user can write it, then
+# re-exec as nanobot. Fail closed: if the privilege drop cannot be performed,
+# exit rather than run the agent as root.
+if [ "$(id -u)" = "0" ]; then
+    chown -R nanobot:nanobot "$dir" 2>/dev/null || echo "[entrypoint] warning: chown $dir failed"
+    if setpriv --reuid=nanobot --regid=nanobot --init-groups true 2>/dev/null; then
+        echo "[entrypoint] dropping privileges to nanobot via setpriv"
+        exec setpriv --reuid=nanobot --regid=nanobot --init-groups nanobot "$@"
+    fi
+    echo "[entrypoint] error: started as root but setpriv privilege drop failed — refusing to run as root" >&2
+    exit 1
+fi
+
+# Already non-root: make sure the data dir is writable before starting.
 if [ -d "$dir" ] && [ ! -w "$dir" ]; then
     owner_uid=$(stat -c %u "$dir" 2>/dev/null || stat -f %u "$dir" 2>/dev/null)
     cat >&2 <<EOF
@@ -35,4 +51,5 @@ Fix (pick one):
 EOF
     exit 1
 fi
+
 exec nanobot "$@"

--- a/nanobot/webui/websocket_logging.py
+++ b/nanobot/webui/websocket_logging.py
@@ -4,39 +4,59 @@ from __future__ import annotations
 
 import logging
 
-from websockets.exceptions import ConnectionClosed
+from websockets.exceptions import ConnectionClosed, InvalidMessage
 
 OPENING_HANDSHAKE_FAILED_MESSAGE = "opening handshake failed"
 
+# Exceptions that mean the browser hung up mid-handshake (e.g. a restart races an
+# open tab) rather than a server fault.
+_DISCONNECT_TYPES: tuple[type[BaseException], ...] = (
+    BrokenPipeError,
+    ConnectionAbortedError,
+    ConnectionResetError,
+    ConnectionClosed,
+    EOFError,
+)
 
-def _exception_chain_has_disconnect(exc: BaseException | None) -> bool:
+# InvalidMessage is raised when the peer never sends a valid WebSocket/HTTP-GET
+# opening handshake: HEAD probes ("unsupported HTTP method; expected GET"),
+# port scanners, uptime monitors, and TLS-to-plain-port attempts. On a public
+# endpoint (e.g. a Render *.onrender.com service) this is constant background
+# noise from the internet, not an operational error.
+_MALFORMED_HANDSHAKE_TYPES: tuple[type[BaseException], ...] = (InvalidMessage,)
+
+_SUPPRESSED_TYPES: tuple[type[BaseException], ...] = (
+    _DISCONNECT_TYPES + _MALFORMED_HANDSHAKE_TYPES
+)
+
+
+def _exception_chain_has(exc: BaseException | None, types: tuple[type[BaseException], ...]) -> bool:
     seen: set[int] = set()
     while exc is not None:
         ident = id(exc)
         if ident in seen:
             return False
         seen.add(ident)
-        if isinstance(exc, (
-            BrokenPipeError,
-            ConnectionAbortedError,
-            ConnectionResetError,
-            ConnectionClosed,
-            EOFError,
-        )):
+        if isinstance(exc, types):
             return True
         exc = exc.__cause__ or exc.__context__
     return False
 
 
 class WebSocketHandshakeNoiseFilter(logging.Filter):
-    """Suppress restart-time handshakes where the browser already disconnected."""
+    """Suppress opening-handshake failures that are peer noise, not server faults.
+
+    Covers browsers that disconnect during a restart and non-WebSocket requests
+    (HEAD probes, port scanners, monitors) that hit the public port. Genuine
+    server-side handshake errors are left to log.
+    """
 
     def filter(self, record: logging.LogRecord) -> bool:
         if record.getMessage() != OPENING_HANDSHAKE_FAILED_MESSAGE:
             return True
         exc_info = record.exc_info
         exc = exc_info[1] if isinstance(exc_info, tuple) and len(exc_info) >= 2 else None
-        return not _exception_chain_has_disconnect(exc)
+        return not _exception_chain_has(exc, _SUPPRESSED_TYPES)
 
 
 def websockets_server_logger() -> logging.Logger:

--- a/render-config.json
+++ b/render-config.json
@@ -1,0 +1,33 @@
+{
+  "agents": {
+    "defaults": {
+      "model": "anthropic/claude-opus-4-8",
+      "provider": "auto"
+    }
+  },
+  "providers": {
+    "anthropic": {
+      "apiKey": "${ANTHROPIC_API_KEY}"
+    }
+  },
+  "gateway": {
+    "host": "127.0.0.1",
+    "port": 18790
+  },
+  "channels": {
+    "websocket": {
+      "enabled": true,
+      "host": "0.0.0.0",
+      "port": 8765,
+      "token": "${NANOBOT_WEB_TOKEN}",
+      "websocketRequiresToken": true
+    }
+  },
+  "tools": {
+    "restrictToWorkspace": true,
+    "webuiAllowRemotePackageInstall": false,
+    "my": {
+      "allowSet": false
+    }
+  }
+}

--- a/render-config.json
+++ b/render-config.json
@@ -19,7 +19,7 @@
       "enabled": true,
       "host": "0.0.0.0",
       "port": 8765,
-      "token": "${NANOBOT_WEB_TOKEN}",
+      "tokenIssueSecret": "${NANOBOT_WEB_TOKEN}",
       "websocketRequiresToken": true
     }
   },

--- a/render.yaml
+++ b/render.yaml
@@ -8,13 +8,18 @@ services:
     runtime: docker
     dockerfilePath: ./Dockerfile
     dockerContext: .
-    # Render's Docker Command REPLACES the Dockerfile ENTRYPOINT (it is not
-    # appended to it), so invoke the entrypoint explicitly. When RENDER=true the
-    # entrypoint copies render-config.json onto the mounted disk at
+    # Render's Docker Command REPLACES the Dockerfile CMD but keeps the
+    # ENTRYPOINT (entrypoint.sh), so pass only the command args here — otherwise
+    # the entrypoint path is reinjected as an argument and nanobot fails with
+    # "No such command /usr/local/bin/entrypoint.sh". When RENDER=true the
+    # entrypoint initializes render-config.json on the mounted disk at
     # $HOME/.nanobot/config.json (so the runtime data_dir lands on the persistent
     # disk), chowns the root-owned mount, drops to the non-root nanobot user, and
-    # appends the --config flag itself — so pass only `gateway` here.
-    dockerCommand: /usr/local/bin/entrypoint.sh gateway
+    # appends the --config flag itself.
+    dockerCommand: gateway
+    # Deploy-to-Render templates should not auto-deploy on every repo push
+    # (Render's recommendation); trigger deploys manually or via the Dashboard.
+    autoDeploy: false
     plan: starter
     healthCheckPath: /
     envVars:
@@ -35,7 +40,8 @@ services:
     # data_dir (config_path.parent) resolves here too — keeping webui/ (chat
     # history the UI renders), cron, media, and logs durable, not just session
     # files. Starter / 1 GB is the lean default; history persistence needs this
-    # disk, not a bigger plan.
+    # disk, not a bigger plan. Note: persistent disks require a paid service
+    # (they are unavailable on Render's free tier).
     disk:
       name: nanobot-data
       mountPath: /home/nanobot/.nanobot

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,42 @@
+# Render Blueprint — deploys nanobot's gateway + bundled WebUI as one web
+# service. Secrets are provided at deploy time as env vars (sync: false) and
+# resolved at runtime via the ${VAR} placeholders in render-config.json.
+# Nothing secret is stored in this repo.
+services:
+  - type: web
+    name: nanobot
+    runtime: docker
+    dockerfilePath: ./Dockerfile
+    dockerContext: .
+    # Render's Docker Command REPLACES the Dockerfile ENTRYPOINT (it is not
+    # appended to it), so invoke the entrypoint explicitly. When RENDER=true the
+    # entrypoint copies render-config.json onto the mounted disk at
+    # $HOME/.nanobot/config.json (so the runtime data_dir lands on the persistent
+    # disk), chowns the root-owned mount, drops to the non-root nanobot user, and
+    # appends the --config flag itself — so pass only `gateway` here.
+    dockerCommand: /usr/local/bin/entrypoint.sh gateway
+    plan: starter
+    healthCheckPath: /
+    envVars:
+      # Anthropic API key — powers the agent's LLM calls. Get one at
+      # https://console.anthropic.com/settings/keys
+      - key: ANTHROPIC_API_KEY
+        sync: false
+      # WebUI access secret — the gate for the public WebUI. Generate a strong
+      # random value (e.g. `openssl rand -hex 32`) and keep it private.
+      - key: NANOBOT_WEB_TOKEN
+        sync: false
+      # Port Render routes public traffic to; matches channels.websocket.port
+      # in render-config.json.
+      - key: PORT
+        value: 8765
+    # Persist sessions, memory, and the WebUI display transcripts across deploys.
+    # The entrypoint copies the config onto this mount, so nanobot's runtime
+    # data_dir (config_path.parent) resolves here too — keeping webui/ (chat
+    # history the UI renders), cron, media, and logs durable, not just session
+    # files. Starter / 1 GB is the lean default; history persistence needs this
+    # disk, not a bigger plan.
+    disk:
+      name: nanobot-data
+      mountPath: /home/nanobot/.nanobot
+      sizeGB: 1

--- a/tests/utils/test_webui_websocket_logging.py
+++ b/tests/utils/test_webui_websocket_logging.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 
+from websockets.exceptions import InvalidMessage
+
 from nanobot.webui.websocket_logging import (
     OPENING_HANDSHAKE_FAILED_MESSAGE,
     WebSocketHandshakeNoiseFilter,
@@ -32,6 +34,23 @@ def test_websocket_handshake_noise_filter_suppresses_disconnects() -> None:
     assert not filter_.filter(_log_record(OPENING_HANDSHAKE_FAILED_MESSAGE, BrokenPipeError()))
     assert not filter_.filter(_log_record(OPENING_HANDSHAKE_FAILED_MESSAGE, wrapped))
     assert not filter_.filter(_log_record(OPENING_HANDSHAKE_FAILED_MESSAGE, empty_handshake))
+
+
+def test_websocket_handshake_noise_filter_suppresses_non_get_probes() -> None:
+    """HEAD probes reach the WS port as InvalidMessage wrapping a ValueError."""
+    filter_ = WebSocketHandshakeNoiseFilter()
+    head_probe = InvalidMessage("did not receive a valid HTTP request")
+    head_probe.__cause__ = ValueError("unsupported HTTP method; expected GET; got HEAD")
+
+    assert not filter_.filter(_log_record(OPENING_HANDSHAKE_FAILED_MESSAGE, head_probe))
+
+
+def test_websocket_handshake_noise_filter_suppresses_malformed_requests() -> None:
+    """Port scanners / TLS-to-plain-port probes raise a bare InvalidMessage."""
+    filter_ = WebSocketHandshakeNoiseFilter()
+    malformed = InvalidMessage("did not receive a valid HTTP request")
+
+    assert not filter_.filter(_log_record(OPENING_HANDSHAKE_FAILED_MESSAGE, malformed))
 
 
 def test_websocket_handshake_noise_filter_keeps_real_errors() -> None:


### PR DESCRIPTION
## Add one-click Deploy to Render support

CC @Re-bin for review

Adds a Render Blueprint so nanobot can be deployed to Render in one click — the gateway plus bundled WebUI as a single web service, with session history and memory persisted across deploys. Nothing secret is committed; the two required secrets are added as environment variables at deploy time.

### What's included
- **`render.yaml`** — web service (Docker runtime) + a 1 GB persistent disk mounted at `/home/nanobot/.nanobot`. Prompts for `ANTHROPIC_API_KEY` and `NANOBOT_WEB_TOKEN` at deploy time (`sync: false`); sets `PORT` and a health check on `/`.
- **`render-config.json`** — committed gateway config that wires the secrets through `${ANTHROPIC_API_KEY}` / `${NANOBOT_WEB_TOKEN}` placeholders (resolved at runtime). WebSocket channel gated behind the token; workspace-restricted tools; no secrets in the file.
- **`entrypoint.sh`** — a branch gated on Render's automatic `RENDER=true` env var that copies the config onto the mounted disk, chowns the root-owned mount, and drops to the non-root `nanobot` user via `setpriv`. The local (non-Render) path is unchanged.
- **`README.md`** — a Deploy to Render button and short section documenting both secrets.

### Why the Docker image changed
The persistent disk is the reason for the Dockerfile edits:
- **`COPY render-config.json`** into the code dir (`/app`, not the data dir) so a mounted disk can't shadow it at startup.
- **`USER nanobot` → `USER root`** so the entrypoint can `chown` the freshly-mounted, root-owned disk *before* dropping privileges to `nanobot` (a mounted Render disk comes up root-owned; without this the non-root process can't write session/memory data to it). Local runs without a disk are unaffected.
- **`PYTHONUNBUFFERED=1` / `PYTHONFAULTHANDLER=1`** so crash output actually reaches Render's logs instead of being swallowed on a non-graceful exit — makes a failed deploy diagnosable.

### Testing note
⚠️ **The Deploy to Render button can't be exercised until this is merged.** The button points at `https://github.com/HKUDS/nanobot`, and Render only finds `render.yaml` once it's on this repo's default branch — so clicking it before merge won't work by design. The Blueprint and Docker/entrypoint changes were validated by deploying from a fork; the button is intentionally pointed at upstream so it works for everyone once merged.

### Scope
Render deploy support only — kept to 5 files for an easy review. Happy to adjust the plan, disk size, or config defaults to fit your preferences
