### PR TITLE
fix(security): harden generated image URL downloads

### DIFF
--- a/.agent/security.md
+++ b/.agent/security.md
@@ -14,9 +14,9 @@ Shell execution (`ExecTool`, `agent/tools/shell.py`) also respects `restrict_to_
 
 ## SSRF Protection
 
-All outbound HTTP requests from agent tools must pass through `validate_url_target` (`security/network.py`). By default it blocks loopback, RFC1918 private addresses, CGNAT ranges, link-local ranges, and cloud metadata endpoints (including `169.254.169.254`).
+All outbound HTTP requests from agent tools must pass through the shared URL guards in `security/network.py` (`validate_url_target` or `resolve_url_target`). By default they block loopback, RFC1918 private addresses, CGNAT ranges, link-local ranges, and cloud metadata endpoints (including `169.254.169.254`).
 
-The only escape hatch is `configure_ssrf_whitelist(cidrs)`, which reads from `config.tools.ssrf_whitelist` at load time.
+For direct requests, the only escape hatch is `configure_ssrf_whitelist(cidrs)`, which reads from `config.tools.ssrf_whitelist` at load time. An explicitly configured `providers.<name>.proxy` is a separate user-authorized trust boundary for provider requests and provider-returned image URL downloads. Those downloads still reject malformed URLs and locally identifiable private/internal targets on every redirect, but hostnames unavailable to local DNS are delegated to the trusted proxy. The user-selected proxy owns final DNS resolution and network egress policy.
 
 HTTP/SSE MCP transports are part of this boundary: validate configured MCP URLs before probing or constructing clients, and validate each outgoing HTTP request before redirects are followed. Local/private HTTP MCP endpoints are allowed only through the explicit SSRF whitelist. Stdio MCP servers are not part of the HTTP SSRF path.
 

--- a/docs/image-generation.md
+++ b/docs/image-generation.md
@@ -70,6 +70,9 @@ Provider settings reuse normal provider config fields:
 | `providers.<name>.apiBase` | Optional custom base URL |
 | `providers.<name>.extraHeaders` | Headers merged into provider requests |
 | `providers.<name>.extraBody` | Extra JSON fields merged into provider request bodies |
+| `providers.<name>.proxy` | Explicit trusted HTTP proxy for provider requests and returned image URL downloads |
+
+For providers that return image URLs, direct downloads use DNS pinning. When an explicit provider `proxy` is configured, nanobot validates the initial URL and every redirect locally, then relies on that trusted proxy for final DNS resolution and network egress. Process-wide proxy environment variables are not used for these downloads.
 
 Both camelCase and snake_case config keys are accepted, but docs use camelCase to match `config.json`.
 

--- a/docs/image-generation.md
+++ b/docs/image-generation.md
@@ -72,7 +72,7 @@ Provider settings reuse normal provider config fields:
 | `providers.<name>.extraBody` | Extra JSON fields merged into provider request bodies |
 | `providers.<name>.proxy` | Explicit trusted HTTP proxy for provider requests and returned image URL downloads |
 
-For providers that return image URLs, direct downloads use DNS pinning. When an explicit provider `proxy` is configured, nanobot validates the initial URL and every redirect locally, then relies on that trusted proxy for final DNS resolution and network egress. Process-wide proxy environment variables are not used for these downloads.
+For providers that return image URLs, direct downloads use DNS pinning. When an explicit provider `proxy` is configured, nanobot rejects malformed URLs and locally identifiable private/internal targets on the initial URL and every redirect. Hostnames unavailable to local DNS are delegated to that trusted proxy, which owns final DNS resolution and network egress. Process-wide proxy environment variables are not used for these downloads.
 
 Both camelCase and snake_case config keys are accepted, but docs use camelCase to match `config.json`.
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -199,7 +199,7 @@ class ProviderConfig(Base):
     extra_headers: dict[str, str] | None = None  # Custom headers (e.g. APP-Code for AiHubMix)
     extra_body: dict[str, Any] | None = None  # Extra provider request fields; shape depends on provider/API surface
     extra_query: dict[str, str] | None = None  # Extra query params (e.g. api-version for Azure-style gateways)
-    proxy: str | None = None  # OpenAI-compatible/Codex HTTP proxy URL
+    proxy: str | None = None  # Explicit HTTP proxy; image downloads trust its DNS and egress
     thinking_style: str | None = None  # Thinking/reasoning style for custom providers
 
     # Valid values mirror the keys of _THINKING_STYLE_MAP in

--- a/nanobot/providers/image_generation.py
+++ b/nanobot/providers/image_generation.py
@@ -16,7 +16,11 @@ import httpx
 from loguru import logger
 
 from nanobot.providers.registry import find_by_name
-from nanobot.security.network import PinnedDNSAsyncTransport, UnsafeURLRequestError
+from nanobot.security.network import (
+    PinnedDNSAsyncTransport,
+    UnsafeURLRequestError,
+    resolve_url_target,
+)
 from nanobot.utils.helpers import detect_image_mime
 
 _OPENROUTER_ATTRIBUTION_HEADERS = {
@@ -137,19 +141,31 @@ def _aihubmix_model_path(model: str) -> str:
 async def _download_image_data_url(
     url: str,
     *,
+    proxy: str | None = None,
     transport: httpx.AsyncBaseTransport | None = None,
 ) -> str:
     try:
-        safe_transport = PinnedDNSAsyncTransport(inner=transport)
-        # Proxies resolve the target independently and would defeat DNS pinning.
-        async with httpx.AsyncClient(
-            transport=safe_transport,
-            follow_redirects=False,
-            timeout=_DEFAULT_TIMEOUT_S,
-            trust_env=False,
-        ) as client:
+        client_kwargs: dict[str, Any] = {
+            "follow_redirects": False,
+            "timeout": _DEFAULT_TIMEOUT_S,
+            "trust_env": False,
+        }
+        if proxy:
+            # An explicit provider proxy is a user-selected trusted egress boundary.
+            # Validate each URL locally, while the proxy owns final DNS resolution.
+            client_kwargs["proxy"] = proxy
+        else:
+            client_kwargs["transport"] = PinnedDNSAsyncTransport(inner=transport)
+
+        async with httpx.AsyncClient(**client_kwargs) as client:
             current_url = url
             for _ in range(_IMAGE_DOWNLOAD_MAX_REDIRECTS + 1):
+                if proxy:
+                    ok, error, _ = resolve_url_target(current_url)
+                    if not ok:
+                        raise ImageGenerationError(
+                            f"blocked unsafe generated image URL: {error}"
+                        )
                 async with client.stream("GET", current_url) as response:
                     if response.is_redirect:
                         location = response.headers.get("location")
@@ -302,6 +318,13 @@ class ImageGenerationProvider(ABC):
             raise ImageGenerationError(f"{label} returned no images: {provider_error}")
         raise ImageGenerationError(f"{label} returned no images for this request")
 
+    def _http_client_kwargs(self) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {"timeout": self.timeout}
+        if self.proxy:
+            kwargs["proxy"] = self.proxy
+            kwargs["trust_env"] = False
+        return kwargs
+
     async def _http_post(
         self,
         url: str,
@@ -314,11 +337,7 @@ class ImageGenerationProvider(ABC):
             return await client.post(url, headers=headers, json=body)
         if self._client is not None:
             return await self._client.post(url, headers=headers, json=body)
-        client_kwargs: dict[str, Any] = {"timeout": self.timeout}
-        if self.proxy:
-            client_kwargs["proxy"] = self.proxy
-            client_kwargs["trust_env"] = False
-        async with httpx.AsyncClient(**client_kwargs) as c:
+        async with httpx.AsyncClient(**self._http_client_kwargs()) as c:
             return await c.post(url, headers=headers, json=body)
 
 
@@ -446,7 +465,7 @@ class AIHubMixImageGenerationClient(ImageGenerationProvider):
         }
         size = _aihubmix_size(aspect_ratio, image_size)
 
-        client = self._client or httpx.AsyncClient(timeout=self.timeout)
+        client = self._client or httpx.AsyncClient(**self._http_client_kwargs())
         try:
             return await self._generate_with_client(
                 client,
@@ -506,7 +525,7 @@ class AIHubMixImageGenerationClient(ImageGenerationProvider):
             raise ImageGenerationError(f"AIHubMix image generation failed: {detail}") from exc
 
         payload = response.json()
-        images = await _aihubmix_images_from_payload(payload)
+        images = await _aihubmix_images_from_payload(payload, proxy=self.proxy)
 
         self._require_images(images, payload)
 
@@ -882,6 +901,8 @@ def _gemini_flash_supported_image_sizes(model: str) -> set[str]:
 
 async def _aihubmix_images_from_payload(
     payload: dict[str, Any],
+    *,
+    proxy: str | None = None,
 ) -> list[str]:
     images: list[str] = []
     candidates: list[Any] = []
@@ -899,7 +920,7 @@ async def _aihubmix_images_from_payload(
             if value.startswith("data:image/"):
                 images.append(value)
             elif value.startswith(("http://", "https://")):
-                images.append(await _download_image_data_url(value))
+                images.append(await _download_image_data_url(value, proxy=proxy))
             return
         if not isinstance(value, dict):
             return
@@ -1100,7 +1121,7 @@ class OpenAIImageGenerationClient(ImageGenerationProvider):
         return model
 
     async def _parse_images_response(self, payload: dict[str, Any]) -> list[str]:
-        return await _openai_images_from_payload(payload)
+        return await _openai_images_from_payload(payload, proxy=self.proxy)
 
     async def _post_image_edit(
         self,
@@ -1130,7 +1151,7 @@ class OpenAIImageGenerationClient(ImageGenerationProvider):
                     data=body,
                     files=files,
                 )
-            async with httpx.AsyncClient(timeout=self.timeout) as c:
+            async with httpx.AsyncClient(**self._http_client_kwargs()) as c:
                 return await c.post(
                     f"{self.api_base}/images/edits",
                     headers=headers,
@@ -1311,7 +1332,7 @@ class CustomImageGenerationClient(ImageGenerationProvider):
         logger.info("Custom Images API response ({}): {}", response.status_code,
                        {k: v for k, v in payload.items() if k != "data"})
 
-        images = await _openai_images_from_payload(payload)
+        images = await _openai_images_from_payload(payload, proxy=self.proxy)
 
         self._require_images(images, payload)
 
@@ -1505,6 +1526,8 @@ def _openai_explicit_size_supported(
 
 async def _openai_images_from_payload(
     payload: dict[str, Any],
+    *,
+    proxy: str | None = None,
 ) -> list[str]:
     """Extract images from OpenAI Images API response.
 
@@ -1520,7 +1543,7 @@ async def _openai_images_from_payload(
             continue
         url = item.get("url")
         if isinstance(url, str) and url:
-            images.append(await _download_image_data_url(url))
+            images.append(await _download_image_data_url(url, proxy=proxy))
     return images
 
 
@@ -1800,7 +1823,7 @@ class ZhipuImageGenerationClient(ImageGenerationProvider):
 
         url = f"{self.api_base}/images/generations"
 
-        client = self._client or httpx.AsyncClient(timeout=self.timeout)
+        client = self._client or httpx.AsyncClient(**self._http_client_kwargs())
         try:
             return await self._generate_with_client(
                 client,
@@ -1834,7 +1857,7 @@ class ZhipuImageGenerationClient(ImageGenerationProvider):
             raise ImageGenerationError(f"Zhipu image generation failed: {detail}") from exc
 
         payload = response.json()
-        images = await _zhipu_images_from_payload(payload)
+        images = await _zhipu_images_from_payload(payload, proxy=self.proxy)
 
         self._require_images(images, payload)
 
@@ -1859,6 +1882,8 @@ def _zhipu_size(
 
 async def _zhipu_images_from_payload(
     payload: dict[str, Any],
+    *,
+    proxy: str | None = None,
 ) -> list[str]:
     """Extract image data URLs from Zhipu API response.
 
@@ -1871,7 +1896,7 @@ async def _zhipu_images_from_payload(
             continue
         url = item.get("url")
         if isinstance(url, str) and url:
-            images.append(await _download_image_data_url(url))
+            images.append(await _download_image_data_url(url, proxy=proxy))
     return images
 
 
@@ -1957,7 +1982,7 @@ class ModelScopeImageGenerationClient(ImageGenerationProvider):
         body.update(self.extra_body)
 
         url = f"{self.api_base}/images/generations"
-        client = self._client or httpx.AsyncClient(timeout=self.timeout)
+        client = self._client or httpx.AsyncClient(**self._http_client_kwargs())
         try:
             return await self._generate_with_client(
                 client,
@@ -2047,8 +2072,8 @@ class ModelScopeImageGenerationClient(ImageGenerationProvider):
             f"{_MODELSCOPE_POLL_MAX_ATTEMPTS} polls"
         )
 
-    @staticmethod
     async def _collect_images(
+        self,
         data: dict[str, Any],
     ) -> list[str]:
         images: list[str] = []
@@ -2057,7 +2082,9 @@ class ModelScopeImageGenerationClient(ImageGenerationProvider):
                 if url.startswith("data:image/"):
                     images.append(url)
                 else:
-                    images.append(await _download_image_data_url(url))
+                    images.append(
+                        await _download_image_data_url(url, proxy=self.proxy)
+                    )
         return images
 
 

--- a/nanobot/providers/image_generation.py
+++ b/nanobot/providers/image_generation.py
@@ -161,7 +161,10 @@ async def _download_image_data_url(
             current_url = url
             for _ in range(_IMAGE_DOWNLOAD_MAX_REDIRECTS + 1):
                 if proxy:
-                    ok, error, _ = resolve_url_target(current_url)
+                    ok, error, _ = resolve_url_target(
+                        current_url,
+                        trust_remote_dns=True,
+                    )
                     if not ok:
                         raise ImageGenerationError(
                             f"blocked unsafe generated image URL: {error}"

--- a/nanobot/providers/image_generation.py
+++ b/nanobot/providers/image_generation.py
@@ -10,11 +10,13 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib.parse import urljoin
 
 import httpx
 from loguru import logger
 
 from nanobot.providers.registry import find_by_name
+from nanobot.security.network import PinnedDNSAsyncTransport, UnsafeURLRequestError
 from nanobot.utils.helpers import detect_image_mime
 
 _OPENROUTER_ATTRIBUTION_HEADERS = {
@@ -23,6 +25,8 @@ _OPENROUTER_ATTRIBUTION_HEADERS = {
     "X-OpenRouter-Categories": "cli-agent,personal-agent",
 }
 _DEFAULT_TIMEOUT_S = 120.0
+_IMAGE_DOWNLOAD_MAX_BYTES = 32 * 1024 * 1024
+_IMAGE_DOWNLOAD_MAX_REDIRECTS = 5
 _AIHUBMIX_TIMEOUT_S = 300.0
 _AIHUBMIX_ASPECT_RATIO_SIZES = {
     "1:1": "1024x1024",
@@ -131,16 +135,66 @@ def _aihubmix_model_path(model: str) -> str:
 
 
 async def _download_image_data_url(
-    client: httpx.AsyncClient,
     url: str,
+    *,
+    transport: httpx.AsyncBaseTransport | None = None,
 ) -> str:
-    response = await client.get(url)
     try:
-        response.raise_for_status()
-    except httpx.HTTPStatusError as exc:
-        detail = response.text[:500]
-        raise ImageGenerationError(f"failed to download generated image: {detail}") from exc
-    raw = response.content
+        safe_transport = PinnedDNSAsyncTransport(inner=transport)
+        # Proxies resolve the target independently and would defeat DNS pinning.
+        async with httpx.AsyncClient(
+            transport=safe_transport,
+            follow_redirects=False,
+            timeout=_DEFAULT_TIMEOUT_S,
+            trust_env=False,
+        ) as client:
+            current_url = url
+            for _ in range(_IMAGE_DOWNLOAD_MAX_REDIRECTS + 1):
+                async with client.stream("GET", current_url) as response:
+                    if response.is_redirect:
+                        location = response.headers.get("location")
+                        if not location:
+                            raise ImageGenerationError(
+                                "generated image URL redirected without a location"
+                            )
+                        current_url = urljoin(str(response.url), location)
+                        continue
+
+                    try:
+                        response.raise_for_status()
+                    except httpx.HTTPStatusError as exc:
+                        raise ImageGenerationError(
+                            f"failed to download generated image (HTTP {response.status_code})"
+                        ) from exc
+
+                    declared_size = response.headers.get("content-length")
+                    if declared_size:
+                        try:
+                            if int(declared_size) > _IMAGE_DOWNLOAD_MAX_BYTES:
+                                raise ImageGenerationError(
+                                    "generated image exceeded the 32 MiB download limit"
+                                )
+                        except ValueError:
+                            pass
+
+                    chunks: list[bytes] = []
+                    total = 0
+                    async for chunk in response.aiter_bytes():
+                        total += len(chunk)
+                        if total > _IMAGE_DOWNLOAD_MAX_BYTES:
+                            raise ImageGenerationError(
+                                "generated image exceeded the 32 MiB download limit"
+                            )
+                        chunks.append(chunk)
+                    raw = b"".join(chunks)
+                    break
+            else:
+                raise ImageGenerationError("generated image URL exceeded the redirect limit")
+    except UnsafeURLRequestError as exc:
+        raise ImageGenerationError(f"blocked unsafe generated image URL: {exc}") from exc
+    except httpx.RequestError as exc:
+        raise ImageGenerationError(f"failed to download generated image: {exc}") from exc
+
     mime = detect_image_mime(raw)
     if mime is None:
         raise ImageGenerationError("generated image URL did not return a supported image")
@@ -452,7 +506,7 @@ class AIHubMixImageGenerationClient(ImageGenerationProvider):
             raise ImageGenerationError(f"AIHubMix image generation failed: {detail}") from exc
 
         payload = response.json()
-        images = await _aihubmix_images_from_payload(client, payload)
+        images = await _aihubmix_images_from_payload(payload)
 
         self._require_images(images, payload)
 
@@ -827,7 +881,6 @@ def _gemini_flash_supported_image_sizes(model: str) -> set[str]:
 
 
 async def _aihubmix_images_from_payload(
-    client: httpx.AsyncClient,
     payload: dict[str, Any],
 ) -> list[str]:
     images: list[str] = []
@@ -846,7 +899,7 @@ async def _aihubmix_images_from_payload(
             if value.startswith("data:image/"):
                 images.append(value)
             elif value.startswith(("http://", "https://")):
-                images.append(await _download_image_data_url(client, value))
+                images.append(await _download_image_data_url(value))
             return
         if not isinstance(value, dict):
             return
@@ -1047,15 +1100,7 @@ class OpenAIImageGenerationClient(ImageGenerationProvider):
         return model
 
     async def _parse_images_response(self, payload: dict[str, Any]) -> list[str]:
-        client = self._client
-        owns_client = client is None
-        if owns_client:
-            client = httpx.AsyncClient(timeout=self.timeout)
-        try:
-            return await _openai_images_from_payload(client, payload)
-        finally:
-            if owns_client:
-                await client.aclose()
+        return await _openai_images_from_payload(payload)
 
     async def _post_image_edit(
         self,
@@ -1266,15 +1311,7 @@ class CustomImageGenerationClient(ImageGenerationProvider):
         logger.info("Custom Images API response ({}): {}", response.status_code,
                        {k: v for k, v in payload.items() if k != "data"})
 
-        client = self._client
-        owns_client = client is None
-        if owns_client:
-            client = httpx.AsyncClient(timeout=self.timeout)
-        try:
-            images = await _openai_images_from_payload(client, payload)
-        finally:
-            if owns_client:
-                await client.aclose()
+        images = await _openai_images_from_payload(payload)
 
         self._require_images(images, payload)
 
@@ -1467,7 +1504,6 @@ def _openai_explicit_size_supported(
 
 
 async def _openai_images_from_payload(
-    client: httpx.AsyncClient,
     payload: dict[str, Any],
 ) -> list[str]:
     """Extract images from OpenAI Images API response.
@@ -1484,7 +1520,7 @@ async def _openai_images_from_payload(
             continue
         url = item.get("url")
         if isinstance(url, str) and url:
-            images.append(await _download_image_data_url(client, url))
+            images.append(await _download_image_data_url(url))
     return images
 
 
@@ -1798,7 +1834,7 @@ class ZhipuImageGenerationClient(ImageGenerationProvider):
             raise ImageGenerationError(f"Zhipu image generation failed: {detail}") from exc
 
         payload = response.json()
-        images = await _zhipu_images_from_payload(client, payload)
+        images = await _zhipu_images_from_payload(payload)
 
         self._require_images(images, payload)
 
@@ -1822,7 +1858,6 @@ def _zhipu_size(
 
 
 async def _zhipu_images_from_payload(
-    client: httpx.AsyncClient,
     payload: dict[str, Any],
 ) -> list[str]:
     """Extract image data URLs from Zhipu API response.
@@ -1836,7 +1871,7 @@ async def _zhipu_images_from_payload(
             continue
         url = item.get("url")
         if isinstance(url, str) and url:
-            images.append(await _download_image_data_url(client, url))
+            images.append(await _download_image_data_url(url))
     return images
 
 
@@ -1999,7 +2034,7 @@ class ModelScopeImageGenerationClient(ImageGenerationProvider):
             status = data.get("task_status")
 
             if status == "SUCCEED":
-                return await self._collect_images(client, data)
+                return await self._collect_images(data)
             if status == "FAILED":
                 raise ImageGenerationError(
                     f"ModelScope image generation task failed: {data}"
@@ -2014,7 +2049,6 @@ class ModelScopeImageGenerationClient(ImageGenerationProvider):
 
     @staticmethod
     async def _collect_images(
-        client: httpx.AsyncClient,
         data: dict[str, Any],
     ) -> list[str]:
         images: list[str] = []
@@ -2023,7 +2057,7 @@ class ModelScopeImageGenerationClient(ImageGenerationProvider):
                 if url.startswith("data:image/"):
                     images.append(url)
                 else:
-                    images.append(await _download_image_data_url(client, url))
+                    images.append(await _download_image_data_url(url))
         return images
 
 

--- a/nanobot/security/network.py
+++ b/nanobot/security/network.py
@@ -20,6 +20,7 @@ _BLOCKED_NETWORKS = [
     ipaddress.ip_network("169.254.0.0/16"),   # link-local / cloud metadata
     ipaddress.ip_network("172.16.0.0/12"),
     ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("::/128"),            # unspecified; may route to local host
     ipaddress.ip_network("::1/128"),
     ipaddress.ip_network("fc00::/7"),          # unique local
     ipaddress.ip_network("fe80::/10"),         # link-local v6

--- a/nanobot/security/network.py
+++ b/nanobot/security/network.py
@@ -74,7 +74,12 @@ def _is_private(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     return any(normalized in net for net in _BLOCKED_NETWORKS)
 
 
-def resolve_url_target(url: str, *, allow_loopback: bool = False) -> tuple[bool, str, tuple[str, ...]]:
+def resolve_url_target(
+    url: str,
+    *,
+    allow_loopback: bool = False,
+    trust_remote_dns: bool = False,
+) -> tuple[bool, str, tuple[str, ...]]:
     """Validate a URL is safe to fetch: scheme, hostname, and resolved IPs.
 
     ``allow_loopback`` is intentionally narrow: it only permits literal
@@ -82,8 +87,14 @@ def resolve_url_target(url: str, *, allow_loopback: bool = False) -> tuple[bool,
     loopback. It does not allow RFC1918, link-local, metadata, or public DNS
     names that happen to resolve to loopback.
 
+    ``trust_remote_dns`` accepts ordinary hostnames unavailable to local DNS.
+    This is only safe when a user-configured trusted proxy owns final DNS
+    resolution and network egress. Localhost names and private/internal IP
+    literals remain blocked.
+
     Returns (ok, error_message, resolved_ips).  When ok is True,
-    resolved_ips contains the public IPs that were validated for this URL.
+    resolved_ips contains the public IPs that were validated for this URL, or
+    is empty when an unresolved hostname is delegated to a trusted proxy.
     """
     try:
         p = urlparse(url)
@@ -102,7 +113,20 @@ def resolve_url_target(url: str, *, allow_loopback: bool = False) -> tuple[bool,
     try:
         infos = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
     except socket.gaierror:
-        return False, f"Cannot resolve hostname: {hostname}", ()
+        if not trust_remote_dns:
+            return False, f"Cannot resolve hostname: {hostname}", ()
+
+        normalized_hostname = hostname.rstrip(".").lower()
+        if normalized_hostname == "localhost" or normalized_hostname.endswith(".localhost"):
+            return False, f"Blocked local/internal hostname: {hostname}", ()
+
+        try:
+            literal_addr = ipaddress.ip_address(normalized_hostname)
+        except ValueError:
+            return True, "", ()
+        if _is_private(literal_addr):
+            return False, f"Blocked private/internal address: {literal_addr}", ()
+        return True, "", (str(_normalize_addr(literal_addr)),)
 
     addrs: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
     for info in infos:

--- a/tests/providers/test_image_generation.py
+++ b/tests/providers/test_image_generation.py
@@ -103,19 +103,19 @@ class CodexStreamingCompleteThenErrorResponse(FakeResponse):
 
 
 @pytest.fixture(autouse=True)
-def generated_image_downloads(monkeypatch) -> list[str]:
+def generated_image_downloads(monkeypatch) -> list[tuple[str, str | None]]:
     """Keep provider response parsing tests independent from outbound HTTP."""
-    urls: list[str] = []
+    downloads: list[tuple[str, str | None]] = []
 
-    async def download(url: str) -> str:
-        urls.append(url)
+    async def download(url: str, *, proxy: str | None = None) -> str:
+        downloads.append((url, proxy))
         return PNG_DATA_URL
 
     monkeypatch.setattr(
         "nanobot.providers.image_generation._download_image_data_url",
         download,
     )
-    return urls
+    return downloads
 
 
 @pytest.mark.asyncio
@@ -294,19 +294,21 @@ async def test_aihubmix_image_edit_payload_uses_reference_images(tmp_path: Path)
 
 @pytest.mark.asyncio
 async def test_aihubmix_image_generation_downloads_url_response(
-    generated_image_downloads: list[str],
+    generated_image_downloads: list[tuple[str, str | None]],
 ) -> None:
     fake = FakeClient(FakeResponse({"data": [{"url": "https://cdn.example/image.png"}]}))
     fake.get_response = FakeResponse({}, content=PNG_BYTES)
+    proxy = "http://127.0.0.1:23458"
     client = AIHubMixImageGenerationClient(
         api_key="sk-ahm-test",
+        proxy=proxy,
         client=fake,  # type: ignore[arg-type]
     )
 
     response = await client.generate(prompt="draw", model="gpt-image-2-free")
 
     assert response.images[0].startswith("data:image/png;base64,")
-    assert generated_image_downloads == ["https://cdn.example/image.png"]
+    assert generated_image_downloads == [("https://cdn.example/image.png", proxy)]
 
 
 @pytest.mark.asyncio
@@ -836,18 +838,22 @@ async def test_openai_b64_json_response_uses_detected_mime() -> None:
 
 
 @pytest.mark.asyncio
-async def test_openai_url_download_fallback(generated_image_downloads: list[str]) -> None:
+async def test_openai_url_download_fallback(
+    generated_image_downloads: list[tuple[str, str | None]],
+) -> None:
     fake = FakeClient(FakeResponse({"data": [{"url": "https://cdn.example/image.png"}]}))
     fake.get_response = FakeResponse({}, content=PNG_BYTES)
+    proxy = "http://127.0.0.1:23458"
     client = OpenAIImageGenerationClient(
         api_key="sk-openai-test",
+        proxy=proxy,
         client=fake,  # type: ignore[arg-type]
     )
 
     response = await client.generate(prompt="draw", model="dall-e-3")
 
     assert response.images[0].startswith("data:image/png;base64,")
-    assert generated_image_downloads == ["https://cdn.example/image.png"]
+    assert generated_image_downloads == [("https://cdn.example/image.png", proxy)]
 
 
 @pytest.mark.asyncio
@@ -1211,14 +1217,16 @@ async def test_custom_generate_maps_one_k_to_openai_dimension() -> None:
 
 @pytest.mark.asyncio
 async def test_custom_generate_extra_body_can_override_defaults(
-    generated_image_downloads: list[str],
+    generated_image_downloads: list[tuple[str, str | None]],
 ) -> None:
     fake = FakeClient(FakeResponse({"data": [{"url": "https://images.example/cat.png"}]}))
     fake.get_response = FakeResponse({}, content=PNG_BYTES)
+    proxy = "http://127.0.0.1:23458"
     client = CustomImageGenerationClient(
         api_key="sk-custom-test",
         api_base="https://custom.example/v1",
         extra_body={"response_format": "url", "size": "2K"},
+        proxy=proxy,
         client=fake,  # type: ignore[arg-type]
     )
 
@@ -1229,7 +1237,7 @@ async def test_custom_generate_extra_body_can_override_defaults(
     )
 
     assert response.images == [PNG_DATA_URL]
-    assert generated_image_downloads == ["https://images.example/cat.png"]
+    assert generated_image_downloads == [("https://images.example/cat.png", proxy)]
     body = fake.calls[0]["json"]
     assert body["response_format"] == "url"
     assert body["size"] == "2K"
@@ -1636,19 +1644,21 @@ async def test_zhipu_image_generation_with_explicit_size() -> None:
 
 @pytest.mark.asyncio
 async def test_zhipu_image_generation_downloads_url_response(
-    generated_image_downloads: list[str],
+    generated_image_downloads: list[tuple[str, str | None]],
 ) -> None:
     fake = FakeClient(FakeResponse({"data": [{"url": "https://cdn.example/image.png"}]}))
     fake.get_response = FakeResponse({}, content=PNG_BYTES)
+    proxy = "http://127.0.0.1:23458"
     client = ZhipuImageGenerationClient(
         api_key="sk-zhipu-test",
+        proxy=proxy,
         client=fake,  # type: ignore[arg-type]
     )
 
     response = await client.generate(prompt="draw", model="glm-image")
 
     assert response.images[0].startswith("data:image/png;base64,")
-    assert generated_image_downloads == ["https://cdn.example/image.png"]
+    assert generated_image_downloads == [("https://cdn.example/image.png", proxy)]
 
 
 @pytest.mark.asyncio
@@ -1728,7 +1738,9 @@ def _modelscope_fast_poll(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_modelscope_image_generation_submit_and_poll() -> None:
+async def test_modelscope_image_generation_submit_and_poll(
+    generated_image_downloads: list[tuple[str, str | None]],
+) -> None:
     submit = FakeResponse({"task_id": "abc123"})
     poll_responses = [
         FakeResponse({"task_status": "PENDING"}),
@@ -1738,9 +1750,11 @@ async def test_modelscope_image_generation_submit_and_poll() -> None:
         }),
     ]
     fake = ModelScopeFakeClient(submit, poll_responses)
+    proxy = "http://127.0.0.1:23458"
     client = ModelScopeImageGenerationClient(
         api_key="ms-token",
         api_base="https://api-inference.modelscope.cn/v1",
+        proxy=proxy,
         client=fake,  # type: ignore[arg-type]
     )
 
@@ -1750,6 +1764,7 @@ async def test_modelscope_image_generation_submit_and_poll() -> None:
     )
 
     assert response.images[0].startswith("data:image/png;base64,")
+    assert generated_image_downloads == [("https://cdn.example/image.png", proxy)]
 
     # Verify POST request
     post_call = fake.calls[0]
@@ -1919,3 +1934,18 @@ async def test_modelscope_image_generation_poll_timeout(monkeypatch) -> None:
 
     # Should have polled up to the (patched) attempt limit.
     assert len(fake.get_calls) == 3
+
+
+
+def test_image_provider_http_client_kwargs_include_explicit_proxy() -> None:
+    proxy = "http://127.0.0.1:23458"
+    client = AIHubMixImageGenerationClient(
+        api_key="sk-ahm-test",
+        proxy=proxy,
+    )
+
+    assert client._http_client_kwargs() == {
+        "timeout": client.timeout,
+        "proxy": proxy,
+        "trust_env": False,
+    }

--- a/tests/providers/test_image_generation.py
+++ b/tests/providers/test_image_generation.py
@@ -102,6 +102,22 @@ class CodexStreamingCompleteThenErrorResponse(FakeResponse):
         )
 
 
+@pytest.fixture(autouse=True)
+def generated_image_downloads(monkeypatch) -> list[str]:
+    """Keep provider response parsing tests independent from outbound HTTP."""
+    urls: list[str] = []
+
+    async def download(url: str) -> str:
+        urls.append(url)
+        return PNG_DATA_URL
+
+    monkeypatch.setattr(
+        "nanobot.providers.image_generation._download_image_data_url",
+        download,
+    )
+    return urls
+
+
 @pytest.mark.asyncio
 async def test_openrouter_image_generation_payload_and_response(tmp_path: Path) -> None:
     ref = tmp_path / "ref.png"
@@ -277,7 +293,9 @@ async def test_aihubmix_image_edit_payload_uses_reference_images(tmp_path: Path)
 
 
 @pytest.mark.asyncio
-async def test_aihubmix_image_generation_downloads_url_response() -> None:
+async def test_aihubmix_image_generation_downloads_url_response(
+    generated_image_downloads: list[str],
+) -> None:
     fake = FakeClient(FakeResponse({"data": [{"url": "https://cdn.example/image.png"}]}))
     fake.get_response = FakeResponse({}, content=PNG_BYTES)
     client = AIHubMixImageGenerationClient(
@@ -288,7 +306,7 @@ async def test_aihubmix_image_generation_downloads_url_response() -> None:
     response = await client.generate(prompt="draw", model="gpt-image-2-free")
 
     assert response.images[0].startswith("data:image/png;base64,")
-    assert fake.get_calls[0]["url"] == "https://cdn.example/image.png"
+    assert generated_image_downloads == ["https://cdn.example/image.png"]
 
 
 @pytest.mark.asyncio
@@ -818,7 +836,7 @@ async def test_openai_b64_json_response_uses_detected_mime() -> None:
 
 
 @pytest.mark.asyncio
-async def test_openai_url_download_fallback() -> None:
+async def test_openai_url_download_fallback(generated_image_downloads: list[str]) -> None:
     fake = FakeClient(FakeResponse({"data": [{"url": "https://cdn.example/image.png"}]}))
     fake.get_response = FakeResponse({}, content=PNG_BYTES)
     client = OpenAIImageGenerationClient(
@@ -829,7 +847,7 @@ async def test_openai_url_download_fallback() -> None:
     response = await client.generate(prompt="draw", model="dall-e-3")
 
     assert response.images[0].startswith("data:image/png;base64,")
-    assert fake.get_calls[0]["url"] == "https://cdn.example/image.png"
+    assert generated_image_downloads == ["https://cdn.example/image.png"]
 
 
 @pytest.mark.asyncio
@@ -1192,7 +1210,9 @@ async def test_custom_generate_maps_one_k_to_openai_dimension() -> None:
 
 
 @pytest.mark.asyncio
-async def test_custom_generate_extra_body_can_override_defaults() -> None:
+async def test_custom_generate_extra_body_can_override_defaults(
+    generated_image_downloads: list[str],
+) -> None:
     fake = FakeClient(FakeResponse({"data": [{"url": "https://images.example/cat.png"}]}))
     fake.get_response = FakeResponse({}, content=PNG_BYTES)
     client = CustomImageGenerationClient(
@@ -1208,9 +1228,8 @@ async def test_custom_generate_extra_body_can_override_defaults() -> None:
         image_size="1K",
     )
 
-    expected_data_url = f"data:image/png;base64,{base64.b64encode(PNG_BYTES).decode('ascii')}"
-    assert response.images == [expected_data_url]
-    assert fake.get_calls[0]["url"] == "https://images.example/cat.png"
+    assert response.images == [PNG_DATA_URL]
+    assert generated_image_downloads == ["https://images.example/cat.png"]
     body = fake.calls[0]["json"]
     assert body["response_format"] == "url"
     assert body["size"] == "2K"
@@ -1616,7 +1635,9 @@ async def test_zhipu_image_generation_with_explicit_size() -> None:
 
 
 @pytest.mark.asyncio
-async def test_zhipu_image_generation_downloads_url_response() -> None:
+async def test_zhipu_image_generation_downloads_url_response(
+    generated_image_downloads: list[str],
+) -> None:
     fake = FakeClient(FakeResponse({"data": [{"url": "https://cdn.example/image.png"}]}))
     fake.get_response = FakeResponse({}, content=PNG_BYTES)
     client = ZhipuImageGenerationClient(
@@ -1627,7 +1648,7 @@ async def test_zhipu_image_generation_downloads_url_response() -> None:
     response = await client.generate(prompt="draw", model="glm-image")
 
     assert response.images[0].startswith("data:image/png;base64,")
-    assert fake.get_calls[0]["url"] == "https://cdn.example/image.png"
+    assert generated_image_downloads == ["https://cdn.example/image.png"]
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_image_generation_security.py
+++ b/tests/providers/test_image_generation_security.py
@@ -139,13 +139,13 @@ class _StreamContext:
 
 
 @pytest.mark.asyncio
-async def test_generated_image_download_uses_explicit_provider_proxy(
+async def test_generated_image_download_delegates_unresolved_host_to_provider_proxy(
     monkeypatch,
 ) -> None:
-    monkeypatch.setattr(
-        "nanobot.security.network.socket.getaddrinfo",
-        _resolve_public,
-    )
+    def fail_local_dns(host: str, port: int | None, *args, **kwargs):
+        raise socket.gaierror(f"cannot resolve {host}")
+
+    monkeypatch.setattr("nanobot.security.network.socket.getaddrinfo", fail_local_dns)
     captured: dict[str, object] = {}
 
     class FakeAsyncClient:
@@ -167,12 +167,12 @@ async def test_generated_image_download_uses_explicit_provider_proxy(
     proxy = "http://127.0.0.1:23458"
 
     result = await _download_image_data_url(
-        "https://cdn.example/image.png",
+        "https://proxy-only.example/image.png",
         proxy=proxy,
     )
 
     assert result.startswith("data:image/png;base64,")
-    assert captured["request"] == ("GET", "https://cdn.example/image.png")
+    assert captured["request"] == ("GET", "https://proxy-only.example/image.png")
     assert captured["kwargs"] == {
         "follow_redirects": False,
         "timeout": image_generation._DEFAULT_TIMEOUT_S,

--- a/tests/providers/test_image_generation_security.py
+++ b/tests/providers/test_image_generation_security.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import socket
+
+import httpx
+import pytest
+
+from nanobot.providers import image_generation
+from nanobot.providers.image_generation import ImageGenerationError, _download_image_data_url
+
+PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+    b"\x00\x00\x00\x01\x08\x04\x00\x00\x00\xb5\x1c\x0c\x02"
+    b"\x00\x00\x00\x0bIDATx\xdacd\xfc\xff\x1f\x00\x03\x03"
+    b"\x02\x00\xef\xbf\xa7\xdb\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+def _resolve_public(host: str, port: int | None, *args, **kwargs):
+    return [
+        (
+            socket.AF_INET,
+            socket.SOCK_STREAM,
+            socket.IPPROTO_TCP,
+            "",
+            ("93.184.216.34", port or 0),
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_generated_image_download_blocks_private_target() -> None:
+    requested = False
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal requested
+        requested = True
+        return httpx.Response(200, content=PNG_BYTES)
+
+    with pytest.raises(ImageGenerationError, match="blocked unsafe generated image URL"):
+        await _download_image_data_url(
+            "http://127.0.0.1/admin",
+            transport=httpx.MockTransport(handler),
+        )
+
+    assert requested is False
+
+
+@pytest.mark.asyncio
+async def test_generated_image_download_revalidates_redirects(monkeypatch) -> None:
+    original_getaddrinfo = socket.getaddrinfo
+
+    def resolve_test_hosts(host: str, port: int | None, *args, **kwargs):
+        if host == "cdn.example":
+            return _resolve_public(host, port, *args, **kwargs)
+        return original_getaddrinfo(host, port, *args, **kwargs)
+
+    monkeypatch.setattr("nanobot.security.network.socket.getaddrinfo", resolve_test_hosts)
+    requested: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requested.append(str(request.url))
+        return httpx.Response(302, headers={"location": "http://169.254.169.254/latest"})
+
+    with pytest.raises(ImageGenerationError, match="blocked unsafe generated image URL"):
+        await _download_image_data_url(
+            "https://cdn.example/image.png",
+            transport=httpx.MockTransport(handler),
+        )
+
+    assert requested == ["https://cdn.example/image.png"]
+
+
+@pytest.mark.asyncio
+async def test_generated_image_download_returns_valid_data_url(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "nanobot.security.network.socket.getaddrinfo",
+        _resolve_public,
+    )
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=PNG_BYTES)
+
+    result = await _download_image_data_url(
+        "https://cdn.example/image.png",
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert result.startswith("data:image/png;base64,")
+
+
+class _OversizedStream(httpx.AsyncByteStream):
+    async def __aiter__(self):
+        yield b"12345"
+        yield b"6789"
+
+
+@pytest.mark.asyncio
+async def test_generated_image_download_enforces_streaming_size_limit(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "nanobot.security.network.socket.getaddrinfo",
+        _resolve_public,
+    )
+    monkeypatch.setattr(image_generation, "_IMAGE_DOWNLOAD_MAX_BYTES", 8)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=_OversizedStream())
+
+    with pytest.raises(ImageGenerationError, match="download limit"):
+        await _download_image_data_url(
+            "https://cdn.example/image.png",
+            transport=httpx.MockTransport(handler),
+        )

--- a/tests/providers/test_image_generation_security.py
+++ b/tests/providers/test_image_generation_security.py
@@ -33,8 +33,16 @@ def _resolve_public(host: str, port: int | None, *args, **kwargs):
     ["http://127.0.0.1/admin", "http://[::]/admin"],
     ids=["ipv4-loopback", "ipv6-unspecified"],
 )
+@pytest.mark.parametrize(
+    "proxy",
+    [None, "http://127.0.0.1:23458"],
+    ids=["direct", "explicit-proxy"],
+)
 @pytest.mark.asyncio
-async def test_generated_image_download_blocks_unsafe_target(url: str) -> None:
+async def test_generated_image_download_blocks_unsafe_target(
+    url: str,
+    proxy: str | None,
+) -> None:
     requested = False
 
     async def handler(request: httpx.Request) -> httpx.Response:
@@ -45,6 +53,7 @@ async def test_generated_image_download_blocks_unsafe_target(url: str) -> None:
     with pytest.raises(ImageGenerationError, match="blocked unsafe generated image URL"):
         await _download_image_data_url(
             url,
+            proxy=proxy,
             transport=httpx.MockTransport(handler),
         )
 
@@ -116,3 +125,103 @@ async def test_generated_image_download_enforces_streaming_size_limit(monkeypatc
             "https://cdn.example/image.png",
             transport=httpx.MockTransport(handler),
         )
+
+
+class _StreamContext:
+    def __init__(self, response: httpx.Response) -> None:
+        self.response = response
+
+    async def __aenter__(self) -> httpx.Response:
+        return self.response
+
+    async def __aexit__(self, exc_type, exc, traceback) -> None:
+        await self.response.aclose()
+
+
+@pytest.mark.asyncio
+async def test_generated_image_download_uses_explicit_provider_proxy(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "nanobot.security.network.socket.getaddrinfo",
+        _resolve_public,
+    )
+    captured: dict[str, object] = {}
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs) -> None:
+            captured["kwargs"] = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback) -> None:
+            return None
+
+        def stream(self, method: str, url: str) -> _StreamContext:
+            captured["request"] = (method, url)
+            request = httpx.Request(method, url)
+            return _StreamContext(httpx.Response(200, content=PNG_BYTES, request=request))
+
+    monkeypatch.setattr(image_generation.httpx, "AsyncClient", FakeAsyncClient)
+    proxy = "http://127.0.0.1:23458"
+
+    result = await _download_image_data_url(
+        "https://cdn.example/image.png",
+        proxy=proxy,
+    )
+
+    assert result.startswith("data:image/png;base64,")
+    assert captured["request"] == ("GET", "https://cdn.example/image.png")
+    assert captured["kwargs"] == {
+        "follow_redirects": False,
+        "timeout": image_generation._DEFAULT_TIMEOUT_S,
+        "trust_env": False,
+        "proxy": proxy,
+    }
+
+
+@pytest.mark.asyncio
+async def test_proxied_generated_image_download_revalidates_redirects(
+    monkeypatch,
+) -> None:
+    original_getaddrinfo = socket.getaddrinfo
+
+    def resolve_test_hosts(host: str, port: int | None, *args, **kwargs):
+        if host == "cdn.example":
+            return _resolve_public(host, port, *args, **kwargs)
+        return original_getaddrinfo(host, port, *args, **kwargs)
+
+    monkeypatch.setattr("nanobot.security.network.socket.getaddrinfo", resolve_test_hosts)
+    requested: list[str] = []
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback) -> None:
+            return None
+
+        def stream(self, method: str, url: str) -> _StreamContext:
+            requested.append(url)
+            request = httpx.Request(method, url)
+            return _StreamContext(
+                httpx.Response(
+                    302,
+                    headers={"location": "http://169.254.169.254/latest"},
+                    request=request,
+                )
+            )
+
+    monkeypatch.setattr(image_generation.httpx, "AsyncClient", FakeAsyncClient)
+
+    with pytest.raises(ImageGenerationError, match="blocked unsafe generated image URL"):
+        await _download_image_data_url(
+            "https://cdn.example/image.png",
+            proxy="http://127.0.0.1:23458",
+        )
+
+    assert requested == ["https://cdn.example/image.png"]

--- a/tests/providers/test_image_generation_security.py
+++ b/tests/providers/test_image_generation_security.py
@@ -28,8 +28,13 @@ def _resolve_public(host: str, port: int | None, *args, **kwargs):
     ]
 
 
+@pytest.mark.parametrize(
+    "url",
+    ["http://127.0.0.1/admin", "http://[::]/admin"],
+    ids=["ipv4-loopback", "ipv6-unspecified"],
+)
 @pytest.mark.asyncio
-async def test_generated_image_download_blocks_private_target() -> None:
+async def test_generated_image_download_blocks_unsafe_target(url: str) -> None:
     requested = False
 
     async def handler(request: httpx.Request) -> httpx.Response:
@@ -39,7 +44,7 @@ async def test_generated_image_download_blocks_private_target() -> None:
 
     with pytest.raises(ImageGenerationError, match="blocked unsafe generated image URL"):
         await _download_image_data_url(
-            "http://127.0.0.1/admin",
+            url,
             transport=httpx.MockTransport(handler),
         )
 

--- a/tests/security/test_security_network.py
+++ b/tests/security/test_security_network.py
@@ -195,6 +195,47 @@ def test_resolve_url_target_returns_validated_public_ips():
     assert resolved_ips == ("93.184.216.34",)
 
 
+@pytest.mark.parametrize(
+    ("trust_remote_dns", "expected_ok"),
+    [(False, False), (True, True)],
+)
+def test_resolve_url_target_only_delegates_dns_to_trusted_proxy(
+    trust_remote_dns: bool,
+    expected_ok: bool,
+):
+    with patch(
+        "nanobot.security.network.socket.getaddrinfo",
+        side_effect=socket.gaierror("local DNS unavailable"),
+    ):
+        ok, err, resolved_ips = resolve_url_target(
+            "https://proxy-only.example/image.png",
+            trust_remote_dns=trust_remote_dns,
+        )
+
+    assert ok is expected_ok, err
+    assert resolved_ips == ()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost/secret",
+        "http://service.localhost/secret",
+        "http://127.0.0.1/secret",
+        "http://169.254.169.254/latest",
+        "http://[::1]/secret",
+    ],
+)
+def test_resolve_url_target_does_not_delegate_local_targets(url: str):
+    with patch(
+        "nanobot.security.network.socket.getaddrinfo",
+        side_effect=socket.gaierror("local DNS unavailable"),
+    ):
+        ok, _, _ = resolve_url_target(url, trust_remote_dns=True)
+
+    assert not ok
+
+
 def test_pin_resolved_url_dns_prevents_second_resolution_rebind():
     def _rebinding_resolver(hostname, port, family=0, type_=0):
         return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("169.254.169.254", 0))]

--- a/tests/security/test_security_network.py
+++ b/tests/security/test_security_network.py
@@ -148,6 +148,7 @@ def test_blocks_sampled_addresses_from_internal_networks():
         "169.254.0.0/16",
         "172.16.0.0/12",
         "192.168.0.0/16",
+        "::/128",
         "::1/128",
         "fc00::/7",
         "fe80::/10",


### PR DESCRIPTION
## Summary

- fetch provider-returned image URLs through a restricted downloader
- validate every redirect hop and reject loopback, private, link-local, CGNAT, metadata, and IPv6 unspecified targets
- pin DNS for direct downloads, stream with a 32 MiB cap, and verify the returned image bytes
- preserve explicitly configured provider proxies for provider requests and returned image downloads

## Security boundary

Direct downloads use the existing DNS-pinning SSRF transport. Process-wide proxy environment variables are ignored so independent proxy DNS resolution cannot bypass the pinned target.

An explicit `providers.<name>.proxy` is treated as a user-selected trusted egress boundary. Proxied downloads still reject malformed URLs and locally identifiable private/internal targets on the initial URL and every redirect; the configured proxy owns final DNS resolution and egress policy. Explicit `tools.ssrfWhitelist` entries remain honored by the shared network guard.

## Validation

- focused network, provider, and image-tool suites (`161 passed`)
- `python -m ruff check` on the changed source and test files
- `git diff --check`
- full GitHub Test Suite required on the current head before merge

Includes the provider-proxy follow-up from #5101 by @chengyongru.
