### PR TITLE
fix(webui): keep late subagent turns visible

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -576,6 +576,21 @@ class AgentLoop:
         """Return the chat id shown in runtime metadata for the model."""
         return str(msg.metadata.get("context_chat_id") or msg.chat_id)
 
+    @staticmethod
+    def _system_delivery_message(msg: InboundMessage) -> InboundMessage:
+        """Return the visible WebUI route carried by an internal system message."""
+        if (
+            msg.channel != "system"
+            or msg.metadata.get("webui") is not True
+            or not msg.chat_id.startswith("websocket:")
+        ):
+            return msg
+        return dataclasses.replace(
+            msg,
+            channel="websocket",
+            chat_id=msg.chat_id.split(":", 1)[1],
+        )
+
     async def _build_bus_progress_callback(
         self, msg: InboundMessage
     ) -> Callable[..., Awaitable[None]]:
@@ -1078,6 +1093,7 @@ class AgentLoop:
         session_key = self._effective_session_key(msg)
         if session_key != msg.session_key:
             msg = dataclasses.replace(msg, session_key_override=session_key)
+        delivery_msg = self._system_delivery_message(msg)
         lock = self._session_locks.setdefault(session_key, asyncio.Lock())
         gate = self._concurrency_gate or nullcontext()
 
@@ -1090,9 +1106,9 @@ class AgentLoop:
                 self._pending_queues[session_key] = pending
                 try:
                     on_stream = on_stream_end = None
-                    if msg.metadata.get("_wants_stream"):
+                    if delivery_msg.metadata.get("_wants_stream"):
                         # Split one answer into distinct stream segments.
-                        stream_base_id = f"{msg.session_key}:{time.time_ns()}"
+                        stream_base_id = f"{delivery_msg.session_key}:{time.time_ns()}"
                         stream_segment = 0
 
                         def _current_stream_id() -> str:
@@ -1101,13 +1117,13 @@ class AgentLoop:
                         async def on_stream(delta: str) -> None:
                             await self.bus.publish_outbound(
                                 outbound_message_for_event(
-                                    channel=msg.channel,
-                                    chat_id=msg.chat_id,
+                                    channel=delivery_msg.channel,
+                                    chat_id=delivery_msg.chat_id,
                                     event=StreamDeltaEvent(
                                         content=delta,
                                         stream_id=_current_stream_id(),
                                     ),
-                                    metadata=msg.metadata,
+                                    metadata=delivery_msg.metadata,
                                 )
                             )
 
@@ -1115,13 +1131,13 @@ class AgentLoop:
                             nonlocal stream_segment
                             await self.bus.publish_outbound(
                                 outbound_message_for_event(
-                                    channel=msg.channel,
-                                    chat_id=msg.chat_id,
+                                    channel=delivery_msg.channel,
+                                    chat_id=delivery_msg.chat_id,
                                     event=StreamEndEvent(
                                         stream_id=_current_stream_id(),
                                         resuming=resuming,
                                     ),
-                                    metadata=msg.metadata,
+                                    metadata=delivery_msg.metadata,
                                 )
                             )
                             stream_segment += 1
@@ -1130,16 +1146,16 @@ class AgentLoop:
                         msg, on_stream=on_stream, on_stream_end=on_stream_end,
                         pending_queue=pending,
                     )
-                    completed_channel = msg.channel
-                    completed_chat_id = msg.chat_id
+                    completed_channel = delivery_msg.channel
+                    completed_chat_id = delivery_msg.chat_id
                     if response is not None:
                         await self.bus.publish_outbound(response)
                         completed_channel = response.channel
                         completed_chat_id = response.chat_id
-                    elif msg.channel == "cli":
+                    elif delivery_msg.channel == "cli":
                         await self.bus.publish_outbound(OutboundMessage(
-                            channel=msg.channel, chat_id=msg.chat_id,
-                            content="", metadata=msg.metadata or {},
+                            channel=delivery_msg.channel, chat_id=delivery_msg.chat_id,
+                            content="", metadata=delivery_msg.metadata or {},
                         ))
                     continuing = turn_continuation.internal_continuation_pending(msg.metadata)
                     if not continuing:
@@ -1147,7 +1163,7 @@ class AgentLoop:
                             channel=completed_channel,
                             chat_id=completed_chat_id,
                             session_key=session_key,
-                            metadata=msg.metadata,
+                            metadata=delivery_msg.metadata,
                         )
                     for _, coordinator in self._automation_turn_coordinators:
                         coordinator.complete(msg, response=response)
@@ -1182,15 +1198,16 @@ class AgentLoop:
                 except Exception as exc:
                     logger.exception("Error processing message for session {}", session_key)
                     await self.bus.publish_outbound(OutboundMessage(
-                        channel=msg.channel, chat_id=msg.chat_id,
+                        channel=delivery_msg.channel, chat_id=delivery_msg.chat_id,
                         content="Sorry, I encountered an error.",
+                        metadata=delivery_msg.metadata,
                     ))
                     if not turn_continuation.internal_continuation_pending(msg.metadata):
                         await self._runtime_events().turn_completed(
-                            channel=msg.channel,
-                            chat_id=msg.chat_id,
+                            channel=delivery_msg.channel,
+                            chat_id=delivery_msg.chat_id,
                             session_key=session_key,
-                            metadata=msg.metadata,
+                            metadata=delivery_msg.metadata,
                         )
                     for _, coordinator in self._automation_turn_coordinators:
                         coordinator.complete(msg, error=exc)
@@ -1221,14 +1238,14 @@ class AgentLoop:
                             )
                     if not turn_continuation.internal_continuation_pending(msg.metadata):
                         await self._runtime_events().run_status_changed(
-                            msg, session_key, "idle"
+                            delivery_msg, session_key, "idle"
                         )
                         self._runtime_events().clear_turn(session_key)
                     await self._publish_next_deferred_automation_turn(session_key)
         finally:
             if pending is None:
                 await self._runtime_events().run_status_changed(
-                    msg, session_key, "idle"
+                    delivery_msg, session_key, "idle"
                 )
                 self._runtime_events().clear_turn(session_key)
                 await self._publish_next_deferred_automation_turn(session_key)
@@ -1264,12 +1281,18 @@ class AgentLoop:
         hook_factories: list[AgentTurnHookFactory] | None = None,
     ) -> OutboundMessage | None:
         """Process a system inbound message (e.g. subagent announce)."""
-        channel, chat_id = (
-            msg.chat_id.split(":", 1) if ":" in msg.chat_id else ("cli", msg.chat_id)
-        )
+        delivery_msg = self._system_delivery_message(msg)
+        if delivery_msg is msg:
+            channel, chat_id = (
+                msg.chat_id.split(":", 1) if ":" in msg.chat_id else ("cli", msg.chat_id)
+            )
+        else:
+            channel, chat_id = delivery_msg.channel, delivery_msg.chat_id
         logger.info("Processing system message from {}", msg.sender_id)
         key = msg.session_key_override or f"{channel}:{chat_id}"
         session = self.sessions.get_or_create(key)
+        if delivery_msg is not msg:
+            await self._runtime_events().session_turn_started(delivery_msg, key)
         self._runtime_events().record_turn_runtime(key, runtime)
         if self._restore_runtime_checkpoint(session):
             self.sessions.save(session)
@@ -1298,7 +1321,7 @@ class AgentLoop:
             "extend_to_user": is_subagent,
         }
         history = session.get_history(**_hist_kwargs)
-        workspace_scope = self.workspace_scopes.for_message(msg, session.metadata)
+        workspace_scope = self.workspace_scopes.for_message(delivery_msg, session.metadata)
 
         messages = self.context.build_messages(
             history=history,
@@ -1314,9 +1337,24 @@ class AgentLoop:
             unified_session=self._unified_session,
         )
         t_wall = time.time()
+        on_retry_wait = None
+        if delivery_msg is not msg:
+            if on_progress is None:
+                on_progress = await self._build_bus_progress_callback(delivery_msg)
+            on_retry_wait = await self._build_retry_wait_callback(delivery_msg)
+            await self._runtime_events().run_status_changed(
+                delivery_msg,
+                key,
+                "running",
+                started_at=t_wall,
+            )
         final_content, _, all_msgs, stop_reason, _ = await self._run_agent_loop(
             messages, session=session, channel=channel, chat_id=chat_id,
             runtime=runtime,
+            on_progress=on_progress,
+            on_stream=on_stream,
+            on_stream_end=on_stream_end,
+            on_retry_wait=on_retry_wait,
             message_id=msg.metadata.get("message_id"),
             metadata=msg.metadata,
             session_key=key,
@@ -1343,7 +1381,11 @@ class AgentLoop:
             )
         )
         content = final_content or "Background task completed."
-        outbound_metadata: dict[str, Any] = {}
+        outbound_metadata: dict[str, Any] = (
+            dict(delivery_msg.metadata) if delivery_msg is not msg else {}
+        )
+        if delivery_msg is not msg:
+            outbound_metadata["latency_ms"] = latency_ms
         if channel == "slack" and key.startswith("slack:") and key.count(":") >= 2:
             outbound_metadata["slack"] = {"thread_ts": key.split(":", 2)[2]}
         if origin_message_id := msg.metadata.get("origin_message_id"):
@@ -1353,6 +1395,11 @@ class AgentLoop:
             chat_id=chat_id,
             content=content,
             metadata=outbound_metadata,
+            event=(
+                StreamedResponseEvent()
+                if on_stream is not None and stop_reason not in {"error", "tool_error"}
+                else None
+            ),
         )
 
     async def _process_message(

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -34,6 +34,7 @@ from nanobot.security.workspace_access import (
 )
 from nanobot.utils.llm_runtime import LLMRuntime
 from nanobot.utils.prompt_templates import render_template
+from nanobot.webui.metadata import fresh_webui_turn_metadata
 
 
 @dataclass(slots=True)
@@ -221,6 +222,7 @@ class SubagentManager:
         origin_chat_id: str = "direct",
         session_key: str | None = None,
         origin_message_id: str | None = None,
+        origin_metadata: dict[str, Any] | None = None,
         temperature: float | None = None,
         workspace_scope: WorkspaceScope | None = None,
         *,
@@ -233,7 +235,12 @@ class SubagentManager:
             runtime = runtime.with_generation_overrides(temperature=temperature)
         task_id = str(uuid.uuid4())[:8]
         display_label = label or task[:30] + ("..." if len(task) > 30 else "")
-        origin = {"channel": origin_channel, "chat_id": origin_chat_id, "session_key": session_key}
+        origin: dict[str, Any] = {
+            "channel": origin_channel,
+            "chat_id": origin_chat_id,
+            "session_key": session_key,
+            "metadata": dict(origin_metadata or {}),
+        }
 
         status = SubagentStatus(
             task_id=task_id,
@@ -277,7 +284,7 @@ class SubagentManager:
         task_id: str,
         task: str,
         label: str,
-        origin: dict[str, str],
+        origin: dict[str, Any],
         status: SubagentStatus,
         runtime: LLMRuntime,
         origin_message_id: str | None = None,
@@ -371,7 +378,7 @@ class SubagentManager:
         label: str,
         task: str,
         result: str,
-        origin: dict[str, str],
+        origin: dict[str, Any],
         status: str,
         origin_message_id: str | None = None,
     ) -> None:
@@ -392,10 +399,15 @@ class SubagentManager:
         # routed to the correct pending queue (mid-turn injection) instead of
         # being dispatched as a competing independent task.
         override = origin.get("session_key") or f"{origin['channel']}:{origin['chat_id']}"
-        metadata: dict[str, Any] = {
+        metadata = fresh_webui_turn_metadata(
+            origin["channel"],
+            origin.get("metadata"),
+            turn_seed=f"subagent:{task_id}",
+        )
+        metadata.update({
             "injected_event": "subagent_result",
             "subagent_task_id": task_id,
-        }
+        })
         if origin_message_id:
             metadata["origin_message_id"] = origin_message_id
         msg = InboundMessage(

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -83,6 +83,7 @@ class SpawnTool(Tool):
             origin_chat_id=origin_chat_id,
             session_key=session_key,
             origin_message_id=request_ctx.message_id,
+            origin_metadata=request_ctx.metadata,
             temperature=temperature,
             workspace_scope=current_workspace_scope(),
         )

--- a/nanobot/webui/metadata.py
+++ b/nanobot/webui/metadata.py
@@ -1,4 +1,23 @@
-"""Shared WebUI metadata keys."""
+"""Shared WebUI metadata keys and turn helpers."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Mapping
 
 WEBUI_TURN_METADATA_KEY = "webui_turn_id"
 WEBUI_MESSAGE_SOURCE_METADATA_KEY = "_webui_message_source"
+
+
+def fresh_webui_turn_metadata(
+    channel: str,
+    metadata: Mapping[str, Any] | None,
+    *,
+    turn_seed: str,
+) -> dict[str, Any]:
+    """Copy WebUI delivery metadata and assign a fresh proactive turn id."""
+    if channel != "websocket" or not metadata or metadata.get("webui") is not True:
+        return {}
+    out = dict(metadata)
+    out[WEBUI_TURN_METADATA_KEY] = f"{turn_seed}:{uuid.uuid4().hex}"
+    return out

--- a/tests/agent/test_loop_progress.py
+++ b/tests/agent/test_loop_progress.py
@@ -20,6 +20,8 @@ from nanobot.bus.outbound_events import (
     TurnEndEvent,
 )
 from nanobot.bus.queue import MessageBus
+from nanobot.channels.manager import ChannelManager
+from nanobot.channels.websocket import WebSocketChannel, WebSocketConfig
 from nanobot.providers.base import LLMResponse, ToolCallRequest
 from nanobot.providers.factory import ProviderSnapshot
 from nanobot.session.webui_turns import WebuiTurnCoordinator
@@ -27,6 +29,9 @@ from nanobot.utils.progress_events import (
     invoke_file_edit_progress,
     on_progress_accepts_file_edit_events,
 )
+from nanobot.webui.gateway_services import build_gateway_services
+from nanobot.webui.metadata import WEBUI_TURN_METADATA_KEY
+from nanobot.webui.transcript import read_transcript_lines
 
 
 def _make_loop(tmp_path: Path) -> AgentLoop:
@@ -528,6 +533,174 @@ class TestToolEventProgress:
         assert len(turn_end_msgs) == 1
         assert turn_end_msgs[0].content == ""
         provider.chat_with_retry.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_late_webui_subagent_keeps_visible_turn_lifecycle(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A subagent result dispatched after its parent turn remains visible in WebUI."""
+        monkeypatch.setattr(
+            "nanobot.webui.transcript.get_webui_dir",
+            lambda: tmp_path / "webui",
+        )
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+        provider.supports_progress_deltas = False
+        first_request_started = asyncio.Event()
+        release_first_request = asyncio.Event()
+        model_messages: list[list[dict]] = []
+        tool_call = ToolCallRequest(id="call-late", name="inspect", arguments={})
+        responses = iter([
+            LLMResponse(content="Checking", tool_calls=[tool_call]),
+            LLMResponse(content="Visible reply", tool_calls=[]),
+        ])
+
+        async def chat_stream_with_retry(*, messages, on_content_delta, **_kwargs):
+            model_messages.append(messages)
+            response = next(responses)
+            if len(model_messages) == 1:
+                first_request_started.set()
+                await release_first_request.wait()
+            await on_content_delta(response.content)
+            return response
+
+        provider.chat_stream_with_retry = chat_stream_with_retry
+        provider.chat_with_retry = AsyncMock()
+        loop = AgentLoop(bus=bus, provider=provider, workspace=tmp_path, model="test-model")
+        _attach_webui_runtime_events(loop, bus)
+        loop.tools.get_definitions = MagicMock(return_value=[])
+        loop.tools.prepare_call = MagicMock(return_value=(None, {}, None))
+        loop.tools.execute = AsyncMock(return_value="inspection complete")
+        loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+        session = loop.sessions.get_or_create("websocket:chat-1")
+        session.metadata.update({"webui": True, "title": "Existing chat"})
+        session.add_message("user", "Start the background work")
+        session.add_message("assistant", "The subagent is running")
+        loop.sessions.save(session)
+
+        await loop.subagents._announce_result(
+            "late-1",
+            "background work",
+            "inspect the project",
+            "subagent result",
+            {
+                "channel": "websocket",
+                "chat_id": "chat-1",
+                "session_key": "websocket:chat-1",
+                "metadata": {
+                    "webui": True,
+                    "_wants_stream": True,
+                    WEBUI_TURN_METADATA_KEY: "completed-parent-turn",
+                },
+            },
+            "ok",
+        )
+        late_result = await bus.consume_inbound()
+        continuation_turn_id = late_result.metadata[WEBUI_TURN_METADATA_KEY]
+        assert continuation_turn_id != "completed-parent-turn"
+        assert "websocket:chat-1" not in loop._pending_queues
+
+        config = WebSocketConfig(websocket_requires_token=False)
+        gateway = build_gateway_services(
+            config=config,
+            bus=bus,
+            session_manager=loop.sessions,
+            static_dist_path=None,
+            workspace_path=tmp_path,
+            default_restrict_to_workspace=False,
+            runtime_model_name="test-model",
+            runtime_surface="browser",
+            runtime_capabilities_overrides=None,
+        )
+        websocket = WebSocketChannel(config, bus, gateway=gateway)
+
+        dispatch = asyncio.create_task(loop._dispatch(late_result))
+        await asyncio.wait_for(first_request_started.wait(), timeout=1)
+        pending = loop._pending_queues["websocket:chat-1"]
+        followup_metadata = {
+            "webui": True,
+            "_wants_stream": True,
+            WEBUI_TURN_METADATA_KEY: "followup-turn",
+        }
+        gateway.transcripts.append_user_message(
+            "chat-1",
+            "Is it done?",
+            metadata=followup_metadata,
+        )
+        pending.put_nowait(InboundMessage(
+            channel="websocket",
+            sender_id="user-1",
+            chat_id="chat-1",
+            content="Is it done?",
+            metadata=followup_metadata,
+        ))
+        release_first_request.set()
+        await asyncio.wait_for(dispatch, timeout=2)
+
+        outbound = []
+        while bus.outbound_size > 0:
+            outbound.append(await bus.consume_outbound())
+
+        statuses = [msg for msg in outbound if isinstance(msg.event, GoalStatusEvent)]
+        assert [msg.event.status for msg in statuses] == ["running", "idle"]
+        assert all(msg.channel == "websocket" and msg.chat_id == "chat-1" for msg in statuses)
+
+        visible = [
+            msg
+            for msg in outbound
+            if isinstance(
+                msg.event,
+                ProgressEvent
+                | StreamDeltaEvent
+                | StreamEndEvent
+                | StreamedResponseEvent
+                | TurnEndEvent,
+            )
+        ]
+        assert visible
+        assert all(msg.channel == "websocket" and msg.chat_id == "chat-1" for msg in visible)
+        assert all(
+            msg.metadata[WEBUI_TURN_METADATA_KEY] == continuation_turn_id
+            for msg in visible
+        )
+        assert any(isinstance(msg.event, ProgressEvent) for msg in visible)
+        assert [
+            msg.content for msg in visible if isinstance(msg.event, StreamDeltaEvent)
+        ] == ["Checking", "Visible reply"]
+        assert len([msg for msg in visible if isinstance(msg.event, TurnEndEvent)]) == 1
+
+        for msg in outbound:
+            if msg.channel == "websocket":
+                await ChannelManager._send_once(websocket, msg)
+
+        transcript = read_transcript_lines("websocket:chat-1")
+        continuation_rows = [
+            row for row in transcript if row.get("turn_id") == continuation_turn_id
+        ]
+        assert any(
+            row.get("event") == "user" and row.get("text") == "Is it done?"
+            for row in transcript
+        )
+        assert any(row.get("event") == "message" for row in continuation_rows)
+        assert any(
+            row.get("event") == "delta" and row.get("text") == "Visible reply"
+            for row in continuation_rows
+        )
+        assert continuation_rows[-1]["event"] == "turn_end"
+
+        loop.sessions.invalidate("websocket:chat-1")
+        persisted = loop.sessions.get_or_create("websocket:chat-1")
+        assert any(message.get("content") == "Is it done?" for message in persisted.messages)
+        assert persisted.messages[-1]["content"] == "Visible reply"
+        assert any("Is it done?" in str(message) for message in model_messages[1])
+
+        background = list(loop._background_tasks)
+        if background:
+            await asyncio.gather(*background, return_exceptions=True)
 
     @pytest.mark.asyncio
     async def test_stream_timeout_recovery_continues_in_new_segment(

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -1544,6 +1544,9 @@ async def test_request_context_passes_thread_session_key_to_spawn(tmp_path: Path
     call = spawn_tool._manager.spawn.await_args.kwargs  # type: ignore[attr-defined]
     assert call["session_key"] == "slack:C123:1700.42"
     assert call["origin_message_id"] == "msg-123"
+    assert call["origin_metadata"] == {
+        "slack": {"thread_ts": "1700.42", "channel_type": "channel"}
+    }
     assert call["runtime"] is runtime
 
 

--- a/tests/agent/test_subagent_lifecycle.py
+++ b/tests/agent/test_subagent_lifecycle.py
@@ -18,6 +18,7 @@ from nanobot.agent.tools.context import current_request_context
 from nanobot.bus.queue import MessageBus
 from nanobot.providers.base import GenerationSettings, LLMProvider
 from nanobot.utils.llm_runtime import LLMRuntime
+from nanobot.webui.metadata import WEBUI_TURN_METADATA_KEY
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -484,6 +485,38 @@ class TestAnnounceResult:
         )
 
         assert published[0].metadata["origin_message_id"] == "msg-123"
+
+    @pytest.mark.asyncio
+    async def test_webui_result_starts_fresh_delivery_turn(self, tmp_path):
+        sm = _manager(tmp_path)
+        published = []
+        sm.bus.publish_inbound = AsyncMock(side_effect=lambda msg: published.append(msg))
+
+        await sm._announce_result(
+            "t1",
+            "label",
+            "task",
+            "result",
+            {
+                "channel": "websocket",
+                "chat_id": "chat-1",
+                "session_key": "websocket:chat-1",
+                "metadata": {
+                    "webui": True,
+                    "_wants_stream": True,
+                    WEBUI_TURN_METADATA_KEY: "completed-turn",
+                    "workspace_scope": {"mode": "default"},
+                },
+            },
+            "ok",
+        )
+
+        metadata = published[0].metadata
+        assert metadata["webui"] is True
+        assert metadata["_wants_stream"] is True
+        assert metadata["workspace_scope"] == {"mode": "default"}
+        assert metadata[WEBUI_TURN_METADATA_KEY].startswith("subagent:t1:")
+        assert metadata[WEBUI_TURN_METADATA_KEY] != "completed-turn"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_contextvars.py
+++ b/tests/test_tool_contextvars.py
@@ -75,6 +75,7 @@ async def test_spawn_tool_keeps_task_local_context() -> None:
             origin_chat_id: str,
             session_key: str,
             origin_message_id: str | None = None,
+            origin_metadata: dict | None = None,
             temperature: float | None = None,
             workspace_scope=None,
         ) -> str:
@@ -206,6 +207,7 @@ async def test_spawn_tool_basic_request_context_and_execute() -> None:
             origin_chat_id,
             session_key,
             origin_message_id=None,
+            origin_metadata=None,
             temperature=None,
             workspace_scope=None,
         ):
@@ -244,6 +246,7 @@ async def test_spawn_tool_rejects_missing_request_runtime() -> None:
             origin_chat_id,
             session_key,
             origin_message_id=None,
+            origin_metadata=None,
             temperature=None,
             workspace_scope=None,
         ):


### PR DESCRIPTION
## Summary

- preserve the originating WebUI delivery metadata when a subagent is spawned
- assign a fresh WebUI turn ID when a late subagent result starts a new dispatch
- route running state, progress, streaming output, final response, turn end, and idle state through the recovered WebSocket chat
- cover a user follow-up arriving while the late continuation is active, including canonical session and WebUI transcript persistence

## Root cause

Subagent completion messages retained the effective session key but dropped the original WebUI metadata. When a completion arrived after the parent pending queue was removed, the independent system dispatch therefore had no visible WebUI lifecycle and published intermediate events against the internal system route.

## Validation

- `uv run --extra dev pytest tests/agent/test_subagent_lifecycle.py tests/test_tool_contextvars.py tests/agent/test_loop_save_turn.py tests/agent/test_loop_progress.py -q` (119 passed)
- `uv run --extra dev pytest tests/agent/test_runner_injections.py tests/channels/test_websocket_channel.py tests/channels/test_channel_manager_delta_coalescing.py tests/bus/test_runtime_events.py -q` (188 passed)
- `uv run --extra dev ruff check nanobot tests`
- full suite: 4737 passed, 21 skipped; three local dependency failures reproduce unchanged on `origin/main`

Fixes #4948