### PR TITLE
fix(agent): preserve output across length recovery

### DIFF
--- a/nanobot/agent/hook.py
+++ b/nanobot/agent/hook.py
@@ -25,6 +25,7 @@ class AgentHookContext:
     tool_events: list[dict[str, str]] = field(default_factory=list)
     streamed_content: bool = False
     streamed_reasoning: bool = False
+    stream_continues_current_message: bool = False
     final_content: str | None = None
     stop_reason: str | None = None
     error: str | None = None

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import inspect
 import os
 import time
 from collections.abc import Mapping
@@ -860,9 +861,9 @@ class AgentLoop:
         """Run the agent iteration loop.
 
         *on_stream*: called with each content delta during streaming.
-        *on_stream_end(resuming)*: called when a streaming session finishes.
-        ``resuming=True`` means tool calls follow (spinner should restart);
-        ``resuming=False`` means this is the final response.
+        *on_stream_end(resuming, merge_next)*: called when a streaming session finishes.
+        ``resuming=True`` means the active turn continues. ``merge_next=True`` means
+        the next text segment belongs to the same user-visible assistant message.
 
         Returns (final_content, tools_used, messages, stop_reason, had_injections).
         """
@@ -1385,6 +1386,19 @@ class AgentLoop:
         if ctx.on_stream is not None:
             stream_callback = ctx.on_stream
             stream_end_callback = ctx.on_stream_end
+            stream_end_accepts_merge_next = False
+            if stream_end_callback is not None:
+                try:
+                    stream_end_signature = inspect.signature(stream_end_callback)
+                    stream_end_accepts_merge_next = (
+                        "merge_next" in stream_end_signature.parameters
+                        or any(
+                            parameter.kind is inspect.Parameter.VAR_KEYWORD
+                            for parameter in stream_end_signature.parameters.values()
+                        )
+                    )
+                except (TypeError, ValueError):
+                    pass
             segment_streamed_content = False
 
             async def _tracked_stream(delta: str) -> None:
@@ -1393,12 +1407,19 @@ class AgentLoop:
                     segment_streamed_content = True
                 await stream_callback(delta)
 
-            async def _tracked_stream_end(*, resuming: bool = False) -> None:
+            async def _tracked_stream_end(
+                *,
+                resuming: bool = False,
+                merge_next: bool = False,
+            ) -> None:
                 nonlocal segment_streamed_content
                 ctx.streamed_content = segment_streamed_content
                 segment_streamed_content = False
                 if stream_end_callback is not None:
-                    await stream_end_callback(resuming=resuming)
+                    if merge_next and stream_end_accepts_merge_next:
+                        await stream_end_callback(resuming=resuming, merge_next=True)
+                    else:
+                        await stream_end_callback(resuming=resuming)
 
             ctx.on_stream = _tracked_stream
             ctx.on_stream_end = _tracked_stream_end

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1070,7 +1070,12 @@ class AgentLoop:
             # Push final content through stream so streaming channels (e.g. Feishu)
             # update the card instead of leaving it empty.
             if on_stream and on_stream_end and should_stream:
-                await on_stream(result.final_content or "")
+                stream_content = (
+                    result.pending_stream_content
+                    if result.pending_stream_content is not None
+                    else result.final_content or ""
+                )
+                await on_stream(stream_content)
                 await on_stream_end(resuming=False)
         elif result.stop_reason == "error":
             logger.error("LLM returned error: {}", (result.final_content or "")[:200])
@@ -1217,6 +1222,14 @@ class AgentLoop:
                     for _, coordinator in self._automation_turn_coordinators:
                         coordinator.complete(msg, error=asyncio.CancelledError())
                     logger.info("Task cancelled for session {}", session_key)
+                    try:
+                        await delivery.abort_stream()
+                    except Exception:
+                        logger.debug(
+                            "Could not close stream for cancelled session {}",
+                            session_key,
+                            exc_info=True,
+                        )
                     # Preserve partial context from the interrupted turn so
                     # the user does not lose tool results and assistant
                     # messages accumulated before /stop.  The checkpoint was

--- a/nanobot/agent/progress_hook.py
+++ b/nanobot/agent/progress_hook.py
@@ -85,7 +85,13 @@ class AgentProgressHook(AgentHook):
     async def on_stream_end(self, context: AgentHookContext, *, resuming: bool) -> None:
         await self.emit_reasoning_end()
         if self._on_stream_end:
-            await self._on_stream_end(resuming=resuming)
+            kwargs: dict[str, bool] = {"resuming": resuming}
+            if (
+                context.stream_continues_current_message
+                and self._on_progress_accepts(self._on_stream_end, "merge_next")
+            ):
+                kwargs["merge_next"] = True
+            await self._on_stream_end(**kwargs)
         self._stream_buf = ""
         self._think_extractor.reset()
 

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -607,7 +607,7 @@ class AgentRunner:
                         reasoning_content=response.reasoning_content,
                         thinking_blocks=response.thinking_blocks,
                     ))
-                    messages.append(build_length_recovery_message())
+                    messages.append(build_length_recovery_message(clean))
                     await hook.after_iteration(context)
                     continue
 

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -392,7 +392,6 @@ class AgentRunner:
         # Per-turn throttle for repeated attempts against the same outside target.
         workspace_violation_counts: dict[str, int] = {}
         empty_content_retries = 0
-        length_recovery_count = 0
         # Segments from one uninterrupted length-recovery chain. Tool work or
         # injected user input starts a new logical answer and clears the chain.
         length_recovery_parts: list[str] = []
@@ -520,7 +519,6 @@ class AgentRunner:
                     )
                     if should_continue:
                         had_injections = True
-                        length_recovery_count = 0
                         length_recovery_parts.clear()
                         continue
                     break
@@ -536,7 +534,6 @@ class AgentRunner:
                     },
                 )
                 empty_content_retries = 0
-                length_recovery_count = 0
                 length_recovery_parts.clear()
                 # Checkpoint 1: drain injections after tools, before next LLM call
                 _drained, injection_cycles = await self._try_drain_injections(
@@ -590,8 +587,7 @@ class AgentRunner:
                 clean = hook.finalize_content(context, response.content)
 
             if response.finish_reason == "length" and not is_blank_text(clean):
-                length_recovery_count += 1
-                if length_recovery_count <= _MAX_LENGTH_RECOVERIES:
+                if len(length_recovery_parts) < _MAX_LENGTH_RECOVERIES:
                     length_recovery_parts.append(
                         _restore_outer_whitespace(clean, original_content)
                     )
@@ -599,7 +595,7 @@ class AgentRunner:
                         "Output truncated on turn {} for {} ({}/{}); continuing",
                         iteration,
                         spec.session_key or "default",
-                        length_recovery_count,
+                        len(length_recovery_parts),
                         _MAX_LENGTH_RECOVERIES,
                     )
                     if hook.wants_streaming():
@@ -637,7 +633,6 @@ class AgentRunner:
                 await hook.on_stream_end(context, resuming=should_continue)
 
             if should_continue:
-                length_recovery_count = 0
                 length_recovery_parts.clear()
                 await hook.after_iteration(context)
                 continue
@@ -660,7 +655,6 @@ class AgentRunner:
                 )
                 if should_continue:
                     had_injections = True
-                    length_recovery_count = 0
                     length_recovery_parts.clear()
                     continue
                 break
@@ -679,7 +673,6 @@ class AgentRunner:
                 )
                 if should_continue:
                     had_injections = True
-                    length_recovery_count = 0
                     length_recovery_parts.clear()
                     continue
                 break

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -60,6 +60,18 @@ _MAX_LENGTH_RECOVERIES = 3
 _MAX_INJECTIONS_PER_TURN = 3
 _MAX_INJECTION_CYCLES = 5
 
+
+def _restore_outer_whitespace(content: str, original: str | None) -> str:
+    """Restore boundary whitespace stripped while cleaning one recovered segment."""
+    if not original:
+        return content
+    leading_size = len(original) - len(original.lstrip())
+    trailing_size = len(original) - len(original.rstrip())
+    leading = original[:leading_size]
+    trailing = original[-trailing_size:] if trailing_size else ""
+    return f"{leading}{content}{trailing}"
+
+
 @dataclass(slots=True)
 class AgentRunSpec:
     """Configuration for a single agent execution."""
@@ -381,6 +393,9 @@ class AgentRunner:
         workspace_violation_counts: dict[str, int] = {}
         empty_content_retries = 0
         length_recovery_count = 0
+        # Segments from one uninterrupted length-recovery chain. Tool work or
+        # injected user input starts a new logical answer and clears the chain.
+        length_recovery_parts: list[str] = []
         had_injections = False
         injection_cycles = 0
         compacted_tool_call_ids: set[str] = set()
@@ -418,6 +433,7 @@ class AgentRunner:
             context.response = response
             context.tool_calls = list(response.tool_calls)
 
+            original_content = response.content
             reasoning_text, cleaned_content = extract_reasoning(
                 response.reasoning_content,
                 response.thinking_blocks,
@@ -519,6 +535,7 @@ class AgentRunner:
                 )
                 empty_content_retries = 0
                 length_recovery_count = 0
+                length_recovery_parts.clear()
                 # Checkpoint 1: drain injections after tools, before next LLM call
                 _drained, injection_cycles = await self._try_drain_injections(
                     spec, messages, None, injection_cycles,
@@ -567,11 +584,15 @@ class AgentRunner:
                 context.response = response
                 context.usage = dict(raw_usage)
                 context.tool_calls = list(response.tool_calls)
+                original_content = response.content
                 clean = hook.finalize_content(context, response.content)
 
             if response.finish_reason == "length" and not is_blank_text(clean):
                 length_recovery_count += 1
                 if length_recovery_count <= _MAX_LENGTH_RECOVERIES:
+                    length_recovery_parts.append(
+                        _restore_outer_whitespace(clean, original_content)
+                    )
                     logger.info(
                         "Output truncated on turn {} for {} ({}/{}); continuing",
                         iteration,
@@ -614,6 +635,7 @@ class AgentRunner:
                 await hook.on_stream_end(context, resuming=should_continue)
 
             if should_continue:
+                length_recovery_parts.clear()
                 await hook.after_iteration(context)
                 continue
 
@@ -635,6 +657,7 @@ class AgentRunner:
                 )
                 if should_continue:
                     had_injections = True
+                    length_recovery_parts.clear()
                     continue
                 break
             if is_blank_text(clean):
@@ -652,6 +675,7 @@ class AgentRunner:
                 )
                 if should_continue:
                     had_injections = True
+                    length_recovery_parts.clear()
                     continue
                 break
 
@@ -671,7 +695,13 @@ class AgentRunner:
                     "pending_tool_calls": [],
                 },
             )
-            final_content = clean
+            if length_recovery_parts:
+                final_content = (
+                    "".join(length_recovery_parts)
+                    + _restore_outer_whitespace(clean, original_content)
+                ).strip()
+            else:
+                final_content = clean
             context.final_content = final_content
             context.stop_reason = stop_reason
             await hook.after_iteration(context)

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -599,6 +599,7 @@ class AgentRunner:
                         _MAX_LENGTH_RECOVERIES,
                     )
                     if hook.wants_streaming():
+                        context.stream_continues_current_message = True
                         await hook.on_stream_end(context, resuming=True)
                     messages.append(build_assistant_message(
                         clean,

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -613,6 +613,23 @@ class AgentRunner:
                     await hook.after_iteration(context)
                     continue
 
+            # Some streaming providers recover with a complete response but no
+            # content deltas. When an earlier length segment is already visible,
+            # emit this terminal segment into the same stream; otherwise the
+            # regular full response would duplicate the visible prefix.
+            if (
+                length_recovery_parts
+                and hook.wants_streaming()
+                and not context.streamed_content
+                and response.finish_reason != "error"
+                and not is_blank_text(clean)
+            ):
+                await hook.on_stream(
+                    context,
+                    _restore_outer_whitespace(clean, original_content),
+                )
+                context.streamed_content = True
+
             assistant_message: dict[str, Any] | None = None
             if response.finish_reason != "error" and not is_blank_text(clean):
                 assistant_message = build_assistant_message(

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -113,6 +113,8 @@ class AgentRunResult:
     error: str | None = None
     tool_events: list[dict[str, str]] = field(default_factory=list)
     had_injections: bool = False
+    # Terminal tail to emit when the preceding final-content prefix was already streamed.
+    pending_stream_content: str | None = None
 
 
 class AgentRunner:
@@ -398,6 +400,7 @@ class AgentRunner:
         had_injections = False
         injection_cycles = 0
         compacted_tool_call_ids: set[str] = set()
+        pending_stream_content: str | None = None
         governance_config = ContextGovernanceConfig(
             provider=spec.runtime.provider,
             model=spec.runtime.model,
@@ -718,17 +721,25 @@ class AgentRunner:
             )
             if drained_after_max_iterations:
                 had_injections = True
-            final_content = None
+            terminal_content = None
             if spec.finalize_on_max_iterations:
-                final_content = await self._try_finalize_after_max_iterations(
+                terminal_content = await self._try_finalize_after_max_iterations(
                     spec,
                     hook,
                     messages,
                     usage,
                 )
-            if final_content is None:
-                final_content = self._max_iterations_fallback(spec)
-            self._append_final_message(messages, final_content)
+            if terminal_content is None:
+                terminal_content = self._max_iterations_fallback(spec)
+            if length_recovery_parts:
+                terminal_tail = f"\n\n{terminal_content.lstrip()}"
+                final_content = (
+                    "".join(length_recovery_parts).rstrip() + terminal_tail
+                ).strip()
+                pending_stream_content = terminal_tail
+            else:
+                final_content = terminal_content
+            self._append_final_message(messages, terminal_content)
 
         return AgentRunResult(
             final_content=final_content,
@@ -739,6 +750,7 @@ class AgentRunner:
             error=error,
             tool_events=tool_events,
             had_injections=had_injections,
+            pending_stream_content=pending_stream_content,
         )
 
     def _build_request_kwargs(

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -520,6 +520,8 @@ class AgentRunner:
                     )
                     if should_continue:
                         had_injections = True
+                        length_recovery_count = 0
+                        length_recovery_parts.clear()
                         continue
                     break
                 await self._emit_checkpoint(
@@ -635,6 +637,7 @@ class AgentRunner:
                 await hook.on_stream_end(context, resuming=should_continue)
 
             if should_continue:
+                length_recovery_count = 0
                 length_recovery_parts.clear()
                 await hook.after_iteration(context)
                 continue
@@ -657,6 +660,7 @@ class AgentRunner:
                 )
                 if should_continue:
                     had_injections = True
+                    length_recovery_count = 0
                     length_recovery_parts.clear()
                     continue
                 break
@@ -675,6 +679,7 @@ class AgentRunner:
                 )
                 if should_continue:
                     had_injections = True
+                    length_recovery_count = 0
                     length_recovery_parts.clear()
                     continue
                 break

--- a/nanobot/agent/turn_delivery.py
+++ b/nanobot/agent/turn_delivery.py
@@ -285,7 +285,12 @@ class TurnDelivery:
             )
         )
 
-    async def _publish_stream_end(self, *, resuming: bool = False) -> None:
+    async def _publish_stream_end(
+        self,
+        *,
+        resuming: bool = False,
+        merge_next: bool = False,
+    ) -> None:
         await self.bus.publish_outbound(
             outbound_message_for_event(
                 channel=self.delivery_message.channel,
@@ -293,8 +298,10 @@ class TurnDelivery:
                 event=StreamEndEvent(
                     stream_id=self._stream_id(),
                     resuming=resuming,
+                    merge_next=merge_next,
                 ),
                 metadata=self.delivery_message.metadata,
             )
         )
-        self._stream_segment += 1
+        if not merge_next:
+            self._stream_segment += 1

--- a/nanobot/agent/turn_delivery.py
+++ b/nanobot/agent/turn_delivery.py
@@ -126,6 +126,7 @@ class TurnDelivery:
     lifecycle_message: InboundMessage = field(init=False)
     _stream_base_id: str | None = field(init=False, default=None)
     _stream_segment: int = field(init=False, default=0)
+    _stream_open: bool = field(init=False, default=False)
 
     def __post_init__(self) -> None:
         self.delivery_message = dataclasses.replace(
@@ -284,6 +285,7 @@ class TurnDelivery:
                 metadata=self.delivery_message.metadata,
             )
         )
+        self._stream_open = True
 
     async def _publish_stream_end(
         self,
@@ -303,5 +305,11 @@ class TurnDelivery:
                 metadata=self.delivery_message.metadata,
             )
         )
+        self._stream_open = merge_next
         if not merge_next:
             self._stream_segment += 1
+
+    async def abort_stream(self) -> None:
+        """Close an interrupted stream so stateful channels can release its buffer."""
+        if self._stream_open:
+            await self._publish_stream_end()

--- a/nanobot/bus/outbound_events.py
+++ b/nanobot/bus/outbound_events.py
@@ -46,6 +46,7 @@ class StreamEndEvent(OutboundEvent):
     content: str = ""
     stream_id: str | None = None
     resuming: bool = False
+    merge_next: bool = False
 
 
 @dataclass(frozen=True)
@@ -176,6 +177,7 @@ def _legacy_event_from_metadata(msg: OutboundMessage) -> OutboundEvent | None:
             content=msg.content,
             stream_id=_metadata_str(meta, "_stream_id"),
             resuming=bool(meta.get("_resuming")),
+            merge_next=bool(meta.get("_merge_next")),
         )
     if meta.get("_stream_delta"):
         return StreamDeltaEvent(

--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -110,6 +110,7 @@ class BaseChannel(ABC):
         stream_id: str | None = None,
         stream_end: bool = False,
         resuming: bool = False,
+        merge_next: bool = False,
     ) -> None:
         """Deliver a streaming text chunk.
 
@@ -118,6 +119,9 @@ class BaseChannel(ABC):
 
         Stateful implementations should key buffers by ``stream_id`` rather
         than only by ``chat_id`` when it is provided.
+
+        ``merge_next`` marks a resumable provider boundary whose next text
+        segment belongs to the same user-visible message.
         """
         pass
 

--- a/nanobot/channels/discord/runtime.py
+++ b/nanobot/channels/discord/runtime.py
@@ -489,6 +489,7 @@ class DiscordChannel(BaseChannel):
         stream_id: str | None = None,
         stream_end: bool = False,
         resuming: bool = False,
+        merge_next: bool = False,
     ) -> None:
         """Progressive Discord delivery: send once, then edit until the stream ends."""
         client = self._client

--- a/nanobot/channels/discord/runtime.py
+++ b/nanobot/channels/discord/runtime.py
@@ -497,6 +497,10 @@ class DiscordChannel(BaseChannel):
             self.logger.warning("client not ready; dropping stream delta")
             return
 
+        if stream_end and merge_next:
+            if not delta:
+                return
+            stream_end = False
         if stream_end:
             buf = self._stream_bufs.get(chat_id)
             if not buf or buf.message is None or not buf.text:

--- a/nanobot/channels/discord/tests/test_discord_channel.py
+++ b/nanobot/channels/discord/tests/test_discord_channel.py
@@ -755,6 +755,36 @@ async def test_send_delta_streams_by_editing_message(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_send_delta_merge_next_keeps_one_message(monkeypatch) -> None:
+    owner = DiscordChannel(DiscordConfig(enabled=True, allow_from=["*"]), MessageBus())
+    client = _FakeDiscordClient(owner, intents=None)
+    owner._client = client
+    owner._running = True
+    target = _FakeChannel(channel_id=123)
+    client.channels[123] = target
+
+    times = iter([1.0, 3.0, 5.0])
+    monkeypatch.setattr("nanobot.channels.discord.runtime.time.monotonic", lambda: next(times, 5.0))
+
+    await owner.send_delta(
+        "123",
+        "first-",
+        stream_id="s1",
+        stream_end=True,
+        merge_next=True,
+    )
+    await owner.send_delta("123", "second", stream_id="s1")
+    await owner.send_delta("123", "", stream_id="s1", stream_end=True)
+
+    assert target.sent_payloads == [{"content": "first-"}]
+    assert target.sent_messages[0].edits == [
+        {"content": "first-second"},
+        {"content": "first-second"},
+    ]
+    assert owner._stream_bufs == {}
+
+
+@pytest.mark.asyncio
 async def test_send_delta_stream_end_splits_oversized_reply(monkeypatch) -> None:
     owner = DiscordChannel(DiscordConfig(enabled=True, allow_from=["*"]), MessageBus())
     client = _FakeDiscordClient(owner, intents=None)

--- a/nanobot/channels/feishu/runtime.py
+++ b/nanobot/channels/feishu/runtime.py
@@ -2216,6 +2216,7 @@ class FeishuChannel(BaseChannel):
         stream_id: str | None = None,
         stream_end: bool = False,
         resuming: bool = False,
+        merge_next: bool = False,
     ) -> None:
         """Progressive streaming via CardKit: create card on first delta, stream-update on subsequent.
 

--- a/nanobot/channels/feishu/runtime.py
+++ b/nanobot/channels/feishu/runtime.py
@@ -2232,6 +2232,10 @@ class FeishuChannel(BaseChannel):
         rid_type = "chat_id" if chat_id.startswith("oc_") else "open_id"
 
         # --- stream end: final update or fallback ---
+        if stream_end and merge_next:
+            if not delta:
+                return
+            stream_end = False
         if stream_end:
             message_id = meta.get("message_id")
             # Only finalize the OnIt -> DONE reaction transition on the truly

--- a/nanobot/channels/feishu/tests/test_feishu_streaming.py
+++ b/nanobot/channels/feishu/tests/test_feishu_streaming.py
@@ -286,6 +286,27 @@ class TestSendDelta:
         assert settings_call.body.sequence == 5  # after final content seq 4
 
     @pytest.mark.asyncio
+    async def test_stream_end_merge_next_preserves_buffer(self):
+        ch = _make_channel()
+        ch._stream_bufs["oc_chat1"] = _FeishuStreamBuf(
+            text="first-",
+            card_id="card_1",
+            sequence=3,
+            last_edit=time.monotonic(),
+        )
+
+        await ch.send_delta(
+            "oc_chat1",
+            "boundary",
+            stream_end=True,
+            merge_next=True,
+        )
+
+        assert ch._stream_bufs["oc_chat1"].text == "first-boundary"
+        ch._client.cardkit.v1.card_element.content.assert_not_called()
+        ch._client.cardkit.v1.card.settings.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_stream_end_fallback_when_no_card_id(self):
         """If card creation failed, stream_end falls back to a plain card message."""
         ch = _make_channel()

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import inspect
 from collections.abc import Callable, Iterable
 from contextlib import suppress
 from pathlib import Path
@@ -763,13 +764,29 @@ class ChannelManager:
         msg: OutboundMessage,
         event: StreamDeltaEvent | StreamEndEvent,
     ) -> None:
+        kwargs: dict[str, Any] = {
+            "stream_id": event.stream_id,
+            "stream_end": isinstance(event, StreamEndEvent),
+            "resuming": event.resuming if isinstance(event, StreamEndEvent) else False,
+        }
+        if isinstance(event, StreamEndEvent) and event.merge_next:
+            try:
+                signature = inspect.signature(channel.send_delta)
+                if (
+                    "merge_next" in signature.parameters
+                    or any(
+                        parameter.kind is inspect.Parameter.VAR_KEYWORD
+                        for parameter in signature.parameters.values()
+                    )
+                ):
+                    kwargs["merge_next"] = True
+            except (TypeError, ValueError):
+                pass
         await channel.send_delta(
             msg.chat_id,
             msg.content,
             msg.metadata,
-            stream_id=event.stream_id,
-            stream_end=isinstance(event, StreamEndEvent),
-            resuming=event.resuming if isinstance(event, StreamEndEvent) else False,
+            **kwargs,
         )
 
     @staticmethod
@@ -850,6 +867,7 @@ class ChannelManager:
                     final_event = StreamEndEvent(
                         stream_id=next_stream_id,
                         resuming=next_event.resuming,
+                        merge_next=next_event.merge_next,
                     )
                     # Stream ended - stop coalescing this stream
                     break

--- a/nanobot/channels/matrix/runtime.py
+++ b/nanobot/channels/matrix/runtime.py
@@ -598,6 +598,7 @@ class MatrixChannel(BaseChannel):
         stream_id: str | None = None,
         stream_end: bool = False,
         resuming: bool = False,
+        merge_next: bool = False,
     ) -> None:
         relates_to = self._build_thread_relates_to(metadata)
 

--- a/nanobot/channels/matrix/runtime.py
+++ b/nanobot/channels/matrix/runtime.py
@@ -602,6 +602,10 @@ class MatrixChannel(BaseChannel):
     ) -> None:
         relates_to = self._build_thread_relates_to(metadata)
 
+        if stream_end and merge_next:
+            if not delta:
+                return
+            stream_end = False
         if stream_end:
             stream_key = _matrix_stream_key(chat_id, stream_id)
             buf = self._stream_bufs.pop(stream_key, None)

--- a/nanobot/channels/matrix/tests/test_matrix_channel.py
+++ b/nanobot/channels/matrix/tests/test_matrix_channel.py
@@ -1938,6 +1938,29 @@ async def test_send_delta_stream_end_replaces_existing_message() -> None:
 
 
 @pytest.mark.asyncio
+async def test_send_delta_merge_next_preserves_buffer() -> None:
+    channel = MatrixChannel(_make_config(), MessageBus())
+    client = _FakeAsyncClient("", "", "", None)
+    channel.client = client
+    channel._stream_bufs["!room:matrix.org"] = matrix_module._StreamBuf(
+        text="first-",
+        event_id="event-1",
+        last_edit=100.0,
+    )
+    channel.monotonic_time = lambda: 100.1
+
+    await channel.send_delta(
+        "!room:matrix.org",
+        "boundary",
+        stream_end=True,
+        merge_next=True,
+    )
+
+    assert channel._stream_bufs["!room:matrix.org"].text == "first-boundary"
+    assert client.room_send_calls == []
+
+
+@pytest.mark.asyncio
 async def test_send_delta_keeps_same_room_stream_ids_independent(monkeypatch) -> None:
     channel = MatrixChannel(_make_config(), MessageBus())
     client = _FakeAsyncClient("", "", "", None)

--- a/nanobot/channels/mattermost/runtime.py
+++ b/nanobot/channels/mattermost/runtime.py
@@ -533,7 +533,11 @@ class MattermostChannel(BaseChannel):
                 final += delta
 
             if resuming:
-                self._clear_stream_state(stream_id)
+                if merge_next:
+                    self._stream_buffers[stream_id] = final
+                    self._stream_committed[stream_id] = final
+                else:
+                    self._clear_stream_state(stream_id)
                 return
 
             if final and not meta.get("_progress"):

--- a/nanobot/channels/mattermost/runtime.py
+++ b/nanobot/channels/mattermost/runtime.py
@@ -515,6 +515,7 @@ class MattermostChannel(BaseChannel):
         stream_id: str | None = None,
         stream_end: bool = False,
         resuming: bool = False,
+        merge_next: bool = False,
     ) -> None:
         if not self._http_client:
             return

--- a/nanobot/channels/mattermost/tests/test_mattermost_channel.py
+++ b/nanobot/channels/mattermost/tests/test_mattermost_channel.py
@@ -583,6 +583,33 @@ async def test_stream_end_keyword_resuming_does_not_post_or_mark_done():
 
 
 @pytest.mark.asyncio
+async def test_stream_end_merge_next_preserves_buffer_until_final_end():
+    channel, fake = _make_channel()
+    channel._self_id = "bot_id"
+    fake.set_post_response("/api/v4/posts", {"id": "stream_post_1"})
+    await channel.send_delta("chan_1", "first ", stream_id="s1")
+
+    await channel.send_delta(
+        "chan_1",
+        "boundary ",
+        stream_id="s1",
+        stream_end=True,
+        resuming=True,
+        merge_next=True,
+    )
+
+    assert channel._stream_buffers["s1"] == "first boundary "
+
+    await channel.send_delta("chan_1", "second", stream_id="s1")
+    await channel.send_delta("chan_1", "", stream_id="s1", stream_end=True)
+
+    posts = [call for call in fake.post_calls if call["path"] == "/api/v4/posts"]
+    assert len(posts) == 1
+    assert posts[0]["json"]["message"] == "first boundary second"
+    assert "s1" not in channel._stream_buffers
+
+
+@pytest.mark.asyncio
 async def test_stream_end_failure_keeps_buffer_for_retry():
     channel, fake = _make_channel()
     channel._self_id = "bot_id"

--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -923,6 +923,7 @@ class TelegramChannel(BaseChannel):
         stream_id: str | None = None,
         stream_end: bool = False,
         resuming: bool = False,
+        merge_next: bool = False,
     ) -> None:
         """Progressive message editing: send on first delta, edit on subsequent ones."""
         if not self._app:

--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -931,6 +931,10 @@ class TelegramChannel(BaseChannel):
         meta = metadata or {}
         int_chat_id = int(chat_id)
 
+        if stream_end and merge_next:
+            if not delta:
+                return
+            stream_end = False
         if stream_end:
             buf = self._stream_bufs.get(chat_id)
             if not buf or not buf.message_id or not buf.text:

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -676,6 +676,33 @@ async def test_send_delta_stream_end_raises_and_keeps_buffer_on_failure() -> Non
 
 
 @pytest.mark.asyncio
+async def test_send_delta_merge_next_preserves_buffer() -> None:
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
+        MessageBus(),
+    )
+    channel._app = _FakeApp(lambda: None)
+    channel._app.bot.edit_message_text = AsyncMock()
+    channel._stream_bufs["123"] = _StreamBuf(
+        text="first-",
+        message_id=7,
+        last_edit=float("inf"),
+        stream_id="s:0",
+    )
+
+    await channel.send_delta(
+        "123",
+        "boundary",
+        stream_id="s:0",
+        stream_end=True,
+        merge_next=True,
+    )
+
+    assert channel._stream_bufs["123"].text == "first-boundary"
+    channel._app.bot.edit_message_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_send_delta_stream_end_treats_not_modified_as_success() -> None:
     from telegram.error import BadRequest
 

--- a/nanobot/channels/websocket/runtime.py
+++ b/nanobot/channels/websocket/runtime.py
@@ -995,13 +995,18 @@ class WebSocketChannel(BaseChannel):
         stream_id: str | None = None,
         stream_end: bool = False,
         resuming: bool = False,
+        merge_next: bool = False,
     ) -> None:
         conns = list(self._subs.get(chat_id, ()))
         meta = metadata or {}
         stream_key = (chat_id, str(stream_id or ""))
         if stream_end:
             body: dict[str, Any] = {"event": "stream_end", "chat_id": chat_id}
-            buffered = self._stream_text_buffers.pop(stream_key, [])
+            buffered = (
+                self._stream_text_buffers.setdefault(stream_key, [])
+                if merge_next
+                else self._stream_text_buffers.pop(stream_key, [])
+            )
             if delta:
                 buffered.append(delta)
             full_text = "".join(buffered)
@@ -1019,6 +1024,8 @@ class WebSocketChannel(BaseChannel):
             body["stream_id"] = stream_id
         if stream_end and resuming:
             body["resuming"] = True
+        if stream_end and merge_next:
+            body["merge_next"] = True
         self._transcripts.prepare_and_append(
             chat_id,
             body,

--- a/nanobot/channels/websocket/tests/test_websocket_channel.py
+++ b/nanobot/channels/websocket/tests/test_websocket_channel.py
@@ -1351,6 +1351,39 @@ async def test_send_delta_marks_resuming_stream_end() -> None:
 
 
 @pytest.mark.asyncio
+async def test_send_delta_keeps_buffer_across_merged_stream_boundary() -> None:
+    bus = MagicMock()
+    channel = WebSocketChannel(
+        {"enabled": True, "allowFrom": ["*"], "streaming": True},
+        bus,
+        gateway=_basic_handler(bus),
+    )
+    mock_ws = AsyncMock()
+    channel._attach(mock_ws, "chat-1")
+
+    await channel.send_delta("chat-1", "first ", stream_id="sid")
+    await channel.send_delta(
+        "chat-1",
+        "",
+        stream_id="sid",
+        stream_end=True,
+        resuming=True,
+        merge_next=True,
+    )
+    await channel.send_delta("chat-1", "second", stream_id="sid")
+    await channel.send_delta("chat-1", "", stream_id="sid", stream_end=True)
+
+    payloads = [json.loads(call.args[0]) for call in mock_ws.send.await_args_list]
+    assert payloads[1]["merge_next"] is True
+    assert payloads[1]["resuming"] is True
+    assert [payload["text"] for payload in payloads if payload["event"] == "delta"] == [
+        "first ",
+        "second",
+    ]
+    assert ("chat-1", "sid") not in channel._stream_text_buffers
+
+
+@pytest.mark.asyncio
 async def test_send_delta_stream_end_includes_inline_final_text() -> None:
     bus = MagicMock()
     channel = WebSocketChannel({"enabled": True, "allowFrom": ["*"], "streaming": True}, bus, gateway=_basic_handler(bus))

--- a/nanobot/channels/weixin/runtime.py
+++ b/nanobot/channels/weixin/runtime.py
@@ -1243,6 +1243,7 @@ class WeixinChannel(BaseChannel):
         stream_id: str | None = None,
         stream_end: bool = False,
         resuming: bool = False,
+        merge_next: bool = False,
     ) -> None:
         """Deliver a streamed reply to WeChat.
 

--- a/nanobot/channels/weixin/runtime.py
+++ b/nanobot/channels/weixin/runtime.py
@@ -1257,6 +1257,10 @@ class WeixinChannel(BaseChannel):
             return
         is_end = stream_end or bool(meta.get("_stream_end"))
         buffer_key = stream_id or chat_id
+        if is_end and merge_next:
+            if delta:
+                self._stream_buffers.setdefault(buffer_key, []).append(delta)
+            return
         # Accumulate intermediate deltas. The stream_end message's own content
         # (present when the manager coalesces deltas into the end message) is
         # folded into `full` below instead of appended here, so a send retry

--- a/nanobot/channels/weixin/tests/test_weixin_channel.py
+++ b/nanobot/channels/weixin/tests/test_weixin_channel.py
@@ -1825,6 +1825,29 @@ async def test_stream_end_flushes_buffered_answer() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stream_end_merge_next_preserves_buffer_until_final_end() -> None:
+    channel, _bus = _make_channel()
+    channel._client = object()
+    channel._token = "token"
+    channel._context_tokens["wx-user"] = "ctx-1"
+    channel._context_token_at["wx-user"] = time.time()
+    channel._send_text = AsyncMock()
+
+    await channel.send_delta(
+        "wx-user",
+        "first-",
+        stream_id="s1",
+        stream_end=True,
+        merge_next=True,
+    )
+    await channel.send_delta("wx-user", "second", stream_id="s1")
+    await channel.send_delta("wx-user", "", stream_id="s1", stream_end=True)
+
+    channel._send_text.assert_awaited_once_with("wx-user", "first-second", "ctx-1")
+    assert "s1" not in channel._stream_buffers
+
+
+@pytest.mark.asyncio
 async def test_stream_end_send_failure_keeps_buffer_for_retry() -> None:
     channel, _bus = _make_channel()
     channel._client = object()

--- a/nanobot/utils/runtime.py
+++ b/nanobot/utils/runtime.py
@@ -14,6 +14,7 @@ _MAX_REPEAT_EXTERNAL_LOOKUPS = 2
 
 # Third same-target workspace violation in a turn escalates to "stop retrying".
 _MAX_REPEAT_WORKSPACE_VIOLATIONS = 2
+_LENGTH_RECOVERY_TAIL_CHARS = 500
 
 EMPTY_FINAL_RESPONSE_MESSAGE = (
     "I completed the tool steps but couldn't produce a final answer. "
@@ -33,8 +34,10 @@ BUDGET_EXHAUSTED_FINALIZATION_PROMPT = (
 )
 
 LENGTH_RECOVERY_PROMPT = (
-    "Output limit reached. Continue exactly where you left off "
-    "— no recap, no apology. Break remaining work into smaller steps if needed."
+    "The previous assistant response was cut off. Continue the same response from its "
+    "exact endpoint. Output only new continuation text in the same language and style. "
+    "Do not acknowledge this instruction, restart the response, repeat its title or any "
+    "existing text, recap, or apologize."
 )
 
 SUSTAINED_GOAL_CONTINUE_PROMPT = (
@@ -79,9 +82,19 @@ def build_budget_exhausted_finalization_message() -> dict[str, str]:
     return {"role": "user", "content": BUDGET_EXHAUSTED_FINALIZATION_PROMPT}
 
 
-def build_length_recovery_message() -> dict[str, str]:
+def build_length_recovery_message(content: str) -> dict[str, str]:
     """Prompt the model to continue after hitting output token limit."""
-    return {"role": "user", "content": LENGTH_RECOVERY_PROMPT}
+    tail = content[-_LENGTH_RECOVERY_TAIL_CHARS:]
+    prompt = (
+        f"{LENGTH_RECOVERY_PROMPT}\n\n"
+        "The following tail was already delivered to the user. Treat it as immutable "
+        "context and do not output it again:\n"
+        "<already_delivered_tail>\n"
+        f"{tail}\n"
+        "</already_delivered_tail>\n"
+        "Begin with the text that belongs immediately after this tail."
+    )
+    return {"role": "user", "content": prompt}
 
 
 def build_goal_continue_message(custom: str | None = None) -> dict[str, str]:

--- a/nanobot/utils/runtime.py
+++ b/nanobot/utils/runtime.py
@@ -14,7 +14,7 @@ _MAX_REPEAT_EXTERNAL_LOOKUPS = 2
 
 # Third same-target workspace violation in a turn escalates to "stop retrying".
 _MAX_REPEAT_WORKSPACE_VIOLATIONS = 2
-_LENGTH_RECOVERY_TAIL_CHARS = 500
+_LENGTH_RECOVERY_TAIL_CHARS = 64
 
 EMPTY_FINAL_RESPONSE_MESSAGE = (
     "I completed the tool steps but couldn't produce a final answer. "

--- a/nanobot/webui/transcript.py
+++ b/nanobot/webui/transcript.py
@@ -1770,6 +1770,7 @@ def replay_transcript_to_ui_messages(
                 buffer_message_id = None
                 buffer_parts = []
                 continue
+            merge_next = rec.get("resuming") is True and rec.get("merge_next") is True
             final_text = rec.get("text")
             if isinstance(final_text, str):
                 if buffer_message_id is None:
@@ -1794,8 +1795,11 @@ def replay_transcript_to_ui_messages(
                                 **_turn_fields(rec, "answer"),
                             }
                             break
-            buffer_message_id = None
-            buffer_parts = []
+                if merge_next:
+                    buffer_parts = [final_text]
+            if not merge_next:
+                buffer_message_id = None
+                buffer_parts = []
             continue
 
         if ev == "reasoning_delta":

--- a/tests/agent/test_loop_progress.py
+++ b/tests/agent/test_loop_progress.py
@@ -581,6 +581,96 @@ class TestToolEventProgress:
         assert {event.stream_id for event in [*deltas, *endings]} == {deltas[0].stream_id}
 
     @pytest.mark.asyncio
+    async def test_length_recovery_at_max_iterations_streams_only_missing_tail(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.supports_progress_deltas = True
+        provider.get_default_model.return_value = "test-model"
+
+        async def chat_stream_with_retry(*, on_content_delta, **kwargs):
+            await on_content_delta("partial")
+            return LLMResponse(content="partial", finish_reason="length")
+
+        provider.chat_stream_with_retry = chat_stream_with_retry
+        provider.chat_with_retry = AsyncMock(
+            return_value=LLMResponse(content="summary", finish_reason="stop")
+        )
+        loop = AgentLoop(bus=bus, provider=provider, workspace=tmp_path, model="test-model")
+        _attach_webui_runtime_events(loop, bus)
+        loop.max_iterations = 1
+        loop.tools.get_definitions = MagicMock(return_value=[])
+        loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+        await loop._dispatch(InboundMessage(
+            channel="websocket",
+            sender_id="u1",
+            chat_id="chat1",
+            content="give a long answer",
+            metadata={"_wants_stream": True},
+        ))
+
+        outbound = []
+        while bus.outbound_size > 0:
+            outbound.append(await bus.consume_outbound())
+
+        deltas = [m.event for m in outbound if isinstance(m.event, StreamDeltaEvent)]
+        endings = [m.event for m in outbound if isinstance(m.event, StreamEndEvent)]
+        final = [m for m in outbound if isinstance(m.event, StreamedResponseEvent)]
+
+        assert [event.content for event in deltas] == ["partial", "\n\nsummary"]
+        assert [event.merge_next for event in endings] == [True, False]
+        assert {event.stream_id for event in [*deltas, *endings]} == {deltas[0].stream_id}
+        assert [message.content for message in final] == ["partial\n\nsummary"]
+
+    @pytest.mark.asyncio
+    async def test_cancelled_length_recovery_closes_merged_stream(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+        loop = AgentLoop(bus=bus, provider=provider, workspace=tmp_path, model="test-model")
+
+        async def cancel_after_merge(
+            _msg: InboundMessage,
+            *,
+            on_stream,
+            on_stream_end,
+            **_kwargs,
+        ):
+            assert on_stream is not None
+            assert on_stream_end is not None
+            await on_stream("partial")
+            await on_stream_end(resuming=True, merge_next=True)
+            raise asyncio.CancelledError
+
+        loop._process_message = cancel_after_merge  # type: ignore[method-assign]
+
+        with pytest.raises(asyncio.CancelledError):
+            await loop._dispatch(InboundMessage(
+                channel="websocket",
+                sender_id="u1",
+                chat_id="chat1",
+                content="give a long answer",
+                metadata={"_wants_stream": True},
+            ))
+
+        outbound = []
+        while bus.outbound_size > 0:
+            outbound.append(await bus.consume_outbound())
+
+        endings = [m.event for m in outbound if isinstance(m.event, StreamEndEvent)]
+        assert [(event.resuming, event.merge_next) for event in endings] == [
+            (True, True),
+            (False, False),
+        ]
+        assert endings[0].stream_id == endings[1].stream_id
+
+    @pytest.mark.asyncio
     async def test_non_streamed_finalization_is_delivered_as_regular_message(
         self,
         tmp_path: Path,

--- a/tests/agent/test_loop_progress.py
+++ b/tests/agent/test_loop_progress.py
@@ -535,6 +535,52 @@ class TestToolEventProgress:
         provider.chat_with_retry.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_length_recovery_keeps_one_user_visible_stream(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.supports_progress_deltas = True
+        provider.get_default_model.return_value = "test-model"
+        responses = iter([
+            LLMResponse(content="first-", finish_reason="length"),
+            LLMResponse(content="second", finish_reason="stop"),
+        ])
+
+        async def chat_stream_with_retry(*, on_content_delta, **kwargs):
+            response = next(responses)
+            await on_content_delta(response.content or "")
+            return response
+
+        provider.chat_stream_with_retry = chat_stream_with_retry
+        provider.chat_with_retry = AsyncMock()
+        loop = AgentLoop(bus=bus, provider=provider, workspace=tmp_path, model="test-model")
+        _attach_webui_runtime_events(loop, bus)
+        loop.tools.get_definitions = MagicMock(return_value=[])
+        loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+        await loop._dispatch(InboundMessage(
+            channel="websocket",
+            sender_id="u1",
+            chat_id="chat1",
+            content="give a long answer",
+            metadata={"_wants_stream": True},
+        ))
+
+        outbound = []
+        while bus.outbound_size > 0:
+            outbound.append(await bus.consume_outbound())
+
+        deltas = [m.event for m in outbound if isinstance(m.event, StreamDeltaEvent)]
+        endings = [m.event for m in outbound if isinstance(m.event, StreamEndEvent)]
+
+        assert [event.content for event in deltas] == ["first-", "second"]
+        assert [event.resuming for event in endings] == [True, False]
+        assert [event.merge_next for event in endings] == [True, False]
+        assert {event.stream_id for event in [*deltas, *endings]} == {deltas[0].stream_id}
+
+    @pytest.mark.asyncio
     async def test_non_streamed_finalization_is_delivered_as_regular_message(
         self,
         tmp_path: Path,

--- a/tests/agent/test_loop_progress.py
+++ b/tests/agent/test_loop_progress.py
@@ -581,6 +581,53 @@ class TestToolEventProgress:
         assert {event.stream_id for event in [*deltas, *endings]} == {deltas[0].stream_id}
 
     @pytest.mark.asyncio
+    async def test_length_recovery_streams_non_delta_terminal_segment(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.supports_progress_deltas = True
+        provider.get_default_model.return_value = "test-model"
+        call_count = 0
+
+        async def chat_stream_with_retry(*, on_content_delta, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                await on_content_delta("first-")
+                return LLMResponse(content="first-", finish_reason="length")
+            return LLMResponse(content="second", finish_reason="stop")
+
+        provider.chat_stream_with_retry = chat_stream_with_retry
+        provider.chat_with_retry = AsyncMock()
+        loop = AgentLoop(bus=bus, provider=provider, workspace=tmp_path, model="test-model")
+        _attach_webui_runtime_events(loop, bus)
+        loop.tools.get_definitions = MagicMock(return_value=[])
+        loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+        await loop._dispatch(InboundMessage(
+            channel="websocket",
+            sender_id="u1",
+            chat_id="chat1",
+            content="give a long answer",
+            metadata={"_wants_stream": True},
+        ))
+
+        outbound = []
+        while bus.outbound_size > 0:
+            outbound.append(await bus.consume_outbound())
+
+        deltas = [m.event for m in outbound if isinstance(m.event, StreamDeltaEvent)]
+        endings = [m.event for m in outbound if isinstance(m.event, StreamEndEvent)]
+        final = [m for m in outbound if m.content == "first-second"]
+
+        assert [event.content for event in deltas] == ["first-", "second"]
+        assert [event.merge_next for event in endings] == [True, False]
+        assert len(final) == 1
+        assert isinstance(final[0].event, StreamedResponseEvent)
+
+    @pytest.mark.asyncio
     async def test_length_recovery_at_max_iterations_streams_only_missing_tail(
         self,
         tmp_path: Path,

--- a/tests/agent/test_runner_core.py
+++ b/tests/agent/test_runner_core.py
@@ -451,6 +451,70 @@ async def test_runner_uses_specific_message_after_empty_finalization_retry():
 
 
 @pytest.mark.asyncio
+async def test_runner_length_recovery_returns_all_segments():
+    """Recovered output segments are returned together instead of only the tail."""
+    from nanobot.agent.runner import AgentRunner
+
+    provider = MagicMock(spec=LLMProvider)
+    provider.chat_with_retry = AsyncMock(side_effect=[
+        LLMResponse(content="first ", finish_reason="length"),
+        LLMResponse(content="second ", finish_reason="length"),
+        LLMResponse(content="third", finish_reason="stop"),
+    ])
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+
+    runner = AgentRunner()
+    result = await runner.run(make_run_spec(provider,
+        initial_messages=[{"role": "user", "content": "give a long answer"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=5,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    ))
+
+    assert result.final_content == "first second third"
+    assert [
+        message["content"]
+        for message in result.messages
+        if message.get("role") == "assistant"
+    ] == ["first", "second", "third"]
+    assert provider.chat_with_retry.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_runner_length_recovery_does_not_leak_across_tool_calls():
+    """A recovered prefix belongs only to its contiguous response chain."""
+    from nanobot.agent.runner import AgentRunner
+
+    provider = MagicMock(spec=LLMProvider)
+    provider.chat_with_retry = AsyncMock(side_effect=[
+        LLMResponse(content="working", finish_reason="length"),
+        LLMResponse(
+            content=None,
+            tool_calls=[ToolCallRequest(id="call_1", name="read_file", arguments={"path": "x"})],
+            finish_reason="tool_calls",
+        ),
+        LLMResponse(content="final answer", finish_reason="stop"),
+    ])
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    tools.execute = AsyncMock(return_value="file content")
+
+    runner = AgentRunner()
+    result = await runner.run(make_run_spec(provider,
+        initial_messages=[{"role": "user", "content": "inspect a file"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=5,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    ))
+
+    assert result.final_content == "final answer"
+    assert result.tools_used == ["read_file"]
+
+
+@pytest.mark.asyncio
 async def test_runner_empty_response_does_not_break_tool_chain():
     """An empty intermediate response must not kill an ongoing tool chain.
 

--- a/tests/agent/test_runner_core.py
+++ b/tests/agent/test_runner_core.py
@@ -483,6 +483,40 @@ async def test_runner_length_recovery_returns_all_segments():
 
 
 @pytest.mark.asyncio
+async def test_runner_length_recovery_preserves_prefix_at_max_iterations():
+    """Budget exhaustion must not replace output already produced by recovery."""
+    from nanobot.agent.runner import AgentRunner
+
+    provider = MagicMock(spec=LLMProvider)
+    provider.chat_with_retry = AsyncMock(
+        return_value=LLMResponse(content="partial answer", finish_reason="length")
+    )
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+
+    runner = AgentRunner()
+    result = await runner.run(make_run_spec(
+        provider,
+        initial_messages=[{"role": "user", "content": "give a long answer"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=1,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        finalize_on_max_iterations=False,
+        max_iterations_message="limit reached",
+    ))
+
+    assert result.stop_reason == "max_iterations"
+    assert result.final_content == "partial answer\n\nlimit reached"
+    assert result.pending_stream_content == "\n\nlimit reached"
+    assert [
+        message["content"]
+        for message in result.messages
+        if message.get("role") == "assistant"
+    ] == ["partial answer", "limit reached"]
+
+
+@pytest.mark.asyncio
 async def test_runner_length_recovery_does_not_leak_across_tool_calls():
     """A recovered prefix belongs only to its contiguous response chain."""
     from nanobot.agent.runner import AgentRunner

--- a/tests/agent/test_runner_hooks.py
+++ b/tests/agent/test_runner_hooks.py
@@ -144,6 +144,55 @@ async def test_runner_streaming_hook_receives_deltas_and_end_signal():
 
 
 @pytest.mark.asyncio
+async def test_runner_length_recovery_streams_segments_once_and_returns_all_content():
+    from nanobot.agent.hook import AgentHook, AgentHookContext
+    from nanobot.agent.runner import AgentRunner
+
+    provider = MagicMock(spec=LLMProvider)
+    streamed: list[str] = []
+    endings: list[bool] = []
+    responses = iter([
+        LLMResponse(content="first ", finish_reason="length"),
+        LLMResponse(content="second", finish_reason="stop"),
+    ])
+
+    async def chat_stream_with_retry(*, on_content_delta, **kwargs):
+        response = next(responses)
+        await on_content_delta(response.content or "")
+        return response
+
+    provider.chat_stream_with_retry = chat_stream_with_retry
+    provider.chat_with_retry = AsyncMock()
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+
+    class StreamingHook(AgentHook):
+        def wants_streaming(self) -> bool:
+            return True
+
+        async def on_stream(self, context: AgentHookContext, delta: str) -> None:
+            streamed.append(delta)
+
+        async def on_stream_end(self, context: AgentHookContext, *, resuming: bool) -> None:
+            endings.append(resuming)
+
+    runner = AgentRunner()
+    result = await runner.run(make_run_spec(provider,
+        initial_messages=[{"role": "user", "content": "give a long answer"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=3,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        hook=StreamingHook(),
+    ))
+
+    assert result.final_content == "first second"
+    assert streamed == ["first ", "second"]
+    assert endings == [True, False]
+    provider.chat_with_retry.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_runner_passes_cached_tokens_to_hook_context():
     """Hook context.usage should contain cached_tokens."""
     from nanobot.agent.hook import AgentHook, AgentHookContext

--- a/tests/agent/test_runner_hooks.py
+++ b/tests/agent/test_runner_hooks.py
@@ -151,6 +151,7 @@ async def test_runner_length_recovery_streams_segments_once_and_returns_all_cont
     provider = MagicMock(spec=LLMProvider)
     streamed: list[str] = []
     endings: list[bool] = []
+    merge_next: list[bool] = []
     responses = iter([
         LLMResponse(content="first ", finish_reason="length"),
         LLMResponse(content="second", finish_reason="stop"),
@@ -175,6 +176,7 @@ async def test_runner_length_recovery_streams_segments_once_and_returns_all_cont
 
         async def on_stream_end(self, context: AgentHookContext, *, resuming: bool) -> None:
             endings.append(resuming)
+            merge_next.append(context.stream_continues_current_message)
 
     runner = AgentRunner()
     result = await runner.run(make_run_spec(provider,
@@ -189,6 +191,7 @@ async def test_runner_length_recovery_streams_segments_once_and_returns_all_cont
     assert result.final_content == "first second"
     assert streamed == ["first ", "second"]
     assert endings == [True, False]
+    assert merge_next == [True, False]
     provider.chat_with_retry.assert_not_awaited()
 
 

--- a/tests/agent/test_runner_injections.py
+++ b/tests/agent/test_runner_injections.py
@@ -353,6 +353,42 @@ async def test_checkpoint2_injects_after_final_response_with_resuming_stream():
 
 
 @pytest.mark.asyncio
+async def test_injected_followup_starts_new_length_recovery_chain():
+    """Recovered content from the prior answer must not prefix a follow-up reply."""
+    from nanobot.agent.runner import AgentRunner
+    from nanobot.bus.events import InboundMessage
+
+    provider = MagicMock()
+    provider.chat_with_retry = AsyncMock(side_effect=[
+        LLMResponse(content="first", finish_reason="length"),
+        LLMResponse(content="second", finish_reason="stop"),
+        LLMResponse(content="follow-up answer", finish_reason="stop"),
+    ])
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+
+    injection_queue = asyncio.Queue()
+    inject_cb = _make_injection_callback(injection_queue)
+    await injection_queue.put(
+        InboundMessage(channel="cli", sender_id="u", chat_id="c", content="follow-up question")
+    )
+
+    runner = AgentRunner()
+    result = await runner.run(make_run_spec(provider,
+        initial_messages=[{"role": "user", "content": "give a long answer"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=5,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        injection_callback=inject_cb,
+    ))
+
+    assert result.had_injections is True
+    assert result.final_content == "follow-up answer"
+    assert provider.chat_with_retry.await_count == 3
+
+
+@pytest.mark.asyncio
 async def test_checkpoint2_preserves_final_response_in_history_before_followup():
     """A follow-up injected after a final answer must still see that answer in history."""
     from nanobot.agent.runner import AgentRunner

--- a/tests/agent/test_runner_injections.py
+++ b/tests/agent/test_runner_injections.py
@@ -354,15 +354,18 @@ async def test_checkpoint2_injects_after_final_response_with_resuming_stream():
 
 @pytest.mark.asyncio
 async def test_injected_followup_starts_new_length_recovery_chain():
-    """Recovered content from the prior answer must not prefix a follow-up reply."""
+    """A follow-up gets a fresh recovery budget and no content from the prior answer."""
     from nanobot.agent.runner import AgentRunner
     from nanobot.bus.events import InboundMessage
 
     provider = MagicMock()
     provider.chat_with_retry = AsyncMock(side_effect=[
-        LLMResponse(content="first", finish_reason="length"),
-        LLMResponse(content="second", finish_reason="stop"),
-        LLMResponse(content="follow-up answer", finish_reason="stop"),
+        LLMResponse(content="first-1 ", finish_reason="length"),
+        LLMResponse(content="first-2 ", finish_reason="length"),
+        LLMResponse(content="first-3 ", finish_reason="length"),
+        LLMResponse(content="first-final", finish_reason="stop"),
+        LLMResponse(content="follow-up ", finish_reason="length"),
+        LLMResponse(content="answer", finish_reason="stop"),
     ])
     tools = MagicMock()
     tools.get_definitions.return_value = []
@@ -378,14 +381,14 @@ async def test_injected_followup_starts_new_length_recovery_chain():
         initial_messages=[{"role": "user", "content": "give a long answer"}],
         tools=tools,
         model="test-model",
-        max_iterations=5,
+        max_iterations=8,
         max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
         injection_callback=inject_cb,
     ))
 
     assert result.had_injections is True
     assert result.final_content == "follow-up answer"
-    assert provider.chat_with_retry.await_count == 3
+    assert provider.chat_with_retry.await_count == 6
 
 
 @pytest.mark.asyncio
@@ -1348,7 +1351,7 @@ async def test_dispatch_republishes_leftover_queue_messages(tmp_path):
 
 @pytest.mark.asyncio
 async def test_drain_injections_on_fatal_tool_error():
-    """Pending injections should be drained even when a fatal tool error occurs."""
+    """A fatal tool error must not leak recovered content into an injected follow-up."""
     from nanobot.agent.runner import AgentRunner
     from nanobot.bus.events import InboundMessage
 
@@ -1359,11 +1362,17 @@ async def test_drain_injections_on_fatal_tool_error():
         call_count["n"] += 1
         if call_count["n"] == 1:
             return LLMResponse(
+                content="stale prefix ",
+                finish_reason="length",
+                usage={},
+            )
+        if call_count["n"] == 2:
+            return LLMResponse(
                 content="",
                 tool_calls=[ToolCallRequest(id="c1", name="exec", arguments={"cmd": "bad"})],
                 usage={},
             )
-        # Second call: respond normally to the injected follow-up
+        # Third call: respond normally to the injected follow-up.
         return LLMResponse(content="reply to follow-up", tool_calls=[], usage={})
 
     provider.chat_with_retry = chat_with_retry
@@ -1391,6 +1400,7 @@ async def test_drain_injections_on_fatal_tool_error():
 
     assert result.had_injections is True
     assert result.final_content == "reply to follow-up"
+    assert call_count["n"] == 3
     # The injection should be in the messages history
     injected = [
         m for m in result.messages

--- a/tests/bus/test_outbound_events.py
+++ b/tests/bus/test_outbound_events.py
@@ -94,7 +94,12 @@ def test_legacy_stream_metadata_flags_create_runtime_events() -> None:
         channel="websocket",
         chat_id="chat-1",
         content="",
-        metadata={"_stream_end": True, "_stream_id": "s1", "_resuming": True},
+        metadata={
+            "_stream_end": True,
+            "_stream_id": "s1",
+            "_resuming": True,
+            "_merge_next": True,
+        },
     )
 
     delta_event = outbound_event_from_message(delta)
@@ -106,6 +111,7 @@ def test_legacy_stream_metadata_flags_create_runtime_events() -> None:
     assert isinstance(end_event, StreamEndEvent)
     assert end_event.stream_id == "s1"
     assert end_event.resuming is True
+    assert end_event.merge_next is True
 
 
 def test_legacy_webui_runtime_metadata_flags_create_runtime_events() -> None:
@@ -221,7 +227,7 @@ def test_replace_outbound_event_keeps_routing_metadata() -> None:
 
     updated = replace_outbound_event(
         msg,
-        StreamEndEvent(stream_id="s1", resuming=True),
+        StreamEndEvent(stream_id="s1", resuming=True, merge_next=True),
         content="hello world",
     )
 
@@ -230,6 +236,7 @@ def test_replace_outbound_event_keeps_routing_metadata() -> None:
     assert isinstance(updated.event, StreamEndEvent)
     assert updated.event.stream_id == "s1"
     assert updated.event.resuming is True
+    assert updated.event.merge_next is True
 
 
 def test_streamed_response_event_keeps_final_content_outside_event_payload() -> None:

--- a/tests/channels/test_channel_manager_delta_coalescing.py
+++ b/tests/channels/test_channel_manager_delta_coalescing.py
@@ -49,6 +49,7 @@ class MockChannel(BaseChannel):
         stream_id=None,
         stream_end=False,
         resuming=False,
+        merge_next=False,
     ):
         return await self._send_delta_mock(
             chat_id,
@@ -57,6 +58,7 @@ class MockChannel(BaseChannel):
             stream_id=stream_id,
             stream_end=stream_end,
             resuming=resuming,
+            merge_next=merge_next,
         )
 
 
@@ -92,11 +94,17 @@ def _end(
     chat_id: str = "chat1",
     stream_id: str | None = None,
     resuming: bool = False,
+    merge_next: bool = False,
 ):
     return outbound_message_for_event(
         channel="mock",
         chat_id=chat_id,
-        event=StreamEndEvent(content=content, stream_id=stream_id, resuming=resuming),
+        event=StreamEndEvent(
+            content=content,
+            stream_id=stream_id,
+            resuming=resuming,
+            merge_next=merge_next,
+        ),
     )
 
 
@@ -137,6 +145,7 @@ class TestDeltaCoalescing:
             stream_id=None,
             stream_end=False,
             resuming=False,
+            merge_next=False,
         )
 
     @pytest.mark.asyncio
@@ -184,13 +193,19 @@ class TestDeltaCoalescing:
     @pytest.mark.asyncio
     async def test_stream_end_terminates_coalescing(self, manager, bus):
         await bus.publish_outbound(_delta("Hello"))
-        await bus.publish_outbound(_end(" world"))
+        await bus.publish_outbound(_end(
+            " world",
+            resuming=True,
+            merge_next=True,
+        ))
 
         first_msg = await bus.consume_outbound()
         merged, pending = manager._coalesce_stream_deltas(first_msg)
 
         assert merged.content == "Hello world"
         assert isinstance(merged.event, StreamEndEvent)
+        assert merged.event.resuming is True
+        assert merged.event.merge_next is True
         assert len(pending) == 0
 
     @pytest.mark.asyncio

--- a/tests/channels/test_channel_plugins.py
+++ b/tests/channels/test_channel_plugins.py
@@ -2818,7 +2818,7 @@ async def test_send_with_retry_no_retry_when_max_is_zero():
 @pytest.mark.asyncio
 async def test_send_with_retry_calls_send_delta():
     """_send_with_retry should call send_delta for stream delta events."""
-    calls: list[tuple[str, str, str | None, bool, bool]] = []
+    calls: list[tuple[str, str, str | None, bool, bool, bool]] = []
 
     class _StreamingChannel(BaseChannel):
         name = "streaming"
@@ -2842,8 +2842,9 @@ async def test_send_with_retry_calls_send_delta():
             stream_id: str | None = None,
             stream_end: bool = False,
             resuming: bool = False,
+            merge_next: bool = False,
         ) -> None:
-            calls.append((chat_id, delta, stream_id, stream_end, resuming))
+            calls.append((chat_id, delta, stream_id, stream_end, resuming, merge_next))
 
     fake_config = SimpleNamespace(
         channels=ChannelsConfig(send_max_retries=3),
@@ -2865,13 +2866,18 @@ async def test_send_with_retry_calls_send_delta():
     end = outbound_message_for_event(
         channel="streaming",
         chat_id="123",
-        event=StreamEndEvent(content="", stream_id="s1", resuming=True),
+        event=StreamEndEvent(
+            content="",
+            stream_id="s1",
+            resuming=True,
+            merge_next=True,
+        ),
     )
     await mgr._send_with_retry(mgr.channels["streaming"], end)
 
     assert calls == [
-        ("123", "test delta", "s1", False, False),
-        ("123", "", "s1", True, True),
+        ("123", "test delta", "s1", False, False, False),
+        ("123", "", "s1", True, True, True),
     ]
 
 

--- a/tests/utils/test_length_recovery_runtime.py
+++ b/tests/utils/test_length_recovery_runtime.py
@@ -1,3 +1,5 @@
+"""Tests for length-recovery prompt construction."""
+
 from nanobot.utils.runtime import build_length_recovery_message
 
 

--- a/tests/utils/test_runtime.py
+++ b/tests/utils/test_runtime.py
@@ -1,0 +1,14 @@
+from nanobot.utils.runtime import build_length_recovery_message
+
+
+def test_length_recovery_message_anchors_the_existing_tail() -> None:
+    omitted_prefix = "OMITTED_PREFIX"
+    tail = "x" * 500
+
+    message = build_length_recovery_message(omitted_prefix + tail)
+
+    assert message["role"] == "user"
+    assert omitted_prefix not in message["content"]
+    assert f"<already_delivered_tail>\n{tail}\n</already_delivered_tail>" in message["content"]
+    assert "Output only new continuation text" in message["content"]
+    assert "Break remaining work into smaller steps" not in message["content"]

--- a/tests/utils/test_runtime.py
+++ b/tests/utils/test_runtime.py
@@ -3,7 +3,7 @@ from nanobot.utils.runtime import build_length_recovery_message
 
 def test_length_recovery_message_anchors_the_existing_tail() -> None:
     omitted_prefix = "OMITTED_PREFIX"
-    tail = "x" * 500
+    tail = "x" * 64
 
     message = build_length_recovery_message(omitted_prefix + tail)
 

--- a/tests/utils/test_webui_transcript.py
+++ b/tests/utils/test_webui_transcript.py
@@ -1121,6 +1121,26 @@ def test_replay_keeps_interrupted_pre_tool_text_in_activity() -> None:
     assert msgs[2]["content"] == "Done. Open index.html to play."
 
 
+def test_replay_merges_length_recovery_segments_into_one_assistant_message() -> None:
+    msgs = replay_transcript_to_ui_messages([
+        {"event": "delta", "chat_id": "t-stream", "text": "first "},
+        {
+            "event": "stream_end",
+            "chat_id": "t-stream",
+            "text": "first ",
+            "resuming": True,
+            "merge_next": True,
+        },
+        {"event": "delta", "chat_id": "t-stream", "text": "second"},
+        {"event": "stream_end", "chat_id": "t-stream"},
+        {"event": "turn_end", "chat_id": "t-stream"},
+    ])
+
+    assert len(msgs) == 1
+    assert msgs[0]["role"] == "assistant"
+    assert msgs[0]["content"] == "first second"
+
+
 def test_replay_tool_events_dedupes_finish_after_start() -> None:
     msgs = replay_transcript_to_ui_messages([
         {

--- a/webui/src/hooks/useNanobotStream.ts
+++ b/webui/src/hooks/useNanobotStream.ts
@@ -26,7 +26,7 @@ import type {
 } from "@/lib/types";
 
 interface StreamBuffer {
-  /** ID of the assistant message currently receiving deltas (cleared on ``stream_end``). */
+  /** ID of the assistant message currently receiving deltas (cleared when its segment closes). */
   messageId: string;
 }
 
@@ -780,15 +780,20 @@ export function useNanobotStream(
           ?? findStreamingAssistantIndex(next, closedAssistantStreamIdsRef.current, turn);
         if (targetIndex !== null) {
           const target = next[targetIndex];
-          next = replaceMessageAt(next, targetIndex, {
+          const merged = {
             ...target,
             content: finalAnswerText,
             isStreaming: true,
             ...turn,
-          });
+          };
+          next = replaceMessageAt(next, targetIndex, merged);
+          if (!options?.closeAnswerSegment) {
+            closedAssistantStreamIdsRef.current.delete(merged.id);
+            activeAssistantRef.current = { id: merged.id, index: targetIndex };
+            buffer.current = { messageId: merged.id };
+          }
         } else {
           const id = crypto.randomUUID();
-          closedAssistantStreamIdsRef.current.add(id);
           next = [
             ...next,
             {
@@ -800,6 +805,12 @@ export function useNanobotStream(
               createdAt: Date.now(),
             },
           ];
+          if (options?.closeAnswerSegment) {
+            closedAssistantStreamIdsRef.current.add(id);
+          } else {
+            activeAssistantRef.current = { id, index: next.length - 1 };
+            buffer.current = { messageId: id };
+          }
         }
       }
       if (options?.closeAnswerSegment) closeActiveAssistantStream();
@@ -911,8 +922,9 @@ export function useNanobotStream(
 
       if (ev.event === "stream_end") {
         const turn = turnFieldsFromEvent(ev, "answer");
+        const mergeNext = ev.resuming === true && ev.merge_next === true;
         flushPendingStreamEvents({
-          closeAnswerSegment: true,
+          closeAnswerSegment: !mergeNext,
           ...(typeof ev.text === "string" ? { finalAnswerText: ev.text } : {}),
           turn,
         });
@@ -920,7 +932,9 @@ export function useNanobotStream(
         if (ev.resuming) {
           cancelStreamEndTimer();
           setIsStreaming(true);
-          setMessages((prev) => finalizeStreamedTurn(prev, turn));
+          if (!mergeNext) {
+            setMessages((prev) => finalizeStreamedTurn(prev, turn));
+          }
           return;
         }
         scheduleStreamEndTimer(turn);

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1118,6 +1118,8 @@ export type InboundEvent =
       text?: string;
       /** This answer segment ended, but the active agent turn will continue. */
       resuming?: boolean;
+      /** The next answer segment continues this same assistant message. */
+      merge_next?: boolean;
     } & InboundTurnMetadata)
   | ({
       event: "reasoning_delta";

--- a/webui/src/tests/useNanobotStream.test.tsx
+++ b/webui/src/tests/useNanobotStream.test.tsx
@@ -2009,6 +2009,79 @@ describe("useNanobotStream", () => {
     expect(result.current.messages.every((message) => !message.isStreaming)).toBe(true);
   });
 
+  it("keeps length-recovery segments in one assistant message", async () => {
+    const fake = fakeClient();
+    const { result } = renderHook(() => useNanobotStream("chat-length", EMPTY_MESSAGES), {
+      wrapper: wrap(fake.client),
+    });
+
+    act(() => {
+      result.current.send("give a long answer");
+    });
+    const activeTurnId = fake.client.sendMessage.mock.calls.at(-1)![3]?.turnId;
+
+    act(() => {
+      fake.emit("chat-length", {
+        event: "delta",
+        chat_id: "chat-length",
+        text: "first ",
+        turn_id: activeTurnId,
+      });
+    });
+    await flushStreamFrame();
+    const assistantId = result.current.messages[1].id;
+
+    act(() => {
+      fake.emit("chat-length", {
+        event: "stream_end",
+        chat_id: "chat-length",
+        text: "first ",
+        resuming: true,
+        merge_next: true,
+        turn_id: activeTurnId,
+      });
+    });
+
+    expect(result.current.messages).toHaveLength(2);
+    expect(result.current.messages[1]).toMatchObject({
+      id: assistantId,
+      content: "first ",
+      isStreaming: true,
+    });
+
+    act(() => {
+      fake.emit("chat-length", {
+        event: "delta",
+        chat_id: "chat-length",
+        text: "second",
+        turn_id: activeTurnId,
+      });
+    });
+    await flushStreamFrame();
+
+    expect(result.current.messages).toHaveLength(2);
+    expect(result.current.messages[1]).toMatchObject({
+      id: assistantId,
+      content: "first second",
+      isStreaming: true,
+    });
+
+    act(() => {
+      fake.emit("chat-length", {
+        event: "turn_end",
+        chat_id: "chat-length",
+        turn_id: activeTurnId,
+      });
+    });
+
+    expect(result.current.messages).toHaveLength(2);
+    expect(result.current.messages[1]).toMatchObject({
+      id: assistantId,
+      content: "first second",
+      isStreaming: false,
+    });
+  });
+
   it("keeps streaming alive across stream_end when tool activity follows", async () => {
     const fake = fakeClient();
     const onTurnEnd = vi.fn();


### PR DESCRIPTION
## Summary

- accumulate contiguous output segments recovered after `finish_reason="length"`
- preserve segment-boundary whitespace while keeping the existing recovery transcript intact
- anchor each recovery prompt with the last 64 characters already delivered, asking for continuation-only output instead of a fresh answer
- reset recovered content across tool execution and injected follow-up boundaries
- keep streaming behavior unchanged so each segment is emitted exactly once

Closes #5051

## Why the tail anchor

A recovery request is a new chat turn rather than a continuation of the provider's decoder state. Repeating the exact cutoff tail at the end of the prompt gives the model a local continuation boundary and explicitly rules out acknowledgements, restarts, headings, and repeated text.

The internal recovery prompt remains in history, preserving the exact request prefix for providers that support context caching.

## Testing

- `pytest tests/utils/test_runtime.py tests/agent/test_runner_core.py tests/agent/test_runner_hooks.py tests/agent/test_runner_injections.py -q` (65 passed)
- `ruff check nanobot/ tests/utils/test_runtime.py`
- `git diff --check`
- manual DeepSeek v4-flash checks with `max_tokens=50`: both 10- and 64-character anchors continued from `红彤彤` directly with `的灯笼`, without restarting or repeating the title
