### PR TITLE
fix(webui): resolve Windows package manager shims

### DIFF
--- a/nanobot/webui/build.py
+++ b/nanobot/webui/build.py
@@ -266,8 +266,8 @@ def ensure_webui_bundle(
 def pick_webui_build_runner() -> str | None:
     """Pick the frontend package manager used to build the WebUI."""
     for candidate in ("bun", "npm"):
-        if shutil.which(candidate):
-            return candidate
+        if executable := shutil.which(candidate):
+            return executable
     return None
 
 

--- a/tests/webui/test_build.py
+++ b/tests/webui/test_build.py
@@ -4,7 +4,11 @@ import os
 import tomllib
 from pathlib import Path
 
-from nanobot.webui.build import ensure_webui_bundle, inspect_webui_bundle
+from nanobot.webui.build import (
+    ensure_webui_bundle,
+    inspect_webui_bundle,
+    pick_webui_build_runner,
+)
 
 _MTIME_BASE_NS = 1_700_000_000_000_000_000
 _MTIME_STEP_NS = 5_000_000_000
@@ -117,6 +121,17 @@ def test_ensure_webui_bundle_auto_builds_stale_dist(tmp_path: Path) -> None:
 
     assert status.stale is False
     assert commands == [("bun", "install"), ("bun", "run", "build")]
+
+
+def test_pick_webui_build_runner_returns_resolved_executable(monkeypatch) -> None:
+    bun_shim = r"C:\tools\npm\bun.CMD"
+
+    monkeypatch.setattr(
+        "nanobot.webui.build.shutil.which",
+        lambda candidate: bun_shim if candidate == "bun" else None,
+    )
+
+    assert pick_webui_build_runner() == bun_shim
 
 
 def test_ensure_webui_bundle_warns_without_building(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- execute the WebUI package manager through the path returned by `shutil.which()`
- add a regression test for Windows command shims such as `bun.CMD`

## Problem

On Windows, npm-style installations expose Bun through a `bun.cmd` shim. The WebUI build helper used `shutil.which("bun")` to confirm that Bun existed, but then discarded the resolved path and passed the bare command name to `subprocess.run()`.

Python's direct Windows process launch does not resolve the bare name to the `.CMD` shim, so `nanobot webui` failed before Bun started:

```text
command failed: bun install ([WinError 2] The system cannot find the file specified.)
```

Returning the resolved executable path preserves the existing Bun-first/npm-fallback behavior while allowing Windows command shims to launch correctly.

## Verification

- `uv run pytest tests/webui/test_build.py tests/cli/test_commands.py -k webui -v` — 20 passed
- `uv run ruff check nanobot/webui/build.py tests/webui/test_build.py` — passed
- Windows smoke test: `uv run nanobot webui --background --no-open --yes` selected `D:\tools\npm\bun.CMD`, completed `bun install` and the Vite production build, and started the gateway
- gateway health check returned HTTP 200 with `{"status": "ok"}`; the isolated gateway was then stopped successfully
