### PR TITLE
style(webui): simplify Markdown code blocks

### DIFF
--- a/webui/src/components/CodeBlock.tsx
+++ b/webui/src/components/CodeBlock.tsx
@@ -40,8 +40,6 @@ const CODE_FONT_STACK = [
 ].join(", ");
 
 const ANSI_LANGUAGES = new Set(["ansi", "ansi-output"]);
-const CODE_SURFACE_LIGHT = "#f4f4f5";
-const CODE_SURFACE_DARK = "#27272a";
 
 const LazyHighlightedCode = lazy(async () => {
   const [
@@ -81,16 +79,12 @@ const LazyHighlightedCode = lazy(async () => {
           language={language || "text"}
           style={transparentTheme}
           customStyle={{
-            background: chrome === "none"
-              ? "transparent"
-              : isDark
-                ? CODE_SURFACE_DARK
-                : CODE_SURFACE_LIGHT,
+            background: "transparent",
             margin: 0,
-            padding: chrome === "none" ? "0.75rem 1rem" : "1rem",
+            padding: chrome === "none" ? "0.75rem 1rem" : "0.75rem",
             fontFamily: CODE_FONT_STACK,
-            fontSize: chrome === "none" ? "13px" : "0.875rem",
-            lineHeight: chrome === "none" ? 1.55 : 1.6,
+            fontSize: "13px",
+            lineHeight: chrome === "none" ? 1.55 : "1.25rem",
             tabSize: 2,
           }}
           codeTagProps={{
@@ -148,9 +142,9 @@ function CodeTextBlock({
   return (
     <pre
       className={cn(
-        "m-0 overflow-x-auto p-4 font-mono text-sm leading-[1.6] text-foreground/90",
+        "m-0 overflow-x-auto p-3 font-mono text-[13px] leading-5 text-foreground/90",
         showLineNumbers ? "whitespace-pre" : "whitespace-pre-wrap",
-        chrome === "default" ? "bg-zinc-100 dark:bg-zinc-800" : "bg-transparent",
+        "bg-transparent",
         chrome === "none" && "p-3 text-[13px] leading-[1.55]",
         className,
       )}
@@ -206,19 +200,14 @@ export function CodeBlock({
     <div
       className={cn(
         "not-prose overflow-hidden",
-        hasChrome && "rounded-lg border",
-        hasChrome && (isDark ? "border-white/10" : "border-black/10"),
+        hasChrome
+          && "rounded-md border border-border/55 bg-background/80 shadow-[0_1px_0_rgba(15,23,42,0.03)]",
         className,
       )}
     >
       {hasChrome ? (
         <div
-          className={cn(
-            "flex items-center justify-between px-4 pb-1.5 pt-2 text-xs font-medium",
-            isDark
-              ? "bg-zinc-800 text-zinc-300"
-              : "bg-zinc-100 text-zinc-600",
-          )}
+          className="flex items-center justify-between border-b border-border/45 bg-muted/30 px-2 py-1 text-[11px] font-medium leading-5 text-muted-foreground"
         >
           <span className="lowercase font-mono">
             {language || t("code.fallbackLanguage")}
@@ -227,10 +216,9 @@ export function CodeBlock({
             type="button"
             onClick={onCopy}
             className={cn(
-              "inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-mono transition-colors",
-              isDark
-                ? "text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200"
-                : "text-zinc-500 hover:bg-zinc-200 hover:text-zinc-700",
+              "inline-flex items-center gap-1 rounded px-1 py-0.5 font-mono transition-colors",
+              "text-muted-foreground hover:bg-muted/65 hover:text-foreground",
+              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/45",
             )}
             aria-label={t("code.copyAria")}
           >

--- a/webui/src/components/CodeBlock.tsx
+++ b/webui/src/components/CodeBlock.tsx
@@ -81,10 +81,10 @@ const LazyHighlightedCode = lazy(async () => {
           customStyle={{
             background: "transparent",
             margin: 0,
-            padding: chrome === "none" ? "0.75rem 1rem" : "0.75rem",
+            padding: chrome === "none" ? "0.75rem 1rem" : "1rem 3.5rem 1rem 1.25rem",
             fontFamily: CODE_FONT_STACK,
             fontSize: "13px",
-            lineHeight: chrome === "none" ? 1.55 : "1.25rem",
+            lineHeight: chrome === "none" ? 1.55 : 1.6,
             tabSize: 2,
           }}
           codeTagProps={{
@@ -142,10 +142,11 @@ function CodeTextBlock({
   return (
     <pre
       className={cn(
-        "m-0 overflow-x-auto p-3 font-mono text-[13px] leading-5 text-foreground/90",
+        "m-0 overflow-x-auto bg-transparent font-mono text-[13px] text-foreground/90",
         showLineNumbers ? "whitespace-pre" : "whitespace-pre-wrap",
-        "bg-transparent",
-        chrome === "none" && "p-3 text-[13px] leading-[1.55]",
+        chrome === "default"
+          ? "py-4 pl-5 pr-14 leading-[1.6]"
+          : "p-3 leading-[1.55]",
         className,
       )}
       data-testid={testId}
@@ -187,6 +188,7 @@ export function CodeBlock({
   const hasChrome = chrome === "default";
   const renderAnsi = shouldRenderAnsi(language, code);
   const syntaxLanguage = normalizeCodeLanguage(language);
+  const copyLabel = copied ? t("code.copied") : t("code.copyAria");
 
   const onCopy = useCallback(() => {
     void copyTextToClipboard(renderAnsi ? stripAnsi(code) : code).then((ok) => {
@@ -199,38 +201,12 @@ export function CodeBlock({
   return (
     <div
       className={cn(
-        "not-prose overflow-hidden",
-        hasChrome
-          && "rounded-md border border-border/55 bg-background/80 shadow-[0_1px_0_rgba(15,23,42,0.03)]",
+        "not-prose relative overflow-hidden",
+        hasChrome && "rounded-[18px] bg-secondary/70",
         className,
       )}
+      data-language={language || t("code.fallbackLanguage")}
     >
-      {hasChrome ? (
-        <div
-          className="flex items-center justify-between border-b border-border/45 bg-muted/30 px-2 py-1 text-[11px] font-medium leading-5 text-muted-foreground"
-        >
-          <span className="lowercase font-mono">
-            {language || t("code.fallbackLanguage")}
-          </span>
-          <button
-            type="button"
-            onClick={onCopy}
-            className={cn(
-              "inline-flex items-center gap-1 rounded px-1 py-0.5 font-mono transition-colors",
-              "text-muted-foreground hover:bg-muted/65 hover:text-foreground",
-              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/45",
-            )}
-            aria-label={t("code.copyAria")}
-          >
-            {copied ? (
-              <Check className="h-3.5 w-3.5" />
-            ) : (
-              <Copy className="h-3.5 w-3.5" />
-            )}
-            <span>{copied ? t("code.copied") : t("code.copy")}</span>
-          </button>
-        </div>
-      ) : null}
       {renderAnsi ? (
         <CodeTextBlock
           code={code}
@@ -267,6 +243,25 @@ export function CodeBlock({
           testId="plain-code-fallback"
         />
       )}
+      {hasChrome ? (
+        <button
+          type="button"
+          onClick={onCopy}
+          className={cn(
+            "absolute right-2.5 top-2.5 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full",
+            "text-muted-foreground/75 transition-colors hover:bg-background/70 hover:text-foreground",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60",
+          )}
+          aria-label={copyLabel}
+          title={copyLabel}
+        >
+          {copied ? (
+            <Check className="h-4 w-4" aria-hidden />
+          ) : (
+            <Copy className="h-4 w-4" aria-hidden />
+          )}
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/webui/src/tests/code-block.test.tsx
+++ b/webui/src/tests/code-block.test.tsx
@@ -48,20 +48,20 @@ describe("CodeBlock", () => {
 
     expect(screen.queryByTestId("highlighted-code")).not.toBeInTheDocument();
     expect(screen.getByText("const value = 1;")).toBeInTheDocument();
-    expect(screen.getByText("ts")).toBeInTheDocument();
+    expect(screen.queryByText("ts")).not.toBeInTheDocument();
     expect(screen.getByTestId("plain-code-fallback")).toHaveClass("text-foreground/90");
     expect(screen.getByTestId("plain-code-fallback")).toHaveClass("bg-transparent");
+    expect(screen.getByTestId("plain-code-fallback")).toHaveClass("py-4", "pl-5", "pr-14");
 
     const container = screen.getByTestId("plain-code-fallback").closest(".not-prose");
-    expect(container).toHaveClass(
-      "rounded-md",
-      "border-border/55",
-      "bg-background/80",
-    );
-    expect(screen.getByText("ts").parentElement).toHaveClass(
-      "border-border/45",
-      "bg-muted/30",
-    );
+    expect(container).toHaveClass("relative", "rounded-[18px]", "bg-secondary/70");
+    expect(container).not.toHaveClass("border");
+    expect(container).toHaveAttribute("data-language", "ts");
+
+    const copyButton = screen.getByRole("button", { name: "Copy code" });
+    expect(copyButton.parentElement).toBe(container);
+    expect(copyButton).toHaveClass("absolute", "h-8", "w-8", "rounded-full");
+    expect(copyButton).toHaveTextContent("");
   });
 
   it("can render without chat-style chrome for file previews", () => {
@@ -127,8 +127,11 @@ describe("CodeBlock", () => {
 
     expect(screen.queryByTestId("highlighted-code")).not.toBeInTheDocument();
     expect(screen.getByTestId("ansi-code")).toBeInTheDocument();
-    expect(screen.getByTestId("ansi-code").closest(".not-prose")).toBeTruthy();
-    expect(screen.getByText("ansi")).toBeInTheDocument();
+    expect(screen.getByTestId("ansi-code").closest(".not-prose")).toHaveAttribute(
+      "data-language",
+      "ansi",
+    );
+    expect(screen.queryByText("ansi")).not.toBeInTheDocument();
     expect(screen.getByText("PASS")).toHaveStyle({ color: "#0dbc79" });
     expect(screen.getByText("<script>alert(1)</script>")).toBeInTheDocument();
     expect(document.querySelector("script")).toBeNull();
@@ -195,7 +198,7 @@ describe("CodeBlock", () => {
       await user.click(screen.getByRole("button", { name: /copy/i }));
 
       await waitFor(() => expect(execCommand).toHaveBeenCalledWith("copy"));
-      expect(screen.getByText("Copied")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
     } finally {
       Reflect.deleteProperty(navigator, "clipboard");
       Reflect.deleteProperty(document, "execCommand");

--- a/webui/src/tests/code-block.test.tsx
+++ b/webui/src/tests/code-block.test.tsx
@@ -50,6 +50,18 @@ describe("CodeBlock", () => {
     expect(screen.getByText("const value = 1;")).toBeInTheDocument();
     expect(screen.getByText("ts")).toBeInTheDocument();
     expect(screen.getByTestId("plain-code-fallback")).toHaveClass("text-foreground/90");
+    expect(screen.getByTestId("plain-code-fallback")).toHaveClass("bg-transparent");
+
+    const container = screen.getByTestId("plain-code-fallback").closest(".not-prose");
+    expect(container).toHaveClass(
+      "rounded-md",
+      "border-border/55",
+      "bg-background/80",
+    );
+    expect(screen.getByText("ts").parentElement).toHaveClass(
+      "border-border/45",
+      "bg-muted/30",
+    );
   });
 
   it("can render without chat-style chrome for file previews", () => {

--- a/webui/src/tests/markdown-text-renderer.test.tsx
+++ b/webui/src/tests/markdown-text-renderer.test.tsx
@@ -163,7 +163,8 @@ describe("MarkdownTextRenderer", () => {
     );
 
     expect(screen.getByText("code without language")).toBeInTheDocument();
-    expect(screen.getByText("text")).toBeInTheDocument();
+    expect(screen.queryByText("text")).not.toBeInTheDocument();
+    expect(container.querySelector(".not-prose")).toHaveAttribute("data-language", "text");
     expect(container.querySelectorAll("pre")).toHaveLength(1);
   });
 


### PR DESCRIPTION
## Summary

- replace the developer-tool-style chrome around rendered Markdown code blocks with a restrained, flat neutral surface that matches the existing chat UI
- remove the visible language header and text copy control while keeping an icon-only copy action in the top-right corner
- preserve syntax highlighting, ANSI/plain-text rendering, keyboard focus, long-content behavior, and the chromeless file-preview variant
- update focused component and Markdown renderer coverage for the revised presentation

## Testing

- `cd webui && npm run test -- src/tests/code-block.test.tsx src/tests/markdown-text-renderer.test.tsx` (38 passed)
- `cd webui && npm run lint -- --quiet`
- `cd webui && npm run build`
- real gateway + headless Playwright: verified light and dark themes, 390px viewport behavior, persisted fenced-code replay, public thread hydration, and reload persistence