### PR TITLE
fix(cmd): add /goal stop command to break sustained-goal loops

### DIFF
--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -18,6 +18,7 @@ from nanobot.command.router import CommandContext, CommandRouter
 from nanobot.utils.helpers import build_status_content
 from nanobot.utils.restart import set_restart_notice_to_env
 from nanobot.utils.workspace_prompts import initialize_workspace_prompt
+from nanobot.session.goal_state import cancel_goal_state, sustained_goal_active
 
 # WebUI protocol contract for how a slash command participates in turn state:
 # - side_channel: returns control text without starting or ending an agent turn.
@@ -107,6 +108,14 @@ BUILTIN_COMMAND_SPECS: tuple[BuiltinCommandSpec, ...] = (
         "<goal>",
         lifecycle="agent_turn_with_args",
         accepts_args=True,
+    ),
+    BuiltinCommandSpec(
+        "/goal stop",
+        "Cancel sustained goal",
+        "Cancel the active sustained-goal loop.",
+        "stop-circle",
+        "",
+        lifecycle="side_channel",
     ),
     BuiltinCommandSpec(
         "/trigger",
@@ -835,6 +844,32 @@ async def cmd_history(ctx: CommandContext) -> OutboundMessage:
     )
 
 
+async def cmd_goal_cancel(ctx: CommandContext) -> OutboundMessage:
+    """Cancel an active sustained goal."""
+    if ctx.session is None:
+        return OutboundMessage(
+            channel=ctx.msg.channel,
+            chat_id=ctx.msg.chat_id,
+            content="No active session to cancel a goal from.",
+            metadata={**dict(ctx.msg.metadata or {}), "render_as": "text"},
+        )
+    meta = ctx.session.metadata
+    if not sustained_goal_active(meta):
+        return OutboundMessage(
+            channel=ctx.msg.channel,
+            chat_id=ctx.msg.chat_id,
+            content="No active goal to cancel.",
+            metadata={**dict(ctx.msg.metadata or {}), "render_as": "text"},
+        )
+    cancel_goal_state(meta)
+    return OutboundMessage(
+        channel=ctx.msg.channel,
+        chat_id=ctx.msg.chat_id,
+        content="✅ Sustained goal has been cancelled.",
+        metadata={**dict(ctx.msg.metadata or {}), "render_as": "text"},
+    )
+
+
 async def cmd_goal(ctx: CommandContext) -> OutboundMessage | None:
     """Mark this turn as an explicit sustained-goal request."""
     goal = ctx.args.strip()
@@ -995,6 +1030,7 @@ def register_builtin_commands(router: CommandRouter) -> None:
     router.exact("/history", cmd_history)
     router.prefix("/history ", cmd_history)
     router.exact("/goal", cmd_goal)
+    router.exact("/goal stop", cmd_goal_cancel)
     router.prefix("/goal ", cmd_goal)
     router.exact("/trigger", cmd_trigger)
     router.prefix("/trigger ", cmd_trigger)

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -15,10 +15,10 @@ from nanobot import __version__
 from nanobot.agent.goal_permission import goal_mutation_permission
 from nanobot.bus.events import OutboundMessage
 from nanobot.command.router import CommandContext, CommandRouter
+from nanobot.session.goal_state import cancel_goal_state, sustained_goal_active
 from nanobot.utils.helpers import build_status_content
 from nanobot.utils.restart import set_restart_notice_to_env
 from nanobot.utils.workspace_prompts import initialize_workspace_prompt
-from nanobot.session.goal_state import cancel_goal_state, sustained_goal_active
 
 # WebUI protocol contract for how a slash command participates in turn state:
 # - side_channel: returns control text without starting or ending an agent turn.

--- a/nanobot/session/goal_state.py
+++ b/nanobot/session/goal_state.py
@@ -53,6 +53,18 @@ def explicit_goal_requested(message_metadata: Mapping[str, Any] | None) -> bool:
     return str(message_metadata.get("original_command") or "").strip() == GOAL_COMMAND
 
 
+def cancel_goal_state(
+    metadata: MutableMapping[str, Any],
+) -> bool:
+    """Cancel the active sustained goal in-place. Returns True if there was one."""
+    if not sustained_goal_active(metadata):
+        return False
+    prior = parse_goal_state(goal_state_raw(metadata)) or {}
+    metadata[GOAL_STATE_KEY] = {**prior, "status": "cancelled"}
+    discard_legacy_goal_state_key(metadata)
+    return True
+
+
 def sustained_goal_turn(
     metadata: Mapping[str, Any] | None,
     *,

--- a/nanobot/utils/runtime.py
+++ b/nanobot/utils/runtime.py
@@ -42,7 +42,8 @@ SUSTAINED_GOAL_CONTINUE_PROMPT = (
     "objective using your tools, or call update_goal with action='complete' "
     "if the work is truly finished."
     " If a user message explicitly asks you to cancel or stop, acknowledge their "
-    "request and call complete_goal with a summary of what was accomplished."
+    "request and call update_goal with action='complete' with a summary of "
+    "what was accomplished."
 )
 
 

--- a/nanobot/utils/runtime.py
+++ b/nanobot/utils/runtime.py
@@ -41,6 +41,8 @@ SUSTAINED_GOAL_CONTINUE_PROMPT = (
     "You have an active sustained goal. Please continue working toward the "
     "objective using your tools, or call update_goal with action='complete' "
     "if the work is truly finished."
+    " If a user message explicitly asks you to cancel or stop, acknowledge their "
+    "request and call complete_goal with a summary of what was accomplished."
 )
 
 


### PR DESCRIPTION
## 问题

`long_task` 创建的 sustained goal 持久化在 session metadata 中。goal 一旦激活，每轮 agent turn 都会注入 `"Goal (active): ... Please continue working"` 提示。当 agent 陷入验证死循环，用户的口头"停下来"被系统级 goal prompt 覆盖——系统说"继续"、用户说"停"，系统指令优先级更高。

`/stop` 命令只能停止当前任务，无法清除 session 中持久化的 goal state。删 API key、换 key、杀进程、重启空间均无效——goal state 存在 session JSONL 文件中，重启后原样加载。目前唯一有效的打断方式是手动重命名 session 文件。

## 改动

| 文件 | 改动 |
|:---|:---|
| `nanobot/session/goal_state.py` | +12 — 新增 `cancel_goal_state()` 函数，将 goal status 设为 `"cancelled"` |
| `nanobot/command/builtin.py` | +36 — `/goal stop` 命令 + handler + `BuiltinCommandSpec` + 路由注册 |
| `nanobot/utils/runtime.py` | +3 — `SUSTAINED_GOAL_CONTINUE_PROMPT` 追加取消提示 |

取消后：
- `sustained_goal_active()` 返回 `False`
- Runtime Context 不再注入 goal prompt
- 死循环自然断开

## 测试

Fork CI 全部通过 ✅

| Job | Result |
|:---|:---:|
| Python 3.14 + coverage | ✅ |
| Python 3.11 (minimum) | ✅ |
| Python 3.14 (Windows) | ✅ |
| webui | ✅ |
| docker | ✅ |

https://github.com/DreamShepherd2006/nanobot/actions/runs/29901654579

## 影响

- 无破坏性变更，不碰 runner/loop 核心逻辑
- 仅 3 文件，净增 51 行
- goal state 设为 `"cancelled"` 而非删除，保留审计痕迹
- `/goal stop` 作为 `side_channel` 注册，不打断当前 turn
- Runtime Context 提示追加 "If a user message explicitly asks you to cancel or stop, acknowledge their request and call update_goal with action='complete'"，支持自然语言取消
