### PR TITLE
fix(pairing): treat null approved channel lists as empty

### DIFF
--- a/nanobot/pairing/store.py
+++ b/nanobot/pairing/store.py
@@ -46,6 +46,8 @@ def _load() -> dict[str, Any]:
 
     # Convert approved lists to str sets for O(1) lookup.
     for channel, users in data.get("approved", {}).items():
+        if not isinstance(users, list):
+            users = []
         data["approved"][channel] = {str(u) for u in users}
     return data
 

--- a/tests/pairing/test_store.py
+++ b/tests/pairing/test_store.py
@@ -240,3 +240,20 @@ class TestStoreDurability:
         # Should recover gracefully and act as empty store
         assert store.list_pending() == []
         assert store.is_approved("telegram", "123") is False
+
+
+def test_load_treats_null_approved_channel_list_as_empty(tmp_path, monkeypatch):
+    """Null approved channel lists must not crash pairing checks.
+
+    JSON stores can contain ``"telegram": null`` after partial edits; treat
+    that like an empty allow-list, matching corrupt-JSON reset behavior.
+    """
+    path = tmp_path / "pairing.json"
+    path.write_text(
+        '{"approved": {"telegram": null, "discord": ["456"]}, "pending": {}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(store, "_store_path", lambda: path)
+    assert store.is_approved("telegram", "123") is False
+    assert store.is_approved("discord", "456") is True
+    assert store.get_approved("telegram") == []


### PR DESCRIPTION
`pairing.json` with `"telegram": null` crashed `is_approved` during load. Treat non-list channel entries as an empty allow-list.

Repro: write `{"approved":{"telegram":null},"pending":{}}` and call `is_approved("telegram", "1")`.