### PR TITLE
perf(webui): index conversation history in SQLite

### DIFF
--- a/nanobot/channels/websocket/runtime.py
+++ b/nanobot/channels/websocket/runtime.py
@@ -730,6 +730,7 @@ class WebSocketChannel(BaseChannel):
 
     async def stop(self) -> None:
         if not self._running:
+            await asyncio.to_thread(self._transcripts.close)
             return
         self._running = False
         if self._stop_event:
@@ -748,6 +749,7 @@ class WebSocketChannel(BaseChannel):
         self._conn_chats.clear()
         self._conn_default.clear()
         self._tokens.clear()
+        await asyncio.to_thread(self._transcripts.close)
 
     async def _safe_send_to(self, connection: Any, raw: str, *, label: str = "") -> None:
         """Send a raw frame to one connection, cleaning up on ConnectionClosed."""

--- a/nanobot/channels/websocket/tests/test_websocket_channel.py
+++ b/nanobot/channels/websocket/tests/test_websocket_channel.py
@@ -2849,7 +2849,11 @@ def test_sessions_list_includes_active_run_started_at(monkeypatch) -> None:
             "updated_at": "2026-05-19T10:01:00Z",
         },
     ]
-    monkeypatch.setattr(ws_http_module, "list_webui_sessions", lambda _session_manager: sessions)
+    monkeypatch.setattr(
+        ws_http_module,
+        "list_webui_sessions",
+        lambda _session_manager, **_kwargs: sessions,
+    )
     channel = WebSocketChannel(
         {"enabled": True, "allowFrom": ["*"]},
         bus,

--- a/nanobot/channels/websocket/tests/test_websocket_channel.py
+++ b/nanobot/channels/websocket/tests/test_websocket_channel.py
@@ -48,7 +48,7 @@ from nanobot.webui.http_utils import (
     parse_request_path as _parse_request_path,
 )
 from nanobot.webui.settings_api import settings_payload, update_provider_settings
-from nanobot.webui.transcript import append_transcript_object, read_transcript_lines
+from nanobot.webui.transcript import append_transcript_object
 
 from .ws_test_client import http_get as _http_get
 
@@ -369,8 +369,6 @@ async def test_token_issue_route_requires_secret_when_static_token_configured(bu
 
 @pytest.mark.asyncio
 async def test_webui_message_envelope_marks_inbound_metadata(bus: MagicMock) -> None:
-    from nanobot.webui.transcript import read_transcript_lines
-
     channel = _ch(bus)
     conn = MagicMock()
     conn.remote_address = ("127.0.0.1", 50123)
@@ -393,7 +391,7 @@ async def test_webui_message_envelope_marks_inbound_metadata(bus: MagicMock) -> 
     assert msg.metadata["webui"] is True
     assert msg.metadata["webui_turn_id"] == "turn-1"
     assert msg.metadata["_wants_stream"] is True
-    lines = read_transcript_lines("websocket:chat-1")
+    lines = channel._transcripts.read_lines("websocket:chat-1")
     assert len(lines) == 1
     assert {key: lines[0].get(key) for key in (
         "event",
@@ -419,8 +417,6 @@ async def test_webui_message_envelope_persists_user_transcript_for_refresh(
     tmp_path,
     monkeypatch,
 ) -> None:
-    from nanobot.webui.transcript import build_webui_thread_response, read_transcript_lines
-
     monkeypatch.setattr("nanobot.config.paths.get_data_dir", lambda: tmp_path)
     channel = _ch(bus)
     conn = AsyncMock()
@@ -437,10 +433,10 @@ async def test_webui_message_envelope_persists_user_transcript_for_refresh(
         {"type": "message", "chat_id": "chat-1", "content": "hello", "webui": True},
     )
 
-    lines = read_transcript_lines("websocket:chat-1")
+    lines = channel._transcripts.read_lines("websocket:chat-1")
     assert [line["event"] for line in lines] == ["user", "message"]
 
-    body = build_webui_thread_response("websocket:chat-1")
+    body = channel._transcripts.build_response("websocket:chat-1")
     assert body is not None
     assert [message["role"] for message in body["messages"]] == ["user", "assistant"]
     assert [message["content"] for message in body["messages"]] == ["hello", "hi back"]
@@ -452,8 +448,6 @@ async def test_webui_stop_control_message_is_not_persisted_as_user_bubble(
     tmp_path,
     monkeypatch,
 ) -> None:
-    from nanobot.webui.transcript import read_transcript_lines
-
     monkeypatch.setattr("nanobot.config.paths.get_data_dir", lambda: tmp_path)
     channel = _ch(bus)
     conn = AsyncMock()
@@ -467,7 +461,7 @@ async def test_webui_stop_control_message_is_not_persisted_as_user_bubble(
 
     msg = bus.publish_inbound.await_args.args[0]
     assert msg.content == "/stop"
-    assert read_transcript_lines("websocket:chat-1") == []
+    assert channel._transcripts.read_lines("websocket:chat-1") == []
 
 
 @pytest.mark.asyncio
@@ -475,11 +469,11 @@ async def test_webui_user_transcript_append_failure_does_not_block_inbound(
     bus: MagicMock,
     monkeypatch,
 ) -> None:
-    def fail_append(_session_key: str, _obj: dict[str, Any]) -> None:
+    def fail_writer() -> None:
         raise OSError("disk full")
 
-    monkeypatch.setattr("nanobot.webui.transcript.append_transcript_object", fail_append)
     channel = _ch(bus)
+    monkeypatch.setattr(channel._transcripts, "_get_writer", fail_writer)
     conn = AsyncMock()
     conn.remote_address = ("127.0.0.1", 50123)
 
@@ -1399,8 +1393,6 @@ async def test_send_reasoning_without_subscribers_is_noop() -> None:
 
 @pytest.mark.asyncio
 async def test_stream_transcript_persists_without_subscribers() -> None:
-    from nanobot.webui.transcript import build_webui_thread_response, read_transcript_lines
-
     bus = MagicMock()
     channel = WebSocketChannel(
         {"enabled": True, "allowFrom": ["*"], "streaming": True},
@@ -1419,9 +1411,9 @@ async def test_stream_transcript_persists_without_subscribers() -> None:
     ))
 
     assert channel._subs == {}
-    lines = read_transcript_lines("websocket:chat-1")
+    lines = channel._transcripts.read_lines("websocket:chat-1")
     assert [line["event"] for line in lines] == ["delta", "delta", "stream_end", "turn_end"]
-    body = build_webui_thread_response("websocket:chat-1")
+    body = channel._transcripts.build_response("websocket:chat-1")
     assert body is not None
     assert body["messages"][-1]["role"] == "assistant"
     assert body["messages"][-1]["content"] == "hello world"
@@ -2669,7 +2661,7 @@ async def test_fork_chat_copies_only_prefix_session_and_transcript(
     saved = sessions.read_session_file(f"websocket:{fork_id}")
     assert [m["content"] for m in saved["messages"]] == ["round1", "answer1"]
     assert saved["metadata"]["title"] == "Fork: Old title"
-    fork_lines = read_transcript_lines(f"websocket:{fork_id}")
+    fork_lines = channel._transcripts.read_lines(f"websocket:{fork_id}")
     assert [line.get("text") for line in fork_lines] == ["round1", "answer1", None]
     assert fork_lines[-1]["event"] == "fork_marker"
     assert all(line.get("chat_id") == fork_id for line in fork_lines)
@@ -2703,7 +2695,7 @@ async def test_webui_message_envelope_appends_user_transcript(
         },
     )
 
-    [line] = read_transcript_lines("websocket:source")
+    [line] = channel._transcripts.read_lines("websocket:source")
     assert {
         "event": line.get("event"),
         "chat_id": line.get("chat_id"),
@@ -2910,7 +2902,8 @@ def test_is_valid_chat_id(value: Any, expected: bool) -> None:
     assert _is_valid_chat_id(value) is expected
 
 
-def test_handle_webui_thread_get_returns_json(tmp_path, monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_handle_webui_thread_get_returns_json(tmp_path, monkeypatch) -> None:
     from urllib.parse import quote
 
     from websockets.datastructures import Headers
@@ -2926,7 +2919,7 @@ def test_handle_webui_thread_get_returns_json(tmp_path, monkeypatch) -> None:
     channel.gateway.tokens.api_tokens["tok"] = time.monotonic() + 300.0
     enc = quote(key, safe="")
     req = Request(f"/api/sessions/{enc}/webui-thread", Headers([("Authorization", "Bearer tok")]))
-    resp = channel.gateway.http._handle_webui_thread_get(req, enc)
+    resp = await channel.gateway.http._handle_webui_thread_get(req, enc)
     assert resp.status_code == 200
     body = json.loads(resp.body.decode())
     assert body["sessionKey"] == key
@@ -2935,7 +2928,8 @@ def test_handle_webui_thread_get_returns_json(tmp_path, monkeypatch) -> None:
     assert body["messages"][0]["content"] == "hi"
 
 
-def test_handle_webui_thread_get_accepts_pagination_query(tmp_path, monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_handle_webui_thread_get_accepts_pagination_query(tmp_path, monkeypatch) -> None:
     from urllib.parse import quote
 
     from websockets.datastructures import Headers
@@ -2965,13 +2959,53 @@ def test_handle_webui_thread_get_accepts_pagination_query(tmp_path, monkeypatch)
         Headers([("Authorization", "Bearer tok")]),
     )
 
-    resp = channel.gateway.http._handle_webui_thread_get(req, enc)
+    resp = await channel.gateway.http._handle_webui_thread_get(req, enc)
 
     assert resp.status_code == 200
     body = json.loads(resp.body.decode())
     assert [message["content"] for message in body["messages"]] == ["q3", "a3"]
     assert body["page"]["has_more_before"] is True
     assert body["page"]["before_cursor"]
+
+
+@pytest.mark.asyncio
+async def test_handle_webui_thread_get_does_not_block_gateway_event_loop(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    import threading
+    from urllib.parse import quote
+
+    from websockets.datastructures import Headers
+    from websockets.http11 import Request
+
+    monkeypatch.setattr("nanobot.config.paths.get_data_dir", lambda: tmp_path)
+    bus = MagicMock()
+    channel = _ch(bus)
+    channel.gateway.tokens.api_tokens["tok"] = time.monotonic() + 300.0
+    release = threading.Event()
+
+    def slow_response(_key: str, **_kwargs: Any) -> dict[str, Any]:
+        release.wait(timeout=1)
+        return {"schemaVersion": 3, "messages": []}
+
+    monkeypatch.setattr(channel._transcripts, "build_response", slow_response)
+    key = "websocket:slow-history"
+    enc = quote(key, safe="")
+    req = Request(f"/api/sessions/{enc}/webui-thread", Headers([("Authorization", "Bearer tok")]))
+    safety_release = threading.Timer(0.25, release.set)
+    safety_release.start()
+
+    started_at = time.monotonic()
+    request_task = asyncio.create_task(channel.gateway.http._handle_webui_thread_get(req, enc))
+    await asyncio.sleep(0.01)
+    event_loop_delay = time.monotonic() - started_at
+    release.set()
+    response = await request_task
+    safety_release.cancel()
+
+    assert event_loop_delay < 0.1
+    assert response.status_code == 200
 
 
 def test_handle_file_preview_returns_workspace_file(tmp_path) -> None:
@@ -3151,7 +3185,8 @@ def test_handle_file_preview_allows_paths_outside_workspace_in_full_access(tmp_p
     assert body["content"].splitlines() == ["value = 42"]
 
 
-def test_handle_webui_thread_get_backfills_legacy_missing_user_rows(
+@pytest.mark.asyncio
+async def test_handle_webui_thread_get_backfills_legacy_missing_user_rows(
     tmp_path,
     monkeypatch,
 ) -> None:
@@ -3184,7 +3219,7 @@ def test_handle_webui_thread_get_backfills_legacy_missing_user_rows(
     channel.gateway.tokens.api_tokens["tok"] = time.monotonic() + 300.0
     enc = quote(key, safe="")
     req = Request(f"/api/sessions/{enc}/webui-thread", Headers([("Authorization", "Bearer tok")]))
-    resp = channel.gateway.http._handle_webui_thread_get(req, enc)
+    resp = await channel.gateway.http._handle_webui_thread_get(req, enc)
 
     assert resp.status_code == 200
     body = json.loads(resp.body.decode())
@@ -3195,7 +3230,8 @@ def test_handle_webui_thread_get_backfills_legacy_missing_user_rows(
     ]
 
 
-def test_handle_webui_thread_get_does_not_backfill_cron_internal_prompt(
+@pytest.mark.asyncio
+async def test_handle_webui_thread_get_does_not_backfill_cron_internal_prompt(
     tmp_path,
     monkeypatch,
 ) -> None:
@@ -3233,7 +3269,7 @@ def test_handle_webui_thread_get_does_not_backfill_cron_internal_prompt(
     channel.gateway.tokens.api_tokens["tok"] = time.monotonic() + 300.0
     enc = quote(key, safe="")
     req = Request(f"/api/sessions/{enc}/webui-thread", Headers([("Authorization", "Bearer tok")]))
-    resp = channel.gateway.http._handle_webui_thread_get(req, enc)
+    resp = await channel.gateway.http._handle_webui_thread_get(req, enc)
 
     assert resp.status_code == 200
     body = json.loads(resp.body.decode())
@@ -3241,7 +3277,8 @@ def test_handle_webui_thread_get_does_not_backfill_cron_internal_prompt(
     assert [message["content"] for message in body["messages"]] == ["提醒已经到期。"]
 
 
-def test_handle_webui_thread_get_does_not_backfill_trigger_internal_prompt(
+@pytest.mark.asyncio
+async def test_handle_webui_thread_get_does_not_backfill_trigger_internal_prompt(
     tmp_path,
     monkeypatch,
 ) -> None:
@@ -3279,7 +3316,7 @@ def test_handle_webui_thread_get_does_not_backfill_trigger_internal_prompt(
     channel.gateway.tokens.api_tokens["tok"] = time.monotonic() + 300.0
     enc = quote(key, safe="")
     req = Request(f"/api/sessions/{enc}/webui-thread", Headers([("Authorization", "Bearer tok")]))
-    resp = channel.gateway.http._handle_webui_thread_get(req, enc)
+    resp = await channel.gateway.http._handle_webui_thread_get(req, enc)
 
     assert resp.status_code == 200
     body = json.loads(resp.body.decode())
@@ -3287,7 +3324,8 @@ def test_handle_webui_thread_get_does_not_backfill_trigger_internal_prompt(
     assert [message["content"] for message in body["messages"]] == ["PR #4502 已经开始 review。"]
 
 
-def test_handle_webui_thread_get_does_not_backfill_hidden_subagent_result(
+@pytest.mark.asyncio
+async def test_handle_webui_thread_get_does_not_backfill_hidden_subagent_result(
     tmp_path,
     monkeypatch,
 ) -> None:
@@ -3325,7 +3363,7 @@ def test_handle_webui_thread_get_does_not_backfill_hidden_subagent_result(
     channel.gateway.tokens.api_tokens["tok"] = time.monotonic() + 300.0
     enc = quote(key, safe="")
     req = Request(f"/api/sessions/{enc}/webui-thread", Headers([("Authorization", "Bearer tok")]))
-    resp = channel.gateway.http._handle_webui_thread_get(req, enc)
+    resp = await channel.gateway.http._handle_webui_thread_get(req, enc)
 
     assert resp.status_code == 200
     body = json.loads(resp.body.decode())

--- a/nanobot/channels/websocket/tests/test_websocket_http_routes.py
+++ b/nanobot/channels/websocket/tests/test_websocket_http_routes.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import random
 import socket
+import sqlite3
 import time
 from contextlib import suppress
 from pathlib import Path
@@ -28,6 +29,7 @@ from nanobot.session.keys import UNIFIED_SESSION_KEY
 from nanobot.session.manager import Session, SessionManager
 from nanobot.triggers.local_store import LocalTriggerStore
 from nanobot.webui.gateway_services import GatewayServices, build_gateway_services
+from nanobot.webui.transcript import WebUITranscriptRecorder
 
 from .ws_test_client import InProcessHttpChannel
 from .ws_test_client import http_get as _http_get
@@ -285,6 +287,48 @@ async def test_sessions_routes_require_bearer_token(
         assert body["key"] == "websocket:abc"
         assert [m["role"] for m in body["messages"]] == ["user", "assistant"]
     finally:
+        await channel.stop()
+        await server_task
+
+
+@pytest.mark.asyncio
+async def test_session_navigation_survives_unsupported_transcript_schema(
+    bus: MagicMock,
+    tmp_path: Path,
+) -> None:
+    sm = _seed_session(tmp_path / "sessions", key="websocket:recoverable")
+    session_path = sm._get_session_path("websocket:recoverable")
+    transcript_path = tmp_path / "webui" / "transcripts.sqlite3"
+    transcript_path.parent.mkdir(parents=True)
+    with sqlite3.connect(transcript_path) as connection:
+        connection.execute("PRAGMA user_version = 99")
+
+    transcripts = WebUITranscriptRecorder(store_path=transcript_path)
+    port = _free_port()
+    channel = _ch(bus, session_manager=sm, port=port)
+    channel.gateway.http.transcripts = transcripts
+    channel.gateway.http._log = MagicMock()
+    server_task = asyncio.create_task(channel.start())
+    try:
+        token = channel.gateway.tokens.issue_api_token(300)
+        auth = {"Authorization": f"Bearer {token}"}
+
+        listing = await _http_get(f"http://127.0.0.1:{port}/api/sessions", headers=auth)
+        assert listing.status_code == 200
+        assert [row["key"] for row in listing.json()["sessions"]] == [
+            "websocket:recoverable"
+        ]
+
+        deleted = await _http_get(
+            f"http://127.0.0.1:{port}/api/sessions/websocket:recoverable/delete",
+            headers=auth,
+        )
+        assert deleted.status_code == 200
+        assert deleted.json() == {"deleted": True}
+        assert not session_path.exists()
+        assert channel.gateway.http._log.warning.call_count == 2
+    finally:
+        transcripts.close()
         await channel.stop()
         await server_task
 

--- a/nanobot/webui/forking.py
+++ b/nanobot/webui/forking.py
@@ -8,6 +8,8 @@ import uuid
 from collections.abc import Mapping
 from typing import Any
 
+from loguru import logger
+
 from nanobot.session.manager import SessionManager
 from nanobot.session.webui_turns import WEBUI_TITLE_METADATA_KEY, clean_generated_title
 from nanobot.webui.transcript import (
@@ -70,11 +72,25 @@ def create_webui_chat_fork(
             forked.metadata[WEBUI_TITLE_METADATA_KEY] = fork_title
             session_manager.save(forked, fsync=True)
     except Exception:
-        if transcripts is None:
-            delete_webui_transcript(target_key)
-        else:
-            transcripts.delete(target_key)
-        session_manager.delete_session(target_key)
+        try:
+            if transcripts is None:
+                delete_webui_transcript(target_key)
+            else:
+                transcripts.delete(target_key)
+        except Exception as cleanup_error:
+            logger.warning(
+                "Failed to clean up WebUI transcript for fork {}: {}",
+                target_key,
+                cleanup_error,
+            )
+        try:
+            session_manager.delete_session(target_key)
+        except Exception as cleanup_error:
+            logger.warning(
+                "Failed to clean up fork session {}: {}",
+                target_key,
+                cleanup_error,
+            )
         raise
     return new_id, target_key
 

--- a/nanobot/webui/forking.py
+++ b/nanobot/webui/forking.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
 import uuid
 from collections.abc import Mapping
@@ -10,6 +11,7 @@ from typing import Any
 from nanobot.session.manager import SessionManager
 from nanobot.session.webui_turns import WEBUI_TITLE_METADATA_KEY, clean_generated_title
 from nanobot.webui.transcript import (
+    WebUITranscriptRecorder,
     append_fork_marker,
     delete_webui_transcript,
     fork_transcript_before_user_index,
@@ -29,6 +31,7 @@ def create_webui_chat_fork(
     source_chat_id: str,
     before_user_index: int,
     title: str | None = None,
+    transcripts: WebUITranscriptRecorder | None = None,
 ) -> tuple[str, str] | None:
     """Return ``(chat_id, session_key)`` for a new fork, or ``None`` for bad input."""
     new_id = str(uuid.uuid4())
@@ -43,21 +46,34 @@ def create_webui_chat_fork(
         if forked is None:
             return None
 
-        transcript_ok = fork_transcript_before_user_index(
-            source_key,
-            target_key,
-            before_user_index,
-        )
-        if not transcript_ok:
-            write_session_messages_as_transcript(target_key, forked.messages)
-        append_fork_marker(target_key)
+        if transcripts is None:
+            transcript_ok = fork_transcript_before_user_index(
+                source_key,
+                target_key,
+                before_user_index,
+            )
+            if not transcript_ok:
+                write_session_messages_as_transcript(target_key, forked.messages)
+            append_fork_marker(target_key)
+        else:
+            transcript_ok = transcripts.fork_before_user_index(
+                source_key,
+                target_key,
+                before_user_index,
+            )
+            if not transcript_ok:
+                transcripts.write_session_messages(target_key, forked.messages)
+            transcripts.append_fork_marker(target_key)
 
         fork_title = clean_generated_title(title)
         if fork_title:
             forked.metadata[WEBUI_TITLE_METADATA_KEY] = fork_title
             session_manager.save(forked, fsync=True)
     except Exception:
-        delete_webui_transcript(target_key)
+        if transcripts is None:
+            delete_webui_transcript(target_key)
+        else:
+            transcripts.delete(target_key)
         session_manager.delete_session(target_key)
         raise
     return new_id, target_key
@@ -85,11 +101,13 @@ async def handle_webui_fork_chat(channel: Any, connection: Any, envelope: Mappin
         return
 
     try:
-        forked = create_webui_chat_fork(
+        forked = await asyncio.to_thread(
+            create_webui_chat_fork,
             session_manager,
             source_chat_id=source_chat_id,
             before_user_index=raw_index,
             title=envelope.get("title") if isinstance(envelope.get("title"), str) else None,
+            transcripts=channel._transcripts,
         )
         if forked is None:
             await channel._send_event(connection, "error", detail="invalid fork source or index")

--- a/nanobot/webui/gateway_services.py
+++ b/nanobot/webui/gateway_services.py
@@ -68,7 +68,7 @@ def build_gateway_services(
         logger=logger,
         attachment_limits=ingress.attachments,
     )
-    transcripts = WebUITranscriptRecorder(log=logger)
+    transcripts = WebUITranscriptRecorder(log=logger, session_manager=session_manager)
     workspaces = WebUIWorkspaceController(
         session_manager=session_manager,
         default_workspace=workspace_path,
@@ -85,6 +85,7 @@ def build_gateway_services(
         tokens=tokens,
         media=media,
         ingress=ingress,
+        transcripts=transcripts,
         workspaces=workspaces,
         skills_workspace_path=workspace_path,
         disabled_skills=disabled_skills,

--- a/nanobot/webui/session_list_index.py
+++ b/nanobot/webui/session_list_index.py
@@ -11,7 +11,7 @@ import json
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from loguru import logger
 
@@ -26,16 +26,23 @@ from nanobot.session.manager import (
     _metadata_title,
 )
 
-_INDEX_VERSION = 2
+_INDEX_VERSION = 3
 _INDEX_FILENAME = ".webui_session_index.json"
 _WEBUI_ACTIVITY_MTIME_NS = "webui_activity_mtime_ns"
 _WEBUI_ACTIVITY_SIZE = "webui_activity_size"
+_WEBUI_ACTIVITY_REVISION = "webui_activity_revision"
 _VISIBLE_TRANSCRIPT_ROLES = {"user", "assistant"}
 
+IndexedActivity = Mapping[str, Mapping[str, int]]
 
-def list_webui_sessions(session_manager: SessionManager) -> list[dict[str, Any]]:
+
+def list_webui_sessions(
+    session_manager: SessionManager,
+    *,
+    indexed_activity: IndexedActivity | None = None,
+) -> list[dict[str, Any]]:
     """Return session rows for the WebUI sidebar, backed by a rebuildable cache."""
-    rows, changed = _reconcile_index(session_manager)
+    rows, changed = _reconcile_index(session_manager, indexed_activity=indexed_activity)
     if changed:
         try:
             _write_index_rows(session_manager.sessions_dir, rows)
@@ -45,7 +52,11 @@ def list_webui_sessions(session_manager: SessionManager) -> list[dict[str, Any]]
     return sorted(sessions, key=lambda row: row.get("updated_at", ""), reverse=True)
 
 
-def _reconcile_index(session_manager: SessionManager) -> tuple[list[dict[str, Any]], bool]:
+def _reconcile_index(
+    session_manager: SessionManager,
+    *,
+    indexed_activity: IndexedActivity | None,
+) -> tuple[list[dict[str, Any]], bool]:
     existing_rows = _read_index_rows(session_manager.sessions_dir)
     existing_by_file = {
         row.get("file"): row
@@ -58,12 +69,29 @@ def _reconcile_index(session_manager: SessionManager) -> tuple[list[dict[str, An
 
     for path in paths:
         row = existing_by_file.get(path.name)
-        if row is not None and _indexed_row_matches_file(row, path):
+        row_matches = False
+        if row is not None:
+            if indexed_activity is None:
+                row_matches = _indexed_row_matches_file(row, path)
+            else:
+                row_matches = _indexed_row_matches_file(
+                    row,
+                    path,
+                    indexed_activity=indexed_activity,
+                )
+        if row_matches:
             rows.append(row)
             continue
 
         changed = True
-        scanned = _scan_session_row(session_manager, path)
+        if indexed_activity is None:
+            scanned = _scan_session_row(session_manager, path)
+        else:
+            scanned = _scan_session_row(
+                session_manager,
+                path,
+                indexed_activity=indexed_activity,
+            )
         if scanned is not None:
             rows.append(scanned)
 
@@ -111,7 +139,12 @@ def _file_signature(path: Path) -> dict[str, int]:
     return {"mtime_ns": stat.st_mtime_ns, "size": stat.st_size}
 
 
-def _indexed_row_matches_file(row: dict[str, Any], path: Path) -> bool:
+def _indexed_row_matches_file(
+    row: dict[str, Any],
+    path: Path,
+    *,
+    indexed_activity: IndexedActivity | None = None,
+) -> bool:
     if not all(isinstance(row.get(key), str) for key in ("key", "created_at", "updated_at")):
         return False
     if not isinstance(row.get("title", ""), str) or not isinstance(row.get("preview", ""), str):
@@ -122,12 +155,16 @@ def _indexed_row_matches_file(row: dict[str, Any], path: Path) -> bool:
         signature = _file_signature(path)
     except OSError:
         return False
-    activity_signature = _webui_activity_signature(str(row.get("key")))
+    activity_signature = _webui_activity_signature(
+        str(row.get("key")),
+        indexed_activity=indexed_activity,
+    )
     return (
         row.get("mtime_ns") == signature["mtime_ns"]
         and row.get("size") == signature["size"]
         and row.get(_WEBUI_ACTIVITY_MTIME_NS) == activity_signature[_WEBUI_ACTIVITY_MTIME_NS]
         and row.get(_WEBUI_ACTIVITY_SIZE) == activity_signature[_WEBUI_ACTIVITY_SIZE]
+        and row.get(_WEBUI_ACTIVITY_REVISION) == activity_signature[_WEBUI_ACTIVITY_REVISION]
     )
 
 
@@ -175,7 +212,11 @@ def _webui_activity_paths(session_key: str) -> list[Path]:
     ]
 
 
-def _webui_activity_signature(session_key: str) -> dict[str, int]:
+def _webui_activity_signature(
+    session_key: str,
+    *,
+    indexed_activity: IndexedActivity | None = None,
+) -> dict[str, int]:
     latest_mtime_ns = 0
     total_size = 0
     for path in _webui_activity_paths(session_key):
@@ -187,9 +228,15 @@ def _webui_activity_signature(session_key: str) -> dict[str, int]:
             continue
         latest_mtime_ns = max(latest_mtime_ns, stat.st_mtime_ns)
         total_size += stat.st_size
+    indexed = (indexed_activity or {}).get(session_key, {})
+    indexed_updated_at_ns = indexed.get("updated_at_ns", 0)
+    indexed_revision = indexed.get("revision", 0)
+    if isinstance(indexed_updated_at_ns, int):
+        latest_mtime_ns = max(latest_mtime_ns, indexed_updated_at_ns)
     return {
         _WEBUI_ACTIVITY_MTIME_NS: latest_mtime_ns,
         _WEBUI_ACTIVITY_SIZE: total_size,
+        _WEBUI_ACTIVITY_REVISION: indexed_revision if isinstance(indexed_revision, int) else 0,
     }
 
 
@@ -241,9 +288,17 @@ def _visible_activity_updated_at(
     return _latest_updated_at(visible_message_at, webui_activity) or stored
 
 
-def _indexed_row_for_session(session: Session, path: Path) -> dict[str, Any]:
+def _indexed_row_for_session(
+    session: Session,
+    path: Path,
+    *,
+    indexed_activity: IndexedActivity | None = None,
+) -> dict[str, Any]:
     signature = _file_signature(path)
-    activity_signature = _webui_activity_signature(session.key)
+    activity_signature = _webui_activity_signature(
+        session.key,
+        indexed_activity=indexed_activity,
+    )
     activity_updated_at = _webui_activity_updated_at(activity_signature)
     visible_message_at = _last_visible_message_at(session.messages)
     return {
@@ -263,7 +318,12 @@ def _indexed_row_for_session(session: Session, path: Path) -> dict[str, Any]:
     }
 
 
-def _scan_session_row(session_manager: SessionManager, path: Path) -> dict[str, Any] | None:
+def _scan_session_row(
+    session_manager: SessionManager,
+    path: Path,
+    *,
+    indexed_activity: IndexedActivity | None = None,
+) -> dict[str, Any] | None:
     storage_key = SessionManager._decode_storage_key(path.stem)
     fallback_key = storage_key or path.stem.replace("_", ":", 1)
     try:
@@ -317,7 +377,10 @@ def _scan_session_row(session_manager: SessionManager, path: Path) -> dict[str, 
                 created_at_s = created_at_s or fallback_time
                 updated_at_s = updated_at_s or fallback_time
             key = data.get("key") or fallback_key
-            activity_signature = _webui_activity_signature(key)
+            activity_signature = _webui_activity_signature(
+                key,
+                indexed_activity=indexed_activity,
+            )
             activity_updated_at = _webui_activity_updated_at(activity_signature)
             return {
                 "key": key,
@@ -338,4 +401,8 @@ def _scan_session_row(session_manager: SessionManager, path: Path) -> dict[str, 
         repaired = session_manager._repair(fallback_key)
         if repaired is None:
             return None
-        return _indexed_row_for_session(repaired, path)
+        return _indexed_row_for_session(
+            repaired,
+            path,
+            indexed_activity=indexed_activity,
+        )

--- a/nanobot/webui/transcript.py
+++ b/nanobot/webui/transcript.py
@@ -1,4 +1,4 @@
-"""Append-only WebUI display transcript (JSONL), separate from agent session."""
+"""Persist and replay WebUI display transcripts separately from agent sessions."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import shutil
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -22,6 +23,11 @@ from nanobot.session.automation_turns import is_automation_kind
 from nanobot.session.history_visibility import is_hidden_history_message
 from nanobot.session.manager import SessionManager
 from nanobot.webui.metadata import WEBUI_MESSAGE_SOURCE_METADATA_KEY, WEBUI_TURN_METADATA_KEY
+from nanobot.webui.transcript_store import (
+    SQLiteTranscriptStore,
+    StoredTurn,
+    TranscriptWriteQueue,
+)
 
 WEBUI_TRANSCRIPT_SCHEMA_VERSION = 3
 WEBUI_FORK_MARKER_EVENT = "fork_marker"
@@ -32,6 +38,7 @@ _TRANSCRIPT_ACTIVE_CHUNK_ID = "active"
 _TRANSCRIPT_SEGMENT_RE = re.compile(r"^\d{6}\.jsonl$")
 _DEFAULT_TRANSCRIPT_PAGE_LIMIT = 160
 _MAX_TRANSCRIPT_PAGE_LIMIT = 1000
+_TRANSCRIPT_STORE_FILENAME = "transcripts.sqlite3"
 _WEBUI_TURN_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
 _MARKDOWN_LOCAL_IMAGE_RE = re.compile(
     r"!\[([^\]]*)\]\((<[^>]+>|[^)\s]+)(\s+(?:\"[^\"]*\"|'[^']*'))?\)"
@@ -123,6 +130,11 @@ def _media_kind_from_name(name: str) -> str:
 def webui_transcript_path(session_key: str) -> Path:
     stem = SessionManager.safe_key(session_key)
     return get_webui_dir() / f"{stem}.jsonl"
+
+
+def webui_transcript_store_path() -> Path:
+    """Return the indexed WebUI transcript database path."""
+    return get_webui_dir() / _TRANSCRIPT_STORE_FILENAME
 
 
 def webui_transcript_segments_dir(session_key: str) -> Path:
@@ -634,11 +646,196 @@ def webui_message_source(metadata: dict[str, Any] | None) -> dict[str, str] | No
 
 
 class WebUITranscriptRecorder:
-    """Prepare and persist WebUI wire events without leaking UI rules into channels."""
+    """Prepare, persist, and page WebUI wire events outside the gateway loop."""
 
-    def __init__(self, log: Any = logger) -> None:
+    def __init__(
+        self,
+        log: Any = logger,
+        *,
+        session_manager: SessionManager | None = None,
+        store_path: Path | None = None,
+        write_batch_window_s: float = 0.05,
+    ) -> None:
         self._log = log
+        self._session_manager = session_manager
+        self._write_batch_window_s = write_batch_window_s
+        self._writer_lock = threading.Lock()
+        self._writer: TranscriptWriteQueue | None = None
+        self._store = SQLiteTranscriptStore(
+            store_path or webui_transcript_store_path(),
+            legacy_loader=self._load_legacy_transcript,
+        )
         self._turn_sequences: dict[tuple[str, str], int] = {}
+
+    @property
+    def store_path(self) -> Path:
+        return self._store.path
+
+    def _load_legacy_transcript(self, session_key: str) -> list[dict[str, Any]]:
+        lines = read_transcript_lines(session_key)
+        if not lines or self._session_manager is None:
+            return lines
+        session_data = self._session_manager.read_session_file(session_key)
+        raw_messages = session_data.get("messages") if isinstance(session_data, dict) else None
+        session_messages = (
+            [message for message in raw_messages if isinstance(message, dict)]
+            if isinstance(raw_messages, list)
+            else None
+        )
+        return inject_missing_user_events_from_session(session_key, lines, session_messages)
+
+    def _get_writer(self) -> TranscriptWriteQueue:
+        with self._writer_lock:
+            if self._writer is None:
+                self._writer = TranscriptWriteQueue(
+                    self._store,
+                    log=self._log,
+                    batch_window_s=self._write_batch_window_s,
+                )
+            return self._writer
+
+    def flush(self) -> None:
+        with self._writer_lock:
+            writer = self._writer
+        if writer is not None:
+            writer.flush()
+
+    def close(self) -> None:
+        with self._writer_lock:
+            writer = self._writer
+            self._writer = None
+        if writer is not None:
+            writer.close()
+
+    def read_lines(self, session_key: str) -> list[dict[str, Any]]:
+        self.flush()
+        return self._store.read_all(session_key)
+
+    def _select_page(
+        self,
+        session_key: str,
+        *,
+        limit: int | None,
+        before: str | None,
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        page_limit = _coerce_page_limit(limit)
+        before_ordinal = _decode_page_cursor(before)
+        selected: list[StoredTurn] = []
+        selected_message_count = 0
+        next_before = before_ordinal
+
+        while selected_message_count < page_limit:
+            turns = self._store.read_turn_batch(
+                session_key,
+                before_ordinal=next_before,
+            )
+            if not turns:
+                break
+            for turn in turns:
+                selected.append(turn)
+                selected_message_count += len(replay_transcript_to_ui_messages(turn.records))
+                if selected_message_count >= page_limit:
+                    break
+            if selected_message_count >= page_limit or len(turns) < 64:
+                break
+            next_before = turns[-1].ordinal
+
+        chronological = list(reversed(selected))
+        lines = [record for turn in chronological for record in turn.records]
+        if not chronological:
+            return [], {
+                "before_cursor": None,
+                "has_more_before": False,
+                "loaded_message_count": 0,
+                "user_message_offset": 0,
+            }
+
+        first_ordinal = chronological[0].ordinal
+        has_more = self._store.has_turn_before(session_key, first_ordinal)
+        return lines, {
+            "before_cursor": _encode_page_cursor(first_ordinal) if has_more else None,
+            "has_more_before": has_more,
+            "loaded_message_count": 0,
+            "user_message_offset": self._store.user_count_before(
+                session_key,
+                first_ordinal,
+            ),
+        }
+
+    def build_response(
+        self,
+        session_key: str,
+        *,
+        augment_user_media: Callable[[list[str]], list[dict[str, Any]]] | None = None,
+        augment_assistant_media: Callable[[list[str]], list[dict[str, Any]]] | None = None,
+        augment_assistant_text: Callable[[str], str] | None = None,
+        limit: int | None = None,
+        direction: str | None = None,
+        before: str | None = None,
+    ) -> dict[str, Any] | None:
+        self.flush()
+        paginated = limit is not None or direction is not None or before is not None
+        page: dict[str, Any] | None = None
+        if paginated:
+            lines, page = self._select_page(session_key, limit=limit, before=before)
+        else:
+            lines = self._store.read_all(session_key)
+        if not lines:
+            return None
+        fork_boundary = fork_boundary_message_count(lines)
+        messages = replay_transcript_to_ui_messages(
+            lines,
+            augment_user_media=augment_user_media,
+            augment_assistant_media=augment_assistant_media,
+            augment_assistant_text=augment_assistant_text,
+        )
+        payload: dict[str, Any] = {
+            "schemaVersion": WEBUI_TRANSCRIPT_SCHEMA_VERSION,
+            "sessionKey": session_key,
+            "messages": messages,
+            "has_pending_tool_calls": has_pending_tool_calls(lines),
+        }
+        if page is not None:
+            page["loaded_message_count"] = len(messages)
+            payload["page"] = page
+        if fork_boundary is not None:
+            payload["fork_boundary_message_count"] = fork_boundary
+        return payload
+
+    def fork_before_user_index(
+        self,
+        source_key: str,
+        target_key: str,
+        before_user_index: int,
+    ) -> bool:
+        return bool(
+            self._get_writer().call(
+                lambda store: store.fork_before_user_index(
+                    source_key,
+                    target_key,
+                    before_user_index,
+                )
+            )
+        )
+
+    def replace(self, session_key: str, records: list[dict[str, Any]]) -> None:
+        self._get_writer().call(lambda store: store.replace(session_key, records))
+
+    def append_fork_marker(self, session_key: str) -> None:
+        chat_id = _chat_id_from_session_key(session_key)
+        marker = _record_for_append({"event": WEBUI_FORK_MARKER_EVENT, "chat_id": chat_id})
+        self._get_writer().call(lambda store: store.append_batch([(session_key, marker)]))
+
+    def write_session_messages(
+        self,
+        session_key: str,
+        messages: list[dict[str, Any]],
+    ) -> None:
+        self.replace(session_key, _session_messages_as_transcript_rows(session_key, messages))
+
+    def delete(self, session_key: str) -> bool:
+        removed = bool(self._get_writer().call(lambda store: store.delete(session_key)))
+        return _delete_legacy_transcript_files(session_key) or removed
 
     def client_turn_metadata(self, value: Any) -> dict[str, str]:
         return {WEBUI_TURN_METADATA_KEY: normalize_webui_turn_id(value)}
@@ -704,8 +901,9 @@ class WebUITranscriptRecorder:
     def append(self, chat_id: str, event: dict[str, Any]) -> None:
         try:
             dup = json.loads(json.dumps(event, ensure_ascii=False))
-            append_transcript_object(f"websocket:{chat_id}", dup)
-        except (OSError, ValueError, TypeError) as e:
+            record = _record_for_append(dup)
+            self._get_writer().append(f"websocket:{chat_id}", record)
+        except (OSError, RuntimeError, ValueError, TypeError) as e:
             self._log.warning("webui transcript append failed: {}", e)
 
     def _next_turn_seq(self, chat_id: str, turn_id: str) -> int:
@@ -797,11 +995,10 @@ def append_fork_marker(session_key: str) -> None:
     )
 
 
-def write_session_messages_as_transcript(
+def _session_messages_as_transcript_rows(
     target_key: str,
     messages: list[dict[str, Any]],
-) -> None:
-    """Write a minimal WebUI transcript from already-truncated session messages."""
+) -> list[dict[str, Any]]:
     target_chat_id = _chat_id_from_session_key(target_key)
     rows: list[dict[str, Any]] = []
     for msg in messages:
@@ -828,10 +1025,19 @@ def write_session_messages_as_transcript(
         else:
             continue
         rows.append(row)
+    return rows
+
+
+def write_session_messages_as_transcript(
+    target_key: str,
+    messages: list[dict[str, Any]],
+) -> None:
+    """Write a minimal legacy transcript from already-truncated session messages."""
+    rows = _session_messages_as_transcript_rows(target_key, messages)
     _write_transcript_lines(target_key, rows)
 
 
-def delete_webui_transcript(session_key: str) -> bool:
+def _delete_legacy_transcript_files(session_key: str) -> bool:
     removed = False
     for path in (webui_transcript_path(session_key), _legacy_webui_thread_path(session_key)):
         if not path.is_file():
@@ -849,6 +1055,13 @@ def delete_webui_transcript(session_key: str) -> bool:
         except OSError as e:
             logger.warning("Failed to delete webui transcript segments {}: {}", segments_dir, e)
     return removed
+
+
+def delete_webui_transcript(session_key: str) -> bool:
+    """Delete indexed and legacy display transcript state for one session."""
+    store = SQLiteTranscriptStore(webui_transcript_store_path())
+    removed = store.delete(session_key)
+    return _delete_legacy_transcript_files(session_key) or removed
 
 
 def build_user_transcript_event(

--- a/nanobot/webui/transcript.py
+++ b/nanobot/webui/transcript.py
@@ -711,6 +711,10 @@ class WebUITranscriptRecorder:
         self.flush()
         return self._store.read_all(session_key)
 
+    def activity_signatures(self) -> dict[str, dict[str, int]]:
+        self.flush()
+        return self._store.activity_signatures()
+
     def _select_page(
         self,
         session_key: str,

--- a/nanobot/webui/transcript_store.py
+++ b/nanobot/webui/transcript_store.py
@@ -1,0 +1,547 @@
+"""Indexed persistence for WebUI display transcripts.
+
+The WebSocket runtime emits many small display events while a turn is running.  This
+module keeps those writes off the gateway event loop and stores them in an indexed
+SQLite read model.  Reads page by turn ordinal, so opening a conversation never scans
+the full transcript.
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+_SCHEMA_VERSION = 1
+_MAX_EVENT_BYTES = 8 * 1024 * 1024
+_DEFAULT_BUSY_TIMEOUT_MS = 30_000
+_DEFAULT_WRITE_BATCH_WINDOW_S = 0.05
+_DEFAULT_WRITE_BATCH_SIZE = 256
+
+LegacyLoader = Callable[[str], list[dict[str, Any]]]
+
+
+@dataclass(frozen=True)
+class StoredTurn:
+    """One persisted turn and its ordered display events."""
+
+    ordinal: int
+    records: list[dict[str, Any]]
+
+
+class SQLiteTranscriptStore:
+    """Synchronous indexed transcript repository.
+
+    Callers choose the execution context.  The gateway uses :class:`TranscriptWriteQueue`
+    for writes and ``asyncio.to_thread`` for reads; focused tests and migration helpers can
+    call the repository directly.
+    """
+
+    def __init__(self, path: Path, *, legacy_loader: LegacyLoader | None = None) -> None:
+        self.path = path
+        self._legacy_loader = legacy_loader
+        self._initialized = False
+        self._initialize_lock = threading.Lock()
+
+    def _connect(self) -> sqlite3.Connection:
+        self._initialize()
+        connection = sqlite3.connect(self.path, timeout=_DEFAULT_BUSY_TIMEOUT_MS / 1000)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute(f"PRAGMA busy_timeout = {_DEFAULT_BUSY_TIMEOUT_MS}")
+        connection.execute("PRAGMA synchronous = FULL")
+        return connection
+
+    def _initialize(self) -> None:
+        if self._initialized:
+            return
+        with self._initialize_lock:
+            if self._initialized:
+                return
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            connection = sqlite3.connect(self.path, timeout=_DEFAULT_BUSY_TIMEOUT_MS / 1000)
+            try:
+                version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+                if version not in {0, _SCHEMA_VERSION}:
+                    raise RuntimeError(
+                        f"unsupported WebUI transcript schema {version}; "
+                        f"expected {_SCHEMA_VERSION}"
+                    )
+                connection.execute("PRAGMA journal_mode = WAL")
+                connection.execute("PRAGMA foreign_keys = ON")
+                connection.executescript(
+                    """
+                    CREATE TABLE IF NOT EXISTS transcript_sessions (
+                        session_key TEXT PRIMARY KEY,
+                        legacy_imported INTEGER NOT NULL DEFAULT 0,
+                        next_sequence INTEGER NOT NULL DEFAULT 0,
+                        active_turn INTEGER NOT NULL DEFAULT 0,
+                        next_user_index INTEGER NOT NULL DEFAULT 0
+                    );
+
+                    CREATE TABLE IF NOT EXISTS transcript_turns (
+                        session_key TEXT NOT NULL,
+                        ordinal INTEGER NOT NULL,
+                        finalized INTEGER NOT NULL DEFAULT 0,
+                        user_offset INTEGER NOT NULL DEFAULT 0,
+                        user_count INTEGER NOT NULL DEFAULT 0,
+                        event_count INTEGER NOT NULL DEFAULT 0,
+                        PRIMARY KEY (session_key, ordinal),
+                        FOREIGN KEY (session_key)
+                            REFERENCES transcript_sessions(session_key)
+                            ON DELETE CASCADE
+                    );
+
+                    CREATE TABLE IF NOT EXISTS transcript_events (
+                        session_key TEXT NOT NULL,
+                        sequence INTEGER NOT NULL,
+                        turn_ordinal INTEGER NOT NULL,
+                        payload TEXT NOT NULL,
+                        PRIMARY KEY (session_key, sequence),
+                        FOREIGN KEY (session_key, turn_ordinal)
+                            REFERENCES transcript_turns(session_key, ordinal)
+                            ON DELETE CASCADE
+                    );
+
+                    CREATE INDEX IF NOT EXISTS transcript_events_by_turn
+                        ON transcript_events(session_key, turn_ordinal, sequence);
+                    """
+                )
+                if version == 0:
+                    connection.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
+                connection.commit()
+            finally:
+                connection.close()
+            self._initialized = True
+
+    @staticmethod
+    def _serialize_record(record: dict[str, Any]) -> str:
+        raw = json.dumps(record, ensure_ascii=False, separators=(",", ":"))
+        if len(raw.encode("utf-8")) > _MAX_EVENT_BYTES:
+            raise ValueError("webui transcript event too large")
+        return raw
+
+    def _is_imported(self, session_key: str) -> bool:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT legacy_imported FROM transcript_sessions WHERE session_key = ?",
+                (session_key,),
+            ).fetchone()
+        return row is not None and bool(row["legacy_imported"])
+
+    def ensure_imported(self, session_key: str) -> None:
+        """Import a legacy JSONL transcript once, preserving the source files."""
+        if self._is_imported(session_key):
+            return
+        records = self._legacy_loader(session_key) if self._legacy_loader is not None else []
+        serialized = [(record, self._serialize_record(record)) for record in records]
+
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT legacy_imported FROM transcript_sessions WHERE session_key = ?",
+                (session_key,),
+            ).fetchone()
+            if row is not None and bool(row["legacy_imported"]):
+                connection.rollback()
+                return
+            connection.execute(
+                """
+                INSERT INTO transcript_sessions (
+                    session_key, legacy_imported, next_sequence, active_turn
+                ) VALUES (?, 0, 0, 0)
+                ON CONFLICT(session_key) DO NOTHING
+                """,
+                (session_key,),
+            )
+            if serialized:
+                self._append_serialized(connection, session_key, serialized)
+            connection.execute(
+                "UPDATE transcript_sessions SET legacy_imported = 1 WHERE session_key = ?",
+                (session_key,),
+            )
+            connection.commit()
+        except BaseException:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    def _append_serialized(
+        self,
+        connection: sqlite3.Connection,
+        session_key: str,
+        records: list[tuple[dict[str, Any], str]],
+    ) -> None:
+        row = connection.execute(
+            """
+            SELECT next_sequence, active_turn, next_user_index
+            FROM transcript_sessions
+            WHERE session_key = ?
+            """,
+            (session_key,),
+        ).fetchone()
+        if row is None:
+            raise RuntimeError(f"transcript session was not initialized: {session_key}")
+        sequence = int(row["next_sequence"])
+        turn_ordinal = int(row["active_turn"])
+        next_user_index = int(row["next_user_index"])
+
+        for record, payload in records:
+            is_user = int(record.get("event") == "user" or record.get("role") == "user")
+            connection.execute(
+                """
+                INSERT INTO transcript_turns (
+                    session_key, ordinal, finalized, user_offset, user_count, event_count
+                ) VALUES (?, ?, 0, ?, ?, 1)
+                ON CONFLICT(session_key, ordinal) DO UPDATE SET
+                    user_count = user_count + excluded.user_count,
+                    event_count = event_count + 1
+                """,
+                (session_key, turn_ordinal, next_user_index, is_user),
+            )
+            connection.execute(
+                """
+                INSERT INTO transcript_events (
+                    session_key, sequence, turn_ordinal, payload
+                ) VALUES (?, ?, ?, ?)
+                """,
+                (session_key, sequence, turn_ordinal, payload),
+            )
+            sequence += 1
+            next_user_index += is_user
+            if record.get("event") == "turn_end":
+                connection.execute(
+                    """
+                    UPDATE transcript_turns
+                    SET finalized = 1
+                    WHERE session_key = ? AND ordinal = ?
+                    """,
+                    (session_key, turn_ordinal),
+                )
+                turn_ordinal += 1
+
+        connection.execute(
+            """
+            UPDATE transcript_sessions
+            SET next_sequence = ?, active_turn = ?, next_user_index = ?
+            WHERE session_key = ?
+            """,
+            (sequence, turn_ordinal, next_user_index, session_key),
+        )
+
+    def append_batch(self, entries: list[tuple[str, dict[str, Any]]]) -> None:
+        if not entries:
+            return
+        grouped: dict[str, list[tuple[dict[str, Any], str]]] = {}
+        for session_key, record in entries:
+            grouped.setdefault(session_key, []).append((record, self._serialize_record(record)))
+        for session_key in grouped:
+            self.ensure_imported(session_key)
+
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            for session_key, records in grouped.items():
+                self._append_serialized(connection, session_key, records)
+            connection.commit()
+        except BaseException:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    def replace(self, session_key: str, records: list[dict[str, Any]]) -> None:
+        serialized = [(record, self._serialize_record(record)) for record in records]
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            connection.execute(
+                "DELETE FROM transcript_sessions WHERE session_key = ?",
+                (session_key,),
+            )
+            connection.execute(
+                """
+                INSERT INTO transcript_sessions (
+                    session_key, legacy_imported, next_sequence, active_turn
+                ) VALUES (?, 1, 0, 0)
+                """,
+                (session_key,),
+            )
+            if serialized:
+                self._append_serialized(connection, session_key, serialized)
+            connection.commit()
+        except BaseException:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    def delete(self, session_key: str) -> bool:
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            cursor = connection.execute(
+                "DELETE FROM transcript_sessions WHERE session_key = ?",
+                (session_key,),
+            )
+            connection.commit()
+            return cursor.rowcount > 0
+        except BaseException:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    def read_turn_batch(
+        self,
+        session_key: str,
+        *,
+        before_ordinal: int | None = None,
+        limit: int = 64,
+    ) -> list[StoredTurn]:
+        self.ensure_imported(session_key)
+        upper = before_ordinal if before_ordinal is not None else 2**63 - 1
+        with self._connect() as connection:
+            turn_rows = connection.execute(
+                """
+                SELECT ordinal
+                FROM transcript_turns
+                WHERE session_key = ? AND ordinal < ?
+                ORDER BY ordinal DESC
+                LIMIT ?
+                """,
+                (session_key, upper, max(1, limit)),
+            ).fetchall()
+            ordinals = [int(row["ordinal"]) for row in turn_rows]
+            if not ordinals:
+                return []
+            placeholders = ",".join("?" for _ in ordinals)
+            event_rows = connection.execute(
+                f"""
+                SELECT turn_ordinal, payload
+                FROM transcript_events
+                WHERE session_key = ? AND turn_ordinal IN ({placeholders})
+                ORDER BY turn_ordinal DESC, sequence ASC
+                """,
+                (session_key, *ordinals),
+            ).fetchall()
+
+        records_by_turn: dict[int, list[dict[str, Any]]] = {ordinal: [] for ordinal in ordinals}
+        for row in event_rows:
+            payload = json.loads(str(row["payload"]))
+            if isinstance(payload, dict):
+                records_by_turn[int(row["turn_ordinal"])].append(payload)
+        return [StoredTurn(ordinal, records_by_turn[ordinal]) for ordinal in ordinals]
+
+    def read_all(self, session_key: str) -> list[dict[str, Any]]:
+        self.ensure_imported(session_key)
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT payload
+                FROM transcript_events
+                WHERE session_key = ?
+                ORDER BY sequence ASC
+                """,
+                (session_key,),
+            ).fetchall()
+        records: list[dict[str, Any]] = []
+        for row in rows:
+            payload = json.loads(str(row["payload"]))
+            if isinstance(payload, dict):
+                records.append(payload)
+        return records
+
+    def user_count_before(self, session_key: str, ordinal: int) -> int:
+        with self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT user_offset
+                FROM transcript_turns
+                WHERE session_key = ? AND ordinal = ?
+                """,
+                (session_key, ordinal),
+            ).fetchone()
+        return int(row["user_offset"]) if row is not None else 0
+
+    def has_turn_before(self, session_key: str, ordinal: int) -> bool:
+        with self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT 1
+                FROM transcript_turns
+                WHERE session_key = ? AND ordinal < ?
+                LIMIT 1
+                """,
+                (session_key, ordinal),
+            ).fetchone()
+        return row is not None
+
+    def fork_before_user_index(
+        self,
+        source_key: str,
+        target_key: str,
+        before_user_index: int,
+    ) -> bool:
+        if before_user_index < 0:
+            return False
+        lines = self.read_all(source_key)
+        if not lines:
+            return False
+        target_chat_id = target_key.split(":", 1)[1] if target_key.startswith("websocket:") else None
+        copied: list[dict[str, Any]] = []
+        user_index = 0
+        found_target = False
+        for row in lines:
+            if row.get("event") == "fork_marker":
+                continue
+            if row.get("event") == "user" or row.get("role") == "user":
+                if user_index == before_user_index:
+                    found_target = True
+                    break
+                user_index += 1
+            duplicate = json.loads(json.dumps(row, ensure_ascii=False))
+            if target_chat_id is not None:
+                duplicate["chat_id"] = target_chat_id
+            copied.append(duplicate)
+        if user_index == before_user_index:
+            found_target = True
+        if not found_target:
+            return False
+        self.replace(target_key, copied)
+        return True
+
+
+@dataclass
+class _WriteCommand:
+    kind: str
+    entry: tuple[str, dict[str, Any]] | None = None
+    action: Callable[[SQLiteTranscriptStore], Any] | None = None
+    done: threading.Event | None = None
+    result: Any = None
+    error: BaseException | None = None
+
+
+class TranscriptWriteQueue:
+    """Single-writer queue that batches transcript persistence off the event loop."""
+
+    def __init__(
+        self,
+        store: SQLiteTranscriptStore,
+        *,
+        log: Any,
+        batch_window_s: float = _DEFAULT_WRITE_BATCH_WINDOW_S,
+        batch_size: int = _DEFAULT_WRITE_BATCH_SIZE,
+    ) -> None:
+        self.store = store
+        self._log = log
+        self._batch_window_s = max(0.0, batch_window_s)
+        self._batch_size = max(1, batch_size)
+        self._queue: queue.Queue[_WriteCommand] = queue.Queue()
+        self._state_lock = threading.Lock()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="nanobot-webui-transcript-writer",
+            daemon=True,
+        )
+        self._closed = False
+        self._failure: BaseException | None = None
+        self._thread.start()
+
+    def append(self, session_key: str, record: dict[str, Any]) -> None:
+        with self._state_lock:
+            if self._closed:
+                raise RuntimeError("webui transcript writer is closed")
+            if self._failure is not None:
+                raise RuntimeError("webui transcript writer has failed") from self._failure
+            self._queue.put(_WriteCommand("append", entry=(session_key, record)))
+
+    def call(self, action: Callable[[SQLiteTranscriptStore], Any]) -> Any:
+        done = threading.Event()
+        command = _WriteCommand("call", action=action, done=done)
+        with self._state_lock:
+            if self._closed:
+                raise RuntimeError("webui transcript writer is closed")
+            self._queue.put(command)
+        done.wait()
+        if command.error is not None:
+            raise command.error
+        return command.result
+
+    def flush(self) -> None:
+        self.call(lambda _store: None)
+
+    def close(self) -> None:
+        done = threading.Event()
+        command = _WriteCommand("stop", done=done)
+        with self._state_lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._queue.put(command)
+        done.wait()
+        self._thread.join()
+        if command.error is not None:
+            raise command.error
+
+    def _record_failure(self, exc: BaseException) -> None:
+        with self._state_lock:
+            if self._failure is None:
+                self._failure = exc
+
+    def _write_batch(self, commands: list[_WriteCommand]) -> None:
+        entries = [command.entry for command in commands if command.entry is not None]
+        if not entries:
+            return
+        try:
+            self.store.append_batch(entries)
+        except Exception as exc:
+            self._record_failure(exc)
+            self._log.warning("webui transcript batch write failed: {}", exc)
+
+    def _finish_control(self, command: _WriteCommand) -> bool:
+        try:
+            if self._failure is not None:
+                raise RuntimeError("webui transcript writer has failed") from self._failure
+            if command.kind == "call" and command.action is not None:
+                command.result = command.action(self.store)
+        except BaseException as exc:
+            command.error = exc
+        finally:
+            if command.done is not None:
+                command.done.set()
+        return command.kind == "stop"
+
+    def _run(self) -> None:
+        deferred: _WriteCommand | None = None
+        while True:
+            command = deferred or self._queue.get()
+            deferred = None
+            if command.kind != "append":
+                if self._finish_control(command):
+                    return
+                continue
+
+            batch = [command]
+            deadline = time.monotonic() + self._batch_window_s
+            while len(batch) < self._batch_size:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                try:
+                    candidate = self._queue.get(timeout=remaining)
+                except queue.Empty:
+                    break
+                if candidate.kind == "append":
+                    batch.append(candidate)
+                else:
+                    deferred = candidate
+                    break
+            self._write_batch(batch)

--- a/nanobot/webui/transcript_store.py
+++ b/nanobot/webui/transcript_store.py
@@ -13,11 +13,12 @@ import queue
 import sqlite3
 import threading
 import time
+from contextlib import closing
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
-_SCHEMA_VERSION = 1
+_SCHEMA_VERSION = 2
 _MAX_EVENT_BYTES = 8 * 1024 * 1024
 _DEFAULT_BUSY_TIMEOUT_MS = 30_000
 _DEFAULT_WRITE_BATCH_WINDOW_S = 0.05
@@ -66,24 +67,31 @@ class SQLiteTranscriptStore:
             self.path.parent.mkdir(parents=True, exist_ok=True)
             connection = sqlite3.connect(self.path, timeout=_DEFAULT_BUSY_TIMEOUT_MS / 1000)
             try:
+                connection.execute(f"PRAGMA busy_timeout = {_DEFAULT_BUSY_TIMEOUT_MS}")
+                connection.execute("PRAGMA journal_mode = WAL")
+                connection.execute("PRAGMA foreign_keys = ON")
+                connection.execute("BEGIN IMMEDIATE")
                 version = int(connection.execute("PRAGMA user_version").fetchone()[0])
-                if version not in {0, _SCHEMA_VERSION}:
+                if version not in {0, 1, _SCHEMA_VERSION}:
                     raise RuntimeError(
                         f"unsupported WebUI transcript schema {version}; "
                         f"expected {_SCHEMA_VERSION}"
                     )
-                connection.execute("PRAGMA journal_mode = WAL")
-                connection.execute("PRAGMA foreign_keys = ON")
-                connection.executescript(
+                connection.execute(
                     """
                     CREATE TABLE IF NOT EXISTS transcript_sessions (
                         session_key TEXT PRIMARY KEY,
                         legacy_imported INTEGER NOT NULL DEFAULT 0,
                         next_sequence INTEGER NOT NULL DEFAULT 0,
                         active_turn INTEGER NOT NULL DEFAULT 0,
-                        next_user_index INTEGER NOT NULL DEFAULT 0
-                    );
-
+                        next_user_index INTEGER NOT NULL DEFAULT 0,
+                        activity_revision INTEGER NOT NULL DEFAULT 0,
+                        activity_updated_at_ns INTEGER NOT NULL DEFAULT 0
+                    )
+                    """
+                )
+                connection.execute(
+                    """
                     CREATE TABLE IF NOT EXISTS transcript_turns (
                         session_key TEXT NOT NULL,
                         ordinal INTEGER NOT NULL,
@@ -95,8 +103,11 @@ class SQLiteTranscriptStore:
                         FOREIGN KEY (session_key)
                             REFERENCES transcript_sessions(session_key)
                             ON DELETE CASCADE
-                    );
-
+                    )
+                    """
+                )
+                connection.execute(
+                    """
                     CREATE TABLE IF NOT EXISTS transcript_events (
                         session_key TEXT NOT NULL,
                         sequence INTEGER NOT NULL,
@@ -106,15 +117,39 @@ class SQLiteTranscriptStore:
                         FOREIGN KEY (session_key, turn_ordinal)
                             REFERENCES transcript_turns(session_key, ordinal)
                             ON DELETE CASCADE
-                    );
-
-                    CREATE INDEX IF NOT EXISTS transcript_events_by_turn
-                        ON transcript_events(session_key, turn_ordinal, sequence);
+                    )
                     """
                 )
-                if version == 0:
+                connection.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS transcript_events_by_turn
+                        ON transcript_events(session_key, turn_ordinal, sequence)
+                    """
+                )
+                session_columns = {
+                    str(row[1])
+                    for row in connection.execute("PRAGMA table_info(transcript_sessions)")
+                }
+                if "activity_revision" not in session_columns:
+                    connection.execute(
+                        """
+                        ALTER TABLE transcript_sessions
+                        ADD COLUMN activity_revision INTEGER NOT NULL DEFAULT 0
+                        """
+                    )
+                if "activity_updated_at_ns" not in session_columns:
+                    connection.execute(
+                        """
+                        ALTER TABLE transcript_sessions
+                        ADD COLUMN activity_updated_at_ns INTEGER NOT NULL DEFAULT 0
+                        """
+                    )
+                if version < _SCHEMA_VERSION:
                     connection.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
                 connection.commit()
+            except BaseException:
+                connection.rollback()
+                raise
             finally:
                 connection.close()
             self._initialized = True
@@ -127,7 +162,7 @@ class SQLiteTranscriptStore:
         return raw
 
     def _is_imported(self, session_key: str) -> bool:
-        with self._connect() as connection:
+        with closing(self._connect()) as connection:
             row = connection.execute(
                 "SELECT legacy_imported FROM transcript_sessions WHERE session_key = ?",
                 (session_key,),
@@ -248,8 +283,10 @@ class SQLiteTranscriptStore:
         connection = self._connect()
         try:
             connection.execute("BEGIN IMMEDIATE")
+            activity_ns = time.time_ns()
             for session_key, records in grouped.items():
                 self._append_serialized(connection, session_key, records)
+                self._touch_activity(connection, session_key, activity_ns)
             connection.commit()
         except BaseException:
             connection.rollback()
@@ -276,12 +313,29 @@ class SQLiteTranscriptStore:
             )
             if serialized:
                 self._append_serialized(connection, session_key, serialized)
+            self._touch_activity(connection, session_key, time.time_ns())
             connection.commit()
         except BaseException:
             connection.rollback()
             raise
         finally:
             connection.close()
+
+    @staticmethod
+    def _touch_activity(
+        connection: sqlite3.Connection,
+        session_key: str,
+        activity_ns: int,
+    ) -> None:
+        connection.execute(
+            """
+            UPDATE transcript_sessions
+            SET activity_revision = activity_revision + 1,
+                activity_updated_at_ns = MAX(activity_updated_at_ns, ?)
+            WHERE session_key = ?
+            """,
+            (activity_ns, session_key),
+        )
 
     def delete(self, session_key: str) -> bool:
         connection = self._connect()
@@ -308,7 +362,7 @@ class SQLiteTranscriptStore:
     ) -> list[StoredTurn]:
         self.ensure_imported(session_key)
         upper = before_ordinal if before_ordinal is not None else 2**63 - 1
-        with self._connect() as connection:
+        with closing(self._connect()) as connection:
             turn_rows = connection.execute(
                 """
                 SELECT ordinal
@@ -340,9 +394,27 @@ class SQLiteTranscriptStore:
                 records_by_turn[int(row["turn_ordinal"])].append(payload)
         return [StoredTurn(ordinal, records_by_turn[ordinal]) for ordinal in ordinals]
 
+    def activity_signatures(self) -> dict[str, dict[str, int]]:
+        """Return per-session activity revisions without importing legacy files."""
+        with closing(self._connect()) as connection:
+            rows = connection.execute(
+                """
+                SELECT session_key, activity_revision, activity_updated_at_ns
+                FROM transcript_sessions
+                WHERE activity_revision > 0
+                """
+            ).fetchall()
+        return {
+            str(row["session_key"]): {
+                "revision": int(row["activity_revision"]),
+                "updated_at_ns": int(row["activity_updated_at_ns"]),
+            }
+            for row in rows
+        }
+
     def read_all(self, session_key: str) -> list[dict[str, Any]]:
         self.ensure_imported(session_key)
-        with self._connect() as connection:
+        with closing(self._connect()) as connection:
             rows = connection.execute(
                 """
                 SELECT payload
@@ -360,7 +432,7 @@ class SQLiteTranscriptStore:
         return records
 
     def user_count_before(self, session_key: str, ordinal: int) -> int:
-        with self._connect() as connection:
+        with closing(self._connect()) as connection:
             row = connection.execute(
                 """
                 SELECT user_offset
@@ -372,7 +444,7 @@ class SQLiteTranscriptStore:
         return int(row["user_offset"]) if row is not None else 0
 
     def has_turn_before(self, session_key: str, ordinal: int) -> bool:
-        with self._connect() as connection:
+        with closing(self._connect()) as connection:
             row = connection.execute(
                 """
                 SELECT 1

--- a/nanobot/webui/ws_http.py
+++ b/nanobot/webui/ws_http.py
@@ -88,8 +88,7 @@ from nanobot.webui.sidebar_state import (
     write_webui_sidebar_state,
 )
 from nanobot.webui.skills_api import webui_skill_detail_payload, webui_skills_payload
-from nanobot.webui.thread_disk import delete_webui_thread
-from nanobot.webui.transcript import build_webui_thread_response
+from nanobot.webui.transcript import WebUITranscriptRecorder
 from nanobot.webui.workspaces import WebUIWorkspaceController
 
 _SLOW_WEBUI_HTTP_LOG_MS = 1_000
@@ -161,6 +160,7 @@ class GatewayHTTPHandler:
         tokens: GatewayTokenStore,
         media: WebUIMediaGateway,
         ingress: WebUIIngressPolicy,
+        transcripts: WebUITranscriptRecorder,
         workspaces: WebUIWorkspaceController,
         skills_workspace_path: Path,
         disabled_skills: set[str] | None = None,
@@ -180,6 +180,7 @@ class GatewayHTTPHandler:
         self.tokens = tokens
         self.media = media
         self.ingress = ingress
+        self.transcripts = transcripts
         self.workspaces = workspaces
         self.skills_workspace_path = skills_workspace_path
         self.disabled_skills = disabled_skills or set()
@@ -381,7 +382,7 @@ class GatewayHTTPHandler:
 
         m = re.match(r"^/api/sessions/([^/]+)/webui-thread$", got)
         if m:
-            return self._handle_webui_thread_get(request, m.group(1))
+            return await self._handle_webui_thread_get(request, m.group(1))
 
         m = re.match(r"^/api/sessions/([^/]+)/file-preview$", got)
         if m:
@@ -393,7 +394,7 @@ class GatewayHTTPHandler:
 
         m = re.match(r"^/api/sessions/([^/]+)/delete$", got)
         if m:
-            return self._handle_session_delete(request, m.group(1))
+            return await self._handle_session_delete(request, m.group(1))
 
         return None
 
@@ -447,7 +448,7 @@ class GatewayHTTPHandler:
         self.media.augment_media_urls(data)
         return _http_json_response(data)
 
-    def _handle_webui_thread_get(self, request: WsRequest, key: str) -> Response:
+    async def _handle_webui_thread_get(self, request: WsRequest, key: str) -> Response:
         if not self.check_api_token(request):
             return _http_error(401, "Unauthorized")
         decoded_key = _decode_api_key(key)
@@ -455,13 +456,6 @@ class GatewayHTTPHandler:
             return _http_error(400, "invalid session key")
         if not _is_websocket_channel_session_key(decoded_key):
             return _http_error(404, "session not found")
-        scope = self.workspaces.scope_for_session_key(decoded_key)
-        session_messages: list[dict[str, Any]] | None = None
-        if self.session_manager is not None:
-            session_data = self.session_manager.read_session_file(decoded_key)
-            raw_messages = session_data.get("messages") if isinstance(session_data, dict) else None
-            if isinstance(raw_messages, list):
-                session_messages = [m for m in raw_messages if isinstance(m, dict)]
         query = _parse_query(request.path)
         raw_limit = _query_first(query, "limit")
         limit: int | None = None
@@ -474,15 +468,30 @@ class GatewayHTTPHandler:
         if direction is not None and direction not in {"latest"}:
             return _http_error(400, "invalid direction")
         before = _query_first(query, "before")
-        data = build_webui_thread_response(
+        return await asyncio.to_thread(
+            self._webui_thread_response,
             decoded_key,
+            limit,
+            direction,
+            before,
+        )
+
+    def _webui_thread_response(
+        self,
+        session_key: str,
+        limit: int | None,
+        direction: str | None,
+        before: str | None,
+    ) -> Response:
+        scope = self.workspaces.scope_for_session_key(session_key)
+        data = self.transcripts.build_response(
+            session_key,
             augment_user_media=self.media.augment_transcript_media,
             augment_assistant_media=self.media.augment_transcript_media,
             augment_assistant_text=lambda text: self.media.rewrite_local_markdown_images(
                 text,
                 workspace_path=scope.project_path,
             ),
-            session_messages=session_messages,
             limit=limit,
             direction=direction,
             before=before,
@@ -533,7 +542,7 @@ class GatewayHTTPHandler:
             )
         )
 
-    def _handle_session_delete(self, request: WsRequest, key: str) -> Response:
+    async def _handle_session_delete(self, request: WsRequest, key: str) -> Response:
         if not self.check_api_token(request):
             return _http_error(401, "Unauthorized")
         if self.session_manager is None:
@@ -565,9 +574,14 @@ class GatewayHTTPHandler:
                         self.local_trigger_store.delete(job.id)
                 elif self.cron_service is not None:
                     self.cron_service.remove_job(job.id)
-        deleted = self.session_manager.delete_session(decoded_key)
-        delete_webui_thread(decoded_key)
+        deleted = await asyncio.to_thread(self._delete_session_storage, decoded_key)
         return _http_json_response({"deleted": bool(deleted)})
+
+    def _delete_session_storage(self, session_key: str) -> bool:
+        assert self.session_manager is not None
+        deleted = self.session_manager.delete_session(session_key)
+        self.transcripts.delete(session_key)
+        return bool(deleted)
 
     # -- Automation routes --------------------------------------------------
 

--- a/nanobot/webui/ws_http.py
+++ b/nanobot/webui/ws_http.py
@@ -408,9 +408,17 @@ class GatewayHTTPHandler:
 
     def _sessions_list_payload(self) -> dict[str, Any]:
         assert self.session_manager is not None
+        try:
+            indexed_activity = self.transcripts.activity_signatures()
+        except Exception as exc:
+            self._log.warning(
+                "Failed to read WebUI transcript activity; using session timestamps: {}",
+                exc,
+            )
+            indexed_activity = {}
         sessions = list_webui_sessions(
             self.session_manager,
-            indexed_activity=self.transcripts.activity_signatures(),
+            indexed_activity=indexed_activity,
         )
         from nanobot.session.webui_turns import websocket_turn_wall_started_at
 
@@ -583,7 +591,14 @@ class GatewayHTTPHandler:
     def _delete_session_storage(self, session_key: str) -> bool:
         assert self.session_manager is not None
         deleted = self.session_manager.delete_session(session_key)
-        self.transcripts.delete(session_key)
+        try:
+            self.transcripts.delete(session_key)
+        except Exception as exc:
+            self._log.warning(
+                "Failed to clean up WebUI transcript for deleted session {}: {}",
+                session_key,
+                exc,
+            )
         return bool(deleted)
 
     # -- Automation routes --------------------------------------------------

--- a/nanobot/webui/ws_http.py
+++ b/nanobot/webui/ws_http.py
@@ -408,7 +408,10 @@ class GatewayHTTPHandler:
 
     def _sessions_list_payload(self) -> dict[str, Any]:
         assert self.session_manager is not None
-        sessions = list_webui_sessions(self.session_manager)
+        sessions = list_webui_sessions(
+            self.session_manager,
+            indexed_activity=self.transcripts.activity_signatures(),
+        )
         from nanobot.session.webui_turns import websocket_turn_wall_started_at
 
         cleaned = []

--- a/tests/utils/test_webui_transcript_store.py
+++ b/tests/utils/test_webui_transcript_store.py
@@ -45,9 +45,12 @@ def test_writer_batches_ordered_events_and_persists_wal_store(tmp_path: Path) ->
         str(index) for index in range(12)
     ]
     assert store.append_batch.call_count == 1
+    activity = store.activity_signatures()["websocket:ordered"]
+    assert activity["revision"] == 1
+    assert activity["updated_at_ns"] > 0
     with sqlite3.connect(store.path) as connection:
         assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 1
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 2
 
     writer.close()
 
@@ -106,6 +109,7 @@ def test_legacy_jsonl_is_imported_once_and_preserved(
         "legacy question",
         "legacy answer",
     ]
+    assert first.activity_signatures() == {}
     first.close()
     assert legacy_path.is_file()
 
@@ -205,3 +209,82 @@ def test_newer_database_schema_fails_without_overwriting_it(tmp_path: Path) -> N
 
     with sqlite3.connect(path) as connection:
         assert connection.execute("PRAGMA user_version").fetchone()[0] == 99
+
+
+def test_schema_one_database_is_migrated_without_losing_events(tmp_path: Path) -> None:
+    path = tmp_path / "transcripts.sqlite3"
+    with sqlite3.connect(path) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE transcript_sessions (
+                session_key TEXT PRIMARY KEY,
+                legacy_imported INTEGER NOT NULL DEFAULT 0,
+                next_sequence INTEGER NOT NULL DEFAULT 0,
+                active_turn INTEGER NOT NULL DEFAULT 0,
+                next_user_index INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE transcript_turns (
+                session_key TEXT NOT NULL,
+                ordinal INTEGER NOT NULL,
+                finalized INTEGER NOT NULL DEFAULT 0,
+                user_offset INTEGER NOT NULL DEFAULT 0,
+                user_count INTEGER NOT NULL DEFAULT 0,
+                event_count INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (session_key, ordinal),
+                FOREIGN KEY (session_key)
+                    REFERENCES transcript_sessions(session_key)
+                    ON DELETE CASCADE
+            );
+            CREATE TABLE transcript_events (
+                session_key TEXT NOT NULL,
+                sequence INTEGER NOT NULL,
+                turn_ordinal INTEGER NOT NULL,
+                payload TEXT NOT NULL,
+                PRIMARY KEY (session_key, sequence),
+                FOREIGN KEY (session_key, turn_ordinal)
+                    REFERENCES transcript_turns(session_key, ordinal)
+                    ON DELETE CASCADE
+            );
+            INSERT INTO transcript_sessions (
+                session_key, legacy_imported, next_sequence, active_turn, next_user_index
+            ) VALUES ('websocket:v1', 1, 1, 0, 1);
+            INSERT INTO transcript_turns (
+                session_key, ordinal, user_offset, user_count, event_count
+            ) VALUES ('websocket:v1', 0, 0, 1, 1);
+            INSERT INTO transcript_events (
+                session_key, sequence, turn_ordinal, payload
+            ) VALUES ('websocket:v1', 0, 0, '{"event":"user","text":"kept"}');
+            PRAGMA user_version = 1;
+            """
+        )
+
+    store = SQLiteTranscriptStore(path)
+
+    assert store.read_all("websocket:v1") == [{"event": "user", "text": "kept"}]
+    assert store.activity_signatures() == {}
+    with sqlite3.connect(path) as connection:
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 2
+        columns = {
+            str(row[1])
+            for row in connection.execute("PRAGMA table_info(transcript_sessions)")
+        }
+    assert {"activity_revision", "activity_updated_at_ns"} <= columns
+
+
+def test_recorder_closes_all_sqlite_handles_after_reads(tmp_path: Path) -> None:
+    path = tmp_path / "transcripts.sqlite3"
+    recorder = WebUITranscriptRecorder(store_path=path, write_batch_window_s=0)
+    _append_turn(recorder, "handles", 1)
+    assert recorder.build_response(
+        "websocket:handles",
+        limit=2,
+        direction="latest",
+    ) is not None
+    assert recorder.activity_signatures()["websocket:handles"]["revision"] > 0
+
+    recorder.close()
+    moved = path.with_name("moved.sqlite3")
+    path.rename(moved)
+    moved.unlink()
+
+    assert not moved.exists()

--- a/tests/utils/test_webui_transcript_store.py
+++ b/tests/utils/test_webui_transcript_store.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from nanobot.session.manager import SessionManager
+from nanobot.webui.transcript import (
+    WebUITranscriptRecorder,
+    append_transcript_object,
+    webui_transcript_path,
+)
+from nanobot.webui.transcript_store import SQLiteTranscriptStore, TranscriptWriteQueue
+
+
+def _append_turn(
+    recorder: WebUITranscriptRecorder,
+    chat_id: str,
+    index: int,
+    *,
+    finish: bool = True,
+) -> None:
+    recorder.append(chat_id, {"event": "user", "chat_id": chat_id, "text": f"q{index}"})
+    recorder.append(chat_id, {"event": "message", "chat_id": chat_id, "text": f"a{index}"})
+    if finish:
+        recorder.append(chat_id, {"event": "turn_end", "chat_id": chat_id})
+
+
+def test_writer_batches_ordered_events_and_persists_wal_store(tmp_path: Path) -> None:
+    store = SQLiteTranscriptStore(tmp_path / "transcripts.sqlite3")
+    original_append_batch = store.append_batch
+    store.append_batch = MagicMock(wraps=original_append_batch)
+    writer = TranscriptWriteQueue(store, log=MagicMock(), batch_window_s=0.1)
+
+    for index in range(12):
+        writer.append(
+            "websocket:ordered",
+            {"event": "delta", "chat_id": "ordered", "text": str(index)},
+        )
+    writer.flush()
+
+    assert [row["text"] for row in store.read_all("websocket:ordered")] == [
+        str(index) for index in range(12)
+    ]
+    assert store.append_batch.call_count == 1
+    with sqlite3.connect(store.path) as connection:
+        assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 1
+
+    writer.close()
+
+
+def test_turn_cursor_stays_stable_when_new_turns_arrive(tmp_path: Path) -> None:
+    recorder = WebUITranscriptRecorder(
+        store_path=tmp_path / "transcripts.sqlite3",
+        write_batch_window_s=0,
+    )
+    for index in range(1, 4):
+        _append_turn(recorder, "paged", index)
+    recorder.flush()
+    recorder._store.read_all = MagicMock(side_effect=AssertionError("full scan is forbidden"))
+
+    latest = recorder.build_response(
+        "websocket:paged",
+        limit=2,
+        direction="latest",
+    )
+    assert latest is not None
+    assert [message["content"] for message in latest["messages"]] == ["q3", "a3"]
+    cursor = latest["page"]["before_cursor"]
+    assert latest["page"]["user_message_offset"] == 2
+
+    _append_turn(recorder, "paged", 4)
+    older = recorder.build_response("websocket:paged", limit=2, before=cursor)
+
+    assert older is not None
+    assert [message["content"] for message in older["messages"]] == ["q2", "a2"]
+    assert older["page"]["user_message_offset"] == 1
+    recorder.close()
+
+
+def test_legacy_jsonl_is_imported_once_and_preserved(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("nanobot.config.paths.get_data_dir", lambda: tmp_path)
+    key = "websocket:legacy"
+    sessions = SessionManager(tmp_path / "sessions")
+    session = sessions.get_or_create(key)
+    session.add_message("user", "legacy question")
+    session.add_message("assistant", "legacy answer")
+    sessions.save(session)
+    append_transcript_object(
+        key,
+        {"event": "message", "chat_id": "legacy", "text": "legacy answer"},
+    )
+    legacy_path = webui_transcript_path(key)
+
+    first = WebUITranscriptRecorder(
+        session_manager=sessions,
+        store_path=tmp_path / "transcripts.sqlite3",
+    )
+    assert [row.get("text") for row in first.read_lines(key)] == [
+        "legacy question",
+        "legacy answer",
+    ]
+    first.close()
+    assert legacy_path.is_file()
+
+    append_transcript_object(
+        key,
+        {"event": "message", "chat_id": "legacy", "text": "late legacy row"},
+    )
+    restarted = WebUITranscriptRecorder(
+        session_manager=sessions,
+        store_path=tmp_path / "transcripts.sqlite3",
+    )
+    assert [row.get("text") for row in restarted.read_lines(key)] == [
+        "legacy question",
+        "legacy answer",
+    ]
+    restarted.close()
+
+
+def test_restart_recovers_an_incomplete_active_turn(tmp_path: Path) -> None:
+    store_path = tmp_path / "transcripts.sqlite3"
+    first = WebUITranscriptRecorder(store_path=store_path, write_batch_window_s=0)
+    first.append("restart", {"event": "user", "chat_id": "restart", "text": "question"})
+    first.append(
+        "restart",
+        {"event": "delta", "chat_id": "restart", "stream_id": "s1", "text": "partial"},
+    )
+    first.close()
+
+    restarted = WebUITranscriptRecorder(store_path=store_path, write_batch_window_s=0)
+    incomplete = restarted.build_response("websocket:restart")
+    assert incomplete is not None
+    assert [message["content"] for message in incomplete["messages"]] == [
+        "question",
+        "partial",
+    ]
+    assert incomplete["has_pending_tool_calls"] is True
+    restarted.append(
+        "restart",
+        {"event": "stream_end", "chat_id": "restart", "stream_id": "s1"},
+    )
+    restarted.append("restart", {"event": "turn_end", "chat_id": "restart"})
+    restarted.close()
+
+    final = WebUITranscriptRecorder(store_path=store_path)
+    completed = final.build_response("websocket:restart")
+    assert completed is not None
+    assert completed["has_pending_tool_calls"] is False
+    final.close()
+
+
+def test_fork_and_delete_are_serialized_with_pending_writes(tmp_path: Path) -> None:
+    recorder = WebUITranscriptRecorder(
+        store_path=tmp_path / "transcripts.sqlite3",
+        write_batch_window_s=0.1,
+    )
+    _append_turn(recorder, "source", 1)
+    _append_turn(recorder, "source", 2)
+
+    assert recorder.fork_before_user_index(
+        "websocket:source",
+        "websocket:target",
+        1,
+    )
+    recorder.append_fork_marker("websocket:target")
+    forked = recorder.build_response("websocket:target")
+    assert forked is not None
+    assert [message["content"] for message in forked["messages"]] == ["q1", "a1"]
+    assert forked["fork_boundary_message_count"] == 2
+
+    assert recorder.delete("websocket:target") is True
+    assert recorder.build_response("websocket:target") is None
+    recorder.close()
+
+
+def test_writer_surfaces_batch_failure_to_flush_and_close() -> None:
+    store = MagicMock(spec=SQLiteTranscriptStore)
+    store.append_batch.side_effect = OSError("disk full")
+    writer = TranscriptWriteQueue(store, log=MagicMock(), batch_window_s=0)
+    writer.append("websocket:broken", {"event": "user", "text": "lost"})
+
+    with pytest.raises(RuntimeError, match="writer has failed") as flush_error:
+        writer.flush()
+    assert isinstance(flush_error.value.__cause__, OSError)
+
+    with pytest.raises(RuntimeError, match="writer has failed"):
+        writer.close()
+
+
+def test_newer_database_schema_fails_without_overwriting_it(tmp_path: Path) -> None:
+    path = tmp_path / "transcripts.sqlite3"
+    with sqlite3.connect(path) as connection:
+        connection.execute("PRAGMA user_version = 99")
+
+    store = SQLiteTranscriptStore(path)
+    with pytest.raises(RuntimeError, match="unsupported WebUI transcript schema 99"):
+        store.read_all("websocket:newer")
+
+    with sqlite3.connect(path) as connection:
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 99

--- a/tests/webui/test_forking.py
+++ b/tests/webui/test_forking.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import uuid
+from unittest.mock import Mock
+
+import pytest
+
+from nanobot.session.manager import SessionManager
+from nanobot.webui.forking import create_webui_chat_fork
+
+
+def test_fork_failure_removes_session_when_transcript_cleanup_also_fails(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    manager = SessionManager(tmp_path)
+    source = manager.get_or_create("websocket:source")
+    source.add_message("user", "round one")
+    source.add_message("assistant", "answer one")
+    manager.save(source)
+
+    fork_id = uuid.UUID("00000000-0000-0000-0000-000000000123")
+    monkeypatch.setattr("nanobot.webui.forking.uuid.uuid4", lambda: fork_id)
+    transcripts = Mock()
+    transcripts.fork_before_user_index.side_effect = OSError("primary transcript failure")
+    transcripts.delete.side_effect = OSError("cleanup transcript failure")
+
+    with pytest.raises(OSError, match="primary transcript failure"):
+        create_webui_chat_fork(
+            manager,
+            source_chat_id="source",
+            before_user_index=1,
+            transcripts=transcripts,
+        )
+
+    target_key = f"websocket:{fork_id}"
+    transcripts.delete.assert_called_once_with(target_key)
+    assert not manager._get_session_path(target_key).exists()
+    assert manager.read_session_file(target_key) is None
+    assert manager.read_session_file("websocket:source") is not None

--- a/tests/webui/test_session_list_index.py
+++ b/tests/webui/test_session_list_index.py
@@ -9,6 +9,7 @@ from nanobot.cron.session_turns import CRON_HISTORY_META
 from nanobot.session.automation_turns import AUTOMATION_HISTORY_META
 from nanobot.session.history_visibility import HIDDEN_HISTORY_META
 from nanobot.session.manager import SessionManager
+from nanobot.webui.transcript import WebUITranscriptRecorder
 
 
 def test_webui_session_list_reuses_valid_index_without_scanning_files(
@@ -200,6 +201,70 @@ def test_webui_session_list_rescans_when_transcript_changes(
 
     assert scanned == [manager._get_session_path("websocket:transcript-change").name]
     assert rows[0]["updated_at"].startswith("2026-06-15T12:30:00")
+
+
+def test_webui_session_list_tracks_per_session_sqlite_activity(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    webui_dir = tmp_path / "webui"
+    webui_dir.mkdir()
+    monkeypatch.setattr(session_list_index, "get_webui_dir", lambda: webui_dir)
+    monkeypatch.setattr("nanobot.config.paths.get_data_dir", lambda: tmp_path)
+
+    manager = SessionManager(tmp_path)
+    old = manager.get_or_create("websocket:old-sqlite")
+    old.created_at = datetime(2000, 1, 1, 10, 0, 0)
+    old.add_message("user", "old sqlite")
+    old.messages[-1]["timestamp"] = "2000-01-01T10:00:00"
+    old.updated_at = datetime(2000, 1, 1, 10, 0, 0)
+    manager.save(old)
+
+    newer = manager.get_or_create("websocket:newer-sqlite")
+    newer.created_at = datetime(2000, 1, 1, 11, 0, 0)
+    newer.add_message("user", "newer sqlite")
+    newer.messages[-1]["timestamp"] = "2000-01-01T11:00:00"
+    newer.updated_at = datetime(2000, 1, 1, 11, 0, 0)
+    manager.save(newer)
+
+    recorder = WebUITranscriptRecorder(
+        session_manager=manager,
+        store_path=webui_dir / "transcripts.sqlite3",
+        write_batch_window_s=0,
+    )
+    assert [row["key"] for row in list_webui_sessions(manager)] == [
+        "websocket:newer-sqlite",
+        "websocket:old-sqlite",
+    ]
+    recorder.append(
+        "old-sqlite",
+        {"event": "message", "chat_id": "old-sqlite", "text": "display-only activity"},
+    )
+    indexed_activity = recorder.activity_signatures()
+
+    original_scan = session_list_index._scan_session_row
+    scanned: list[str] = []
+
+    def record_scan(
+        session_manager: SessionManager,
+        path: Path,
+        **kwargs,
+    ) -> dict | None:
+        scanned.append(path.name)
+        return original_scan(session_manager, path, **kwargs)
+
+    monkeypatch.setattr(session_list_index, "_scan_session_row", record_scan)
+    rows = session_list_index.list_webui_sessions(
+        manager,
+        indexed_activity=indexed_activity,
+    )
+
+    assert scanned == [manager._get_session_path("websocket:old-sqlite").name]
+    assert [row["key"] for row in rows] == [
+        "websocket:old-sqlite",
+        "websocket:newer-sqlite",
+    ]
+    recorder.close()
 
 
 def test_webui_session_list_sorts_by_message_activity_not_maintenance_timestamp(

--- a/webui/src/hooks/useSessions.ts
+++ b/webui/src/hooks/useSessions.ts
@@ -244,6 +244,7 @@ export function useSessionHistory(key: string | null): {
       return;
     }
     let cancelled = false;
+    const controller = new AbortController();
     // Mark the new key as loading immediately so callers never see stale
     // messages from the previous session during the render right after a switch.
     setState((prev) => prev.key === key
@@ -266,6 +267,7 @@ export function useSessionHistory(key: string | null): {
         const body = await fetchWebuiThread(token, key, {
           limit: INITIAL_HISTORY_PAGE_LIMIT,
           direction: "latest",
+          signal: controller.signal,
         });
         if (cancelled) return;
         if (!body?.messages?.length) {
@@ -337,6 +339,7 @@ export function useSessionHistory(key: string | null): {
     })();
     return () => {
       cancelled = true;
+      controller.abort();
     };
   }, [key, token, refreshSeq]);
 

--- a/webui/src/hooks/useSessions.ts
+++ b/webui/src/hooks/useSessions.ts
@@ -196,6 +196,10 @@ export function useSessionHistory(key: string | null): {
 } {
   const { token } = useClient();
   const loadingOlderRef = useRef(false);
+  const olderRequestRef = useRef<{
+    key: string;
+    controller: AbortController;
+  } | null>(null);
   const [refreshSeq, setRefreshSeq] = useState(0);
   const refresh = useCallback(() => {
     setRefreshSeq((value) => value + 1);
@@ -227,6 +231,11 @@ export function useSessionHistory(key: string | null): {
   });
 
   useEffect(() => {
+    if (olderRequestRef.current) {
+      olderRequestRef.current.controller.abort();
+      olderRequestRef.current = null;
+      loadingOlderRef.current = false;
+    }
     if (!key) {
       setState({
         key: null,
@@ -340,6 +349,11 @@ export function useSessionHistory(key: string | null): {
     return () => {
       cancelled = true;
       controller.abort();
+      if (olderRequestRef.current?.key === key) {
+        olderRequestRef.current.controller.abort();
+        olderRequestRef.current = null;
+        loadingOlderRef.current = false;
+      }
     };
   }, [key, token, refreshSeq]);
 
@@ -347,13 +361,18 @@ export function useSessionHistory(key: string | null): {
     if (!key || loadingOlderRef.current) return;
     const before = state.key === key ? state.beforeCursor : null;
     if (!before || !state.hasMoreBefore) return;
+    const controller = new AbortController();
+    const request = { key, controller };
     loadingOlderRef.current = true;
+    olderRequestRef.current = request;
     setState((prev) => prev.key === key ? { ...prev, loadingOlder: true, error: null } : prev);
     try {
       const body = await fetchWebuiThread(token, key, {
         limit: OLDER_HISTORY_PAGE_LIMIT,
         before,
+        signal: controller.signal,
       });
+      if (controller.signal.aborted) return;
       setState((prev) => {
         if (prev.key !== key) return prev;
         if (!body?.messages?.length) {
@@ -386,6 +405,7 @@ export function useSessionHistory(key: string | null): {
         };
       });
     } catch (e) {
+      if (controller.signal.aborted) return;
       setState((prev) => prev.key === key
         ? {
             ...prev,
@@ -394,7 +414,10 @@ export function useSessionHistory(key: string | null): {
           }
         : prev);
     } finally {
-      loadingOlderRef.current = false;
+      if (olderRequestRef.current === request) {
+        olderRequestRef.current = null;
+        loadingOlderRef.current = false;
+      }
     }
   }, [
     key,

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -158,6 +158,7 @@ export interface FetchWebuiThreadOptions {
   limit?: number;
   direction?: "latest";
   before?: string | null;
+  signal?: AbortSignal;
 }
 
 export async function fetchWebuiThread(
@@ -178,6 +179,7 @@ export async function fetchWebuiThread(
   const res = await fetchWithTimeout(url, {
     headers: { Authorization: `Bearer ${token}` },
     credentials: "same-origin",
+    signal: options?.signal,
   });
   if (res.status === 404) return null;
   if (!res.ok) throw new ApiError(res.status, `HTTP ${res.status}`);

--- a/webui/src/lib/http.ts
+++ b/webui/src/lib/http.ts
@@ -12,6 +12,13 @@ export async function fetchWithTimeout(
   const controller = typeof AbortController !== "undefined"
     ? new AbortController()
     : null;
+  const externalSignal = init.signal;
+  const abortFromCaller = () => controller?.abort(externalSignal?.reason);
+  if (externalSignal?.aborted) {
+    abortFromCaller();
+  } else {
+    externalSignal?.addEventListener("abort", abortFromCaller, { once: true });
+  }
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
   const request = fetch(input, {
@@ -29,5 +36,6 @@ export async function fetchWithTimeout(
     return await Promise.race([request, timeout]);
   } finally {
     if (timeoutId !== undefined) clearTimeout(timeoutId);
+    externalSignal?.removeEventListener("abort", abortFromCaller);
   }
 }

--- a/webui/src/tests/useSessions.test.tsx
+++ b/webui/src/tests/useSessions.test.tsx
@@ -480,6 +480,39 @@ describe("useSessions", () => {
     expect(result.current.hasPendingToolCalls).toBe(false);
   });
 
+  it("aborts the stale history request when switching sessions", async () => {
+    let firstSignal: AbortSignal | undefined;
+    vi.mocked(api.fetchWebuiThread).mockImplementation(
+      async (_token, key, optionsOrBase) => {
+        if (key === "websocket:first") {
+          firstSignal = typeof optionsOrBase === "object" ? optionsOrBase.signal : undefined;
+          await new Promise<never>((_resolve, reject) => {
+            firstSignal?.addEventListener(
+              "abort",
+              () => reject(new DOMException("aborted", "AbortError")),
+              { once: true },
+            );
+          });
+        }
+        return null;
+      },
+    );
+
+    const { result, rerender } = renderHook(
+      ({ sessionKey }) => useSessionHistory(sessionKey),
+      {
+        initialProps: { sessionKey: "websocket:first" },
+        wrapper: wrap(fakeClient()),
+      },
+    );
+
+    await waitFor(() => expect(firstSignal).toBeDefined());
+    rerender({ sessionKey: "websocket:second" });
+
+    expect(firstSignal?.aborted).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+  });
+
   it("loads older transcript pages before the current history", async () => {
     vi.mocked(api.fetchWebuiThread)
       .mockResolvedValueOnce({
@@ -514,10 +547,15 @@ describe("useSessions", () => {
     });
 
     await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(api.fetchWebuiThread).toHaveBeenCalledWith("tok", "websocket:paged", {
-      limit: 160,
-      direction: "latest",
-    });
+    expect(api.fetchWebuiThread).toHaveBeenCalledWith(
+      "tok",
+      "websocket:paged",
+      expect.objectContaining({
+        limit: 160,
+        direction: "latest",
+        signal: expect.any(AbortSignal),
+      }),
+    );
     expect(result.current.hasMoreBefore).toBe(true);
     expect(result.current.userMessageOffset).toBe(1);
 

--- a/webui/src/tests/useSessions.test.tsx
+++ b/webui/src/tests/useSessions.test.tsx
@@ -566,6 +566,7 @@ describe("useSessions", () => {
     expect(api.fetchWebuiThread).toHaveBeenLastCalledWith("tok", "websocket:paged", {
       limit: 120,
       before: "cursor-2",
+      signal: expect.any(AbortSignal),
     });
     expect(result.current.messages.map((message) => message.content)).toEqual([
       "old question",
@@ -575,6 +576,84 @@ describe("useSessions", () => {
     ]);
     expect(result.current.hasMoreBefore).toBe(false);
     expect(result.current.userMessageOffset).toBe(0);
+  });
+
+  it("releases older-page loading when switching sessions", async () => {
+    let staleSignal: AbortSignal | undefined;
+    vi.mocked(api.fetchWebuiThread).mockImplementation(
+      async (_token, key, optionsOrBase) => {
+        const options = typeof optionsOrBase === "object" ? optionsOrBase : undefined;
+        if (key === "websocket:first" && !options?.before) {
+          return {
+            schemaVersion: 3,
+            messages: [{ id: "a1", role: "assistant", content: "first", createdAt: 1 }],
+            page: {
+              before_cursor: "first-cursor",
+              has_more_before: true,
+              loaded_message_count: 1,
+              user_message_offset: 1,
+            },
+          };
+        }
+        if (key === "websocket:first") {
+          staleSignal = options?.signal;
+          await new Promise<never>((_resolve, reject) => {
+            staleSignal?.addEventListener(
+              "abort",
+              () => reject(new DOMException("aborted", "AbortError")),
+              { once: true },
+            );
+          });
+        }
+        if (!options?.before) {
+          return {
+            schemaVersion: 3,
+            messages: [{ id: "b2", role: "assistant", content: "second", createdAt: 2 }],
+            page: {
+              before_cursor: "second-cursor",
+              has_more_before: true,
+              loaded_message_count: 1,
+              user_message_offset: 1,
+            },
+          };
+        }
+        return {
+          schemaVersion: 3,
+          messages: [{ id: "b1", role: "assistant", content: "second older", createdAt: 1 }],
+          page: {
+            before_cursor: null,
+            has_more_before: false,
+            loaded_message_count: 1,
+            user_message_offset: 0,
+          },
+        };
+      },
+    );
+
+    const { result, rerender } = renderHook(
+      ({ sessionKey }) => useSessionHistory(sessionKey),
+      {
+        initialProps: { sessionKey: "websocket:first" },
+        wrapper: wrap(fakeClient()),
+      },
+    );
+    await waitFor(() => expect(result.current.hasMoreBefore).toBe(true));
+    act(() => {
+      void result.current.loadOlder();
+    });
+    await waitFor(() => expect(staleSignal).toBeDefined());
+
+    rerender({ sessionKey: "websocket:second" });
+    expect(staleSignal?.aborted).toBe(true);
+    await waitFor(() => expect(result.current.messages[0]?.content).toBe("second"));
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+
+    expect(result.current.messages.map((message) => message.content)).toEqual([
+      "second older",
+      "second",
+    ]);
   });
 
   it("keeps the session in the list when delete fails", async () => {


### PR DESCRIPTION
## Summary

- replace runtime WebUI transcript JSONL reads with an indexed SQLite WAL read model
- batch display-event writes on a dedicated single-writer thread and move history/fork/delete disk work off the gateway event loop
- page by stable turn ordinals with precomputed user offsets instead of rebuilding/scanning transcript chunks
- lazily migrate legacy JSONL through an explicit schema-versioned store while preserving the source files
- keep sidebar ordering cache-correct with per-session SQLite activity revisions
- isolate optional display-store failures from core session listing/deletion contracts
- abort stale initial and older-page browser requests when switching sessions

## Why

Conversation loading and streaming transcript writes shared the gateway event loop. Active JSONL rotation/manifest recovery, transcript replay, session backfill reads, and per-event fsyncs could therefore create head-of-line blocking and leave the UI on `Loading conversation...` for seconds.

The agent session remains the source of truth. The SQLite database is a WebUI display read model at `<config-dir>/webui/transcripts.sqlite3`. Runtime writes are ordered through one worker; paginated reads only decode selected turns. Graceful gateway shutdown flushes the writer, all read handles are closed deterministically, fork cleanup is best-effort on each owned resource, and unsupported newer database schemas fail without being overwritten. If the optional activity index is unavailable, session navigation falls back to authoritative session timestamps.

## Migration and downgrade behavior

Legacy JSONL files are preserved as the one-time migration source and as a pre-upgrade snapshot; they are not dual-written after migration. Schema v1 databases created by an earlier development build migrate transactionally to v2 without losing events.

Downgrading to a release that predates this SQLite read model will not show WebUI-only transcript events created after the upgrade. The authoritative agent session remains intact, but an older WebUI cannot reconstruct the complete post-upgrade assistant display/tool trace. If new legacy JSONL display turns are created while running that older release, upgrading again does not automatically merge them into a session already marked as imported; this change does not provide bidirectional cross-version history merging.

## Verification

- `pytest -q` — 5121 passed, 38 skipped
- focused transcript store, session index, fork cleanup, and unsupported-schema route tests — 23 passed
- `pytest nanobot/channels/websocket/tests/test_websocket_channel.py -q` — 135 passed
- `pytest nanobot/channels/websocket/tests/test_websocket_http_routes.py -q` — 66 passed
- `bunx vitest run --maxWorkers=1 --minWorkers=1`
- `bun run build`
- `bun run lint`
- `ruff check` on changed Python files
- real gateway + headless Playwright: `/model` persisted through the public history API, browser reload, and gateway restart; legacy JSONL migrated once through the public API and remained intact

## Test note

On this Windows host, the default parallel Vitest run twice exceeded an existing 1-second wait in `thread-shell.test.tsx` under suite-wide contention. That test passes in isolation, its full file passes, and the complete suite passes with one worker.

## Follow-up

The writer stops accepting new events after it observes a storage failure, but the in-memory command queue has no explicit item cap while SQLite is stalled. A follow-up should add delta coalescing or a bounded overload policy without reintroducing event-loop blocking.