### PR TITLE
feat(goal): add durable state-graph planning and recovery

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -51,6 +51,7 @@ from nanobot.bus.runtime_events import (
 )
 from nanobot.command import CommandContext, CommandRouter, register_builtin_commands
 from nanobot.config.schema import AgentDefaults, ModelPresetConfig
+from nanobot.goal_driver import GoalDriver
 from nanobot.providers.base import LLMProvider
 from nanobot.providers.factory import ProviderSnapshot
 from nanobot.runtime_context import (
@@ -71,7 +72,7 @@ from nanobot.session.automation_turns import automation_history_overrides
 from nanobot.session.goal_state import (
     goal_state_runtime_lines,
     runner_wall_llm_timeout_s,
-    sustained_goal_active,
+    sustained_goal_runnable,
 )
 from nanobot.session.history_visibility import HIDDEN_HISTORY_META
 from nanobot.session.keys import UNIFIED_SESSION_KEY
@@ -401,6 +402,12 @@ class AgentLoop:
         # When a session has an active task, new messages for that session
         # are routed here instead of creating a new task.
         self._pending_queues: dict[str, asyncio.Queue] = {}
+        self.goal_driver = GoalDriver(
+            workspace,
+            bus,
+            self.sessions,
+            session_busy=lambda key: key in self._pending_queues,
+        )
         self._deferred_automation_turns: dict[str, list[InboundMessage]] = {}
         self._cron_turns = CronTurnCoordinator(
             publish_inbound=self.bus.publish_inbound,
@@ -984,7 +991,7 @@ class AgentLoop:
                     metadata=session_metadata,
                     message_metadata=metadata,
                 ),
-                goal_active_predicate=lambda: sustained_goal_active(session.metadata) if session is not None else False,
+                goal_active_predicate=lambda: sustained_goal_runnable(session.metadata) if session is not None else False,
                 goal_continue_message=_goal_continue,
                 finalize_on_max_iterations=turn_continuation.should_finalize_on_max_iterations(
                     pending_queue_available=pending_queue is not None and session is not None,
@@ -1020,6 +1027,7 @@ class AgentLoop:
         self._running = True
         try:
             await self._connect_mcp()
+            self._schedule_background(self.goal_driver.run(lambda: self._running))
             logger.info("Agent loop started")
 
             while self._running:
@@ -1113,6 +1121,8 @@ class AgentLoop:
                     else None
                 )
         finally:
+            self._running = False
+            self.goal_driver.close()
             # MCP stdio transports use AnyIO cancel scopes; close them from the task that opened them.
             await self.close_mcp()
 
@@ -1275,6 +1285,9 @@ class AgentLoop:
                 )
                 self._runtime_events().clear_turn(session_key)
                 await self._publish_next_deferred_automation_turn(session_key)
+            if self._running:
+                with suppress(Exception):
+                    await self.goal_driver.after_turn(msg)
 
     async def close_mcp(self) -> None:
         """Drain background work, stop exec sessions, then close MCP connections."""

--- a/nanobot/agent/tools/goal_plan.py
+++ b/nanobot/agent/tools/goal_plan.py
@@ -1,0 +1,278 @@
+"""Minimal command tools for the durable Goal state graph."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from nanobot.agent.tools.base import Tool, ToolResult, tool_parameters
+from nanobot.agent.tools.context import current_request_context
+from nanobot.goals import (
+    Goal,
+    GoalConflictError,
+    GoalError,
+    GoalStore,
+    compact_ref,
+    projection,
+    workspace_fingerprint,
+)
+from nanobot.session.goal_state import GOAL_STATE_KEY, parse_goal_state
+
+GOAL_NODE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "id": {"type": "string", "minLength": 1, "maxLength": 64},
+        "title": {"type": "string", "minLength": 1, "maxLength": 300},
+        "outcome": {"type": "string", "minLength": 1, "maxLength": 2000},
+        "kind": {"type": "string", "enum": ["action", "coarse"]},
+        "depends_on": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1, "maxLength": 64},
+            "maxItems": 32,
+        },
+    },
+    "required": ["id", "title", "outcome", "depends_on"],
+    "additionalProperties": False,
+}
+
+
+class _GoalPlanTool(Tool):
+    def __init__(
+        self,
+        sessions: Any,
+        *,
+        workspace: str | Path | None = None,
+        goal_store_root: str | Path | None = None,
+    ) -> None:
+        self.sessions = sessions
+        self.workspace = Path(workspace or sessions.workspace).expanduser().resolve(strict=False)
+        self.goal_store_root = Path(goal_store_root) if goal_store_root is not None else None
+
+    @classmethod
+    def create(cls, ctx: Any) -> Tool:
+        sessions = getattr(ctx, "sessions", None)
+        assert sessions is not None
+        return cls(sessions, workspace=getattr(ctx, "workspace", None))
+
+    @classmethod
+    def enabled(cls, ctx: Any) -> bool:
+        return getattr(ctx, "sessions", None) is not None
+
+    def _workspace(self) -> Path:
+        request = current_request_context()
+        if request is not None and request.workspace is not None:
+            return Path(request.workspace).expanduser().resolve(strict=False)
+        return self.workspace
+
+    def _load(self) -> tuple[Any, dict[str, Any], GoalStore, Goal] | None:
+        request = current_request_context()
+        if request is None or not request.session_key:
+            return None
+        session = self.sessions.get_or_create(request.session_key)
+        ref = parse_goal_state(session.metadata.get(GOAL_STATE_KEY))
+        if not isinstance(ref, dict) or ref.get("status") != "active":
+            return None
+        workspace = self._workspace()
+        if ref.get("workspace") != workspace_fingerprint(workspace):
+            raise GoalError("Goal reference belongs to a different workspace")
+        store = GoalStore.for_workspace(workspace, root=self.goal_store_root)
+        goal = store.get(str(ref.get("goal_id") or ""))
+        if goal is None or goal.status != "active":
+            raise GoalError("active Goal reference could not be resolved")
+        return session, ref, store, goal
+
+    def _save(self, session: Any, goal: Goal) -> None:
+        previous = deepcopy(session.metadata)
+        session.metadata[GOAL_STATE_KEY] = compact_ref(goal, self._workspace())
+        try:
+            self.sessions.save(session)
+        except BaseException:
+            session.metadata.clear()
+            session.metadata.update(previous)
+            raise
+
+    @staticmethod
+    def _result(goal: Goal) -> str:
+        return json.dumps(projection(goal), ensure_ascii=False)
+
+
+@tool_parameters(
+    {
+        "type": "object",
+        "properties": {
+            "expected_version": {"type": "integer", "minimum": 1},
+            "nodes": {
+                "type": "array",
+                "items": GOAL_NODE_SCHEMA,
+                "minItems": 1,
+                "maxItems": 64,
+            },
+        },
+        "required": ["expected_version", "nodes"],
+        "additionalProperties": False,
+    }
+)
+class PlanGoalTool(_GoalPlanTool):
+    @property
+    def name(self) -> str:
+        return "plan_goal"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Create the active Goal's initial dependency graph. Split the objective into stable "
+            "outcome nodes; dependencies must form a DAG. Mark work that needs later refinement "
+            "as kind='coarse' instead of guessing its executable steps."
+        )
+
+    async def execute(self, expected_version: int, nodes: list[dict[str, Any]], **kwargs: Any) -> str:
+        try:
+            loaded = self._load()
+            if loaded is None:
+                return ToolResult.error("Error: plan_goal requires an active durable Goal.")
+            session, _ref, store, goal = loaded
+            updated = await asyncio.to_thread(
+                store.apply,
+                goal.id,
+                expected_version,
+                {"action": "plan", "nodes": nodes},
+            )
+            self._save(session, updated)
+            return self._result(updated)
+        except (GoalConflictError, GoalError, TypeError, ValueError) as exc:
+            return ToolResult.error(f"Error: Goal plan was rejected: {exc}")
+
+
+@tool_parameters(
+    {
+        "type": "object",
+        "properties": {
+            "expected_version": {"type": "integer", "minimum": 1},
+            "node_id": {"type": "string", "minLength": 1, "maxLength": 64},
+            "nodes": {
+                "type": "array",
+                "items": GOAL_NODE_SCHEMA,
+                "minItems": 1,
+                "maxItems": 16,
+            },
+        },
+        "required": ["expected_version", "node_id", "nodes"],
+        "additionalProperties": False,
+    }
+)
+class ExpandGoalNodeTool(_GoalPlanTool):
+    @property
+    def name(self) -> str:
+        return "expand_goal_node"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Refine one expandable coarse node into a child DAG when its dependencies have "
+            "succeeded. This is normal rolling-wave planning, not failure recovery, and does not "
+            "set needs_replan."
+        )
+
+    async def execute(
+        self,
+        expected_version: int,
+        node_id: str,
+        nodes: list[dict[str, Any]],
+        **kwargs: Any,
+    ) -> str:
+        try:
+            loaded = self._load()
+            if loaded is None:
+                return ToolResult.error("Error: expand_goal_node requires an active durable Goal.")
+            session, _ref, store, goal = loaded
+            updated = await asyncio.to_thread(
+                store.apply,
+                goal.id,
+                expected_version,
+                {"action": "expand", "node_id": node_id, "nodes": nodes},
+            )
+            self._save(session, updated)
+            return self._result(updated)
+        except (GoalConflictError, GoalError, TypeError, ValueError) as exc:
+            return ToolResult.error(f"Error: Goal expansion was rejected: {exc}")
+
+
+@tool_parameters(
+    {
+        "type": "object",
+        "properties": {
+            "expected_version": {"type": "integer", "minimum": 1},
+            "node_id": {"type": "string", "minLength": 1, "maxLength": 64},
+            "action": {"type": "string", "enum": ["begin", "succeed", "block"]},
+            "result": {"type": ["string", "null"], "maxLength": 8000},
+            "reason": {"type": ["string", "null"], "maxLength": 8000},
+        },
+        "required": ["expected_version", "node_id", "action"],
+        "additionalProperties": False,
+    }
+)
+class UpdateGoalNodeTool(_GoalPlanTool):
+    @property
+    def name(self) -> str:
+        return "update_goal_node"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Apply one constrained node transition: begin a ready node, succeed a running node "
+            "with a result summary, or block a ready/running node with failure evidence. Blocking "
+            "one path never terminates the Goal or prevents independent ready work."
+        )
+
+    async def execute(
+        self,
+        expected_version: int,
+        node_id: str,
+        action: str,
+        result: str | None = None,
+        reason: str | None = None,
+        **kwargs: Any,
+    ) -> str:
+        try:
+            loaded = self._load()
+            if loaded is None:
+                return ToolResult.error("Error: update_goal_node requires an active durable Goal.")
+            session, _ref, store, goal = loaded
+            command = {
+                "action": action,
+                "node_id": node_id,
+                "result": result,
+                "reason": reason,
+            }
+            updated = await asyncio.to_thread(store.apply, goal.id, expected_version, command)
+            self._save(session, updated)
+            return self._result(updated)
+        except (GoalConflictError, GoalError, TypeError, ValueError) as exc:
+            return ToolResult.error(f"Error: Goal node update was rejected: {exc}")
+
+
+@tool_parameters({"type": "object", "properties": {}, "additionalProperties": False})
+class GetGoalPlanTool(_GoalPlanTool):
+    @property
+    def name(self) -> str:
+        return "get_goal_plan"
+
+    @property
+    def description(self) -> str:
+        return "Read the authoritative bounded Goal graph projection and current version."
+
+    @property
+    def read_only(self) -> bool:
+        return True
+
+    async def execute(self, **kwargs: Any) -> str:
+        try:
+            loaded = self._load()
+            if loaded is None:
+                return ToolResult.error("Error: get_goal_plan requires an active durable Goal.")
+            return self._result(loaded[3])
+        except (GoalError, ValueError) as exc:
+            return ToolResult.error(f"Error: Goal plan could not be read: {exc}")

--- a/nanobot/agent/tools/goal_replan.py
+++ b/nanobot/agent/tools/goal_replan.py
@@ -1,0 +1,224 @@
+"""Clean-context recovery planning for one blocked Goal path."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Mapping
+
+from nanobot.agent.tools.base import Schema, ToolResult, tool_parameters
+from nanobot.agent.tools.context import current_request_context
+from nanobot.agent.tools.goal_plan import GOAL_NODE_SCHEMA, _GoalPlanTool
+from nanobot.goals import Goal, GoalConflictError, GoalError
+from nanobot.providers.base import parse_tool_arguments
+
+_MAX_RECOVERY_NODES = 16
+_SUBMIT_PARAMETERS = {
+    "type": "object",
+    "properties": {
+        "rationale": {"type": "string", "minLength": 1, "maxLength": 2000},
+        "nodes": {
+            "type": "array",
+            "items": GOAL_NODE_SCHEMA,
+            "minItems": 1,
+            "maxItems": _MAX_RECOVERY_NODES,
+        },
+    },
+    "required": ["rationale", "nodes"],
+    "additionalProperties": False,
+}
+_SUBMIT_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "submit_recovery_plan",
+        "description": "Submit the smallest valid replacement DAG for the blocked path.",
+        "parameters": _SUBMIT_PARAMETERS,
+    },
+}
+_SYSTEM_PROMPT = """You are a Recovery Planner operating in a clean context.
+You receive only durable Goal evidence, never the original chat. Repair the specified blocked path;
+do not expand unrelated scope or declare the Goal terminated. Avoid repeating recorded failures.
+Return the smallest replacement DAG through submit_recovery_plan. Node IDs must be new. Dependencies
+may reference only new nodes or the listed succeeded node IDs. The replacement DAG leaves will be
+connected automatically to the blocked node's downstream consumers."""
+
+
+@tool_parameters(
+    {
+        "type": "object",
+        "properties": {
+            "expected_version": {"type": "integer", "minimum": 1},
+            "blocked_node_id": {"type": "string", "minLength": 1, "maxLength": 64},
+        },
+        "required": ["expected_version", "blocked_node_id"],
+        "additionalProperties": False,
+    }
+)
+class ReplanGoalTool(_GoalPlanTool):
+    @property
+    def name(self) -> str:
+        return "replan_goal"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Repair one blocked Goal path with a clean-context Recovery Planner. It receives the "
+            "ultimate objective, successful predecessor results, bounded progress, and failure "
+            "experience, then atomically replaces only that path. Independent work stays active."
+        )
+
+    async def execute(
+        self,
+        expected_version: int,
+        blocked_node_id: str,
+        **kwargs: Any,
+    ) -> str:
+        try:
+            loaded = self._load()
+            if loaded is None:
+                return ToolResult.error("Error: replan_goal requires an active durable Goal.")
+            session, _ref, store, goal = loaded
+            if goal.version != expected_version:
+                raise GoalConflictError(
+                    f"goal is at version {goal.version}, expected {expected_version}"
+                )
+            target = goal.state.get("nodes", {}).get(blocked_node_id)
+            if not isinstance(target, dict) or target.get("status") != "blocked":
+                raise GoalError("Recovery Planner requires a blocked node")
+            remaining = 64 - len(goal.state.get("nodes", {}))
+            if remaining < 1:
+                raise GoalError("Goal has no remaining node capacity for a recovery plan")
+
+            request = current_request_context()
+            runtime = request.runtime if request is not None else None
+            if runtime is None:
+                raise GoalError("Recovery Planner requires the active model runtime")
+            try:
+                response = await runtime.provider.chat_with_retry(
+                    messages=build_recovery_messages(goal, blocked_node_id, min(remaining, 16)),
+                    tools=[_SUBMIT_TOOL],
+                    model=runtime.model,
+                    max_tokens=min(runtime.generation.max_tokens, 4096),
+                    temperature=0,
+                    reasoning_effort=runtime.generation.reasoning_effort,
+                    tool_choice="required",
+                    retry_mode="standard",
+                )
+            except Exception as exc:
+                return ToolResult.error(f"Error: Recovery Planner model call failed: {exc}")
+            goal = await asyncio.to_thread(
+                store.apply,
+                goal.id,
+                expected_version,
+                {"action": "recovery_attempt", "node_id": blocked_node_id},
+            )
+            self._save(session, goal)
+            proposal = _proposal_from_response(response)
+            if len(proposal["nodes"]) > remaining:
+                raise GoalError("Recovery Planner proposed more nodes than the Goal can retain")
+            updated = await asyncio.to_thread(
+                store.apply,
+                goal.id,
+                goal.version,
+                {
+                    "action": "replan",
+                    "node_id": blocked_node_id,
+                    "nodes": proposal["nodes"],
+                    "rationale": proposal["rationale"],
+                },
+            )
+            self._save(session, updated)
+            return self._result(updated)
+        except (GoalConflictError, GoalError, TypeError, ValueError) as exc:
+            return ToolResult.error(f"Error: Goal recovery replan was rejected: {exc}")
+
+
+def build_recovery_messages(goal: Goal, blocked_node_id: str, max_nodes: int) -> list[dict[str, str]]:
+    nodes: Mapping[str, Mapping[str, Any]] = goal.state["nodes"]
+    target = nodes[blocked_node_id]
+    predecessors = _successful_predecessors(nodes, target)
+    failures = [
+        {
+            "id": node["id"],
+            "title": node["title"],
+            "failure": str(node.get("failure") or "")[:1000],
+        }
+        for node in nodes.values()
+        if node.get("failure")
+    ][-8:]
+    statuses: dict[str, int] = {}
+    for node in nodes.values():
+        status = str(node["status"])
+        statuses[status] = statuses.get(status, 0) + 1
+    evidence = {
+        "schema": 1,
+        "ultimate_objective": str(goal.state.get("objective") or ""),
+        "blocked_path": {
+            "id": target["id"],
+            "title": target["title"],
+            "required_outcome": target["outcome"],
+            "failure": str(target.get("failure") or "")[:2000],
+        },
+        "successful_predecessors": predecessors,
+        "failure_experience": failures,
+        "progress_summary": {
+            "label": goal.summary,
+            "plan_revision": goal.state.get("revision", 0),
+            "status_counts": statuses,
+            "retained_nodes": [
+                {"id": node["id"], "title": node["title"], "status": node["status"]}
+                for node in nodes.values()
+                if node["status"] != "superseded"
+            ][:24],
+        },
+        "constraints": {
+            "max_replacement_nodes": max_nodes,
+            "existing_node_ids": list(nodes),
+            "allowed_existing_dependencies": [
+                node_id for node_id, node in nodes.items() if node["status"] == "succeeded"
+            ],
+        },
+    }
+    return [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": json.dumps(evidence, ensure_ascii=False)},
+    ]
+
+
+def _successful_predecessors(
+    nodes: Mapping[str, Mapping[str, Any]],
+    target: Mapping[str, Any],
+) -> list[dict[str, str]]:
+    pending = list(target.get("depends_on", []))
+    seen: set[str] = set()
+    results: list[dict[str, str]] = []
+    while pending and len(results) < 16:
+        node_id = pending.pop(0)
+        if node_id in seen or node_id not in nodes:
+            continue
+        seen.add(node_id)
+        node = nodes[node_id]
+        pending.extend(node.get("depends_on", []))
+        if node.get("status") == "succeeded":
+            results.append(
+                {
+                    "id": node_id,
+                    "title": str(node.get("title") or "")[:300],
+                    "outcome": str(node.get("outcome") or "")[:1000],
+                    "result": str(node.get("result") or "")[:2000],
+                }
+            )
+    return results
+
+
+def _proposal_from_response(response: Any) -> dict[str, Any]:
+    calls = [call for call in response.tool_calls if call.name == "submit_recovery_plan"]
+    if len(calls) != 1:
+        raise GoalError("Recovery Planner did not return exactly one structured proposal")
+    proposal = parse_tool_arguments(calls[0].arguments)
+    if not isinstance(proposal, dict):
+        raise GoalError("Recovery Planner proposal is not a JSON object")
+    errors = Schema.validate_json_schema_value(proposal, _SUBMIT_PARAMETERS)
+    if errors:
+        raise GoalError("invalid Recovery Planner proposal: " + "; ".join(errors[:3]))
+    return proposal

--- a/nanobot/agent/tools/long_task.py
+++ b/nanobot/agent/tools/long_task.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 from copy import deepcopy
 from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from nanobot.agent.goal_permission import (
@@ -14,7 +16,9 @@ from nanobot.agent.tools.base import Tool, ToolResult, tool_parameters
 from nanobot.agent.tools.context import RequestContext, current_request_context
 from nanobot.agent.tools.schema import StringSchema, tool_parameters_schema
 from nanobot.bus.runtime_events import GoalStateChanged, RuntimeEventBus, RuntimeEventContext
+from nanobot.goals import GoalConflictError, GoalError, GoalStore, compact_ref, projection
 from nanobot.runtime_context import RuntimeContextBlock, wrap_runtime_context_lines
+from nanobot.session.automation_turns import is_automation_turn
 from nanobot.session.goal_state import (
     GOAL_STATE_KEY,
     MAX_GOAL_OBJECTIVE_CHARS,
@@ -32,7 +36,7 @@ if TYPE_CHECKING:
     from nanobot.session.manager import SessionManager
 
 
-_GOAL_ACTIONS = ("complete", "cancel", "block", "replace")
+_GOAL_ACTIONS = ("complete", "cancel", "block", "replace", "resume")
 _CREATE_UNAVAILABLE_ERROR = (
     "Error: create_goal is unavailable for this turn. Ask the user to submit the complete "
     "objective as `/goal <task>`."
@@ -54,9 +58,14 @@ class _GoalToolsMixin:
         self,
         sessions: SessionManager,
         runtime_events: RuntimeEventBus | None = None,
+        *,
+        workspace: str | Path | None = None,
+        goal_store_root: str | Path | None = None,
     ) -> None:
         self._sessions = sessions
         self._runtime_events = runtime_events
+        self._workspace = Path(workspace or sessions.workspace).expanduser().resolve(strict=False)
+        self._goal_store_root = Path(goal_store_root) if goal_store_root is not None else None
 
     def _session(self):
         request_ctx = current_request_context()
@@ -69,6 +78,20 @@ class _GoalToolsMixin:
 
     def _goal_mutation_allowed(self) -> bool:
         return current_request_context() is not None and goal_mutation_allowed()
+
+    def _active_workspace(self) -> Path:
+        request = current_request_context()
+        return (
+            Path(request.workspace).expanduser().resolve(strict=False)
+            if request is not None and request.workspace is not None
+            else self._workspace
+        )
+
+    def _store(self, workspace: str | Path | None = None) -> GoalStore:
+        return GoalStore.for_workspace(
+            workspace or self._active_workspace(),
+            root=self._goal_store_root,
+        )
 
     def _save_goal_state(
         self,
@@ -134,8 +157,17 @@ class CreateGoalTool(Tool, _GoalToolsMixin):
         self,
         sessions: Any,
         runtime_events: RuntimeEventBus | None = None,
+        *,
+        workspace: str | Path | None = None,
+        goal_store_root: str | Path | None = None,
     ) -> None:
-        _GoalToolsMixin.__init__(self, sessions, runtime_events)
+        _GoalToolsMixin.__init__(
+            self,
+            sessions,
+            runtime_events,
+            workspace=workspace,
+            goal_store_root=goal_store_root,
+        )
 
     @classmethod
     def create(cls, ctx: Any) -> Tool:
@@ -144,6 +176,7 @@ class CreateGoalTool(Tool, _GoalToolsMixin):
         return cls(
             sessions=sess,
             runtime_events=getattr(ctx, "runtime_events", None),
+            workspace=getattr(ctx, "workspace", None),
         )
 
     @classmethod
@@ -184,7 +217,71 @@ class CreateGoalTool(Tool, _GoalToolsMixin):
             goal_start_requested=goal_start_requested,
             goal_active=goal_active,
         )
-        state = wrap_runtime_context_lines(goal_state_runtime_lines(session.metadata))
+        state_lines = goal_state_runtime_lines(session.metadata)
+        ref = parse_goal_state(goal_state_raw(session.metadata))
+        if isinstance(ref, dict) and isinstance(ref.get("goal_id"), str):
+            try:
+                store = self._store(request.workspace)
+                stored = await asyncio.to_thread(store.get, ref["goal_id"])
+                if stored is not None and stored.status not in {"active", "waiting"}:
+                    current = await asyncio.to_thread(store.current, request.session_key)
+                    if current is not None:
+                        stored = current
+                    self._save_goal_state(
+                        session,
+                        compact_ref(stored, request.workspace or self._workspace),
+                    )
+                if stored is not None:
+                    view = projection(stored)
+                    state_lines = [
+                        f"Goal {stored.id} ({stored.status}, version {stored.version}):",
+                        str(view["objective"]),
+                        f"Plan revision: {view['revision']}; nodes: {view['node_count']}",
+                    ]
+                    if view["expandable"]:
+                        state_lines.append(
+                            "Expandable: "
+                            + ", ".join(
+                                f"{node['id']} ({node['title']})"
+                                for node in view["expandable"]
+                            )
+                        )
+                    if view["frontier"]:
+                        state_lines.append(
+                            "Ready: "
+                            + ", ".join(
+                                f"{node['id']} ({node['title']})" for node in view["frontier"]
+                            )
+                        )
+                    if view["running"]:
+                        state_lines.append(
+                            "Running: " + ", ".join(node["id"] for node in view["running"])
+                        )
+                    if view["blocked"]:
+                        state_lines.append(
+                            "Blocked paths: "
+                            + ", ".join(
+                                f"{node['id']}: {node.get('failure', '')}"
+                                for node in view["blocked"]
+                            )
+                        )
+                    if view["needs_replan"]:
+                        state_lines.append(
+                            "Call replan_goal for a blocked path using the current version; "
+                            "independent ready nodes may continue."
+                        )
+                    state_lines.append(
+                        "Recovery attempts: "
+                        f"{view['recovery_attempts']}/{view['max_recovery_attempts']}."
+                    )
+                    if stored.status == "waiting":
+                        state_lines.append(
+                            "Goal is waiting for user intervention: "
+                            + (view["status_reason"] or "reason not recorded")
+                        )
+            except (GoalError, ValueError):
+                state_lines = ["Goal reference could not be resolved from durable storage."]
+        state = wrap_runtime_context_lines(state_lines)
         content = "\n\n".join(part for part in (guidance, state) if part)
         return RuntimeContextBlock(source="goal", content=content)
 
@@ -202,7 +299,7 @@ class CreateGoalTool(Tool, _GoalToolsMixin):
         if not self._goal_mutation_allowed():
             return ToolResult.error(_CREATE_UNAVAILABLE_ERROR)
         prior = parse_goal_state(goal_state_raw(sess.metadata))
-        if isinstance(prior, dict) and prior.get("status") == "active":
+        if isinstance(prior, dict) and sustained_goal_active(sess.metadata):
             return ToolResult.error(
                 "Error: a sustained goal is already active. Use update_goal with "
                 "action='replace' only if the user explicitly changes the objective."
@@ -216,18 +313,28 @@ class CreateGoalTool(Tool, _GoalToolsMixin):
                 f"Error: objective must not exceed {MAX_GOAL_OBJECTIVE_CHARS} characters."
             )
         summary = (ui_summary or "").strip()[:120]
-        blob = {
-            "status": "active",
-            "objective": objective_text,
-            "ui_summary": summary,
-            "started_at": _iso_now(),
-        }
+        request = current_request_context()
+        route = {
+            "channel": request.channel,
+            "chat_id": request.chat_id or "",
+        } if request is not None else {}
+        try:
+            stored = await asyncio.to_thread(
+                self._store().create,
+                sess.key,
+                objective_text,
+                summary,
+                route,
+            )
+        except (GoalConflictError, GoalError, ValueError) as exc:
+            return ToolResult.error(f"Error: could not create durable Goal: {exc}")
+        blob = compact_ref(stored, self._active_workspace())
         self._save_goal_state(sess, blob, reset_continuation=True)
         await self._publish_goal_state_changed(sess.metadata)
         extra = f"\nSummary line: {summary}" if summary else ""
         return (
-            "Goal recorded. Keep working toward the objective using ordinary tools. "
-            "When fully done and verified, call update_goal with action='complete'."
+            "Goal recorded durably. Create its initial state graph with plan_goal, then execute "
+            "ready nodes. Complete the Goal only after every retained node succeeds."
             f"{extra}"
         )
 
@@ -264,8 +371,17 @@ class UpdateGoalTool(Tool, _GoalToolsMixin):
         self,
         sessions: Any,
         runtime_events: RuntimeEventBus | None = None,
+        *,
+        workspace: str | Path | None = None,
+        goal_store_root: str | Path | None = None,
     ) -> None:
-        _GoalToolsMixin.__init__(self, sessions, runtime_events)
+        _GoalToolsMixin.__init__(
+            self,
+            sessions,
+            runtime_events,
+            workspace=workspace,
+            goal_store_root=goal_store_root,
+        )
 
     @classmethod
     def create(cls, ctx: Any) -> Tool:
@@ -274,6 +390,7 @@ class UpdateGoalTool(Tool, _GoalToolsMixin):
         return cls(
             sessions=sess,
             runtime_events=getattr(ctx, "runtime_events", None),
+            workspace=getattr(ctx, "workspace", None),
         )
 
     @classmethod
@@ -287,10 +404,10 @@ class UpdateGoalTool(Tool, _GoalToolsMixin):
     @property
     def description(self) -> str:
         return (
-            "Update the active sustained goal. Use action='complete' only after the objective "
-            "is actually achieved and verified. Use action='cancel' when the user cancels, "
-            "action='block' when progress is genuinely blocked, and action='replace' only when "
-            "the requested objective changes."
+            "Update the current sustained goal. Use action='complete' only after the objective "
+            "is actually achieved and verified, action='cancel' when the user cancels, and "
+            "action='resume' only after the user resolves a waiting condition. Durable Goal path "
+            "failures must use update_goal_node action='block'; they do not close the Goal."
         )
 
     async def execute(
@@ -305,13 +422,98 @@ class UpdateGoalTool(Tool, _GoalToolsMixin):
         if sess is None:
             return ToolResult.error("Error: update_goal requires an active chat session.")
         prior = parse_goal_state(goal_state_raw(sess.metadata))
-        if not isinstance(prior, dict) or prior.get("status") != "active":
-            return "No active goal to update."
+        if not isinstance(prior, dict) or not sustained_goal_active(sess.metadata):
+            return "No active or waiting goal to update."
 
         normalized = (action or "").strip().lower()
         if normalized not in _GOAL_ACTIONS:
             return ToolResult.error(
-                "Error: action must be one of complete, cancel, block, or replace."
+                "Error: action must be one of complete, cancel, block, replace, or resume."
+            )
+        request = current_request_context()
+        if normalized in {"block", "cancel", "resume"} and is_automation_turn(
+            request.metadata if request is not None else None
+        ):
+            return ToolResult.error(
+                f"Error: an automation turn cannot {normalized} the user's Goal."
+            )
+
+        goal_id = prior.get("goal_id")
+        if isinstance(goal_id, str):
+            try:
+                store = self._store()
+                current = await asyncio.to_thread(store.current, sess.key)
+                if current is not None and current.id != goal_id:
+                    self._save_goal_state(
+                        sess,
+                        compact_ref(current, self._active_workspace()),
+                        reset_continuation=normalized == "replace",
+                    )
+                    if (
+                        normalized == "replace"
+                        and current.state.get("objective") == (objective or "").strip()
+                    ):
+                        await self._publish_goal_state_changed(sess.metadata)
+                        return "Goal replaced; create a new initial plan."
+                    goal_id = current.id
+                    prior = compact_ref(current, self._active_workspace())
+                if normalized == "block":
+                    return ToolResult.error(
+                        "Error: block the affected path with update_goal_node action='block'; "
+                        "a blocked node does not terminate the Goal."
+                    )
+                if normalized == "replace":
+                    if not self._goal_mutation_allowed():
+                        return ToolResult.error(_REPLACE_UNAVAILABLE_ERROR)
+                    objective_text = (objective or "").strip()
+                    if not objective_text:
+                        return ToolResult.error(
+                            "Error: update_goal action='replace' requires a replacement objective."
+                        )
+                    if len(objective_text) > MAX_GOAL_OBJECTIVE_CHARS:
+                        return ToolResult.error(
+                            "Error: objective must not exceed "
+                            f"{MAX_GOAL_OBJECTIVE_CHARS} characters."
+                        )
+                    stored = await asyncio.to_thread(
+                        store.replace,
+                        goal_id,
+                        int(prior.get("version", 0)),
+                        objective_text,
+                        (ui_summary or "").strip()[:120],
+                    )
+                elif normalized == "resume":
+                    stored = await asyncio.to_thread(
+                        store.set_status,
+                        goal_id,
+                        int(prior.get("version", 0)),
+                        "active",
+                        (recap or "").strip(),
+                    )
+                else:
+                    stored = await asyncio.to_thread(
+                        store.close,
+                        goal_id,
+                        int(prior.get("version", 0)),
+                        "completed" if normalized == "complete" else "cancelled",
+                        (recap or "").strip(),
+                    )
+            except (GoalConflictError, GoalError, TypeError, ValueError) as exc:
+                return ToolResult.error(f"Error: durable Goal update was rejected: {exc}")
+            self._save_goal_state(
+                sess,
+                compact_ref(stored, self._active_workspace()),
+                reset_continuation=normalized == "replace",
+            )
+            if normalized != "replace":
+                revoke_goal_mutation_permission()
+            await self._publish_goal_state_changed(sess.metadata)
+            return (
+                "Goal replaced; create a new initial plan."
+                if normalized == "replace"
+                else "Goal resumed."
+                if normalized == "resume"
+                else f"Goal marked {'complete' if normalized == 'complete' else 'cancelled'}."
             )
 
         if normalized == "replace":
@@ -340,6 +542,12 @@ class UpdateGoalTool(Tool, _GoalToolsMixin):
             await self._publish_goal_state_changed(sess.metadata)
             extra = f"\nSummary line: {summary}" if summary else ""
             return "Goal replaced. Continue toward the new objective using ordinary tools." + extra
+
+        if normalized == "resume":
+            blob = {**prior, "status": "active", "recap": (recap or "").strip()}
+            self._save_goal_state(sess, blob)
+            await self._publish_goal_state_changed(sess.metadata)
+            return "Goal resumed."
 
         ended = _iso_now()
         status = {

--- a/nanobot/goal_driver.py
+++ b/nanobot/goal_driver.py
@@ -1,0 +1,247 @@
+"""Small restart-safe driver for active durable Goals."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from nanobot.bus.events import InboundMessage, OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.goals import (
+    MAX_RECOVERY_ATTEMPTS,
+    Goal,
+    GoalConflictError,
+    GoalError,
+    GoalStore,
+    compact_ref,
+)
+from nanobot.session.automation_turns import AutomationTurnSpec
+from nanobot.session.goal_state import GOAL_STATE_KEY
+from nanobot.session.manager import SessionManager
+
+GOAL_DRIVER_META = "_goal_driver"
+MAX_DRIVER_STALLS = 3
+
+
+def _history_text(trigger: Mapping[str, Any]) -> str:
+    return str(trigger.get("persist_content") or "Continue the durable Goal.")
+
+
+GOAL_DRIVER_AUTOMATION_SPEC = AutomationTurnSpec(
+    kind="goal_driver",
+    trigger_meta_key=GOAL_DRIVER_META,
+    history_fields={"goal_id": "goal_id"},
+    text_builder=_history_text,
+)
+
+
+class GoalDriver:
+    """Wake runnable Goals one bounded turn at a time."""
+
+    def __init__(
+        self,
+        workspace: str | Path,
+        bus: MessageBus,
+        sessions: SessionManager,
+        *,
+        session_busy: Callable[[str], bool] = lambda _key: False,
+        store_root: str | Path | None = None,
+        interval: float = 5,
+    ) -> None:
+        self.workspace = Path(workspace).expanduser().resolve(strict=False)
+        self.bus = bus
+        self.sessions = sessions
+        self.session_busy = session_busy
+        self.store = GoalStore.for_workspace(self.workspace, root=store_root)
+        self.interval = interval
+        self._scan_lock = asyncio.Lock()
+        self._scheduled: set[str] = set()
+        self._stopped = asyncio.Event()
+
+    async def run(self, is_running: Callable[[], bool]) -> None:
+        self._stopped.clear()
+        while is_running():
+            try:
+                await self.scan_once()
+            except Exception:
+                logger.exception("Goal driver scan failed")
+            try:
+                await asyncio.wait_for(self._stopped.wait(), timeout=self.interval)
+            except asyncio.TimeoutError:
+                pass
+
+    def close(self) -> None:
+        self._stopped.set()
+
+    async def scan_once(self) -> None:
+        if self._scan_lock.locked():
+            return
+        async with self._scan_lock:
+            goals = await asyncio.to_thread(self.store.active)
+            for goal in goals:
+                if self.session_busy(goal.session_key):
+                    continue
+                try:
+                    await self._drive(goal)
+                except (GoalConflictError, GoalError, ValueError):
+                    logger.debug("Goal {} changed while driver scanned it", goal.id)
+                except Exception:
+                    logger.exception("Goal driver failed for {}", goal.id)
+
+    async def after_turn(self, msg: InboundMessage) -> None:
+        trigger = msg.metadata.get(GOAL_DRIVER_META)
+        if isinstance(trigger, dict):
+            await self._record_turn(trigger)
+        await self.scan_once()
+
+    async def _drive(self, goal: Goal) -> None:
+        if goal.id in self._scheduled:
+            return
+        driver = goal.state.get("driver") or {}
+        nodes = goal.state.get("nodes") or {}
+        running = [node for node in nodes.values() if node.get("status") == "running"]
+        if running:
+            await self._stop(
+                goal,
+                "waiting",
+                "Execution was interrupted while a node was running; automatic replay could "
+                "duplicate side effects.",
+            )
+            return
+        if int(driver.get("stalls", 0)) >= MAX_DRIVER_STALLS:
+            await self._stop(
+                goal,
+                "waiting",
+                "The Goal was paused after three continuation turns made no durable progress.",
+            )
+            return
+
+        reason = self._runnable_reason(goal)
+        if reason is None:
+            return
+        if reason == "recovery_exhausted":
+            await self._stop(
+                goal,
+                "waiting",
+                "All runnable paths are blocked and automated recovery needs user input.",
+            )
+            return
+
+        route = self._route(goal)
+        if route is None:
+            await self._stop(goal, "waiting", "The Goal has no usable delivery route.")
+            return
+        text = (
+            "Continue the durable Goal for one bounded step. Read Goal Runtime Context, use the "
+            "authoritative version, and persist every node transition. Expand coarse work when "
+            "ready; replan blocked paths; do not treat this automation turn as user authority. "
+            f"Driver reason: {reason}."
+        )
+        self._sync_ref(goal)
+        self._scheduled.add(goal.id)
+        try:
+            await self.bus.publish_inbound(
+                InboundMessage(
+                    channel=route["channel"],
+                    sender_id="goal-driver",
+                    chat_id=route["chat_id"],
+                    content=text,
+                    metadata={
+                        GOAL_DRIVER_META: {
+                            "goal_id": goal.id,
+                            "start_version": goal.version,
+                            "persist_content": text,
+                        }
+                    },
+                    session_key_override=goal.session_key,
+                )
+            )
+        except BaseException:
+            self._scheduled.discard(goal.id)
+            raise
+
+    @staticmethod
+    def _runnable_reason(goal: Goal) -> str | None:
+        nodes = goal.state.get("nodes") or {}
+        if not nodes:
+            return "initial_plan"
+        if any(
+            node.get("kind") == "coarse"
+            and node.get("status") == "pending"
+            and all(nodes[dep]["status"] == "succeeded" for dep in node.get("depends_on", []))
+            for node in nodes.values()
+        ):
+            return "plan_expansion"
+        if any(node.get("status") == "ready" for node in nodes.values()):
+            return "ready_frontier"
+        if goal.state.get("needs_replan"):
+            return (
+                "recovery_plan"
+                if int(goal.state.get("recovery_attempts", 0)) < MAX_RECOVERY_ATTEMPTS
+                else "recovery_exhausted"
+            )
+        retained = [node for node in nodes.values() if node.get("status") != "superseded"]
+        if retained and all(node.get("status") == "succeeded" for node in retained):
+            return "finalize"
+        return None
+
+    async def _record_turn(self, trigger: Mapping[str, Any]) -> None:
+        goal_id = str(trigger.get("goal_id") or "")
+        self._scheduled.discard(goal_id)
+        goal = await asyncio.to_thread(self.store.get, goal_id)
+        if goal is None or goal.status != "active":
+            return
+        try:
+            updated = await asyncio.to_thread(
+                self.store.apply,
+                goal.id,
+                goal.version,
+                {
+                    "action": "driver_turn",
+                    "progressed": goal.version > int(trigger.get("start_version", 0)),
+                },
+            )
+            self._sync_ref(updated)
+        except (GoalConflictError, GoalError, TypeError, ValueError):
+            logger.debug("Goal {} changed while recording its driver turn", goal.id)
+
+    async def _stop(self, goal: Goal, status: str, reason: str) -> None:
+        updated = await asyncio.to_thread(
+            self.store.set_status,
+            goal.id,
+            goal.version,
+            status,
+            reason,
+        )
+        self._sync_ref(updated)
+        route = self._route(goal)
+        if route is not None:
+            label = "paused" if status == "waiting" else "stopped"
+            await self.bus.publish_outbound(
+                OutboundMessage(
+                    channel=route["channel"],
+                    chat_id=route["chat_id"],
+                    content=f"Long-running Goal {label}: {reason}",
+                )
+            )
+
+    def _sync_ref(self, goal: Goal) -> None:
+        session = self.sessions.get_or_create(goal.session_key)
+        ref = compact_ref(goal, self.workspace)
+        if session.metadata.get(GOAL_STATE_KEY) == ref:
+            return
+        session.metadata[GOAL_STATE_KEY] = ref
+        self.sessions.save(session)
+
+    @staticmethod
+    def _route(goal: Goal) -> dict[str, str] | None:
+        route = goal.state.get("route") or {}
+        channel = str(route.get("channel") or "").strip()
+        chat_id = str(route.get("chat_id") or "").strip()
+        if not channel and ":" in goal.session_key:
+            channel, chat_id = goal.session_key.split(":", 1)
+        return {"channel": channel, "chat_id": chat_id} if channel and chat_id else None

--- a/nanobot/goals.py
+++ b/nanobot/goals.py
@@ -1,0 +1,670 @@
+"""Small durable state graph for sustained goals.
+
+The whole current graph is one versioned JSON snapshot. SQLite provides atomic compare-and-swap
+writes and a compact audit log; graph policy stays in the pure :func:`reduce_goal` function.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import sqlite3
+import threading
+import time
+import uuid
+from contextlib import closing
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Mapping
+
+from nanobot.config.paths import get_runtime_subdir
+
+_CURRENT_STATUSES = ("active", "waiting")
+_NODE_ID = re.compile(r"[A-Za-z0-9_.-]{1,64}")
+_NODE_STATUSES = {"pending", "ready", "running", "succeeded", "blocked", "superseded"}
+_MAX_NODES = 64
+_MAX_DEPTH = 16
+MAX_RECOVERY_ATTEMPTS = 4
+
+
+class GoalError(RuntimeError):
+    pass
+
+
+class GoalConflictError(GoalError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class Goal:
+    id: str
+    session_key: str
+    status: str
+    version: int
+    summary: str
+    state: dict[str, Any]
+
+
+def workspace_fingerprint(workspace: str | Path) -> str:
+    resolved = Path(workspace).expanduser().resolve(strict=False)
+    normalized = os.path.normcase(str(resolved)).replace("\\", "/")
+    return hashlib.sha256(normalized.encode()).hexdigest()[:16]
+
+
+class GoalStore:
+    """Two-table SQLite store with short connections and optimistic versions."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self._initialized = False
+        self._init_lock = threading.Lock()
+
+    @classmethod
+    def for_workspace(
+        cls,
+        workspace: str | Path,
+        *,
+        root: str | Path | None = None,
+    ) -> GoalStore:
+        base = Path(root) if root is not None else get_runtime_subdir("goals")
+        return cls(base / workspace_fingerprint(workspace) / "goals.sqlite3")
+
+    def initialize(self) -> None:
+        if self._initialized:
+            return
+        with self._init_lock:
+            if self._initialized:
+                return
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            for attempt in range(5):
+                try:
+                    with closing(self._connect()) as db:
+                        db.executescript(
+                            """
+                            PRAGMA journal_mode = WAL;
+                            CREATE TABLE IF NOT EXISTS goal_runs (
+                                id TEXT PRIMARY KEY,
+                                session_key TEXT NOT NULL,
+                                status TEXT NOT NULL,
+                                version INTEGER NOT NULL,
+                                summary TEXT NOT NULL,
+                                state_json TEXT NOT NULL,
+                                created_at TEXT NOT NULL,
+                                updated_at TEXT NOT NULL
+                            );
+                            CREATE UNIQUE INDEX IF NOT EXISTS uq_goal_current_session
+                            ON goal_runs(session_key) WHERE status IN ('active', 'waiting');
+                            CREATE TABLE IF NOT EXISTS goal_events (
+                                goal_id TEXT NOT NULL REFERENCES goal_runs(id) ON DELETE CASCADE,
+                                sequence INTEGER NOT NULL,
+                                event_type TEXT NOT NULL,
+                                payload_json TEXT NOT NULL,
+                                created_at TEXT NOT NULL,
+                                PRIMARY KEY(goal_id, sequence)
+                            );
+                            """
+                        )
+                    break
+                except sqlite3.OperationalError as exc:
+                    if "locked" not in str(exc).lower() or attempt == 4:
+                        raise
+                    time.sleep(0.05 * (attempt + 1))
+            self._initialized = True
+
+    def create(
+        self,
+        session_key: str,
+        objective: str,
+        summary: str = "",
+        route: Mapping[str, str] | None = None,
+    ) -> Goal:
+        session_key, objective = session_key.strip(), objective.strip()
+        if not session_key or not objective:
+            raise ValueError("session key and objective are required")
+        state = {
+            "schema": 1,
+            "objective": objective,
+            "revision": 0,
+            "nodes": {},
+            "needs_replan": False,
+            "recovery_attempts": 0,
+            "route": dict(route or {}),
+        }
+        now, goal_id = _now(), f"goal_{uuid.uuid4().hex}"
+        self.initialize()
+        try:
+            with self._write() as db:
+                existing = db.execute(
+                    "SELECT * FROM goal_runs WHERE session_key=? AND status IN ('active','waiting')",
+                    (session_key,),
+                ).fetchone()
+                if existing is not None:
+                    goal = _goal(existing)
+                    if goal.state.get("objective") == objective:
+                        return goal
+                    raise GoalConflictError("this session already has a current goal")
+                db.execute(
+                    "INSERT INTO goal_runs VALUES (?,?,?,?,?,?,?,?)",
+                    (goal_id, session_key, "active", 1, summary[:120], _json(state), now, now),
+                )
+                self._event(db, goal_id, 1, "goal_created", {"objective": objective}, now)
+                return self._require(db, goal_id)
+        except sqlite3.IntegrityError as exc:
+            raise GoalConflictError("this session already has a current goal") from exc
+
+    def get(self, goal_id: str) -> Goal | None:
+        self.initialize()
+        with closing(self._connect()) as db:
+            row = db.execute("SELECT * FROM goal_runs WHERE id=?", (goal_id,)).fetchone()
+            return _goal(row) if row is not None else None
+
+    def current(self, session_key: str) -> Goal | None:
+        self.initialize()
+        with closing(self._connect()) as db:
+            row = db.execute(
+                "SELECT * FROM goal_runs WHERE session_key=? AND status IN ('active','waiting')",
+                (session_key,),
+            ).fetchone()
+            return _goal(row) if row is not None else None
+
+    def active(self) -> list[Goal]:
+        """Return active Goals for restart/periodic driving."""
+        self.initialize()
+        with closing(self._connect()) as db:
+            rows = db.execute("SELECT * FROM goal_runs WHERE status='active'").fetchall()
+        return [_goal(row) for row in rows]
+
+    def apply(
+        self,
+        goal_id: str,
+        expected_version: int,
+        command: Mapping[str, Any],
+    ) -> Goal:
+        """Apply one pure state command and append its event in the same transaction."""
+        self.initialize()
+        with self._write() as db:
+            current = self._require(db, goal_id)
+            if current.version != expected_version:
+                raise GoalConflictError(
+                    f"goal is at version {current.version}, expected {expected_version}"
+                )
+            if current.status not in _CURRENT_STATUSES:
+                raise GoalError("only a current goal can be updated")
+            state, event_type = reduce_goal(current.state, command)
+            version, now = current.version + 1, _now()
+            cursor = db.execute(
+                "UPDATE goal_runs SET version=?, state_json=?, updated_at=? "
+                "WHERE id=? AND version=? AND status IN ('active','waiting')",
+                (version, _json(state), now, goal_id, expected_version),
+            )
+            if cursor.rowcount != 1:
+                raise GoalConflictError("goal changed while applying the command")
+            self._event(db, goal_id, version, event_type, dict(command), now)
+            return self._require(db, goal_id)
+
+    def close(self, goal_id: str, expected_version: int, status: str, recap: str = "") -> Goal:
+        if status not in {"completed", "cancelled"}:
+            raise ValueError("invalid terminal goal status")
+        self.initialize()
+        with self._write() as db:
+            current = self._require(db, goal_id)
+            if current.version != expected_version:
+                raise GoalConflictError(
+                    f"goal is at version {current.version}, expected {expected_version}"
+                )
+            if current.status not in _CURRENT_STATUSES:
+                raise GoalError("only a current goal can be closed")
+            if status == "completed":
+                nodes = _nodes(current.state)
+                retained = [node for node in nodes.values() if node["status"] != "superseded"]
+                if not retained or any(node["status"] != "succeeded" for node in retained):
+                    raise GoalError("goal cannot complete until every retained node succeeds")
+            version, now = current.version + 1, _now()
+            state = {**current.state, "recap": recap[:8000]}
+            db.execute(
+                "UPDATE goal_runs SET status=?, version=?, state_json=?, updated_at=? "
+                "WHERE id=? AND version=?",
+                (status, version, _json(state), now, goal_id, expected_version),
+            )
+            self._event(db, goal_id, version, f"goal_{status}", {"recap": recap}, now)
+            return self._require(db, goal_id)
+
+    def set_status(
+        self,
+        goal_id: str,
+        expected_version: int,
+        status: str,
+        reason: str = "",
+    ) -> Goal:
+        """Pause, resume, or fail a Goal without changing its graph."""
+        if status not in {"active", "waiting", "failed"}:
+            raise ValueError("invalid goal status transition")
+        self.initialize()
+        with self._write() as db:
+            current = self._require(db, goal_id)
+            if current.version != expected_version:
+                raise GoalConflictError(
+                    f"goal is at version {current.version}, expected {expected_version}"
+                )
+            allowed = (
+                current.status == "active" and status in {"waiting", "failed"}
+            ) or (current.status == "waiting" and status == "active")
+            if not allowed:
+                raise GoalError(f"goal cannot transition from {current.status} to {status}")
+            version, now = current.version + 1, _now()
+            state = deepcopy(current.state)
+            state["status_reason"] = reason[:8000]
+            state.pop("driver", None)
+            if status == "active":
+                state["recovery_attempts"] = 0
+            db.execute(
+                "UPDATE goal_runs SET status=?,version=?,state_json=?,updated_at=? "
+                "WHERE id=? AND version=?",
+                (status, version, _json(state), now, goal_id, expected_version),
+            )
+            self._event(db, goal_id, version, f"goal_{status}", {"reason": reason}, now)
+            return self._require(db, goal_id)
+
+    def replace(
+        self,
+        goal_id: str,
+        expected_version: int,
+        objective: str,
+        summary: str = "",
+    ) -> Goal:
+        objective = objective.strip()
+        if not objective:
+            raise ValueError("replacement objective is required")
+        self.initialize()
+        with self._write() as db:
+            old = self._require(db, goal_id)
+            if old.version != expected_version:
+                raise GoalConflictError(
+                    f"goal is at version {old.version}, expected {expected_version}"
+                )
+            if old.status not in _CURRENT_STATUSES:
+                raise GoalError("only a current goal can be replaced")
+            now, new_id = _now(), f"goal_{uuid.uuid4().hex}"
+            db.execute(
+                "UPDATE goal_runs SET status='replaced',version=?,updated_at=? WHERE id=?",
+                (old.version + 1, now, old.id),
+            )
+            self._event(db, old.id, old.version + 1, "goal_replaced", {"by": new_id}, now)
+            state = {
+                "schema": 1,
+                "objective": objective,
+                "revision": 0,
+                "nodes": {},
+                "needs_replan": False,
+                "recovery_attempts": 0,
+                "route": dict(old.state.get("route") or {}),
+            }
+            db.execute(
+                "INSERT INTO goal_runs VALUES (?,?,?,?,?,?,?,?)",
+                (new_id, old.session_key, "active", 1, summary[:120], _json(state), now, now),
+            )
+            self._event(db, new_id, 1, "goal_created", {"objective": objective}, now)
+            return self._require(db, new_id)
+
+    def events(self, goal_id: str, limit: int = 50) -> list[dict[str, Any]]:
+        self.initialize()
+        with closing(self._connect()) as db:
+            rows = db.execute(
+                "SELECT * FROM goal_events WHERE goal_id=? ORDER BY sequence DESC LIMIT ?",
+                (goal_id, max(1, min(limit, 100))),
+            ).fetchall()
+        return [
+            {
+                "sequence": row["sequence"],
+                "type": row["event_type"],
+                "payload": json.loads(row["payload_json"]),
+                "created_at": row["created_at"],
+            }
+            for row in rows
+        ]
+
+    def _connect(self) -> sqlite3.Connection:
+        db = sqlite3.connect(self.path, timeout=5)
+        db.row_factory = sqlite3.Row
+        db.execute("PRAGMA foreign_keys=ON")
+        db.execute("PRAGMA busy_timeout=5000")
+        return db
+
+    def _write(self):
+        return _Transaction(self._connect())
+
+    @staticmethod
+    def _require(db: sqlite3.Connection, goal_id: str) -> Goal:
+        row = db.execute("SELECT * FROM goal_runs WHERE id=?", (goal_id,)).fetchone()
+        if row is None:
+            raise GoalError("goal does not exist")
+        return _goal(row)
+
+    @staticmethod
+    def _event(
+        db: sqlite3.Connection,
+        goal_id: str,
+        sequence: int,
+        event_type: str,
+        payload: Mapping[str, Any],
+        created_at: str,
+    ) -> None:
+        db.execute(
+            "INSERT INTO goal_events VALUES (?,?,?,?,?)",
+            (goal_id, sequence, event_type, _json(dict(payload)), created_at),
+        )
+
+
+class _Transaction:
+    def __init__(self, db: sqlite3.Connection) -> None:
+        self.db = db
+
+    def __enter__(self) -> sqlite3.Connection:
+        self.db.execute("BEGIN IMMEDIATE")
+        return self.db
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        try:
+            self.db.rollback() if exc_type else self.db.commit()
+        finally:
+            self.db.close()
+
+
+def reduce_goal(state: Mapping[str, Any], command: Mapping[str, Any]) -> tuple[dict[str, Any], str]:
+    """Pure, deterministic transition for plan and node commands."""
+    next_state = deepcopy(dict(state))
+    nodes = _nodes(next_state)
+    action = str(command.get("action") or "").strip()
+    if action == "driver_turn":
+        driver = dict(next_state.get("driver") or {})
+        progressed = bool(command.get("progressed"))
+        next_state["driver"] = {"stalls": 0 if progressed else int(driver.get("stalls", 0)) + 1}
+        return next_state, "goal_driver_turn"
+    if action == "recovery_attempt":
+        node_id = str(command.get("node_id") or "").strip()
+        node = nodes.get(node_id)
+        if node is None or node["status"] != "blocked":
+            raise GoalError("recovery requires a blocked node")
+        attempts = int(next_state.get("recovery_attempts", 0))
+        if attempts >= MAX_RECOVERY_ATTEMPTS:
+            raise GoalError("Goal recovery budget is exhausted")
+        next_state["recovery_attempts"] = attempts + 1
+        return next_state, "recovery_attempted"
+    if action == "plan":
+        if nodes:
+            raise GoalError("initial plan already exists")
+        planned = _parse_nodes(command.get("nodes"))
+        _validate_graph(planned)
+        _unlock(planned)
+        next_state.update(nodes=planned, revision=1, needs_replan=False)
+        return next_state, "goal_planned"
+
+    node_id = str(command.get("node_id") or "").strip()
+    node = nodes.get(node_id)
+    if node is None:
+        raise GoalError("node is not in the current plan")
+    if action == "begin":
+        if node.get("kind", "action") != "action":
+            raise GoalError("a coarse node must be expanded before execution")
+        if node["status"] != "ready":
+            raise GoalError("only a ready node can begin")
+        node["status"] = "running"
+        event = "node_started"
+    elif action == "succeed":
+        if node["status"] != "running":
+            raise GoalError("only a running node can succeed")
+        result = str(command.get("result") or "").strip()
+        if not result:
+            raise GoalError("a successful node requires a result summary")
+        node.update(status="succeeded", result=result[:8000])
+        _unlock(nodes)
+        event = "node_succeeded"
+    elif action == "block":
+        if node["status"] not in {"ready", "running"}:
+            raise GoalError("only a ready or running node can be blocked")
+        reason = str(command.get("reason") or "").strip()
+        if not reason:
+            raise GoalError("a blocked node requires failure evidence")
+        node.update(status="blocked", failure=reason[:8000])
+        next_state["needs_replan"] = True
+        event = "node_blocked"
+    elif action == "expand":
+        if node.get("kind", "action") != "coarse" or node["status"] != "pending":
+            raise GoalError("only a pending coarse node can be expanded")
+        if not all(nodes[dep]["status"] == "succeeded" for dep in node["depends_on"]):
+            raise GoalError("a coarse node can expand only after its dependencies succeed")
+        _replace_with_subgraph(nodes, node_id, command.get("nodes"), inherit_dependencies=True)
+        event = "plan_expanded"
+    elif action == "replan":
+        if node["status"] != "blocked":
+            raise GoalError("only a blocked node can be replanned")
+        _replace_with_subgraph(nodes, node_id, command.get("nodes"))
+        next_state["needs_replan"] = any(
+            item["status"] == "blocked" for item in nodes.values()
+        )
+        next_state["recovery_attempts"] = 0
+        event = "goal_replanned"
+    else:
+        raise GoalError("unknown goal command")
+    next_state["revision"] = int(next_state.get("revision", 0)) + 1
+    return next_state, event
+
+
+def _parse_nodes(
+    specs: Any,
+    *,
+    existing_ids: set[str] | None = None,
+) -> dict[str, dict[str, Any]]:
+    if not isinstance(specs, list) or not specs or len(specs) > _MAX_NODES:
+        raise GoalError(f"plan must contain 1-{_MAX_NODES} nodes")
+    existing_ids = existing_ids or set()
+    planned: dict[str, dict[str, Any]] = {}
+    for raw in specs:
+        if not isinstance(raw, Mapping):
+            raise GoalError("plan nodes must be objects")
+        node_id = str(raw.get("id") or "").strip()
+        if _NODE_ID.fullmatch(node_id) is None or node_id in planned or node_id in existing_ids:
+            raise GoalError("node ids must be unique letters, numbers, dot, dash, or underscore")
+        title = str(raw.get("title") or "").strip()
+        outcome = str(raw.get("outcome") or "").strip()
+        kind = str(raw.get("kind") or "action").strip()
+        deps = raw.get("depends_on", [])
+        if (
+            not title
+            or not outcome
+            or kind not in {"action", "coarse"}
+            or not isinstance(deps, list)
+            or len(deps) > _MAX_NODES
+        ):
+            raise GoalError("each node needs title, outcome, and depends_on")
+        planned[node_id] = {
+            "id": node_id,
+            "title": title[:300],
+            "outcome": outcome[:2000],
+            "kind": kind,
+            "depends_on": list(dict.fromkeys(str(dep).strip() for dep in deps)),
+            "status": "pending",
+        }
+    return planned
+
+
+def _replace_with_subgraph(
+    nodes: dict[str, dict[str, Any]],
+    node_id: str,
+    specs: Any,
+    *,
+    inherit_dependencies: bool = False,
+) -> None:
+    replacements = _parse_nodes(specs, existing_ids=set(nodes))
+    if len(nodes) + len(replacements) > _MAX_NODES:
+        raise GoalError(f"replacement plan would exceed {_MAX_NODES} total nodes")
+    succeeded = {item_id for item_id, item in nodes.items() if item["status"] == "succeeded"}
+    if any(
+        dep in nodes and dep not in succeeded
+        for replacement in replacements.values()
+        for dep in replacement["depends_on"]
+    ):
+        raise GoalError("replacement nodes may depend only on new or succeeded nodes")
+    replacement_ids = set(replacements)
+    if inherit_dependencies:
+        inherited = nodes[node_id]["depends_on"]
+        for replacement in replacements.values():
+            if not any(dep in replacement_ids for dep in replacement["depends_on"]):
+                replacement["depends_on"] = list(
+                    dict.fromkeys([*inherited, *replacement["depends_on"]])
+                )
+    referenced = {dep for item in replacements.values() for dep in item["depends_on"]}
+    leaves = [item_id for item_id in replacements if item_id not in referenced]
+    nodes[node_id]["status"] = "superseded"
+    for downstream in nodes.values():
+        if node_id in downstream["depends_on"]:
+            downstream["depends_on"] = list(
+                dict.fromkeys(
+                    dep
+                    for original in downstream["depends_on"]
+                    for dep in (leaves if original == node_id else [original])
+                )
+            )
+    nodes.update(replacements)
+    _validate_graph(nodes)
+    _unlock(nodes)
+
+
+def projection(goal: Goal, limit: int = 8) -> dict[str, Any]:
+    nodes = _nodes(goal.state)
+    ordered = list(nodes.values())
+    return {
+        "goal_id": goal.id,
+        "status": goal.status,
+        "version": goal.version,
+        "objective": goal.state.get("objective", ""),
+        "revision": goal.state.get("revision", 0),
+        "expandable": [
+            _project_node(node)
+            for node in ordered
+            if node.get("kind") == "coarse"
+            and node["status"] == "pending"
+            and all(nodes[dep]["status"] == "succeeded" for dep in node["depends_on"])
+        ][:limit],
+        "frontier": [_project_node(node) for node in ordered if node["status"] == "ready"][
+            :limit
+        ],
+        "running": [_project_node(node) for node in ordered if node["status"] == "running"][
+            :limit
+        ],
+        "blocked": [_project_node(node) for node in ordered if node["status"] == "blocked"][
+            :limit
+        ],
+        "succeeded": [
+            _project_node(node) for node in ordered if node["status"] == "succeeded"
+        ][-limit:],
+        "needs_replan": bool(goal.state.get("needs_replan")),
+        "recovery_attempts": int(goal.state.get("recovery_attempts", 0)),
+        "max_recovery_attempts": MAX_RECOVERY_ATTEMPTS,
+        "status_reason": str(goal.state.get("status_reason") or "")[:1000],
+        "node_count": len(nodes),
+    }
+
+
+def _project_node(node: Mapping[str, Any]) -> dict[str, Any]:
+    projected = dict(node)
+    for field in ("result", "failure"):
+        if field in projected:
+            projected[field] = str(projected[field])[:1000]
+    return projected
+
+
+def compact_ref(goal: Goal, workspace: str | Path) -> dict[str, Any]:
+    return {
+        "schema": 1,
+        "goal_id": goal.id,
+        "workspace": workspace_fingerprint(workspace),
+        "status": goal.status,
+        "version": goal.version,
+        "ui_summary": goal.summary,
+    }
+
+
+def _validate_graph(nodes: Mapping[str, Mapping[str, Any]]) -> None:
+    for node_id, node in nodes.items():
+        deps = node["depends_on"]
+        if node_id in deps or any(dep not in nodes for dep in deps):
+            raise GoalError("dependencies must reference other nodes in the plan")
+    visiting: set[str] = set()
+    depths: dict[str, int] = {}
+
+    def visit(node_id: str) -> int:
+        if node_id in visiting:
+            raise GoalError("plan dependencies must be acyclic")
+        if node_id in depths:
+            return depths[node_id]
+        visiting.add(node_id)
+        depth = 1 + max((visit(dep) for dep in nodes[node_id]["depends_on"]), default=0)
+        visiting.remove(node_id)
+        if depth > _MAX_DEPTH:
+            raise GoalError(f"plan depth exceeds {_MAX_DEPTH}")
+        depths[node_id] = depth
+        return depth
+
+    for node_id in nodes:
+        visit(node_id)
+
+
+def _unlock(nodes: Mapping[str, dict[str, Any]]) -> None:
+    for node in nodes.values():
+        if (
+            node["status"] == "pending"
+            and node.get("kind", "action") == "action"
+            and all(
+            nodes[dep]["status"] == "succeeded" for dep in node["depends_on"]
+            )
+        ):
+            node["status"] = "ready"
+
+
+def _nodes(state: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    nodes = state.get("nodes")
+    if not isinstance(nodes, dict):
+        raise GoalError("goal state has invalid nodes")
+    for node in nodes.values():
+        if not isinstance(node, dict) or node.get("status") not in _NODE_STATUSES:
+            raise GoalError("goal state contains an invalid node")
+    return nodes
+
+
+def _goal(row: sqlite3.Row) -> Goal:
+    try:
+        state = json.loads(row["state_json"])
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise GoalError("goal state is not valid JSON") from exc
+    if not isinstance(state, dict):
+        raise GoalError("goal state must be a JSON object")
+    return Goal(
+        id=str(row["id"]),
+        session_key=str(row["session_key"]),
+        status=str(row["status"]),
+        version=int(row["version"]),
+        summary=str(row["summary"]),
+        state=state,
+    )
+
+
+def _json(value: Any) -> str:
+    try:
+        return json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise GoalError("goal data must be JSON serializable") from exc
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()

--- a/nanobot/goals.py
+++ b/nanobot/goals.py
@@ -221,7 +221,7 @@ class GoalStore:
             if status == "completed":
                 nodes = _nodes(current.state)
                 retained = [node for node in nodes.values() if node["status"] != "superseded"]
-                if not retained or any(node["status"] != "succeeded" for node in retained):
+                if retained and any(node["status"] != "succeeded" for node in retained):
                     raise GoalError("goal cannot complete until every retained node succeeds")
             version, now = current.version + 1, _now()
             state = {**current.state, "recap": recap[:8000]}
@@ -297,6 +297,7 @@ class GoalStore:
             state = {
                 "schema": 1,
                 "objective": objective,
+                "previous_objective": str(old.state.get("objective") or "")[:4000],
                 "revision": 0,
                 "nodes": {},
                 "needs_replan": False,
@@ -579,14 +580,21 @@ def _project_node(node: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def compact_ref(goal: Goal, workspace: str | Path) -> dict[str, Any]:
-    return {
+    ref = {
         "schema": 1,
         "goal_id": goal.id,
         "workspace": workspace_fingerprint(workspace),
         "status": goal.status,
         "version": goal.version,
+        # Compatibility/display snapshot only; GoalStore remains authoritative.
+        "objective": str(goal.state.get("objective") or "")[:4000],
         "ui_summary": goal.summary,
     }
+    for field in ("previous_objective", "recap"):
+        value = str(goal.state.get(field) or "")
+        if value:
+            ref[field] = value[:8000]
+    return ref
 
 
 def _validate_graph(nodes: Mapping[str, Mapping[str, Any]]) -> None:

--- a/nanobot/session/automation_turns.py
+++ b/nanobot/session/automation_turns.py
@@ -56,9 +56,10 @@ def automation_history_overrides_for_spec(
 def _automation_specs() -> tuple[AutomationTurnSpec, ...]:
     # Source modules import the generic helpers above, so keep spec loading lazy.
     from nanobot.cron.session_turns import CRON_AUTOMATION_SPEC
+    from nanobot.goal_driver import GOAL_DRIVER_AUTOMATION_SPEC
     from nanobot.triggers.local_session_turns import LOCAL_TRIGGER_AUTOMATION_SPEC
 
-    return (CRON_AUTOMATION_SPEC, LOCAL_TRIGGER_AUTOMATION_SPEC)
+    return (CRON_AUTOMATION_SPEC, LOCAL_TRIGGER_AUTOMATION_SPEC, GOAL_DRIVER_AUTOMATION_SPEC)
 
 
 def automation_history_overrides(
@@ -70,6 +71,10 @@ def automation_history_overrides(
         if extra:
             return text, extra
     return None, {}
+
+
+def is_automation_turn(metadata: Mapping[str, Any] | None) -> bool:
+    return any(automation_trigger(metadata, spec) is not None for spec in _automation_specs())
 
 
 def is_automation_history_message(message: Mapping[str, Any] | None) -> bool:

--- a/nanobot/session/goal_state.py
+++ b/nanobot/session/goal_state.py
@@ -18,6 +18,7 @@ MAX_GOAL_OBJECTIVE_CHARS = 4000
 # Older builds stored the same JSON blob under this key.
 _LEGACY_GOAL_STATE_SESSION_KEY = "thread_goal"
 _MAX_OBJECTIVE_WS = 600
+_CURRENT_GOAL_STATUSES = {"active", "waiting", "blocked"}
 
 
 def _session_goal_raw(metadata: Mapping[str, Any] | None) -> Any:
@@ -39,7 +40,13 @@ def goal_state_raw(metadata: Mapping[str, Any] | None) -> Any:
 
 
 def sustained_goal_active(metadata: Mapping[str, Any] | None) -> bool:
-    """True when this session has an active sustained objective."""
+    """True while this session has a current sustained objective."""
+    goal = parse_goal_state(goal_state_raw(metadata))
+    return isinstance(goal, dict) and goal.get("status") in _CURRENT_GOAL_STATUSES
+
+
+def sustained_goal_runnable(metadata: Mapping[str, Any] | None) -> bool:
+    """True only while a sustained objective may continue automatically."""
     goal = parse_goal_state(goal_state_raw(metadata))
     return isinstance(goal, dict) and goal.get("status") == "active"
 
@@ -81,8 +88,17 @@ def goal_state_runtime_lines(metadata: Mapping[str, Any] | None) -> list[str]:
     if not metadata:
         return []
     goal = parse_goal_state(_session_goal_raw(metadata))
-    if not isinstance(goal, dict) or goal.get("status") != "active":
+    if not isinstance(goal, dict) or goal.get("status") not in _CURRENT_GOAL_STATUSES:
         return []
+    status = str(goal.get("status"))
+    goal_id = str(goal.get("goal_id") or "").strip()
+    if goal_id:
+        version = goal.get("version")
+        suffix = f", version {version}" if isinstance(version, int) else ""
+        return [
+            f"Goal: {status} durable reference {goal_id}{suffix}.",
+            "Use Goal Runtime Context or get_goal_plan for the authoritative objective and graph.",
+        ]
     objective = str(goal.get("objective") or "").strip()
     if not objective:
         return ["Goal: active (no objective text stored)."]
@@ -98,12 +114,17 @@ def goal_state_runtime_lines(metadata: Mapping[str, Any] | None) -> list[str]:
 def goal_state_ws_blob(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
     """JSON-safe snapshot for WebSocket ``goal_state`` events (one chat_id per frame)."""
     goal = parse_goal_state(_session_goal_raw(metadata)) if metadata else None
-    if isinstance(goal, dict) and goal.get("status") == "active":
+    if isinstance(goal, dict) and goal.get("status") in _CURRENT_GOAL_STATUSES:
+        goal_id = str(goal.get("goal_id") or "").strip()
         objective = str(goal.get("objective") or "").strip()
         if len(objective) > _MAX_OBJECTIVE_WS:
             objective = objective[:_MAX_OBJECTIVE_WS].rstrip() + "…"
         summary = str(goal.get("ui_summary") or "").strip()[:120]
         blob: dict[str, Any] = {"active": True}
+        if goal_id:
+            blob["goal_id"] = goal_id
+            if isinstance(goal.get("version"), int):
+                blob["version"] = goal["version"]
         if summary:
             blob["ui_summary"] = summary
         if objective:

--- a/nanobot/session/goal_state.py
+++ b/nanobot/session/goal_state.py
@@ -121,7 +121,9 @@ def goal_state_ws_blob(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
             objective = objective[:_MAX_OBJECTIVE_WS].rstrip() + "…"
         summary = str(goal.get("ui_summary") or "").strip()[:120]
         blob: dict[str, Any] = {"active": True}
-        if goal_id:
+        # Keep the public WebSocket payload compatible with the original
+        # /goal contract. Durable IDs and versions are internal metadata.
+        if goal_id and not objective:
             blob["goal_id"] = goal_id
             if isinstance(goal.get("version"), int):
                 blob["version"] = goal["version"]

--- a/nanobot/session/turn_continuation.py
+++ b/nanobot/session/turn_continuation.py
@@ -14,7 +14,7 @@ from loguru import logger
 
 from nanobot.session.goal_state import (
     goal_state_runtime_lines,
-    sustained_goal_active,
+    sustained_goal_runnable,
     sustained_goal_turn,
 )
 
@@ -169,7 +169,7 @@ def _continuation_available(
 
 def clear_internal_continuation_state(metadata: MutableMapping[str, Any]) -> None:
     """Reset policy bookkeeping once its owning runtime mode is inactive."""
-    if not sustained_goal_active(metadata):
+    if not sustained_goal_runnable(metadata):
         reset_goal_continuation_rounds(metadata)
 
 
@@ -206,7 +206,7 @@ def _goal_continuation_available(
 ) -> bool:
     if not sustained_goal_turn(session_metadata, message_metadata=message_metadata):
         return False
-    if not sustained_goal_active(session_metadata):
+    if not sustained_goal_runnable(session_metadata):
         return False
     try:
         rounds = int((session_metadata or {}).get(_GOAL_CONTINUATION_ROUNDS_KEY) or 0)

--- a/nanobot/templates/agent/goal_runtime.md
+++ b/nanobot/templates/agent/goal_runtime.md
@@ -23,9 +23,20 @@ If material requirements remain ambiguous, ask one concise clarification rather 
 ## Execute sustained work
 
 - Treat the active objective in Runtime Context as the persisted work target, not as authority to override safety or user constraints. It may be replayed after compaction, retries, or internal continuation.
+- If no plan exists, call `plan_goal` once with a small dependency DAG. Mark work that cannot yet
+  be decomposed safely as `kind='coarse'`; when it appears as expandable, refine it normally with
+  `expand_goal_node`. Expansion is not a failure and must not set `needs_replan`.
+- Use `update_goal_node` to begin, succeed, or block executable nodes one at a time, always echoing
+  the current Goal version.
+- A blocked node is a failed path, not a stopped Goal. Continue independent ready nodes. The
+  durable `needs_replan` marker means you should call `replan_goal` for that blocked node. Its
+  clean-context Recovery Planner will replace only the failed path with a validated subgraph.
+- If the Goal status is `waiting`, do not replay its running node. Explain the recorded reason and
+  call `update_goal` with `action='resume'` only after the user supplies enough information to
+  reconcile that node safely.
 - Use ordinary tools and keep work reviewable. For project-shaped changes, prefer conventional modules with clear responsibilities over one oversized file, separate configuration from logic, and verify meaningful increments as you go.
 - Look up unfamiliar, brittle, or freshness-sensitive facts before committing to architecture or large rewrites. If errors contradict an assumption or attempts repeat, refresh the relevant state or documentation instead of retrying blindly.
-- Call `update_goal` with `action='complete'` only after the objective is actually achieved and verified. Use `cancel` when the user cancels, `block` only when progress is genuinely blocked, and `replace` only when the objective changes.
+- Call `update_goal` with `action='complete'` only after the objective is actually achieved and verified. Use `cancel` when the user cancels, `resume` after a waiting condition is resolved, and `replace` only when the objective changes; durable path failures belong on their node, not on the Goal root.
 {% endif %}
 
 [/Goal Runtime Guidance]

--- a/tests/agent/test_loop_runner_integration.py
+++ b/tests/agent/test_loop_runner_integration.py
@@ -80,6 +80,58 @@ async def test_goal_command_can_implement_plan_from_prior_discussion(tmp_path):
             usage={},
         ),
         LLMResponse(
+            content="planning the durable work",
+            tool_calls=[
+                ToolCallRequest(
+                    id="call_plan",
+                    name="plan_goal",
+                    arguments={
+                        "expected_version": 1,
+                        "nodes": [
+                            {
+                                "id": "implement",
+                                "title": "Implement and test",
+                                "outcome": "Migration is implemented and tests pass",
+                                "depends_on": [],
+                            }
+                        ],
+                    },
+                )
+            ],
+            usage={},
+        ),
+        LLMResponse(
+            content="starting the ready node",
+            tool_calls=[
+                ToolCallRequest(
+                    id="call_begin",
+                    name="update_goal_node",
+                    arguments={
+                        "expected_version": 2,
+                        "node_id": "implement",
+                        "action": "begin",
+                    },
+                )
+            ],
+            usage={},
+        ),
+        LLMResponse(
+            content="recording the verified result",
+            tool_calls=[
+                ToolCallRequest(
+                    id="call_succeed",
+                    name="update_goal_node",
+                    arguments={
+                        "expected_version": 3,
+                        "node_id": "implement",
+                        "action": "succeed",
+                        "result": "Implemented and tests passed.",
+                    },
+                )
+            ],
+            usage={},
+        ),
+        LLMResponse(
             content="closing goal",
             tool_calls=[
                 ToolCallRequest(

--- a/tests/agent/tools/test_goal_plan.py
+++ b/tests/agent/tools/test_goal_plan.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from nanobot.agent.goal_permission import goal_mutation_permission
+from nanobot.agent.tools.context import RequestContext, request_context
+from nanobot.agent.tools.goal_plan import (
+    ExpandGoalNodeTool,
+    GetGoalPlanTool,
+    PlanGoalTool,
+    UpdateGoalNodeTool,
+)
+from nanobot.agent.tools.long_task import CreateGoalTool, UpdateGoalTool
+from nanobot.goals import GoalStore
+from nanobot.session.goal_state import GOAL_STATE_KEY
+from nanobot.session.manager import SessionManager
+
+
+def _context() -> RequestContext:
+    return RequestContext(
+        channel="websocket",
+        chat_id="c1",
+        session_key="websocket:c1",
+        metadata={"goal_requested": True, "original_command": "/goal"},
+    )
+
+
+def _tools(sm: SessionManager):
+    root = sm.workspace / "test-goals"
+    common = {"sessions": sm, "workspace": sm.workspace, "goal_store_root": root}
+    return (
+        CreateGoalTool(**common),
+        UpdateGoalTool(**common),
+        PlanGoalTool(**common),
+        UpdateGoalNodeTool(**common),
+        GetGoalPlanTool(**common),
+        GoalStore.for_workspace(sm.workspace, root=root),
+    )
+
+
+async def _create(create: CreateGoalTool) -> None:
+    with request_context(_context()), goal_mutation_permission(True):
+        result = await create.execute(objective="Build and publish", ui_summary="ship")
+    assert "recorded durably" in result
+
+
+def _nodes() -> list[dict]:
+    return [
+        {"id": "build", "title": "Build", "outcome": "Artifact exists", "depends_on": []},
+        {
+            "id": "publish",
+            "title": "Publish",
+            "outcome": "Artifact is published",
+            "depends_on": ["build"],
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_goal_tools_execute_graph_and_keep_session_reference_compact(tmp_path) -> None:
+    sm = SessionManager(tmp_path)
+    create, update, plan, node, get_plan, store = _tools(sm)
+    await _create(create)
+
+    with request_context(_context()):
+        planned = json.loads(await plan.execute(expected_version=1, nodes=_nodes()))
+        started = json.loads(
+            await node.execute(expected_version=2, node_id="build", action="begin")
+        )
+        succeeded = json.loads(
+            await node.execute(
+                expected_version=3,
+                node_id="build",
+                action="succeed",
+                result="focused tests passed",
+            )
+        )
+        queried = json.loads(await get_plan.execute())
+
+    assert [item["id"] for item in planned["frontier"]] == ["build"]
+    assert started["running"][0]["id"] == "build"
+    assert [item["id"] for item in succeeded["frontier"]] == ["publish"]
+    assert queried == succeeded
+    ref = sm.get_or_create("websocket:c1").metadata[GOAL_STATE_KEY]
+    assert set(ref) == {
+        "schema",
+        "goal_id",
+        "workspace",
+        "status",
+        "version",
+        "objective",
+        "ui_summary",
+    }
+    assert "nodes" not in ref
+    assert store.get(ref["goal_id"]).state["objective"] == "Build and publish"
+
+    with request_context(_context()), goal_mutation_permission(True):
+        rejected = await update.execute(action="complete", recap="Not finished")
+    assert "every retained node succeeds" in str(rejected)
+
+
+@pytest.mark.asyncio
+async def test_block_tool_keeps_goal_active_and_independent_node_ready(tmp_path) -> None:
+    sm = SessionManager(tmp_path)
+    create, _update, plan, node, _get_plan, _store = _tools(sm)
+    await _create(create)
+    independent = [
+        {"id": "primary", "title": "Primary", "outcome": "Done", "depends_on": []},
+        {"id": "other", "title": "Other", "outcome": "Done", "depends_on": []},
+    ]
+
+    with request_context(_context()):
+        await plan.execute(expected_version=1, nodes=independent)
+        await node.execute(expected_version=2, node_id="primary", action="begin")
+        blocked = json.loads(
+            await node.execute(
+                expected_version=3,
+                node_id="primary",
+                action="block",
+                reason="path is infeasible",
+            )
+        )
+
+    assert blocked["status"] == "active"
+    assert blocked["needs_replan"] is True
+    assert [item["id"] for item in blocked["frontier"]] == ["other"]
+    assert sm.get_or_create("websocket:c1").metadata[GOAL_STATE_KEY]["status"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_runtime_context_resolves_authoritative_store_projection(tmp_path) -> None:
+    sm = SessionManager(tmp_path)
+    create, _update, plan, _node, _get_plan, _store = _tools(sm)
+    await _create(create)
+    with request_context(_context()):
+        await plan.execute(expected_version=1, nodes=_nodes())
+        context = await create._provide_runtime_context(_context())
+
+    assert context is not None
+    assert "Build and publish" in context.content
+    assert "build (Build)" in context.content
+    assert "version 2" in context.content
+
+
+@pytest.mark.asyncio
+async def test_node_commands_require_current_version_and_valid_transition(tmp_path) -> None:
+    sm = SessionManager(tmp_path)
+    create, _update, plan, node, _get_plan, _store = _tools(sm)
+    await _create(create)
+    with request_context(_context()):
+        await plan.execute(expected_version=1, nodes=_nodes())
+        stale = await node.execute(expected_version=1, node_id="build", action="begin")
+        invalid = await node.execute(expected_version=2, node_id="publish", action="begin")
+
+    assert "expected 1" in str(stale)
+    assert "only a ready node" in str(invalid)
+
+
+@pytest.mark.asyncio
+async def test_expand_goal_node_refines_coarse_work_without_replanning(tmp_path) -> None:
+    sm = SessionManager(tmp_path)
+    create, _update, plan, _node, _get_plan, _store = _tools(sm)
+    expand = ExpandGoalNodeTool(
+        sessions=sm,
+        workspace=sm.workspace,
+        goal_store_root=sm.workspace / "test-goals",
+    )
+    await _create(create)
+    with request_context(_context()):
+        planned = json.loads(
+            await plan.execute(
+                expected_version=1,
+                nodes=[
+                    {
+                        "id": "coarse",
+                        "title": "Determine implementation",
+                        "outcome": "Feature exists",
+                        "kind": "coarse",
+                        "depends_on": [],
+                    },
+                    {
+                        "id": "publish",
+                        "title": "Publish",
+                        "outcome": "Published",
+                        "depends_on": ["coarse"],
+                    },
+                ],
+            )
+        )
+        context = await create._provide_runtime_context(_context())
+        expanded = json.loads(
+            await expand.execute(
+                expected_version=2,
+                node_id="coarse",
+                nodes=[
+                    {
+                        "id": "implement",
+                        "title": "Implement",
+                        "outcome": "Feature exists",
+                        "depends_on": [],
+                    }
+                ],
+            )
+        )
+
+    assert [node["id"] for node in planned["expandable"]] == ["coarse"]
+    assert planned["frontier"] == []
+    assert context is not None and "Expandable: coarse" in context.content
+    assert [node["id"] for node in expanded["frontier"]] == ["implement"]
+    assert expanded["needs_replan"] is False
+    assert sm.get_or_create("websocket:c1").metadata[GOAL_STATE_KEY]["version"] == 3

--- a/tests/agent/tools/test_goal_replan.py
+++ b/tests/agent/tools/test_goal_replan.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.agent.goal_permission import goal_mutation_permission
+from nanobot.agent.tools.context import RequestContext, request_context
+from nanobot.agent.tools.goal_plan import PlanGoalTool, UpdateGoalNodeTool
+from nanobot.agent.tools.goal_replan import ReplanGoalTool
+from nanobot.agent.tools.long_task import CreateGoalTool
+from nanobot.goals import GoalStore
+from nanobot.providers.base import GenerationSettings, LLMProvider, LLMResponse, ToolCallRequest
+from nanobot.session.goal_state import GOAL_STATE_KEY
+from nanobot.session.manager import SessionManager
+from nanobot.utils.llm_runtime import LLMRuntime
+
+
+def _runtime(response: LLMResponse) -> tuple[LLMRuntime, AsyncMock]:
+    provider = MagicMock(spec=LLMProvider)
+    provider.chat_with_retry = AsyncMock(return_value=response)
+    runtime = LLMRuntime(
+        provider=provider,
+        model="test-model",
+        generation=GenerationSettings(temperature=0.7, max_tokens=2048),
+        context_window_tokens=32_000,
+    )
+    return runtime, provider.chat_with_retry
+
+
+def _context(runtime: LLMRuntime) -> RequestContext:
+    return RequestContext(
+        channel="websocket",
+        chat_id="c1",
+        session_key="websocket:c1",
+        original_user_text="SECRET ORIGINAL CHAT MUST NOT BE COPIED",
+        runtime=runtime,
+        metadata={"goal_requested": True, "original_command": "/goal"},
+    )
+
+
+def _proposal_response() -> LLMResponse:
+    return LLMResponse(
+        content=None,
+        tool_calls=[
+            ToolCallRequest(
+                id="recovery",
+                name="submit_recovery_plan",
+                arguments={
+                    "rationale": "Use the verified preparation with a different endpoint.",
+                    "nodes": [
+                        {
+                            "id": "alternate",
+                            "title": "Alternate route",
+                            "outcome": "Artifact",
+                            "depends_on": ["prep"],
+                        }
+                    ],
+                },
+            )
+        ],
+        finish_reason="tool_calls",
+    )
+
+
+async def _blocked_goal(sm: SessionManager, runtime: LLMRuntime):
+    root = sm.workspace / "test-goals"
+    common = {"sessions": sm, "workspace": sm.workspace, "goal_store_root": root}
+    create = CreateGoalTool(**common)
+    plan = PlanGoalTool(**common)
+    node = UpdateGoalNodeTool(**common)
+    replan = ReplanGoalTool(**common)
+    ctx = _context(runtime)
+    with request_context(ctx), goal_mutation_permission(True):
+        await create.execute(objective="Build through a recoverable route", ui_summary="recover")
+    with request_context(ctx):
+        await plan.execute(
+            expected_version=1,
+            nodes=[
+                {"id": "prep", "title": "Prepare", "outcome": "Ready", "depends_on": []},
+                {
+                    "id": "primary",
+                    "title": "Primary route",
+                    "outcome": "Artifact",
+                    "depends_on": ["prep"],
+                },
+                {
+                    "id": "finish",
+                    "title": "Finish",
+                    "outcome": "Done",
+                    "depends_on": ["primary"],
+                },
+                {"id": "other", "title": "Other", "outcome": "Done", "depends_on": []},
+            ],
+        )
+        await node.execute(expected_version=2, node_id="prep", action="begin")
+        await node.execute(
+            expected_version=3,
+            node_id="prep",
+            action="succeed",
+            result="Preparation verified",
+        )
+        await node.execute(expected_version=4, node_id="primary", action="begin")
+        await node.execute(
+            expected_version=5,
+            node_id="primary",
+            action="block",
+            reason="Primary endpoint is unavailable",
+        )
+    store = GoalStore.for_workspace(sm.workspace, root=root)
+    ref = sm.get_or_create("websocket:c1").metadata[GOAL_STATE_KEY]
+    return replan, ctx, store, ref
+
+
+@pytest.mark.asyncio
+async def test_recovery_planner_uses_clean_evidence_and_atomically_replaces_path(tmp_path) -> None:
+    runtime, planner_call = _runtime(_proposal_response())
+    sm = SessionManager(tmp_path)
+    replan, ctx, store, ref = await _blocked_goal(sm, runtime)
+
+    with request_context(ctx):
+        result = json.loads(await replan.execute(expected_version=6, blocked_node_id="primary"))
+
+    goal = store.get(ref["goal_id"])
+    assert goal is not None
+    assert goal.state["nodes"]["primary"]["status"] == "superseded"
+    assert goal.state["nodes"]["alternate"]["status"] == "ready"
+    assert goal.state["nodes"]["finish"]["depends_on"] == ["alternate"]
+    assert goal.state["nodes"]["other"]["status"] == "ready"
+    assert result["needs_replan"] is False
+    assert sm.get_or_create("websocket:c1").metadata[GOAL_STATE_KEY]["version"] == 8
+    assert goal.state["recovery_attempts"] == 0
+
+    kwargs = planner_call.await_args.kwargs
+    assert [message["role"] for message in kwargs["messages"]] == ["system", "user"]
+    evidence = json.loads(kwargs["messages"][1]["content"])
+    assert evidence["ultimate_objective"] == "Build through a recoverable route"
+    assert evidence["successful_predecessors"][0]["result"] == "Preparation verified"
+    assert evidence["failure_experience"][0]["failure"] == "Primary endpoint is unavailable"
+    assert "SECRET ORIGINAL CHAT" not in kwargs["messages"][1]["content"]
+    assert [tool["function"]["name"] for tool in kwargs["tools"]] == [
+        "submit_recovery_plan"
+    ]
+    assert kwargs["tool_choice"] == "required"
+
+
+@pytest.mark.asyncio
+async def test_invalid_recovery_proposal_consumes_budget_but_keeps_blocked_path(tmp_path) -> None:
+    runtime, planner_call = _runtime(LLMResponse(content='{"nodes": []}', tool_calls=[]))
+    sm = SessionManager(tmp_path)
+    replan, ctx, store, ref = await _blocked_goal(sm, runtime)
+
+    with request_context(ctx):
+        result = await replan.execute(expected_version=6, blocked_node_id="primary")
+
+    goal = store.get(ref["goal_id"])
+    assert "did not return exactly one structured proposal" in str(result)
+    assert goal is not None and goal.version == 7
+    assert goal.state["recovery_attempts"] == 1
+    assert goal.state["nodes"]["primary"]["status"] == "blocked"
+    assert goal.state["needs_replan"] is True
+    planner_call.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_model_failure_does_not_consume_recovery_budget(tmp_path) -> None:
+    runtime, planner_call = _runtime(LLMResponse(content=None))
+    planner_call.side_effect = RuntimeError("provider unavailable")
+    sm = SessionManager(tmp_path)
+    replan, ctx, store, ref = await _blocked_goal(sm, runtime)
+
+    with request_context(ctx):
+        result = await replan.execute(expected_version=6, blocked_node_id="primary")
+
+    goal = store.get(ref["goal_id"])
+    assert "provider unavailable" in str(result)
+    assert goal is not None and goal.version == 6
+    assert goal.state["recovery_attempts"] == 0
+
+
+@pytest.mark.asyncio
+async def test_stale_replan_is_rejected_before_calling_model(tmp_path) -> None:
+    runtime, planner_call = _runtime(LLMResponse(content=None))
+    sm = SessionManager(tmp_path)
+    replan, ctx, store, ref = await _blocked_goal(sm, runtime)
+
+    with request_context(ctx):
+        result = await replan.execute(expected_version=5, blocked_node_id="primary")
+
+    assert "expected 5" in str(result)
+    assert store.get(ref["goal_id"]).version == 6
+    planner_call.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_goal_change_wins_over_slow_recovery_proposal(tmp_path) -> None:
+    runtime, planner_call = _runtime(_proposal_response())
+    sm = SessionManager(tmp_path)
+    replan, ctx, store, ref = await _blocked_goal(sm, runtime)
+
+    async def change_goal_before_proposal_returns(**_kwargs):
+        store.apply(ref["goal_id"], 6, {"action": "begin", "node_id": "other"})
+        return _proposal_response()
+
+    planner_call.side_effect = change_goal_before_proposal_returns
+    with request_context(ctx):
+        result = await replan.execute(expected_version=6, blocked_node_id="primary")
+
+    goal = store.get(ref["goal_id"])
+    assert "goal is at version 7, expected 6" in str(result)
+    assert goal is not None and goal.state["nodes"]["primary"]["status"] == "blocked"
+    assert "alternate" not in goal.state["nodes"]
+    assert goal.state["nodes"]["other"]["status"] == "running"

--- a/tests/agent/tools/test_long_task.py
+++ b/tests/agent/tools/test_long_task.py
@@ -22,6 +22,7 @@ from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.bus.outbound_events import GoalStateSyncEvent
 from nanobot.bus.queue import MessageBus
 from nanobot.bus.runtime_events import RuntimeEventBus
+from nanobot.goals import GoalStore, compact_ref
 from nanobot.session.goal_state import GOAL_STATE_KEY, MAX_GOAL_OBJECTIVE_CHARS
 from nanobot.session.manager import SessionManager
 from nanobot.session.turn_continuation import should_finalize_on_max_iterations
@@ -57,10 +58,18 @@ def _tools(
     *,
     metadata: dict[str, object] | None = None,
 ) -> tuple[CreateGoalTool, UpdateGoalTool, RequestContext]:
-    create = CreateGoalTool(sessions=sm)
-    update = UpdateGoalTool(sessions=sm)
+    create = CreateGoalTool(sessions=sm, goal_store_root=_goal_store_root(sm))
+    update = UpdateGoalTool(sessions=sm, goal_store_root=_goal_store_root(sm))
     rc = _request_context(metadata=metadata)
     return create, update, rc
+
+
+def _goal_store_root(sm: SessionManager):
+    return sm.workspace / "test-goals"
+
+
+def _stored_goal(sm: SessionManager, blob: dict):
+    return GoalStore.for_workspace(sm.workspace, root=_goal_store_root(sm)).get(blob["goal_id"])
 
 
 async def _execute(tool, ctx: RequestContext, *, allowed: bool = True, **kwargs):
@@ -87,7 +96,9 @@ async def test_create_goal_records_goal_metadata(tmp_path):
     assert isinstance(blob, dict)
     assert blob["status"] == "active"
     assert blob["objective"] == "Do the thing"
+    assert "nodes" not in blob
     assert blob["ui_summary"] == "thing"
+    assert _stored_goal(sm, blob).state["objective"] == "Do the thing"
     assert "_sustained_goal_continuation_rounds" not in sess.metadata
     assert "_sustained_goal_continuation_rounds" not in (
         SessionManager(tmp_path).get_or_create("websocket:c1").metadata
@@ -120,7 +131,7 @@ async def test_create_goal_rejects_without_explicit_goal_permission(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_update_goal_complete_closes_active_goal(tmp_path):
+async def test_update_goal_complete_allows_an_unplanned_simple_goal(tmp_path):
     sm = SessionManager(tmp_path)
     create, update, ctx = _tools(sm)
 
@@ -130,7 +141,7 @@ async def test_update_goal_complete_closes_active_goal(tmp_path):
         denied = await create.execute(objective="Another")
         assert goal_mutation_allowed() is False
 
-    assert "marked complete" in out
+    assert "marked complete" in str(out)
     assert "create_goal is unavailable for this turn" in str(denied)
 
     sess = sm.get_or_create("websocket:c1")
@@ -161,6 +172,7 @@ async def test_update_goal_replace_keeps_goal_active_with_new_objective(tmp_path
     assert blob["status"] == "active"
     assert blob["objective"] == "New"
     assert blob["previous_objective"] == "Old"
+    assert _stored_goal(sm, blob).state["objective"] == "New"
     assert blob["ui_summary"] == "new"
     assert "_sustained_goal_continuation_rounds" not in sess.metadata
     assert "_sustained_goal_continuation_rounds" not in (
@@ -205,10 +217,12 @@ async def test_goal_state_mutations_roll_back_on_save_failure(tmp_path, monkeypa
     with pytest.raises(OSError, match="disk unavailable"):
         await _execute(update, replace_context, action="replace", objective="New")
 
-    assert sess.metadata[GOAL_STATE_KEY]["objective"] == "Old"
+    old_ref = sess.metadata[GOAL_STATE_KEY]
+    assert old_ref["status"] == "active"
+    assert old_ref["objective"] == "Old"
     assert sess.metadata["_sustained_goal_continuation_rounds"] == 12
     persisted = SessionManager(tmp_path).get_or_create("websocket:c1").metadata
-    assert persisted[GOAL_STATE_KEY]["objective"] == "Old"
+    assert persisted[GOAL_STATE_KEY] == old_ref
     assert persisted["_sustained_goal_continuation_rounds"] == 12
 
     monkeypatch.setattr(sm, "save", original_save)
@@ -219,16 +233,14 @@ async def test_goal_state_mutations_roll_back_on_save_failure(tmp_path, monkeypa
         objective="New",
     )
     assert "_sustained_goal_continuation_rounds" not in sess.metadata
-    assert (
-        SessionManager(tmp_path).get_or_create("websocket:c1").metadata[GOAL_STATE_KEY]["objective"]
-        == "New"
-    )
+    repaired = SessionManager(tmp_path).get_or_create("websocket:c1").metadata[GOAL_STATE_KEY]
+    assert _stored_goal(sm, repaired).state["objective"] == "New"
 
 
 @pytest.mark.asyncio
 async def test_goal_tools_reject_oversized_objectives(tmp_path):
     sm = SessionManager(tmp_path)
-    create = CreateGoalTool(sessions=sm)
+    create = CreateGoalTool(sessions=sm, goal_store_root=_goal_store_root(sm))
     create_context = _request_context()
     oversized = "x" * (MAX_GOAL_OBJECTIVE_CHARS + 1)
 
@@ -242,14 +254,14 @@ async def test_goal_tools_reject_oversized_objectives(tmp_path):
         objective="x" * MAX_GOAL_OBJECTIVE_CHARS,
     )
 
-    update = UpdateGoalTool(sessions=sm)
+    update = UpdateGoalTool(sessions=sm, goal_store_root=_goal_store_root(sm))
     replace_context = _request_context()
     replace_out = await _execute(update, replace_context, action="replace", objective=oversized)
 
     assert f"must not exceed {MAX_GOAL_OBJECTIVE_CHARS}" in str(replace_out)
-    assert len(sm.get_or_create("websocket:c1").metadata[GOAL_STATE_KEY]["objective"]) == (
-        MAX_GOAL_OBJECTIVE_CHARS
-    )
+    blob = sm.get_or_create("websocket:c1").metadata[GOAL_STATE_KEY]
+    assert len(blob["objective"]) == MAX_GOAL_OBJECTIVE_CHARS
+    assert len(_stored_goal(sm, blob).state["objective"]) == MAX_GOAL_OBJECTIVE_CHARS
 
 
 @pytest.mark.asyncio
@@ -286,7 +298,9 @@ async def test_update_goal_replace_requires_explicit_goal_permission(tmp_path):
 
     assert "replacing the goal is unavailable for this turn" in str(unauthorized)
     assert "/goal <task>" in str(unauthorized)
-    assert sm.get_or_create("websocket:c1").metadata[GOAL_STATE_KEY]["objective"] == "Old"
+    blob = sm.get_or_create("websocket:c1").metadata[GOAL_STATE_KEY]
+    assert blob["objective"] == "Old"
+    assert _stored_goal(sm, blob).state["objective"] == "Old"
     replace_context = _request_context()
 
     with request_context(replace_context), goal_mutation_permission(True):
@@ -295,14 +309,16 @@ async def test_update_goal_replace_requires_explicit_goal_permission(tmp_path):
         assert goal_mutation_allowed() is True
 
     assert "Goal replaced" in reused
-    assert sm.get_or_create("websocket:c1").metadata[GOAL_STATE_KEY]["objective"] == "Another"
+    blob = sm.get_or_create("websocket:c1").metadata[GOAL_STATE_KEY]
+    assert blob["objective"] == "Another"
+    assert _stored_goal(sm, blob).state["objective"] == "Another"
 
 
 @pytest.mark.asyncio
 async def test_goal_tools_keep_request_context_per_task(tmp_path):
     sm = SessionManager(tmp_path)
-    create = CreateGoalTool(sessions=sm)
-    update = UpdateGoalTool(sessions=sm)
+    create = CreateGoalTool(sessions=sm, goal_store_root=_goal_store_root(sm))
+    update = UpdateGoalTool(sessions=sm, goal_store_root=_goal_store_root(sm))
     ctx_a = RequestContext(
         channel="websocket",
         chat_id="a",
@@ -320,8 +336,12 @@ async def test_goal_tools_keep_request_context_per_task(tmp_path):
     task_b = asyncio.create_task(_execute(create, ctx_b, objective="Goal B"))
     await asyncio.gather(task_a, task_b)
 
-    assert sm.get_or_create("websocket:a").metadata[GOAL_STATE_KEY]["objective"] == "Goal A"
-    assert sm.get_or_create("websocket:b").metadata[GOAL_STATE_KEY]["objective"] == "Goal B"
+    a_blob = sm.get_or_create("websocket:a").metadata[GOAL_STATE_KEY]
+    b_blob = sm.get_or_create("websocket:b").metadata[GOAL_STATE_KEY]
+    assert a_blob["objective"] == "Goal A"
+    assert b_blob["objective"] == "Goal B"
+    assert _stored_goal(sm, a_blob).state["objective"] == "Goal A"
+    assert _stored_goal(sm, b_blob).state["objective"] == "Goal B"
 
     a_revoked = asyncio.Event()
 
@@ -340,14 +360,16 @@ async def test_goal_tools_keep_request_context_per_task(tmp_path):
     await asyncio.gather(complete_a(), replace_b())
 
     assert sm.get_or_create("websocket:a").metadata[GOAL_STATE_KEY]["recap"] == "Done A"
-    assert sm.get_or_create("websocket:b").metadata[GOAL_STATE_KEY]["objective"] == "Goal B2"
+    b_blob = sm.get_or_create("websocket:b").metadata[GOAL_STATE_KEY]
+    assert b_blob["objective"] == "Goal B2"
+    assert _stored_goal(sm, b_blob).state["objective"] == "Goal B2"
 
 
 @pytest.mark.asyncio
 async def test_registry_does_not_reuse_goal_context_after_request_scope(tmp_path):
     sm = SessionManager(tmp_path)
-    create = CreateGoalTool(sessions=sm)
-    update = UpdateGoalTool(sessions=sm)
+    create = CreateGoalTool(sessions=sm, goal_store_root=_goal_store_root(sm))
+    update = UpdateGoalTool(sessions=sm, goal_store_root=_goal_store_root(sm))
     registry = ToolRegistry()
     registry.register(create)
     registry.register(update)
@@ -387,8 +409,16 @@ async def test_goal_state_events_publish_active_then_inactive(tmp_path):
         sessions=sm,
         schedule_background=lambda _coro: None,
     ).subscribe(runtime_events)
-    create = CreateGoalTool(sessions=sm, runtime_events=runtime_events)
-    update = UpdateGoalTool(sessions=sm, runtime_events=runtime_events)
+    create = CreateGoalTool(
+        sessions=sm,
+        runtime_events=runtime_events,
+        goal_store_root=_goal_store_root(sm),
+    )
+    update = UpdateGoalTool(
+        sessions=sm,
+        runtime_events=runtime_events,
+        goal_store_root=_goal_store_root(sm),
+    )
     rc = _request_context(chat_id="chat-99")
     await _execute(
         create,
@@ -416,8 +446,8 @@ async def test_goal_state_events_publish_active_then_inactive(tmp_path):
             chat_id="chat-99",
             session_key="websocket:chat-99",
         ),
-        action="complete",
-        recap="Done.",
+        action="cancel",
+        recap="Cancelled.",
     )
 
     bus.publish_outbound.assert_awaited_once()
@@ -433,6 +463,80 @@ async def test_update_goal_without_active_is_noop_message(tmp_path):
 
     out = await _execute(update, ctx, action="complete", recap="n/a")
     assert "No active" in out
+
+
+@pytest.mark.asyncio
+async def test_waiting_goal_can_resume_after_user_intervention(tmp_path):
+    sm = SessionManager(tmp_path)
+    create, update, ctx = _tools(sm)
+    await _execute(create, ctx, objective="Safely finish the work")
+    session = sm.get_or_create("websocket:c1")
+    store = GoalStore.for_workspace(sm.workspace, root=_goal_store_root(sm))
+    goal = store.get(session.metadata[GOAL_STATE_KEY]["goal_id"])
+    waiting = store.set_status(goal.id, goal.version, "waiting", "confirm remote effect")
+    session.metadata[GOAL_STATE_KEY] = compact_ref(waiting, sm.workspace)
+    sm.save(session)
+
+    out = await _execute(update, ctx, action="resume", recap="user confirmed no effect")
+
+    assert out == "Goal resumed."
+    assert store.get(goal.id).status == "active"
+
+
+@pytest.mark.asyncio
+async def test_automation_cannot_cancel_or_resume_goal(tmp_path):
+    sm = SessionManager(tmp_path)
+    create, update, ctx = _tools(sm)
+    await _execute(create, ctx, objective="Keep user control")
+    automation = _request_context(metadata={"_goal_driver": {"goal_id": "g"}})
+
+    denied = await _execute(update, automation, action="cancel")
+
+    assert "automation turn cannot cancel" in str(denied)
+    session = sm.get_or_create("websocket:c1")
+    store = GoalStore.for_workspace(sm.workspace, root=_goal_store_root(sm))
+    goal = _stored_goal(sm, session.metadata[GOAL_STATE_KEY])
+    waiting = store.set_status(goal.id, goal.version, "waiting", "need user input")
+    session.metadata[GOAL_STATE_KEY] = compact_ref(waiting, sm.workspace)
+    denied = await _execute(update, automation, action="resume")
+
+    assert "automation turn cannot resume" in str(denied)
+    assert store.get(goal.id).status == "waiting"
+
+
+@pytest.mark.asyncio
+async def test_runtime_context_repairs_terminal_session_reference(tmp_path):
+    sm = SessionManager(tmp_path)
+    create, _update, ctx = _tools(sm)
+    await _execute(create, ctx, objective="Finish durably")
+    session = sm.get_or_create("websocket:c1")
+    ref = session.metadata[GOAL_STATE_KEY]
+    store = GoalStore.for_workspace(sm.workspace, root=_goal_store_root(sm))
+    goal = store.get(ref["goal_id"])
+    goal = store.apply(
+        goal.id,
+        goal.version,
+        {
+            "action": "plan",
+            "nodes": [{"id": "done", "title": "Done", "outcome": "Done", "depends_on": []}],
+        },
+    )
+    goal = store.apply(goal.id, goal.version, {"action": "begin", "node_id": "done"})
+    goal = store.apply(
+        goal.id,
+        goal.version,
+        {"action": "succeed", "node_id": "done", "result": "verified"},
+    )
+    store.close(goal.id, goal.version, "completed")
+
+    with request_context(ctx):
+        await create._provide_runtime_context(ctx)
+
+    assert session.metadata[GOAL_STATE_KEY]["status"] == "completed"
+    assert should_finalize_on_max_iterations(
+        pending_queue_available=True,
+        session_metadata=session.metadata,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_goal_state.py
+++ b/tests/session/test_goal_state.py
@@ -12,6 +12,7 @@ from nanobot.session.goal_state import (
     parse_goal_state,
     runner_wall_llm_timeout_s,
     sustained_goal_active,
+    sustained_goal_runnable,
 )
 from nanobot.session.manager import SessionManager
 
@@ -98,6 +99,9 @@ def test_goal_state_ws_blob_active_shape():
             "ui_summary": "feat",
         },
     }
+
+    waiting = {GOAL_STATE_KEY: {"status": "waiting", "goal_id": "g", "version": 2}}
+    assert goal_state_ws_blob(waiting) == {"active": True, "goal_id": "g", "version": 2}
     assert goal_state_ws_blob(meta) == {
         "active": True,
         "ui_summary": "feat",
@@ -114,6 +118,18 @@ def test_sustained_goal_active_false_when_missing_or_completed():
 def test_sustained_goal_active_true_when_active():
     meta = {GOAL_STATE_KEY: {"status": "active", "objective": "Run long task."}}
     assert sustained_goal_active(meta) is True
+
+
+def test_only_active_goal_is_runnable():
+    active = {GOAL_STATE_KEY: {"status": "active"}}
+    waiting = {GOAL_STATE_KEY: {"status": "waiting"}}
+    blocked = {GOAL_STATE_KEY: {"status": "blocked"}}
+
+    assert sustained_goal_runnable(active) is True
+    assert sustained_goal_active(waiting) is True
+    assert sustained_goal_active(blocked) is True
+    assert sustained_goal_runnable(waiting) is False
+    assert sustained_goal_runnable(blocked) is False
 
 
 def test_sustained_goal_active_respects_legacy_thread_goal_key():

--- a/tests/session/test_turn_continuation.py
+++ b/tests/session/test_turn_continuation.py
@@ -139,6 +139,10 @@ def test_internal_continuation_requires_budget_boundary_and_queue():
         pending_queue_available=True,
         session_metadata={},
     )
+    assert should_finalize_on_max_iterations(
+        pending_queue_available=True,
+        session_metadata={GOAL_STATE_KEY: {"status": "waiting"}},
+    )
 
 
 def test_save_skip_matches_prefix_when_current_message_merged():

--- a/tests/test_goal_driver.py
+++ b/tests/test_goal_driver.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from nanobot.bus.queue import MessageBus
+from nanobot.goal_driver import GOAL_DRIVER_META, GoalDriver
+from nanobot.goals import GoalStore
+from nanobot.session.automation_turns import automation_history_overrides
+from nanobot.session.goal_state import GOAL_STATE_KEY
+from nanobot.session.manager import SessionManager
+
+
+def _setup(tmp_path: Path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    root = tmp_path / "goals"
+    sessions = SessionManager(workspace)
+    store = GoalStore.for_workspace(workspace, root=root)
+    bus = MessageBus()
+    return workspace, root, sessions, store, bus
+
+
+def _plan(store: GoalStore, goal_id: str, version: int, *, two: bool = False):
+    nodes = [
+        {"id": "main", "title": "Main", "outcome": "done", "depends_on": []},
+    ]
+    if two:
+        nodes.append(
+            {"id": "other", "title": "Other", "outcome": "done", "depends_on": []}
+        )
+    return store.apply(goal_id, version, {"action": "plan", "nodes": nodes})
+
+
+@pytest.mark.asyncio
+async def test_repeated_scan_schedules_one_turn(tmp_path: Path) -> None:
+    workspace, root, sessions, store, bus = _setup(tmp_path)
+    goal = store.create(
+        "websocket:c1",
+        "finish later",
+        route={"channel": "websocket", "chat_id": "c1"},
+    )
+    _plan(store, goal.id, goal.version)
+    driver = GoalDriver(workspace, bus, sessions, store_root=root)
+
+    await asyncio.gather(driver.scan_once(), driver.scan_once())
+    await driver.scan_once()
+
+    assert bus.inbound_size == 1
+    message = await bus.consume_inbound()
+    assert message.metadata[GOAL_DRIVER_META]["start_version"] == 2
+    text, extra = automation_history_overrides(message.metadata)
+    assert text == message.content
+    assert extra["_automation_turn"]["kind"] == "goal_driver"
+
+
+@pytest.mark.asyncio
+async def test_restart_reschedules_unfinished_goal_immediately(tmp_path: Path) -> None:
+    workspace, root, sessions, store, old_bus = _setup(tmp_path)
+    goal = store.create("websocket:c1", "finish after restart")
+    _plan(store, goal.id, goal.version)
+    await GoalDriver(workspace, old_bus, sessions, store_root=root).scan_once()
+
+    new_bus = MessageBus()
+    await GoalDriver(workspace, new_bus, sessions, store_root=root).scan_once()
+
+    assert new_bus.inbound_size == 1
+    message = await new_bus.consume_inbound()
+    assert message.metadata[GOAL_DRIVER_META]["goal_id"] == goal.id
+    ref = sessions.get_or_create("websocket:c1").metadata[GOAL_STATE_KEY]
+    assert ref["goal_id"] == goal.id
+
+
+@pytest.mark.asyncio
+async def test_interrupted_running_node_waits_and_reports(tmp_path: Path) -> None:
+    workspace, root, sessions, store, bus = _setup(tmp_path)
+    goal = store.create("websocket:c1", "safe work")
+    goal = _plan(store, goal.id, goal.version)
+    store.apply(goal.id, goal.version, {"action": "begin", "node_id": "main"})
+    driver = GoalDriver(workspace, bus, sessions, store_root=root)
+
+    await driver.scan_once()
+
+    stored = store.get(goal.id)
+    assert stored is not None and stored.status == "waiting"
+    assert "duplicate side effects" in stored.state["status_reason"]
+    assert bus.inbound_size == 0
+    assert "paused" in (await bus.consume_outbound()).content
+    assert sessions.get_or_create("websocket:c1").metadata[GOAL_STATE_KEY]["status"] == "waiting"
+
+
+@pytest.mark.asyncio
+async def test_exhausted_recovery_keeps_independent_ready_work(tmp_path: Path) -> None:
+    workspace, root, sessions, store, bus = _setup(tmp_path)
+    goal = store.create("websocket:c1", "keep independent work")
+    goal = _plan(store, goal.id, goal.version, two=True)
+    goal = store.apply(
+        goal.id,
+        goal.version,
+        {"action": "block", "node_id": "main", "reason": "route unavailable"},
+    )
+    for _ in range(4):
+        goal = store.apply(
+            goal.id,
+            goal.version,
+            {"action": "recovery_attempt", "node_id": "main"},
+        )
+
+    await GoalDriver(workspace, bus, sessions, store_root=root).scan_once()
+
+    stored = store.get(goal.id)
+    assert stored is not None and stored.status == "active"
+    assert bus.inbound_size == 1
+    assert "ready_frontier" in (await bus.consume_inbound()).content
+
+
+@pytest.mark.asyncio
+async def test_exhausted_recovery_without_other_path_waits_and_reports(tmp_path: Path) -> None:
+    workspace, root, sessions, store, bus = _setup(tmp_path)
+    goal = store.create("websocket:c1", "try recoveries")
+    goal = _plan(store, goal.id, goal.version)
+    goal = store.apply(
+        goal.id,
+        goal.version,
+        {"action": "block", "node_id": "main", "reason": "route unavailable"},
+    )
+    for _ in range(4):
+        goal = store.apply(
+            goal.id,
+            goal.version,
+            {"action": "recovery_attempt", "node_id": "main"},
+        )
+
+    await GoalDriver(workspace, bus, sessions, store_root=root).scan_once()
+
+    stored = store.get(goal.id)
+    assert stored is not None and stored.status == "waiting"
+    assert "needs user input" in (await bus.consume_outbound()).content
+    resumed = store.set_status(stored.id, stored.version, "active", "user supplied context")
+    assert resumed.state["recovery_attempts"] == 0
+
+
+@pytest.mark.asyncio
+async def test_three_driver_turns_without_progress_pause_the_goal(tmp_path: Path) -> None:
+    workspace, root, sessions, store, bus = _setup(tmp_path)
+    goal = store.create("websocket:c1", "make progress")
+    _plan(store, goal.id, goal.version)
+    driver = GoalDriver(workspace, bus, sessions, store_root=root)
+    await driver.scan_once()
+
+    for _ in range(3):
+        message = await bus.consume_inbound()
+        await driver.after_turn(message)
+
+    stored = store.get(goal.id)
+    assert stored is not None and stored.status == "waiting"
+    assert "no durable progress" in (await bus.consume_outbound()).content

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+
+import pytest
+
+from nanobot.goals import GoalConflictError, GoalError, GoalStore, projection
+
+
+def _store(tmp_path) -> GoalStore:
+    return GoalStore(tmp_path / "goals.sqlite3")
+
+
+def _plan() -> dict:
+    return {
+        "action": "plan",
+        "nodes": [
+            {"id": "build", "title": "Build", "outcome": "Artifact exists", "depends_on": []},
+            {
+                "id": "publish",
+                "title": "Publish",
+                "outcome": "Artifact is published",
+                "depends_on": ["build"],
+            },
+        ],
+    }
+
+
+def test_store_uses_two_tables_and_keeps_current_graph_in_one_snapshot(tmp_path) -> None:
+    store = _store(tmp_path)
+    goal = store.create("cli:test", "Ship safely", "ship")
+    planned = store.apply(goal.id, 1, _plan())
+
+    with sqlite3.connect(store.path) as db:
+        tables = {
+            row[0]
+            for row in db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+            )
+        }
+
+    assert tables == {"goal_runs", "goal_events"}
+    assert planned.version == 2
+    assert planned.state["nodes"]["build"]["status"] == "ready"
+    assert planned.state["nodes"]["publish"]["status"] == "pending"
+    assert [event["type"] for event in store.events(goal.id)] == [
+        "goal_planned",
+        "goal_created",
+    ]
+
+
+def test_store_closes_read_connections(tmp_path, monkeypatch) -> None:
+    store = _store(tmp_path)
+    goal = store.create("cli:test", "Close reads")
+    connection = store._connect()
+
+    class TrackedConnection:
+        closed = False
+
+        def execute(self, *args, **kwargs):
+            return connection.execute(*args, **kwargs)
+
+        def close(self):
+            self.closed = True
+            connection.close()
+
+    tracked = TrackedConnection()
+    monkeypatch.setattr(store, "_connect", lambda: tracked)
+
+    assert store.get(goal.id) == goal
+    assert tracked.closed is True
+
+
+def test_success_unlocks_dependencies_and_completion_is_gated(tmp_path) -> None:
+    store = _store(tmp_path)
+    goal = store.create("cli:test", "Ship")
+    goal = store.apply(goal.id, 1, _plan())
+
+    with pytest.raises(GoalError, match="every retained node succeeds"):
+        store.close(goal.id, 2, "completed")
+
+    goal = store.apply(goal.id, 2, {"action": "begin", "node_id": "build"})
+    goal = store.apply(
+        goal.id,
+        3,
+        {"action": "succeed", "node_id": "build", "result": "build passed"},
+    )
+    assert goal.state["nodes"]["publish"]["status"] == "ready"
+    goal = store.apply(goal.id, 4, {"action": "begin", "node_id": "publish"})
+    goal = store.apply(
+        goal.id,
+        5,
+        {"action": "succeed", "node_id": "publish", "result": "published"},
+    )
+
+    completed = store.close(goal.id, 6, "completed", "All nodes succeeded")
+    assert completed.status == "completed"
+    assert store.current("cli:test") is None
+
+
+def test_blocked_path_preserves_independent_frontier_and_active_goal(tmp_path) -> None:
+    store = _store(tmp_path)
+    goal = store.create("cli:test", "Try independent paths")
+    goal = store.apply(
+        goal.id,
+        1,
+        {
+            "action": "plan",
+            "nodes": [
+                {"id": "primary", "title": "Primary", "outcome": "Done", "depends_on": []},
+                {"id": "other", "title": "Other", "outcome": "Done", "depends_on": []},
+            ],
+        },
+    )
+    goal = store.apply(goal.id, 2, {"action": "begin", "node_id": "primary"})
+    goal = store.apply(
+        goal.id,
+        3,
+        {"action": "block", "node_id": "primary", "reason": "endpoint unavailable"},
+    )
+    view = projection(goal)
+
+    assert goal.status == "active"
+    assert view["needs_replan"] is True
+    assert [node["id"] for node in view["frontier"]] == ["other"]
+    assert view["blocked"][0]["failure"] == "endpoint unavailable"
+
+
+def test_invalid_or_stale_graph_commands_do_not_change_state(tmp_path) -> None:
+    store = _store(tmp_path)
+    goal = store.create("cli:test", "Ship")
+    cyclic = {
+        "action": "plan",
+        "nodes": [
+            {"id": "a", "title": "A", "outcome": "A", "depends_on": ["b"]},
+            {"id": "b", "title": "B", "outcome": "B", "depends_on": ["a"]},
+        ],
+    }
+    with pytest.raises(GoalError, match="acyclic"):
+        store.apply(goal.id, 1, cyclic)
+    assert store.get(goal.id).version == 1
+
+    planned = store.apply(goal.id, 1, _plan())
+    with pytest.raises(GoalConflictError, match="expected 1"):
+        store.apply(goal.id, 1, {"action": "begin", "node_id": "build"})
+    assert store.get(goal.id) == planned
+
+
+def test_replace_is_atomic_and_preserves_one_current_goal_per_session(tmp_path) -> None:
+    store = _store(tmp_path)
+    old = store.create("cli:test", "Old")
+    new = store.replace(old.id, 1, "New", "new")
+
+    assert store.get(old.id).status == "replaced"
+    assert store.current("cli:test") == new
+    assert new.state["objective"] == "New"
+    with pytest.raises(GoalConflictError):
+        store.create("cli:test", "Different")
+
+
+def test_concurrent_create_is_idempotent_across_store_instances(tmp_path) -> None:
+    path = tmp_path / "goals.sqlite3"
+    stores = [GoalStore(path), GoalStore(path)]
+    barrier = Barrier(2)
+
+    def create(store: GoalStore):
+        barrier.wait()
+        return store.create("cli:test", "Same objective")
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        goals = list(pool.map(create, stores))
+
+    assert goals[0].id == goals[1].id
+    assert len(stores[0].events(goals[0].id)) == 1
+
+
+def test_concurrent_compare_and_swap_allows_one_writer(tmp_path) -> None:
+    path = tmp_path / "goals.sqlite3"
+    primary = GoalStore(path)
+    goal = primary.apply(primary.create("cli:test", "Ship").id, 1, _plan())
+    stores = [GoalStore(path), GoalStore(path)]
+    barrier = Barrier(2)
+
+    def begin(store: GoalStore):
+        barrier.wait()
+        try:
+            return store.apply(goal.id, goal.version, {"action": "begin", "node_id": "build"})
+        except GoalConflictError as exc:
+            return exc
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(begin, stores))
+
+    assert sum(not isinstance(result, Exception) for result in results) == 1
+    assert sum(isinstance(result, GoalConflictError) for result in results) == 1
+    assert primary.get(goal.id).version == goal.version + 1
+
+
+def test_terminal_goal_rejects_further_mutation_and_projection_is_bounded(tmp_path) -> None:
+    store = _store(tmp_path)
+    goal = store.create("cli:test", "Bound context")
+    goal = store.apply(
+        goal.id,
+        goal.version,
+        {
+            "action": "plan",
+            "nodes": [{"id": "path", "title": "Path", "outcome": "Done", "depends_on": []}],
+        },
+    )
+    goal = store.apply(
+        goal.id,
+        goal.version,
+        {"action": "block", "node_id": "path", "reason": "x" * 8000},
+    )
+    assert len(projection(goal)["blocked"][0]["failure"]) == 1000
+
+    terminal = store.close(goal.id, goal.version, "cancelled")
+    with pytest.raises(GoalError, match="current goal"):
+        store.close(terminal.id, terminal.version, "cancelled")
+    with pytest.raises(GoalError, match="current goal"):
+        store.apply(terminal.id, terminal.version, {"action": "begin", "node_id": "path"})
+
+
+def test_replan_supersedes_blocked_path_and_rewires_downstream(tmp_path) -> None:
+    store = _store(tmp_path)
+    goal = store.create("cli:test", "Recover")
+    goal = store.apply(
+        goal.id,
+        goal.version,
+        {
+            "action": "plan",
+            "nodes": [
+                {"id": "prep", "title": "Prep", "outcome": "Ready", "depends_on": []},
+                {
+                    "id": "failed",
+                    "title": "Failed path",
+                    "outcome": "Artifact",
+                    "depends_on": ["prep"],
+                },
+                {
+                    "id": "finish",
+                    "title": "Finish",
+                    "outcome": "Done",
+                    "depends_on": ["failed"],
+                },
+                {"id": "other", "title": "Other", "outcome": "Done", "depends_on": []},
+            ],
+        },
+    )
+    goal = store.apply(goal.id, goal.version, {"action": "begin", "node_id": "prep"})
+    goal = store.apply(
+        goal.id,
+        goal.version,
+        {"action": "succeed", "node_id": "prep", "result": "prepared"},
+    )
+    goal = store.apply(goal.id, goal.version, {"action": "begin", "node_id": "failed"})
+    goal = store.apply(
+        goal.id,
+        goal.version,
+        {"action": "block", "node_id": "failed", "reason": "route is unavailable"},
+    )
+    goal = store.apply(
+        goal.id,
+        goal.version,
+        {
+            "action": "replan",
+            "node_id": "failed",
+            "nodes": [
+                {
+                    "id": "alternate",
+                    "title": "Alternate route",
+                    "outcome": "Artifact",
+                    "depends_on": ["prep"],
+                },
+                {
+                    "id": "verify_alt",
+                    "title": "Verify alternate",
+                    "outcome": "Verified artifact",
+                    "depends_on": ["alternate"],
+                },
+            ],
+        },
+    )
+
+    nodes = goal.state["nodes"]
+    assert nodes["failed"]["status"] == "superseded"
+    assert nodes["alternate"]["status"] == "ready"
+    assert nodes["verify_alt"]["status"] == "pending"
+    assert nodes["finish"]["depends_on"] == ["verify_alt"]
+    assert nodes["other"]["status"] == "ready"
+    assert goal.state["needs_replan"] is False
+
+
+def test_replan_rejects_dependency_on_unfinished_existing_node(tmp_path) -> None:
+    store = _store(tmp_path)
+    goal = store.create("cli:test", "Recover")
+    goal = store.apply(
+        goal.id,
+        goal.version,
+        {
+            "action": "plan",
+            "nodes": [
+                {"id": "failed", "title": "Failed", "outcome": "Done", "depends_on": []},
+                {"id": "other", "title": "Other", "outcome": "Done", "depends_on": []},
+            ],
+        },
+    )
+    goal = store.apply(
+        goal.id,
+        goal.version,
+        {"action": "block", "node_id": "failed", "reason": "unavailable"},
+    )
+
+    with pytest.raises(GoalError, match="succeeded nodes"):
+        store.apply(
+            goal.id,
+            goal.version,
+            {
+                "action": "replan",
+                "node_id": "failed",
+                "nodes": [
+                    {
+                        "id": "bad_alt",
+                        "title": "Bad alternate",
+                        "outcome": "Done",
+                        "depends_on": ["other"],
+                    }
+                ],
+            },
+        )
+    assert store.get(goal.id) == goal
+
+
+def test_coarse_node_becomes_expandable_and_expansion_rewires_downstream(tmp_path) -> None:
+    store = _store(tmp_path)
+    goal = store.create("cli:test", "Plan progressively")
+    goal = store.apply(
+        goal.id,
+        goal.version,
+        {
+            "action": "plan",
+            "nodes": [
+                {"id": "prep", "title": "Prepare", "outcome": "Ready", "depends_on": []},
+                {
+                    "id": "coarse",
+                    "title": "Implement unknown details",
+                    "outcome": "Feature exists",
+                    "kind": "coarse",
+                    "depends_on": ["prep"],
+                },
+                {
+                    "id": "release",
+                    "title": "Release",
+                    "outcome": "Released",
+                    "depends_on": ["coarse"],
+                },
+            ],
+        },
+    )
+    assert [node["id"] for node in projection(goal)["frontier"]] == ["prep"]
+    assert projection(goal)["expandable"] == []
+
+    goal = store.apply(goal.id, goal.version, {"action": "begin", "node_id": "prep"})
+    goal = store.apply(
+        goal.id,
+        goal.version,
+        {"action": "succeed", "node_id": "prep", "result": "requirements known"},
+    )
+    assert goal.state["nodes"]["coarse"]["status"] == "pending"
+    assert [node["id"] for node in projection(goal)["expandable"]] == ["coarse"]
+
+    goal = store.apply(
+        goal.id,
+        goal.version,
+        {
+            "action": "expand",
+            "node_id": "coarse",
+            "nodes": [
+                {
+                    "id": "implement",
+                    "title": "Implement",
+                    "outcome": "Feature exists",
+                    "depends_on": [],
+                },
+                {
+                    "id": "test",
+                    "title": "Test",
+                    "outcome": "Feature verified",
+                    "depends_on": ["implement"],
+                },
+            ],
+        },
+    )
+    nodes = goal.state["nodes"]
+    assert nodes["coarse"]["status"] == "superseded"
+    assert nodes["implement"]["depends_on"] == ["prep"]
+    assert nodes["implement"]["status"] == "ready"
+    assert nodes["test"]["status"] == "pending"
+    assert nodes["release"]["depends_on"] == ["test"]
+    assert goal.state["needs_replan"] is False
+    assert store.events(goal.id)[0]["type"] == "plan_expanded"
+
+
+def test_expansion_requires_satisfied_dependencies_and_never_uses_blockage(tmp_path) -> None:
+    store = _store(tmp_path)
+    goal = store.create("cli:test", "Plan progressively")
+    goal = store.apply(
+        goal.id,
+        goal.version,
+        {
+            "action": "plan",
+            "nodes": [
+                {"id": "prep", "title": "Prepare", "outcome": "Ready", "depends_on": []},
+                {
+                    "id": "coarse",
+                    "title": "Later work",
+                    "outcome": "Done",
+                    "kind": "coarse",
+                    "depends_on": ["prep"],
+                },
+            ],
+        },
+    )
+    command = {
+        "action": "expand",
+        "node_id": "coarse",
+        "nodes": [{"id": "detail", "title": "Detail", "outcome": "Done", "depends_on": []}],
+    }
+    with pytest.raises(GoalError, match="dependencies succeed"):
+        store.apply(goal.id, goal.version, command)
+    with pytest.raises(GoalError, match="coarse node must be expanded"):
+        store.apply(goal.id, goal.version, {"action": "begin", "node_id": "coarse"})
+    assert store.get(goal.id) == goal

--- a/tests/tools/test_tool_loader.py
+++ b/tests/tools/test_tool_loader.py
@@ -88,9 +88,11 @@ def test_discover_finds_concrete_tools():
     discovered = loader.discover()
     class_names = {cls.__name__ for cls in discovered}
     assert "ApplyPatchTool" in class_names
+    assert "ExpandGoalNodeTool" in class_names
     assert "ExecTool" in class_names
     assert "CliAppsTool" in class_names
     assert "MessageTool" in class_names
+    assert "ReplanGoalTool" in class_names
     assert "SpawnTool" in class_names
     assert "WriteStdinTool" in class_names
 


### PR DESCRIPTION
## Why

The current `/goal` flow mainly stores a long-lived objective in session metadata. It does not preserve a structured execution plan, dependency state, or recovery path when part of a long task fails. After conversation history is compacted, the model may also lose track of earlier work and reconstruct too much from the remaining chat context.

## What this PR changes

- Adds a durable, versioned Goal state tree backed by a workspace-scoped SQLite store, while keeping only a compact reference in session metadata.
- Reloads the authoritative objective and current plan projection from durable storage on active Goal turns, while retaining node results and failure evidence outside chat history. This keeps structured Goal progress intact across history compaction and restart.
- Adds dependency-aware planning, coarse-node expansion, constrained node transitions, and completion checks.
- Adds clean-context replanning for blocked paths using the objective, successful predecessor results, progress, and recorded failure experience.
- Adds a lightweight single-gateway driver for restart recovery, bounded continuation, safe waiting, and user feedback without terminating the whole Goal for an ordinary blocked path.

The result is a more reliable `/goal` workflow that can preserve structured progress, refine plans as information becomes available, and recover from failed paths without depending on the full chat context.