### PR TITLE
fix(subagent): cascade exec session termination on /stop

### DIFF
--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -457,6 +457,7 @@ class SubagentManager:
             t.cancel()
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
+        await self._exec_session_manager.terminate_by_owner(session_key)
         return len(tasks)
 
     async def close(self) -> None:

--- a/nanobot/agent/tools/exec_session.py
+++ b/nanobot/agent/tools/exec_session.py
@@ -341,10 +341,25 @@ class ExecSessionManager:
             for sid, s in list(self._sessions.items()):
                 if s.owner_session_key == owner_session_key:
                     victims.append(self._sessions.pop(sid))
-        await asyncio.gather(
+        results = await asyncio.gather(
             *(s.kill() for s in victims),
             return_exceptions=True,
         )
+        failures = [
+            (session, result)
+            for session, result in zip(victims, results, strict=True)
+            if isinstance(result, BaseException)
+        ]
+        if failures:
+            async with self._lock:
+                for session, _ in failures:
+                    self._sessions[session.session_id] = session
+            if len(failures) == 1:
+                raise failures[0][1]
+            raise BaseExceptionGroup(
+                "failed to terminate exec sessions by owner",
+                [result for _, result in failures],
+            )
         return len(victims)
 
     async def _cleanup_locked(self) -> None:

--- a/nanobot/agent/tools/exec_session.py
+++ b/nanobot/agent/tools/exec_session.py
@@ -334,6 +334,19 @@ class ExecSessionManager:
             )
         return len(sessions)
 
+    async def terminate_by_owner(self, owner_session_key: str) -> int:
+        """Terminate all sessions owned by owner_session_key. Returns count."""
+        async with self._lock:
+            victims = []
+            for sid, s in list(self._sessions.items()):
+                if s.owner_session_key == owner_session_key:
+                    victims.append(self._sessions.pop(sid))
+        await asyncio.gather(
+            *(s.kill() for s in victims),
+            return_exceptions=True,
+        )
+        return len(victims)
+
     async def _cleanup_locked(self) -> None:
         now = time.monotonic()
         stale = [

--- a/tests/agent/test_task_cancel.py
+++ b/tests/agent/test_task_cancel.py
@@ -275,6 +275,27 @@ class TestSubagentCancellation:
         assert await mgr.cancel_by_session("nonexistent") == 0
 
     @pytest.mark.asyncio
+    async def test_cancel_by_session_terminates_exec_sessions(self):
+        from nanobot.agent.subagent import SubagentManager
+        from nanobot.agent.tools.exec_session import ExecSessionManager
+        from nanobot.bus.queue import MessageBus
+
+        bus = MessageBus()
+        mgr = SubagentManager(
+            workspace=MagicMock(),
+            bus=bus,
+            max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        )
+        # Replace the real exec session manager with a mock
+        mock_exec_mgr = AsyncMock(spec=ExecSessionManager)
+        mock_exec_mgr.terminate_by_owner = AsyncMock(return_value=0)
+        mgr._exec_session_manager = mock_exec_mgr
+
+        await mgr.cancel_by_session("test:c1")
+
+        mock_exec_mgr.terminate_by_owner.assert_awaited_once_with("test:c1")
+
+    @pytest.mark.asyncio
     async def test_subagent_preserves_reasoning_fields_in_tool_turn(self, monkeypatch, tmp_path):
         from nanobot.agent.subagent import SubagentManager
         from nanobot.bus.queue import MessageBus

--- a/tests/tools/test_exec_session_tools.py
+++ b/tests/tools/test_exec_session_tools.py
@@ -679,6 +679,29 @@ def test_terminate_by_owner_returns_zero_for_no_match(tmp_path):
     asyncio.run(run())
 
 
+def test_terminate_by_owner_retains_failed_sessions():
+    async def run() -> None:
+        manager = ExecSessionManager()
+        session = SimpleNamespace(
+            session_id="failed",
+            owner_session_key="cli:a",
+            kill=AsyncMock(side_effect=OSError("termination failed")),
+        )
+        manager._sessions[session.session_id] = session
+
+        with pytest.raises(OSError, match="termination failed"):
+            await manager.terminate_by_owner("cli:a")
+
+        assert manager._sessions == {session.session_id: session}
+        session.kill.assert_awaited_once()
+
+        session.kill.side_effect = None
+        assert await manager.terminate_by_owner("cli:a") == 1
+        assert manager._sessions == {}
+
+    asyncio.run(run())
+
+
 def test_terminate_by_owner_skips_sessions_without_owner_key(tmp_path):
     async def run() -> None:
         manager = ExecSessionManager()

--- a/tests/tools/test_exec_session_tools.py
+++ b/tests/tools/test_exec_session_tools.py
@@ -622,6 +622,88 @@ def test_agent_loop_shutdown_attempts_all_cleanup_after_errors(monkeypatch):
     asyncio.run(run())
 
 
+def test_terminate_by_owner_kills_matching_sessions(tmp_path):
+    async def run() -> None:
+        manager = ExecSessionManager()
+        tool = ExecTool(working_dir=str(tmp_path), timeout=30, session_manager=manager)
+
+        token_a = bind_request_context(
+            RequestContext(channel="cli", chat_id="a", session_key="cli:a")
+        )
+        try:
+            initial_a = await tool.execute(
+                command=_waiting_shell_command("a_ready"),
+                yield_time_ms=100,
+            )
+        finally:
+            reset_request_context(token_a)
+        sid_a = _session_id(initial_a)
+
+        token_b = bind_request_context(
+            RequestContext(channel="cli", chat_id="b", session_key="cli:b")
+        )
+        try:
+            initial_b = await tool.execute(
+                command=_waiting_shell_command("b_ready"),
+                yield_time_ms=100,
+            )
+        finally:
+            reset_request_context(token_b)
+        sid_b = _session_id(initial_b)
+
+        proc_a = manager._sessions[sid_a].process
+        proc_b = manager._sessions[sid_b].process
+        assert proc_a.returncode is None
+        assert proc_b.returncode is None
+
+        killed = await manager.terminate_by_owner("cli:a")
+
+        assert killed == 1
+        assert proc_a.returncode is not None
+        assert proc_b.returncode is None
+        assert sid_a not in manager._sessions
+        assert sid_b in manager._sessions
+
+        await manager.close_all()
+
+    asyncio.run(run())
+
+
+def test_terminate_by_owner_returns_zero_for_no_match(tmp_path):
+    async def run() -> None:
+        manager = ExecSessionManager()
+        killed = await manager.terminate_by_owner("nonexistent")
+        assert killed == 0
+        assert manager._sessions == {}
+
+    asyncio.run(run())
+
+
+def test_terminate_by_owner_skips_sessions_without_owner_key(tmp_path):
+    async def run() -> None:
+        manager = ExecSessionManager()
+        tool = ExecTool(working_dir=str(tmp_path), timeout=30, session_manager=manager)
+
+        # Spawn without owner (no request context)
+        initial = await tool.execute(
+            command=_waiting_shell_command("ready"),
+            yield_time_ms=100,
+        )
+        sid = _session_id(initial)
+        proc = manager._sessions[sid].process
+        assert proc.returncode is None
+
+        killed = await manager.terminate_by_owner("cli:a")
+
+        assert killed == 0
+        assert proc.returncode is None
+        assert sid in manager._sessions
+
+        await manager.close_all()
+
+    asyncio.run(run())
+
+
 def test_agent_loop_shutdown_preserves_single_cleanup_error(monkeypatch):
     async def run() -> None:
         loop = object.__new__(AgentLoop)


### PR DESCRIPTION
## Problem

  `/stop` cancels subagent asyncio tasks but leaves their child processes running. If a subagent had spawned a long-running shell via the `exec` tool, those subprocesses survived the cancellation and could persist for up to 30 minutes (idle timeout) — or indefinitely if no further exec calls triggered the lazy cleanup path.

  Root cause: `cancel_by_session()` only called `Task.cancel()`, which does not cascade to `asyncio.subprocess.Process`. Meanwhile `ExecSessionManager` has no background reaper; cleanup is purely lazy, triggered only on the next `start`/`write`/`list` call.

  ## Fix

- Add `ExecSessionManager.terminate_by_owner()` — terminates all exec
    sessions owned by a given session key, reusing the existing `kill()` logic
    (process tree termination + stdout/stderr drain).
- Call `terminate_by_owner()` at the end of `cancel_by_session()` so that
    `/stop` fully tears down both the logical task and its underlying OS
    resources.