### PR TITLE
fix(memory): preserve unprocessed dream history

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -433,13 +433,33 @@ class MemoryStore:
         ]
 
     def compact_history(self) -> None:
-        """Drop oldest entries if the file exceeds *max_history_entries*."""
+        """Drop oldest processed entries without discarding pending Dream input."""
         if self.max_history_entries <= 0:
             return
         entries = self._read_entries()
         if len(entries) <= self.max_history_entries:
             return
-        kept = entries[-self.max_history_entries:]
+        last_dream_cursor = self.get_last_dream_cursor()
+        first_unprocessed = next(
+            (
+                index
+                for index, entry in enumerate(entries)
+                if (
+                    (cursor := self._valid_cursor(entry.get("cursor"))) is not None
+                    and cursor > last_dream_cursor
+                )
+            ),
+            len(entries),
+        )
+        keep_from = min(len(entries) - self.max_history_entries, first_unprocessed)
+        kept = entries[keep_from:]
+        if len(kept) > self.max_history_entries:
+            logger.warning(
+                "History compaction retained {} unprocessed entries beyond the configured "
+                "limit of {}",
+                len(kept),
+                self.max_history_entries,
+            )
         self._write_entries(kept)
 
     # -- JSONL helpers -------------------------------------------------------

--- a/tests/agent/test_memory_store.py
+++ b/tests/agent/test_memory_store.py
@@ -235,10 +235,22 @@ class TestHistoryWithCursor:
         store.append_history("event 3")
         store.append_history("event 4")
         store.append_history("event 5")
+        store.set_last_dream_cursor(5)
         store.compact_history()
         entries = store.read_unprocessed_history(since_cursor=0)
         assert len(entries) == 2
         assert entries[0]["cursor"] in {4, 5}
+
+    def test_compact_history_preserves_entries_after_dream_cursor(self, tmp_path):
+        store = MemoryStore(tmp_path, max_history_entries=50)
+        for index in range(1, 101):
+            store.append_history(f"event {index}")
+        store.set_last_dream_cursor(20)
+
+        store.compact_history()
+
+        entries = store.read_unprocessed_history(since_cursor=0)
+        assert [entry["cursor"] for entry in entries] == list(range(21, 101))
 
     def test_write_entries_uses_atomic_write(self, tmp_path):
         """_write_entries uses temp file + os.replace for atomicity."""


### PR DESCRIPTION
## Summary

- protect history entries newer than the Dream cursor during compaction
- retain the configured tail limit when all older entries have already been processed
- warn when protecting pending Dream input requires retaining more than the configured limit
- add the cursor 20 / history 100 / limit 50 regression case from the issue

## Root cause

`MemoryStore.compact_history()` previously retained only the newest `max_history_entries` records. Both manual and scheduled Dream paths call compaction from `finally`, including when the cursor is not advanced, so an unprocessed backlog larger than the limit could be deleted permanently.

Compaction now moves its cutoff back to the earliest entry after the persisted Dream cursor. This keeps ordinary bounded trimming for processed history while preserving every pending Dream input.

## Tests

- `uv run --extra dev pytest tests/agent/test_memory_store.py tests/agent/test_dream.py tests/command/test_builtin_dream.py tests/cli/test_commands.py -q`
- `uv run --extra dev pytest -q`
- `uv run --extra dev ruff check nanobot/agent/memory.py tests/agent/test_memory_store.py`

Fixes #4055