### PR TITLE
fix(channels): add per-sender message rate limiting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1597,6 +1597,47 @@ Global settings that apply to all channels. Configure under the `channels` secti
 
 Telegram `richMessages` defaults to `false`. Enable it only to opt in to Bot API 10.1 `sendRichMessage` rendering; leave it disabled for Telegram Web clients that show unsupported-message errors for rich messages.
 
+### Rate Limiting
+
+`channels.rateLimitPerMin` caps how many inbound messages a single sender may deliver within any trailing 60-second window (per channel identity, so the same person is limited independently on each channel). It defaults to `0`, which disables rate limiting entirely — existing configs are unaffected. `channels.rateLimitBurst` optionally adds a tighter cap over a short 10-second window to catch rapid-fire bursts that a 60-second budget alone would smooth over.
+
+```json
+{
+  "channels": {
+    "rateLimitPerMin": 20,
+    "rateLimitBurst": 5,
+    "telegram": {
+      "enabled": true
+    }
+  }
+}
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `rateLimitPerMin` | `0` | Max inbound messages per sender per 60s window. `0` disables rate limiting. |
+| `rateLimitBurst` | _(none)_ | Optional tighter cap within a 10s window, checked in addition to `rateLimitPerMin`. |
+
+Both settings can be overridden per channel, following the same override pattern as `sendProgress`/`sendToolHints`:
+
+```json
+{
+  "channels": {
+    "rateLimitPerMin": 20,
+    "telegram": {
+      "enabled": true,
+      "rateLimitPerMin": 5
+    },
+    "websocket": {
+      "enabled": true,
+      "rateLimitPerMin": 0
+    }
+  }
+}
+```
+
+When a sender exceeds the limit, the message is dropped before it reaches the agent loop. Direct messages get a single friendly cooldown notice (further rejected messages stay silent until the sender is allowed through again, so a burst of retries does not itself flood the chat); group/channel messages are dropped silently to avoid drawing attention to the limiter in shared chats.
+
 ### Retry Behavior
 
 Retry is intentionally simple.

--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.queue import MessageBus
+from nanobot.channels.rate_limit import RateLimiter, format_cooldown_reply
 from nanobot.pairing import (
     PAIRING_CODE_META_KEY,
     format_pairing_reply,
@@ -44,6 +45,21 @@ class BaseChannel(ABC):
         self.logger = logger.bind(channel=self.name)
         self.bus = bus
         self._running = False
+        # Per-channel config wins when set; ChannelManager additionally
+        # applies the global channels.rateLimitPerMin default for sections
+        # that do not declare their own override (mirrors how
+        # send_progress/send_tool_hints/show_reasoning are resolved).
+        self._rate_limiter = RateLimiter(
+            per_minute=self._config_get("rate_limit_per_min", 0) or 0,
+            burst=self._config_get("rate_limit_burst", None),
+        )
+        self._rate_limit_notified: set[str] = set()
+
+    def _config_get(self, key: str, default: Any = None) -> Any:
+        """Read *key* from ``self.config`` regardless of dict-or-object shape."""
+        if isinstance(self.config, dict):
+            return self.config.get(key, default)
+        return getattr(self.config, key, default)
 
     async def transcribe_audio(self, file_path: str | Path) -> str:
         """Transcribe an audio file via Whisper (OpenAI or Groq). Returns empty string on failure."""
@@ -260,6 +276,29 @@ class BaseChannel(ABC):
                     sender_id,
                 )
             return
+
+        if self._rate_limiter.enabled:
+            rate_key = f"{self.name}:{permission_id}"
+            retry_after = self._rate_limiter.check(rate_key)
+            if retry_after is not None:
+                self.logger.warning(
+                    "Rate limit exceeded for sender {} in chat {} (retry in {:.1f}s)",
+                    sender_id, chat_id, retry_after,
+                )
+                # Notify at most once per cooldown window so a burst of
+                # rejected messages does not itself flood the chat with
+                # cooldown replies.
+                if is_dm and rate_key not in self._rate_limit_notified:
+                    self._rate_limit_notified.add(rate_key)
+                    await self.send(
+                        OutboundMessage(
+                            channel=self.name,
+                            chat_id=str(chat_id),
+                            content=format_cooldown_reply(retry_after),
+                        )
+                    )
+                return
+            self._rate_limit_notified.discard(rate_key)
 
         meta = metadata or {}
         if self.supports_streaming:

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -32,6 +32,7 @@ from nanobot.channels.contracts import (
     channel_runtime_name,
     resolve_channel_action_target,
 )
+from nanobot.channels.rate_limit import RateLimiter
 from nanobot.channels.registry import channel_default_enabled
 from nanobot.config.schema import Config
 from nanobot.utils.restart import (
@@ -191,7 +192,27 @@ class ChannelManager:
         channel.show_reasoning = self._resolve_bool_override(
             section, "show_reasoning", self.config.channels.show_reasoning,
         )
+        self._apply_rate_limit_override(channel, section)
         return channel
+
+    def _apply_rate_limit_override(self, channel: BaseChannel, section: Any) -> None:
+        """Fall back to the global rate-limit config when a channel section
+        does not declare its own ``rate_limit_per_min``/``rate_limit_burst``.
+        """
+        per_min = self._section_value(section, "rate_limit_per_min", "rateLimitPerMin")
+        burst = self._section_value(section, "rate_limit_burst", "rateLimitBurst")
+        if per_min is None:
+            per_min = self.config.channels.rate_limit_per_min
+        if burst is None:
+            burst = self.config.channels.rate_limit_burst
+        channel._rate_limiter = RateLimiter(per_minute=per_min or 0, burst=burst)
+
+    @staticmethod
+    def _section_value(section: Any, key: str, camel_key: str) -> Any:
+        if isinstance(section, dict):
+            value = section.get(key)
+            return value if value is not None else section.get(camel_key)
+        return getattr(section, key, None)
 
     def _init_channels(self) -> None:
         """Initialize enabled runtimes from dependency-free channel descriptors."""

--- a/nanobot/channels/rate_limit.py
+++ b/nanobot/channels/rate_limit.py
@@ -1,0 +1,88 @@
+"""Lightweight in-process per-sender message rate limiting for channels.
+
+Private-assistant scale: no external store, just a small sliding-window
+counter kept in memory per ``(channel, sender)`` pair. This is intentionally
+simple — it resets on process restart and is not shared across multiple
+gateway processes, which matches how pairing/session state already works
+for nanobot's single-process deployment model.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from dataclasses import dataclass, field
+
+
+@dataclass
+class RateLimiter:
+    """Sliding-window rate limiter keyed by an arbitrary string identity.
+
+    ``per_minute`` caps the number of messages allowed in any trailing
+    60-second window. ``burst`` optionally caps a shorter trailing window
+    (``burst_window_s`` seconds, default 10s) to catch rapid-fire bursts
+    that would otherwise be smoothed out by the per-minute window alone.
+
+    A ``per_minute`` of 0 (the default) disables rate limiting entirely.
+    """
+
+    per_minute: int = 0
+    burst: int | None = None
+    burst_window_s: float = 10.0
+    _hits: dict[str, deque[float]] = field(default_factory=dict, repr=False)
+
+    @property
+    def enabled(self) -> bool:
+        return self.per_minute > 0
+
+    def check(self, key: str, *, now: float | None = None) -> float | None:
+        """Record a message attempt for *key* and return a cooldown in seconds.
+
+        Returns ``None`` when the message is allowed. Returns the number of
+        seconds until the next message would be allowed when *key* has
+        exceeded either the per-minute or burst limit. The attempt is still
+        recorded even when it will not need retrying (matches token-bucket
+        style limiters where rejected calls still count toward history for
+        the purposes of computing the next allowed time).
+        """
+        if not self.enabled:
+            return None
+
+        current = time.monotonic() if now is None else now
+        window = self._hits.setdefault(key, deque())
+
+        # Drop timestamps outside the 60s window (deque is time-ordered).
+        cutoff = current - 60.0
+        while window and window[0] <= cutoff:
+            window.popleft()
+
+        retry_after = None
+        if len(window) >= self.per_minute:
+            retry_after = window[0] + 60.0 - current
+
+        if self.burst and self.burst > 0:
+            burst_cutoff = current - self.burst_window_s
+            burst_count = sum(1 for ts in window if ts > burst_cutoff)
+            if burst_count >= self.burst:
+                burst_retry = window[-burst_count] + self.burst_window_s - current
+                retry_after = burst_retry if retry_after is None else max(retry_after, burst_retry)
+
+        if retry_after is not None:
+            return max(retry_after, 0.0)
+
+        window.append(current)
+        return None
+
+    def reset(self, key: str | None = None) -> None:
+        """Clear rate-limit history for *key*, or every key when omitted."""
+        if key is None:
+            self._hits.clear()
+        else:
+            self._hits.pop(key, None)
+
+
+def format_cooldown_reply(retry_after: float) -> str:
+    """Return a short, friendly message for a rate-limited sender."""
+    seconds = max(1, round(retry_after))
+    unit = "second" if seconds == 1 else "seconds"
+    return f"You're sending messages too quickly. Please wait {seconds} {unit} and try again."

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -36,6 +36,8 @@ class ChannelsConfig(Base):
     send_max_retries: int = Field(default=3, ge=0, le=10)  # Max delivery attempts (initial send included)
     transcription_provider: str = "groq"  # Deprecated: use top-level transcription.provider
     transcription_language: str | None = Field(default=None, pattern=r"^[a-z]{2,3}$")  # Deprecated: use top-level transcription.language
+    rate_limit_per_min: int = Field(default=0, ge=0)  # Max inbound messages per sender per 60s window (0 disables)
+    rate_limit_burst: int | None = Field(default=None, ge=1)  # Optional tighter cap within a short burst window
 
 
 class TranscriptionConfig(Base):

--- a/tests/channels/test_base_channel.py
+++ b/tests/channels/test_base_channel.py
@@ -125,3 +125,88 @@ async def test_handle_message_rejects_when_authorization_id_is_not_allowed() -> 
 
     assert bus.inbound_size == 0
 
+
+class TestRateLimiting:
+    @pytest.mark.asyncio
+    async def test_disabled_by_default(self) -> None:
+        bus = MessageBus()
+        channel = _DummyChannel({"allowFrom": ["*"]}, bus)
+
+        for _ in range(50):
+            await channel._handle_message(sender_id="alice", chat_id="c1", content="hi")
+
+        assert bus.inbound_size == 50
+
+    @pytest.mark.asyncio
+    async def test_blocks_sender_over_the_limit(self) -> None:
+        bus = MessageBus()
+        channel = _DummyChannel(
+            {"allowFrom": ["*"], "rate_limit_per_min": 2}, bus
+        )
+
+        for _ in range(5):
+            await channel._handle_message(sender_id="alice", chat_id="c1", content="hi")
+
+        assert bus.inbound_size == 2
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_is_per_sender(self) -> None:
+        bus = MessageBus()
+        channel = _DummyChannel(
+            {"allowFrom": ["*"], "rate_limit_per_min": 1}, bus
+        )
+
+        await channel._handle_message(sender_id="alice", chat_id="c1", content="hi")
+        await channel._handle_message(sender_id="bob", chat_id="c1", content="hi")
+        await channel._handle_message(sender_id="alice", chat_id="c1", content="hi again")
+
+        assert bus.inbound_size == 2
+
+    @pytest.mark.asyncio
+    async def test_dm_gets_a_single_cooldown_notice_not_a_reply_per_message(self) -> None:
+        bus = MessageBus()
+        channel = _DummyChannel(
+            {"allowFrom": ["*"], "rate_limit_per_min": 1}, bus
+        )
+
+        for _ in range(5):
+            await channel._handle_message(
+                sender_id="alice", chat_id="c1", content="hi", is_dm=True
+            )
+
+        assert bus.inbound_size == 1
+        assert len(channel._sent) == 1
+        assert "too quickly" in channel._sent[0].content
+
+    @pytest.mark.asyncio
+    async def test_group_chat_is_silently_dropped_without_cooldown_spam(self) -> None:
+        bus = MessageBus()
+        channel = _DummyChannel(
+            {"allowFrom": ["*"], "rate_limit_per_min": 1}, bus
+        )
+
+        for _ in range(5):
+            await channel._handle_message(
+                sender_id="alice", chat_id="c1", content="hi", is_dm=False
+            )
+
+        assert bus.inbound_size == 1
+        assert channel._sent == []
+
+    @pytest.mark.asyncio
+    async def test_burst_limit_narrower_than_per_minute_still_applies(self) -> None:
+        bus = MessageBus()
+        channel = _DummyChannel(
+            {
+                "allowFrom": ["*"],
+                "rate_limit_per_min": 100,
+                "rate_limit_burst": 2,
+            },
+            bus,
+        )
+
+        for _ in range(5):
+            await channel._handle_message(sender_id="alice", chat_id="c1", content="hi")
+
+        assert bus.inbound_size == 2
+

--- a/tests/channels/test_channel_plugins.py
+++ b/tests/channels/test_channel_plugins.py
@@ -3524,3 +3524,81 @@ async def test_restart_notice_retries_until_running_channel_accepts_delivery():
     assert channel.attempts == 2
     assert channel.sent is not None
     assert channel.sent.content == "Restart completed."
+
+
+# ---------------------------------------------------------------------------
+# Rate limit config resolution (global default with per-channel override)
+# ---------------------------------------------------------------------------
+
+
+def _rate_limit_manager(monkeypatch, channels_config: dict) -> ChannelManager:
+    plugin = _channel_plugin(_FakePlugin, default_enabled=True)
+    _stub_channel_registry(monkeypatch, plugin)
+    config = Config.model_validate({"channels": channels_config})
+    return ChannelManager(config, MessageBus())
+
+
+def test_rate_limit_disabled_by_default(monkeypatch):
+    manager = _rate_limit_manager(monkeypatch, {"fakeplugin": {"enabled": True}})
+    channel = manager.channels["fakeplugin"]
+    assert channel._rate_limiter.enabled is False
+
+
+def test_rate_limit_global_default_applies_without_channel_override(monkeypatch):
+    manager = _rate_limit_manager(
+        monkeypatch,
+        {
+            "rateLimitPerMin": 5,
+            "fakeplugin": {"enabled": True},
+        },
+    )
+    channel = manager.channels["fakeplugin"]
+    assert channel._rate_limiter.enabled is True
+    assert channel._rate_limiter.per_minute == 5
+
+
+def test_rate_limit_global_burst_default_applies(monkeypatch):
+    manager = _rate_limit_manager(
+        monkeypatch,
+        {
+            "rateLimitPerMin": 30,
+            "rateLimitBurst": 3,
+            "fakeplugin": {"enabled": True},
+        },
+    )
+    channel = manager.channels["fakeplugin"]
+    assert channel._rate_limiter.per_minute == 30
+    assert channel._rate_limiter.burst == 3
+
+
+def test_rate_limit_channel_section_overrides_global_default(monkeypatch):
+    manager = _rate_limit_manager(
+        monkeypatch,
+        {
+            "rateLimitPerMin": 5,
+            "fakeplugin": {"enabled": True, "rate_limit_per_min": 20},
+        },
+    )
+    channel = manager.channels["fakeplugin"]
+    assert channel._rate_limiter.per_minute == 20
+
+
+def test_rate_limit_channel_section_can_disable_when_global_is_enabled(monkeypatch):
+    manager = _rate_limit_manager(
+        monkeypatch,
+        {
+            "rateLimitPerMin": 5,
+            "fakeplugin": {"enabled": True, "rate_limit_per_min": 0},
+        },
+    )
+    channel = manager.channels["fakeplugin"]
+    assert channel._rate_limiter.enabled is False
+
+
+def test_rate_limit_channel_section_accepts_camel_case_alias(monkeypatch):
+    manager = _rate_limit_manager(
+        monkeypatch,
+        {"fakeplugin": {"enabled": True, "rateLimitPerMin": 15}},
+    )
+    channel = manager.channels["fakeplugin"]
+    assert channel._rate_limiter.per_minute == 15

--- a/tests/channels/test_rate_limit.py
+++ b/tests/channels/test_rate_limit.py
@@ -1,0 +1,118 @@
+"""Tests for the per-sender channel rate limiter."""
+
+from __future__ import annotations
+
+from nanobot.channels.rate_limit import RateLimiter, format_cooldown_reply
+
+
+class TestRateLimiterDisabled:
+    def test_disabled_by_default(self) -> None:
+        limiter = RateLimiter()
+        assert limiter.enabled is False
+        for _ in range(1000):
+            assert limiter.check("user") is None
+
+    def test_zero_per_minute_disables(self) -> None:
+        limiter = RateLimiter(per_minute=0, burst=5)
+        assert limiter.enabled is False
+        assert limiter.check("user") is None
+
+
+class TestRateLimiterPerMinute:
+    def test_allows_up_to_the_limit(self) -> None:
+        limiter = RateLimiter(per_minute=3)
+        now = 1000.0
+        assert limiter.check("user", now=now) is None
+        assert limiter.check("user", now=now + 1) is None
+        assert limiter.check("user", now=now + 2) is None
+
+    def test_rejects_once_limit_is_exceeded(self) -> None:
+        limiter = RateLimiter(per_minute=3)
+        now = 1000.0
+        for i in range(3):
+            assert limiter.check("user", now=now + i) is None
+        retry_after = limiter.check("user", now=now + 3)
+        assert retry_after is not None
+        assert retry_after > 0
+
+    def test_window_slides_and_recovers(self) -> None:
+        limiter = RateLimiter(per_minute=2)
+        now = 1000.0
+        assert limiter.check("user", now=now) is None
+        assert limiter.check("user", now=now + 1) is None
+        # Still within the 60s window from `now`, so this is rejected.
+        retry_after = limiter.check("user", now=now + 30)
+        assert retry_after is not None
+        # After the first hit ages out of the 60s window, a new message fits.
+        assert limiter.check("user", now=now + 61) is None
+
+    def test_keys_are_independent(self) -> None:
+        limiter = RateLimiter(per_minute=1)
+        now = 1000.0
+        assert limiter.check("alice", now=now) is None
+        assert limiter.check("bob", now=now) is None
+        assert limiter.check("alice", now=now + 1) is not None
+        assert limiter.check("bob", now=now + 1) is not None
+
+    def test_rejected_attempt_does_not_extend_the_window(self) -> None:
+        limiter = RateLimiter(per_minute=1)
+        now = 1000.0
+        assert limiter.check("user", now=now) is None
+        # Rejected attempts must not be recorded, or the window would never
+        # recover for a sender who keeps retrying while still blocked.
+        assert limiter.check("user", now=now + 10) is not None
+        assert limiter.check("user", now=now + 61) is None
+
+
+class TestRateLimiterBurst:
+    def test_burst_limit_applies_within_short_window(self) -> None:
+        limiter = RateLimiter(per_minute=100, burst=2, burst_window_s=10)
+        now = 1000.0
+        assert limiter.check("user", now=now) is None
+        assert limiter.check("user", now=now + 1) is None
+        # Third message within the 10s burst window is rejected even though
+        # the per-minute budget of 100 is nowhere close to being hit.
+        retry_after = limiter.check("user", now=now + 2)
+        assert retry_after is not None
+
+    def test_burst_limit_recovers_after_window(self) -> None:
+        limiter = RateLimiter(per_minute=100, burst=2, burst_window_s=10)
+        now = 1000.0
+        assert limiter.check("user", now=now) is None
+        assert limiter.check("user", now=now + 1) is None
+        assert limiter.check("user", now=now + 11) is None
+
+    def test_none_burst_disables_burst_check(self) -> None:
+        limiter = RateLimiter(per_minute=100, burst=None)
+        now = 1000.0
+        for i in range(10):
+            assert limiter.check("user", now=now + i * 0.1) is None
+
+
+class TestRateLimiterReset:
+    def test_reset_single_key(self) -> None:
+        limiter = RateLimiter(per_minute=1)
+        now = 1000.0
+        assert limiter.check("user", now=now) is None
+        assert limiter.check("user", now=now + 1) is not None
+        limiter.reset("user")
+        assert limiter.check("user", now=now + 1) is None
+
+    def test_reset_all_keys(self) -> None:
+        limiter = RateLimiter(per_minute=1)
+        now = 1000.0
+        assert limiter.check("alice", now=now) is None
+        assert limiter.check("bob", now=now) is None
+        limiter.reset()
+        assert limiter.check("alice", now=now) is None
+        assert limiter.check("bob", now=now) is None
+
+
+class TestFormatCooldownReply:
+    def test_rounds_and_pluralizes(self) -> None:
+        assert "1 second" in format_cooldown_reply(0.6)
+        assert "5 seconds" in format_cooldown_reply(4.6)
+
+    def test_never_reports_zero_or_negative(self) -> None:
+        assert "1 second" in format_cooldown_reply(0.0)
+        assert "1 second" in format_cooldown_reply(-5.0)


### PR DESCRIPTION
## Summary

No channel adapter implements per-user or per-chat message rate limiting. A paired/approved user on any channel could send messages at maximum rate, each consuming LLM tokens, spawning tool executions, and growing session history — with no debounce, no throttling, and no cooldown.

## Changes

- Added `nanobot/channels/rate_limit.py`: a small in-process sliding-window `RateLimiter` (per-minute cap, plus an optional tighter burst cap over a short window). No external dependencies, matching nanobot's existing pairing-store style of lightweight in-process state.
- Wired the limiter into `BaseChannel._handle_message()` right after the existing authorization check, so every channel gets rate limiting for free with zero per-channel code changes.
- Added `channels.rateLimitPerMin` (default `0`, i.e. disabled — fully backwards compatible) and `channels.rateLimitBurst` (optional) to `ChannelsConfig`.
- `ChannelManager._build_channel` resolves the final limiter the same way `sendProgress`/`sendToolHints`/`showReasoning` are already resolved: a channel section can override the global default, or explicitly opt out with `rate_limit_per_min: 0`.
- DMs get a single friendly cooldown notice per cooldown window (further rejected retries stay silent until the sender is allowed through again, so a burst of rejected messages cannot itself flood the chat). Group/channel messages are dropped silently to avoid drawing attention to the limiter in shared chats.
- Updated `docs/configuration.md` with a new "Rate Limiting" section under Channel Settings, following the existing documentation style.

## Testing

- `tests/channels/test_rate_limit.py`: unit tests for the sliding-window limiter itself (per-minute window, burst window, sliding/recovery behavior, per-key isolation, reset, cooldown message formatting).
- `tests/channels/test_base_channel.py`: integration tests through `BaseChannel._handle_message()` (disabled by default, blocks over-limit senders, per-sender isolation, single DM cooldown notice vs. silent group drops, burst cap).
- `tests/channels/test_channel_plugins.py`: tests for `ChannelManager`'s global-default-with-per-channel-override resolution (including camelCase config aliases).
- Full test suite passes locally (`pytest -q`): 5396 passed, 20 skipped, 1 pre-existing unrelated failure (`test_exec_guard_allows_public_urls`, fails identically on `main` without this change — looks like a local network/DNS environment issue, not related to this PR).
- `ruff check` passes on all changed/added files.

Addresses #4791.