### PR TITLE
fix(providers): omit temperature for Moonshot Kimi K2.5/K2.6

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -71,6 +71,10 @@ _KIMI_ALWAYS_THINKING_MODELS: frozenset[str] = frozenset({
     "kimi-k2.7-code",
     "kimi-k2.7-code-highspeed",
 })
+_KIMI_SERVER_MANAGED_TEMPERATURE_MODELS: frozenset[str] = frozenset({
+    "kimi-k2.5",
+    "kimi-k2.6",
+})
 _TEXT_TOOL_CALL_RE = re.compile(r"<tool_call>\s*(.*?)\s*</tool_call>", re.DOTALL)
 # Thinking-capable MiMo models per Xiaomi docs (see
 # tests/providers/test_xiaomi_mimo_thinking.py). mimo-v2-flash is omitted
@@ -763,6 +767,16 @@ class OpenAICompatProvider(LLMProvider):
                 if pattern in model_lower:
                     kwargs.update(overrides)
                     break
+
+        # Moonshot selects the only valid temperature from the K2.5/K2.6 thinking mode:
+        # 1.0 when enabled and 0.6 when disabled. Omitting the parameter lets the API
+        # apply the matching value for both its default and explicit thinking controls.
+        if (
+            spec
+            and spec.name == "moonshot"
+            and _model_slug(model_name) in _KIMI_SERVER_MANAGED_TEMPERATURE_MODELS
+        ):
+            kwargs.pop("temperature", None)
 
         # Normalize reasoning_effort into a semantic form (OpenAI vocab)
         # used for internal decisions, and a wire form actually sent out.

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -471,7 +471,8 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="https://dashscope.aliyuncs.com/compatible-mode/v1",
         thinking_style="enable_thinking",
     ),
-    # Moonshot (月之暗面): Kimi K2.5+ enforce temperature >= 1.0.
+    # Moonshot (月之暗面): Kimi K2.5/K2.6 choose temperature from thinking mode;
+    # the OpenAI-compatible provider omits it. K2.7 models require 1.0.
     ProviderSpec(
         name="moonshot",
         keywords=("moonshot", "kimi"),
@@ -480,8 +481,6 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         backend="openai_compat",
         default_api_base="https://api.moonshot.ai/v1",
         model_overrides=(
-            ("kimi-k2.5", {"temperature": 1.0}),
-            ("kimi-k2.6", {"temperature": 1.0}),
             ("kimi-k2.7", {"temperature": 1.0}),
             ("kimi-k2.7-code", {"temperature": 1.0}),
             ("kimi-k2.7-code-highspeed", {"temperature": 1.0}),

--- a/tests/providers/test_litellm_kwargs.py
+++ b/tests/providers/test_litellm_kwargs.py
@@ -1604,10 +1604,14 @@ def test_kimi_k27_code_thinking_none_with_openrouter_prefix_omits_disabled() -> 
     assert "reasoning_effort" not in kw
 
 
-def test_moonshot_kimi_k26_temperature_override() -> None:
-    """Moonshot registry forces temperature 1.0 for kimi-k2.6 (API requirement)."""
-    kw = _build_kwargs_for("moonshot", "kimi-k2.6", reasoning_effort=None)
-    assert kw["temperature"] == 1.0
+@pytest.mark.parametrize("model", ["kimi-k2.5", "kimi-k2.6"])
+@pytest.mark.parametrize("reasoning_effort", [None, "none", "minimal", "medium", "high"])
+def test_moonshot_kimi_k25_k26_omit_temperature(
+    model: str, reasoning_effort: str | None,
+) -> None:
+    """Moonshot chooses the valid temperature from the K2.5/K2.6 thinking mode."""
+    kw = _build_kwargs_for("moonshot", model, reasoning_effort=reasoning_effort)
+    assert "temperature" not in kw
 
 
 def test_moonshot_kimi_k27_code_temperature_override() -> None:


### PR DESCRIPTION
## Summary

- stop sending `temperature` for `kimi-k2.5` and `kimi-k2.6` through the direct Moonshot provider
- let Moonshot select its fixed temperature from the effective thinking mode (`1.0` for thinking and `0.6` for non-thinking)
- keep the existing Kimi K2.7 temperature overrides unchanged
- add regression coverage for default, enabled, and disabled thinking states on both affected models

## Root cause

nanobot always supplies a generation temperature, and the Moonshot registry then forced `temperature=1.0` for both models. That value is valid in thinking mode but rejected when thinking is disabled, while changing the override to `0.6` would break the default thinking mode. Moonshot's documentation recommends omitting the parameter so its API can apply the mode-specific fixed value.

## User impact

Users can now switch Kimi K2.5 or K2.6 thinking on or off without receiving an invalid-temperature error, and their general nanobot temperature setting no longer conflicts with Moonshot's fixed sampler values for these models.

Fixes #4961

## Test plan

- `pytest tests/providers/test_litellm_kwargs.py -q` (99 passed)
- `ruff check nanobot/`