### PR TITLE
fix(webui): prevent long messages from widening mobile thread

### DIFF
--- a/webui/src/components/thread/ThreadViewport.tsx
+++ b/webui/src/components/thread/ThreadViewport.tsx
@@ -638,7 +638,7 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
             <div
               ref={messageRegionRef}
               data-testid="thread-message-region"
-              className="row-start-1 flex min-h-0 flex-col justify-start px-3 pb-4 pt-4 sm:px-4"
+              className="row-start-1 flex min-h-0 min-w-0 flex-col justify-start px-3 pb-4 pt-4 sm:px-4"
             >
               <div ref={messageContentRef} className="mx-auto w-full max-w-[49.5rem]">
                 <ThreadMessages

--- a/webui/src/tests/thread-viewport.test.tsx
+++ b/webui/src/tests/thread-viewport.test.tsx
@@ -223,6 +223,28 @@ describe("ThreadViewport", () => {
     expect(messageRegion.className).not.toContain("5rem");
   });
 
+  it("allows long messages to shrink within the shared mobile grid column", () => {
+    render(
+      <ThreadViewport
+        messages={[
+          ...messages,
+          {
+            id: "a-long-link",
+            role: "assistant",
+            content:
+              "https://github.com/HKUDS/nanobot/discussions/17788077"
+              + "/a-very-long-unbroken-segment-that-must-not-widen-the-thread",
+            createdAt: Date.now(),
+          },
+        ]}
+        isStreaming={false}
+        composer={<div>composer</div>}
+      />,
+    );
+
+    expect(screen.getByTestId("thread-message-region")).toHaveClass("min-w-0");
+  });
+
   it("top-aligns a short active turn while the agent is responding", () => {
     render(
       <ThreadViewport


### PR DESCRIPTION
## Summary

- allow the thread message region to shrink within its shared grid column
- prevent long unbroken Markdown from widening both the chat viewport and composer on mobile
- add regression coverage for the grid-item shrink constraint

## Root cause

The message region was a grid item with the default `min-width: auto`. Long unbroken content therefore contributed its intrinsic width to the shared grid column, expanding both the message region and composer beyond the viewport. At 390px, the affected column grew to 816px and was then clipped by the outer overflow guard.

This is a follow-up to #4694 for the remaining grid intrinsic-sizing edge case.

## Verification

- `npm run test -- src/tests/thread-viewport.test.tsx src/tests/markdown-text-renderer.test.tsx src/tests/message-bubble.test.tsx` (101 passed)
- `npm run test` (782 passed)
- `npm run lint`
- `npm run build`
- real gateway + built WebUI black-box checks:
  - 390px viewport: thread/composer width reduced from 816px to 390px
  - 320px viewport: all composer controls remain visible
  - 1280px viewport: no desktop overflow regression