### PR TITLE
fix: add one second to retry after delays

### DIFF
--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -18,6 +18,7 @@ from loguru import logger
 STREAM_IDLE_TIMEOUT_ENV = "NANOBOT_STREAM_IDLE_TIMEOUT_S"
 DEFAULT_STREAM_IDLE_TIMEOUT_S = 90.0
 MAX_STREAM_IDLE_TIMEOUT_S = 3600.0
+RETRY_AFTER_BUFFER = 1
 
 
 def resolve_stream_idle_timeout_s(
@@ -952,8 +953,9 @@ class LLMProvider(ABC):
                     )
                 break
 
+            retry_after = self._extract_retry_after_from_response(response)
             base_delay = delays[min(attempt - 1, len(delays) - 1)]
-            delay = self._extract_retry_after_from_response(response) or base_delay
+            delay = retry_after + RETRY_AFTER_BUFFER if retry_after else base_delay
             if persistent:
                 delay = min(delay, self._PERSISTENT_MAX_DELAY)
 

--- a/tests/providers/test_provider_retry.py
+++ b/tests/providers/test_provider_retry.py
@@ -3,7 +3,7 @@ import copy
 
 import pytest
 
-from nanobot.providers.base import GenerationSettings, LLMProvider, LLMResponse
+from nanobot.providers.base import RETRY_AFTER_BUFFER, GenerationSettings, LLMProvider, LLMResponse
 
 
 class ScriptedProvider(LLMProvider):
@@ -402,8 +402,8 @@ async def test_chat_with_retry_uses_retry_after_and_emits_wait_progress(monkeypa
     )
 
     assert response.content == "ok"
-    assert delays == [7.0]
-    assert progress and "7s" in progress[0]
+    assert delays == [7.0 + RETRY_AFTER_BUFFER]
+    assert progress and f"{int(7 + RETRY_AFTER_BUFFER)}s" in progress[0]
 
 
 def test_extract_retry_after_supports_common_provider_formats() -> None:
@@ -444,7 +444,7 @@ async def test_chat_with_retry_prefers_structured_retry_after_when_present(monke
     response = await provider.chat_with_retry(messages=[{"role": "user", "content": "hello"}])
 
     assert response.content == "ok"
-    assert delays == [9.0]
+    assert delays == [9.0 + RETRY_AFTER_BUFFER]
 
 
 @pytest.mark.asyncio
@@ -521,7 +521,7 @@ async def test_chat_with_retry_retries_429_transient_rate_limit(monkeypatch) -> 
 
     assert response.content == "ok"
     assert provider.calls == 2
-    assert delays == [0.2]
+    assert delays == [0.2 + RETRY_AFTER_BUFFER]
 
 
 @pytest.mark.asyncio
@@ -591,7 +591,7 @@ async def test_chat_with_retry_prefers_structured_retry_after(monkeypatch) -> No
     response = await provider.chat_with_retry(messages=[{"role": "user", "content": "hello"}])
 
     assert response.content == "ok"
-    assert delays == [0.2]
+    assert delays == [0.2 + RETRY_AFTER_BUFFER]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
I keep consistently seeing log messages like these:

```
2026-07-16 20:52:33 | WARNING | - | LLM transient error (attempt 1/3), retrying in 25s: error: {'message': 'requests limit reached: too many requests per minute for this model.'}
2026-07-16 20:52:58 | WARNING | - | LLM transient error (attempt 2/3), retrying in 0s: error: {'message': 'requests limit reached: too many requests per minute for this model.'}
2026-07-16 20:52:58 | WARNING | - | LLM transient error (attempt 3/3), retrying in 0s: error: {'message': 'requests limit reached: too many requests per minute for this model.'}
```

I think that adding a single second won't hurt, since sometimes the last request arrives too early (after a <1s delay) and the request fails completely