### PR TITLE
feat(agent): support inline subagent consultation

### DIFF
--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -146,7 +146,7 @@ class SubagentManager:
         self.runner = AgentRunner()
         self._exec_session_manager = ExecSessionManager()
         self._llm_wall_timeout_for_session = llm_wall_timeout_for_session
-        self._running_tasks: dict[str, asyncio.Task[None]] = {}
+        self._running_tasks: dict[str, asyncio.Task[str]] = {}
         self._task_statuses: dict[str, SubagentStatus] = {}
         self._session_tasks: dict[str, set[str]] = {}  # session_key -> {task_id, ...}
 
@@ -275,6 +275,54 @@ class SubagentManager:
         logger.info("Spawned subagent [{}]: {}", task_id, display_label)
         return f"Subagent [{display_label}] started (id: {task_id}). I'll notify you when it completes."
 
+    async def run_inline(
+        self,
+        task: str,
+        label: str | None = None,
+        origin_channel: str = "cli",
+        origin_chat_id: str = "direct",
+        session_key: str | None = None,
+        origin_message_id: str | None = None,
+        temperature: float | None = None,
+        workspace_scope: WorkspaceScope | None = None,
+        *,
+        runtime: LLMRuntime | None = None,
+    ) -> str:
+        """Run a subagent synchronously and return its result to the caller."""
+        if runtime is None:
+            runtime = self._compat_spawn_runtime()
+        if temperature is not None:
+            runtime = runtime.with_generation_overrides(temperature=temperature)
+        task_id = str(uuid.uuid4())[:8]
+        display_label = label or task[:30] + ("..." if len(task) > 30 else "")
+        origin = {
+            "channel": origin_channel,
+            "chat_id": origin_chat_id,
+            "session_key": session_key,
+        }
+        status = SubagentStatus(
+            task_id=task_id,
+            label=display_label,
+            task_description=task,
+            started_at=time.monotonic(),
+        )
+        self._task_statuses[task_id] = status
+        logger.info("Running inline subagent [{}]: {}", task_id, display_label)
+        try:
+            return await self._run_subagent(
+                task_id,
+                task,
+                display_label,
+                origin,
+                status,
+                runtime,
+                origin_message_id,
+                workspace_scope,
+                announce=False,
+            )
+        finally:
+            self._task_statuses.pop(task_id, None)
+
     async def _run_subagent(
         self,
         task_id: str,
@@ -285,7 +333,9 @@ class SubagentManager:
         runtime: LLMRuntime,
         origin_message_id: str | None = None,
         workspace_scope: WorkspaceScope | None = None,
-    ) -> None:
+        *,
+        announce: bool = True,
+    ) -> str:
         """Execute the subagent task and announce the result."""
         logger.info("Subagent [{}] starting task: {}", task_id, label)
 
@@ -347,27 +397,43 @@ class SubagentManager:
 
             if result.stop_reason == "tool_error":
                 status.tool_events = list(result.tool_events)
-                await self._announce_result(
-                    task_id, label, task,
-                    self._format_partial_progress(result),
-                    origin, "error", origin_message_id,
-                )
+                final_result = self._format_partial_progress(result)
+                final_status = "error"
             elif result.stop_reason == "error":
-                await self._announce_result(
-                    task_id, label, task,
-                    result.error or "Error: subagent execution failed.",
-                    origin, "error", origin_message_id,
-                )
+                final_result = result.error or "Error: subagent execution failed."
+                final_status = "error"
             else:
                 final_result = result.final_content or "Task completed but no final response was generated."
+                final_status = "ok"
                 logger.info("Subagent [{}] completed successfully", task_id)
-                await self._announce_result(task_id, label, task, final_result, origin, "ok", origin_message_id)
+            if announce:
+                await self._announce_result(
+                    task_id,
+                    label,
+                    task,
+                    final_result,
+                    origin,
+                    final_status,
+                    origin_message_id,
+                )
+            return final_result
 
         except Exception as e:
             status.phase = "error"
             status.error = str(e)
             logger.exception("Subagent [{}] failed", task_id)
-            await self._announce_result(task_id, label, task, f"Error: {e}", origin, "error", origin_message_id)
+            final_result = f"Error: {e}"
+            if announce:
+                await self._announce_result(
+                    task_id,
+                    label,
+                    task,
+                    final_result,
+                    origin,
+                    "error",
+                    origin_message_id,
+                )
+            return final_result
 
     async def _announce_result(
         self,

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -13,6 +13,7 @@ from loguru import logger
 
 from nanobot.agent.hook import AgentHook, AgentHookContext
 from nanobot.agent.runner import AgentRunner, AgentRunSpec
+from nanobot.agent.tools.base import ToolResult
 from nanobot.agent.tools.context import (
     RequestContext,
     ToolContext,
@@ -308,8 +309,8 @@ class SubagentManager:
         )
         self._task_statuses[task_id] = status
         logger.info("Running inline subagent [{}]: {}", task_id, display_label)
-        try:
-            return await self._run_subagent(
+        inline_task = asyncio.create_task(
+            self._run_subagent(
                 task_id,
                 task,
                 display_label,
@@ -320,8 +321,22 @@ class SubagentManager:
                 workspace_scope,
                 announce=False,
             )
+        )
+        self._running_tasks[task_id] = inline_task
+        if session_key:
+            self._session_tasks.setdefault(session_key, set()).add(task_id)
+        try:
+            result = await inline_task
+            if status.phase == "error" or status.stop_reason in {"error", "tool_error"}:
+                return ToolResult.error(result)
+            return result
         finally:
+            self._running_tasks.pop(task_id, None)
             self._task_statuses.pop(task_id, None)
+            if session_key and (ids := self._session_tasks.get(session_key)):
+                ids.discard(task_id)
+                if not ids:
+                    del self._session_tasks[session_key]
 
     async def _run_subagent(
         self,

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -6,7 +6,12 @@ from typing import TYPE_CHECKING, Any
 
 from nanobot.agent.tools.base import Tool, ToolResult, tool_parameters
 from nanobot.agent.tools.context import current_request_context
-from nanobot.agent.tools.schema import NumberSchema, StringSchema, tool_parameters_schema
+from nanobot.agent.tools.schema import (
+    BooleanSchema,
+    NumberSchema,
+    StringSchema,
+    tool_parameters_schema,
+)
 from nanobot.security.workspace_access import current_workspace_scope
 
 if TYPE_CHECKING:
@@ -25,6 +30,14 @@ if TYPE_CHECKING:
             ),
             minimum=0.0,
             maximum=2.0,
+        ),
+        wait=BooleanSchema(
+            description=(
+                "Wait for the subagent and return its result directly. Use this for a "
+                "blocking consultation that must inform the current turn. Defaults to "
+                "false for background execution."
+            ),
+            default=False,
         ),
         required=["task"],
     )
@@ -48,6 +61,7 @@ class SpawnTool(Tool):
         return (
             "Spawn a subagent to handle a task in the background. "
             "Use this for complex or time-consuming tasks that can run independently. "
+            "Set wait=true for a consultation whose result must inform the current turn. "
             "The subagent will complete the task and report back when done. "
             "For deliverables or existing projects, inspect the workspace first "
             "and use a dedicated subdirectory when helpful."
@@ -58,6 +72,7 @@ class SpawnTool(Tool):
         task: str,
         label: str | None = None,
         temperature: float | None = None,
+        wait: bool = False,
         **kwargs: Any,
     ) -> str:
         """Spawn a subagent to execute the given task."""
@@ -75,7 +90,8 @@ class SpawnTool(Tool):
         origin_channel = request_ctx.channel
         origin_chat_id = request_ctx.chat_id
         session_key = request_ctx.session_key or f"{origin_channel}:{origin_chat_id}"
-        return await self._manager.spawn(
+        method = self._manager.run_inline if wait else self._manager.spawn
+        return await method(
             task=task,
             runtime=request_ctx.runtime,
             label=label,

--- a/tests/agent/tools/test_subagent_tools.py
+++ b/tests/agent/tools/test_subagent_tools.py
@@ -20,6 +20,37 @@ def _runtime(provider: MagicMock, model: str = "test-model") -> LLMRuntime:
 
 
 @pytest.mark.asyncio
+async def test_run_inline_returns_result_without_announcement(tmp_path):
+    """Inline subagents return directly instead of injecting a follow-up."""
+    from nanobot.agent.subagent import SubagentManager
+    from nanobot.bus.queue import MessageBus
+
+    provider = MagicMock()
+    manager = SubagentManager(
+        workspace=tmp_path,
+        bus=MessageBus(),
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    )
+    manager.runner.run = AsyncMock(return_value=SimpleNamespace(
+        stop_reason="done",
+        final_content="review result",
+        error=None,
+        tool_events=[],
+    ))
+    manager._announce_result = AsyncMock()
+
+    result = await manager.run_inline(
+        task="review this",
+        session_key="test:c1",
+        runtime=_runtime(provider),
+    )
+
+    assert result == "review result"
+    manager._announce_result.assert_not_awaited()
+    assert manager._task_statuses == {}
+
+
+@pytest.mark.asyncio
 async def test_subagent_exec_tool_receives_allowed_env_keys(tmp_path):
     """allowed_env_keys from ExecToolConfig must be forwarded to the subagent's ExecTool."""
     from nanobot.agent.subagent import SubagentManager, SubagentStatus
@@ -198,6 +229,40 @@ async def test_spawn_tool_rejects_when_at_concurrency_limit(tmp_path):
     release.set()
     # Allow cleanup
     await asyncio.gather(*mgr._running_tasks.values(), return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_spawn_tool_waits_for_inline_result():
+    from nanobot.agent.tools.context import RequestContext, request_context
+    from nanobot.agent.tools.spawn import SpawnTool
+
+    class Manager:
+        max_concurrent_subagents = 1
+
+        def __init__(self):
+            self.inline = AsyncMock(return_value="review result")
+            self.spawn = AsyncMock(return_value="started")
+
+        def get_running_count(self):
+            return 0
+
+        async def run_inline(self, **kwargs):
+            return await self.inline(**kwargs)
+
+    manager = Manager()
+    tool = SpawnTool(manager)
+    runtime = _runtime(MagicMock())
+    with request_context(RequestContext(
+        channel="test",
+        chat_id="c1",
+        session_key="test:c1",
+        runtime=runtime,
+    )):
+        result = await tool.execute(task="review this", wait=True)
+
+    assert result == "review result"
+    manager.inline.assert_awaited_once()
+    manager.spawn.assert_not_awaited()
 
 
 def test_subagent_default_max_concurrent_matches_agent_defaults(tmp_path):

--- a/tests/agent/tools/test_subagent_tools.py
+++ b/tests/agent/tools/test_subagent_tools.py
@@ -47,7 +47,40 @@ async def test_run_inline_returns_result_without_announcement(tmp_path):
 
     assert result == "review result"
     manager._announce_result.assert_not_awaited()
+    assert manager._running_tasks == {}
     assert manager._task_statuses == {}
+    assert manager._session_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_run_inline_returns_structured_error(tmp_path):
+    """Inline subagent failures remain tool errors for the parent runner."""
+    from nanobot.agent.subagent import SubagentManager
+    from nanobot.agent.tools.registry import is_tool_error_result
+    from nanobot.bus.queue import MessageBus
+
+    manager = SubagentManager(
+        workspace=tmp_path,
+        bus=MessageBus(),
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    )
+    manager.runner.run = AsyncMock(return_value=SimpleNamespace(
+        stop_reason="error",
+        final_content=None,
+        error="subagent failed",
+        tool_events=[],
+    ))
+
+    result = await manager.run_inline(
+        task="review this",
+        session_key="test:c1",
+        runtime=_runtime(MagicMock()),
+    )
+
+    assert result == "subagent failed"
+    assert is_tool_error_result("spawn", result)
+    assert manager._running_tasks == {}
+    assert manager._session_tasks == {}
 
 
 @pytest.mark.asyncio
@@ -263,6 +296,86 @@ async def test_spawn_tool_waits_for_inline_result():
     assert result == "review result"
     manager.inline.assert_awaited_once()
     manager.spawn.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_inline_spawn_counts_toward_concurrency_limit(tmp_path):
+    from nanobot.agent.subagent import SubagentManager
+    from nanobot.agent.tools.context import RequestContext, request_context
+    from nanobot.agent.tools.spawn import SpawnTool
+    from nanobot.bus.queue import MessageBus
+
+    manager = SubagentManager(
+        workspace=tmp_path,
+        bus=MessageBus(),
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        max_concurrent_subagents=1,
+    )
+    release = asyncio.Event()
+    entered = asyncio.Event()
+
+    async def fake_run(spec):
+        entered.set()
+        await release.wait()
+        return SimpleNamespace(
+            stop_reason="done",
+            final_content="done",
+            error=None,
+            tool_events=[],
+        )
+
+    manager.runner.run = AsyncMock(side_effect=fake_run)
+    tool = SpawnTool(manager)
+    with request_context(RequestContext(
+        channel="test",
+        chat_id="c1",
+        session_key="test:c1",
+        runtime=_runtime(MagicMock()),
+    )):
+        first = asyncio.create_task(tool.execute(task="first", wait=True))
+        await asyncio.wait_for(entered.wait(), timeout=1.0)
+
+        second = await tool.execute(task="second", wait=True)
+
+        assert "concurrency limit reached" in second
+        assert manager.get_running_count() == 1
+        release.set()
+        assert await first == "done"
+
+    assert manager.get_running_count() == 0
+    assert manager._session_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_cancel_by_session_cancels_inline_subagent(tmp_path):
+    from nanobot.agent.subagent import SubagentManager
+    from nanobot.bus.queue import MessageBus
+
+    manager = SubagentManager(
+        workspace=tmp_path,
+        bus=MessageBus(),
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    )
+    entered = asyncio.Event()
+
+    async def fake_run(spec):
+        entered.set()
+        await asyncio.Event().wait()
+
+    manager.runner.run = AsyncMock(side_effect=fake_run)
+    inline = asyncio.create_task(manager.run_inline(
+        task="wait",
+        session_key="test:c1",
+        runtime=_runtime(MagicMock()),
+    ))
+    await asyncio.wait_for(entered.wait(), timeout=1.0)
+
+    assert await manager.cancel_by_session("test:c1") == 1
+    with pytest.raises(asyncio.CancelledError):
+        await inline
+    assert manager._running_tasks == {}
+    assert manager._task_statuses == {}
+    assert manager._session_tasks == {}
 
 
 def test_subagent_default_max_concurrent_matches_agent_defaults(tmp_path):


### PR DESCRIPTION
## Summary

- add an optional `wait` argument to the spawn tool for inline subagent consultation
- return the subagent result directly when `wait=true`
- count inline work against the existing concurrency limit and session lifecycle
- preserve structured tool-error status and cancellation behavior
- keep existing background execution and bus announcement behavior as the default

## Behavior

`wait=false` remains backward compatible: the task starts in the background and its result is announced through the message bus. With `wait=true`, the same subagent runtime executes inline, returns its result to the caller, skips the duplicate announcement, and participates in normal status, cancellation, and concurrency management.

## Validation

- `pytest tests/agent/tools/test_subagent_tools.py tests/agent/test_subagent.py tests/agent/test_subagent_lifecycle.py tests/agent/test_task_cancel.py -q` — 84 passed
- `ruff check nanobot/agent/subagent.py nanobot/agent/tools/spawn.py tests/agent/tools/test_subagent_tools.py` — passed
