### PR TITLE
fix(pairing): treat null approved/pending maps as empty

### DIFF
--- a/nanobot/pairing/store.py
+++ b/nanobot/pairing/store.py
@@ -43,6 +43,9 @@ def _load() -> dict[str, Any]:
     except (json.JSONDecodeError, OSError):
         logger.warning("Corrupted pairing store, resetting")
         return {"approved": {}, "pending": {}}
+    if not isinstance(data, dict):
+        logger.warning("Corrupted pairing store, resetting")
+        return {"approved": {}, "pending": {}}
 
     # JSON stores may contain null maps after partial edits; treat like {}.
     approved = data.get("approved") or {}
@@ -89,7 +92,15 @@ def _gc_pending(data: dict[str, Any]) -> None:
     expired = [
         code
         for code, info in pending.items()
-        if not isinstance(info, dict) or info.get("expires_at", 0) < now
+        if (
+            not isinstance(info, dict)
+            or not isinstance(info.get("channel"), str)
+            or not info.get("channel")
+            or info.get("sender_id") is None
+            or isinstance(info.get("expires_at"), bool)
+            or not isinstance(info.get("expires_at"), (int, float))
+            or info["expires_at"] < now
+        )
     ]
     for code in expired:
         del pending[code]
@@ -220,6 +231,7 @@ def clear_channel(channel: str) -> dict[str, int]:
     """Remove approved senders and pending requests for *channel*."""
     with _LOCK:
         data = _load()
+        _gc_pending(data)
         approved: dict[str, set[str]] = data.get("approved", {})
         approved_users = approved.pop(channel, set())
 

--- a/nanobot/pairing/store.py
+++ b/nanobot/pairing/store.py
@@ -44,8 +44,18 @@ def _load() -> dict[str, Any]:
         logger.warning("Corrupted pairing store, resetting")
         return {"approved": {}, "pending": {}}
 
+    # JSON stores may contain null maps after partial edits; treat like {}.
+    approved = data.get("approved") or {}
+    if not isinstance(approved, dict):
+        approved = {}
+    data["approved"] = approved
+    pending = data.get("pending") or {}
+    if not isinstance(pending, dict):
+        pending = {}
+    data["pending"] = pending
+
     # Convert approved lists to str sets for O(1) lookup.
-    for channel, users in data.get("approved", {}).items():
+    for channel, users in approved.items():
         if not isinstance(users, list):
             users = []
         data["approved"][channel] = {str(u) for u in users}
@@ -56,9 +66,15 @@ def _save(data: dict[str, Any]) -> None:
     path = _store_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     # Convert sets back to lists for JSON serialization
+    approved = data.get("approved") or {}
+    pending = data.get("pending") or {}
+    if not isinstance(approved, dict):
+        approved = {}
+    if not isinstance(pending, dict):
+        pending = {}
     payload = {
-        "approved": {ch: sorted(list(users)) for ch, users in data.get("approved", {}).items()},
-        "pending": dict(data.get("pending", {})),
+        "approved": {ch: sorted(list(users)) for ch, users in approved.items()},
+        "pending": dict(pending),
     }
     _write_text_atomic(path, json.dumps(payload, indent=2, ensure_ascii=False))
 
@@ -66,10 +82,18 @@ def _save(data: dict[str, Any]) -> None:
 def _gc_pending(data: dict[str, Any]) -> None:
     """Remove expired pending entries in-place."""
     now = time.time()
-    pending: dict[str, Any] = data.get("pending", {})
-    expired = [code for code, info in pending.items() if info.get("expires_at", 0) < now]
+    pending: dict[str, Any] = data.get("pending") or {}
+    if not isinstance(pending, dict):
+        data["pending"] = {}
+        return
+    expired = [
+        code
+        for code, info in pending.items()
+        if not isinstance(info, dict) or info.get("expires_at", 0) < now
+    ]
     for code in expired:
         del pending[code]
+    data["pending"] = pending
 
 
 def generate_code(
@@ -152,6 +176,7 @@ def list_pending() -> list[dict[str, Any]]:
         return [
             {"code": code, **info}
             for code, info in data.get("pending", {}).items()
+            if isinstance(info, dict)
         ]
 
 

--- a/tests/pairing/test_store.py
+++ b/tests/pairing/test_store.py
@@ -272,11 +272,34 @@ def test_load_treats_null_approved_and_pending_maps_as_empty(tmp_path, monkeypat
     assert store.get_approved("telegram") == []
 
 
+@pytest.mark.parametrize("payload", ["null", "[]", "true"])
+def test_load_treats_non_object_store_as_empty(tmp_path, monkeypatch, payload):
+    path = tmp_path / "pairing.json"
+    path.write_text(payload, encoding="utf-8")
+    monkeypatch.setattr(store, "_store_path", lambda: path)
+    assert store.list_pending() == []
+    assert store.is_approved("telegram", "123") is False
+
+
 def test_list_pending_skips_null_pending_entries(tmp_path, monkeypatch):
     """Null pending entry values must be dropped instead of crashing list_pending."""
     path = tmp_path / "pairing.json"
     path.write_text(
         '{"approved": {}, "pending": {"ABCD-EFGH": null}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(store, "_store_path", lambda: path)
+    assert store.list_pending() == []
+    assert store.clear_channel("telegram") == {"approved": 0, "pending": 0}
+
+
+def test_pending_gc_drops_malformed_entries(tmp_path, monkeypatch):
+    path = tmp_path / "pairing.json"
+    path.write_text(
+        '{"approved": {}, "pending": {'
+        '"bad-expiry": {"channel": "telegram", "sender_id": "123", "expires_at": null},'
+        '"missing-sender": {"channel": "telegram", "expires_at": 9999999999}'
+        "}}",
         encoding="utf-8",
     )
     monkeypatch.setattr(store, "_store_path", lambda: path)

--- a/tests/pairing/test_store.py
+++ b/tests/pairing/test_store.py
@@ -257,3 +257,27 @@ def test_load_treats_null_approved_channel_list_as_empty(tmp_path, monkeypatch):
     assert store.is_approved("telegram", "123") is False
     assert store.is_approved("discord", "456") is True
     assert store.get_approved("telegram") == []
+
+
+def test_load_treats_null_approved_and_pending_maps_as_empty(tmp_path, monkeypatch):
+    """Top-level approved/pending null must not crash pairing load or list_pending."""
+    path = tmp_path / "pairing.json"
+    path.write_text(
+        '{"approved": null, "pending": null}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(store, "_store_path", lambda: path)
+    assert store.is_approved("telegram", "123") is False
+    assert store.list_pending() == []
+    assert store.get_approved("telegram") == []
+
+
+def test_list_pending_skips_null_pending_entries(tmp_path, monkeypatch):
+    """Null pending entry values must be dropped instead of crashing list_pending."""
+    path = tmp_path / "pairing.json"
+    path.write_text(
+        '{"approved": {}, "pending": {"ABCD-EFGH": null}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(store, "_store_path", lambda: path)
+    assert store.list_pending() == []


### PR DESCRIPTION
pairing.json with top-level "approved": null or "pending": null crashed _load on .items(). Per-channel null lists are already tolerated.

Treat null approved/pending maps as empty, with a test.