### PR TITLE
fix(utils): avoid hang in split_message when max_len <= 0

### DIFF
--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -526,6 +526,9 @@ def split_message(content: str, max_len: int = 2000) -> list[str]:
     """
     if not content:
         return []
+    # Non-positive max_len cannot advance the cut pointer; return unsplit.
+    if max_len <= 0:
+        return [content]
     if len(content) <= max_len:
         return [content]
     chunks: list[str] = []

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -12,6 +12,13 @@ def test_split_message_no_code_blocks_unchanged():
     assert split_message(content, max_len=12) == ["alpha beta", "gamma delta"]
 
 
+def test_split_message_nonpositive_maxlen_returns_unsplit():
+    content = "alpha beta gamma delta"
+
+    assert split_message(content, max_len=0) == [content]
+    assert split_message(content, max_len=-1) == [content]
+
+
 def test_truncate_text_to_tokens_keeps_text_within_budget():
     text = "hello world " * 100
 


### PR DESCRIPTION
When max_len is 0 or negative, the cut pointer never advances and split_message loops forever. Return the content unsplit (same pattern as truncate_text_to_tokens for a non-positive budget).

Repro: split_message("hello", max_len=0).