### PR TITLE
fix(feishu): avoid hang in fallback text chunks when limit <= 0

### DIFF
--- a/nanobot/channels/feishu/runtime.py
+++ b/nanobot/channels/feishu/runtime.py
@@ -1915,6 +1915,10 @@ class FeishuChannel(BaseChannel):
         text = text.strip()
         if not text:
             return []
+        # Non-positive limit cannot advance the cut pointer; return unsplit
+        # (same policy as split_message / _split_telegram_markdown).
+        if limit <= 0:
+            return [text]
         chunks: list[str] = []
         remaining = text
         while remaining:

--- a/nanobot/channels/feishu/tests/test_feishu_fallback_chunks.py
+++ b/nanobot/channels/feishu/tests/test_feishu_fallback_chunks.py
@@ -1,0 +1,16 @@
+from nanobot.channels.feishu.runtime import FeishuChannel
+
+
+def test_fallback_text_chunks_nonpositive_limit_returns_unsplit() -> None:
+    content = "hello world\nmore text that would hang without a limit guard"
+
+    assert FeishuChannel._fallback_text_chunks(content, limit=0) == [content]
+    assert FeishuChannel._fallback_text_chunks(content, limit=-1) == [content]
+
+
+def test_fallback_text_chunks_positive_limit_splits() -> None:
+    content = ("line one with some words\n" * 8).strip()
+    chunks = FeishuChannel._fallback_text_chunks(content, limit=40)
+    assert len(chunks) > 1
+    assert all(len(chunk) <= 40 for chunk in chunks)
+    assert all(chunk for chunk in chunks)


### PR DESCRIPTION
`FeishuChannel._fallback_text_chunks` never advances its cut pointer when `limit` is 0 or negative, so it loops forever on non-empty text. Same failure mode as `split_message` (#4971) and `_split_telegram_markdown` (#4981): return the text unsplit.

Repro: `FeishuChannel._fallback_text_chunks("hello world", 0)` hangs. With the guard it returns `["hello world"]`.