### PR TITLE
fix(telegram): avoid hang in markdown split when max_len <= 0

### DIFF
--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -51,6 +51,10 @@ def _split_telegram_markdown(content: str, max_len: int) -> list[str]:
     content = content.lstrip()
     if not content:
         return []
+    # Non-positive max_len cannot advance the cut pointer; return unsplit
+    # (same policy as split_message).
+    if max_len <= 0:
+        return [content]
     if len(content) <= max_len:
         return [content]
 

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -188,6 +188,13 @@ def _assert_code_blocks_render_balanced(chunks: list[str]) -> None:
         assert html.count("<pre><code>") == html.count("</code></pre>")
 
 
+def test_split_telegram_markdown_nonpositive_maxlen_returns_unsplit() -> None:
+    content = "hello world\nmore text that would hang without a max_len guard"
+
+    assert _split_telegram_markdown(content, max_len=0) == [content]
+    assert _split_telegram_markdown(content, max_len=-1) == [content]
+
+
 def test_split_telegram_markdown_inside_code_block_moves_before_fence() -> None:
     content = "Intro paragraph.\n```python\nprint('a')\nprint('b')\n```\nDone"
 


### PR DESCRIPTION
`_split_telegram_markdown` never advances its cut pointer when `max_len` is 0 or negative, so it loops forever on non-empty content. Same failure mode as `split_message` (#4971): return the content unsplit.

Repro: `_split_telegram_markdown("hello world", 0)` hangs. With the guard it returns `["hello world"]`.