### PR TITLE
chore: defer compatibility cleanup to v0.3.1

### DIFF
--- a/nanobot/channels/registry.py
+++ b/nanobot/channels/registry.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 @cache
 def _warn_legacy_channel_entry_points() -> None:
-    # TODO(v0.2.4): Remove this detection and warning. v0.2.3 is the final
+    # TODO(v0.3.1): Remove this detection and warning. v0.3.0 is the final
     # migration window for installed legacy channel entry points.
     names = sorted({entry_point.name for entry_point in entry_points(group="nanobot.channels")})
     if not names:

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -209,7 +209,7 @@ def _migrate_config(data: dict) -> dict:
         defaults.pop("maxMessages", None)
         defaults.pop("max_messages", None)
         if had_legacy_max_messages:
-            # TODO(v0.2.4): Remove this legacy cleanup branch. v0.2.3 is the
+            # TODO(v0.3.1): Remove this legacy cleanup branch. v0.3.0 is the
             # final release that warns before the schema silently ignores the field.
             logger.warning(
                 "agents.defaults.maxMessages/max_messages is legacy and ignored; "

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -513,7 +513,7 @@ class SessionManager:
         if path.exists():
             return path
 
-        # TODO(v0.2.4): Remove both legacy fallbacks. v0.2.3 is the final
+        # TODO(v0.3.1): Remove both legacy fallbacks. v0.3.0 is the final
         # compatibility window for reading and lazily migrating legacy session files.
         fallback_paths = [
             (self._get_legacy_lossy_path(key), "legacy lossy path"),


### PR DESCRIPTION
## Summary

- move the three compatibility cleanup TODOs from v0.2.4 to v0.3.1
- mark v0.3.0 as the final compatibility window
- keep all runtime behavior unchanged

## Compatibility windows

- legacy session path fallback and lazy migration
- ignored `agents.defaults.maxMessages` warning
- legacy `nanobot.channels` entry-point warning

## Validation

- `git diff --check`
- verified no remaining v0.2.4 cleanup markers

Tests were not run because this change only updates comments.