### PR TITLE
fix(session): tolerate unsupported directory fsync

### DIFF
--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -1,6 +1,7 @@
 """Session management for conversation history."""
 
 import base64
+import errno
 import json
 import os
 import re
@@ -688,12 +689,16 @@ class SessionManager:
             if fsync:
                 # fsync the directory so the rename is durable.
                 # On Windows, opening a directory with O_RDONLY raises
-                # PermissionError — skip the dir sync there (NTFS
-                # journals metadata synchronously).
+                # PermissionError; some shared filesystems allow the open but
+                # reject directory fsync with EINVAL.
                 with suppress(PermissionError):
                     fd = os.open(str(path.parent), os.O_RDONLY)
                     try:
-                        os.fsync(fd)
+                        try:
+                            os.fsync(fd)
+                        except OSError as exc:
+                            if exc.errno != errno.EINVAL:
+                                raise
                     finally:
                         os.close(fd)
         except BaseException:

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -694,11 +694,10 @@ class SessionManager:
                 with suppress(PermissionError):
                     fd = os.open(str(path.parent), os.O_RDONLY)
                     try:
-                        try:
-                            os.fsync(fd)
-                        except OSError as exc:
-                            if exc.errno != errno.EINVAL:
-                                raise
+                        os.fsync(fd)
+                    except OSError as exc:
+                        if exc.errno != errno.EINVAL:
+                            raise
                     finally:
                         os.close(fd)
         except BaseException:

--- a/tests/session/test_session_fsync.py
+++ b/tests/session/test_session_fsync.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import errno
+import os
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -54,6 +56,46 @@ class TestSaveFsync:
         with patch("os.fsync") as mock_fsync:
             manager.save(session)
             mock_fsync.assert_not_called()
+
+    def test_save_ignores_unsupported_directory_fsync(
+        self, manager: SessionManager
+    ) -> None:
+        """Shared filesystems may open directories but reject directory fsync."""
+        session = manager.get_or_create("test:unsupported-directory-fsync")
+        session.add_message("user", "hello")
+        directory_fd = 987654
+        with (
+            patch("nanobot.session.manager.os.open", return_value=directory_fd) as open_dir,
+            patch(
+                "nanobot.session.manager.os.fsync",
+                side_effect=[None, OSError(errno.EINVAL, "Invalid argument")],
+            ),
+            patch("nanobot.session.manager.os.close") as close_dir,
+        ):
+            manager.save(session, fsync=True)
+
+        assert manager._get_session_path(session.key).exists()
+        open_dir.assert_called_once_with(str(manager.sessions_dir), os.O_RDONLY)
+        close_dir.assert_called_once_with(directory_fd)
+
+    def test_save_propagates_other_directory_fsync_errors(
+        self, manager: SessionManager
+    ) -> None:
+        """Only EINVAL is an expected unsupported-directory-fsync result."""
+        session = manager.get_or_create("test:directory-fsync-io-error")
+        directory_fd = 987654
+        with (
+            patch("nanobot.session.manager.os.open", return_value=directory_fd),
+            patch(
+                "nanobot.session.manager.os.fsync",
+                side_effect=[None, OSError(errno.EIO, "I/O error")],
+            ),
+            patch("nanobot.session.manager.os.close") as close_dir,
+            pytest.raises(OSError, match="I/O error"),
+        ):
+            manager.save(session, fsync=True)
+
+        close_dir.assert_called_once_with(directory_fd)
 
 
 class TestFlushAll:


### PR DESCRIPTION
## Summary

- tolerate `EINVAL` when syncing the session directory after an atomic rename
- continue propagating other directory `fsync` errors
- add regression coverage for both supported and unsupported error paths

## Why

Some shared filesystems allow a directory to be opened but reject directory
`fsync` with `EINVAL`. At that point, the session file itself has already been
flushed and atomically replaced, so reporting the save as failed causes
unnecessary failures during durable session saves and graceful shutdown.

This matches the compatibility behavior already used by
`CronService._atomic_write`.

## Testing

- `pytest tests/session/test_session_fsync.py tests/cron/test_cron_persistence.py tests/triggers/test_local_triggers.py -q`
  - 43 passed
- `ruff check nanobot/session/manager.py tests/session/test_session_fsync.py`
- `git diff --check`