### PR TITLE
docs(security): recommend env-var references over plaintext API keys

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,6 +21,11 @@ We aim to respond to security reports within 48 hours.
 **CRITICAL**: Never commit API keys to version control.
 
 ```bash
+# ✅ Best: Use environment variable references in config (never writes the key to disk)
+# In ~/.nanobot/config.json:
+#   "apiKey": "${ANTHROPIC_API_KEY}"
+# Then supply the key at runtime via env var or Docker secret.
+
 # ✅ Good: Store in config file with restricted permissions
 chmod 600 ~/.nanobot/config.json
 
@@ -28,9 +33,9 @@ chmod 600 ~/.nanobot/config.json
 ```
 
 **Recommendations:**
-- Store API keys in `~/.nanobot/config.json` with file permissions set to `0600`
-- Consider using environment variables for sensitive keys
-- Use OS keyring/credential manager for production deployments
+- **Prefer environment variable references** (`${VAR}`) in config — the config file stores the `${VAR}` placeholder, and the plaintext value only exists in memory at runtime. See [Configuration: Environment Variables for Secrets](https://nanobot.wiki/docs/latest/use-nanobot/configuration/#environment-variables-for-secrets) for details.
+- When plaintext keys are stored in `~/.nanobot/config.json`, set file permissions to `0600` (`chmod 600`)
+- Consider using an OS keyring/credential manager for production deployments
 - Rotate API keys regularly
 - Use separate API keys for development and production
 
@@ -237,7 +242,7 @@ If you suspect a security breach:
 ⚠️ **Current Security Limitations:**
 
 1. **No Rate Limiting** - Users can send unlimited messages (add your own if needed)
-2. **Plain Text Config** - API keys stored in plain text (use keyring for production)
+2. **Plain Text Config** - API keys stored in plain text in `config.json` (prefer `${VAR}` env references when possible, or use keyring for production)
 3. **No Session Management** - No automatic session expiry
 4. **Limited Command Filtering** - Only blocks obvious dangerous patterns (enable the bwrap sandbox for kernel-level isolation on Linux)
 5. **No Audit Trail** - Limited security event logging (enhance as needed)
@@ -260,7 +265,7 @@ Before deploying nanobot:
 
 ## Updates
 
-**Last Updated**: 2026-04-05
+**Last Updated**: 2026-07-21
 
 For the latest security updates and announcements, check:
 - GitHub Security Advisories: https://github.com/HKUDS/nanobot/security/advisories


### PR DESCRIPTION
## Summary

Update SECURITY.md to recommend \\\ env references as the primary way to store API keys, clarifying that the config file stores a placeholder (not the real secret). Plaintext + \chmod 600\ remains available as a secondary option.

## Changes

- **SECURITY.md §1 (API Key Management):** promote \\\ references to the top recommendation with an \\\ example; add link to Configuration docs
- **Known Limitations #2:** mention \\\ as preferred mitigation
- **Date:** 2026-04-05 → 2026-07-21

## Design

- Documentation-only PR — zero code changes
- Does **not** add \exclude=True\ to the schema (would break WebUI key storage, \\\ placeholders, and \pi.api_key\ auth)
- Does **not** add runtime warnings (to keep scope minimal)

Closes #4803