### PR TITLE
fix(providers): use canonical OpenRouter app URL

### DIFF
--- a/nanobot/providers/image_generation.py
+++ b/nanobot/providers/image_generation.py
@@ -14,14 +14,10 @@ from typing import Any
 import httpx
 from loguru import logger
 
+from nanobot.providers.openrouter_attribution import OPENROUTER_ATTRIBUTION_HEADERS
 from nanobot.providers.registry import find_by_name
 from nanobot.utils.helpers import detect_image_mime
 
-_OPENROUTER_ATTRIBUTION_HEADERS = {
-    "HTTP-Referer": "https://github.com/HKUDS/nanobot",
-    "X-OpenRouter-Title": "nanobot",
-    "X-OpenRouter-Categories": "cli-agent,personal-agent",
-}
 _DEFAULT_TIMEOUT_S = 120.0
 _AIHUBMIX_TIMEOUT_S = 300.0
 _AIHUBMIX_ASPECT_RATIO_SIZES = {
@@ -305,7 +301,7 @@ class OpenRouterImageGenerationClient(ImageGenerationProvider):
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
-            **_OPENROUTER_ATTRIBUTION_HEADERS,
+            **OPENROUTER_ATTRIBUTION_HEADERS,
             **self.extra_headers,
         }
         url = f"{self.api_base}/chat/completions"

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -35,6 +35,7 @@ from nanobot.providers.openai_responses import (
     convert_tools,
     parse_response_output,
 )
+from nanobot.providers.openrouter_attribution import OPENROUTER_ATTRIBUTION_HEADERS
 
 if TYPE_CHECKING:
     from openai import AsyncOpenAI as AsyncOpenAIType
@@ -54,11 +55,6 @@ _ALNUM = string.ascii_letters + string.digits
 
 _STANDARD_TC_KEYS = frozenset({"id", "type", "index", "function"})
 _STANDARD_FN_KEYS = frozenset({"name", "arguments"})
-_DEFAULT_OPENROUTER_HEADERS = {
-    "HTTP-Referer": "https://github.com/HKUDS/nanobot",
-    "X-OpenRouter-Title": "nanobot",
-    "X-OpenRouter-Categories": "cli-agent,personal-agent",
-}
 _KIMI_K3_MODEL = "kimi-k3"
 _KIMI_THINKING_MODELS: frozenset[str] = frozenset({
     "kimi-k2.5",
@@ -450,7 +446,7 @@ class OpenAICompatProvider(LLMProvider):
         self._effective_base = effective_base
         self._default_headers = {"x-session-affinity": uuid.uuid4().hex}
         if _uses_openrouter_attribution(spec, effective_base):
-            self._default_headers.update(_DEFAULT_OPENROUTER_HEADERS)
+            self._default_headers.update(OPENROUTER_ATTRIBUTION_HEADERS)
         if extra_headers:
             self._default_headers.update(extra_headers)
         self._api_key_for_client = api_key or "no-key"

--- a/nanobot/providers/openrouter_attribution.py
+++ b/nanobot/providers/openrouter_attribution.py
@@ -1,0 +1,7 @@
+"""Shared OpenRouter app attribution headers."""
+
+OPENROUTER_ATTRIBUTION_HEADERS = {
+    "HTTP-Referer": "https://nanobot.wiki",
+    "X-OpenRouter-Title": "nanobot",
+    "X-OpenRouter-Categories": "cli-agent,personal-agent",
+}

--- a/tests/providers/test_image_generation.py
+++ b/tests/providers/test_image_generation.py
@@ -142,6 +142,9 @@ async def test_openrouter_image_generation_payload_and_response(tmp_path: Path) 
     call = fake.calls[0]
     assert call["url"] == "https://openrouter.ai/api/v1/chat/completions"
     assert call["headers"]["Authorization"] == "Bearer sk-or-test"
+    assert call["headers"]["HTTP-Referer"] == "https://nanobot.wiki"
+    assert call["headers"]["X-OpenRouter-Title"] == "nanobot"
+    assert call["headers"]["X-OpenRouter-Categories"] == "cli-agent,personal-agent"
     assert call["headers"]["X-Test"] == "1"
     body = call["json"]
     assert body["modalities"] == ["image", "text"]

--- a/tests/providers/test_litellm_kwargs.py
+++ b/tests/providers/test_litellm_kwargs.py
@@ -485,7 +485,7 @@ async def test_openrouter_sets_default_attribution_headers() -> None:
         await provider._ensure_client()
 
     headers = mock_client_cls.call_args.kwargs["default_headers"]
-    assert headers["HTTP-Referer"] == "https://github.com/HKUDS/nanobot"
+    assert headers["HTTP-Referer"] == "https://nanobot.wiki"
     assert headers["X-OpenRouter-Title"] == "nanobot"
     assert headers["X-OpenRouter-Categories"] == "cli-agent,personal-agent"
     assert "x-session-affinity" in headers


### PR DESCRIPTION
## Summary
- identify nanobot OpenRouter traffic with the canonical product site, `https://nanobot.wiki`
- share one attribution header definition between text and image generation requests
- keep user-provided OpenRouter headers authoritative

## Why
OpenRouter uses `HTTP-Referer` as the primary app identifier and discovers app branding from that URL. The current GitHub repository URL makes the app page inherit GitHub branding instead of the nanobot icon.

## Rollout guard
Do not merge this PR until OpenRouter Support confirms that these existing records are merged:

- app `2735766`: `https://github.com/HKUDS/nanobot`, slug `/apps/nanobot`, about 41.54B historical tokens
- app `3396829`: `https://nanobot.wiki/`, about 596M historical tokens

The requested final state is app `2735766` retained as the canonical record, `https://nanobot.wiki/` set as its canonical URL, and the GitHub URL retained as a related alias. Historical usage, rankings, slug, categories, and description must remain intact.

OpenRouter documents that traffic from related app aliases is merged into the canonical visible app, but does not expose a self-service alias API.

The corresponding website change adds standard root favicon paths in Re-bin/nanobot-web#15.

## Compatibility
- no provider configuration fields change
- custom `extraHeaders` still override every default attribution header
- attribution headers do not affect OpenRouter response cache keys

## Verification
- rebased on current `origin/main`
- `PYTHONPATH="$PWD" pytest tests/providers/test_litellm_kwargs.py tests/providers/test_image_generation.py -q` (185 passed)
- `ruff check nanobot/providers/openrouter_attribution.py nanobot/providers/openai_compat_provider.py nanobot/providers/image_generation.py tests/providers/test_litellm_kwargs.py tests/providers/test_image_generation.py`
- `git diff --check`