### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,14 @@
 
 ## Deploy to Render
 
-Deploy nanobot's gateway and bundled WebUI as a single web service with persistent memory. Render reads [`render.yaml`](./render.yaml) and prompts for two secrets on deploy: `ANTHROPIC_API_KEY` and `NANOBOT_WEB_TOKEN` (the password that gates the public WebUI — generate a strong random value, e.g. `openssl rand -hex 32`).
+Run nanobot online without managing a server. The blueprint deploys the gateway and bundled WebUI together, with a persistent disk so sessions, memory, and chat history survive restarts.
 
-> **Note:** The blueprint attaches a persistent disk so sessions, memory, and WebUI history survive restarts. Persistent disks require a paid service (they are not available on Render's free tier).
+> [!IMPORTANT]
+> This setup requires a paid Render service because persistent disks are not available on the free tier. During setup, provide `ANTHROPIC_API_KEY` and set `NANOBOT_WEB_TOKEN` to a strong private password (for example, generate one with `openssl rand -hex 32`).
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/HKUDS/nanobot)
+
+[Review the deployment blueprint](./render.yaml)
 
 ## What can nanobot do?
 
@@ -68,19 +71,20 @@ nanobot is a self-hosted personal AI agent runtime. It can:
 - expose a Python SDK and OpenAI-compatible API for integrations
 - deploy as a long-running local or server-side agent gateway
 
-## Latest Release
+## Releases
 
-**v0.2.2 - Durability Release**
+**Coming next: v0.3.0 - The Agency Release**
 
-Highlights:
+The Agency Release turns nanobot from a durable workbench into an agent runtime that can coordinate helpers, switch models per session, and carry authorized work through to completion.
 
-- Segmented WebUI transcripts
-- Python SDK runtime controls
-- Automation management
-- Search/STT provider improvements
-- Gateway/session/provider reliability
+- Consult inline subagents without leaving the current task
+- Switch model presets per session directly from the composer
+- Start from a guided WebUI setup with clearer execution controls
+- Apply configuration changes live across a more reliable provider, channel, and tool runtime
 
-[See full changelog](https://github.com/HKUDS/nanobot/releases/tag/v0.2.2)
+[Follow the v0.3.0 release candidate](https://github.com/HKUDS/nanobot/pull/5081)
+
+**Current stable:** [v0.2.2 - The Durability Release](https://github.com/HKUDS/nanobot/releases/tag/v0.2.2)
 
 ## Open Source Partners
 
@@ -91,11 +95,11 @@ Highlights:
 
 ## Recent Updates
 
-- **2026-07-12** Explicit `/goal` activation, safer runtime and workspace access.
-- **2026-07-11** Syntax-highlighted previews and diffs, queued prompts, safer edits.
-- **2026-07-10** Stable model routing, multiline CLI input, new automation guide.
-- **2026-07-09** Live file-edit diffs, safer localhost setup, Matrix image fixes.
-- **2026-07-08** Safer WebUI/API setup, onboard refresh, responsive prompt rail.
+- **2026-07-24** Guided first-run setup, inline subagents, and model switching from the composer.
+- **2026-07-23** Grok OAuth with hosted X Search, live image settings, and clearer fallback models.
+- **2026-07-22** Parallel Search, live configuration reloads, richer app discovery, and a smoother mobile WebUI.
+- **2026-07-21** Codex fast mode, visible skill references, safer configuration saves, and sturdier task cleanup.
+- **2026-07-20** Cleaner code blocks and copy actions, self-contained channels, and steadier QQ reconnects.
 
 For older updates, see the [release archive](./docs/release-archive.md) or [GitHub releases](https://github.com/HKUDS/nanobot/releases).
 

--- a/README.md
+++ b/README.md
@@ -46,18 +46,7 @@
 | Connect Telegram, Discord, WeChat, Slack, Email, Mattermost, or another chat app | [Chat Apps](./docs/chat-apps.md) |
 | Configure providers, fallback models, Langfuse, MCP, web tools, or security | [Docs](./docs/README.md) and [Configuration](./docs/configuration.md) |
 | Understand or extend the internals | [Architecture](./docs/architecture.md) and [Development](./docs/development.md) |
-| Deploy to the cloud in one click | [Deploy to Render](#deploy-to-render) |
-
-## Deploy to Render
-
-Run nanobot online without managing a server. The blueprint deploys the gateway and bundled WebUI together, with a persistent disk so sessions, memory, and chat history survive restarts.
-
-> [!IMPORTANT]
-> This setup requires a paid Render service because persistent disks are not available on the free tier. During setup, provide `ANTHROPIC_API_KEY` and set `NANOBOT_WEB_TOKEN` to a strong private password (for example, generate one with `openssl rand -hex 32`).
-
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/HKUDS/nanobot)
-
-[Review the deployment blueprint](./render.yaml)
+| Deploy to the cloud or keep nanobot running as a service | [Deployment](./docs/deployment.md), including [one-click Render setup](./docs/deployment.md#render) |
 
 ## What can nanobot do?
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,7 +4,7 @@ Use this page after `nanobot agent -m "Hello!"` works locally. Deployment keeps 
 
 ## Before You Deploy
 
-Check these once before Docker, systemd, or LaunchAgent:
+Check these once before Render, Docker, systemd, or LaunchAgent:
 
 | Check | Why it matters |
 |---|---|
@@ -22,10 +22,22 @@ Restart the deployed process after editing `config.json`. Long-running processes
 
 | Runtime | Use it for | State location | Useful first command |
 |---|---|---|---|
+| Render | One-click hosted gateway and WebUI | Persistent disk at `/home/nanobot/.nanobot` | [Deploy to Render](#render) |
 | Docker Compose | Repeatable container runs on Linux servers or workstations | Bind-mount `~/.nanobot` to `/home/nanobot/.nanobot` | `docker compose run --rm nanobot-cli agent -m "Hello!"` |
 | Docker CLI | Manual container testing or small one-off hosts | Bind-mount `~/.nanobot` to `/home/nanobot/.nanobot` | `docker run -v ~/.nanobot:/home/nanobot/.nanobot --rm nanobot status` |
 | systemd user service | Linux user-level gateway that restarts automatically | Host user's `~/.nanobot` unless you pass explicit paths | `systemctl --user status nanobot-gateway` |
 | macOS LaunchAgent | macOS gateway that starts after login | Host user's `~/.nanobot` unless the plist passes explicit paths | `launchctl list | grep ai.nanobot.gateway` |
+
+## Render
+
+Run nanobot online without managing a server. The blueprint deploys the gateway and bundled WebUI together, with a persistent disk so sessions, memory, and chat history survive restarts.
+
+> [!IMPORTANT]
+> This setup requires a paid Render service because persistent disks are not available on the free tier. During setup, provide `ANTHROPIC_API_KEY` and set `NANOBOT_WEB_TOKEN` to a strong private password (for example, generate one with `openssl rand -hex 32`).
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/HKUDS/nanobot)
+
+[Review the deployment blueprint](../render.yaml)
 
 ## Docker
 

--- a/docs/release-archive.md
+++ b/docs/release-archive.md
@@ -6,6 +6,18 @@ For tagged releases, see [GitHub Releases](https://github.com/HKUDS/nanobot/rele
 
 ## Highlights
 
+- **2026-07-24** 🧭 Guided first-run setup, inline subagents, and model switching from the composer.
+- **2026-07-23** 🔎 Grok OAuth with hosted X Search, live image settings, and clearer fallback models.
+- **2026-07-22** 🔌 Parallel Search, live configuration reloads, richer app discovery, and a smoother mobile WebUI.
+- **2026-07-21** ⚡ Codex fast mode, visible skill references, safer configuration saves, and sturdier task cleanup.
+- **2026-07-20** 💬 Cleaner code blocks and copy actions, self-contained channels, and steadier QQ reconnects.
+- **2026-07-19** 🔀 Cross-provider failover, safer local triggers, WhatsApp group allowlists, and sturdier workspace staging.
+- **2026-07-18** 🧰 More resilient automation recovery and UTF-8 CLI App installs.
+- **2026-07-17** 🌙 Kimi K3 support, more reliable scheduled jobs, and cleaner provider behavior.
+- **2026-07-16** 📁 Native folder picker bridges, tighter Docker defaults, and bounded session caching.
+- **2026-07-15** 🔐 Short-lived Render access, safer gateway shutdown, validated file previews, and highlighted app mentions.
+- **2026-07-14** 📎 Document attachments, one-click Render deployment, clearer workflow docs, and stronger Windows support.
+- **2026-07-13** 🌍 Guided WebUI setup, Brazilian Portuguese, and steadier Dream, gateway, and Discord behavior.
 - **2026-07-12** 🎯 Explicit `/goal` activation, safer runtime and workspace access.
 - **2026-07-11** 🛠️ Syntax-highlighted previews and diffs, queued prompts, safer edits.
 - **2026-07-10** 🧠 Stable model routing, multiline CLI input, new automation guide.

--- a/nanobot/__init__.py
+++ b/nanobot/__init__.py
@@ -22,7 +22,7 @@ def _resolve_version() -> str:
         return _pkg_version("nanobot-ai")
     except PackageNotFoundError:
         # Source checkouts often import nanobot without installed dist-info.
-        return _read_pyproject_version() or "0.2.2"
+        return _read_pyproject_version() or "0.3.0"
 
 
 __version__ = _resolve_version()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nanobot-ai"
-version = "0.2.2"
+version = "0.3.0"
 description = "A lightweight personal AI assistant framework"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/webui/src/components/thread/ModelPresetBadge.tsx
+++ b/webui/src/components/thread/ModelPresetBadge.tsx
@@ -266,7 +266,7 @@ export function ModelPresetBadge({
         <span
           data-testid="composer-model-pill-viewport"
           className={cn(
-            "composer-model-pill-viewport pointer-events-none absolute -left-2 right-0 overflow-hidden bg-transparent",
+            "composer-model-pill-viewport pointer-events-none absolute right-0 w-max max-w-[calc(44vw+0.5rem)] overflow-hidden bg-transparent pl-2 sm:max-w-[18.5rem]",
             isHero ? "-bottom-2.5 -top-2.5" : "-bottom-3 -top-3",
           )}
           aria-hidden
@@ -274,7 +274,7 @@ export function ModelPresetBadge({
           <span
             data-testid="composer-model-pill-track"
             data-settling={motion.settling ? "true" : undefined}
-            className="composer-model-pill-track ml-auto flex w-[calc(100%-0.5rem)] flex-col items-end gap-1 will-change-transform"
+            className="composer-model-pill-track ml-auto flex w-max max-w-full flex-col items-end gap-1 will-change-transform"
             onTransitionEnd={(event) => {
               if (motion.settling && event.currentTarget === event.target) setMotion(null);
             }}

--- a/webui/src/components/thread/ModelPresetBadge.tsx
+++ b/webui/src/components/thread/ModelPresetBadge.tsx
@@ -245,13 +245,23 @@ export function ModelPresetBadge({
       onDragStart={(event) => event.preventDefault()}
       style={{ touchAction: canSwitch ? "manipulation" : undefined }}
       className={cn(
-        "thread-composer-model-badge group/model-badge relative inline-flex w-[5.75rem] min-w-0 justify-end appearance-none border-0 bg-transparent p-0 shadow-none",
+        "thread-composer-model-badge group/model-badge relative inline-flex w-fit min-w-0 max-w-[min(18rem,44vw)] justify-end appearance-none border-0 bg-transparent p-0 shadow-none",
         interactive && "cursor-pointer",
         canSwitch && "cursor-grab select-none focus-visible:outline-none",
         motion && "z-10 cursor-grabbing",
-        isHero ? "h-8 max-w-[44vw]" : "h-9 max-w-[44vw]",
+        isHero ? "h-8" : "h-9",
       )}
     >
+      <PresetPill
+        className={motion && "invisible"}
+        label={label}
+        modelDetail={modelDetail}
+        provider={provider}
+        providerLabel={providerLabel}
+        needsSetup={needsSetup}
+        fallbackModelName={fallbackModelName}
+        isHero={isHero}
+      />
       {motion ? (
         <span
           data-testid="composer-model-pill-viewport"
@@ -291,22 +301,13 @@ export function ModelPresetBadge({
             })}
           </span>
         </span>
-      ) : (
-        <PresetPill
-          label={label}
-          modelDetail={modelDetail}
-          provider={provider}
-          providerLabel={providerLabel}
-          needsSetup={needsSetup}
-          fallbackModelName={fallbackModelName}
-          isHero={isHero}
-        />
-      )}
+      ) : null}
     </Container>
   );
 }
 
 function PresetPill({
+  className,
   label,
   modelDetail,
   provider,
@@ -317,6 +318,7 @@ function PresetPill({
   offset,
   scale,
 }: {
+  className?: string | false | null;
   label: string;
   modelDetail?: string | null;
   provider?: string | null;
@@ -363,6 +365,7 @@ function PresetPill({
         needsSetup && "border-amber-500/35 bg-amber-50/70 text-amber-900 dark:bg-amber-500/10 dark:text-amber-200",
         isHero ? "gap-1.5 px-2.5 text-[12px]" : "gap-2 px-3 text-[12.5px]",
         offset !== undefined && "composer-model-pill-dock",
+        className,
       )}
       style={scale === undefined ? undefined : {
         height: `${isHero ? 32 : 36}px`,

--- a/webui/src/tests/thread-composer.test.tsx
+++ b/webui/src/tests/thread-composer.test.tsx
@@ -479,9 +479,16 @@ describe("ThreadComposer", () => {
     longPress(badge);
     expect(badge).toHaveAttribute("data-switching", "true");
     const viewport = screen.getByTestId("composer-model-pill-viewport");
-    expect(viewport).toHaveClass("overflow-hidden", "-left-2", "-top-3", "-bottom-3");
+    expect(viewport).toHaveClass(
+      "right-0",
+      "w-max",
+      "max-w-[calc(44vw+0.5rem)]",
+      "overflow-hidden",
+      "-top-3",
+      "-bottom-3",
+    );
     const track = screen.getByTestId("composer-model-pill-track");
-    expect(track).toHaveClass("items-end", "gap-1");
+    expect(track).toHaveClass("w-max", "max-w-full", "items-end", "gap-1");
     const activeTouchMove = new Event("touchmove", {
       bubbles: true,
       cancelable: true,

--- a/webui/src/tests/thread-composer.test.tsx
+++ b/webui/src/tests/thread-composer.test.tsx
@@ -406,6 +406,34 @@ describe("ThreadComposer", () => {
     expect(input.parentElement?.parentElement?.className).toContain("max-w-[58rem]");
   });
 
+  it("lets long model preset labels use their intrinsic width", () => {
+    render(
+      <ThreadComposer
+        onSend={vi.fn()}
+        modelLabel="gpt-5.6-sol"
+        modelPreset="gpt-5-6-sol"
+        modelProvider="openai_codex"
+        modelPresets={[
+          {
+            name: "gpt-5-6-sol",
+            label: "gpt-5.6-sol",
+            model: "openai-codex/gpt-5.6-sol",
+            provider: "openai_codex",
+          },
+          ...MODEL_PRESETS,
+        ]}
+        onModelPresetChange={vi.fn()}
+        placeholder="Ask anything..."
+        variant="hero"
+      />,
+    );
+
+    const badge = screen.getByRole("spinbutton", { name: "gpt-5.6-sol" });
+    expect(badge).toHaveClass("w-fit", "max-w-[min(18rem,44vw)]");
+    expect(badge).not.toHaveClass("w-[5.75rem]");
+    expect(screen.getByText("gpt-5.6-sol")).toBeInTheDocument();
+  });
+
   it("keeps the thread composer compact while matching the hero style", () => {
     render(
       <ThreadComposer


### PR DESCRIPTION
## Summary

- bump package and source-tree fallback versions from `0.2.2` to `0.3.0`
- fix the composer model badge so names use their intrinsic width when space is available instead of being forced into a fixed 92 px slot
- preserve the existing long-press preset switcher with an invisible sizing anchor, so its dock animation does not collapse or shift
- stage **v0.3.0 - The Agency Release** in the README as an upcoming release without claiming it is already public
- keep the README product-focused by moving detailed Render setup into the unified deployment guide, where cost, persistence, and credential requirements sit beside the other runtimes
- refresh the five latest user-facing updates and complete the matching release archive through July 24

The UI fix came directly from release-candidate testing: `gpt-5.6-sol` was rendered as `gpt-5.6-…` even in a wide composer.

## Verification

Full release-candidate baseline:

- `python -m ruff check nanobot tests`
- `python -m pytest -q` — 5,451 passed, 16 skipped
- `cd webui && bun install --frozen-lockfile`
- `cd webui && bun run test` — 49 files, 737 tests passed

After the model badge follow-up:

- `cd webui && bun run test -- src/tests/thread-composer.test.tsx` — 66 passed
- `cd webui && bun run build`
- verified the short-preset long-press menu at runtime: all options retain their natural widths with no truncation

Release artifacts:

- `python -m build`
- `python -m twine check dist/*`
- wheel and sdist contain version `0.3.0` and the rebuilt WebUI
- archive security audit found no release-machine paths, private keys, API tokens, Git credentials, `.env`, `.git`, `node_modules`, or user config
- clean virtualenv install reports `0.3.0`, includes the WebUI, passes `pip check` and `nanobot --help`, and creates no user-home files

Documentation follow-up:

- `git diff --check`
- verified `render.yaml` matches the documented paid persistent-disk and secret requirements
- verified the release candidate and current stable release links return successfully
- README audit completed; its only findings are four pre-existing GIFs without useful alt text

## Release gate

The final wheel and sdist must be rebuilt from the exact merged `main` commit before tagging or uploading.

1. merge this PR after the refreshed CI matrix is green
2. rebuild and smoke-test artifacts from merged `main`
3. tag that exact commit as `v0.3.0`
4. publish the GitHub Release and PyPI package
5. replace the upcoming-release link with the public release notes and promote the prepared stable website docs
