### PR TITLE
fix(webui): keep Markdown table diffs inline

### DIFF
--- a/webui/src/components/thread/activity/DiffSyntaxHighlight.tsx
+++ b/webui/src/components/thread/activity/DiffSyntaxHighlight.tsx
@@ -79,7 +79,7 @@ const LazyDiffSyntaxHighlight = lazy(async () => {
                 const node = rows[index];
                 if (!node) return line.content || " ";
                 return createSyntaxElement({
-                  node: trimTrailingLineBreak(node),
+                  node: stripConflictingTableClass(trimTrailingLineBreak(node)),
                   stylesheet,
                   useInlineStyles,
                   key: `diff-code-${index}`,
@@ -183,4 +183,27 @@ function trimTrailingLineBreak(node: SyntaxNode): SyntaxNode {
   const children = [...node.children];
   children[children.length - 1] = trimTrailingLineBreak(children[children.length - 1]!);
   return { ...node, children };
+}
+
+function stripConflictingTableClass(node: SyntaxNode): SyntaxNode {
+  const className = node.properties?.className;
+  const children = node.children?.map(stripConflictingTableClass);
+  const hasTableClass = Array.isArray(className) && className.includes("table");
+
+  if (!hasTableClass && !children) return node;
+
+  return {
+    ...node,
+    ...(hasTableClass
+      ? {
+          properties: {
+            ...node.properties,
+            // Tailwind's global `.table` utility changes Prism's inline Markdown
+            // table tokens into CSS tables, splitting a single diff line vertically.
+            className: className.filter((name) => name !== "table"),
+          },
+        }
+      : {}),
+    ...(children ? { children } : {}),
+  };
 }

--- a/webui/src/tests/diff-syntax-highlight.integration.test.tsx
+++ b/webui/src/tests/diff-syntax-highlight.integration.test.tsx
@@ -61,4 +61,41 @@ describe("DiffSyntaxHighlight with Prism", () => {
     expect(highlighted).toHaveAttribute("data-language", "tsx");
     expect(highlighted.querySelectorAll("tbody tr")).toHaveLength(4);
   });
+
+  it("preserves markdown table line boundaries", async () => {
+    const lines = [
+      "## 发布安排",
+      "",
+      "| 日期 | 角色 | 方向 | 是否进实验 |",
+      "| --- | --- | --- | --- |",
+      "| 7/22 | trust / core | data-driven | yes |",
+    ];
+
+    render(
+      <ThemeProvider theme="light">
+        <DiffSyntaxHighlight
+          language="markdown"
+          lines={lines.map((content, index) => ({
+            kind: "add" as const,
+            old_lineno: null,
+            new_lineno: 20 + index,
+            content,
+          }))}
+        />
+      </ThemeProvider>,
+    );
+
+    const highlighted = await screen.findByTestId(
+      "syntax-highlighted-diff-hunk",
+      {},
+      { timeout: 10_000 },
+    );
+    const rows = [...highlighted.querySelectorAll("tbody tr")];
+
+    expect(rows).toHaveLength(lines.length);
+    expect(rows.map((row) => row.querySelector("td:last-child")?.textContent)).toEqual(
+      lines.map((line) => line || " "),
+    );
+    expect(highlighted.querySelector(".token.table")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

- prevent Prism's Markdown `table` token class from colliding with Tailwind's global `.table` layout utility in file-edit diffs
- preserve the existing per-line diff rendering and syntax highlighting for Markdown content
- add a Prism integration regression test covering a Markdown table diff

## Root cause

Prism emits `table` as a token class for Markdown tables. Tailwind also defines `.table { display: table }`, so those inline syntax tokens were laid out as CSS tables and a single diff line expanded vertically.

## Verification

- [x] `bun run test -- src/tests/diff-syntax-highlight.test.tsx src/tests/diff-syntax-highlight.integration.test.tsx` (3 tests passed)
- [x] `bun run lint`
- [x] `bun run build`
- [x] Real gateway + headless Playwright: 5 source lines rendered as 5 rows at 22px each, all syntax tokens remained inline, and no `.token.table` elements remained