### PR TITLE
fix(providers): add Qwen model-level thinking style mapping

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -99,9 +99,20 @@ _THINKING_STYLE_MAP: dict[str, Any] = {
 _GATEWAY_REASONING_STYLE_MAP: dict[str, Any] = {
     "reasoning_effort": lambda effort: {"reasoning": {"effort": effort}},
 }
+_QWEN_THINKING_MODELS: frozenset[str] = frozenset({
+    "qwen3.7-max",
+    "qwen3.7-plus",
+    "qwen3.6-max-preview",
+    "qwen3.6-plus",
+    "qwen3.6-flash",
+    "qwen3.5-plus",
+    "qwen3.5-flash",
+})
+
 _MODEL_THINKING_STYLES: dict[str, str] = {
     **dict.fromkeys(_KIMI_THINKING_MODELS, "thinking_type"),
     **dict.fromkeys(_MIMO_THINKING_MODELS, "thinking_type"),
+    **dict.fromkeys(_QWEN_THINKING_MODELS, "enable_thinking"),
 }
 
 

--- a/tests/providers/test_litellm_kwargs.py
+++ b/tests/providers/test_litellm_kwargs.py
@@ -1707,6 +1707,27 @@ def test_dashscope_thinking_disabled_for_none_string() -> None:
     assert "reasoning_effort" not in kw
 
 
+def test_qwen_thinking_enabled_via_model_level_mapping() -> None:
+    """Non-DashScope providers (e.g. OpenRouter) must pick up model-level
+    enable_thinking for Qwen models when reasoning_effort is set."""
+    kw = _build_kwargs_for("openrouter", "qwen/qwen3.6-flash", reasoning_effort="medium")
+    assert kw["extra_body"] == {"enable_thinking": True, "reasoning": {"effort": "medium"}}
+
+
+def test_qwen_thinking_disabled_via_model_level_mapping() -> None:
+    """reasoning_effort='none' must send enable_thinking: False via model-level
+    mapping on non-DashScope providers."""
+    kw = _build_kwargs_for("openrouter", "qwen/qwen3.5-flash", reasoning_effort="none")
+    assert kw["extra_body"] == {"enable_thinking": False}
+
+
+def test_qwen_no_extra_body_when_reasoning_effort_omitted() -> None:
+    """Without reasoning_effort the model-level mapping must not inject extra_body
+    on its own — the provider default applies."""
+    kw = _build_kwargs_for("openrouter", "qwen/qwen3.6-flash", reasoning_effort=None)
+    assert "extra_body" not in kw
+
+
 def test_deepseek_no_backfill_when_reasoning_effort_none_string() -> None:
     """reasoning_effort='none' must NOT trigger reasoning_content backfill (thinking inactive)."""
     spec = find_by_name("deepseek")

--- a/tests/providers/test_litellm_kwargs.py
+++ b/tests/providers/test_litellm_kwargs.py
@@ -1716,9 +1716,10 @@ def test_qwen_thinking_enabled_via_model_level_mapping() -> None:
 
 def test_qwen_thinking_disabled_via_model_level_mapping() -> None:
     """reasoning_effort='none' must send enable_thinking: False via model-level
-    mapping on non-DashScope providers."""
+    mapping on non-DashScope providers. OpenRouter also emits its own
+    reasoning.effort alongside the provider-level thinking control."""
     kw = _build_kwargs_for("openrouter", "qwen/qwen3.5-flash", reasoning_effort="none")
-    assert kw["extra_body"] == {"enable_thinking": False}
+    assert kw["extra_body"] == {"enable_thinking": False, "reasoning": {"effort": "none"}}
 
 
 def test_qwen_no_extra_body_when_reasoning_effort_omitted() -> None:


### PR DESCRIPTION
## Summary

Add Qwen 3.5/3.6/3.7 models to _MODEL_THINKING_STYLES with enable_thinking style. This enables thinking control for Qwen models on providers that do NOT set a provider-level thinking_style (e.g. OpenRouter, custom OpenAI-compatible endpoints).

## Background

DashScope's ProviderSpec already sets thinking_style="enable_thinking" (registry.py:472), so DashScope + Qwen users can already control thinking via reasoning_effort. This PR adds model-level mapping so non-DashScope providers also get the correct extra_body parameters.

## Changes

- Added _QWEN_THINKING_MODELS frozenset with 7 Qwen 3.5/3.6/3.7 models
- Mapped to enable_thinking in _MODEL_THINKING_STYLES via fromkeys

## Note for DashScope users

When reasoning_effort is omitted, the provider default applies — no extra_body is sent. To suppress Qwen thinking content, set reasoning_effort: none in your model preset.

Closes #4934