### PR TITLE
feat(channels): add guarded tool gateway

### DIFF
--- a/docs/channel-package-guide.md
+++ b/docs/channel-package-guide.md
@@ -205,6 +205,36 @@ curl -X POST http://localhost:9000/message \
 
 The agent receives the message and processes it. Replies arrive in your `send()` method.
 
+### Optional: Run Guarded Agent Tools
+
+Most channels should publish inbound messages and let the agent decide which
+tools to call. A real-time channel that must execute a tool itself can opt in
+to a narrow gateway. Declare `wants_tool_gateway = True` and accept the
+keyword-only `tool_gateway` constructor argument:
+
+```python
+from nanobot.channels.base import BaseChannel, ToolGateway
+
+
+class RealtimeChannel(BaseChannel):
+    wants_tool_gateway = True
+
+    def __init__(self, config, bus, *, tool_gateway: ToolGateway):
+        super().__init__(config, bus)
+        self.tool_gateway = tool_gateway
+
+    async def run_external_call(self, chat_id: str, name: str, args: dict):
+        session_key = f"{self.name}:{chat_id}"
+        return await self.tool_gateway.execute_tool(
+            session_key, name, args, channel=self.name, chat_id=chat_id,
+        )
+```
+
+The gateway exposes only the live tool schemas and guarded tool execution. It
+uses the normal tool registry and binds the same workspace, request, and
+per-session file-state context as an agent turn. Do not instantiate tools or
+bypass this gateway in a channel package.
+
 ## Channel Package Requirements
 
 Every channel is a self-contained package at `nanobot/channels/<channel>/`; channel-specific runtime code, setup metadata, tests, WebUI structure, components, and translations stay under that directory.

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -528,6 +528,48 @@ class AgentLoop:
         """Select a context limit for future turns."""
         return self.runtime_resolver.select_context_window(context_window_tokens)
 
+    def get_tool_definitions(self) -> list[dict[str, Any]]:
+        """Return the live tool schemas for an opt-in channel integration."""
+        return self.tools.get_definitions()
+
+    async def execute_tool(
+        self,
+        session_key: str,
+        name: str,
+        args: Any,
+        *,
+        channel: str,
+        chat_id: str | None = None,
+    ) -> Any:
+        """Execute one channel-requested tool under normal turn safety context.
+
+        This is intentionally narrower than an agent turn: it does not invoke a
+        model or persist messages, but it binds the same workspace, request, and
+        per-session file-state context that regular tool execution receives.
+        """
+        session = self.sessions.get_or_create(session_key)
+        scope = self.workspace_scopes.for_turn(
+            channel=channel,
+            message_metadata=None,
+            session_metadata=session.metadata,
+        )
+        request = RequestContext(
+            channel=channel,
+            chat_id=chat_id or "",
+            session_key=session_key,
+            runtime=self.llm_runtime(),
+            workspace=scope.project_path,
+        )
+        file_state_token = bind_file_states(self._file_state_store.for_session(session_key))
+        request_token = bind_request_context(request)
+        workspace_token = bind_workspace_scope(scope)
+        try:
+            return await self.tools.execute(name, args)
+        finally:
+            reset_workspace_scope(workspace_token)
+            reset_request_context(request_token)
+            reset_file_states(file_state_token)
+
     def _register_default_tools(
         self,
         *,

--- a/nanobot/channels/__init__.py
+++ b/nanobot/channels/__init__.py
@@ -1,5 +1,5 @@
 """Shared contracts for chat channels."""
 
-from nanobot.channels.base import BaseChannel
+from nanobot.channels.base import BaseChannel, ToolGateway
 
-__all__ = ["BaseChannel"]
+__all__ = ["BaseChannel", "ToolGateway"]

--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 from loguru import logger
 
@@ -16,6 +16,22 @@ from nanobot.pairing import (
     generate_code,
     is_approved,
 )
+
+
+class ToolGateway(Protocol):
+    """Narrow, guarded tool access exposed to opt-in channel plugins."""
+
+    def get_tool_definitions(self) -> list[dict[str, Any]]: ...
+
+    async def execute_tool(
+        self,
+        session_key: str,
+        name: str,
+        args: Any,
+        *,
+        channel: str,
+        chat_id: str | None = None,
+    ) -> Any: ...
 
 
 class BaseChannel(ABC):
@@ -31,6 +47,9 @@ class BaseChannel(ABC):
     send_progress: bool = True
     send_tool_hints: bool = False
     show_reasoning: bool = True
+    # Plugins that need to invoke agent tools must opt in and accept a
+    # ``tool_gateway=`` constructor keyword argument.
+    wants_tool_gateway: bool = False
 
     def __init__(self, config: Any, bus: MessageBus):
         """

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -24,7 +24,7 @@ from nanobot.bus.outbound_events import (
 )
 from nanobot.bus.queue import MessageBus
 from nanobot.channels._setup import channel_setup_spec
-from nanobot.channels.base import BaseChannel
+from nanobot.channels.base import BaseChannel, ToolGateway
 from nanobot.channels.contracts import (
     channel_default_config,
     channel_instance_specs,
@@ -97,6 +97,7 @@ class ChannelManager:
         webui_static_dist: bool = True,
         webui_runtime_surface: str = "browser",
         webui_runtime_capabilities: dict[str, Any] | None = None,
+        tool_gateway: ToolGateway | None = None,
     ):
         self.config = config
         self.bus = bus
@@ -109,6 +110,7 @@ class ChannelManager:
         self._webui_static_dist = webui_static_dist
         self._webui_runtime_surface = webui_runtime_surface
         self._webui_runtime_capabilities = dict(webui_runtime_capabilities or {})
+        self._tool_gateway = tool_gateway
         self.channels: dict[str, BaseChannel] = {}
         self._channel_owners: dict[str, str] = {}
         self._channel_runtime_specs: dict[str, tuple[str, str]] = {}
@@ -178,6 +180,10 @@ class ChannelManager:
                 logger=logger,
             )
             kwargs["gateway"] = gateway
+        if cls.wants_tool_gateway:
+            if self._tool_gateway is None:
+                raise RuntimeError(f"{cls.name} requires a tool gateway but none is configured")
+            kwargs["tool_gateway"] = self._tool_gateway
         channel = cls(section, self.bus, **kwargs)
         if runtime_name and runtime_name != channel.name:
             channel.name = runtime_name

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1926,6 +1926,7 @@ def _run_gateway(
         webui_static_dist=webui_static_dist,
         webui_runtime_surface=webui_runtime_surface,
         webui_runtime_capabilities=webui_runtime_capabilities,
+        tool_gateway=agent,
     )
 
     def _pick_heartbeat_target() -> tuple[str, str]:

--- a/tests/agent/test_channel_tool_gateway.py
+++ b/tests/agent/test_channel_tool_gateway.py
@@ -1,0 +1,92 @@
+"""Tests for the guarded tool gateway exposed to opt-in channel plugins."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from nanobot.agent.tools.base import Tool
+from nanobot.agent.tools.context import current_request_context
+from nanobot.agent.tools.schema import StringSchema, tool_parameters_schema
+from nanobot.security.workspace_access import current_workspace_scope
+
+
+class _ContextProbeTool(Tool):
+    @property
+    def name(self) -> str:
+        return "context_probe"
+
+    @property
+    def description(self) -> str:
+        return "Expose the runtime context for a regression test."
+
+    @property
+    def parameters(self) -> dict:
+        return tool_parameters_schema(value=StringSchema("Value to echo"), required=["value"])
+
+    async def execute(self, value: str) -> dict:
+        request = current_request_context()
+        scope = current_workspace_scope()
+        assert request is not None
+        assert scope is not None
+        return {
+            "value": value,
+            "channel": request.channel,
+            "chat_id": request.chat_id,
+            "session_key": request.session_key,
+            "workspace": str(request.workspace),
+            "scope_workspace": str(scope.project_path),
+        }
+
+
+def _provider() -> MagicMock:
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.generation = SimpleNamespace(
+        max_tokens=4096,
+        temperature=0.1,
+        reasoning_effort=None,
+    )
+    return provider
+
+
+@pytest.mark.asyncio
+async def test_channel_tool_gateway_binds_turn_context_and_resets_it(tmp_path, loop_factory):
+    loop = loop_factory(provider=_provider())
+    loop.tools.register(_ContextProbeTool())
+
+    result = await loop.execute_tool(
+        "websocket:chat-1",
+        "context_probe",
+        {"value": "ok"},
+        channel="websocket",
+        chat_id="chat-1",
+    )
+
+    assert result == {
+        "value": "ok",
+        "channel": "websocket",
+        "chat_id": "chat-1",
+        "session_key": "websocket:chat-1",
+        "workspace": str(tmp_path),
+        "scope_workspace": str(tmp_path),
+    }
+    assert current_request_context() is None
+    assert current_workspace_scope() is None
+
+
+@pytest.mark.asyncio
+async def test_channel_tool_gateway_uses_registry_validation(loop_factory):
+    loop = loop_factory(provider=_provider())
+    loop.tools.register(_ContextProbeTool())
+
+    result = await loop.execute_tool(
+        "cli:direct",
+        "context_probe",
+        {},
+        channel="cli",
+        chat_id="direct",
+    )
+
+    assert result.is_error
+    assert "missing required value" in result

--- a/tests/channels/test_channel_plugins.py
+++ b/tests/channels/test_channel_plugins.py
@@ -83,6 +83,24 @@ class _SetupPlugin(_FakePlugin):
         }
 
 
+class _ToolGatewayPlugin(BaseChannel):
+    name = "toolgateway"
+    display_name = "Tool Gateway"
+    wants_tool_gateway = True
+
+    def __init__(self, config, bus, *, tool_gateway):
+        super().__init__(config, bus)
+        self.tool_gateway = tool_gateway
+
+    async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
+
+    async def send(self, msg: OutboundMessage) -> None:
+        pass
+
 class _FakeLine(_FakePlugin):
     name = "line"
     display_name = "Line"
@@ -262,6 +280,16 @@ def test_channels_config_getattr_returns_extra():
     section = getattr(cfg, "myplugin", None)
     assert isinstance(section, dict)
     assert section["enabled"] is True
+
+
+def test_channel_manager_injects_tool_gateway_only_for_opted_in_plugin(monkeypatch: pytest.MonkeyPatch):
+    _stub_channel_registry(monkeypatch, _channel_plugin(_ToolGatewayPlugin))
+    gateway = object()
+    config = Config.model_validate({"channels": {"toolgateway": {"enabled": True}}})
+
+    manager = ChannelManager(config, MessageBus(), tool_gateway=gateway)
+
+    assert manager.channels["toolgateway"].tool_gateway is gateway
 
 
 def test_channels_config_has_no_per_channel_fields():


### PR DESCRIPTION
Closes #4911

## Summary

- Add an opt-in `ToolGateway` protocol for channel plugins.
- Inject it only into channels that declare `wants_tool_gateway = True`.
- Execute gateway tool calls under the same workspace, request, and per-session file-state context as agent turns, through the existing tool registry.
- Document the plugin contract and add regression coverage.

## User impact

Channel plugins that need to run a provider-emitted tool can reuse nanobot's existing validation, workspace restriction, SSRF, and tool-state protections without adding an unguarded execution path. Existing channels are unchanged.

## Validation

- `python -m pytest tests/agent/test_channel_tool_gateway.py tests/channels/test_channel_plugins.py tests/cli/test_commands.py -q`
- `ruff check nanobot/agent/loop.py nanobot/channels/__init__.py nanobot/channels/base.py nanobot/channels/manager.py nanobot/cli/commands.py tests/agent/test_channel_tool_gateway.py tests/channels/test_channel_plugins.py`