### PR TITLE
fix(providers): preserve multimodal tool outputs

### DIFF
--- a/nanobot/providers/openai_responses/converters.py
+++ b/nanobot/providers/openai_responses/converters.py
@@ -54,8 +54,8 @@ def convert_messages(messages: list[dict[str, Any]]) -> tuple[str, list[dict[str
 
         if role == "tool":
             call_id, _ = split_tool_call_id(msg.get("tool_call_id"))
-            output_text = content if isinstance(content, str) else json.dumps(content, ensure_ascii=False)
-            input_items.append({"type": "function_call_output", "call_id": call_id, "output": output_text})
+            output = convert_tool_output(content)
+            input_items.append({"type": "function_call_output", "call_id": call_id, "output": output})
 
     return system_prompt, input_items
 
@@ -82,6 +82,49 @@ def convert_user_message(content: Any) -> dict[str, Any]:
         if converted:
             return {"role": "user", "content": converted}
     return {"role": "user", "content": [{"type": "input_text", "text": ""}]}
+
+
+def convert_tool_output(content: Any) -> str | list[dict[str, Any]]:
+    """Convert a tool result to Responses API function-call output content.
+
+    The Responses API accepts text, image, and file blocks as function tool
+    output. Nanobot's file tools use Chat Completions-style ``text`` and
+    ``image_url`` blocks for image reads; serializing those blocks as JSON
+    turns the image into inert text and can make the request unnecessarily
+    large. Preserve supported multimodal blocks and strip internal metadata.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        converted: list[dict[str, Any]] = []
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            item_type = item.get("type")
+            if item_type in {"text", "input_text"}:
+                text = item.get("text")
+                if isinstance(text, str):
+                    converted.append({"type": "input_text", "text": text})
+            elif item_type in {"image_url", "input_image"}:
+                image = item.get("image_url")
+                url = image.get("url") if isinstance(image, dict) else image
+                if isinstance(url, str) and url:
+                    converted.append({
+                        "type": "input_image",
+                        "image_url": url,
+                        "detail": item.get("detail", "auto"),
+                    })
+            elif item_type in {"file", "input_file"}:
+                block = {"type": "input_file"}
+                for key in ("file_data", "file_id", "file_url", "filename"):
+                    value = item.get(key)
+                    if isinstance(value, str) and value:
+                        block[key] = value
+                if len(block) > 1:
+                    converted.append(block)
+        if converted:
+            return converted
+    return json.dumps(content, ensure_ascii=False)
 
 
 def convert_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/nanobot/providers/openai_responses/converters.py
+++ b/nanobot/providers/openai_responses/converters.py
@@ -99,31 +99,60 @@ def convert_tool_output(content: Any) -> str | list[dict[str, Any]]:
         converted: list[dict[str, Any]] = []
         for item in content:
             if not isinstance(item, dict):
-                continue
+                break
             item_type = item.get("type")
             if item_type in {"text", "input_text"}:
+                if set(item) - {"type", "text", "_meta"}:
+                    break
                 text = item.get("text")
-                if isinstance(text, str):
-                    converted.append({"type": "input_text", "text": text})
+                if not isinstance(text, str):
+                    break
+                converted.append({"type": "input_text", "text": text})
             elif item_type in {"image_url", "input_image"}:
                 image = item.get("image_url")
+                if isinstance(image, dict) and set(image) - {"url", "detail"}:
+                    break
+                if set(item) - {"type", "image_url", "file_id", "detail", "_meta"}:
+                    break
                 url = image.get("url") if isinstance(image, dict) else image
+                file_id = item.get("file_id")
+                detail = item.get(
+                    "detail",
+                    image.get("detail", "auto") if isinstance(image, dict) else "auto",
+                )
+                if detail not in {"low", "high", "auto", "original"}:
+                    break
+                block = {"type": "input_image", "detail": detail}
                 if isinstance(url, str) and url:
-                    converted.append({
-                        "type": "input_image",
-                        "image_url": url,
-                        "detail": item.get("detail", "auto"),
-                    })
+                    block["image_url"] = url
+                elif isinstance(file_id, str) and file_id:
+                    block["file_id"] = file_id
+                else:
+                    break
+                converted.append(block)
             elif item_type in {"file", "input_file"}:
+                if set(item) - {
+                    "type",
+                    "file_data",
+                    "file_id",
+                    "file_url",
+                    "filename",
+                    "_meta",
+                }:
+                    break
                 block = {"type": "input_file"}
                 for key in ("file_data", "file_id", "file_url", "filename"):
                     value = item.get(key)
                     if isinstance(value, str) and value:
                         block[key] = value
-                if len(block) > 1:
-                    converted.append(block)
-        if converted:
-            return converted
+                if not any(key in block for key in ("file_data", "file_id", "file_url")):
+                    break
+                converted.append(block)
+            else:
+                break
+        else:
+            if converted:
+                return converted
     return json.dumps(content, ensure_ascii=False)
 
 

--- a/tests/providers/test_openai_responses.py
+++ b/tests/providers/test_openai_responses.py
@@ -240,6 +240,49 @@ class TestConvertMessages:
         }])
         assert items[0]["output"] == '{"key": "value"}'
 
+    def test_tool_message_preserves_image_content(self):
+        _, items = convert_messages([{
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,abc"},
+                    "_meta": {"path": "/private/image.png"},
+                },
+                {"type": "text", "text": "(Image file: image.png)"},
+            ],
+        }])
+
+        assert items[0]["output"] == [
+            {
+                "type": "input_image",
+                "image_url": "data:image/png;base64,abc",
+                "detail": "auto",
+            },
+            {"type": "input_text", "text": "(Image file: image.png)"},
+        ]
+        assert "_meta" not in str(items[0])
+
+    def test_tool_message_preserves_file_content(self):
+        _, items = convert_messages([{
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": [{
+                "type": "input_file",
+                "file_id": "file_123",
+                "filename": "report.pdf",
+                "_meta": {"path": "/private/report.pdf"},
+            }],
+        }])
+
+        assert items[0]["output"] == [{
+            "type": "input_file",
+            "file_id": "file_123",
+            "filename": "report.pdf",
+        }]
+        assert "_meta" not in str(items[0])
+
     def test_non_standard_keys_not_leaked(self):
         """Extra keys on messages must not appear in converted items."""
         _, items = convert_messages([{

--- a/tests/providers/test_openai_responses.py
+++ b/tests/providers/test_openai_responses.py
@@ -283,6 +283,20 @@ class TestConvertMessages:
         }]
         assert "_meta" not in str(items[0])
 
+    def test_tool_message_preserves_unknown_list_as_json(self):
+        content = [
+            {"type": "text", "text": "status", "code": 7},
+            {"kind": "record", "value": 42},
+        ]
+
+        _, items = convert_messages([{
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": content,
+        }])
+
+        assert items[0]["output"] == json.dumps(content, ensure_ascii=False)
+
     def test_non_standard_keys_not_leaked(self):
         """Extra keys on messages must not appear in converted items."""
         _, items = convert_messages([{


### PR DESCRIPTION
## Summary

- preserve text, image, and file blocks returned by tools when converting OpenAI Responses function outputs
- avoid serializing base64 image content into inert JSON text
- preserve backward compatibility by using the existing JSON fallback unless the complete list is a valid multimodal content list
- strip internal metadata without discarding ordinary structured tool data

## Problem

The Responses API accepts structured `input_text`, `input_image`, and `input_file` blocks as a function-call output. The current converter JSON-serializes every non-string tool result, so multimodal results such as an image returned by `read_file` become ordinary text and cannot be inspected by the model.

The conversion is intentionally strict: unknown items, invalid blocks, and non-content fields retain the legacy JSON representation instead of being partially converted.

## Validation

- `pytest tests/providers/test_openai_responses.py -q` — 77 passed
- `ruff check nanobot/providers/openai_responses/converters.py tests/providers/test_openai_responses.py` — passed
