### PR TITLE
test(agent): use python3 in ExecTool workspace scope tests

### DIFF
--- a/tests/agent/test_workspace_scope.py
+++ b/tests/agent/test_workspace_scope.py
@@ -270,7 +270,7 @@ async def test_exec_tool_uses_scope_project_as_default_cwd(tmp_path: Path) -> No
     try:
         result = await tool.execute(
             command=(
-                'python -c "from pathlib import Path; '
+                'python3 -c "from pathlib import Path; '
                 "Path('scoped-marker.txt').write_text('ok')\""
             )
         )
@@ -297,7 +297,7 @@ async def test_exec_full_scope_allows_explicit_cwd_outside_project(tmp_path: Pat
     try:
         result = await tool.execute(
             command=(
-                'python -c "from pathlib import Path; '
+                'python3 -c "from pathlib import Path; '
                 "Path('outside-marker.txt').write_text('ok')\""
             ),
             working_dir=str(outside),


### PR DESCRIPTION
Fixes #5062

## Summary

In `tests/agent/test_workspace_scope.py`, two tests hardcoded `python` as the command string executed by `ExecTool`. On systems where only `python3` is installed in `PATH` (such as Debian/Ubuntu without `python-is-python3`), these tests fail with exit code 127 (`python: command not found`).

This PR replaces `python` with `python3` in the command string.

## Testing

Ran `pytest tests/agent/test_workspace_scope.py` on a system where `python` is absent:
- Before: FAILED (`python: command not found`)
- After: 12 passed