### PR TITLE
feat(skills): support explicit context loading

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -84,12 +84,14 @@ class ContextBuilder:
             parts.append(f"# Memory\n\n{memory}")
 
         always_skills = self.skills.get_always_skills()
-        if always_skills:
-            always_content = self.skills.load_skills_for_context(always_skills)
-            if always_content:
-                parts.append(f"# Active Skills\n\n{always_content}")
+        requested_skills = self.skills.validate_skill_names(skill_names or [])
+        active_skills = list(dict.fromkeys([*always_skills, *requested_skills]))
+        if active_skills:
+            active_content = self.skills.load_skills_for_context(active_skills)
+            if active_content:
+                parts.append(f"# Active Skills\n\n{active_content}")
 
-        skills_summary = self.skills.build_skills_summary(exclude=set(always_skills))
+        skills_summary = self.skills.build_skills_summary(exclude=set(active_skills))
         if skills_summary:
             parts.append(render_template("agent/skills_section.md", skills_summary=skills_summary))
 

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -99,6 +99,10 @@ if TYPE_CHECKING:
     )
     from nanobot.cron.service import CronService
 
+
+_TURN_SKILL_NAMES_META_KEY = "_turn_skill_names"
+
+
 class TurnState(Enum):
     RESTORE = auto()
     COMPACT = auto()
@@ -701,9 +705,11 @@ class AgentLoop:
         assert ctx.session is not None
         is_subagent = ctx.kind is TurnKind.SYSTEM and ctx.msg.sender_id == "subagent"
         scope = self.workspace_scopes.for_message(ctx.msg, ctx.session.metadata)
+        skill_names = ctx.msg.metadata.get(_TURN_SKILL_NAMES_META_KEY)
         return self.context.build_messages(
             history=ctx.history,
             current_message="" if is_subagent else ctx.msg.content,
+            skill_names=skill_names,
             media=ctx.msg.media if ctx.kind is TurnKind.USER and ctx.msg.media else None,
             channel=ctx.route.channel,
             chat_id=str(ctx.msg.metadata.get("context_chat_id") or ctx.route.chat_id),
@@ -1939,6 +1945,7 @@ class AgentLoop:
         chat_id: str = "direct",
         sender_id: str = "user",
         media: list[str] | None = None,
+        skill_names: list[str] | None = None,
         on_progress: Callable[..., Awaitable[None]] | None = None,
         on_stream: Callable[[str], Awaitable[None]] | None = None,
         on_stream_end: Callable[..., Awaitable[None]] | None = None,
@@ -1953,8 +1960,15 @@ class AgentLoop:
         """Process an external message directly and return the outbound payload."""
         if channel == "system":
             raise ValueError("channel 'system' is reserved for internal messages")
+        if skill_names is not None and (
+            not isinstance(skill_names, list)
+            or any(not isinstance(name, str) or not name for name in skill_names)
+        ):
+            raise ValueError("skill_names must be a list of non-empty strings")
         await self._connect_mcp()
         metadata: dict[str, Any] = {}
+        if skill_names is not None:
+            metadata[_TURN_SKILL_NAMES_META_KEY] = list(skill_names)
         if not persist_user_message:
             metadata[turn_continuation.SKIP_USER_PERSIST_META] = True
         msg = InboundMessage(

--- a/nanobot/agent/skills.py
+++ b/nanobot/agent/skills.py
@@ -4,6 +4,8 @@ import json
 import os
 import re
 import shutil
+from copy import deepcopy
+from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
@@ -18,6 +20,16 @@ _STRIP_SKILL_FRONTMATTER = re.compile(
 )
 
 
+@dataclass(frozen=True)
+class _CachedSkill:
+    """Parsed skill file cached until its filesystem signature changes."""
+
+    mtime_ns: int
+    size: int
+    content: str
+    metadata: dict[str, object] | None
+
+
 class SkillsLoader:
     """
     Loader for agent skills.
@@ -26,11 +38,17 @@ class SkillsLoader:
     specific tools or perform certain tasks.
     """
 
-    def __init__(self, workspace: Path, builtin_skills_dir: Path | None = None, disabled_skills: set[str] | None = None):
+    def __init__(
+        self,
+        workspace: Path,
+        builtin_skills_dir: Path | None = None,
+        disabled_skills: set[str] | None = None,
+    ):
         self.workspace = workspace
         self.workspace_skills = workspace / "skills"
         self.builtin_skills = builtin_skills_dir or BUILTIN_SKILLS_DIR
         self.disabled_skills = disabled_skills or set()
+        self._skill_cache: dict[Path, _CachedSkill] = {}
 
     def _skill_entries_from_dir(self, base: Path, source: str, *, skip_names: set[str] | None = None) -> list[dict[str, str]]:
         if not base.exists():
@@ -88,8 +106,27 @@ class SkillsLoader:
         for root in roots:
             path = root / name / "SKILL.md"
             if path.exists():
-                return path.read_text(encoding="utf-8")
+                cached = self._read_skill(path)
+                return cached.content if cached else None
         return None
+
+    def validate_skill_names(self, skill_names: list[str]) -> list[str]:
+        """Validate explicitly requested skills and return them without duplicates."""
+        entries = {entry["name"] for entry in self.list_skills(filter_unavailable=False)}
+        validated: list[str] = []
+        for name in skill_names:
+            if name in validated:
+                continue
+            if name in self.disabled_skills:
+                raise ValueError(f"Skill '{name}' is disabled.")
+            if name not in entries:
+                raise ValueError(f"Skill '{name}' was not found.")
+            available, missing = self.get_skill_availability(name)
+            if not available:
+                detail = f": {missing}" if missing else ""
+                raise ValueError(f"Skill '{name}' is unavailable{detail}.")
+            validated.append(name)
+        return validated
 
     def load_skills_for_context(self, skill_names: list[str]) -> str:
         """
@@ -133,12 +170,13 @@ class SkillsLoader:
             meta = self._get_skill_meta(skill_name)
             available = self._check_requirements(meta)
             desc = self._get_skill_description(skill_name)
+            display_path = (Path("skills") / skill_name / "SKILL.md").as_posix()
             if available:
-                lines.append(f"- **{skill_name}** — {desc}  `{entry['path']}`")
+                lines.append(f"- **{skill_name}** — {desc}  `{display_path}`")
             else:
                 missing = self._get_missing_requirements(meta)
                 suffix = f" (unavailable: {missing})" if missing else " (unavailable)"
-                lines.append(f"- **{skill_name}** — {desc}{suffix}  `{entry['path']}`")
+                lines.append(f"- **{skill_name}** — {desc}{suffix}  `{display_path}`")
         return "\n".join(lines)
 
     def _get_missing_requirements(self, skill_meta: dict) -> str:
@@ -214,7 +252,7 @@ class SkillsLoader:
         )
 
     def _get_skill_meta(self, name: str) -> dict:
-        """Get nanobot metadata for a skill (cached in frontmatter)."""
+        """Get nanobot metadata for a skill."""
         raw_meta = self.get_skill_metadata(name) or {}
         return self._parse_nanobot_metadata(raw_meta.get("metadata"))
 
@@ -240,8 +278,45 @@ class SkillsLoader:
         Returns:
             Metadata dict or None.
         """
-        content = self.load_skill(name)
-        if not content or not content.startswith("---"):
+        roots = [self.workspace_skills]
+        if self.builtin_skills:
+            roots.append(self.builtin_skills)
+        for root in roots:
+            path = root / name / "SKILL.md"
+            if path.exists():
+                cached = self._read_skill(path)
+                if cached and cached.metadata is not None:
+                    return deepcopy(cached.metadata)
+                return None
+        return None
+
+    def _read_skill(self, path: Path) -> _CachedSkill | None:
+        """Read and parse a skill once, invalidating the cache after file changes."""
+        try:
+            stat = path.stat()
+        except OSError:
+            self._skill_cache.pop(path, None)
+            return None
+
+        cached = self._skill_cache.get(path)
+        if cached and cached.mtime_ns == stat.st_mtime_ns and cached.size == stat.st_size:
+            return cached
+
+        content = path.read_text(encoding="utf-8")
+        metadata = self._parse_frontmatter(content)
+        cached = _CachedSkill(
+            mtime_ns=stat.st_mtime_ns,
+            size=stat.st_size,
+            content=content,
+            metadata=metadata,
+        )
+        self._skill_cache[path] = cached
+        return cached
+
+    @staticmethod
+    def _parse_frontmatter(content: str) -> dict[str, object] | None:
+        """Parse YAML frontmatter while preserving native YAML value types."""
+        if not content.startswith("---"):
             return None
         match = _STRIP_SKILL_FRONTMATTER.match(content)
         if not match:
@@ -252,9 +327,4 @@ class SkillsLoader:
             return None
         if not isinstance(parsed, dict):
             return None
-        # yaml.safe_load returns native types (int, bool, list, etc.);
-        # keep values as-is so downstream consumers get correct types.
-        metadata: dict[str, object] = {}
-        for key, value in parsed.items():
-            metadata[str(key)] = value
-        return metadata
+        return {str(key): value for key, value in parsed.items()}

--- a/nanobot/nanobot.py
+++ b/nanobot/nanobot.py
@@ -132,6 +132,7 @@ class Nanobot:
         chat_id: str = "direct",
         sender_id: str = "user",
         media: list[str] | None = None,
+        skill_names: list[str] | None = None,
         ephemeral: bool = False,
         hooks: list[AgentHook] | None = None,
         model: str | None = None,
@@ -147,6 +148,7 @@ class Nanobot:
             chat_id: Logical chat identifier for runtime context.
             sender_id: Logical sender identifier for runtime context.
             media: Optional local media paths attached to the message.
+            skill_names: Skills to preload for this run only.
             ephemeral: If true, do not persist the turn or compact session history.
             hooks: Optional lifecycle hooks for this run.
             model: Override the model for this run only.
@@ -165,6 +167,7 @@ class Nanobot:
             chat_id=chat_id,
             sender_id=sender_id,
             media=media,
+            skill_names=skill_names,
             ephemeral=ephemeral,
         )
         if runtime is not None:
@@ -186,6 +189,7 @@ class Nanobot:
         chat_id: str = "direct",
         sender_id: str = "user",
         media: list[str] | None = None,
+        skill_names: list[str] | None = None,
         ephemeral: bool = False,
         hooks: list[AgentHook] | None = None,
         model: str | None = None,
@@ -216,6 +220,7 @@ class Nanobot:
                 chat_id=chat_id,
                 sender_id=sender_id,
                 media=media,
+                skill_names=skill_names,
                 ephemeral=ephemeral,
                 on_stream=_on_stream,
                 on_stream_end=_on_stream_end,
@@ -270,6 +275,7 @@ class Nanobot:
         chat_id: str = "direct",
         sender_id: str = "user",
         media: list[str] | None = None,
+        skill_names: list[str] | None = None,
         ephemeral: bool = False,
         hooks: list[AgentHook] | None = None,
         model: str | None = None,
@@ -283,6 +289,7 @@ class Nanobot:
             chat_id=chat_id,
             sender_id=sender_id,
             media=media,
+            skill_names=skill_names,
             ephemeral=ephemeral,
             hooks=hooks,
             model=model,

--- a/nanobot/sdk/runtime.py
+++ b/nanobot/sdk/runtime.py
@@ -22,6 +22,7 @@ def build_process_direct_kwargs(
     sender_id: str,
     media: list[str] | None,
     ephemeral: bool,
+    skill_names: list[str] | None = None,
     on_stream: Any | None = None,
     on_stream_end: Any | None = None,
 ) -> dict[str, Any]:
@@ -34,6 +35,8 @@ def build_process_direct_kwargs(
         kwargs["sender_id"] = sender_id
     if media is not None:
         kwargs["media"] = media
+    if skill_names is not None:
+        kwargs["skill_names"] = list(skill_names)
     if ephemeral:
         kwargs["ephemeral"] = True
         kwargs["_run_extra_hooks_for_ephemeral"] = True

--- a/tests/agent/test_context_builder.py
+++ b/tests/agent/test_context_builder.py
@@ -263,6 +263,28 @@ class TestBuildSystemPrompt:
         assert "## AGENTS.md" not in result
         assert "[Archived Context Summary]" not in result
 
+    def test_requested_skill_is_loaded_and_removed_from_summary(self, tmp_path):
+        skill_dir = tmp_path / "skills" / "review"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: review\ndescription: Review code\n---\n\n# Review Instructions\n",
+            encoding="utf-8",
+        )
+        builder = _builder(tmp_path)
+
+        result = builder.build_system_prompt(skill_names=["review"])
+
+        assert "# Active Skills" in result
+        assert "### Skill: review" in result
+        assert "# Review Instructions" in result
+        assert "- **review**" not in result
+
+    def test_requested_skill_must_exist(self, tmp_path):
+        builder = _builder(tmp_path)
+
+        with pytest.raises(ValueError, match="not found"):
+            builder.build_system_prompt(skill_names=["missing"])
+
 
 # ---------------------------------------------------------------------------
 # build_messages

--- a/tests/agent/test_loop_runner_integration.py
+++ b/tests/agent/test_loop_runner_integration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -232,6 +233,100 @@ async def test_runtime_context_provider_runs_once_across_tool_iterations(tmp_pat
     assert provider_calls == 1
     for call in provider.chat_with_retry.await_args_list:
         assert "frozen context" in str(call.kwargs["messages"])
+
+
+@pytest.mark.asyncio
+async def test_process_direct_preloads_skills_for_current_turn_only(tmp_path):
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    skill_dir = tmp_path / "skills" / "review"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: review\ndescription: Review code\n---\n\n"
+        "# Per-run Review Instructions\n",
+        encoding="utf-8",
+    )
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.generation = GenerationSettings()
+    provider.chat_with_retry = AsyncMock(side_effect=[
+        LLMResponse(content="first answer", usage={}),
+        LLMResponse(content="second answer", usage={}),
+    ])
+    loop = AgentLoop(bus=MessageBus(), provider=provider, workspace=tmp_path, model="test-model")
+    loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=None)
+
+    await loop.process_direct(
+        "first turn",
+        session_key="sdk:skills",
+        skill_names=["review"],
+    )
+    await loop.process_direct("second turn", session_key="sdk:skills")
+
+    first_messages = provider.chat_with_retry.await_args_list[0].kwargs["messages"]
+    second_messages = provider.chat_with_retry.await_args_list[1].kwargs["messages"]
+    first_system = first_messages[0]["content"]
+    second_system = second_messages[0]["content"]
+    assert "### Skill: review" in first_system
+    assert "# Per-run Review Instructions" in first_system
+    assert "- **review**" not in first_system
+    assert "# Per-run Review Instructions" not in second_system
+    assert "- **review**" in second_system
+
+
+@pytest.mark.asyncio
+async def test_process_direct_rejects_malformed_skill_names(tmp_path):
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.generation = GenerationSettings()
+    loop = AgentLoop(bus=MessageBus(), provider=provider, workspace=tmp_path, model="test-model")
+
+    with pytest.raises(ValueError, match="list of non-empty strings"):
+        await loop.process_direct("test", skill_names="review")  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_process_direct_keeps_concurrent_skill_contexts_isolated(tmp_path):
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    for name in ("alpha", "beta"):
+        skill_dir = tmp_path / "skills" / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: {name} skill\n---\n\n"
+            f"# {name.title()} Unique Instructions\n",
+            encoding="utf-8",
+        )
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.generation = GenerationSettings()
+    captured: dict[str, str] = {}
+
+    async def capture_messages(**kwargs):
+        messages = kwargs["messages"]
+        user_text = str(messages[-1]["content"])
+        captured[user_text] = messages[0]["content"]
+        await asyncio.sleep(0)
+        return LLMResponse(content="done", usage={})
+
+    provider.chat_with_retry = AsyncMock(side_effect=capture_messages)
+    loop = AgentLoop(bus=MessageBus(), provider=provider, workspace=tmp_path, model="test-model")
+    loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=None)
+
+    await asyncio.gather(
+        loop.process_direct("alpha turn", session_key="sdk:alpha", skill_names=["alpha"]),
+        loop.process_direct("beta turn", session_key="sdk:beta", skill_names=["beta"]),
+    )
+
+    assert "# Alpha Unique Instructions" in captured["alpha turn"]
+    assert "# Beta Unique Instructions" not in captured["alpha turn"]
+    assert "# Beta Unique Instructions" in captured["beta turn"]
+    assert "# Alpha Unique Instructions" not in captured["beta turn"]
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_skills_loader.py
+++ b/tests/agent/test_skills_loader.py
@@ -282,6 +282,48 @@ def test_disabled_skills_empty_set_no_effect(tmp_path: Path) -> None:
     assert len(entries) == 2
 
 
+def test_validate_skill_names_rejects_disabled_missing_and_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "ws"
+    ws_skills = workspace / "skills"
+    ws_skills.mkdir(parents=True)
+    _write_skill(ws_skills, "disabled", body="# Disabled")
+    _write_skill(
+        ws_skills,
+        "unavailable",
+        metadata_json={"requires": {"bins": ["nanobot_test_fake_binary"]}},
+    )
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+    monkeypatch.setattr("nanobot.agent.skills.shutil.which", lambda _cmd: None)
+
+    loader = SkillsLoader(
+        workspace,
+        builtin_skills_dir=builtin,
+        disabled_skills={"disabled"},
+    )
+    with pytest.raises(ValueError, match="disabled"):
+        loader.validate_skill_names(["disabled"])
+    with pytest.raises(ValueError, match="not found"):
+        loader.validate_skill_names(["missing"])
+    with pytest.raises(ValueError, match="CLI: nanobot_test_fake_binary"):
+        loader.validate_skill_names(["unavailable"])
+
+
+def test_validate_skill_names_preserves_order_and_removes_duplicates(tmp_path: Path) -> None:
+    workspace = tmp_path / "ws"
+    ws_skills = workspace / "skills"
+    ws_skills.mkdir(parents=True)
+    _write_skill(ws_skills, "alpha")
+    _write_skill(ws_skills, "beta")
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+
+    loader = SkillsLoader(workspace, builtin_skills_dir=builtin)
+    assert loader.validate_skill_names(["beta", "alpha", "beta"]) == ["beta", "alpha"]
+
+
 def test_disabled_skills_excluded_from_build_skills_summary(tmp_path: Path) -> None:
     workspace = tmp_path / "ws"
     ws_skills = workspace / "skills"
@@ -339,6 +381,72 @@ def test_build_skills_summary_folded_description(tmp_path: Path) -> None:
     summary = loader.build_skills_summary()
     assert "pdf" in summary
     assert "visual quality" in summary
+
+
+def test_build_skills_summary_uses_stable_workspace_relative_paths(tmp_path: Path) -> None:
+    workspace = tmp_path / "ws"
+    ws_skills = workspace / "skills"
+    ws_skills.mkdir(parents=True)
+    skill_path = _write_skill(ws_skills, "alpha", body="# Alpha")
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+
+    loader = SkillsLoader(workspace, builtin_skills_dir=builtin)
+    summary = loader.build_skills_summary()
+    assert "`skills/alpha/SKILL.md`" in summary
+    assert str(skill_path) not in summary
+
+
+def test_skill_file_is_read_once_until_it_changes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "ws"
+    ws_skills = workspace / "skills"
+    ws_skills.mkdir(parents=True)
+    skill_path = _write_skill(ws_skills, "alpha", body="# Alpha")
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+    original_read_text = Path.read_text
+    reads = 0
+
+    def tracked_read_text(path: Path, *args, **kwargs) -> str:
+        nonlocal reads
+        if path == skill_path:
+            reads += 1
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", tracked_read_text)
+    loader = SkillsLoader(workspace, builtin_skills_dir=builtin)
+
+    loader.build_skills_summary()
+    loader.get_skill_metadata("alpha")
+    loader.load_skill("alpha")
+    assert reads == 1
+
+    skill_path.write_text("---\ndescription: Updated description\n---\n\n# Alpha\n", encoding="utf-8")
+    assert "Updated description" in loader.build_skills_summary()
+    assert reads == 2
+
+
+def test_cached_metadata_is_not_mutated_by_callers(tmp_path: Path) -> None:
+    workspace = tmp_path / "ws"
+    ws_skills = workspace / "skills"
+    ws_skills.mkdir(parents=True)
+    _write_skill(
+        ws_skills,
+        "alpha",
+        metadata_json={"requires": {"bins": ["original"]}},
+    )
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+    loader = SkillsLoader(workspace, builtin_skills_dir=builtin)
+
+    metadata = loader.get_skill_metadata("alpha")
+    assert metadata is not None
+    metadata["metadata"]["nanobot"]["requires"]["bins"].append("mutated")
+
+    requirements = loader.get_skill_requirements("alpha")
+    assert requirements["bins"] == ["original"]
 
 
 def test_build_skills_summary_literal_description(tmp_path: Path) -> None:

--- a/tests/test_nanobot_facade.py
+++ b/tests/test_nanobot_facade.py
@@ -450,6 +450,41 @@ async def test_run_ephemeral_still_captures_runner_observability(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_run_preloads_requested_skill_in_provider_system_prompt(tmp_path):
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+    from nanobot.providers.base import GenerationSettings, LLMResponse
+
+    skill_dir = tmp_path / "skills" / "review"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: review\ndescription: Review code\n---\n\n"
+        "# SDK Review Instructions\n",
+        encoding="utf-8",
+    )
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.generation = GenerationSettings()
+    provider.chat_with_retry = AsyncMock(
+        return_value=LLMResponse(content="done", tool_calls=[], usage={})
+    )
+    bot = Nanobot(AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+    ))
+    bot._loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=None)
+
+    result = await bot.run("review this", skill_names=["review"])
+
+    assert result.content == "done"
+    messages = provider.chat_with_retry.await_args.kwargs["messages"]
+    assert "### Skill: review" in messages[0]["content"]
+    assert "# SDK Review Instructions" in messages[0]["content"]
+
+
+@pytest.mark.asyncio
 async def test_run_forwards_non_default_runtime_options(tmp_path):
     from nanobot.bus.events import OutboundMessage
 
@@ -466,6 +501,7 @@ async def test_run_forwards_non_default_runtime_options(tmp_path):
         chat_id="chat-a",
         sender_id="alice",
         media=["/tmp/image.png"],
+        skill_names=["review"],
         ephemeral=True,
     )
 
@@ -476,6 +512,7 @@ async def test_run_forwards_non_default_runtime_options(tmp_path):
         chat_id="chat-a",
         sender_id="alice",
         media=["/tmp/image.png"],
+        skill_names=["review"],
         ephemeral=True,
         _run_extra_hooks_for_ephemeral=True,
         hooks=ANY,
@@ -905,6 +942,7 @@ async def test_run_streamed_forwards_runtime_options(tmp_path):
         chat_id="chat-a",
         sender_id="alice",
         media=["/tmp/image.png"],
+        skill_names=["review"],
         ephemeral=True,
     )
     await run.wait()
@@ -917,6 +955,7 @@ async def test_run_streamed_forwards_runtime_options(tmp_path):
     assert kwargs["chat_id"] == "chat-a"
     assert kwargs["sender_id"] == "alice"
     assert kwargs["media"] == ["/tmp/image.png"]
+    assert kwargs["skill_names"] == ["review"]
     assert kwargs["ephemeral"] is True
     assert callable(kwargs["on_stream"])
     assert callable(kwargs["on_stream_end"])


### PR DESCRIPTION
## Problem
nanobot already exposes a `skill_names` input on `ContextBuilder`, but the value was ignored when building the system prompt. As a result, direct callers could not preload explicitly requested skills; only `always: true` skills were injected automatically, while ordinary skills remained in the progressive-loading summary.
Prompt construction also repeatedly read and parsed the same `SKILL.md` frontmatter, and the generated skill summary embedded machine-specific absolute paths. That added avoidable filesystem/YAML work and made the system prompt less stable across workspaces.

## Current approach
- validate explicitly supplied `skill_names`, rejecting missing, disabled, or unavailable skills
- merge requested skills with `always: true` skills, inject their full content under `# Active Skills`, and remove them from the remaining skill summary
- cache parsed `SKILL.md` content and metadata by file modification time and size, invalidating the entry when the file changes
- return defensive copies of cached metadata so callers cannot mutate the cached value
- use stable `skills/<name>/SKILL.md` paths in progressive-loading summaries instead of host-specific absolute paths


## Validation
- `221 passed` across skill loading, context, prompt-cache, command, filesystem, subagent, and WebUI route tests
- `ruff check nanobot/agent/skills.py nanobot/agent/context.py tests/agent/test_skills_loader.py tests/agent/test_context_builder.py`
- `git diff --check origin/main...HEAD`