### PR TITLE
fix(session): cap messages at persistence boundary

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -353,6 +353,7 @@ class AgentLoop:
 
         self.context = ContextBuilder(workspace, timezone=timezone, disabled_skills=disabled_skills)
         self.sessions = session_manager or SessionManager(workspace)
+        self.sessions.set_file_cap_archiver(self.context.memory.raw_archive)
         self.tools = ToolRegistry()
         # One file-read/write tracker per logical session. The tool registry is
         # shared by this loop, so tools resolve the active state via contextvars.

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 from weakref import WeakValueDictionary
 
 from loguru import logger
@@ -425,6 +425,7 @@ class SessionManager:
         # Preserve identity for sessions held by active callers without retaining idle ones.
         self._overflow_cache: WeakValueDictionary[str, Session] = WeakValueDictionary()
         self._max_cached_sessions = SESSION_CACHE_MAX_SIZE
+        self._file_cap_archiver: Callable[..., None] | None = None
 
     def _remember(self, session: Session) -> None:
         """Keep recent sessions strongly cached without duplicating live objects."""
@@ -445,6 +446,10 @@ class SessionManager:
         if session is not None:
             self._remember(session)
         return session
+
+    def set_file_cap_archiver(self, archiver: Callable[..., None]) -> None:
+        """Archive unconsolidated overflow whenever a session is persisted."""
+        self._file_cap_archiver = archiver
 
     @staticmethod
     def safe_key(key: str) -> str:
@@ -663,6 +668,14 @@ class SessionManager:
         write-back caching (e.g. rclone VFS, NFS, FUSE mounts) do not lose
         the most recent writes.
         """
+        if self._file_cap_archiver is not None:
+            session.enforce_file_cap(
+                on_archive=lambda messages: self._file_cap_archiver(
+                    messages,
+                    session_key=session.key,
+                )
+            )
+
         path = self._get_session_path(session.key)
         tmp_path = path.with_suffix(".jsonl.tmp")
 

--- a/tests/test_nanobot_facade.py
+++ b/tests/test_nanobot_facade.py
@@ -35,6 +35,7 @@ from nanobot.runtime_context import (
     RuntimeContextBlock,
     append_runtime_context,
 )
+from nanobot.session.manager import FILE_MAX_MESSAGES
 from nanobot.utils.llm_runtime import runtime_from_provider_snapshot
 
 
@@ -1203,6 +1204,27 @@ async def test_sessions_ingest_imports_transcript_without_running_model(tmp_path
     reloaded = bot.sessions.get("sdk:history")
     assert reloaded is not None
     assert reloaded.messages == snapshot.messages
+
+
+@pytest.mark.asyncio
+async def test_sessions_ingest_archives_overflow_at_persistence_boundary(tmp_path):
+    config_path = _write_config(tmp_path)
+    bot = Nanobot.from_config(config_path, workspace=tmp_path)
+
+    snapshot = await bot.sessions.ingest(
+        "sdk:overflow",
+        [
+            {"role": "user", "content": f"message-{index}"}
+            for index in range(FILE_MAX_MESSAGES + 1)
+        ],
+    )
+
+    assert len(snapshot.messages) == FILE_MAX_MESSAGES
+    assert snapshot.messages[0]["content"] == "message-1"
+    history = bot.memory.read_history(session_key="sdk:overflow")
+    assert len(history) == 1
+    assert "[RAW] 1 messages" in history[0]["content"]
+    assert "message-0" in history[0]["content"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- enforce the existing 2,000-message file cap whenever `SessionManager.save()` persists a session
- bind the agent's raw-memory archiver at the persistence boundary
- cover the SDK ingest bypass path with a regression test

## Problem

Normal agent turns already call `Session.enforce_file_cap()`, but shortcut commands, proactive deliveries, SDK imports, and recovery paths can persist sessions without passing through that turn-completion path. Those sessions can therefore grow beyond `FILE_MAX_MESSAGES`.

## Fix

`SessionManager.save()` now applies the cap immediately before the atomic write. The active `AgentLoop` supplies `ContextBuilder.memory.raw_archive` as the overflow callback, so only unconsolidated dropped messages are archived. Existing normal-turn enforcement remains unchanged; the save-time call is a no-op once the session is already within the limit.

The branch is rebased onto current `main`, including #4957's bounded session cache, and the two changes are verified together.

## Tests

- Added an SDK regression test that ingests 2,001 messages, then verifies 2,000 remain persisted and the oldest message was raw-archived.
- Mutation check on current `main`: removing the archiver binding restores the 2,001-message failure; restoring it passes.
- Session/SDK regression scope: `94 passed`
- Full suite: `5248 passed, 27 skipped`
- `ruff check nanobot tests`
- `git diff --check`

Fixes #4787