### PR TITLE
fix(telegram): advance markdown split on long single-line fences

### DIFF
--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -102,7 +102,7 @@ def _split_telegram_markdown(content: str, max_len: int) -> list[str]:
                     adjusted = recut.rfind("\n", min_code_pos)
                     if adjusted < min_code_pos:
                         adjusted = recut.rfind(" ", min_code_pos)
-                    pos = adjusted if adjusted >= min_code_pos else budget
+                    pos = adjusted if adjusted > min_code_pos else budget
                 elif pos + len(closing) > max_len:
                     budget = max_len - len(closing)
                     if budget <= min_code_pos:
@@ -113,7 +113,11 @@ def _split_telegram_markdown(content: str, max_len: int) -> list[str]:
                     adjusted = recut.rfind("\n", min_code_pos)
                     if adjusted < min_code_pos:
                         adjusted = recut.rfind(" ", min_code_pos)
-                    pos = adjusted if adjusted >= min_code_pos else budget
+                    pos = adjusted if adjusted > min_code_pos else budget
+                if pos <= min_code_pos:
+                    chunks.append(content[:max_len])
+                    content = content[max_len:].lstrip()
+                    continue
                 chunks.append(content[:pos] + closing)
                 remainder = content[pos:]
                 if remainder.startswith("\n"):

--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -90,18 +90,27 @@ def _split_telegram_markdown(content: str, max_len: int) -> list[str]:
                 min_code_pos = len(fence)
                 if content.startswith(fence + "\n"):
                     min_code_pos += 1
-                if pos < min_code_pos and min_code_pos + len(closing) > max_len:
-                    chunks.append(content[:max_len])
-                    content = content[max_len:].lstrip()
-                    continue
-                if pos + len(closing) > max_len:
+                # When the only break in range is the opening fence newline,
+                # cutting there re-emits the same fence and never advances.
+                if pos < min_code_pos:
+                    if min_code_pos + len(closing) > max_len:
+                        chunks.append(content[:max_len])
+                        content = content[max_len:].lstrip()
+                        continue
+                    budget = max_len - len(closing)
+                    recut = content[:budget]
+                    adjusted = recut.rfind("\n", min_code_pos)
+                    if adjusted < min_code_pos:
+                        adjusted = recut.rfind(" ", min_code_pos)
+                    pos = adjusted if adjusted >= min_code_pos else budget
+                elif pos + len(closing) > max_len:
                     budget = max_len - len(closing)
                     if budget > 0:
                         recut = content[:budget]
-                        adjusted = recut.rfind("\n")
-                        if adjusted <= 0:
-                            adjusted = recut.rfind(" ")
-                        pos = adjusted if adjusted > 0 else budget
+                        adjusted = recut.rfind("\n", min_code_pos)
+                        if adjusted < min_code_pos:
+                            adjusted = recut.rfind(" ", min_code_pos)
+                        pos = adjusted if adjusted >= min_code_pos else budget
                     else:
                         closing = "```"
                         pos = max_len - len(closing)

--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -93,7 +93,7 @@ def _split_telegram_markdown(content: str, max_len: int) -> list[str]:
                 # When the only break in range is the opening fence newline,
                 # cutting there re-emits the same fence and never advances.
                 if pos < min_code_pos:
-                    if min_code_pos + len(closing) > max_len:
+                    if min_code_pos + len(closing) >= max_len:
                         chunks.append(content[:max_len])
                         content = content[max_len:].lstrip()
                         continue
@@ -105,15 +105,15 @@ def _split_telegram_markdown(content: str, max_len: int) -> list[str]:
                     pos = adjusted if adjusted >= min_code_pos else budget
                 elif pos + len(closing) > max_len:
                     budget = max_len - len(closing)
-                    if budget > 0:
-                        recut = content[:budget]
-                        adjusted = recut.rfind("\n", min_code_pos)
-                        if adjusted < min_code_pos:
-                            adjusted = recut.rfind(" ", min_code_pos)
-                        pos = adjusted if adjusted >= min_code_pos else budget
-                    else:
-                        closing = "```"
-                        pos = max_len - len(closing)
+                    if budget <= min_code_pos:
+                        chunks.append(content[:max_len])
+                        content = content[max_len:].lstrip()
+                        continue
+                    recut = content[:budget]
+                    adjusted = recut.rfind("\n", min_code_pos)
+                    if adjusted < min_code_pos:
+                        adjusted = recut.rfind(" ", min_code_pos)
+                    pos = adjusted if adjusted >= min_code_pos else budget
                 chunks.append(content[:pos] + closing)
                 remainder = content[pos:]
                 if remainder.startswith("\n"):

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -268,6 +268,32 @@ def test_split_telegram_markdown_long_single_line_code_body() -> None:
     _assert_code_blocks_render_balanced(chunks)
 
 
+def test_split_telegram_markdown_tiny_limit_hard_cuts_fence_prefix() -> None:
+    """Adaptive HTML limits can shrink max_len to the fence+closer size."""
+    body = "a" * 100
+    content = f"```\n{body}"
+
+    chunks = _split_telegram_markdown(content, max_len=8)
+
+    assert chunks
+    assert all(len(chunk) <= 8 for chunk in chunks)
+    assert "".join(chunks).replace("```", "").replace("\n", "") == body
+
+
+def test_split_telegram_markdown_tiny_limit_with_early_body_newline() -> None:
+    body = "a" * 100
+    content = f"```\na\n{body}"
+
+    chunks = _split_telegram_markdown(content, max_len=8)
+
+    assert chunks
+    assert all(len(chunk) <= 8 for chunk in chunks)
+    plain = "".join(chunks).replace("```", "")
+    assert "a" in plain
+    assert plain.count("a") >= 100
+
+
+
 @pytest.mark.asyncio
 async def test_start_creates_separate_pools_with_proxy(monkeypatch) -> None:
     _FakeHTTPXRequest.clear()

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -293,6 +293,19 @@ def test_split_telegram_markdown_tiny_limit_with_early_body_newline() -> None:
     assert plain.count("a") >= 100
 
 
+def test_split_telegram_markdown_leading_space_in_fence_body() -> None:
+    body = "a" * 4500
+    content = f"```\n {body}"
+
+    chunks = _split_telegram_markdown(content, TELEGRAM_MAX_MESSAGE_LEN)
+
+    assert chunks
+    assert all(len(chunk) <= TELEGRAM_MAX_MESSAGE_LEN for chunk in chunks)
+    plain = "".join(chunks).replace("```", "").replace("\n", "")
+    assert plain.count("a") == 4500
+
+
+
 
 @pytest.mark.asyncio
 async def test_start_creates_separate_pools_with_proxy(monkeypatch) -> None:

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -15,6 +15,7 @@ from nanobot.bus.events import OutboundMessage
 from nanobot.bus.outbound_events import ProgressEvent
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.telegram.runtime import (
+    TELEGRAM_MAX_MESSAGE_LEN,
     TELEGRAM_REPLY_CONTEXT_MAX_LEN,
     TelegramChannel,
     TelegramConfig,
@@ -240,6 +241,30 @@ def test_split_telegram_markdown_leading_whitespace_before_fence() -> None:
     assert chunks
     assert all(chunk.strip() for chunk in chunks)
     assert chunks[0].startswith("```python\n")
+    _assert_code_blocks_render_balanced(chunks)
+
+
+def test_split_telegram_markdown_long_single_line_code_body() -> None:
+    """Long fence bodies with no interior newlines must still advance."""
+    body = "a" * 4500
+    content = f"```\n{body}\n```"
+
+    chunks = _split_telegram_markdown(content, TELEGRAM_MAX_MESSAGE_LEN)
+
+    assert len(chunks) > 1
+    assert all(len(chunk) <= TELEGRAM_MAX_MESSAGE_LEN for chunk in chunks)
+    assert chunks[0].startswith("```\n")
+    assert chunks[0].endswith("\n```")
+    assert chunks[1].startswith("```\n")
+    reassembled = []
+    for chunk in chunks:
+        part = chunk.split("\n", 1)[1]
+        if part.endswith("\n```"):
+            part = part[:-4]
+        elif part.endswith("```"):
+            part = part[:-3]
+        reassembled.append(part)
+    assert "".join(reassembled) == body
     _assert_code_blocks_render_balanced(chunks)
 
 


### PR DESCRIPTION
Splitting a Telegram reply that contains a fenced code block with one very long body line (no interior newlines) never advanced and hung the send path.

Hard-cut / reopen the fence so the splitter always makes progress.