### PR TITLE
fix(feishu): tolerate null text fields when extracting post content

### DIFF
--- a/nanobot/channels/feishu/runtime.py
+++ b/nanobot/channels/feishu/runtime.py
@@ -356,7 +356,8 @@ def _extract_post_content(content_json: dict) -> tuple[str, list[str]]:
         if not isinstance(block, dict) or not isinstance(block.get("content"), list):
             return None, []
         texts, images = [], []
-        if title := block.get("title"):
+        title = block.get("title")
+        if isinstance(title, str) and title:
             texts.append(title)
         for row in block["content"]:
             if not isinstance(row, list):
@@ -366,12 +367,19 @@ def _extract_post_content(content_json: dict) -> tuple[str, list[str]]:
                     continue
                 tag = el.get("tag")
                 if tag in ("text", "a"):
-                    texts.append(el.get("text", ""))
+                    text = el.get("text", "")
+                    if isinstance(text, str):
+                        texts.append(text)
                 elif tag == "at":
-                    texts.append(f"@{el.get('user_name', 'user')}")
+                    user = el.get("user_name", "user")
+                    texts.append(f"@{user if isinstance(user, str) and user else 'user'}")
                 elif tag == "code_block":
                     lang = el.get("language", "")
                     code_text = el.get("text", "")
+                    if not isinstance(lang, str):
+                        lang = ""
+                    if not isinstance(code_text, str):
+                        code_text = ""
                     texts.append(f"\n```{lang}\n{code_text}\n```\n")
                 elif tag == "img" and (key := el.get("image_key")):
                     images.append(key)

--- a/nanobot/channels/feishu/tests/test_feishu_card_extraction.py
+++ b/nanobot/channels/feishu/tests/test_feishu_card_extraction.py
@@ -42,19 +42,21 @@ def test_extract_interactive_card_reads_table_rows() -> None:
     assert _extract_share_card_content(content, "interactive") == "Name | Score\nAlice | 98"
 
 
-def test_extract_post_content_tolerates_null_text_fields() -> None:
+def test_extract_post_content_tolerates_null_fields() -> None:
     text, images = _extract_post_content(
         {
-            "title": "T",
+            "title": None,
             "content": [
                 [
                     {"tag": "text", "text": None},
                     {"tag": "a", "text": None},
+                    {"tag": "at", "user_name": None},
                     {"tag": "text", "text": "ok"},
                     {"tag": "code_block", "language": None, "text": None},
                 ]
             ],
         }
     )
+    assert "@user" in text
     assert "ok" in text
     assert images == []

--- a/nanobot/channels/feishu/tests/test_feishu_card_extraction.py
+++ b/nanobot/channels/feishu/tests/test_feishu_card_extraction.py
@@ -1,6 +1,9 @@
 import json
 
-from nanobot.channels.feishu.runtime import _extract_share_card_content
+from nanobot.channels.feishu.runtime import (
+    _extract_post_content,
+    _extract_share_card_content,
+)
 
 
 def test_extract_interactive_card_reads_user_dsl_body_elements() -> None:
@@ -37,9 +40,6 @@ def test_extract_interactive_card_reads_table_rows() -> None:
     }
 
     assert _extract_share_card_content(content, "interactive") == "Name | Score\nAlice | 98"
-
-
-from nanobot.channels.feishu.runtime import _extract_post_content
 
 
 def test_extract_post_content_tolerates_null_text_fields() -> None:

--- a/nanobot/channels/feishu/tests/test_feishu_card_extraction.py
+++ b/nanobot/channels/feishu/tests/test_feishu_card_extraction.py
@@ -37,3 +37,24 @@ def test_extract_interactive_card_reads_table_rows() -> None:
     }
 
     assert _extract_share_card_content(content, "interactive") == "Name | Score\nAlice | 98"
+
+
+from nanobot.channels.feishu.runtime import _extract_post_content
+
+
+def test_extract_post_content_tolerates_null_text_fields() -> None:
+    text, images = _extract_post_content(
+        {
+            "title": "T",
+            "content": [
+                [
+                    {"tag": "text", "text": None},
+                    {"tag": "a", "text": None},
+                    {"tag": "text", "text": "ok"},
+                    {"tag": "code_block", "language": None, "text": None},
+                ]
+            ],
+        }
+    )
+    assert "ok" in text
+    assert images == []


### PR DESCRIPTION
Feishu post elements with "text": null reached " ".join and raised TypeError.

Skip null text fields when extracting post content, with a test.