### PR TITLE
fix(agent): preserve pending message runtime context

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -745,14 +745,23 @@ class AgentLoop:
         self,
         ctx: TurnContext,
     ) -> list[RuntimeContextBlock]:
-        tools = ctx.tools or self.tools
+        assert ctx.request_context is not None
+        return await self._resolve_runtime_context_for_request(
+            ctx.request_context,
+            ctx.tools or self.tools,
+        )
+
+    async def _resolve_runtime_context_for_request(
+        self,
+        request: RequestContext,
+        tools: ToolRegistry,
+    ) -> list[RuntimeContextBlock]:
         providers = [
             *tools.get_runtime_context_providers(),
             *self._runtime_context_providers,
         ]
-        assert ctx.request_context is not None
-        blocks = runtime_context_blocks_from_metadata(ctx.request_context.metadata)
-        blocks.extend(await resolve_runtime_context(providers, ctx.request_context))
+        blocks = runtime_context_blocks_from_metadata(request.metadata)
+        blocks.extend(await resolve_runtime_context(providers, request))
         return blocks
 
     async def _dispatch_command_inline(
@@ -855,7 +864,7 @@ class AgentLoop:
             if pending_queue is None:
                 return []
 
-            def _to_user_message(pending_msg: InboundMessage) -> dict[str, Any]:
+            async def _to_user_message(pending_msg: InboundMessage) -> dict[str, Any]:
                 content = pending_msg.content
                 media = pending_msg.media if pending_msg.media else None
                 if media:
@@ -864,6 +873,31 @@ class AgentLoop:
                 user_content = self.context._build_user_content(content, media)
                 row: dict[str, Any] = {"role": "user", "content": user_content}
                 metadata = pending_msg.metadata if isinstance(pending_msg.metadata, dict) else {}
+                if pending_msg.channel != "system":
+                    scope = self.workspace_scopes.for_turn(
+                        channel=pending_msg.channel,
+                        message_metadata=metadata,
+                        session_metadata=session.metadata if session is not None else None,
+                    )
+                    pending_request = RequestContext(
+                        channel=pending_msg.channel,
+                        chat_id=pending_msg.chat_id,
+                        message_id=metadata.get("message_id"),
+                        session_key=active_session_key,
+                        original_user_text=pending_msg.content,
+                        runtime=runtime,
+                        metadata=dict(metadata),
+                        sender_id=pending_msg.sender_id,
+                        turn_id=request_ctx.turn_id,
+                        workspace=scope.project_path,
+                    )
+                    blocks = await self._resolve_runtime_context_for_request(
+                        pending_request,
+                        effective_tools,
+                    )
+                    row["content"], marker = append_runtime_context(user_content, blocks)
+                    if marker is not None:
+                        row["_meta"] = {RUNTIME_CONTEXT_MESSAGE_META: marker}
                 if (
                     pending_msg.sender_id == "subagent"
                     and metadata.get("injected_event") == "subagent_result"
@@ -880,7 +914,7 @@ class AgentLoop:
             items: list[dict[str, Any]] = []
             while len(items) < limit:
                 try:
-                    items.append(_to_user_message(pending_queue.get_nowait()))
+                    items.append(await _to_user_message(pending_queue.get_nowait()))
                 except asyncio.QueueEmpty:
                     break
 
@@ -898,10 +932,10 @@ class AgentLoop:
                         session.key,
                     )
                     return items
-                items.append(_to_user_message(msg))
+                items.append(await _to_user_message(msg))
                 while len(items) < limit:
                     try:
-                        items.append(_to_user_message(pending_queue.get_nowait()))
+                        items.append(await _to_user_message(pending_queue.get_nowait()))
                     except asyncio.QueueEmpty:
                         break
 

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -19,6 +19,11 @@ from nanobot.agent.context_governance import (
 from nanobot.agent.hook import AgentHook, AgentHookContext, AgentRunHookContext
 from nanobot.agent.tools.registry import ToolRegistry, is_tool_error_result
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+from nanobot.runtime_context import (
+    RUNTIME_CONTEXT_MESSAGE_META,
+    detach_runtime_context,
+    reattach_runtime_context,
+)
 from nanobot.session.history_visibility import is_hidden_history_message
 from nanobot.utils.helpers import (
     IncrementalThinkExtractor,
@@ -137,10 +142,51 @@ class AgentRunner:
                 and not is_hidden_history_message(messages[-1])
             ):
                 merged = dict(messages[-1])
-                merged["content"] = cls._merge_message_content(
-                    merged.get("content"),
-                    injection.get("content"),
+                left_meta = merged.get("_meta")
+                right_meta = injection.get("_meta")
+                left_marker = (
+                    left_meta.get(RUNTIME_CONTEXT_MESSAGE_META)
+                    if isinstance(left_meta, dict)
+                    else None
                 )
+                right_marker = (
+                    right_meta.get(RUNTIME_CONTEXT_MESSAGE_META)
+                    if isinstance(right_meta, dict)
+                    else None
+                )
+                detached_left = (
+                    detach_runtime_context(merged.get("content"), left_marker)
+                    if isinstance(left_marker, dict)
+                    else (merged.get("content"), [], [])
+                )
+                detached_right = (
+                    detach_runtime_context(injection.get("content"), right_marker)
+                    if isinstance(right_marker, dict)
+                    else (injection.get("content"), [], [])
+                )
+                if detached_left is not None and detached_right is not None:
+                    left_content, left_sources, left_blocks = detached_left
+                    right_content, right_sources, right_blocks = detached_right
+                    merged_content = cls._merge_message_content(left_content, right_content)
+                    context_blocks = [*left_blocks, *right_blocks]
+                    if context_blocks:
+                        merged_content, marker = reattach_runtime_context(
+                            merged_content,
+                            [*left_sources, *right_sources],
+                            context_blocks,
+                        )
+                        internal_meta = dict(left_meta) if isinstance(left_meta, dict) else {}
+                        if isinstance(right_meta, dict):
+                            for key, value in right_meta.items():
+                                internal_meta.setdefault(key, value)
+                        internal_meta[RUNTIME_CONTEXT_MESSAGE_META] = marker
+                        merged["_meta"] = internal_meta
+                    merged["content"] = merged_content
+                else:
+                    merged["content"] = cls._merge_message_content(
+                        merged.get("content"),
+                        injection.get("content"),
+                    )
                 messages[-1] = merged
                 continue
             messages.append(injection)

--- a/nanobot/runtime_context.py
+++ b/nanobot/runtime_context.py
@@ -139,6 +139,70 @@ def append_runtime_context(
     }
 
 
+def detach_runtime_context(
+    content: Any,
+    marker: Mapping[str, Any],
+) -> tuple[Any, list[str], list[dict[str, Any]]] | None:
+    """Detach one validated runtime-context suffix for safe message merging."""
+    if marker.get("version") != 1:
+        return None
+    raw_sources = marker.get("sources")
+    sources = [
+        source
+        for source in raw_sources
+        if isinstance(source, str) and source
+    ] if isinstance(raw_sources, list) else []
+
+    suffix = marker.get("suffix")
+    if isinstance(content, str) and isinstance(suffix, str) and suffix:
+        if content == suffix:
+            clean_content = ""
+        elif content.endswith("\n\n" + suffix):
+            clean_content = content[: -(len(suffix) + 2)]
+        else:
+            return None
+        return clean_content, sources, [{"type": "text", "text": suffix}]
+
+    expected = marker.get("blocks")
+    if isinstance(content, list) and isinstance(expected, list) and expected:
+        count = len(expected)
+        if content[-count:] != expected:
+            return None
+        return content[:-count], sources, deepcopy(expected)
+    return None
+
+
+def reattach_runtime_context(
+    content: Any,
+    sources: Sequence[str],
+    blocks: Sequence[Mapping[str, Any]],
+) -> tuple[Any, dict[str, Any]]:
+    """Append detached runtime-context blocks after visible messages are merged."""
+    context_blocks = [deepcopy(dict(block)) for block in blocks]
+    if isinstance(content, str) and all(
+        block.get("type") == "text" and isinstance(block.get("text"), str)
+        for block in context_blocks
+    ):
+        suffix = "\n\n".join(block["text"] for block in context_blocks)
+        merged = f"{content}\n\n{suffix}" if content else suffix
+        return merged, {
+            "version": 1,
+            "sources": list(sources),
+            "suffix": suffix,
+        }
+
+    visible_blocks = (
+        [*content]
+        if isinstance(content, list)
+        else ([] if content is None else [{"type": "text", "text": str(content)}])
+    )
+    return [*visible_blocks, *context_blocks], {
+        "version": 1,
+        "sources": list(sources),
+        "blocks": context_blocks,
+    }
+
+
 def public_history_message(message: Mapping[str, Any]) -> dict[str, Any]:
     """Return a user-visible copy with trusted runtime context removed exactly."""
     cleaned = deepcopy(dict(message))

--- a/tests/agent/test_runner_injections.py
+++ b/tests/agent/test_runner_injections.py
@@ -527,6 +527,17 @@ async def test_pending_injection_resolves_its_own_runtime_context(tmp_path):
             "thread_id": "topic-7",
         },
     ))
+    await pending_queue.put(InboundMessage(
+        channel="telegram",
+        sender_id="user-c",
+        chat_id="group-1",
+        content="another follow-up",
+        metadata={
+            "message_id": "message-3",
+            "sender_name": "Carol",
+            "thread_id": "topic-7",
+        },
+    ))
 
     _, _, all_messages, _, _ = await loop._run_agent_loop(
         [{"role": "user", "content": "initial message from user A"}],
@@ -538,28 +549,48 @@ async def test_pending_injection_resolves_its_own_runtime_context(tmp_path):
         pending_queue=pending_queue,
     )
 
-    assert seen_contexts == [(
-        "telegram",
-        "group-1",
-        "user-b",
-        "message-2",
-        session.key,
-        "follow-up from the second speaker",
-        "Bob",
-        "topic-7",
-    )]
+    assert seen_contexts == [
+        (
+            "telegram",
+            "group-1",
+            "user-b",
+            "message-2",
+            session.key,
+            "follow-up from the second speaker",
+            "Bob",
+            "topic-7",
+        ),
+        (
+            "telegram",
+            "group-1",
+            "user-c",
+            "message-3",
+            session.key,
+            "another follow-up",
+            "Carol",
+            "topic-7",
+        ),
+    ]
 
     injected = [message for message in all_messages if message.get("role") == "user"][-1]
     assert "follow-up from the second speaker" in str(injected["content"])
     model_messages = provider.chat_with_retry.await_args_list[-1].kwargs["messages"]
     assert "telegram | group-1 | user-b | message-2" in str(model_messages)
     assert "Bob | topic-7" in str(model_messages)
-    assert injected["_meta"][RUNTIME_CONTEXT_MESSAGE_META]["sources"] == ["identity"]
+    assert "telegram | group-1 | user-c | message-3" in str(model_messages)
+    assert "Carol | topic-7" in str(model_messages)
+    assert injected["_meta"][RUNTIME_CONTEXT_MESSAGE_META]["sources"] == [
+        "identity",
+        "identity",
+    ]
 
     loop._save_turn(session, all_messages, skip=1)
     persisted = [message for message in session.messages if message.get("role") == "user"][-1]
     assert "telegram | group-1 | user-b | message-2" in str(persisted["content"])
-    assert public_history_message(persisted)["content"] == "follow-up from the second speaker"
+    assert "telegram | group-1 | user-c | message-3" in str(persisted["content"])
+    assert public_history_message(persisted)["content"] == (
+        "follow-up from the second speaker\n\nanother follow-up"
+    )
 
 
 @pytest.mark.asyncio
@@ -686,6 +717,58 @@ async def test_runner_merges_multiple_injected_user_messages_without_losing_medi
         for block in injected["content"]
         if isinstance(block, dict)
     )
+
+
+def test_runner_merge_preserves_runtime_markers_with_media() -> None:
+    from nanobot.agent.runner import AgentRunner
+    from nanobot.runtime_context import (
+        RUNTIME_CONTEXT_HISTORY_META,
+        RUNTIME_CONTEXT_MESSAGE_META,
+        RuntimeContextBlock,
+        append_runtime_context,
+        public_history_message,
+    )
+
+    first_visible = [
+        {"type": "text", "text": "first"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AA=="}},
+    ]
+    first_content, first_marker = append_runtime_context(
+        first_visible,
+        [RuntimeContextBlock(source="first", content="private first")],
+    )
+    second_content, second_marker = append_runtime_context(
+        "second",
+        [RuntimeContextBlock(source="second", content="private second")],
+    )
+    messages: list[dict] = []
+
+    AgentRunner._append_injected_messages(messages, [
+        {
+            "role": "user",
+            "content": first_content,
+            "_meta": {RUNTIME_CONTEXT_MESSAGE_META: first_marker},
+        },
+        {
+            "role": "user",
+            "content": second_content,
+            "_meta": {RUNTIME_CONTEXT_MESSAGE_META: second_marker},
+        },
+    ])
+
+    assert len(messages) == 1
+    merged = messages[0]
+    assert "private first" in str(merged["content"])
+    assert "private second" in str(merged["content"])
+    persisted = {
+        "role": "user",
+        "content": merged["content"],
+        RUNTIME_CONTEXT_HISTORY_META: merged["_meta"][RUNTIME_CONTEXT_MESSAGE_META],
+    }
+    assert public_history_message(persisted)["content"] == [
+        *first_visible,
+        {"type": "text", "text": "second"},
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_runner_injections.py
+++ b/tests/agent/test_runner_injections.py
@@ -469,6 +469,100 @@ async def test_loop_injected_followup_preserves_image_media(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_pending_injection_resolves_its_own_runtime_context(tmp_path):
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.events import InboundMessage
+    from nanobot.bus.queue import MessageBus
+    from nanobot.runtime_context import (
+        RUNTIME_CONTEXT_MESSAGE_META,
+        RuntimeContextBlock,
+        public_history_message,
+        wrap_runtime_context_lines,
+    )
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.chat_with_retry = AsyncMock(side_effect=[
+        LLMResponse(content="first answer", tool_calls=[], usage={}),
+        LLMResponse(content="second answer", tool_calls=[], usage={}),
+    ])
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+    )
+    loop.tools.get_definitions = MagicMock(return_value=[])
+    seen_contexts = []
+
+    async def provide_identity(request):
+        seen_contexts.append((
+            request.channel,
+            request.chat_id,
+            request.sender_id,
+            request.message_id,
+            request.session_key,
+            request.original_user_text,
+            request.metadata["sender_name"],
+            request.metadata["thread_id"],
+        ))
+        return RuntimeContextBlock(
+            source="identity",
+            content=wrap_runtime_context_lines([
+                " | ".join(str(value) for value in seen_contexts[-1]),
+            ]),
+        )
+
+    loop.register_runtime_context_provider(provide_identity)
+    session = loop.sessions.get_or_create("telegram:group-1")
+    pending_queue = asyncio.Queue()
+    await pending_queue.put(InboundMessage(
+        channel="telegram",
+        sender_id="user-b",
+        chat_id="group-1",
+        content="follow-up from the second speaker",
+        metadata={
+            "message_id": "message-2",
+            "sender_name": "Bob",
+            "thread_id": "topic-7",
+        },
+    ))
+
+    _, _, all_messages, _, _ = await loop._run_agent_loop(
+        [{"role": "user", "content": "initial message from user A"}],
+        runtime=loop.llm_runtime(),
+        session=session,
+        channel="telegram",
+        chat_id="group-1",
+        session_key=session.key,
+        pending_queue=pending_queue,
+    )
+
+    assert seen_contexts == [(
+        "telegram",
+        "group-1",
+        "user-b",
+        "message-2",
+        session.key,
+        "follow-up from the second speaker",
+        "Bob",
+        "topic-7",
+    )]
+
+    injected = [message for message in all_messages if message.get("role") == "user"][-1]
+    assert "follow-up from the second speaker" in str(injected["content"])
+    model_messages = provider.chat_with_retry.await_args_list[-1].kwargs["messages"]
+    assert "telegram | group-1 | user-b | message-2" in str(model_messages)
+    assert "Bob | topic-7" in str(model_messages)
+    assert injected["_meta"][RUNTIME_CONTEXT_MESSAGE_META]["sources"] == ["identity"]
+
+    loop._save_turn(session, all_messages, skip=1)
+    persisted = [message for message in session.messages if message.get("role") == "user"][-1]
+    assert "telegram | group-1 | user-b | message-2" in str(persisted["content"])
+    assert public_history_message(persisted)["content"] == "follow-up from the second speaker"
+
+
+@pytest.mark.asyncio
 async def test_subagent_pending_injection_is_hidden_history_and_not_merged(tmp_path):
     from nanobot.agent.loop import AgentLoop
     from nanobot.bus.events import InboundMessage


### PR DESCRIPTION
## Summary

Related: #4064. That issue described the pending-message symptom under the former default runtime-identity envelope. This PR addresses the remaining runtime-context pipeline gap without restoring that envelope.

- Resolve trusted metadata blocks and registered `RuntimeContextProvider` instances for each queued mid-turn user message using that message's own `RequestContext`.
- Preserve provider-owned runtime-context blocks and their markers when consecutive pending user messages are merged.
- Persist model-only markers so those blocks remain hidden from public history.
- Keep system and subagent injections on their existing internal path.

## Behavior boundary

`RequestContext` is an internal routing and tool snapshot. Its channel, chat, session, sender, message, metadata, workspace, and original-text fields are not automatically serialized into model input. A value reaches the model only when an explicitly registered provider or trusted channel metadata returns a `RuntimeContextBlock`.

This PR does not restore the removed default `Current Time` / `Channel` / `Chat ID` / `Sender ID` runtime envelope.

## Root cause

The pending-drain callback converted each `InboundMessage` directly into a plain user message. Unlike a normal inbound turn, it skipped the optional runtime-context pipeline, so queued follow-ups could lose feature-owned context such as Goal state, CLI App attachments, trusted WebUI quotes, or third-party provider blocks.

When multiple pending user messages were merged to preserve role alternation, their individual runtime-context markers also had to be combined; otherwise model-only blocks could not be removed reliably from persisted or public history.

## Validation

- `uv run --extra dev pytest tests/agent/test_runner_injections.py tests/agent/test_loop_runner_integration.py tests/agent/test_runtime_context.py tests/agent/test_loop_save_turn.py -q` — 113 passed
- `uv run --extra dev pytest -q` — 5141 passed, 22 skipped
- `uv run --extra dev ruff check nanobot/agent/loop.py tests/agent/test_runner_injections.py` — passed
- `git diff --check` — passed