### PR TITLE
fix(triggers): reject deliveries to disabled channels

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -2076,7 +2076,7 @@ def _run_gateway(
                     run_local_trigger_queue(
                         store=trigger_store,
                         submit_turn=getattr(agent, "submit_local_trigger_turn", None),
-                        is_channel_available=lambda name: name in channels.channels,
+                        is_channel_enabled=lambda name: channels.get_channel(name) is not None,
                     ),
                     name="nanobot-local-triggers",
                 ),

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -2076,6 +2076,7 @@ def _run_gateway(
                     run_local_trigger_queue(
                         store=trigger_store,
                         submit_turn=getattr(agent, "submit_local_trigger_turn", None),
+                        is_channel_available=lambda name: name in channels.channels,
                     ),
                     name="nanobot-local-triggers",
                 ),

--- a/nanobot/triggers/local_runner.py
+++ b/nanobot/triggers/local_runner.py
@@ -21,6 +21,7 @@ async def run_local_trigger_queue(
     *,
     store: LocalTriggerStore,
     submit_turn: Callable[[InboundMessage], Awaitable[OutboundMessage | None]] | None = None,
+    is_channel_available: Callable[[str], bool] | None = None,
     poll_interval_s: float = 0.5,
     batch_size: int = 20,
 ) -> None:
@@ -46,6 +47,7 @@ async def run_local_trigger_queue(
                     store,
                     delivery,
                     submit_turn=submit_turn,
+                    is_channel_available=is_channel_available,
                 )
                 store.complete_delivery(delivery)
             except asyncio.CancelledError as exc:
@@ -130,12 +132,15 @@ async def _deliver_delivery(
     delivery: TriggerDelivery,
     *,
     submit_turn: Callable[[InboundMessage], Awaitable[OutboundMessage | None]],
+    is_channel_available: Callable[[str], bool] | None = None,
 ) -> None:
     trigger = store.get(delivery.trigger_id)
     if trigger is None:
         raise _TerminalDeliveryError("trigger not found")
     if not trigger.enabled:
         raise _TerminalDeliveryError("trigger is disabled")
+    if is_channel_available is not None and not is_channel_available(trigger.channel):
+        raise _TerminalDeliveryError(f"target channel is not enabled: {trigger.channel}")
 
     store.write_delivery_run_record(delivery, trigger=trigger, status="processing")
     msg = InboundMessage(

--- a/nanobot/triggers/local_runner.py
+++ b/nanobot/triggers/local_runner.py
@@ -21,7 +21,7 @@ async def run_local_trigger_queue(
     *,
     store: LocalTriggerStore,
     submit_turn: Callable[[InboundMessage], Awaitable[OutboundMessage | None]] | None = None,
-    is_channel_available: Callable[[str], bool] | None = None,
+    is_channel_enabled: Callable[[str], bool],
     poll_interval_s: float = 0.5,
     batch_size: int = 20,
 ) -> None:
@@ -47,7 +47,7 @@ async def run_local_trigger_queue(
                     store,
                     delivery,
                     submit_turn=submit_turn,
-                    is_channel_available=is_channel_available,
+                    is_channel_enabled=is_channel_enabled,
                 )
                 store.complete_delivery(delivery)
             except asyncio.CancelledError as exc:
@@ -132,14 +132,14 @@ async def _deliver_delivery(
     delivery: TriggerDelivery,
     *,
     submit_turn: Callable[[InboundMessage], Awaitable[OutboundMessage | None]],
-    is_channel_available: Callable[[str], bool] | None = None,
+    is_channel_enabled: Callable[[str], bool],
 ) -> None:
     trigger = store.get(delivery.trigger_id)
     if trigger is None:
         raise _TerminalDeliveryError("trigger not found")
     if not trigger.enabled:
         raise _TerminalDeliveryError("trigger is disabled")
-    if is_channel_available is not None and not is_channel_available(trigger.channel):
+    if not is_channel_enabled(trigger.channel):
         raise _TerminalDeliveryError(f"target channel is not enabled: {trigger.channel}")
 
     store.write_delivery_run_record(delivery, trigger=trigger, status="processing")

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -2748,7 +2748,7 @@ def test_gateway_local_trigger_queue_submits_agent_turns(
         enabled_channels: list[str] = []
 
         def __init__(self, *_args, **_kwargs) -> None:
-            return None
+            self.channels: dict[str, object] = {}
 
         async def start_all(self) -> None:
             await asyncio.Event().wait()
@@ -2776,6 +2776,7 @@ def test_gateway_local_trigger_queue_submits_agent_turns(
     assert kwargs["store"] is agent_kwargs["local_trigger_store"]
     assert "bus" not in kwargs
     assert kwargs["submit_turn"] is agent.submit_local_trigger_turn
+    assert kwargs["is_channel_available"]("websocket") is False
 
 
 def test_gateway_workspace_override_does_not_migrate_legacy_cron(

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -2748,7 +2748,10 @@ def test_gateway_local_trigger_queue_submits_agent_turns(
         enabled_channels: list[str] = []
 
         def __init__(self, *_args, **_kwargs) -> None:
-            self.channels: dict[str, object] = {}
+            return None
+
+        def get_channel(self, name: str) -> object | None:
+            return object() if name == "websocket" else None
 
         async def start_all(self) -> None:
             await asyncio.Event().wait()
@@ -2776,7 +2779,8 @@ def test_gateway_local_trigger_queue_submits_agent_turns(
     assert kwargs["store"] is agent_kwargs["local_trigger_store"]
     assert "bus" not in kwargs
     assert kwargs["submit_turn"] is agent.submit_local_trigger_turn
-    assert kwargs["is_channel_available"]("websocket") is False
+    assert kwargs["is_channel_enabled"]("websocket") is True
+    assert kwargs["is_channel_enabled"]("telegram") is False
 
 
 def test_gateway_workspace_override_does_not_migrate_legacy_cron(

--- a/tests/triggers/test_local_triggers.py
+++ b/tests/triggers/test_local_triggers.py
@@ -299,6 +299,52 @@ async def test_local_trigger_queue_submits_bound_inbound_message(tmp_path: Path)
 
 
 @pytest.mark.asyncio
+async def test_local_trigger_queue_rejects_unavailable_target_channel(tmp_path: Path) -> None:
+    store = LocalTriggerStore(tmp_path)
+    trigger = store.create(
+        name="PR review",
+        channel="telegram",
+        chat_id="chat-1",
+        session_key="telegram:chat-1",
+    )
+    delivery = store.enqueue(trigger.id, "Review PR #4502")
+    submitted: list[InboundMessage] = []
+
+    async def _submit_turn(msg: InboundMessage):
+        submitted.append(msg)
+        return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id, content="done")
+
+    task = asyncio.create_task(
+        run_local_trigger_queue(
+            store=store,
+            submit_turn=_submit_turn,
+            is_channel_available=lambda name: name == "websocket",
+            poll_interval_s=0.01,
+        )
+    )
+    try:
+        for _ in range(100):
+            stored = store.get(trigger.id)
+            if stored and stored.last_status == "error":
+                break
+            await asyncio.sleep(0.01)
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    stored = store.get(trigger.id)
+    assert submitted == []
+    assert stored is not None
+    assert stored.last_status == "error"
+    assert stored.last_error == "target channel is not enabled: telegram"
+    assert store.claim_deliveries() == []
+    record = _read_run_record(store, delivery.id)
+    assert record["status"] == "error"
+    assert record["error"] == "target channel is not enabled: telegram"
+
+
+@pytest.mark.asyncio
 async def test_local_trigger_queue_waits_for_submitted_turn_before_ack(
     tmp_path: Path,
 ) -> None:

--- a/tests/triggers/test_local_triggers.py
+++ b/tests/triggers/test_local_triggers.py
@@ -16,6 +16,10 @@ from nanobot.triggers.local_store import LocalTriggerStore, TriggerDisabledError
 from nanobot.webui.metadata import WEBUI_MESSAGE_SOURCE_METADATA_KEY, WEBUI_TURN_METADATA_KEY
 
 
+def _channel_is_enabled(_name: str) -> bool:
+    return True
+
+
 def _write_delivery_file(path: Path, *, trigger_id: str, delivery_id: str) -> None:
     path.write_text(
         json.dumps(
@@ -256,7 +260,12 @@ async def test_local_trigger_queue_submits_bound_inbound_message(tmp_path: Path)
         return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id, content="done")
 
     task = asyncio.create_task(
-        run_local_trigger_queue(store=store, submit_turn=_submit_turn, poll_interval_s=0.01)
+        run_local_trigger_queue(
+            store=store,
+            submit_turn=_submit_turn,
+            is_channel_enabled=_channel_is_enabled,
+            poll_interval_s=0.01,
+        )
     )
     try:
         for _ in range(100):
@@ -318,7 +327,7 @@ async def test_local_trigger_queue_rejects_unavailable_target_channel(tmp_path: 
         run_local_trigger_queue(
             store=store,
             submit_turn=_submit_turn,
-            is_channel_available=lambda name: name == "websocket",
+            is_channel_enabled=lambda name: name == "websocket",
             poll_interval_s=0.01,
         )
     )
@@ -368,6 +377,7 @@ async def test_local_trigger_queue_waits_for_submitted_turn_before_ack(
         run_local_trigger_queue(
             store=store,
             submit_turn=_submit_turn,
+            is_channel_enabled=_channel_is_enabled,
             poll_interval_s=0.01,
         )
     )
@@ -427,6 +437,7 @@ async def test_local_trigger_queue_requeues_when_submitted_turn_is_interrupted(
         run_local_trigger_queue(
             store=store,
             submit_turn=_submit_turn,
+            is_channel_enabled=_channel_is_enabled,
             poll_interval_s=0.01,
         )
     )
@@ -472,6 +483,7 @@ async def test_local_trigger_queue_does_not_retry_completed_agent_failure(
         run_local_trigger_queue(
             store=store,
             submit_turn=_submit_turn,
+            is_channel_enabled=_channel_is_enabled,
             poll_interval_s=0.01,
         )
     )
@@ -520,7 +532,12 @@ async def test_local_trigger_queue_recovers_processing_delivery_on_start(
 
     restarted = LocalTriggerStore(tmp_path)
     task = asyncio.create_task(
-        run_local_trigger_queue(store=restarted, submit_turn=_submit_turn, poll_interval_s=0.01)
+        run_local_trigger_queue(
+            store=restarted,
+            submit_turn=_submit_turn,
+            is_channel_enabled=_channel_is_enabled,
+            poll_interval_s=0.01,
+        )
     )
     try:
         for _ in range(100):


### PR DESCRIPTION
Closes #4991

## Summary

Prevent local triggers from running agent turns after their target channel has
been disabled.

## Root Cause

Local triggers persist the channel and chat ID that created them. When that
channel is later disabled, the trigger queue still submitted an agent turn.
The outbound dispatcher then dropped the response as an unknown channel, while
the trigger delivery was recorded as successful.

This can consume model usage without delivering a result to the user.

## Changes

- Check that a local trigger's target channel is currently loaded before
  submitting its agent turn.
- Record an unavailable target channel as a terminal delivery error.
- Pass the gateway's live channel set to the local trigger queue.
- Add regression coverage verifying that unavailable targets do not invoke the
  agent and are recorded as failed.

## Validation

- `python -m pytest tests/triggers/test_local_triggers.py tests/cli/test_commands.py -q`
- `133 passed, 1 skipped`
- `python -m ruff check nanobot/triggers/local_runner.py nanobot/cli/commands.py tests/triggers/test_local_triggers.py tests/cli/test_commands.py`
- `git diff --check`