### PR TITLE
fix(cli): point onboarding to the WebUI launcher

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -632,14 +632,6 @@ def main(
 # ============================================================================
 
 
-def _print_onboard_completion(
-    *,
-    webui_cmd: str,
-) -> None:
-    """Show the single shortest path from onboarding to a working nanobot."""
-    typer.echo(f"\n✓ nanobot is ready. Run: {webui_cmd}")
-
-
 @app.command()
 def onboard(
     workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace directory"),
@@ -729,9 +721,7 @@ def onboard(
     if explicit_config:
         webui_cmd += f' -c "{config_path}"'
 
-    _print_onboard_completion(
-        webui_cmd=webui_cmd,
-    )
+    typer.echo(f"\n✓ nanobot is ready. Run: {webui_cmd}")
 
 
 def _onboard_plugins(config_path: Path) -> None:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -632,6 +632,14 @@ def main(
 # ============================================================================
 
 
+def _print_onboard_completion(
+    *,
+    webui_cmd: str,
+) -> None:
+    """Show the single shortest path from onboarding to a working nanobot."""
+    typer.echo(f"\n✓ nanobot is ready. Run: {webui_cmd}")
+
+
 @app.command()
 def onboard(
     workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace directory"),
@@ -643,6 +651,7 @@ def onboard(
     from nanobot.config.loader import get_config_path, load_config, save_config, set_config_path
     from nanobot.config.schema import Config
 
+    explicit_config = config is not None
     if config:
         config_path = Path(config).expanduser().resolve()
         set_config_path(config_path)
@@ -716,23 +725,12 @@ def onboard(
 
     sync_workspace_templates(workspace_path)
 
-    agent_cmd = 'nanobot agent -m "Hello!"'
-    gateway_cmd = "nanobot gateway"
-    if config:
-        agent_cmd += f" --config {config_path}"
-        gateway_cmd += f" --config {config_path}"
+    webui_cmd = "nanobot webui"
+    if explicit_config:
+        webui_cmd += f' -c "{config_path}"'
 
-    console.print(f"\n{__logo__} nanobot is ready!")
-    console.print("\nNext steps:")
-    if wizard:
-        console.print(f"  1. Chat: [cyan]{agent_cmd}[/cyan]")
-        console.print(f"  2. Start gateway: [cyan]{gateway_cmd}[/cyan]")
-    else:
-        console.print(f"  1. Add your API key to [cyan]{config_path}[/cyan]")
-        console.print("     Get one at: https://openrouter.ai/keys")
-        console.print(f"  2. Chat: [cyan]{agent_cmd}[/cyan]")
-    console.print(
-        "\n[dim]Want Telegram/WhatsApp? See: https://github.com/HKUDS/nanobot#-chat-apps[/dim]"
+    _print_onboard_completion(
+        webui_cmd=webui_cmd,
     )
 
 

--- a/nanobot/cli/onboard.py
+++ b/nanobot/cli/onboard.py
@@ -1792,16 +1792,12 @@ def _show_quick_start_summary(config: Config) -> None:
         )
         has_api_key = is_local or bool(provider_config and provider_config.api_key)
 
-    start_command = "`nanobot webui`"
-    next_step = f"Run {start_command}"
     status = "Ready"
     if not has_api_key:
         status = f"{provider_label} API key missing"
-        next_step = f"Add your {provider_label} API key, then run {start_command}"
 
     rows = [
         ("Status", status),
-        ("Next", next_step),
         ("WebSocket channel", "enabled"),
     ]
     _print_summary_panel(rows, "Quick Start")

--- a/nanobot/cli/onboard.py
+++ b/nanobot/cli/onboard.py
@@ -1792,7 +1792,7 @@ def _show_quick_start_summary(config: Config) -> None:
         )
         has_api_key = is_local or bool(provider_config and provider_config.api_key)
 
-    start_command = "`nanobot gateway`"
+    start_command = "`nanobot webui`"
     next_step = f"Run {start_command}"
     status = "Ready"
     if not has_api_key:
@@ -1803,7 +1803,6 @@ def _show_quick_start_summary(config: Config) -> None:
         ("Status", status),
         ("Next", next_step),
         ("WebSocket channel", "enabled"),
-        ("Open", "http://127.0.0.1:8765"),
     ]
     _print_summary_panel(rows, "Quick Start")
 

--- a/tests/agent/test_onboard_logic.py
+++ b/tests/agent/test_onboard_logic.py
@@ -1451,7 +1451,7 @@ class TestMainMenuUpdate:
         assert "primary" not in config.model_presets
 
     def test_quick_start_summary_calls_out_missing_api_key(self, monkeypatch):
-        """Quick Start summary should direct users to the one-step WebUI launcher."""
+        """Quick Start summary should flag a missing key without repeating the next step."""
         config = Config()
         config.model_presets["primary"] = ModelPresetConfig(
             model="deepseek-v4-flash",
@@ -1472,10 +1472,7 @@ class TestMainMenuUpdate:
         labels = [label for label, _value in captured["rows"]]
         rows = dict(captured["rows"])
         assert rows["Status"] == "DeepSeek API key missing"
-        assert "API key" in rows["Next"]
-        assert "nanobot webui" in rows["Next"]
-        assert "nanobot gateway" not in rows["Next"]
-        assert "agent -m" not in rows["Next"]
+        assert "Next" not in labels
         assert "Open" not in labels
         assert "Model" not in rows
         assert "Entry point" not in rows

--- a/tests/agent/test_onboard_logic.py
+++ b/tests/agent/test_onboard_logic.py
@@ -1451,7 +1451,7 @@ class TestMainMenuUpdate:
         assert "primary" not in config.model_presets
 
     def test_quick_start_summary_calls_out_missing_api_key(self, monkeypatch):
-        """Quick Start summary should flag a missing key without repeating the next step."""
+        """Quick Start summary should retain the missing-key status."""
         config = Config()
         config.model_presets["primary"] = ModelPresetConfig(
             model="deepseek-v4-flash",
@@ -1469,15 +1469,9 @@ class TestMainMenuUpdate:
 
         onboard_wizard._show_quick_start_summary(config)
 
-        labels = [label for label, _value in captured["rows"]]
         rows = dict(captured["rows"])
         assert rows["Status"] == "DeepSeek API key missing"
-        assert "Next" not in labels
-        assert "Open" not in labels
-        assert "Model" not in rows
-        assert "Entry point" not in rows
-        assert "API key" not in rows
-        assert "Defaults" not in rows
+        assert rows["WebSocket channel"] == "enabled"
 
     def test_configure_login_channel_defaults_to_login(self, monkeypatch):
         """The channel wizard should start login before exposing advanced fields."""

--- a/tests/agent/test_onboard_logic.py
+++ b/tests/agent/test_onboard_logic.py
@@ -1451,7 +1451,7 @@ class TestMainMenuUpdate:
         assert "primary" not in config.model_presets
 
     def test_quick_start_summary_calls_out_missing_api_key(self, monkeypatch):
-        """Quick Start summary should not tell users to run gateway before adding a key."""
+        """Quick Start summary should direct users to the one-step WebUI launcher."""
         config = Config()
         config.model_presets["primary"] = ModelPresetConfig(
             model="deepseek-v4-flash",
@@ -1473,9 +1473,10 @@ class TestMainMenuUpdate:
         rows = dict(captured["rows"])
         assert rows["Status"] == "DeepSeek API key missing"
         assert "API key" in rows["Next"]
-        assert "nanobot gateway" in rows["Next"]
+        assert "nanobot webui" in rows["Next"]
+        assert "nanobot gateway" not in rows["Next"]
         assert "agent -m" not in rows["Next"]
-        assert labels.index("Next") < labels.index("Open")
+        assert "Open" not in labels
         assert "Model" not in rows
         assert "Entry point" not in rows
         assert "API key" not in rows

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -268,18 +268,12 @@ def test_onboard_fresh_install(mock_paths):
     assert mock_ws.call_args.args == (expected_workspace,)
 
 
-def test_onboard_recommends_the_shortest_provider_neutral_path(mock_paths):
-    """Default onboarding should recommend only the guided WebUI launcher."""
+def test_onboard_recommends_webui(mock_paths):
+    """Default onboarding should recommend the guided WebUI launcher."""
     result = runner.invoke(app, ["onboard"])
 
     assert result.exit_code == 0
-    assert "OpenRouter" not in result.stdout
-    assert "openrouter.ai" not in result.stdout
     assert "✓ nanobot is ready. Run: nanobot webui" in result.stdout
-    assert "nanobot agent" not in result.stdout
-    assert "nanobot gateway" not in result.stdout
-    assert "https://" not in result.stdout
-    assert "┌" not in result.stdout
 
 
 def test_onboard_existing_config_refresh(mock_paths):
@@ -411,13 +405,8 @@ def test_onboard_interactive_discard_does_not_save_or_create_workspace(mock_path
 def test_onboard_uses_explicit_config_and_workspace_paths(tmp_path, monkeypatch):
     config_path = tmp_path / "instance" / "config.json"
     workspace_path = tmp_path / "workspace"
-    completion: dict = {}
 
     monkeypatch.setattr("nanobot.channels.registry.discover_all", lambda: {})
-    monkeypatch.setattr(
-        "nanobot.cli.commands._print_onboard_completion",
-        lambda **kwargs: completion.update(kwargs),
-    )
 
     result = runner.invoke(
         app,
@@ -432,13 +421,12 @@ def test_onboard_uses_explicit_config_and_workspace_paths(tmp_path, monkeypatch)
     compact_output = stripped_output.replace("\n", "")
     resolved_config = str(config_path.resolve())
     assert resolved_config in compact_output
-    assert completion["webui_cmd"] == f'nanobot webui -c "{resolved_config}"'
+    assert f'nanobot webui -c "{resolved_config}"' in result.stdout
 
 
 def test_onboard_wizard_preserves_explicit_config_in_next_steps(tmp_path, monkeypatch):
     config_path = tmp_path / "instance" / "config.json"
     workspace_path = tmp_path / "workspace"
-    completion: dict = {}
 
     from nanobot.cli.onboard import OnboardResult
 
@@ -447,10 +435,6 @@ def test_onboard_wizard_preserves_explicit_config_in_next_steps(tmp_path, monkey
         lambda initial_config: OnboardResult(config=initial_config, should_save=True),
     )
     monkeypatch.setattr("nanobot.channels.registry.discover_all", lambda: {})
-    monkeypatch.setattr(
-        "nanobot.cli.commands._print_onboard_completion",
-        lambda **kwargs: completion.update(kwargs),
-    )
 
     result = runner.invoke(
         app,
@@ -459,7 +443,7 @@ def test_onboard_wizard_preserves_explicit_config_in_next_steps(tmp_path, monkey
 
     assert result.exit_code == 0
     resolved_config = str(config_path.resolve())
-    assert completion["webui_cmd"] == f'nanobot webui -c "{resolved_config}"'
+    assert f'nanobot webui -c "{resolved_config}"' in result.stdout
 
 
 def test_config_matches_github_copilot_codex_with_hyphen_prefix():

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -268,6 +268,20 @@ def test_onboard_fresh_install(mock_paths):
     assert mock_ws.call_args.args == (expected_workspace,)
 
 
+def test_onboard_recommends_the_shortest_provider_neutral_path(mock_paths):
+    """Default onboarding should recommend only the guided WebUI launcher."""
+    result = runner.invoke(app, ["onboard"])
+
+    assert result.exit_code == 0
+    assert "OpenRouter" not in result.stdout
+    assert "openrouter.ai" not in result.stdout
+    assert "✓ nanobot is ready. Run: nanobot webui" in result.stdout
+    assert "nanobot agent" not in result.stdout
+    assert "nanobot gateway" not in result.stdout
+    assert "https://" not in result.stdout
+    assert "┌" not in result.stdout
+
+
 def test_onboard_existing_config_refresh(mock_paths):
     """Config exists, user declines overwrite — should refresh (load-merge-save)."""
     config_file, workspace_dir, _ = mock_paths
@@ -397,8 +411,13 @@ def test_onboard_interactive_discard_does_not_save_or_create_workspace(mock_path
 def test_onboard_uses_explicit_config_and_workspace_paths(tmp_path, monkeypatch):
     config_path = tmp_path / "instance" / "config.json"
     workspace_path = tmp_path / "workspace"
+    completion: dict = {}
 
     monkeypatch.setattr("nanobot.channels.registry.discover_all", lambda: {})
+    monkeypatch.setattr(
+        "nanobot.cli.commands._print_onboard_completion",
+        lambda **kwargs: completion.update(kwargs),
+    )
 
     result = runner.invoke(
         app,
@@ -413,12 +432,13 @@ def test_onboard_uses_explicit_config_and_workspace_paths(tmp_path, monkeypatch)
     compact_output = stripped_output.replace("\n", "")
     resolved_config = str(config_path.resolve())
     assert resolved_config in compact_output
-    assert f"--config {resolved_config}" in compact_output
+    assert completion["webui_cmd"] == f'nanobot webui -c "{resolved_config}"'
 
 
 def test_onboard_wizard_preserves_explicit_config_in_next_steps(tmp_path, monkeypatch):
     config_path = tmp_path / "instance" / "config.json"
     workspace_path = tmp_path / "workspace"
+    completion: dict = {}
 
     from nanobot.cli.onboard import OnboardResult
 
@@ -427,6 +447,10 @@ def test_onboard_wizard_preserves_explicit_config_in_next_steps(tmp_path, monkey
         lambda initial_config: OnboardResult(config=initial_config, should_save=True),
     )
     monkeypatch.setattr("nanobot.channels.registry.discover_all", lambda: {})
+    monkeypatch.setattr(
+        "nanobot.cli.commands._print_onboard_completion",
+        lambda **kwargs: completion.update(kwargs),
+    )
 
     result = runner.invoke(
         app,
@@ -434,11 +458,8 @@ def test_onboard_wizard_preserves_explicit_config_in_next_steps(tmp_path, monkey
     )
 
     assert result.exit_code == 0
-    stripped_output = _strip_ansi(result.stdout)
-    compact_output = stripped_output.replace("\n", "")
     resolved_config = str(config_path.resolve())
-    assert f'nanobot agent -m "Hello!" --config {resolved_config}' in compact_output
-    assert f"nanobot gateway --config {resolved_config}" in compact_output
+    assert completion["webui_cmd"] == f'nanobot webui -c "{resolved_config}"'
 
 
 def test_config_matches_github_copilot_codex_with_hyphen_prefix():


### PR DESCRIPTION
## Summary

- replace provider-specific and stale post-onboard guidance with one plain-text `nanobot webui` next step
- preserve explicit config paths in the recommended WebUI command
- align the interactive Quick Start summary with the WebUI launcher and remove the manual localhost step

## Testing

- `PYTHONPATH=. pytest tests/agent/test_onboard_logic.py tests/cli/test_commands.py -q` (`251 passed, 1 skipped`)
- `ruff check nanobot/cli/commands.py nanobot/cli/onboard.py tests/cli/test_commands.py tests/agent/test_onboard_logic.py`
- `git diff --check`