### PR TITLE
fix(providers): keep all images when merging consecutive multimodal u…

### DIFF
--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -496,6 +496,33 @@ class LLMProvider(ABC):
         return True
 
     @staticmethod
+    def _merge_same_role_content(left: Any, right: Any) -> str | list[dict[str, Any]]:
+        """Concatenate consecutive same-role contents, including multimodal blocks.
+
+        String+string stays text. Any list/mixed content becomes an ordered
+        block list so prior ``image_url`` parts are not dropped when merging
+        consecutive user turns (e.g. Feishu album listen + later @mention).
+        """
+        if isinstance(left, str) and isinstance(right, str):
+            if not left:
+                return right
+            if not right:
+                return left
+            return f"{left}\n\n{right}".strip()
+
+        def _to_blocks(value: Any) -> list[dict[str, Any]]:
+            if isinstance(value, list):
+                return [
+                    item if isinstance(item, dict) else {"type": "text", "text": str(item)}
+                    for item in value
+                ]
+            if value is None or value == "":
+                return []
+            return [{"type": "text", "text": str(value)}]
+
+        return _to_blocks(left) + _to_blocks(right)
+
+    @staticmethod
     def _enforce_role_alternation(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Merge consecutive same-role messages and drop trailing assistant messages.
 
@@ -525,12 +552,12 @@ class LLMProvider(ABC):
                         continue
                     if prev_has_tools:
                         continue
-                prev_content = prev.get("content") or ""
-                curr_content = msg.get("content") or ""
-                if isinstance(prev_content, str) and isinstance(curr_content, str):
-                    prev["content"] = (prev_content + "\n\n" + curr_content).strip()
-                else:
-                    merged[-1] = dict(msg)
+                prev_content = prev.get("content")
+                curr_content = msg.get("content")
+                prev["content"] = LLMProvider._merge_same_role_content(
+                    prev_content if prev_content is not None else "",
+                    curr_content if curr_content is not None else "",
+                )
             else:
                 merged.append(dict(msg))
 

--- a/tests/providers/test_enforce_role_alternation.py
+++ b/tests/providers/test_enforce_role_alternation.py
@@ -112,14 +112,64 @@ class TestEnforceRoleAlternation:
         assert result[1]["content"] is None
         assert result[2]["role"] == "tool"
 
-    def test_non_string_content_uses_latest(self):
+    def test_non_string_content_concatenates_blocks(self):
+        """Multimodal consecutive users keep all blocks (not keep-latest)."""
         msgs = [
             {"role": "user", "content": [{"type": "text", "text": "A"}]},
             {"role": "user", "content": "B"},
         ]
         result = LLMProvider._enforce_role_alternation(msgs)
         assert len(result) == 1
-        assert result[0]["content"] == "B"
+        content = result[0]["content"]
+        assert isinstance(content, list)
+        assert content[0] == {"type": "text", "text": "A"}
+        assert content[1] == {"type": "text", "text": "B"}
+
+    def test_consecutive_multimodal_users_keep_all_image_url_blocks(self):
+        """Feishu album listen: N image-only user turns must not drop earlier images."""
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,aaa"}},
+                    {"type": "text", "text": ""},
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,bbb"}},
+                    {"type": "text", "text": ""},
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,ccc"}},
+                    {"type": "text", "text": "@bot what do you think?"},
+                ],
+            },
+        ]
+        result = LLMProvider._enforce_role_alternation(msgs)
+        assert len(result) == 1
+        content = result[0]["content"]
+        assert isinstance(content, list)
+        image_urls = [
+            part["image_url"]["url"]
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "image_url"
+        ]
+        assert image_urls == [
+            "data:image/png;base64,aaa",
+            "data:image/png;base64,bbb",
+            "data:image/png;base64,ccc",
+        ]
+        assert any(
+            isinstance(part, dict)
+            and part.get("type") == "text"
+            and "@bot what do you think?" in str(part.get("text", ""))
+            for part in content
+        )
 
     def test_original_messages_not_mutated(self):
         msgs = [


### PR DESCRIPTION
## Summary
- OpenAI-compatible role alternation previously replaced non-string consecutive user content with the **latest** message only.
- Album / multi-image flows that land as consecutive multimodal `user` turns then kept only the last image.
- Concatenate multimodal content blocks when merging same-role messages instead of keep-latest.

### Before
Only the last image was passed as vision content to LLM.
<img width="1124" height="2036" alt="image" src="https://github.com/user-attachments/assets/834b6bc7-2ac5-4c8f-aa52-a6904ab43da2" />

### After
Images sequence is the storyline.
<img width="1124" height="2036" alt="image" src="https://github.com/user-attachments/assets/2fd4004a-80b1-461e-b325-519708a11355" />
<img width="1124" height="2036" alt="image" src="https://github.com/user-attachments/assets/dc52267f-20dc-4a74-aa43-be4114d741a8" />


## Test plan
- [x] `pytest tests/providers/test_enforce_role_alternation.py`
- [ ] Confirm consecutive multimodal user messages retain every `image_url` part after `_enforce_role_alternation`