### PR TITLE
fix(webui): allow media directory access when restrictToWorkspace is enabled

### DIFF
--- a/nanobot/webui/file_preview.py
+++ b/nanobot/webui/file_preview.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import unquote, urlparse
 
+from nanobot.config.paths import get_media_dir
 from nanobot.security.workspace_access import WorkspaceScope
 from nanobot.security.workspace_policy import WorkspaceBoundaryError, resolve_allowed_path
 
@@ -86,10 +87,12 @@ def _resolve_preview_path(raw_path: str | None, *, scope: WorkspaceScope) -> Pat
         raise WebUIFilePreviewError(400, "path is too long")
 
     try:
+        extra_roots = [get_media_dir()] if scope.restrict_to_workspace else None
         resolved = resolve_allowed_path(
             path,
             workspace=scope.project_path,
             allowed_root=scope.project_path if scope.restrict_to_workspace else None,
+            extra_allowed_roots=extra_roots,
             strict=True,
         )
     except FileNotFoundError as e:

--- a/tests/webui/test_file_preview.py
+++ b/tests/webui/test_file_preview.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import pytest
+
+from nanobot.security.workspace_access import default_workspace_scope
+from nanobot.webui.file_preview import WebUIFilePreviewError, file_preview_payload
+
+
+def test_restricted_preview_allows_media_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    media = tmp_path / "media"
+    media.mkdir()
+    uploaded = media / "upload.txt"
+    uploaded.write_text("uploaded", encoding="utf-8")
+    monkeypatch.setattr("nanobot.webui.file_preview.get_media_dir", lambda: media)
+
+    scope = default_workspace_scope(workspace, restrict_to_workspace=True)
+
+    payload = file_preview_payload(str(uploaded), scope=scope)
+
+    assert payload["content"] == "uploaded"
+    assert Path(payload["path"]) == uploaded.resolve()
+
+
+def test_restricted_preview_rejects_other_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    media = tmp_path / "media"
+    media.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret", encoding="utf-8")
+    monkeypatch.setattr("nanobot.webui.file_preview.get_media_dir", lambda: media)
+
+    scope = default_workspace_scope(workspace, restrict_to_workspace=True)
+
+    with pytest.raises(WebUIFilePreviewError, match="outside the current workspace") as exc_info:
+        file_preview_payload(str(outside), scope=scope)
+
+    assert exc_info.value.status == 403


### PR DESCRIPTION
## Summary

Fix a bug where the WebUI file preview fails for files in the media directory when \estrictToWorkspace\ is enabled. The \_resolve_preview_path\ function now includes \get_media_dir()\ as an extra allowed root, matching the existing behavior of the filesystem tools (\_resolve_read\).

## Problem

When files are uploaded through chat channels (Feishu, WeChat, etc.), they are stored in the \media/\ directory at the same level as the workspace. The filesystem tools (\ReadFileTool\, \GrepTool\, etc.) already include \get_media_dir()\ as an extra allowed root via \include_media_dir=True\ in \esolve_workspace_path\.

However, the WebUI file preview path (\\_resolve_preview_path\ in \webui/file_preview.py\) called \esolve_allowed_path\ directly without passing the media directory as an extra root. This caused preview failures for uploaded images and documents when \estrictToWorkspace\ was enabled.

## Fix

Added \get_media_dir()\ to \extra_allowed_roots\ in \webui/file_preview.py\ when workspace restriction is active, consistent with the existing filesystem tool behavior.

Closes #5028