### PR TITLE
fix(config): write config.json atomically via temp+replace

### DIFF
--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -11,6 +11,7 @@ from loguru import logger
 from pydantic import BaseModel
 
 from nanobot.config.schema import Config, _resolve_tool_config_refs
+from nanobot.utils.helpers import _write_text_atomic
 
 # Global variable to store current config path (for multi-instance support)
 _current_config_path: Path | None = None
@@ -85,8 +86,8 @@ def save_config(config: Config, config_path: Path | None = None) -> None:
             "proxy": config.providers.openai_codex.proxy,
         }
 
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
+    # Temp + replace so a crash mid-write cannot leave a truncated config.json.
+    _write_text_atomic(path, json.dumps(data, indent=2, ensure_ascii=False))
 
 
 def merge_missing_defaults(existing: Any, defaults: Any) -> Any:

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import time
 import uuid
 from contextlib import suppress
@@ -447,8 +448,13 @@ def _cleanup_tool_result_buckets(root: Path, current_bucket: Path) -> None:
 
 def _write_text_atomic(path: Path, content: str) -> None:
     tmp = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    existing_mode: int | None = None
+    with suppress(OSError):
+        existing_mode = stat.S_IMODE(path.stat().st_mode)
     try:
         with open(tmp, "w", encoding="utf-8") as f:
+            if existing_mode is not None:
+                os.chmod(tmp, existing_mode)
             f.write(content)
             f.flush()
             os.fsync(f.fileno())

--- a/tests/config/test_config_atomic_save.py
+++ b/tests/config/test_config_atomic_save.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import stat
 from pathlib import Path
 
 import pytest
@@ -16,6 +18,17 @@ def test_save_config_round_trips(tmp_path: Path) -> None:
     save_config(Config(), path)
     loaded = load_config(path)
     assert loaded.agents.defaults.model
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not expose POSIX file modes")
+def test_save_config_preserves_existing_file_mode(tmp_path: Path) -> None:
+    path = tmp_path / "config.json"
+    path.write_text("{}", encoding="utf-8")
+    path.chmod(0o600)
+
+    save_config(Config(), path)
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
 
 
 def test_save_config_preserves_existing_file_when_write_fails(

--- a/tests/config/test_config_atomic_save.py
+++ b/tests/config/test_config_atomic_save.py
@@ -1,0 +1,36 @@
+"""Tests for atomic config.json writes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nanobot.config.loader import load_config, save_config
+from nanobot.config.schema import Config
+
+
+def test_save_config_round_trips(tmp_path: Path) -> None:
+    path = tmp_path / "config.json"
+    save_config(Config(), path)
+    loaded = load_config(path)
+    assert loaded.agents.defaults.model
+
+
+def test_save_config_preserves_existing_file_when_write_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "config.json"
+    save_config(Config(), path)
+    before = path.read_text(encoding="utf-8")
+
+    def boom(self: Path, target: Path) -> Path:  # noqa: ARG001
+        raise OSError("simulated crash before replace")
+
+    monkeypatch.setattr(Path, "replace", boom)
+    with pytest.raises(OSError, match="simulated crash"):
+        save_config(Config(), path)
+
+    assert path.read_text(encoding="utf-8") == before
+    assert json.loads(before)  # still valid JSON


### PR DESCRIPTION
save_config opened config.json with "w" and wrote in place, so a crash mid-write could leave a truncated file. Route through _write_text_atomic like the pairing store so a failed write leaves the prior config intact.

Repro: save_config twice; if Path.replace raises before the swap, the original config.json remains valid JSON.