### PR TITLE
fix(gitstore): resolve staged paths relative to workspace

### DIFF
--- a/nanobot/utils/gitstore.py
+++ b/nanobot/utils/gitstore.py
@@ -113,7 +113,10 @@ class GitStore:
                     p.write_text("", encoding="utf-8")
 
             # Initial commit
-            porcelain.add(str(self._workspace), paths=[".gitignore"] + self._tracked_files)
+            porcelain.add(
+                str(self._workspace),
+                paths=self._staging_paths(".gitignore", *self._tracked_files),
+            )
             porcelain.commit(
                 str(self._workspace),
                 message=b"init: nanobot memory store",
@@ -146,7 +149,7 @@ class GitStore:
                 return None
 
             msg_bytes = message.encode("utf-8") if isinstance(message, str) else message
-            porcelain.add(str(self._workspace), paths=self._tracked_files)
+            porcelain.add(str(self._workspace), paths=self._staging_paths(*self._tracked_files))
             sha_bytes = porcelain.commit(
                 str(self._workspace),
                 message=msg_bytes,
@@ -163,6 +166,10 @@ class GitStore:
             return None
 
     # -- internal helpers ------------------------------------------------------
+
+    def _staging_paths(self, *paths: str) -> list[str]:
+        """Return absolute paths so Dulwich resolves them inside this workspace."""
+        return [str((self._workspace / path).resolve()) for path in paths]
 
     def _resolve_sha(self, short_sha: str) -> bytes | None:
         """Resolve a short SHA prefix to the full SHA bytes."""

--- a/nanobot/utils/gitstore.py
+++ b/nanobot/utils/gitstore.py
@@ -168,8 +168,8 @@ class GitStore:
     # -- internal helpers ------------------------------------------------------
 
     def _staging_paths(self, *paths: str) -> list[str]:
-        """Return absolute paths so Dulwich resolves them inside this workspace."""
-        return [str((self._workspace / path).resolve()) for path in paths]
+        """Return absolute paths without resolving tracked-file symlinks."""
+        return [str((self._workspace / path).absolute()) for path in paths]
 
     def _resolve_sha(self, short_sha: str) -> bytes | None:
         """Resolve a short SHA prefix to the full SHA bytes."""

--- a/tests/utils/test_gitstore.py
+++ b/tests/utils/test_gitstore.py
@@ -2,6 +2,7 @@
 
 import subprocess
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -225,20 +226,47 @@ class TestNestedRepoProtection:
         assert result is True
         assert (workspace / ".git").is_dir()
 
-    def test_staging_paths_are_resolved_from_workspace(self, tmp_path, monkeypatch):
+    def test_staging_paths_are_absolute_from_workspace(self, tmp_path, monkeypatch):
         """Git operations should not depend on the process working directory."""
+        from dulwich import porcelain
+
         workspace = tmp_path / "workspace"
         workspace.mkdir()
         monkeypatch.chdir(tmp_path)
 
         git = GitStore(workspace, tracked_files=["MEMORY.md"])
 
-        assert git.init() is True
-        assert len(git.log()) == 1
+        with patch.object(porcelain, "add", wraps=porcelain.add) as mock_add:
+            assert git.init() is True
+            assert len(git.log()) == 1
 
-        (workspace / "MEMORY.md").write_text("updated\n", encoding="utf-8")
-        assert git.auto_commit("update memory") is not None
-        assert len(git.log()) == 2
+            (workspace / "MEMORY.md").write_text("updated\n", encoding="utf-8")
+            assert git.auto_commit("update memory") is not None
+            assert len(git.log()) == 2
+
+        assert len(mock_add.call_args_list) == 2
+        for call in mock_add.call_args_list:
+            staging_paths = [Path(path) for path in call.kwargs["paths"]]
+            assert all(path.is_absolute() for path in staging_paths)
+            assert all(path.is_relative_to(workspace) for path in staging_paths)
+
+    def test_staging_paths_preserve_symlinks(self, tmp_path):
+        """Absolute staging paths should still identify the tracked symlink itself."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        target = tmp_path / "shared-memory.md"
+        target.write_text("shared\n", encoding="utf-8")
+        link = workspace / "MEMORY.md"
+        try:
+            link.symlink_to(target)
+        except OSError as exc:
+            pytest.skip(f"symlinks unavailable: {exc}")
+
+        git = GitStore(workspace, tracked_files=["MEMORY.md"])
+
+        staging_path = Path(git._staging_paths("MEMORY.md")[0])
+        assert staging_path == link.absolute()
+        assert staging_path.is_symlink()
 
     def test_init_refuses_inside_git_worktree(self, tmp_path):
         """init() should refuse when the parent checkout is a git worktree."""

--- a/tests/utils/test_gitstore.py
+++ b/tests/utils/test_gitstore.py
@@ -225,6 +225,21 @@ class TestNestedRepoProtection:
         assert result is True
         assert (workspace / ".git").is_dir()
 
+    def test_staging_paths_are_resolved_from_workspace(self, tmp_path, monkeypatch):
+        """Git operations should not depend on the process working directory."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        monkeypatch.chdir(tmp_path)
+
+        git = GitStore(workspace, tracked_files=["MEMORY.md"])
+
+        assert git.init() is True
+        assert len(git.log()) == 1
+
+        (workspace / "MEMORY.md").write_text("updated\n", encoding="utf-8")
+        assert git.auto_commit("update memory") is not None
+        assert len(git.log()) == 2
+
     def test_init_refuses_inside_git_worktree(self, tmp_path):
         """init() should refuse when the parent checkout is a git worktree."""
         repo = tmp_path / "repo"


### PR DESCRIPTION
Closes #4980

## Summary

Git-backed memory stores fail to initialize when the configured workspace is
different from the process working directory.

## Root Cause

`GitStore` passed relative paths such as `.gitignore` and `MEMORY.md` to
Dulwich's `porcelain.add()`.

Dulwich resolves those paths against the current process directory instead of
the target repository. As a result, Git initialization and later automatic
commits can fail with a `ValueError`, and the failure is swallowed by
`GitStore`, leaving the memory store without commits.

## Changes

1. Resolve staging paths relative to the configured workspace.
2. Apply the same path handling to initial setup and later auto-commits.
3. Add a regression test covering a workspace outside the process working
  directory.

## Validation

1. `python -m pytest tests/utils/test_gitstore.py tests/agent/test_git_store.py -q`
2. `python -m pytest tests/agent/test_dream.py -q`
3. `python -m ruff check nanobot/utils/gitstore.py tests/utils/test_gitstore.py`
4. `git diff --check`

All relevant tests pass.