### PR TITLE
fix(filesystem): bind workspace checks to opened files

### DIFF
--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -4,8 +4,9 @@ import difflib
 import mimetypes
 import os
 from dataclasses import dataclass
+from io import BytesIO
 from pathlib import Path
-from typing import Any
+from typing import Any, BinaryIO
 
 from nanobot.agent.tools.base import Tool, ToolResult, tool_parameters
 from nanobot.agent.tools.file_state import FileStates, _hash_file, current_file_states
@@ -18,6 +19,7 @@ from nanobot.agent.tools.schema import (
 )
 from nanobot.config_base import Base
 from nanobot.security.workspace_access import current_tool_workspace
+from nanobot.security.workspace_policy import WORKSPACE_BOUNDARY_NOTE, WorkspaceBoundaryError
 from nanobot.utils.helpers import build_image_content_blocks, detect_image_mime
 
 
@@ -152,6 +154,53 @@ class _FsTool(Tool):
 
     def _resolve(self, path: str) -> Path:
         return self._resolve_read(path)
+
+    def _open_validated_file(
+        self,
+        path: Path,
+        *,
+        write: bool,
+        validate_write_access: bool = False,
+    ) -> BinaryIO:
+        """Open without destructive writes, then bind validation to the file handle."""
+        flags = os.O_WRONLY | os.O_CREAT if write else os.O_RDONLY
+        flags |= getattr(os, "O_BINARY", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(path, flags, 0o666)
+        try:
+            resolver = self._resolve_write if validate_write_access else self._resolve_read
+            current_path = resolver(str(path))
+            if not os.path.samestat(os.fstat(fd), os.stat(current_path)):
+                raise WorkspaceBoundaryError(
+                    f"Path {path} changed during workspace validation"
+                    + WORKSPACE_BOUNDARY_NOTE
+                )
+            if write:
+                # Truncate only after the opened handle passes the boundary check.
+                os.ftruncate(fd, 0)
+            return os.fdopen(fd, "wb" if write else "rb")
+        except BaseException:
+            os.close(fd)
+            raise
+
+    def _read_bytes(self, path: Path, *, validate_write_access: bool = False) -> bytes:
+        with self._open_validated_file(
+            path,
+            write=False,
+            validate_write_access=validate_write_access,
+        ) as file:
+            return file.read()
+
+    def _write_bytes(self, path: Path, content: bytes) -> None:
+        with self._open_validated_file(
+            path,
+            write=True,
+            validate_write_access=True,
+        ) as file:
+            file.write(content)
+
+    def _write_text(self, path: Path, content: str) -> None:
+        self._write_bytes(path, content.encode("utf-8"))
 
     def _display_workspace(self) -> Path | None:
         return current_tool_workspace(self._workspace).project_path
@@ -290,15 +339,16 @@ class ReadFileTool(_FsTool):
             if not fp.is_file():
                 return ToolResult.error(f"Error: Not a file: {path}")
 
+            raw = self._read_bytes(fp)
+
             # PDF support
             if fp.suffix.lower() == ".pdf":
-                return self._read_pdf(fp, pages)
+                return self._read_pdf(fp, raw, pages)
 
             # Office document support
             if fp.suffix.lower() in {".docx", ".xlsx", ".pptx"}:
-                return self._read_office_doc(fp)
+                return self._read_office_doc(fp, raw)
 
-            raw = fp.read_bytes()
             if not raw:
                 return f"(Empty file: {path})"
 
@@ -343,7 +393,7 @@ class ReadFileTool(_FsTool):
                     entry.can_dedup = False
 
             # Read the file content after dedup check
-            raw = fp.read_bytes()
+            raw = self._read_bytes(fp)
             try:
                 text_content = raw.decode("utf-8")
             except UnicodeDecodeError:
@@ -393,12 +443,12 @@ class ReadFileTool(_FsTool):
         except Exception as e:
             return ToolResult.error(f"Error reading file: {e}")
 
-    def _read_pdf(self, fp: Path, pages: str | None) -> str:
+    def _read_pdf(self, fp: Path, raw: bytes, pages: str | None) -> str:
         from nanobot.utils.document import PdfPageRangeError, PdfSafetyError, extract_pdf_pages
 
         try:
             extraction = extract_pdf_pages(
-                fp,
+                BytesIO(raw),
                 pages=pages,
                 max_pages=self._MAX_PDF_PAGES,
                 max_chars=self._MAX_CHARS,
@@ -423,10 +473,10 @@ class ReadFileTool(_FsTool):
             )
         return result
 
-    def _read_office_doc(self, fp: Path) -> str:
+    def _read_office_doc(self, fp: Path, raw: bytes) -> str:
         from nanobot.utils.document import extract_text
 
-        result = extract_text(fp)
+        result = extract_text(fp, content=raw)
 
         if result is None:
             return ToolResult.error(f"Error: Unsupported file format: {fp.suffix}")
@@ -480,7 +530,7 @@ class WriteFileTool(_FsTool):
                 raise ValueError("Unknown content")
             fp = self._resolve_write(path)
             fp.parent.mkdir(parents=True, exist_ok=True)
-            fp.write_text(content, encoding="utf-8")
+            self._write_text(fp, content)
             self._file_states.record_write(fp)
             return f"Successfully wrote {len(content)} characters to {fp}"
         except PermissionError as e:
@@ -847,7 +897,7 @@ class EditFileTool(_FsTool):
             if not fp.exists():
                 if old_text == "":
                     fp.parent.mkdir(parents=True, exist_ok=True)
-                    fp.write_text(new_text, encoding="utf-8")
+                    self._write_text(fp, new_text)
                     self._file_states.record_write(fp)
                     return f"Successfully created {fp}"
                 return self._file_not_found_msg(path, fp)
@@ -862,18 +912,18 @@ class EditFileTool(_FsTool):
 
             # Create-file: old_text='' but file exists and not empty → reject
             if old_text == "":
-                raw = fp.read_bytes()
+                raw = self._read_bytes(fp, validate_write_access=True)
                 content = raw.decode("utf-8")
                 if content.strip():
                     return ToolResult.error(f"Error: Cannot create file — {path} already exists and is not empty.")
-                fp.write_text(new_text, encoding="utf-8")
+                self._write_text(fp, new_text)
                 self._file_states.record_write(fp)
                 return f"Successfully edited {fp}"
 
             # Read-before-edit check
             warning = self._file_states.check_read(fp)
 
-            raw = fp.read_bytes()
+            raw = self._read_bytes(fp, validate_write_access=True)
             uses_crlf = b"\r\n" in raw
             content = raw.decode("utf-8").replace("\r\n", "\n")
             norm_old = old_text.replace("\r\n", "\n")
@@ -954,7 +1004,7 @@ class EditFileTool(_FsTool):
             if uses_crlf:
                 new_content = new_content.replace("\n", "\r\n")
 
-            fp.write_bytes(new_content.encode("utf-8"))
+            self._write_bytes(fp, new_content.encode("utf-8"))
             self._file_states.record_write(fp)
             msg = f"Successfully edited {fp}"
             if warning:

--- a/nanobot/utils/document.py
+++ b/nanobot/utils/document.py
@@ -2,7 +2,9 @@
 
 import mimetypes
 from dataclasses import dataclass
+from io import BytesIO
 from pathlib import Path
+from typing import BinaryIO
 from zipfile import BadZipFile, ZipFile
 
 from loguru import logger
@@ -95,11 +97,12 @@ class PdfExtraction:
     end_page: int
 
 
-def extract_text(path: Path) -> str | None:
+def extract_text(path: Path, *, content: bytes | None = None) -> str | None:
     """Extract text from a file.
 
     Args:
-        path: Path to the file.
+        path: Path to the file. Its suffix selects the parser.
+        content: Optional validated file snapshot to parse instead of reopening ``path``.
 
     Returns:
         Extracted text as string, None for unsupported types,
@@ -108,28 +111,35 @@ def extract_text(path: Path) -> str | None:
     if not isinstance(path, Path):
         path = Path(path)
 
-    if not path.exists():
-        return f"[error: file not found: {path}]"
-    try:
-        if path.stat().st_size > _MAX_EXTRACT_FILE_SIZE:
-            return f"[error: file exceeds {_MAX_EXTRACT_FILE_SIZE // (1024 * 1024)} MB limit]"
-    except OSError as e:
-        return f"[error: failed to inspect file: {e!s}]"
+    if content is None:
+        if not path.exists():
+            return f"[error: file not found: {path}]"
+        try:
+            size = path.stat().st_size
+        except OSError as e:
+            return f"[error: failed to inspect file: {e!s}]"
+        source: Path | BinaryIO = path
+    else:
+        size = len(content)
+        source = BytesIO(content)
+
+    if size > _MAX_EXTRACT_FILE_SIZE:
+        return f"[error: file exceeds {_MAX_EXTRACT_FILE_SIZE // (1024 * 1024)} MB limit]"
 
     ext = path.suffix.lower()
 
     # Parsers stay lazy even though they are bundled so idle processes do not
     # retain their import cost (see issue #3422).
     if ext == ".pdf":
-        return _extract_pdf(path)
+        return _extract_pdf(source)
     elif ext == ".docx":
-        return _extract_docx(path)
+        return _extract_docx(source)
     elif ext == ".xlsx":
-        return _extract_xlsx(path)
+        return _extract_xlsx(source)
     elif ext == ".pptx":
-        return _extract_pptx(path)
+        return _extract_pptx(source)
     elif _is_text_extension(ext):
-        return _extract_text_file(path)
+        return _extract_text_file(source)
     elif ext in {".png", ".jpg", ".jpeg", ".gif", ".webp"}:
         # Image files - for future OCR support
         return f"[image: {path.name}]"
@@ -138,11 +148,11 @@ def extract_text(path: Path) -> str | None:
         return None
 
 
-def _extract_pdf(path: Path) -> str:
+def _extract_pdf(source: Path | BinaryIO) -> str:
     """Extract text from PDF using pypdf."""
     try:
         result = extract_pdf_pages(
-            path,
+            source,
             max_pages=_MAX_PDF_ATTACHMENT_PAGES,
             max_chars=_MAX_TEXT_LENGTH,
         )
@@ -151,12 +161,12 @@ def _extract_pdf(path: Path) -> str:
             text += f"\n\n(Showing pages 1-{result.end_page + 1} of {result.total_pages}.)"
         return text
     except Exception as e:
-        logger.exception("Failed to extract PDF {}", path)
+        logger.exception("Failed to extract PDF {}", source)
         return f"[error: failed to extract PDF: {e!s}]"
 
 
 def extract_pdf_pages(
-    path: Path,
+    path: Path | BinaryIO,
     *,
     pages: str | None = None,
     max_pages: int = _MAX_PDF_ATTACHMENT_PAGES,
@@ -206,16 +216,17 @@ def _parse_pdf_page_range(pages: str | None, total_pages: int) -> tuple[int, int
     return start - 1, min(end, total_pages) - 1
 
 
-def _extract_docx(path: Path) -> str:
+def _extract_docx(source: Path | BinaryIO) -> str:
     """Extract text from DOCX using python-docx."""
     try:
         from docx import Document as DocxDocument
     except ImportError:
         return "[error: python-docx not installed]"
     try:
-        if error := _office_archive_error(path):
+        if error := _office_archive_error(source):
             return error
-        doc = DocxDocument(path)
+        _rewind(source)
+        doc = DocxDocument(source)
         collector = _TextCollector(_MAX_TEXT_LENGTH)
         for paragraph in doc.paragraphs:
             text = paragraph.text.strip()
@@ -223,20 +234,21 @@ def _extract_docx(path: Path) -> str:
                 break
         return collector.render()
     except Exception as e:
-        logger.exception("Failed to extract DOCX {}", path)
+        logger.exception("Failed to extract DOCX {}", source)
         return f"[error: failed to extract DOCX: {e!s}]"
 
 
-def _extract_xlsx(path: Path) -> str:
+def _extract_xlsx(source: Path | BinaryIO) -> str:
     """Extract text from XLSX using openpyxl."""
     try:
         from openpyxl import load_workbook
     except ImportError:
         return "[error: openpyxl not installed]"
     try:
-        if error := _office_archive_error(path):
+        if error := _office_archive_error(source):
             return error
-        wb = load_workbook(path, read_only=True, data_only=True)
+        _rewind(source)
+        wb = load_workbook(source, read_only=True, data_only=True)
         try:
             collector = _TextCollector(_MAX_TEXT_LENGTH)
             for sheet_name in wb.sheetnames:
@@ -258,20 +270,21 @@ def _extract_xlsx(path: Path) -> str:
         finally:
             wb.close()
     except Exception as e:
-        logger.exception("Failed to extract XLSX {}", path)
+        logger.exception("Failed to extract XLSX {}", source)
         return f"[error: failed to extract XLSX: {e!s}]"
 
 
-def _extract_pptx(path: Path) -> str:
+def _extract_pptx(source: Path | BinaryIO) -> str:
     """Extract text from PPTX using python-pptx."""
     try:
         from pptx import Presentation as PptxPresentation
     except ImportError:
         return "[error: python-pptx not installed]"
     try:
-        if error := _office_archive_error(path):
+        if error := _office_archive_error(source):
             return error
-        prs = PptxPresentation(path)
+        _rewind(source)
+        prs = PptxPresentation(source)
         collector = _TextCollector(_MAX_TEXT_LENGTH)
         for i, slide in enumerate(prs.slides, 1):
             slide_text: list[str] = []
@@ -285,7 +298,7 @@ def _extract_pptx(path: Path) -> str:
                     break
         return collector.render()
     except Exception as e:
-        logger.exception("Failed to extract PPTX {}", path)
+        logger.exception("Failed to extract PPTX {}", source)
         return f"[error: failed to extract PPTX: {e!s}]"
 
 
@@ -314,10 +327,10 @@ def _collect_pptx_shape_text(shape, out: list[str]) -> None:
         out.append(text)
 
 
-def _office_archive_error(path: Path) -> str | None:
+def _office_archive_error(source: Path | BinaryIO) -> str | None:
     """Reject oversized or encrypted OOXML containers before parsing XML."""
     try:
-        with ZipFile(path) as archive:
+        with ZipFile(source) as archive:
             members = archive.infolist()
     except (BadZipFile, OSError) as e:
         return f"[error: invalid Office document: {e!s}]"
@@ -336,17 +349,31 @@ def _office_archive_error(path: Path) -> str | None:
     return None
 
 
-def _extract_text_file(path: Path) -> str:
+def _rewind(source: Path | BinaryIO) -> None:
+    """Reset a file-like parser source after a preflight inspection."""
+    if not isinstance(source, Path):
+        source.seek(0)
+
+
+def _extract_text_file(source: Path | BinaryIO) -> str:
     """Extract text from a plain text file."""
     try:
         # Try UTF-8 first, then latin-1 fallback
         try:
-            content = path.read_text(encoding="utf-8")
+            if isinstance(source, Path):
+                content = source.read_text(encoding="utf-8")
+            else:
+                _rewind(source)
+                content = source.read().decode("utf-8")
         except UnicodeDecodeError:
-            content = path.read_text(encoding="latin-1")
+            if isinstance(source, Path):
+                content = source.read_text(encoding="latin-1")
+            else:
+                _rewind(source)
+                content = source.read().decode("latin-1")
         return _truncate(content, _MAX_TEXT_LENGTH)
     except Exception as e:
-        logger.exception("Failed to read text file {}", path)
+        logger.exception("Failed to read text file {}", source)
         return f"[error: failed to read file: {e!s}]"
 
 

--- a/tests/test_document_parsing.py
+++ b/tests/test_document_parsing.py
@@ -1,5 +1,6 @@
 """Tests for document text extraction utilities."""
 
+from io import BytesIO
 from pathlib import Path
 from zipfile import ZipFile
 
@@ -130,8 +131,10 @@ class TestExtractText:
 
         wb.save(xlsx_file)
         wb.close()
+        snapshot = xlsx_file.read_bytes()
+        xlsx_file.write_bytes(b"not the validated workbook")
 
-        result = extract_text(xlsx_file)
+        result = extract_text(xlsx_file, content=snapshot)
         assert result is not None
         assert "--- Sheet: Sheet1 ---" in result
         assert "--- Sheet: Sheet2 ---" in result
@@ -174,6 +177,23 @@ class TestExtractText:
         assert "This is paragraph one." in result
         assert "This is paragraph two." in result
 
+    def test_extract_text_docx_uses_supplied_content_snapshot(self, tmp_path: Path):
+        """Validated bytes should be parsed without reopening the path."""
+        from docx import Document
+
+        snapshot = BytesIO()
+        doc = Document()
+        doc.add_paragraph("validated snapshot")
+        doc.save(snapshot)
+
+        docx_file = tmp_path / "test.docx"
+        docx_file.write_bytes(b"not the validated document")
+
+        result = extract_text(docx_file, content=snapshot.getvalue())
+
+        assert result is not None
+        assert "validated snapshot" in result
+
     def test_extract_text_docx_empty(self, tmp_path: Path):
         """Test extracting text from an empty .docx file."""
         from docx import Document
@@ -206,8 +226,10 @@ class TestExtractText:
         text_frame.text = "Bullet point content"
 
         prs.save(pptx_file)
+        snapshot = pptx_file.read_bytes()
+        pptx_file.write_bytes(b"not the validated presentation")
 
-        result = extract_text(pptx_file)
+        result = extract_text(pptx_file, content=snapshot)
         assert result is not None
         assert "--- Slide 1 ---" in result
         assert "--- Slide 2 ---" in result

--- a/tests/tools/test_filesystem_tools.py
+++ b/tests/tools/test_filesystem_tools.py
@@ -1,5 +1,8 @@
 """Tests for enhanced filesystem tools: ReadFileTool, EditFileTool, ListDirTool."""
 
+import os
+import subprocess
+
 import pytest
 
 from nanobot.agent.tools.filesystem import (
@@ -295,6 +298,142 @@ class TestListDirTool:
 # ---------------------------------------------------------------------------
 
 class TestWorkspaceRestriction:
+
+    @staticmethod
+    def _replace_directory_with_link(directory, outside):
+        original = directory.with_name(f"{directory.name}-original")
+        directory.rename(original)
+        if os.name == "nt":
+            result = subprocess.run(
+                ["cmd", "/c", "mklink", "/J", str(directory), str(outside)],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode:
+                original.rename(directory)
+                pytest.skip(f"junction creation is unavailable: {result.stderr}")
+        else:
+            try:
+                directory.symlink_to(outside, target_is_directory=True)
+            except OSError as exc:
+                original.rename(directory)
+                pytest.skip(f"symlink creation is unavailable: {exc}")
+        return original
+
+    @staticmethod
+    def _restore_directory(directory, original):
+        if os.name == "nt":
+            directory.rmdir()
+        else:
+            directory.unlink()
+        original.rename(directory)
+
+    @staticmethod
+    def _race_files(tmp_path, filename="note.txt"):
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        checked_dir = workspace / "checked"
+        checked_dir.mkdir()
+        target = checked_dir / filename
+        target.write_text("workspace content", encoding="utf-8")
+        outside_dir = tmp_path / "outside"
+        outside_dir.mkdir()
+        outside = outside_dir / filename
+        outside.write_text("outside secret", encoding="utf-8")
+        return workspace, checked_dir, target, outside_dir, outside
+
+    @staticmethod
+    def _swap_directory_after_resolve(
+        tool, resolver_name, directory, outside, monkeypatch,
+    ):
+        original_resolver = getattr(tool, resolver_name)
+        swapped = False
+
+        def resolve_and_swap(path):
+            nonlocal swapped
+            resolved = original_resolver(path)
+            if not swapped:
+                TestWorkspaceRestriction._replace_directory_with_link(directory, outside)
+                swapped = True
+            return resolved
+
+        monkeypatch.setattr(tool, resolver_name, resolve_and_swap)
+
+    @pytest.mark.parametrize(
+        ("tool_cls", "resolver_name", "execute_kwargs"),
+        [
+            (ReadFileTool, "_resolve_read", {}),
+            (WriteFileTool, "_resolve_write", {"content": "replacement"}),
+            (
+                EditFileTool,
+                "_resolve_write",
+                {"old_text": "outside secret", "new_text": "replacement"},
+            ),
+        ],
+        ids=["read", "write", "edit"],
+    )
+    @pytest.mark.asyncio
+    async def test_file_access_blocks_directory_swap_after_workspace_check(
+        self, tmp_path, monkeypatch, tool_cls, resolver_name, execute_kwargs,
+    ):
+        workspace, checked_dir, target, outside_dir, outside = self._race_files(tmp_path)
+        tool = tool_cls(workspace=workspace, allowed_dir=workspace)
+        self._swap_directory_after_resolve(
+            tool, resolver_name, checked_dir, outside_dir, monkeypatch,
+        )
+
+        result = await tool.execute(path=str(target), **execute_kwargs)
+
+        assert "Error" in result
+        assert "outside secret" not in result
+        assert outside.read_text(encoding="utf-8") == "outside secret"
+
+    @pytest.mark.asyncio
+    async def test_office_read_blocks_directory_swap_before_parser(
+        self, tmp_path, monkeypatch,
+    ):
+        workspace, checked_dir, target, outside_dir, _ = self._race_files(
+            tmp_path, "note.docx",
+        )
+        tool = ReadFileTool(workspace=workspace, allowed_dir=workspace)
+        self._swap_directory_after_resolve(
+            tool, "_resolve_read", checked_dir, outside_dir, monkeypatch,
+        )
+        monkeypatch.setattr(
+            "nanobot.utils.document.extract_text",
+            lambda path, content=None: path.read_text(encoding="utf-8"),
+        )
+
+        result = await tool.execute(path=str(target))
+
+        assert "Error" in result
+        assert "outside secret" not in result
+
+    @pytest.mark.asyncio
+    async def test_read_blocks_swap_restored_before_boundary_recheck(self, tmp_path, monkeypatch):
+        workspace, checked_dir, target, outside_dir, _ = self._race_files(tmp_path)
+        tool = ReadFileTool(workspace=workspace, allowed_dir=workspace)
+        original_resolver = tool._resolve_read
+        original_dir = None
+        calls = 0
+
+        def resolve_with_transient_swap(path):
+            nonlocal calls, original_dir
+            calls += 1
+            if calls == 1:
+                resolved = original_resolver(path)
+                original_dir = self._replace_directory_with_link(checked_dir, outside_dir)
+                return resolved
+            if calls == 2 and original_dir is not None:
+                self._restore_directory(checked_dir, original_dir)
+            return original_resolver(path)
+
+        monkeypatch.setattr(tool, "_resolve_read", resolve_with_transient_swap)
+
+        result = await tool.execute(path=str(target))
+
+        assert "Error" in result
+        assert "outside secret" not in result
 
     @pytest.mark.asyncio
     async def test_read_blocked_outside_workspace(self, tmp_path):


### PR DESCRIPTION
## Summary

- bind workspace validation to opened file handles for `read_file`, `write_file`,
  and `edit_file`
- use `O_NOFOLLOW` where supported, then re-resolve the path and compare
  `fstat()` with `stat()` before reading or modifying file contents
- defer truncation until the opened handle passes validation
- parse PDF and Office documents from validated byte snapshots instead of
  reopening their paths

## Problem

Filesystem tools previously resolved and validated a path before accessing it
through a separate `Path.read_*` or `Path.write_*` operation.

A checked parent directory could be replaced with a symlink or Windows junction
between those operations, causing the later access to reach a file outside the
workspace.

`O_NOFOLLOW` alone does not protect intermediate path components, so the opened
handle must also be checked against the current validated path.

## Approach

File access now follows this sequence:

1. resolve the path through the existing workspace policy
2. open the target without truncating it
3. run the workspace policy again after opening
4. compare the opened handle with the re-resolved path using
   `os.path.samestat(os.fstat(fd), os.stat(current_path))`
5. only then read, truncate, or write through the validated handle

The identity comparison also covers a transient attack where the parent
directory is replaced for `os.open()` and restored before the second workspace
check.

PDF, DOCX, XLSX, and PPTX parsing now consumes the validated byte snapshot so
document parsers cannot reopen a raced path.

## Scope

This PR is limited to the `read_file`, `write_file`, and `edit_file` access paths
identified in #4790, including their PDF and Office document branches.

Multi-file `apply_patch` transactions and attachment ingestion have separate
rollback and lifecycle semantics and are not redesigned in this change.

## Testing

- deterministic parent-directory swap tests for read, write, and edit
- Windows junction and POSIX symlink coverage
- transient swap-and-restore coverage for the handle identity check
- Office parser regression test that fails when validated handle reads are removed
- validated byte-snapshot tests for DOCX, XLSX, and PPTX
- mutation verification: restoring the old path-based Office read produces
  `outside secret` and fails the regression test
- `ruff check nanobot tests`
- `5253 passed, 27 skipped`

Fixes #4790