### PR TITLE
fix(exec): retain stale sessions after cleanup failure

### DIFF
--- a/nanobot/agent/tools/exec_session.py
+++ b/nanobot/agent/tools/exec_session.py
@@ -370,8 +370,9 @@ class ExecSessionManager:
             if now - session.last_access > self.idle_timeout
         ]
         for session_id in stale:
-            session = self._sessions.pop(session_id)
+            session = self._sessions[session_id]
             await session.kill()
+            self._sessions.pop(session_id, None)
 
     async def _spawn(
         self,

--- a/tests/tools/test_exec_session_tools.py
+++ b/tests/tools/test_exec_session_tools.py
@@ -702,6 +702,30 @@ def test_terminate_by_owner_retains_failed_sessions():
     asyncio.run(run())
 
 
+def test_stale_cleanup_retains_session_when_kill_fails():
+    async def run() -> None:
+        manager = ExecSessionManager(idle_timeout=1)
+        session = SimpleNamespace(
+            session_id="stale-failed",
+            owner_session_key="cli:a",
+            last_access=time.monotonic() - 10,
+            kill=AsyncMock(side_effect=OSError("termination failed")),
+        )
+        manager._sessions[session.session_id] = session
+
+        with pytest.raises(OSError, match="termination failed"):
+            await manager.list(owner_session_key="cli:a")
+
+        assert manager._sessions == {session.session_id: session}
+        session.kill.assert_awaited_once()
+
+        session.kill.side_effect = None
+        assert await manager.list(owner_session_key="cli:a") == []
+        assert manager._sessions == {}
+
+    asyncio.run(run())
+
+
 def test_terminate_by_owner_skips_sessions_without_owner_key(tmp_path):
     async def run() -> None:
         manager = ExecSessionManager()


### PR DESCRIPTION
## Summary

- remove stale exec sessions only after process termination succeeds
- retain sessions after cleanup failure so a later cleanup or shutdown can retry
- cover the failure and retry lifecycle through the public session-list path

## Problem

`ExecSessionManager._cleanup_locked()` removed an idle session from the manager
before awaiting `session.kill()`. If process termination raised, the subprocess
could remain alive while its session was no longer tracked.

Later exec operations, `/stop`, and shutdown could therefore no longer retry the
failed termination.

## Fix

Keep the stale session registered until `kill()` succeeds, then remove it. This
preserves the existing fail-fast cleanup behavior while matching the
failure-retention invariant used by `close_all()` and `terminate_by_owner()`.

No public API, configuration, timeout, or cleanup ordering behavior changes.

## Validation

- `python -m pytest tests/tools/test_exec_session_tools.py tests/tools/test_exec_platform.py tests/tools/test_shell_reap.py -q` — 93 passed, 2 skipped
- old-behavior mutation: restoring pop-before-kill makes the regression test fail
- `python -m ruff check nanobot tests conftest.py`
- `git diff --check origin/main...HEAD`