### PR TITLE
test(agent): use python3 in ExecTool workspace scope tests

### DIFF
--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -11,6 +12,12 @@ import pytest
 from nanobot.agent.loop import AgentLoop
 from nanobot.bus.queue import MessageBus
 from nanobot.providers.base import LLMProvider
+
+
+@pytest.fixture
+def cmd_python() -> str:
+    """Return the Python command name available to ExecTool tests."""
+    return "python" if os.name == "nt" else "python3"
 
 
 def make_provider(

--- a/tests/agent/test_workspace_scope.py
+++ b/tests/agent/test_workspace_scope.py
@@ -270,7 +270,7 @@ async def test_exec_tool_uses_scope_project_as_default_cwd(tmp_path: Path) -> No
     try:
         result = await tool.execute(
             command=(
-                'python -c "from pathlib import Path; '
+                'python3 -c "from pathlib import Path; '
                 "Path('scoped-marker.txt').write_text('ok')\""
             )
         )
@@ -297,7 +297,7 @@ async def test_exec_full_scope_allows_explicit_cwd_outside_project(tmp_path: Pat
     try:
         result = await tool.execute(
             command=(
-                'python -c "from pathlib import Path; '
+                'python3 -c "from pathlib import Path; '
                 "Path('outside-marker.txt').write_text('ok')\""
             ),
             working_dir=str(outside),

--- a/tests/agent/test_workspace_scope.py
+++ b/tests/agent/test_workspace_scope.py
@@ -257,7 +257,10 @@ async def test_filesystem_write_tool_full_scope_allows_outside_project(tmp_path:
 
 
 @pytest.mark.asyncio
-async def test_exec_tool_uses_scope_project_as_default_cwd(tmp_path: Path) -> None:
+async def test_exec_tool_uses_scope_project_as_default_cwd(
+    tmp_path: Path,
+    cmd_python: str,
+) -> None:
     project = tmp_path / "project"
     project.mkdir()
     tool = ExecTool(working_dir=str(tmp_path), restrict_to_workspace=False, timeout=5)
@@ -267,7 +270,6 @@ async def test_exec_tool_uses_scope_project_as_default_cwd(tmp_path: Path) -> No
         default_restrict_to_workspace=False,
     )
     token = bind_workspace_scope(scope)
-    cmd_python = "python" if os.name == "nt" else "python3"
     try:
         result = await tool.execute(
             command=(
@@ -283,7 +285,10 @@ async def test_exec_tool_uses_scope_project_as_default_cwd(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
-async def test_exec_full_scope_allows_explicit_cwd_outside_project(tmp_path: Path) -> None:
+async def test_exec_full_scope_allows_explicit_cwd_outside_project(
+    tmp_path: Path,
+    cmd_python: str,
+) -> None:
     project = tmp_path / "project"
     outside = tmp_path / "outside"
     project.mkdir()
@@ -295,7 +300,6 @@ async def test_exec_full_scope_allows_explicit_cwd_outside_project(tmp_path: Pat
         default_restrict_to_workspace=True,
     )
     token = bind_workspace_scope(scope)
-    cmd_python = "python" if os.name == "nt" else "python3"
     try:
         result = await tool.execute(
             command=(

--- a/tests/agent/test_workspace_scope.py
+++ b/tests/agent/test_workspace_scope.py
@@ -267,10 +267,11 @@ async def test_exec_tool_uses_scope_project_as_default_cwd(tmp_path: Path) -> No
         default_restrict_to_workspace=False,
     )
     token = bind_workspace_scope(scope)
+    cmd_python = "python" if os.name == "nt" else "python3"
     try:
         result = await tool.execute(
             command=(
-                'python3 -c "from pathlib import Path; '
+                f'{cmd_python} -c "from pathlib import Path; '
                 "Path('scoped-marker.txt').write_text('ok')\""
             )
         )
@@ -294,10 +295,11 @@ async def test_exec_full_scope_allows_explicit_cwd_outside_project(tmp_path: Pat
         default_restrict_to_workspace=True,
     )
     token = bind_workspace_scope(scope)
+    cmd_python = "python" if os.name == "nt" else "python3"
     try:
         result = await tool.execute(
             command=(
-                'python3 -c "from pathlib import Path; '
+                f'{cmd_python} -c "from pathlib import Path; '
                 "Path('outside-marker.txt').write_text('ok')\""
             ),
             working_dir=str(outside),


### PR DESCRIPTION
Fixes #5062

## Summary

In `tests/agent/test_workspace_scope.py`, two tests hardcoded `python` as the command string executed by `ExecTool`. On systems where only `python3` is installed in `PATH` (such as Debian/Ubuntu without `python-is-python3`), these tests fail with exit code 127 (`python: command not found`).

This PR replaces `python` with `python3` in the command string.

## Testing

Ran `pytest tests/agent/test_workspace_scope.py` on a system where `python` is absent:
- Before: FAILED (`python: command not found`)
- After: 12 passed