### PR TITLE
fix(channels): ignore confirmations after connect cancellation

### DIFF
--- a/nanobot/channels/feishu/connect.py
+++ b/nanobot/channels/feishu/connect.py
@@ -127,9 +127,16 @@ class FeishuConnectStore:
             session.last_error = str(exc)
             return _pending_payload(session)
 
-        session.domain = str(result.get("domain") or session.domain)
         status = result.get("status")
         if status == "succeeded":
+            if self._sessions.get(session_id) is not session:
+                return {
+                    "session_id": session_id,
+                    "instance_id": session.instance_id,
+                    "status": "cancelled",
+                    "message": "Feishu connection cancelled.",
+                }
+            session.domain = str(result.get("domain") or session.domain)
             session.instance_id = feishu.save_registration_result(
                 result,
                 instance_id=session.instance_id,
@@ -145,6 +152,7 @@ class FeishuConnectStore:
                 "app_id": result.get("app_id"),
             }
 
+        session.domain = str(result.get("domain") or session.domain)
         if status == "failed":
             self._sessions.pop(session_id, None)
             return {

--- a/nanobot/channels/feishu/connect.py
+++ b/nanobot/channels/feishu/connect.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import secrets
+import threading
 import time
 from dataclasses import dataclass
 from typing import Any
@@ -41,6 +42,7 @@ class FeishuConnectStore:
 
     def __init__(self) -> None:
         self._sessions: dict[str, FeishuConnectSession] = {}
+        self._completion_lock = threading.Lock()
 
     async def handle(self, action: str, query: QueryParams) -> dict[str, Any]:
         """Handle one generic settings connection action."""
@@ -58,7 +60,7 @@ class FeishuConnectStore:
         if action == "poll":
             return await asyncio.to_thread(self.poll, session_id)
         if action == "cancel":
-            return self.cancel(session_id)
+            return await asyncio.to_thread(self.cancel, session_id)
         raise ChannelConnectError(f"unsupported Feishu connect action: {action}", status=404)
 
     def start(
@@ -129,28 +131,29 @@ class FeishuConnectStore:
 
         status = result.get("status")
         if status == "succeeded":
-            if self._sessions.get(session_id) is not session:
+            with self._completion_lock:
+                if self._sessions.get(session_id) is not session:
+                    return {
+                        "session_id": session_id,
+                        "instance_id": session.instance_id,
+                        "status": "cancelled",
+                        "message": "Feishu connection cancelled.",
+                    }
+                session.domain = str(result.get("domain") or session.domain)
+                session.instance_id = feishu.save_registration_result(
+                    result,
+                    instance_id=session.instance_id,
+                    name=session.instance_name,
+                )
+                self._sessions.pop(session_id, None)
                 return {
                     "session_id": session_id,
                     "instance_id": session.instance_id,
-                    "status": "cancelled",
-                    "message": "Feishu connection cancelled.",
+                    "status": "succeeded",
+                    "message": "Feishu is connected.",
+                    "domain": session.domain,
+                    "app_id": result.get("app_id"),
                 }
-            session.domain = str(result.get("domain") or session.domain)
-            session.instance_id = feishu.save_registration_result(
-                result,
-                instance_id=session.instance_id,
-                name=session.instance_name,
-            )
-            self._sessions.pop(session_id, None)
-            return {
-                "session_id": session_id,
-                "instance_id": session.instance_id,
-                "status": "succeeded",
-                "message": "Feishu is connected.",
-                "domain": session.domain,
-                "app_id": result.get("app_id"),
-            }
 
         session.domain = str(result.get("domain") or session.domain)
         if status == "failed":
@@ -166,7 +169,8 @@ class FeishuConnectStore:
         return _pending_payload(session)
 
     def cancel(self, session_id: str) -> dict[str, Any]:
-        session = self._sessions.pop(session_id, None)
+        with self._completion_lock:
+            session = self._sessions.pop(session_id, None)
         return {
             "session_id": session_id,
             "instance_id": session.instance_id if session else DEFAULT_INSTANCE_ID,

--- a/nanobot/channels/feishu/tests/test_connect.py
+++ b/nanobot/channels/feishu/tests/test_connect.py
@@ -63,3 +63,60 @@ async def test_feishu_cancel_wins_over_inflight_confirmation(
     assert cancelled["status"] == "cancelled"
     assert completed["status"] == "cancelled"
     assert saved_results == []
+
+
+@pytest.mark.asyncio
+async def test_feishu_cancel_does_not_interleave_with_registration_save(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    save_started = threading.Event()
+    release_save = threading.Event()
+
+    monkeypatch.setattr(feishu, "_init_registration", lambda _domain: None)
+    monkeypatch.setattr(
+        feishu,
+        "_begin_registration",
+        lambda _domain: {
+            "device_code": "device-lock",
+            "qr_url": "https://qr.example/lock",
+            "expire_in": 600,
+            "interval": 2,
+        },
+    )
+    monkeypatch.setattr(
+        feishu,
+        "poll_registration_once",
+        lambda **_kwargs: {
+            "status": "succeeded",
+            "domain": "feishu",
+            "app_id": "saved-app",
+            "app_secret": "saved-secret",
+        },
+    )
+
+    def fake_save_registration_result(
+        _result: dict[str, Any],
+        **_kwargs: Any,
+    ) -> str:
+        save_started.set()
+        assert release_save.wait(timeout=5)
+        return "default"
+
+    monkeypatch.setattr(feishu, "save_registration_result", fake_save_registration_result)
+
+    store = FeishuConnectStore()
+    started = await store.handle("start", {})
+    query = {"session_id": [started["session_id"]]}
+    poll_task = asyncio.create_task(store.handle("poll", query))
+    assert await asyncio.to_thread(save_started.wait, 5)
+
+    cancel_task = asyncio.create_task(store.handle("cancel", query))
+    await asyncio.sleep(0)
+    assert not cancel_task.done()
+
+    release_save.set()
+    completed = await poll_task
+    cancelled = await cancel_task
+
+    assert completed["status"] == "succeeded"
+    assert cancelled["status"] == "cancelled"

--- a/nanobot/channels/feishu/tests/test_connect.py
+++ b/nanobot/channels/feishu/tests/test_connect.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any
+
+import pytest
+
+from nanobot.channels.feishu import runtime as feishu
+from nanobot.channels.feishu.connect import FeishuConnectStore
+
+
+@pytest.mark.asyncio
+async def test_feishu_cancel_wins_over_inflight_confirmation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    poll_started = threading.Event()
+    release_poll = threading.Event()
+    saved_results: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(feishu, "_init_registration", lambda _domain: None)
+    monkeypatch.setattr(
+        feishu,
+        "_begin_registration",
+        lambda _domain: {
+            "device_code": "device-cancel",
+            "qr_url": "https://qr.example/cancel",
+            "expire_in": 600,
+            "interval": 2,
+        },
+    )
+
+    def fake_poll_registration_once(**_kwargs: Any) -> dict[str, str]:
+        poll_started.set()
+        assert release_poll.wait(timeout=5)
+        return {
+            "status": "succeeded",
+            "domain": "feishu",
+            "app_id": "late-app",
+            "app_secret": "late-secret",
+        }
+
+    def fake_save_registration_result(
+        result: dict[str, Any],
+        **_kwargs: Any,
+    ) -> str:
+        saved_results.append(result)
+        return "default"
+
+    monkeypatch.setattr(feishu, "poll_registration_once", fake_poll_registration_once)
+    monkeypatch.setattr(feishu, "save_registration_result", fake_save_registration_result)
+
+    store = FeishuConnectStore()
+    started = await store.handle("start", {})
+    query = {"session_id": [started["session_id"]]}
+    poll_task = asyncio.create_task(store.handle("poll", query))
+    assert await asyncio.to_thread(poll_started.wait, 5)
+
+    cancelled = await store.handle("cancel", query)
+    release_poll.set()
+    completed = await poll_task
+
+    assert cancelled["status"] == "cancelled"
+    assert completed["status"] == "cancelled"
+    assert saved_results == []

--- a/nanobot/channels/weixin/connect.py
+++ b/nanobot/channels/weixin/connect.py
@@ -130,6 +130,12 @@ class WeixinConnectStore:
 
         status = status_data.get("status", "")
         if status == "confirmed":
+            if self._sessions.get(session_id) is not session:
+                return {
+                    "session_id": session_id,
+                    "status": "cancelled",
+                    "message": "WeChat login cancelled.",
+                }
             token = str(status_data.get("bot_token", "") or "")
             if not token:
                 self._sessions.pop(session_id, None)

--- a/nanobot/channels/weixin/tests/test_connect.py
+++ b/nanobot/channels/weixin/tests/test_connect.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any
 
@@ -97,3 +98,52 @@ async def test_weixin_reconnect_keeps_existing_account_until_scan_succeeds(
     cancelled = await store.cancel(started["session_id"])
     assert cancelled["status"] == "cancelled"
     assert json.loads(state_file.read_text(encoding="utf-8")) == existing
+
+
+@pytest.mark.asyncio
+async def test_weixin_cancel_wins_over_inflight_confirmation(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state_dir = tmp_path / "weixin-state"
+    config_path = tmp_path / "config.json"
+    save_config(
+        Config.model_validate({"channels": {"weixin": {"stateDir": str(state_dir)}}}),
+        config_path,
+    )
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    poll_started = asyncio.Event()
+    release_poll = asyncio.Event()
+
+    async def fake_fetch_qr_code(self: WeixinChannel) -> tuple[str, str]:
+        return "qr-cancel", "https://qr.example/cancel"
+
+    async def fake_api_get_with_base(
+        self: WeixinChannel,
+        **_kwargs: Any,
+    ) -> dict[str, str]:
+        poll_started.set()
+        await release_poll.wait()
+        return {
+            "status": "confirmed",
+            "bot_token": "late-token",
+            "ilink_user_id": "late-user",
+        }
+
+    monkeypatch.setattr(WeixinChannel, "_fetch_qr_code", fake_fetch_qr_code)
+    monkeypatch.setattr(WeixinChannel, "_api_get_with_base", fake_api_get_with_base)
+
+    store = WeixinConnectStore()
+    started = await store.handle("start", {})
+    query = {"session_id": [started["session_id"]]}
+    poll_task = asyncio.create_task(store.handle("poll", query))
+    await asyncio.wait_for(poll_started.wait(), timeout=5)
+
+    cancelled = await store.handle("cancel", query)
+    release_poll.set()
+    completed = await poll_task
+
+    assert cancelled["status"] == "cancelled"
+    assert completed["status"] == "cancelled"
+    assert not (state_dir / "account.json").exists()


### PR DESCRIPTION
## Problem

A QR connection poll can still be in flight when the user cancels the connection. If that request later returned a successful confirmation, the WeChat or Feishu connector could save credentials from the cancelled session.

## Fix

Re-check that the same connection session is still active immediately before saving a successful confirmation. Cancelled sessions now ignore the late result instead of persisting it.

Focused regression tests cover the public `start`, `poll`, and `cancel` connector actions for both channels.

## Scope

This only changes successful confirmations received after their session has been cancelled. Normal QR connection behavior, public APIs, and configuration formats are unchanged.

## Validation

- regression tests fail against the previous behavior
- old-behavior mutation check makes both tests fail again
- WeChat and Feishu channel suites: 241 passed, 2 skipped
- full Python suite: 5519 passed, 35 skipped
- Ruff checks passed for all changed files
- `git diff --check` passed