### PR TITLE
fix(session): tolerate files removed during listing

### DIFF
--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -986,6 +986,8 @@ class SessionManager:
                                     "path": str(path),
                                 }
                             )
+            except FileNotFoundError:
+                continue
             except _SESSION_DATA_ERRORS:
                 repaired = self._repair(fallback_key, path=path)
                 if repaired is not None:

--- a/tests/agent/test_auto_compact.py
+++ b/tests/agent/test_auto_compact.py
@@ -782,6 +782,40 @@ class TestProactiveAutoCompact:
         await _drain_background_tasks(loop)
 
     @pytest.mark.asyncio
+    async def test_idle_tick_survives_session_removed_during_listing(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)
+        removed = loop.sessions.get_or_create("cli:removed")
+        removed.add_message("user", "remove me")
+        loop.sessions.save(removed)
+        healthy = loop.sessions.get_or_create("cli:healthy")
+        healthy.add_message("user", "keep me")
+        loop.sessions.save(healthy)
+
+        removed_path = loop.sessions._get_session_path(removed.key)
+        original_open = open
+
+        def remove_before_open(path, *args, **kwargs):
+            if Path(path) == removed_path:
+                removed_path.unlink()
+            return original_open(path, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", remove_before_open)
+
+        async def idle_once():
+            loop._running = False
+            raise asyncio.TimeoutError
+
+        monkeypatch.setattr(loop.bus, "consume_inbound", idle_once)
+
+        await loop.run()
+
+        assert [row["key"] for row in loop.sessions.list_sessions()] == ["cli:healthy"]
+
+    @pytest.mark.asyncio
     async def test_no_check_when_ttl_disabled(self, tmp_path):
         """check_expired should be a no-op when TTL is 0."""
         loop = _make_loop(tmp_path, session_ttl_minutes=0)


### PR DESCRIPTION
## Problem

`SessionManager.list_sessions()` enumerates session files before opening them. If another process removes a file between those operations, `FileNotFoundError` escapes from the listing.

The agent loop calls this method during its idle auto-compact check. As a result, one concurrently removed session file can terminate `AgentLoop.run()` and stop further message processing.

## Root cause

Session loading was changed to propagate runtime filesystem failures instead of treating them as corrupt data. A file disappearing after directory enumeration is different: it is a normal filesystem race and should be treated as no longer present.

## Fix

Skip only session files that disappear while they are being listed.

Other filesystem failures, including `PermissionError`, continue to propagate unchanged.

## Validation

- Added a regression test through the real `AgentLoop.run()` idle-check path
- Removes one session immediately before it is opened
- Verifies the loop survives and the remaining healthy session is still listed
- Verified the test fails when the old behavior is restored
- `5507 passed, 35 skipped`
- `ruff check .`
- `git diff --check`