### PR TITLE
fix(providers): correct Moonshot kimi-k2.6 temperature override to 0.6

### DIFF
--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -471,7 +471,8 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="https://dashscope.aliyuncs.com/compatible-mode/v1",
         thinking_style="enable_thinking",
     ),
-    # Moonshot (月之暗面): Kimi K2.5+ enforce temperature >= 1.0.
+    # Moonshot (月之暗面): Kimi K2.5/K2.7 enforce temperature >= 1.0; K2.6 now
+    # rejects anything but exactly 0.6.
     ProviderSpec(
         name="moonshot",
         keywords=("moonshot", "kimi"),
@@ -481,7 +482,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="https://api.moonshot.ai/v1",
         model_overrides=(
             ("kimi-k2.5", {"temperature": 1.0}),
-            ("kimi-k2.6", {"temperature": 1.0}),
+            ("kimi-k2.6", {"temperature": 0.6}),
             ("kimi-k2.7", {"temperature": 1.0}),
             ("kimi-k2.7-code", {"temperature": 1.0}),
             ("kimi-k2.7-code-highspeed", {"temperature": 1.0}),

--- a/tests/providers/test_litellm_kwargs.py
+++ b/tests/providers/test_litellm_kwargs.py
@@ -1605,9 +1605,9 @@ def test_kimi_k27_code_thinking_none_with_openrouter_prefix_omits_disabled() -> 
 
 
 def test_moonshot_kimi_k26_temperature_override() -> None:
-    """Moonshot registry forces temperature 1.0 for kimi-k2.6 (API requirement)."""
+    """Moonshot registry forces temperature 0.6 for kimi-k2.6 (API requirement)."""
     kw = _build_kwargs_for("moonshot", "kimi-k2.6", reasoning_effort=None)
-    assert kw["temperature"] == 1.0
+    assert kw["temperature"] == 0.6
 
 
 def test_moonshot_kimi_k27_code_temperature_override() -> None:


### PR DESCRIPTION
## Summary
- Moonshot changed kimi-k2.6's temperature requirement from >= 1.0 to exactly 0.6.
- The registry's hardcoded `model_overrides` still forced 1.0, silently overriding user config and causing every request to fail with `invalid temperature: only 0.6 is allowed for this model`.
- Updated the override value (and its test) to 0.6.

Fixes #4961 

## Test plan
- [x] `ruff check nanobot/` passes
- [x] `pytest tests/providers/test_litellm_kwargs.py` — 90 passed