### PR TITLE
fix(utils): handle empty commit messages in CommitInfo.format

### DIFF
--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -650,7 +650,7 @@ def _format_dream_restore_list(commits: list) -> str:
         "",
     ]
     for c in commits:
-        lines.append(f"- `{c.sha}` {c.timestamp} - {c.message.splitlines()[0]}")
+        lines.append(f"- `{c.sha}` {c.timestamp} - {c.subject()}")
     lines.extend([
         "",
         "Preview a version with `/dream-log <sha>` before restoring it.",

--- a/nanobot/utils/gitstore.py
+++ b/nanobot/utils/gitstore.py
@@ -22,9 +22,14 @@ class CommitInfo:
     message: str
     timestamp: str  # Formatted datetime
 
+    def subject(self) -> str:
+        """First line of the commit message, or a placeholder if empty."""
+        lines = self.message.splitlines()
+        return lines[0] if lines else "(no message)"
+
     def format(self, diff: str = "") -> str:
         """Format this commit for display, optionally with a diff."""
-        header = f"## {self.message.splitlines()[0]}\n`{self.sha}` — {self.timestamp}\n"
+        header = f"## {self.subject()}\n`{self.sha}` — {self.timestamp}\n"
         if diff:
             return f"{header}\n```diff\n{diff}\n```"
         return f"{header}\n(no file changes)"

--- a/tests/agent/test_git_store.py
+++ b/tests/agent/test_git_store.py
@@ -227,6 +227,14 @@ class TestCommitInfoFormat:
         result = c.format()
         assert "(no file changes)" in result
 
+    def test_format_empty_message(self):
+        from nanobot.utils.gitstore import CommitInfo
+        c = CommitInfo(sha="abcd1234", message="", timestamp="2026-04-02 12:00")
+        result = c.format()
+        assert "(no message)" in result
+        assert "`abcd1234`" in result
+        assert c.subject() == "(no message)"
+
 
 class TestRevert:
     def test_returns_none_when_not_initialized(self, git):


### PR DESCRIPTION
Empty git commit messages made message.splitlines()[0] raise IndexError in CommitInfo.format and in /dream-restore list rendering. Centralize the first-line policy as CommitInfo.subject().

Repro: CommitInfo("abcd1234", "", "2026-01-01").format().