### PR TITLE
chore: pin migration TODOs to v0.2.4

### DIFF
--- a/nanobot/channels/registry.py
+++ b/nanobot/channels/registry.py
@@ -21,7 +21,8 @@ if TYPE_CHECKING:
 
 @cache
 def _warn_legacy_channel_entry_points() -> None:
-    # TODO: Remove this legacy entry-point detection and warning after the migration window.
+    # TODO(v0.2.4): Remove this detection and warning. v0.2.3 is the final
+    # migration window for installed legacy channel entry points.
     names = sorted({entry_point.name for entry_point in entry_points(group="nanobot.channels")})
     if not names:
         return

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -209,8 +209,8 @@ def _migrate_config(data: dict) -> dict:
         defaults.pop("maxMessages", None)
         defaults.pop("max_messages", None)
         if had_legacy_max_messages:
-            # TODO(next version): Remove this legacy cleanup branch; the schema
-            # will silently ignore this field once the warning grace period ends.
+            # TODO(v0.2.4): Remove this legacy cleanup branch. v0.2.3 is the
+            # final release that warns before the schema silently ignores the field.
             logger.warning(
                 "agents.defaults.maxMessages/max_messages is legacy and ignored; "
                 "replay max messages is now an internal safety cap. Remove it from "


### PR DESCRIPTION
## Summary

- pin the legacy `maxMessages` cleanup TODO to v0.2.4
- pin the legacy channel entry-point warning cleanup TODO to v0.2.4
- document v0.2.3 as the final warning and migration window

## Why

Both compatibility warnings landed after v0.2.2, so removing them before v0.2.3 ships would eliminate the migration window before users see it. Explicit version targets make the cleanup boundary searchable and prevent ambiguous "next version" maintenance.

This is comment-only and does not change runtime behavior.

## Verification

- `ruff check nanobot/config/loader.py nanobot/channels/registry.py`
- `pytest tests/config/test_config_migration.py -q` — 15 passed
- `pytest tests/channels/test_channel_plugins.py -q` — 122 passed
- `git diff --check`