### PR TITLE
fix(triggers): treat null runHistory as empty when loading triggers

### DIFF
--- a/nanobot/triggers/local_types.py
+++ b/nanobot/triggers/local_types.py
@@ -68,9 +68,10 @@ class LocalTrigger:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "LocalTrigger":
+        raw_history = data.get("runHistory", data.get("run_history", [])) or []
         history = [
             record if isinstance(record, TriggerRunRecord) else TriggerRunRecord.from_dict(record)
-            for record in data.get("runHistory", data.get("run_history", []))
+            for record in raw_history
             if isinstance(record, (dict, TriggerRunRecord))
         ]
         return cls(

--- a/tests/triggers/test_local_triggers.py
+++ b/tests/triggers/test_local_triggers.py
@@ -617,3 +617,21 @@ def test_local_trigger_from_dict_coerces_string_last_run_at_ms() -> None:
         }
     )
     assert trigger_null.last_run_at_ms is None
+
+
+def test_local_trigger_from_dict_accepts_null_run_history() -> None:
+    """Null runHistory must load as empty, matching CronJobState.from_store_dict."""
+    trigger = LocalTrigger.from_dict(
+        {
+            "id": "t1",
+            "name": "n",
+            "enabled": True,
+            "channel": "websocket",
+            "chatId": "c1",
+            "sessionKey": "websocket:c1",
+            "runHistory": None,
+            "createdAtMs": 1,
+            "updatedAtMs": 1,
+        }
+    )
+    assert trigger.run_history == []


### PR DESCRIPTION
triggers.json with "runHistory": null failed LocalTrigger.from_dict (None is not iterable). Cron already uses or [].

Treat null runHistory as empty, with a test.