### PR TITLE
fix(transcription): resolve ${VAR} env refs in transcription api_key/api_base

### DIFF
--- a/nanobot/audio/transcription.py
+++ b/nanobot/audio/transcription.py
@@ -20,6 +20,7 @@ from nanobot.audio.transcription_registry import (
     get_transcription_provider,
     resolve_transcription_provider,
 )
+from nanobot.config.loader import resolve_env_refs
 from nanobot.config.paths import get_media_dir
 from nanobot.providers.registry import find_by_name
 from nanobot.utils.media_decode import FileSizeExceeded, save_base64_data_url
@@ -82,7 +83,7 @@ def _provider_default_api_base(provider: str) -> str | None:
 
 
 def _resolve_transcription_api_key(provider: str, provider_cfg: Any) -> str:
-    api_key = getattr(provider_cfg, "api_key", None) if provider_cfg else None
+    api_key = resolve_env_refs(getattr(provider_cfg, "api_key", None) or "") if provider_cfg else ""
     if api_key:
         return api_key
 
@@ -97,7 +98,7 @@ def _resolve_transcription_api_key(provider: str, provider_cfg: Any) -> str:
 
 
 def _resolve_transcription_api_base(provider: str, provider_cfg: Any) -> str:
-    api_base = getattr(provider_cfg, "api_base", None) if provider_cfg else None
+    api_base = resolve_env_refs(getattr(provider_cfg, "api_base", None) or "") if provider_cfg else ""
     if api_base:
         return api_base
     return _provider_default_api_base(provider) or ""

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -116,6 +116,21 @@ def resolve_config_env_vars(config: Config) -> Config:
     return _resolve_in_place(config)
 
 
+def resolve_env_refs(value: str) -> str:
+    """Resolve ``${VAR}`` references in a single string, leniently.
+
+    Unlike :func:`resolve_config_env_vars` (which walks a whole ``Config`` and
+    raises on a missing variable), this resolves one value and substitutes an
+    empty string for any unset reference. It is meant for individual, lazily
+    consumed secret fields — e.g. a transcription provider's ``api_key`` — so a
+    missing variable degrades to "not configured" instead of sending the literal
+    ``${VAR}`` text to the provider. Non-string input is returned unchanged.
+    """
+    if not isinstance(value, str):
+        return value
+    return _ENV_REF_PATTERN.sub(lambda m: os.environ.get(m.group(1), ""), value)
+
+
 def _resolve_in_place(obj: Any) -> Any:
     if isinstance(obj, str):
         new = _ENV_REF_PATTERN.sub(_env_replace, obj)

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -120,15 +120,18 @@ def resolve_env_refs(value: str) -> str:
     """Resolve ``${VAR}`` references in a single string, leniently.
 
     Unlike :func:`resolve_config_env_vars` (which walks a whole ``Config`` and
-    raises on a missing variable), this resolves one value and substitutes an
-    empty string for any unset reference. It is meant for individual, lazily
-    consumed secret fields — e.g. a transcription provider's ``api_key`` — so a
-    missing variable degrades to "not configured" instead of sending the literal
-    ``${VAR}`` text to the provider. Non-string input is returned unchanged.
+    raises on a missing variable), this resolves one value and returns an empty
+    string if any reference is unset. It is meant for individual, lazily consumed
+    fields — e.g. a transcription provider's ``api_key`` or ``api_base`` — so a
+    missing variable degrades to "not configured" instead of producing a partial
+    value. Non-string input is returned unchanged.
     """
     if not isinstance(value, str):
         return value
-    return _ENV_REF_PATTERN.sub(lambda m: os.environ.get(m.group(1), ""), value)
+    names = _ENV_REF_PATTERN.findall(value)
+    if any(name not in os.environ for name in names):
+        return ""
+    return _ENV_REF_PATTERN.sub(lambda m: os.environ[m.group(1)], value)
 
 
 def _resolve_in_place(obj: Any) -> Any:

--- a/tests/providers/test_transcription.py
+++ b/tests/providers/test_transcription.py
@@ -157,6 +157,46 @@ def test_resolver_supports_siliconflow_transcription_api_key_env() -> None:
     assert resolved.api_base == "https://api.siliconflow.cn/v1"
 
 
+def test_resolver_interpolates_env_ref_in_api_key() -> None:
+    # load_config() does not interpolate ${VAR}; the transcription path receives
+    # the raw config, so an env reference in the key must be resolved here rather
+    # than sent verbatim to the provider (which yields a 401).
+    config = Config()
+    config.transcription.provider = "groq"
+    config.providers.groq.api_key = "${MY_GROQ_KEY}"
+
+    with patch.dict(os.environ, {"MY_GROQ_KEY": "gsk-real-value"}, clear=True):
+        resolved = resolve_transcription_config(config)
+
+    assert resolved.api_key == "gsk-real-value"
+
+
+def test_resolver_env_ref_missing_var_degrades_to_not_configured() -> None:
+    config = Config()
+    config.transcription.provider = "groq"
+    config.providers.groq.api_key = "${MISSING_GROQ_KEY}"
+
+    with patch.dict(os.environ, {}, clear=True):
+        resolved = resolve_transcription_config(config)
+
+    # Unresolved reference degrades to a falsy key rather than the literal
+    # "${...}" string, so the config reports itself as not configured.
+    assert not resolved.api_key
+    assert resolved.configured is False
+
+
+def test_resolver_interpolates_env_ref_in_api_base() -> None:
+    config = Config()
+    config.transcription.provider = "groq"
+    config.providers.groq.api_key = "gsk-test"
+    config.providers.groq.api_base = "${MY_GROQ_BASE}"
+
+    with patch.dict(os.environ, {"MY_GROQ_BASE": "https://groq.example/v1"}, clear=True):
+        resolved = resolve_transcription_config(config)
+
+    assert resolved.api_base == "https://groq.example/v1"
+
+
 def test_resolver_supports_xiaomi_mimo_transcription_provider() -> None:
     config = Config()
     config.transcription.provider = "xiaomi_mimo"

--- a/tests/providers/test_transcription.py
+++ b/tests/providers/test_transcription.py
@@ -185,6 +185,18 @@ def test_resolver_env_ref_missing_var_degrades_to_not_configured() -> None:
     assert resolved.configured is False
 
 
+def test_resolver_missing_embedded_api_key_ref_degrades_to_not_configured() -> None:
+    config = Config()
+    config.transcription.provider = "groq"
+    config.providers.groq.api_key = "Bearer ${MISSING_GROQ_KEY}"
+
+    with patch.dict(os.environ, {}, clear=True):
+        resolved = resolve_transcription_config(config)
+
+    assert not resolved.api_key
+    assert resolved.configured is False
+
+
 def test_resolver_interpolates_env_ref_in_api_base() -> None:
     config = Config()
     config.transcription.provider = "groq"
@@ -195,6 +207,18 @@ def test_resolver_interpolates_env_ref_in_api_base() -> None:
         resolved = resolve_transcription_config(config)
 
     assert resolved.api_base == "https://groq.example/v1"
+
+
+def test_resolver_missing_embedded_api_base_ref_uses_provider_default() -> None:
+    config = Config()
+    config.transcription.provider = "groq"
+    config.providers.groq.api_key = "gsk-test"
+    config.providers.groq.api_base = "https://${MISSING_GROQ_HOST}/openai/v1"
+
+    with patch.dict(os.environ, {}, clear=True):
+        resolved = resolve_transcription_config(config)
+
+    assert resolved.api_base == "https://api.groq.com/openai/v1"
 
 
 def test_resolver_supports_xiaomi_mimo_transcription_provider() -> None:


### PR DESCRIPTION
## Summary

Voice transcription fails with **`Groq transcription HTTP 401 Unauthorized: Invalid API Key`** even when the configured key is valid and current. The cause is env-var interpolation not being applied on the transcription path.

`config.loader.load_config()` deliberately returns the **raw** config with `${VAR}` references intact — interpolation is a separate, explicit step (`resolve_config_env_vars`). That separation is on purpose: the ~20 settings-UI read/edit/save callers must see raw `${VAR}` so secrets are never displayed in the UI or re-materialized into `config.json` on save.

But the transcription path never applies the interpolation step. Both entry points build their effective config as:

```python
resolve_transcription_config(load_config())
```

- `nanobot/channels/base.py` — `transcribe_audio` (channel voice notes)
- `nanobot/webui/transcription_ws.py` — WebUI recording

So a provider `api_key` of `"${GROQ_API_KEY}"` (the documented way to reference secrets, per the "Environment Variables for Secrets" docs) is passed to the provider **verbatim** as the bearer token → 401. 

## Fix

Resolve the reference at the **single choke point both callers share** — `_resolve_transcription_api_key` / `_resolve_transcription_api_base` in `nanobot/audio/transcription.py` — via a new lenient helper `loader.resolve_env_refs(value)`:

- Resolves `${VAR}` in one string; an **unset** variable becomes `""` (so a missing var degrades to "not configured" rather than raising, or leaking the literal `${...}`).
- Distinct from `resolve_config_env_vars`, which walks a whole `Config` and raises on any missing var — too broad here (it would require every unrelated channel's env var to be present just to transcribe, and the settings UI calls `resolve_transcription_config` too).

### Why this level

- **Not `load_config()`** — the settings-UI callers rely on it returning raw `${VAR}`; resolving there would leak/persist secrets.
- **Not per-call-site** — both transcription entry points independently forgot the resolve step (easy to drift; a third caller would forget again). Fixing the shared resolver covers both and is drift-proof.
- The settings API calls `resolve_transcription_config` only to read the derived `configured` flag (never `api_key`), so there's no secret exposure — and `configured` now reflects the truly-resolved value.

Literal (non-`${}`) keys are unchanged.

## Tests

`pytest tests/providers/test_transcription.py tests/webui/test_transcription_ws.py -q` — adds:

- `test_resolver_interpolates_env_ref_in_api_key` — `${MY_GROQ_KEY}` → resolved value.
- `test_resolver_env_ref_missing_var_degrades_to_not_configured` — unset ref → falsy key, `configured is False` (no literal `${...}` sent).
- `test_resolver_interpolates_env_ref_in_api_base` — same for `api_base`.

`ruff check nanobot/config/loader.py nanobot/audio/transcription.py`
