### PR TITLE
fix(web): keep sensitive URLs out of Jina Reader

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1792,27 +1792,27 @@ Create a key at [serper.dev](https://serper.dev). You can also set `SERPER_API_K
 > { "tools": { "web": { "userAgent": "Not-A-Browser", "fetch": { "useJinaReader": false } } } }
 > ```
 
-nanobot by default uses [Jina Reader](https://jina.ai/reader/), a third-party API, to convert arbitrary pages into Markdown format for easy digestion by the LLM, with a local fallback based on [readability-lxml](https://github.com/buriy/python-readability) if the former fails.
-
-If you want to always use the local conversion, you can force it using:
+nanobot uses local conversion based on [readability-lxml](https://github.com/buriy/python-readability) by default. You may explicitly enable [Jina Reader](https://jina.ai/reader/) when you want its third-party conversion service:
 
 ```json
 {
   "tools": {
     "web": {
       "fetch": {
-        "useJinaReader": false
+        "useJinaReader": true
       }
     }
   }
 }
 ```
 
+When enabled, Jina Reader receives the URL it fetches. URLs containing credentials or query strings are always processed locally, so password-bearing and signed URLs are not forwarded; URL fragments are removed before an ordinary URL is sent to Jina. Set `useJinaReader` to `false` to always keep conversion local.
+
 #### `tools.web.fetch`
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `useJinaReader` | boolean | `true` | If true, Jina Reader will be preferred over the local conversion |
+| `useJinaReader` | boolean | `false` | If true, use Jina Reader for URLs without credentials or query strings; otherwise use local conversion |
 
 ## Image Generation
 

--- a/docs/guides/configure-web-search.md
+++ b/docs/guides/configure-web-search.md
@@ -74,7 +74,7 @@ in the WebUI or logs.
 - Keep API keys in environment variables.
 - Set `maxResults` when you need fewer or more search results per query.
 - Set `tools.web.proxy` only to a proxy you trust.
-- Use `fetch.useJinaReader: false` if you need local page conversion.
+- Local page conversion is the default. Set `fetch.useJinaReader: true` only when you intend to share eligible URLs with Jina Reader.
 
 ## Security notes
 

--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -8,7 +8,7 @@ import json
 import os
 import re
 from typing import Any, Callable
-from urllib.parse import quote, urljoin, urlparse
+from urllib.parse import quote, urljoin, urlparse, urlsplit, urlunsplit
 
 import httpx
 from loguru import logger
@@ -65,7 +65,7 @@ class WebSearchConfig(Base):
 
 class WebFetchConfig(Base):
     """Web fetch tool configuration."""
-    use_jina_reader: bool = True
+    use_jina_reader: bool = False
 
 
 class WebToolsConfig(Base):
@@ -109,6 +109,20 @@ def _validate_url_safe(url: str) -> tuple[bool, str]:
     from nanobot.security.network import validate_url_target
 
     return validate_url_target(url)
+
+
+def _jina_reader_url(url: str) -> str | None:
+    """Return a URL safe to share with Jina Reader, or None to use local extraction.
+
+    Jina Reader fetches the target from its own infrastructure. Do not disclose
+    URLs containing credentials or query strings, which commonly carry access
+    tokens and signed-resource parameters. Fragments are client-side only and
+    are removed before forwarding ordinary URLs.
+    """
+    parsed = urlsplit(url)
+    if parsed.username is not None or parsed.password is not None or parsed.query:
+        return None
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
 
 
 def _resolve_url_safe(url: str) -> tuple[bool, str, tuple[str, ...]]:
@@ -1028,7 +1042,11 @@ class WebFetchTool(Tool):
 
         result = None
         if self.config.use_jina_reader:
-            result = await self._fetch_jina(url, max_chars)
+            jina_url = _jina_reader_url(url)
+            if jina_url is None:
+                logger.debug("Skipping Jina Reader for a URL with credentials or a query string")
+            else:
+                result = await self._fetch_jina(jina_url, max_chars)
         if result is None:
             result = await self._fetch_readability(url, extract_mode, max_chars)
         return result

--- a/tests/channels/test_websocket_channel.py
+++ b/tests/channels/test_websocket_channel.py
@@ -1917,7 +1917,7 @@ async def test_settings_api_returns_safe_subset_and_updates_whitelist(
         assert body["web_search"]["provider"] == "brave"
         assert body["web_search"]["api_key_hint"] == "brav••••cret"
         assert body["web_search"]["max_results"] == 5
-        assert body["web"]["fetch"]["use_jina_reader"] is True
+        assert body["web"]["fetch"]["use_jina_reader"] is False
         search_providers = {provider["name"]: provider for provider in body["web_search"]["providers"]}
         assert search_providers["duckduckgo"]["credential"] == "none"
         assert search_providers["exa"]["credential"] == "api_key"
@@ -2056,7 +2056,7 @@ async def test_settings_api_returns_safe_subset_and_updates_whitelist(
             "http://127.0.0.1:"
             f"{port}/api/settings/web-search/update?provider=searxng"
             "&base_url=https%3A%2F%2Fsearch.example.com"
-            "&max_results=8&timeout=45&use_jina_reader=false",
+            "&max_results=8&timeout=45&use_jina_reader=true",
             headers={"Authorization": "Bearer tok"},
         )
         assert search_updated.status_code == 200
@@ -2067,7 +2067,7 @@ async def test_settings_api_returns_safe_subset_and_updates_whitelist(
         assert search_body["web_search"]["api_key_hint"] is None
         assert search_body["web_search"]["base_url"] == "https://search.example.com"
         assert search_body["web_search"]["max_results"] == 8
-        assert search_body["web"]["fetch"]["use_jina_reader"] is False
+        assert search_body["web"]["fetch"]["use_jina_reader"] is True
 
         network_safety_updated = await _http_get(
             "http://127.0.0.1:"
@@ -2148,7 +2148,7 @@ async def test_settings_api_returns_safe_subset_and_updates_whitelist(
         assert saved.tools.web.search.base_url == "https://search.example.com"
         assert saved.tools.web.search.max_results == 8
         assert saved.tools.web.search.timeout == 45
-        assert saved.tools.web.fetch.use_jina_reader is False
+        assert saved.tools.web.fetch.use_jina_reader is True
         assert saved.tools.webui_allow_local_service_access is False
         assert saved.tools.image_generation.enabled is True
         assert saved.tools.image_generation.provider == "openrouter"

--- a/tests/tools/test_web_fetch_security.py
+++ b/tests/tools/test_web_fetch_security.py
@@ -128,7 +128,7 @@ async def test_web_fetch_blocks_localhost_even_in_full_workspace_scope(tmp_path)
 @pytest.mark.asyncio
 async def test_web_fetch_result_contains_untrusted_flag(monkeypatch: pytest.MonkeyPatch):
     """When fetch succeeds, result JSON must include untrusted=True and the banner."""
-    tool = WebFetchTool()
+    tool = WebFetchTool(config=WebFetchConfig(use_jina_reader=True))
     _patch_web_fetch_fake_client(monkeypatch)
 
     with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve_public):
@@ -189,7 +189,10 @@ async def test_safe_redirect_requests_use_independent_pinned_dns_concurrently(mo
 
 @pytest.mark.asyncio
 async def test_web_fetch_proxy_remains_supported(monkeypatch):
-    tool = WebFetchTool(proxy="http://config-proxy.example:7890")
+    tool = WebFetchTool(
+        config=WebFetchConfig(use_jina_reader=True),
+        proxy="http://config-proxy.example:7890",
+    )
     client_kwargs = _patch_web_fetch_fake_client(monkeypatch)
 
     monkeypatch.setenv("HTTPS_PROXY", "http://env-proxy.example:8080")
@@ -207,7 +210,7 @@ async def test_web_fetch_proxy_remains_supported(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_web_fetch_env_proxy_adds_proxy_mounts_and_keeps_pinned_transport(monkeypatch):
-    tool = WebFetchTool()
+    tool = WebFetchTool(config=WebFetchConfig(use_jina_reader=True))
     client_kwargs = _patch_web_fetch_fake_client(monkeypatch)
 
     monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
@@ -237,6 +240,73 @@ def test_web_fetch_no_proxy_env_keeps_pinned_direct_route(monkeypatch):
 
     assert "transport" in kwargs
     assert any(transport is None for transport in kwargs["mounts"].values())
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_uses_local_reader_by_default(monkeypatch: pytest.MonkeyPatch):
+    tool = WebFetchTool()
+    _patch_web_fetch_fake_client(monkeypatch)
+
+    async def _unexpected_jina(*args, **kwargs):
+        raise AssertionError("Jina Reader must require explicit configuration")
+
+    async def _local_reader(*args, **kwargs):
+        return '{"extractor":"readability"}'
+
+    monkeypatch.setattr(tool, "_fetch_jina", _unexpected_jina)
+    monkeypatch.setattr(tool, "_fetch_readability", _local_reader)
+
+    with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve_public):
+        result = await tool.execute(url="https://example.com/page")
+
+    assert json.loads(result)["extractor"] == "readability"
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_strips_fragment_before_calling_jina(monkeypatch: pytest.MonkeyPatch):
+    tool = WebFetchTool(config=WebFetchConfig(use_jina_reader=True))
+    _patch_web_fetch_fake_client(monkeypatch)
+    jina_urls: list[str] = []
+
+    async def _jina_reader(url: str, max_chars: int):
+        jina_urls.append(url)
+        return '{"extractor":"jina"}'
+
+    monkeypatch.setattr(tool, "_fetch_jina", _jina_reader)
+
+    with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve_public):
+        result = await tool.execute(url="https://example.com/page#private-section")
+
+    assert json.loads(result)["extractor"] == "jina"
+    assert jina_urls == ["https://example.com/page"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://user:secret@example.com/page",
+        "https://example.com/page?token=secret",
+    ],
+)
+async def test_web_fetch_never_sends_sensitive_urls_to_jina(monkeypatch: pytest.MonkeyPatch, url: str):
+    tool = WebFetchTool(config=WebFetchConfig(use_jina_reader=True))
+    _patch_web_fetch_fake_client(monkeypatch)
+
+    async def _unexpected_jina(*args, **kwargs):
+        raise AssertionError("Sensitive URLs must not be sent to Jina Reader")
+
+    async def _local_reader(local_url: str, *args, **kwargs):
+        assert local_url == url
+        return '{"extractor":"readability"}'
+
+    monkeypatch.setattr(tool, "_fetch_jina", _unexpected_jina)
+    monkeypatch.setattr(tool, "_fetch_readability", _local_reader)
+
+    with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve_public):
+        result = await tool.execute(url=url)
+
+    assert json.loads(result)["extractor"] == "readability"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #4884

## Summary

Jina Reader was enabled by default and received the original URL, including URL credentials, query-string tokens, signed-resource parameters, and fragments. This change makes third-party conversion an explicit choice and keeps sensitive URLs on the existing local readability path.

## Plan implemented

1. **Privacy policy** — `useJinaReader` now defaults to `false`; Jina is used only when explicitly enabled.
2. **Jina boundary** — a single URL gate removes fragments and declines Jina for URLs with userinfo or query strings. Those requests continue through local readability with the existing SSRF-protected fetch path.
3. **Regression coverage** — tests prove the default stays local, fragments are not forwarded, and credential/query URLs never reach Jina while still using the local fallback.
4. **Documentation** — configuration reference and web-search guide now describe the opt-in behavior and third-party URL disclosure boundary.
5. **Verification** — ran the focused WebFetch and WebUI settings tests plus Ruff.

## User impact

Existing configurations that omit `tools.web.fetch.useJinaReader` now use local conversion. Users who want Jina for ordinary public URLs can explicitly set it to `true`; signed/authenticated URLs remain local even then.

## Validation

- `python -m pytest tests/tools/test_web_fetch_security.py tests/tools/test_web_fetch_url_sanitization.py -q`
- `python -m pytest tests/channels/test_websocket_channel.py::test_settings_api_returns_safe_subset_and_updates_whitelist -q`
- `ruff check nanobot/agent/tools/web.py tests/tools/test_web_fetch_security.py tests/channels/test_websocket_channel.py`
