### PR TITLE
fix(webui): keep composer model badge in sync

### DIFF
--- a/webui/src/components/thread/ThreadShell.tsx
+++ b/webui/src/components/thread/ThreadShell.tsx
@@ -195,7 +195,7 @@ function toModelBadgeInfo(
   const preset = modelPresetForBadge(settings, scopedPreset);
   const model = scopedPreset
     ? preset?.model || null
-    : modelName || settings?.agent.model || null;
+    : settings?.agent.model || modelName || null;
   const label = toModelBadgeLabel(model);
   const rawProvider = preset?.provider
     || (!scopedPreset ? settings?.agent.provider : null)

--- a/webui/src/tests/thread-shell.test.tsx
+++ b/webui/src/tests/thread-shell.test.tsx
@@ -369,6 +369,26 @@ describe("ThreadShell", () => {
     expect(await screen.findByTestId("composer-model-logo-openai_codex")).toBeInTheDocument();
   });
 
+  it("keeps the composer model name and provider on the same settings snapshot", async () => {
+    const client = makeClient();
+    render(
+      wrap(
+        client,
+        <ThreadShell
+          session={session("model-settings-sync")}
+          title="Model settings sync"
+          onToggleSidebar={() => {}}
+          settingsSnapshot={modelSettings("openai-codex/gpt-5.5", "openai_codex")}
+        />,
+        "ling/ling-3.0-flash",
+      ),
+    );
+
+    expect(await screen.findByTestId("composer-model-logo-openai_codex")).toBeInTheDocument();
+    expect(screen.getByText("gpt-5.5")).toBeInTheDocument();
+    expect(screen.queryByText("ling-3.0-flash")).not.toBeInTheDocument();
+  });
+
   it("resolves the composer model from the active session preset", async () => {
     const client = makeClient();
     render(


### PR DESCRIPTION
## Summary

- derive the composer model name and provider from the same active Settings snapshot
- retain the bootstrap runtime model as a fallback while Settings is unavailable
- cover the config-refresh race where an old runtime model event arrives after a new model is saved

## Why

After changing models in Settings, the config watcher can briefly broadcast the pre-refresh runtime model. The composer previously combined that stale model name with the newly loaded provider, producing mismatched badges such as an OpenAI logo beside a Ling model name.

## Verification

- `cd webui && bun run test` — 715 passed
- `cd webui && bun run lint`
- `cd webui && bun run build`
- `git diff --check`