### PR TITLE
fix(agent): keep background (cron / local trigger) turns silent when the model ends empty

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -51,6 +51,7 @@ from nanobot.bus.runtime_events import (
 )
 from nanobot.command import CommandContext, CommandRouter, register_builtin_commands
 from nanobot.config.schema import AgentDefaults, ModelPresetConfig
+from nanobot.cron.session_turns import cron_trigger
 from nanobot.providers.base import LLMProvider
 from nanobot.providers.factory import ProviderSnapshot
 from nanobot.runtime_context import (
@@ -80,6 +81,7 @@ from nanobot.session.manager import (
     SessionManager,
     replay_max_messages_for_context,
 )
+from nanobot.triggers.local_session_turns import local_trigger
 from nanobot.triggers.local_turns import LocalTriggerTurnCoordinator
 from nanobot.utils.cancellation import task_is_cancelling
 from nanobot.utils.document import extract_documents, reference_non_image_attachments
@@ -187,13 +189,17 @@ class TurnContext:
 def _is_background_turn(msg: InboundMessage) -> bool:
     """True when a turn runs with no interactive user waiting on the reply.
 
-    Currently that means scheduled cron jobs (``sender_id == "cron"``). Such a
-    turn ending with no assistant text is a legitimate silent outcome — e.g. a
-    monitor that found nothing to report — so it must not deliver the
-    ``EMPTY_FINAL_RESPONSE_MESSAGE`` placeholder, which for a session-bound cron
-    job would otherwise be auto-published to the chat as a spurious message.
+    That means the automation paths whose assembled response is auto-published
+    to a bound chat: scheduled cron jobs and local triggers. Such a turn ending
+    with no assistant text is a legitimate silent outcome — e.g. a monitor that
+    found nothing to report — so it must not deliver the
+    ``EMPTY_FINAL_RESPONSE_MESSAGE`` placeholder, which would otherwise reach
+    the chat as a spurious message on every no-op run.
+
+    Keyed off the metadata each coordinator stamps rather than ``sender_id``,
+    which is a per-trigger setting a local trigger may override.
     """
-    return msg.sender_id == "cron"
+    return cron_trigger(msg.metadata) is not None or local_trigger(msg.metadata) is not None
 
 
 class AgentLoop:

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -184,6 +184,18 @@ class TurnContext:
     trace: list[StateTraceEntry] = field(default_factory=list)
 
 
+def _is_background_turn(msg: InboundMessage) -> bool:
+    """True when a turn runs with no interactive user waiting on the reply.
+
+    Currently that means scheduled cron jobs (``sender_id == "cron"``). Such a
+    turn ending with no assistant text is a legitimate silent outcome — e.g. a
+    monitor that found nothing to report — so it must not manufacture the
+    ``EMPTY_FINAL_RESPONSE_MESSAGE`` placeholder, which for a session-bound cron
+    job would otherwise be auto-published to the chat as a spurious message.
+    """
+    return msg.sender_id == "cron"
+
+
 class AgentLoop:
     """
     The agent loop is the core processing engine.
@@ -1625,6 +1637,7 @@ class AgentLoop:
             ctx.kind is TurnKind.USER
             and (ctx.final_content is None or not ctx.final_content.strip())
             and not ctx.suppress_response
+            and not _is_background_turn(ctx.msg)
         ):
             ctx.final_content = EMPTY_FINAL_RESPONSE_MESSAGE
 

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -189,7 +189,7 @@ def _is_background_turn(msg: InboundMessage) -> bool:
 
     Currently that means scheduled cron jobs (``sender_id == "cron"``). Such a
     turn ending with no assistant text is a legitimate silent outcome — e.g. a
-    monitor that found nothing to report — so it must not manufacture the
+    monitor that found nothing to report — so it must not deliver the
     ``EMPTY_FINAL_RESPONSE_MESSAGE`` placeholder, which for a session-bound cron
     job would otherwise be auto-published to the chat as a spurious message.
     """
@@ -1633,11 +1633,18 @@ class AgentLoop:
     async def _state_save(self, ctx: TurnContext) -> str:
         turn_continuation.prepare_save_boundary(ctx)
 
-        if (
+        blank_final = ctx.final_content is None or not ctx.final_content.strip()
+        if _is_background_turn(ctx.msg):
+            # AgentRunner substitutes the placeholder itself the moment the model
+            # returns blank text, so a background turn usually arrives here with
+            # it already in place rather than with an empty final. Suppress both
+            # shapes, otherwise the earlier substitution slips past this guard.
+            if blank_final or ctx.stop_reason == "empty_final_response":
+                ctx.suppress_response = True
+        elif (
             ctx.kind is TurnKind.USER
-            and (ctx.final_content is None or not ctx.final_content.strip())
+            and blank_final
             and not ctx.suppress_response
-            and not _is_background_turn(ctx.msg)
         ):
             ctx.final_content = EMPTY_FINAL_RESPONSE_MESSAGE
 

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -147,38 +147,65 @@ def test_persist_cron_turn_uses_distinct_history_marker(tmp_path: Path) -> None:
     assert message["cron_prompt_ref"] == prompt_ref
 
 
+def _automation_metadata(source: str) -> dict:
+    """Metadata as the cron / local-trigger coordinators stamp it on an inbound."""
+    from nanobot.cron.session_turns import CRON_TRIGGER_META
+    from nanobot.triggers.local_session_turns import LOCAL_TRIGGER_META
+
+    if source == "cron":
+        return {CRON_TRIGGER_META: {"job_id": "job-1", "run_id": "job-1:1"}}
+    if source == "trigger":
+        return {LOCAL_TRIGGER_META: {"trigger_id": "trg-1", "delivery_id": "d-1"}}
+    return {}
+
+
 @pytest.mark.parametrize(
-    ("sender_id", "runner_substituted", "expect_delivered"),
+    ("source", "sender_id", "runner_substituted", "expect_delivered"),
     [
         # AgentRunner normally substitutes the placeholder itself on blank text,
         # so both shapes reach _state_save in practice and both must be handled.
-        ("user", False, True),   # interactive: manufacture the placeholder
-        ("user", True, True),    # interactive: keep the runner's placeholder
-        ("cron", False, False),  # scheduled cron job: stay silent
-        ("cron", True, False),   # scheduled cron job: drop the runner's placeholder
+        ("interactive", "user", False, True),   # manufacture the placeholder
+        ("interactive", "user", True, True),    # keep the runner's placeholder
+        ("cron", "cron", False, False),         # scheduled job: stay silent
+        ("cron", "cron", True, False),          # scheduled job: drop the placeholder
+        ("trigger", "trigger", False, False),   # local trigger: stay silent
+        ("trigger", "trigger", True, False),    # local trigger: drop the placeholder
+        # sender_id is a per-trigger setting, so the gate must not depend on it.
+        ("trigger", "ci-bot", True, False),
     ],
 )
-async def test_empty_final_placeholder_skipped_for_cron_turns(
-    tmp_path: Path, sender_id: str, runner_substituted: bool, expect_delivered: bool
+async def test_empty_final_placeholder_skipped_for_background_turns(
+    tmp_path: Path, source: str, sender_id: str, runner_substituted: bool, expect_delivered: bool
 ) -> None:
-    """A cron turn that ends empty stays silent; an interactive turn still gets the
-    'couldn't produce a final answer' placeholder so the waiting user has a reply."""
-    from nanobot.agent.loop import TurnContext, TurnState
+    """A background (cron / local-trigger) turn that ends empty stays silent, while an
+    interactive turn still gets the 'couldn't produce a final answer' placeholder so the
+    waiting user has a reply. Both are auto-published to a bound chat, so an empty result
+    must not be turned into a spurious message on every no-op run.
+
+    Note these are all ``TurnKind.USER`` turns: automation turns arrive on the origin
+    channel, not on ``system``, so the kind split does not identify them."""
+    from nanobot.agent.loop import TurnContext, TurnKind, TurnRoute, TurnState
     from nanobot.utils.runtime import EMPTY_FINAL_RESPONSE_MESSAGE
 
     loop = _make_full_loop(tmp_path)
-    session_key = f"telegram:{sender_id}"
+    session_key = f"telegram:{source}"
     session = loop.sessions.get_or_create(session_key)
 
     ctx = TurnContext(
         msg=InboundMessage(
-            channel="telegram", sender_id=sender_id, chat_id="c1", content="run watch"
+            channel="telegram",
+            sender_id=sender_id,
+            chat_id="c1",
+            content="run watch",
+            metadata=_automation_metadata(source),
         ),
         session=session,
         session_key=session_key,
         state=TurnState.SAVE,
         turn_id=f"{session_key}:1",
         runtime=loop.llm_runtime(),
+        kind=TurnKind.USER,
+        route=TurnRoute(channel="telegram", chat_id="c1"),
         final_content=EMPTY_FINAL_RESPONSE_MESSAGE if runner_substituted else "",
         stop_reason="empty_final_response",
         ephemeral=True,  # skip file-cap / consolidation side effects

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -147,6 +147,48 @@ def test_persist_cron_turn_uses_distinct_history_marker(tmp_path: Path) -> None:
     assert message["cron_prompt_ref"] == prompt_ref
 
 
+@pytest.mark.parametrize(
+    ("sender_id", "expect_placeholder"),
+    [
+        ("user", True),     # interactive: keep the placeholder
+        ("cron", False),    # scheduled cron job: stay silent
+    ],
+)
+async def test_empty_final_placeholder_skipped_for_cron_turns(
+    tmp_path: Path, sender_id: str, expect_placeholder: bool
+) -> None:
+    """A cron turn that ends empty stays silent; an interactive turn keeps the
+    'couldn't produce a final answer' placeholder so the waiting user still gets
+    a reply."""
+    from nanobot.agent.loop import TurnContext, TurnState
+    from nanobot.utils.runtime import EMPTY_FINAL_RESPONSE_MESSAGE
+
+    loop = _make_full_loop(tmp_path)
+    session_key = f"telegram:{sender_id}"
+    session = loop.sessions.get_or_create(session_key)
+
+    ctx = TurnContext(
+        msg=InboundMessage(
+            channel="telegram", sender_id=sender_id, chat_id="c1", content="run watch"
+        ),
+        session=session,
+        session_key=session_key,
+        state=TurnState.SAVE,
+        turn_id=f"{session_key}:1",
+        runtime=loop.llm_runtime(),
+        final_content="",
+        stop_reason="empty_final_response",
+        ephemeral=True,  # skip file-cap / consolidation side effects
+    )
+
+    await loop._state_save(ctx)
+
+    if expect_placeholder:
+        assert ctx.final_content == EMPTY_FINAL_RESPONSE_MESSAGE
+    else:
+        assert not (ctx.final_content or "").strip()
+
+
 def test_persist_local_trigger_turn_uses_hidden_automation_marker(tmp_path: Path) -> None:
     loop = _make_full_loop(tmp_path)
     session = loop.sessions.get_or_create("websocket:auto")

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -148,18 +148,21 @@ def test_persist_cron_turn_uses_distinct_history_marker(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    ("sender_id", "expect_placeholder"),
+    ("sender_id", "runner_substituted", "expect_delivered"),
     [
-        ("user", True),     # interactive: keep the placeholder
-        ("cron", False),    # scheduled cron job: stay silent
+        # AgentRunner normally substitutes the placeholder itself on blank text,
+        # so both shapes reach _state_save in practice and both must be handled.
+        ("user", False, True),   # interactive: manufacture the placeholder
+        ("user", True, True),    # interactive: keep the runner's placeholder
+        ("cron", False, False),  # scheduled cron job: stay silent
+        ("cron", True, False),   # scheduled cron job: drop the runner's placeholder
     ],
 )
 async def test_empty_final_placeholder_skipped_for_cron_turns(
-    tmp_path: Path, sender_id: str, expect_placeholder: bool
+    tmp_path: Path, sender_id: str, runner_substituted: bool, expect_delivered: bool
 ) -> None:
-    """A cron turn that ends empty stays silent; an interactive turn keeps the
-    'couldn't produce a final answer' placeholder so the waiting user still gets
-    a reply."""
+    """A cron turn that ends empty stays silent; an interactive turn still gets the
+    'couldn't produce a final answer' placeholder so the waiting user has a reply."""
     from nanobot.agent.loop import TurnContext, TurnState
     from nanobot.utils.runtime import EMPTY_FINAL_RESPONSE_MESSAGE
 
@@ -176,17 +179,19 @@ async def test_empty_final_placeholder_skipped_for_cron_turns(
         state=TurnState.SAVE,
         turn_id=f"{session_key}:1",
         runtime=loop.llm_runtime(),
-        final_content="",
+        final_content=EMPTY_FINAL_RESPONSE_MESSAGE if runner_substituted else "",
         stop_reason="empty_final_response",
         ephemeral=True,  # skip file-cap / consolidation side effects
     )
 
     await loop._state_save(ctx)
+    await loop._state_respond(ctx)
 
-    if expect_placeholder:
-        assert ctx.final_content == EMPTY_FINAL_RESPONSE_MESSAGE
+    if expect_delivered:
+        assert ctx.outbound is not None
+        assert ctx.outbound.content == EMPTY_FINAL_RESPONSE_MESSAGE
     else:
-        assert not (ctx.final_content or "").strip()
+        assert ctx.outbound is None
 
 
 def test_persist_local_trigger_turn_uses_hidden_automation_marker(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

When a turn finishes with no assistant text, nanobot substitutes the `EMPTY_FINAL_RESPONSE_MESSAGE` placeholder:

> I completed the tool steps but couldn't produce a final answer. Please try again or narrow the task.

That placeholder is a useful UX affordance for an **interactive** user who is waiting on a reply. But for a **scheduled cron turn** an empty completion is frequently a legitimate *silent* outcome — e.g. a "silent monitor" job that runs a check and has nothing to report. Because such jobs are session-bound to a chat and the turn's final response is auto-published to that chat, the placeholder is delivered to the user on **every no-op run**.

This suppresses the response for **background turns** that end with no real content, via a small `_is_background_turn()` helper. Interactive turns are unchanged.

## How this shows up

A `deliver: false` "silent monitor" cron job (run a script/check, only message the user if it finds something) runs on a schedule. On a no-op run the model runs its tools, finds nothing, and legitimately ends the turn with no text. Because the job is session-bound, that empty turn becomes the placeholder and is auto-published to the chat — one spurious *"couldn't produce a final answer"* message per no-op run.

Trace for one run:

```
Cron: executing job 'monitor'
  Tool call: exec(...)          # -> nothing new
  Tool call: read_file(...)     # -> expected miss / empty
  Empty response on turn 3 ... after 2 retries; attempting finalization
Response to <channel>:cron: I completed the tool steps but couldn't produce a final answer. ...
```

This became user-visible after cron jobs were migrated to session-bound payloads, which gave their final response a real chat to publish to.

## The placeholder has two sources

Worth calling out, because gating only one of them looks like a fix but is a no-op in practice.

1. `AgentLoop._state_save` substitutes the placeholder when a turn arrives at the save boundary with blank content.
2. `AgentRunner` (`runner.py`, the `is_blank_text(clean)` branch) substitutes the **same** string the moment the model returns blank text, appends it to the transcript, and sets `stop_reason = "empty_final_response"`.

The runner path runs first and almost always wins, so a cron turn typically reaches `_state_save` with `final_content` **already** set to the placeholder — a guard that only declines to *manufacture* it never fires. Observed live, on a build carrying exactly such a partial gate:

```
06:35:24 | WARNING | Empty response on turn 4 for <channel>:<session> after 2 retries; attempting finalization
06:35:26 | INFO    | Response to <channel>:cron: I completed the tool steps but couldn't produce a final answer. ...
06:45:23 | WARNING | Empty response on turn 3 for <channel>:<session> after 2 retries; attempting finalization
06:45:29 | INFO    | Response to <channel>:cron: I completed the tool steps but couldn't produce a final answer. ...
07:15:17 | WARNING | Empty response on turn 3 for <channel>:<session> after 2 retries; attempting finalization
07:15:19 | INFO    | Response to <channel>:cron: I completed the tool steps but couldn't produce a final answer. ...
```

So both shapes are handled here, through the existing `suppress_response` flag rather than two separate mechanisms. Using `suppress_response` also closes a gap in the narrower approach: leaving `final_content` empty still assembles an `OutboundMessage` with empty content and relies on a downstream channel-level guard to drop it, whereas `_state_respond` skips assembly entirely when the turn is suppressed.

## Which turns are gated, and why

The fault is specific to turns whose final response is **auto-published** to a bound chat with no interactive user waiting. Auditing every non-`"user"` `sender_id` in the codebase, that is exactly two paths:

- **cron** (`cron/bound_runner.py`)
- **local triggers** (`triggers/local_runner.py`) — same `AutomationTurnCoordinator` base, same bus, same auto-publish, and no notify gate. Structurally identical to cron.

The gate keys off the metadata each coordinator stamps on the inbound (`cron_trigger()` / `local_trigger()`) rather than on `sender_id`. For cron those are equivalent, but a local trigger's `sender_id` is a **per-trigger setting** (`LocalTrigger.sender_id`, default `"trigger"`), so a string literal would be defeatable by configuration.

The remaining non-user senders are not affected:

- `subagent` posts on channel `"system"`, which is not a registered channel — the outbound dispatcher drops it (`Unknown channel: system`). Subagents reach the user via the `message` tool instead.
- `webui-settings` is a runtime-control message, intercepted before the turn machinery; it never runs a turn.
- `runtime` is an event-context stub, not a submitted turn.
- The OpenAI-compatible HTTP API has its own fallback to the same constant (`api/server.py`). That one is **correct and left alone** — an HTTP caller is waiting and the response needs a body.

The heartbeat loop is likewise **not** affected, for two independent reasons:

1. It doesn't auto-publish — `process_direct` returns the outbound to the heartbeat handler, which gates delivery behind a fail-closed notify-evaluator (and suppresses `message()` tool delivery during the turn).
2. It skips the agent turn entirely when `HEARTBEAT.md` has no active tasks, so the empty-final path is usually never reached.

So widening the gate to heartbeat would overstate the fix.

## Relation to existing issues / PRs

- Addresses the cron/scheduled slice of #3106.
- Complementary to #3127 (fall back to short tool-results for *interactive* users). Note #3127 keeps the placeholder for noisy retrieval tools like `read_file`/`exec` — exactly what silent monitors call last — so it would not silence this case; and where it *does* substitute tool-result text, that text is non-empty and would still be auto-published on a cron no-op run. The two changes are complementary but the cron gate is still needed.
- Complementary to #4002 (recover empty responses via the fallback chain) — that reduces empty-finals at the provider level; this handles the delivery side for scheduled turns.

## A more robust follow-up (not in this PR)

The minimal fix keys off *"automated turn AND no real content"*. The more principled fix is to honor the cron payload's existing `deliver: false` flag at delivery time: thread `deliver` into the cron turn's metadata and, for `deliver == False` turns, suppress the auto-assembled response entirely (explicit `message()` tool sends are unaffected). That is *silent by contract* rather than *silent because the content happened to be empty or placeholder-shaped*.

The two-source finding above is an argument for that direction: content-keyed gates are fragile precisely because more than one layer can put content there. It also stays correct if #3127 lands, which can make `final_content` non-empty (and not placeholder-equal) before it reaches this gate. I kept it out of this PR because it touches the cron→turn boundary and changes delivery semantics for `deliver: true` jobs too — happy to follow up if maintainers prefer that direction.

## Tests

- `pytest tests/agent/test_loop_save_turn.py -q` — 54 passed. `test_empty_final_placeholder_skipped_for_background_turns` is parametrized over interactive / cron / local-trigger × both placeholder sources, plus a case with an overridden trigger `sender_id` to pin the metadata-keyed behavior. It asserts on the assembled outbound rather than on `final_content`, so the runner-substituted shape is covered.
- `pytest tests/agent/ tests/cron -q` — 1426 passed (2 pre-existing failures in `test_workspace_scope.py`, unrelated and present on the branch point).
- `pytest tests/ -q --ignore=tests/agent` — 3778 passed, 11 skipped.
- `ruff check nanobot/agent/loop.py`
