### PR TITLE
feat(webui): expose Dream runs as read-only sessions

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -759,28 +759,33 @@ class MemoryStore:
         return f"{prefix}\n\n{diff_body}"
 
     @staticmethod
-    def prune_dream_sessions(sessions_dir: Path, *, keep: int = 10) -> None:
+    def prune_dream_sessions(sessions_dir: Path, *, keep: int = 10) -> list[str]:
         """Remove the oldest Dream session files, keeping only the N most recent.
 
         Only current base64url-encoded Dream session keys are considered.
         Non-dream session files are never touched.
+
+        Returns the decoded session keys whose files were removed.
         """
-        dream_files = []
+        dream_files: list[tuple[Path, str]] = []
         for path in sessions_dir.glob("*.jsonl"):
             decoded_key = SessionManager._decode_storage_key(path.stem)
             if decoded_key is not None and decoded_key.startswith("dream:"):
-                dream_files.append(path)
-        dream_files.sort(key=lambda p: p.stat().st_mtime)
+                dream_files.append((path, decoded_key))
+        dream_files.sort(key=lambda item: item[0].stat().st_mtime)
         if len(dream_files) <= keep:
-            return
+            return []
 
         to_remove = dream_files[: len(dream_files) - keep]
-        for path in to_remove:
+        removed_keys: list[str] = []
+        for path, session_key in to_remove:
             try:
                 path.unlink()
+                removed_keys.append(session_key)
                 logger.debug("Pruned old dream session: {}", path.stem)
             except OSError:
                 logger.warning("Failed to prune dream session {}", path)
+        return removed_keys
 
 
 # ---------------------------------------------------------------------------

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -11,7 +11,7 @@ import weakref
 from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Iterator
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterator
 
 from loguru import logger
 
@@ -47,20 +47,26 @@ if TYPE_CHECKING:
 class DreamRunProgress:
     """Track tool failures that make a nominally completed Dream run unsafe to advance."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        delegate: Callable[..., Awaitable[None]] | None = None,
+    ) -> None:
         self.had_tool_errors = False
+        self._delegate = delegate
 
     async def __call__(
         self,
-        *_args: Any,
+        *args: Any,
         tool_events: list[dict[str, Any]] | None = None,
-        **_kwargs: Any,
+        **kwargs: Any,
     ) -> None:
         if any(
             isinstance(event, dict) and event.get("phase") == "error"
             for event in tool_events or ()
         ):
             self.had_tool_errors = True
+        if self._delegate is not None:
+            await self._delegate(*args, tool_events=tool_events, **kwargs)
 
 
 class MemoryStore:
@@ -589,7 +595,7 @@ class MemoryStore:
 
         batch = entries[:max_entries]
         history_text = "\n".join(
-            f"[{e['timestamp']}] {truncate_text(e['content'], 500)}"
+            f"[{e['timestamp']}] {e['content']}"
             for e in batch
         )
         template = self._dream_template()
@@ -670,6 +676,7 @@ class MemoryStore:
         tools.register(WriteFileTool(
             workspace=workspace,
             allowed_dir=skills_dir,
+            extra_write_allowed_files=editable_files,
             file_states=file_states,
         ))
         return tools

--- a/nanobot/agent/turn_hooks.py
+++ b/nanobot/agent/turn_hooks.py
@@ -51,9 +51,6 @@ def build_agent_turn_hook(spec: AgentTurnHookSpec) -> AgentHook:
         tool_hint_max_length=spec.tool_hint_max_length,
         on_iteration=spec.on_iteration,
     )
-    if spec.ephemeral and not spec.run_extra_hooks_for_ephemeral:
-        return progress_hook
-
     turn_context = AgentTurnHookContext(
         on_progress=spec.on_progress,
         workspace=spec.workspace,
@@ -66,16 +63,17 @@ def build_agent_turn_hook(spec: AgentTurnHookSpec) -> AgentHook:
     )
     hook_chain: list[AgentHook] = [progress_hook]
 
-    for factory in spec.registered_hook_factories:
-        try:
-            created_hook = factory(turn_context)
-        except Exception:
-            logger.exception("Agent turn hook factory failed: {}", factory)
-            continue
-        if created_hook is not None:
-            hook_chain.append(created_hook)
+    if not spec.ephemeral or spec.run_extra_hooks_for_ephemeral:
+        for factory in spec.registered_hook_factories:
+            try:
+                created_hook = factory(turn_context)
+            except Exception:
+                logger.exception("Agent turn hook factory failed: {}", factory)
+                continue
+            if created_hook is not None:
+                hook_chain.append(created_hook)
 
-    hook_chain.extend(spec.registered_hooks)
+        hook_chain.extend(spec.registered_hooks)
 
     for factory in spec.turn_hook_factories:
         try:

--- a/nanobot/channels/websocket/tests/test_websocket_channel.py
+++ b/nanobot/channels/websocket/tests/test_websocket_channel.py
@@ -3310,6 +3310,34 @@ def test_handle_file_preview_returns_workspace_file(tmp_path) -> None:
     assert body["truncated"] is False
 
 
+def test_handle_file_preview_returns_workspace_file_for_dream_session(tmp_path) -> None:
+    from urllib.parse import quote
+
+    from websockets.datastructures import Headers
+    from websockets.http11 import Request
+
+    workspace = tmp_path / "workspace"
+    source = workspace / "USER.md"
+    workspace.mkdir()
+    source.write_text("# User\n", encoding="utf-8")
+
+    gateway = _basic_handler(MagicMock(), workspace_path=workspace)
+    gateway.tokens.api_tokens["tok"] = time.monotonic() + 300.0
+    key = "dream:20260727-174700"
+    enc = quote(key, safe="")
+    req = Request(
+        f"/api/sessions/{enc}/file-preview?path=USER.md",
+        Headers([("Authorization", "Bearer tok")]),
+    )
+
+    resp = gateway.http._handle_file_preview(req, enc)
+
+    assert resp.status_code == 200
+    body = json.loads(resp.body.decode())
+    assert body["display_path"] == "USER.md"
+    assert body["content"].splitlines() == ["# User"]
+
+
 def test_handle_file_preview_probe_checks_availability_without_content(tmp_path) -> None:
     from urllib.parse import quote
 

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1805,7 +1805,10 @@ def _run_gateway(
         # Dream is an internal job — run directly, not through the agent loop.
         if job.name == "dream":
             from nanobot.agent.memory import DreamRunProgress, MemoryStore
-            from nanobot.webui.transcript import WebUISessionTranscriptRecorder
+            from nanobot.webui.transcript import (
+                WebUISessionTranscriptRecorder,
+                delete_webui_transcript,
+            )
 
             dream_session_key = MemoryStore.dream_session_key
             prune_dream_sessions = MemoryStore.prune_dream_sessions
@@ -1881,7 +1884,8 @@ def _run_gateway(
                 if sha:
                     logger.info("Dream commit: {}", sha)
                 store.compact_history()
-                prune_dream_sessions(agent.sessions.sessions_dir)
+                for session_key in prune_dream_sessions(agent.sessions.sessions_dir):
+                    delete_webui_transcript(session_key)
             return None
 
         # Heartbeat is a system job that checks HEARTBEAT.md for active tasks.

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1805,13 +1805,14 @@ def _run_gateway(
         # Dream is an internal job — run directly, not through the agent loop.
         if job.name == "dream":
             from nanobot.agent.memory import DreamRunProgress, MemoryStore
+            from nanobot.webui.transcript import WebUISessionTranscriptRecorder
 
             dream_session_key = MemoryStore.dream_session_key
             prune_dream_sessions = MemoryStore.prune_dream_sessions
 
             store = agent.context.memory
-            progress = DreamRunProgress()
             resp = None
+            transcript = None
             diff_body = ""
             try:
                 result = store.build_dream_prompt()
@@ -1820,6 +1821,9 @@ def _run_gateway(
                     return None
                 prompt, last_cursor = result
                 key = dream_session_key()
+                transcript = WebUISessionTranscriptRecorder(key)
+                transcript.start(prompt)
+                progress = DreamRunProgress(transcript.progress)
                 resolve_dream_runtime = getattr(agent, "dream_runtime", None)
                 dream_runtime = (
                     resolve_dream_runtime() if callable(resolve_dream_runtime) else None
@@ -1830,8 +1834,12 @@ def _run_gateway(
                     ephemeral=True,
                     tools=store.build_dream_tools(),
                     on_progress=progress,
+                    on_stream=transcript.on_stream,
+                    on_stream_end=transcript.on_stream_end,
+                    hook_factories=[create_file_edit_activity_hook],
                     runtime=dream_runtime,
                 )
+                transcript.finish(resp)
                 # The real file delta grounds the audit record; clean completion
                 # decides whether this history batch has finished processing.
                 diff_body = store.dream_content_diff()
@@ -1857,7 +1865,9 @@ def _run_gateway(
                         "Dream cron job did not complete; cursor remains at {}",
                         store.get_last_dream_cursor(),
                     )
-            except Exception:
+            except Exception as exc:
+                if transcript is not None:
+                    transcript.finish(error=f"Dream failed: {exc}")
                 logger.exception("Dream cron job failed")
             finally:
                 from nanobot.webui.token_usage import record_response_token_usage

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -406,7 +406,10 @@ async def cmd_dream(ctx: CommandContext) -> OutboundMessage:
     async def _run_dream():
         from nanobot.agent.hooks import create_file_edit_activity_hook
         from nanobot.agent.memory import DreamRunProgress, MemoryStore
-        from nanobot.webui.transcript import WebUISessionTranscriptRecorder
+        from nanobot.webui.transcript import (
+            WebUISessionTranscriptRecorder,
+            delete_webui_transcript,
+        )
 
         dream_session_key = MemoryStore.dream_session_key
         build_dream_commit_message = MemoryStore.build_dream_commit_message
@@ -484,7 +487,8 @@ async def cmd_dream(ctx: CommandContext) -> OutboundMessage:
                 if sha:
                     content += f" (commit {sha})"
             store.compact_history()
-            prune_dream_sessions(loop.sessions.sessions_dir)
+            for session_key in prune_dream_sessions(loop.sessions.sessions_dir):
+                delete_webui_transcript(session_key)
         await loop.bus.publish_outbound(OutboundMessage(
             channel=msg.channel, chat_id=msg.chat_id, content=content,
         ))

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -404,16 +404,18 @@ async def cmd_dream(ctx: CommandContext) -> OutboundMessage:
     msg = ctx.msg
 
     async def _run_dream():
+        from nanobot.agent.hooks import create_file_edit_activity_hook
         from nanobot.agent.memory import DreamRunProgress, MemoryStore
+        from nanobot.webui.transcript import WebUISessionTranscriptRecorder
 
         dream_session_key = MemoryStore.dream_session_key
         build_dream_commit_message = MemoryStore.build_dream_commit_message
         prune_dream_sessions = MemoryStore.prune_dream_sessions
 
         store = loop.context.memory
-        progress = DreamRunProgress()
         content = ""
         resp = None
+        transcript = None
         diff_body = ""
         t0 = time.monotonic()
         try:
@@ -427,6 +429,9 @@ async def cmd_dream(ctx: CommandContext) -> OutboundMessage:
                 return
             prompt, last_cursor = result
             key = dream_session_key()
+            transcript = WebUISessionTranscriptRecorder(key)
+            transcript.start(prompt)
+            progress = DreamRunProgress(transcript.progress)
             resolve_dream_runtime = getattr(loop, "dream_runtime", None)
             dream_runtime = resolve_dream_runtime() if callable(resolve_dream_runtime) else None
             resp = await loop.process_direct(
@@ -435,8 +440,12 @@ async def cmd_dream(ctx: CommandContext) -> OutboundMessage:
                 ephemeral=True,
                 tools=store.build_dream_tools(),
                 on_progress=progress,
+                on_stream=transcript.on_stream,
+                on_stream_end=transcript.on_stream_end,
+                hook_factories=[create_file_edit_activity_hook],
                 runtime=dream_runtime,
             )
+            transcript.finish(resp)
             elapsed = time.monotonic() - t0
             # The real file delta grounds the audit record; clean completion
             # decides whether this history batch has finished processing.
@@ -457,6 +466,8 @@ async def cmd_dream(ctx: CommandContext) -> OutboundMessage:
                     "memory cursor was not advanced."
                 )
         except Exception as e:
+            if transcript is not None:
+                transcript.finish(error=f"Dream failed: {e}")
             elapsed = time.monotonic() - t0
             content = f"Dream failed after {elapsed:.1f}s: {e}"
         finally:

--- a/nanobot/webui/transcript.py
+++ b/nanobot/webui/transcript.py
@@ -10,6 +10,7 @@ import re
 import shutil
 import time
 import uuid
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Mapping, NamedTuple
 from urllib.parse import unquote, urlparse
@@ -33,6 +34,107 @@ _TRANSCRIPT_SEGMENT_RE = re.compile(r"^\d{6}\.jsonl$")
 _DEFAULT_TRANSCRIPT_PAGE_LIMIT = 160
 _MAX_TRANSCRIPT_PAGE_LIMIT = 1000
 _WEBUI_TURN_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+
+
+def _session_message_created_at_ms(message: Mapping[str, Any]) -> int | None:
+    value = message.get("timestamp")
+    if not isinstance(value, str):
+        return None
+    try:
+        return int(datetime.fromisoformat(value).timestamp() * 1000)
+    except ValueError:
+        return None
+
+
+def _session_messages_as_transcript_lines(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    lines: list[dict[str, Any]] = []
+    tool_calls: dict[str, tuple[str, Any]] = {}
+    for message in messages:
+        role = message.get("role")
+        created_at_ms = _session_message_created_at_ms(message)
+        content = message.get("content")
+        text = content if isinstance(content, str) else ""
+
+        if role == "user":
+            lines.append({
+                "event": "user",
+                "text": text,
+                "created_at_ms": created_at_ms,
+            })
+            continue
+
+        if role == "assistant":
+            if text.strip():
+                lines.append({
+                    "event": "message",
+                    "kind": "answer",
+                    "text": text,
+                    "created_at_ms": created_at_ms,
+                })
+            started: list[dict[str, Any]] = []
+            for call in message.get("tool_calls") or []:
+                if not isinstance(call, dict):
+                    continue
+                function = call.get("function")
+                function = function if isinstance(function, dict) else {}
+                call_id = call.get("id")
+                name = function.get("name")
+                if not isinstance(call_id, str) or not call_id:
+                    continue
+                if not isinstance(name, str) or not name:
+                    continue
+                arguments = function.get("arguments")
+                if isinstance(arguments, str):
+                    try:
+                        arguments = json.loads(arguments)
+                    except json.JSONDecodeError:
+                        pass
+                tool_calls[call_id] = (name, arguments)
+                started.append({
+                    "version": 1,
+                    "phase": "start",
+                    "call_id": call_id,
+                    "name": name,
+                    "arguments": arguments,
+                })
+            if started:
+                lines.append({
+                    "event": "message",
+                    "kind": "tool_hint",
+                    "text": "",
+                    "tool_events": started,
+                    "created_at_ms": created_at_ms,
+                })
+            continue
+
+        if role != "tool":
+            continue
+        call_id = message.get("tool_call_id")
+        if not isinstance(call_id, str) or not call_id:
+            continue
+        known_name, arguments = tool_calls.get(call_id, ("", {}))
+        name = message.get("name") or known_name
+        if not isinstance(name, str) or not name:
+            continue
+        lines.append({
+            "event": "message",
+            "kind": "progress",
+            "text": "",
+            "tool_events": [{
+                "version": 1,
+                "phase": "end",
+                "call_id": call_id,
+                "name": name,
+                "arguments": arguments,
+                "result": content,
+            }],
+            "created_at_ms": created_at_ms,
+        })
+    return lines
+
+
 _MARKDOWN_LOCAL_IMAGE_RE = re.compile(
     r"!\[([^\]]*)\]\((<[^>]+>|[^)\s]+)(\s+(?:\"[^\"]*\"|'[^']*'))?\)"
 )
@@ -661,6 +763,7 @@ class WebUITranscriptRecorder:
         chat_id: str,
         event: dict[str, Any],
         *,
+        session_key: str | None = None,
         metadata: dict[str, Any] | None = None,
         phase: str | None = None,
         include_source: bool = False,
@@ -676,7 +779,7 @@ class WebUITranscriptRecorder:
         record = dict(event)
         if transcript_overrides:
             record.update(transcript_overrides)
-        self.append(chat_id, record)
+        self.append(chat_id, record, session_key=session_key)
 
     def append_user_message(
         self,
@@ -684,6 +787,7 @@ class WebUITranscriptRecorder:
         text: str,
         *,
         metadata: dict[str, Any],
+        session_key: str | None = None,
         media_paths: list[str] | None = None,
         cli_apps: list[dict[str, Any]] | None = None,
         mcp_presets: list[dict[str, Any]] | None = None,
@@ -699,12 +803,24 @@ class WebUITranscriptRecorder:
         )
         if payload is None:
             return
-        self.prepare_and_append(chat_id, payload, metadata=metadata, phase="user")
+        self.prepare_and_append(
+            chat_id,
+            payload,
+            session_key=session_key,
+            metadata=metadata,
+            phase="user",
+        )
 
-    def append(self, chat_id: str, event: dict[str, Any]) -> None:
+    def append(
+        self,
+        chat_id: str,
+        event: dict[str, Any],
+        *,
+        session_key: str | None = None,
+    ) -> None:
         try:
             dup = json.loads(json.dumps(event, ensure_ascii=False))
-            append_transcript_object(f"websocket:{chat_id}", dup)
+            append_transcript_object(session_key or f"websocket:{chat_id}", dup)
         except (OSError, ValueError, TypeError) as e:
             self._log.warning("webui transcript append failed: {}", e)
 
@@ -731,6 +847,158 @@ class WebUITranscriptRecorder:
         event["turn_seq"] = self._next_turn_seq(chat_id, turn_id)
         if phase == "complete":
             self._turn_sequences.pop((chat_id, turn_id), None)
+
+
+class WebUISessionTranscriptRecorder:
+    """Record a direct agent run with the same transcript events as a WebUI turn."""
+
+    def __init__(self, session_key: str, log: Any = logger) -> None:
+        self.session_key = session_key
+        self.chat_id = session_key.split(":", 1)[-1]
+        self._recorder = WebUITranscriptRecorder(log=log)
+        self._metadata = self._recorder.client_turn_metadata(None)
+        self._stream_id = self._metadata[WEBUI_TURN_METADATA_KEY]
+        self._answer_started = False
+        self._finished = False
+
+    def start(self, text: str) -> None:
+        self._recorder.append_user_message(
+            self.chat_id,
+            text,
+            session_key=self.session_key,
+            metadata=self._metadata,
+        )
+
+    async def progress(
+        self,
+        content: str,
+        *,
+        tool_hint: bool = False,
+        tool_events: list[dict[str, Any]] | None = None,
+        file_edit_events: list[dict[str, Any]] | None = None,
+        reasoning: bool = False,
+        reasoning_end: bool = False,
+    ) -> None:
+        if reasoning_end:
+            event = {
+                "event": "reasoning_end",
+                "chat_id": self.chat_id,
+                "stream_id": self._stream_id,
+            }
+            phase = "reasoning"
+        elif reasoning:
+            event = {
+                "event": "reasoning_delta",
+                "chat_id": self.chat_id,
+                "text": content,
+                "stream_id": self._stream_id,
+            }
+            phase = "reasoning"
+        elif file_edit_events:
+            event = {
+                "event": "file_edit",
+                "chat_id": self.chat_id,
+                "edits": file_edit_events,
+            }
+            phase = "activity"
+        else:
+            event = {
+                "event": "message",
+                "chat_id": self.chat_id,
+                "text": content,
+                "kind": "tool_hint" if tool_hint else "progress",
+            }
+            if tool_events:
+                event["tool_events"] = tool_events
+            phase = "activity"
+        self._recorder.prepare_and_append(
+            self.chat_id,
+            event,
+            session_key=self.session_key,
+            metadata=self._metadata,
+            phase=phase,
+        )
+
+    async def on_stream(self, delta: str) -> None:
+        if delta:
+            self._answer_started = True
+        self._recorder.prepare_and_append(
+            self.chat_id,
+            {
+                "event": "delta",
+                "chat_id": self.chat_id,
+                "text": delta,
+                "stream_id": self._stream_id,
+            },
+            session_key=self.session_key,
+            metadata=self._metadata,
+            phase="answer",
+        )
+
+    async def on_stream_end(
+        self,
+        *,
+        resuming: bool = False,
+        merge_next: bool = False,
+    ) -> None:
+        event: dict[str, Any] = {
+            "event": "stream_end",
+            "chat_id": self.chat_id,
+            "stream_id": self._stream_id,
+        }
+        if resuming:
+            event["resuming"] = True
+        if merge_next:
+            event["merge_next"] = True
+        self._recorder.prepare_and_append(
+            self.chat_id,
+            event,
+            session_key=self.session_key,
+            metadata=self._metadata,
+            phase="answer",
+        )
+
+    def finish(self, response: Any = None, *, error: str | None = None) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        metadata = getattr(response, "metadata", None)
+        metadata = metadata if isinstance(metadata, dict) else {}
+        if not self._answer_started:
+            content = error or getattr(response, "content", "")
+            if isinstance(content, str) and content:
+                event: dict[str, Any] = {
+                    "event": "message",
+                    "chat_id": self.chat_id,
+                    "text": content,
+                }
+                media = getattr(response, "media", None)
+                if isinstance(media, list) and media:
+                    event["media"] = media
+                latency_ms = metadata.get("latency_ms")
+                if isinstance(latency_ms, (int, float)):
+                    event["latency_ms"] = int(latency_ms)
+                self._recorder.prepare_and_append(
+                    self.chat_id,
+                    event,
+                    session_key=self.session_key,
+                    metadata=self._metadata,
+                    phase="answer",
+                )
+        turn_end: dict[str, Any] = {
+            "event": "turn_end",
+            "chat_id": self.chat_id,
+        }
+        latency_ms = metadata.get("latency_ms")
+        if isinstance(latency_ms, (int, float)):
+            turn_end["latency_ms"] = int(latency_ms)
+        self._recorder.prepare_and_append(
+            self.chat_id,
+            turn_end,
+            session_key=self.session_key,
+            metadata=self._metadata,
+            phase="complete",
+        )
 
 
 def _chat_id_from_session_key(session_key: str) -> str | None:
@@ -2013,6 +2281,8 @@ def build_webui_thread_response(
         lines, page = _select_transcript_page(session_key, limit=limit, before=before)
     else:
         lines = read_transcript_lines(session_key)
+    if not lines and session_messages:
+        lines = _session_messages_as_transcript_lines(session_messages)
     if not lines:
         return None
     lines = inject_missing_user_events_from_session(session_key, lines, session_messages)

--- a/nanobot/webui/transcript.py
+++ b/nanobot/webui/transcript.py
@@ -52,6 +52,11 @@ def _session_messages_as_transcript_lines(
     lines: list[dict[str, Any]] = []
     tool_calls: dict[str, tuple[str, Any]] = {}
     for message in messages:
+        if is_hidden_history_message(message):
+            continue
+        message = public_history_message(message)
+        if message.get("role") == "user" and _is_legacy_raw_subagent_result(message):
+            continue
         role = message.get("role")
         created_at_ms = _session_message_created_at_ms(message)
         content = message.get("content")
@@ -964,8 +969,9 @@ class WebUISessionTranscriptRecorder:
         self._finished = True
         metadata = getattr(response, "metadata", None)
         metadata = metadata if isinstance(metadata, dict) else {}
-        if not self._answer_started:
-            content = error or getattr(response, "content", "")
+        stop_reason = metadata.get("_stop_reason")
+        content = error or getattr(response, "content", "")
+        if error or stop_reason == "error" or not self._answer_started:
             if isinstance(content, str) and content:
                 event: dict[str, Any] = {
                     "event": "message",

--- a/nanobot/webui/ws_http.py
+++ b/nanobot/webui/ws_http.py
@@ -413,13 +413,21 @@ class GatewayHTTPHandler:
         cleaned = []
         for s in sessions:
             key = s.get("key")
-            if not (isinstance(key, str) and key.startswith("websocket:")):
+            is_websocket = isinstance(key, str) and key.startswith("websocket:")
+            is_dream = isinstance(key, str) and key.startswith("dream:")
+            if not (is_websocket or is_dream):
                 continue
             row = {k: v for k, v in s.items() if k != "path"}
-            chat_id = key.split(":", 1)[1]
-            started_at = websocket_turn_wall_started_at(chat_id)
-            if started_at is not None:
-                row["run_started_at"] = started_at
+            if is_dream:
+                row["title"] = row.get("title") or "Dream"
+                row["preview"] = ""
+                row["read_only"] = True
+                row["kind"] = "dream"
+            else:
+                chat_id = key.split(":", 1)[1]
+                started_at = websocket_turn_wall_started_at(chat_id)
+                if started_at is not None:
+                    row["run_started_at"] = started_at
             scope = self.workspaces.scope_for_session_key(key)
             row["workspace_scope"] = scope.payload()
             cleaned.append(row)
@@ -433,7 +441,7 @@ class GatewayHTTPHandler:
         decoded_key = _decode_api_key(key)
         if decoded_key is None:
             return _http_error(400, "invalid session key")
-        if not _is_websocket_channel_session_key(decoded_key):
+        if not _is_readable_session_key(decoded_key):
             return _http_error(404, "session not found")
         data = self.session_manager.read_session_file(decoded_key)
         if data is None:
@@ -453,7 +461,7 @@ class GatewayHTTPHandler:
         decoded_key = _decode_api_key(key)
         if decoded_key is None:
             return _http_error(400, "invalid session key")
-        if not _is_websocket_channel_session_key(decoded_key):
+        if not _is_readable_session_key(decoded_key):
             return _http_error(404, "session not found")
         scope = self.workspaces.scope_for_session_key(decoded_key)
         session_messages: list[dict[str, Any]] | None = None
@@ -498,7 +506,7 @@ class GatewayHTTPHandler:
         decoded_key = _decode_api_key(key)
         if decoded_key is None:
             return _http_error(400, "invalid session key")
-        if not _is_websocket_channel_session_key(decoded_key):
+        if not _is_readable_session_key(decoded_key):
             return _http_error(404, "session not found")
         query = _parse_query(request.path)
         path = _query_first(query, "path")
@@ -1031,3 +1039,7 @@ def _positive_int(value: Any) -> int | None:
 
 def _is_websocket_channel_session_key(key: str) -> bool:
     return key.startswith("websocket:")
+
+
+def _is_readable_session_key(key: str) -> bool:
+    return _is_websocket_channel_session_key(key) or key.startswith("dream:")

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -127,15 +127,13 @@ class TestBuildDreamPrompt:
         prompt, _ = result
         assert "memory consolidation engine" in prompt
 
-    def test_truncates_long_entries(self, store):
+    def test_preserves_long_entries(self, store):
         long_content = "x" * 2000
         store.append_history(long_content)
         result = store.build_dream_prompt()
         assert result is not None
         prompt, _ = result
-        # The full 2000 chars should not appear — truncated to 500
-        assert long_content not in prompt
-        assert "x" * 500 in prompt
+        assert long_content in prompt
 
     def test_batches_oldest_unprocessed_entries_first(self, store):
         for i in range(25):
@@ -222,11 +220,20 @@ class TestDreamTools:
                 "new_text": "Precise",
             },
         )
+        user_result = await tools.execute(
+            "write_file",
+            {
+                "path": "USER.md",
+                "content": "# User Profile\n\n- **Name**: Ada\n",
+            },
+        )
 
         assert "Patch applied" in memory_result
         assert "Successfully edited" in soul_result
+        assert "Successfully wrote" in user_result
         assert "Project Y active" in store.memory_file.read_text(encoding="utf-8")
         assert "Precise" in store.soul_file.read_text(encoding="utf-8")
+        assert "**Name**: Ada" in store.user_file.read_text(encoding="utf-8")
 
     @pytest.mark.asyncio
     async def test_dream_can_write_workspace_skills(self, store):
@@ -306,9 +313,17 @@ class TestDreamTools:
                 "new_text": "2",
             },
         )
+        history_write_result = await tools.execute(
+            "write_file",
+            {
+                "path": "memory/history.jsonl",
+                "content": "after\n",
+            },
+        )
 
         assert "outside allowed directory" in history_result
         assert "outside allowed directory" in cursor_result
+        assert "outside allowed directory" in history_write_result
         assert store.history_file.read_text(encoding="utf-8") == "before\n"
         assert store._dream_cursor_file.read_text(encoding="utf-8") == "1"
 
@@ -331,11 +346,10 @@ class TestDreamTools:
             },
         )
         user_result = await tools.execute(
-            "edit_file",
+            "write_file",
             {
                 "path": "USER.md/evil.txt",
-                "old_text": "",
-                "new_text": "owned",
+                "content": "owned",
             },
         )
 

--- a/tests/agent/test_dream_session.py
+++ b/tests/agent/test_dream_session.py
@@ -34,6 +34,7 @@ class TestPruneDreamSessions:
 
         base_time = time.time() - 100
         dream_paths = []
+        dream_keys = []
 
         for i in range(15):
             key = f"dream:20260528-{100000 + i:06d}"
@@ -46,12 +47,14 @@ class TestPruneDreamSessions:
             )
             os.utime(path, (base_time + i, base_time + i))
             dream_paths.append(path)
+            dream_keys.append(key)
 
         normal_path = sessions_dir / "telegram_123.jsonl"
         normal_path.write_text('{"_type": "metadata"}\n', encoding="utf-8")
 
-        MemoryStore.prune_dream_sessions(sessions_dir, keep=10)
+        removed = MemoryStore.prune_dream_sessions(sessions_dir, keep=10)
 
+        assert removed == dream_keys[:5]
         assert [path.exists() for path in dream_paths] == [False] * 5 + [True] * 10
         assert normal_path.exists()
 
@@ -81,8 +84,9 @@ class TestPruneDreamSessions:
         )
         os.utime(legacy_path, (base_time - 1, base_time - 1))
 
-        MemoryStore.prune_dream_sessions(sessions_dir, keep=1)
+        removed = MemoryStore.prune_dream_sessions(sessions_dir, keep=1)
 
+        assert removed == ["dream:20260713-100000"]
         assert [path.exists() for path in current_paths] == [False, True]
         assert legacy_path.exists()
 
@@ -94,11 +98,13 @@ class TestPruneDreamSessions:
             path = sessions_dir / f"{SessionManager._storage_key(key)}.jsonl"
             path.write_text("{}", encoding="utf-8")
 
-        MemoryStore.prune_dream_sessions(sessions_dir, keep=10)
+        removed = MemoryStore.prune_dream_sessions(sessions_dir, keep=10)
+        assert removed == []
         assert len(list(sessions_dir.glob("*.jsonl"))) == 3
 
     def test_empty_dir_noop(self, tmp_path):
         sessions_dir = tmp_path / "sessions"
         sessions_dir.mkdir()
-        MemoryStore.prune_dream_sessions(sessions_dir, keep=10)
+        removed = MemoryStore.prune_dream_sessions(sessions_dir, keep=10)
+        assert removed == []
         assert list(sessions_dir.iterdir()) == []

--- a/tests/agent/test_turn_hooks.py
+++ b/tests/agent/test_turn_hooks.py
@@ -116,6 +116,24 @@ async def test_turn_hook_builder_skips_extra_hooks_for_ephemeral_turns_by_defaul
 
 
 @pytest.mark.asyncio
+async def test_turn_hook_builder_runs_explicit_factory_for_ephemeral_turn() -> None:
+    events: list[str] = []
+
+    def factory(context: AgentTurnHookContext) -> AgentHook:
+        return RecordingHook(events, "turn_factory")
+
+    hook = build_agent_turn_hook(AgentTurnHookSpec(
+        registered_hooks=[RecordingHook(events, "registered")],
+        turn_hook_factories=[factory],
+        ephemeral=True,
+    ))
+
+    await hook.before_iteration(AgentHookContext(iteration=1, messages=[]))
+
+    assert events == ["turn_factory:1"]
+
+
+@pytest.mark.asyncio
 async def test_turn_hook_builder_can_include_extra_hooks_for_ephemeral_turns() -> None:
     events: list[str] = []
 

--- a/tests/command/test_builtin_dream.py
+++ b/tests/command/test_builtin_dream.py
@@ -19,6 +19,11 @@ from nanobot.command.router import CommandContext
 from nanobot.utils.gitstore import CommitInfo
 
 
+@pytest.fixture(autouse=True)
+def _isolate_webui_data(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("nanobot.config.paths.get_data_dir", lambda: tmp_path / "data")
+
+
 class _FakeStore:
     def __init__(
         self,

--- a/tests/command/test_builtin_dream.py
+++ b/tests/command/test_builtin_dream.py
@@ -261,6 +261,29 @@ async def test_dream_advances_cursor_on_completed_noop(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_dream_removes_webui_transcripts_for_pruned_sessions(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    ctx, _store = _build_runnable_dream(tmp_path, initialized=False, content_diff="")
+    deleted: list[str] = []
+    monkeypatch.setattr(
+        MemoryStore,
+        "prune_dream_sessions",
+        staticmethod(lambda _sessions_dir: ["dream:old"]),
+    )
+    monkeypatch.setattr(
+        "nanobot.webui.transcript.delete_webui_transcript",
+        deleted.append,
+    )
+
+    await cmd_dream(ctx)
+    await asyncio.sleep(0)
+
+    assert deleted == ["dream:old"]
+
+
+@pytest.mark.asyncio
 async def test_dream_keeps_cursor_when_incomplete_with_diff(tmp_path) -> None:
     """An incomplete run remains retryable even if it left a partial edit."""
     ctx, store = _build_runnable_dream(

--- a/tests/utils/test_webui_transcript.py
+++ b/tests/utils/test_webui_transcript.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from nanobot.bus.events import OutboundMessage
+from nanobot.runtime_context import RUNTIME_CONTEXT_HISTORY_META
 from nanobot.session.history_visibility import HIDDEN_HISTORY_META
 from nanobot.webui.transcript import (
     WEBUI_TRANSCRIPT_SCHEMA_VERSION,
@@ -338,6 +340,47 @@ def test_build_response_replays_tool_calls_from_session_messages(
     }]
 
 
+def test_session_message_fallback_only_replays_public_history(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr("nanobot.config.paths.get_data_dir", lambda: tmp_path)
+    runtime_context = "[Runtime Context]\ninternal metadata"
+
+    out = build_webui_thread_response(
+        "dream:20260727-161858",
+        session_messages=[
+            {
+                "role": "user",
+                "content": "hidden subagent payload",
+                HIDDEN_HISTORY_META: True,
+            },
+            {
+                "role": "user",
+                "content": f"visible prompt\n\n{runtime_context}",
+                RUNTIME_CONTEXT_HISTORY_META: {
+                    "version": 1,
+                    "suffix": runtime_context,
+                },
+            },
+            {
+                "role": "user",
+                "content": (
+                    "[Subagent 'worker']\n\nTask: hidden task\n\nResult: hidden result\n\n"
+                    "Summarize this naturally"
+                ),
+            },
+            {"role": "assistant", "content": "visible answer"},
+        ],
+    )
+
+    assert out is not None
+    assert [(message["role"], message["content"]) for message in out["messages"]] == [
+        ("user", "visible prompt"),
+        ("assistant", "visible answer"),
+    ]
+
+
 async def test_direct_session_recorder_preserves_webui_turn_events(
     tmp_path,
     monkeypatch,
@@ -404,6 +447,60 @@ async def test_direct_session_recorder_preserves_webui_turn_events(
         if message.get("role") == "assistant" and message.get("reasoning")
     )
     assert reasoning["reasoning"] == "Checking memory"
+
+
+async def test_direct_session_recorder_keeps_exception_after_partial_stream(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr("nanobot.config.paths.get_data_dir", lambda: tmp_path)
+    key = "dream:20260727-171636"
+    recorder = WebUISessionTranscriptRecorder(key)
+    recorder.start("Consolidate memory")
+    await recorder.on_stream("Partial answer")
+
+    recorder.finish(error="Dream failed: provider disconnected")
+
+    lines = read_transcript_lines(key)
+    out = build_webui_thread_response(key)
+    assert [(line["event"], line.get("text")) for line in lines] == [
+        ("user", "Consolidate memory"),
+        ("delta", "Partial answer"),
+        ("message", "Dream failed: provider disconnected"),
+        ("turn_end", None),
+    ]
+    assert out is not None
+    assert [message["content"] for message in out["messages"]] == [
+        "Consolidate memory",
+        "Partial answer",
+        "Dream failed: provider disconnected",
+    ]
+
+
+async def test_direct_session_recorder_keeps_provider_error_after_partial_stream(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr("nanobot.config.paths.get_data_dir", lambda: tmp_path)
+    key = "dream:20260727-171637"
+    recorder = WebUISessionTranscriptRecorder(key)
+    recorder.start("Consolidate memory")
+    await recorder.on_stream("Partial answer")
+
+    recorder.finish(OutboundMessage(
+        channel="cli",
+        chat_id="direct",
+        content="Error calling LLM: stream stalled",
+        metadata={"_stop_reason": "error"},
+    ))
+
+    lines = read_transcript_lines(key)
+    assert [(line["event"], line.get("text")) for line in lines] == [
+        ("user", "Consolidate memory"),
+        ("delta", "Partial answer"),
+        ("message", "Error calling LLM: stream stalled"),
+        ("turn_end", None),
+    ]
 
 
 def test_replay_delta_and_turn_end(tmp_path, monkeypatch) -> None:

--- a/tests/utils/test_webui_transcript.py
+++ b/tests/utils/test_webui_transcript.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from nanobot.session.history_visibility import HIDDEN_HISTORY_META
 from nanobot.webui.transcript import (
     WEBUI_TRANSCRIPT_SCHEMA_VERSION,
+    WebUISessionTranscriptRecorder,
     append_fork_marker,
     append_transcript_object,
     build_webui_thread_response,
@@ -277,6 +278,132 @@ def test_write_session_messages_as_transcript_builds_canonical_prefix(
     ]
     msgs = replay_transcript_to_ui_messages(lines)
     assert [m["content"] for m in msgs] == ["round1", "answer1"]
+
+
+def test_build_response_replays_tool_calls_from_session_messages(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr("nanobot.config.paths.get_data_dir", lambda: tmp_path)
+
+    out = build_webui_thread_response(
+        "dream:20260727-161857",
+        session_messages=[
+            {
+                "role": "user",
+                "content": "Consolidate memory",
+                "timestamp": "2026-07-27T16:18:57",
+            },
+            {
+                "role": "assistant",
+                "content": "",
+                "timestamp": "2026-07-27T16:19:00",
+                "tool_calls": [{
+                    "id": "call-read",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": '{"path":"MEMORY.md"}',
+                    },
+                }],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call-read",
+                "name": "read_file",
+                "content": "memory contents",
+                "timestamp": "2026-07-27T16:19:01",
+            },
+            {
+                "role": "assistant",
+                "content": "Memory consolidated.",
+                "timestamp": "2026-07-27T16:19:02",
+            },
+        ],
+    )
+
+    assert out is not None
+    assert [(message["role"], message["content"]) for message in out["messages"]] == [
+        ("user", "Consolidate memory"),
+        ("tool", 'read_file({"path": "MEMORY.md"})'),
+        ("assistant", "Memory consolidated."),
+    ]
+    assert out["messages"][1]["toolEvents"] == [{
+        "version": 1,
+        "phase": "end",
+        "call_id": "call-read",
+        "name": "read_file",
+        "arguments": {"path": "MEMORY.md"},
+        "result": "memory contents",
+    }]
+
+
+async def test_direct_session_recorder_preserves_webui_turn_events(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr("nanobot.config.paths.get_data_dir", lambda: tmp_path)
+    recorder = WebUISessionTranscriptRecorder("dream:20260727-171635")
+    recorder.start("Consolidate memory")
+    await recorder.progress("Checking memory", reasoning=True)
+    await recorder.progress("", reasoning_end=True)
+    await recorder.progress(
+        'read_file({"path":"MEMORY.md"})',
+        tool_hint=True,
+        tool_events=[{
+            "version": 1,
+            "phase": "start",
+            "call_id": "call-read",
+            "name": "read_file",
+            "arguments": {"path": "MEMORY.md"},
+        }],
+    )
+    await recorder.progress(
+        "",
+        tool_events=[{
+            "version": 1,
+            "phase": "end",
+            "call_id": "call-read",
+            "name": "read_file",
+            "arguments": {"path": "MEMORY.md"},
+            "result": "memory contents",
+        }],
+    )
+    await recorder.on_stream("Memory consolidated.")
+    await recorder.on_stream_end()
+    recorder.finish()
+
+    lines = read_transcript_lines("dream:20260727-171635")
+    out = build_webui_thread_response("dream:20260727-171635")
+
+    assert [line["event"] for line in lines] == [
+        "user",
+        "reasoning_delta",
+        "reasoning_end",
+        "message",
+        "message",
+        "delta",
+        "stream_end",
+        "turn_end",
+    ]
+    assert out is not None
+    assert {message.get("turnId") for message in out["messages"]} == {
+        lines[0]["turn_id"],
+    }
+    trace = next(message for message in out["messages"] if message.get("role") == "tool")
+    assert trace["toolEvents"][0]["phase"] == "end"
+    answer = next(
+        message
+        for message in out["messages"]
+        if message.get("role") == "assistant" and message.get("content")
+    )
+    assert answer["content"] == "Memory consolidated."
+    reasoning = next(
+        message
+        for message in out["messages"]
+        if message.get("role") == "assistant" and message.get("reasoning")
+    )
+    assert reasoning["reasoning"] == "Checking memory"
 
 
 def test_replay_delta_and_turn_end(tmp_path, monkeypatch) -> None:

--- a/tests/webui/test_gateway_webui_smoke.py
+++ b/tests/webui/test_gateway_webui_smoke.py
@@ -15,6 +15,8 @@ import httpx
 import pytest
 import websockets
 
+from nanobot.session.manager import SessionManager
+
 _BOOTSTRAP_SECRET = "smoke-secret"
 
 
@@ -148,6 +150,11 @@ async def test_gateway_webui_bootstrap_message_and_thread_hydration(tmp_path: Pa
         ws_port=ws_port,
         gateway_port=gateway_port,
     )
+    dream_key = "dream:20260727-141409"
+    dream_session = SessionManager(workspace).get_or_create(dream_key)
+    dream_session.add_message("user", "Dream consolidation prompt")
+    dream_session.add_message("assistant", "Dream memory update completed")
+    SessionManager(workspace).save(dream_session)
 
     process = _start_gateway(config_path, log_path)
     base_url = f"http://127.0.0.1:{ws_port}"
@@ -180,6 +187,11 @@ async def test_gateway_webui_bootstrap_message_and_thread_hydration(tmp_path: Pa
         sessions = _get_json(f"{base_url}/api/sessions", token=api_token)
         key = f"websocket:{chat_id}"
         assert key in {row["key"] for row in sessions["sessions"]}
+        dream_row = next(row for row in sessions["sessions"] if row["key"] == dream_key)
+        assert dream_row["title"] == "Dream"
+        assert dream_row["read_only"] is True
+        assert dream_row["kind"] == "dream"
+        assert dream_row["preview"] == ""
 
         encoded_key = quote(key, safe="")
         thread = _get_json(
@@ -189,5 +201,15 @@ async def test_gateway_webui_bootstrap_message_and_thread_hydration(tmp_path: Pa
         contents = [str(message.get("content") or "") for message in thread["messages"]]
         assert "/model" in contents
         assert any("Current model: `custom/smoke-model`" in text for text in contents)
+
+        encoded_dream_key = quote(dream_key, safe="")
+        dream_thread = _get_json(
+            f"{base_url}/api/sessions/{encoded_dream_key}/webui-thread",
+            token=api_token,
+        )
+        assert any(
+            "Dream memory update completed" in str(message.get("content") or "")
+            for message in dream_thread["messages"]
+        )
     finally:
         _stop_gateway(process)

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -1496,7 +1496,7 @@ function Shell({
     (groupId: string) => {
       void updateSidebarState((current) => {
         const collapsedGroups = { ...current.collapsed_groups };
-        if (groupId === "workspace:chats" || groupId === "date:all") {
+        if (groupId === "workspace:chats" || groupId === "date:all" || groupId === "dream") {
           if (collapsedGroups[groupId] === false) {
             delete collapsedGroups[groupId];
           } else {

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -1850,9 +1850,11 @@ function Shell({
   }, []);
 
   const headerTitle = activeSession
-    ? sidebarState.title_overrides[activeSession.key] ||
-      activeSession.title ||
-      deriveTitle(activeSession.preview, t("chat.newChat"))
+    ? activeSession.kind === "dream"
+      ? t("chat.groups.dreams")
+      : sidebarState.title_overrides[activeSession.key] ||
+        activeSession.title ||
+        deriveTitle(activeSession.preview, t("chat.newChat"))
     : t("app.brand");
 
   useEffect(() => {

--- a/webui/src/components/ChatList.tsx
+++ b/webui/src/components/ChatList.tsx
@@ -23,7 +23,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { deriveTitle, relativeTime, visibleSessionPreview } from "@/lib/format";
+import { deriveTitle, fmtDateTime, relativeTime, visibleSessionPreview } from "@/lib/format";
 import {
   COLLAPSED_CHATS_VISIBLE_COUNT,
   displayTitle,
@@ -110,6 +110,7 @@ export const ChatList = memo(function ChatList({
     earlier: t("chat.groups.earlier"),
     archived: t("chat.groups.archived"),
     projects: t("chat.groups.projects"),
+    dreams: t("chat.groups.dreams"),
     fallbackTitle: t("chat.newChat"),
   }), [t]);
   const groups = useMemo(
@@ -204,7 +205,7 @@ export const ChatList = memo(function ChatList({
                 <ProjectGroupHeader
                   label={group.label}
                   path={group.projectPath}
-                  collapsed={Boolean(collapsedGroups[group.id])}
+                  collapsed={isCollapsedProject(group, collapsedGroups)}
                   onToggle={() => onToggleGroup?.(group.id)}
                   onRequestRename={
                     group.projectKey && onRequestRenameProject
@@ -219,10 +220,16 @@ export const ChatList = memo(function ChatList({
                   actionMenuPortalContainer={actionMenuPortalContainer}
                   updatedAt={showTimestamps ? group.updatedAt : null}
                 />
+              ) : group.kind === "dream" ? (
+                <DreamGroupHeader
+                  label={group.label}
+                  collapsed={isCollapsedProject(group, collapsedGroups)}
+                  onToggle={() => onToggleGroup?.(group.id)}
+                />
               ) : (
                 <ChatsGroupHeader label={group.label} />
               )}
-              {group.kind === "project" && collapsedGroups[group.id] ? null : (
+              {isCollapsedProject(group, collapsedGroups) ? null : (
                 <ul className="space-y-0.5">
                   {visibleSessions.map((s) => {
                     const active = s.key === activeKey;
@@ -230,19 +237,25 @@ export const ChatList = memo(function ChatList({
                       id: s.chatId.slice(0, 6),
                     });
                     const generatedTitle = s.title?.trim() || "";
-                    const title = displayTitle(s, titleOverrides, t("chat.newChat"));
-                    const tooltipTitle =
-                      titleOverrides[s.key]?.trim() ||
-                      generatedTitle ||
-                      deriveTitle(s.preview, fallbackTitle);
+                    const dreamMode = group.kind === "dream";
+                    const dreamTimestamp = dreamMode
+                      ? fmtDateTime(s.updatedAt ?? s.createdAt)
+                      : "";
+                    const title = dreamTimestamp ||
+                      displayTitle(s, titleOverrides, t("chat.newChat"));
+                    const tooltipTitle = dreamMode
+                      ? title
+                      : titleOverrides[s.key]?.trim() ||
+                        generatedTitle ||
+                        deriveTitle(s.preview, fallbackTitle);
                     const isPinned = pinned.has(s.key);
                     const isArchived = archived.has(s.key);
                     const preview = visibleSessionPreview(s.preview);
                     const showPreview = showPreviews && preview && preview !== title;
-                    const timestamp = showTimestamps
+                    const timestamp = !dreamMode && showTimestamps
                       ? relativeTime(s.updatedAt ?? s.createdAt)
                       : "";
-                    const projectMode = group.kind === "project";
+                    const projectMode = group.kind === "project" || group.kind === "dream";
                     const activityState = running.has(s.chatId)
                       ? "running"
                       : updated.has(s.chatId) && !active
@@ -301,7 +314,7 @@ export const ChatList = memo(function ChatList({
                             ) : null}
                           </button>
                           <SessionActivityIndicator state={activityState} />
-                          <DropdownMenu modal={false}>
+                          {!s.readOnly ? <DropdownMenu modal={false}>
                             <DropdownMenuTrigger
                               className={cn(
                                 "inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/75 opacity-40 transition-opacity",
@@ -361,7 +374,7 @@ export const ChatList = memo(function ChatList({
                                 {t("chat.delete")}
                               </DropdownMenuItem>
                             </DropdownMenuContent>
-                          </DropdownMenu>
+                          </DropdownMenu> : null}
                         </div>
                       </li>
                     );
@@ -488,6 +501,30 @@ function ChatsGroupHeader({ label }: { label: string }) {
   return (
     <div className="px-2 pb-1 text-[12px] font-medium text-muted-foreground/65">
       {label}
+    </div>
+  );
+}
+
+function DreamGroupHeader({
+  label,
+  collapsed,
+  onToggle,
+}: {
+  label: string;
+  collapsed: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div className="group flex min-w-0 items-center gap-1 px-1 pb-1 pt-1 text-[12px] font-medium text-muted-foreground/78">
+      <button
+        type="button"
+        aria-expanded={!collapsed}
+        onClick={onToggle}
+        className="flex min-w-0 flex-1 items-center gap-2 rounded-lg px-1.5 py-1 text-left transition-colors hover:bg-sidebar-accent/45 hover:text-sidebar-foreground"
+      >
+        <Folder className="h-3.5 w-3.5 shrink-0" aria-hidden />
+        <span className="min-w-0 flex-1 truncate">{label}</span>
+      </button>
     </div>
   );
 }

--- a/webui/src/components/MessageBubble.tsx
+++ b/webui/src/components/MessageBubble.tsx
@@ -199,14 +199,14 @@ export function MessageBubble({
           />
         ) : null}
         {hasText ? (
-          <p
+          <div
             className={cn(
               "ml-auto w-fit max-w-full min-w-0 rounded-[18px] bg-secondary/70 px-4 py-2",
               "text-left text-[16px]/[1.75] whitespace-pre-wrap [overflow-wrap:anywhere]",
             )}
           >
             {messageText}
-          </p>
+          </div>
         ) : null}
         {hasText && showCopyAction ? (
           <TooltipProvider delayDuration={220} skipDelayDuration={80}>

--- a/webui/src/components/UserMessageText.tsx
+++ b/webui/src/components/UserMessageText.tsx
@@ -1,5 +1,4 @@
-import { Fragment } from "react";
-
+import { MarkdownText } from "@/components/MarkdownText";
 import {
   CliAppMentionToken,
   McpPresetMentionToken,
@@ -60,6 +59,25 @@ function splitUserMessageSegments(
   return segments;
 }
 
+function MarkdownUserTextSegment({ text }: { text: string }) {
+  const match = /^(\s*)([\s\S]*?\S)?(\s*)$/.exec(text);
+  const leading = match?.[1] ?? "";
+  const content = match?.[2] ?? "";
+  const trailing = match?.[3] ?? "";
+  if (!content) return <>{text}</>;
+  return (
+    <>
+      {leading ? <span>{leading}</span> : null}
+      <MarkdownText
+        className="prose-p:my-0 prose-headings:my-1 prose-ul:my-1 prose-ol:my-1"
+      >
+        {content}
+      </MarkdownText>
+      {trailing ? <span>{trailing}</span> : null}
+    </>
+  );
+}
+
 export function UserMessageText({
   text,
   cliApps,
@@ -74,7 +92,7 @@ export function UserMessageText({
     <>
       {segments.map((segment, index) => {
         if (segment.kind === "text") {
-          return <Fragment key={`text-${index}`}>{segment.text}</Fragment>;
+          return <MarkdownUserTextSegment key={`text-${index}`} text={segment.text} />;
         }
         if (segment.kind === "skill") return (
           <InlineTokenHighlight

--- a/webui/src/components/thread/ThreadMessages.tsx
+++ b/webui/src/components/thread/ThreadMessages.tsx
@@ -118,7 +118,7 @@ export function ThreadMessages({
             hasBodyBelow={hasBodyBelow}
             deferOffscreenRender={deferOffscreenRender}
             isTurnStreaming={liveActivityClusterIndices.has(index)}
-            forkIndex={forkIndex}
+            forkIndex={onForkFromMessage ? forkIndex : undefined}
             showForkBoundary={index === forkBoundaryAfterUnitIndex}
             forkBoundaryLabel={t("thread.forkedFromHistory")}
             cliApps={cliApps}

--- a/webui/src/components/thread/ThreadShell.tsx
+++ b/webui/src/components/thread/ThreadShell.tsx
@@ -959,7 +959,14 @@ export function ThreadShell({
         />
       ) : null}
       {session ? (
-        <ThreadComposer
+        session.readOnly ? (
+          <div
+            className="mx-auto flex w-full max-w-3xl items-center justify-center rounded-2xl border border-border/60 bg-muted/35 px-4 py-3 text-sm text-muted-foreground"
+            data-testid="readonly-session-banner"
+          >
+            {t("thread.readOnlySession", { defaultValue: "This session is read-only." })}
+          </div>
+        ) : <ThreadComposer
           onSend={handleThreadSend}
           disabled={!chatId}
           isStreaming={turnActive}
@@ -1100,7 +1107,7 @@ export function ThreadShell({
             userMessageOffset={userMessageOffset}
             onLoadOlder={loadOlder}
             onOpenFilePreview={historyKey ? handleOpenFilePreview : undefined}
-            onForkFromMessage={onForkChat ? handleForkFromMessage : undefined}
+            onForkFromMessage={onForkChat && !session?.readOnly ? handleForkFromMessage : undefined}
             onQuoteSelection={session ? handleQuoteSelection : undefined}
           />
         </FilePreviewAvailabilityProvider>

--- a/webui/src/components/thread/ThreadShell.tsx
+++ b/webui/src/components/thread/ThreadShell.tsx
@@ -964,7 +964,7 @@ export function ThreadShell({
             className="mx-auto flex w-full max-w-3xl items-center justify-center rounded-2xl border border-border/60 bg-muted/35 px-4 py-3 text-sm text-muted-foreground"
             data-testid="readonly-session-banner"
           >
-            {t("thread.readOnlySession", { defaultValue: "This session is read-only." })}
+            {t("thread.readOnlySession")}
           </div>
         ) : <ThreadComposer
           onSend={handleThreadSend}
@@ -1057,7 +1057,7 @@ export function ThreadShell({
       <HeroGreeting text={t(heroGreetingKey)} />
     </div>
   );
-  const sessionInfoAction = historyKey ? (
+  const sessionInfoAction = historyKey && !session?.readOnly ? (
     <SessionInfoPopover sessionKey={historyKey} token={token} title={title} />
   ) : undefined;
   const promptNavigatorAction = historyKey ? (

--- a/webui/src/i18n/locales/en/common.json
+++ b/webui/src/i18n/locales/en/common.json
@@ -853,6 +853,7 @@
       "pinned": "Pinned",
       "all": "Topics",
       "projects": "Projects",
+      "dreams": "Dream",
       "today": "Today",
       "yesterday": "Yesterday",
       "earlier": "Earlier",

--- a/webui/src/i18n/locales/en/common.json
+++ b/webui/src/i18n/locales/en/common.json
@@ -893,6 +893,7 @@
   },
   "thread": {
     "loadingConversation": "Loading conversation…",
+    "readOnlySession": "This session is read-only.",
     "empty": {
       "greetings": {
         "workOn": "What should we work on?",

--- a/webui/src/i18n/locales/es/common.json
+++ b/webui/src/i18n/locales/es/common.json
@@ -880,6 +880,7 @@
   },
   "thread": {
     "loadingConversation": "Cargando conversación…",
+    "readOnlySession": "Esta sesión es de solo lectura.",
     "empty": {
       "greetings": {
         "workOn": "¿En qué trabajamos juntos?",

--- a/webui/src/i18n/locales/es/common.json
+++ b/webui/src/i18n/locales/es/common.json
@@ -840,6 +840,7 @@
       "pinned": "Pinned",
       "all": "Temas",
       "projects": "Projects",
+      "dreams": "Sueños",
       "today": "Today",
       "yesterday": "Yesterday",
       "earlier": "Earlier",

--- a/webui/src/i18n/locales/fr/common.json
+++ b/webui/src/i18n/locales/fr/common.json
@@ -879,6 +879,7 @@
   },
   "thread": {
     "loadingConversation": "Chargement de la conversation…",
+    "readOnlySession": "Cette session est en lecture seule.",
     "empty": {
       "greetings": {
         "workOn": "Sur quoi travaillons-nous ensemble ?",

--- a/webui/src/i18n/locales/fr/common.json
+++ b/webui/src/i18n/locales/fr/common.json
@@ -839,6 +839,7 @@
       "pinned": "Pinned",
       "all": "Sujets",
       "projects": "Projects",
+      "dreams": "Rêves",
       "today": "Today",
       "yesterday": "Yesterday",
       "earlier": "Earlier",

--- a/webui/src/i18n/locales/id/common.json
+++ b/webui/src/i18n/locales/id/common.json
@@ -839,6 +839,7 @@
       "pinned": "Pinned",
       "all": "Topik",
       "projects": "Projects",
+      "dreams": "Mimpi",
       "today": "Today",
       "yesterday": "Yesterday",
       "earlier": "Earlier",

--- a/webui/src/i18n/locales/id/common.json
+++ b/webui/src/i18n/locales/id/common.json
@@ -879,6 +879,7 @@
   },
   "thread": {
     "loadingConversation": "Memuat percakapan…",
+    "readOnlySession": "Sesi ini hanya dapat dibaca.",
     "empty": {
       "greetings": {
         "workOn": "Apa yang kita kerjakan bersama?",

--- a/webui/src/i18n/locales/ja/common.json
+++ b/webui/src/i18n/locales/ja/common.json
@@ -879,6 +879,7 @@
   },
   "thread": {
     "loadingConversation": "会話を読み込み中…",
+    "readOnlySession": "このセッションは読み取り専用です。",
     "empty": {
       "greetings": {
         "workOn": "一緒に何に取り組みましょうか？",

--- a/webui/src/i18n/locales/ja/common.json
+++ b/webui/src/i18n/locales/ja/common.json
@@ -839,6 +839,7 @@
       "pinned": "Pinned",
       "all": "トピック",
       "projects": "Projects",
+      "dreams": "夢",
       "today": "Today",
       "yesterday": "Yesterday",
       "earlier": "Earlier",

--- a/webui/src/i18n/locales/ko/common.json
+++ b/webui/src/i18n/locales/ko/common.json
@@ -879,6 +879,7 @@
   },
   "thread": {
     "loadingConversation": "대화 불러오는 중…",
+    "readOnlySession": "이 세션은 읽기 전용입니다.",
     "empty": {
       "greetings": {
         "workOn": "우리 무엇을 함께 해볼까요?",

--- a/webui/src/i18n/locales/ko/common.json
+++ b/webui/src/i18n/locales/ko/common.json
@@ -839,6 +839,7 @@
       "pinned": "Pinned",
       "all": "주제",
       "projects": "Projects",
+      "dreams": "꿈",
       "today": "Today",
       "yesterday": "Yesterday",
       "earlier": "Earlier",

--- a/webui/src/i18n/locales/pt-BR/common.json
+++ b/webui/src/i18n/locales/pt-BR/common.json
@@ -853,6 +853,7 @@
       "pinned": "Fixadas",
       "all": "Tópicos",
       "projects": "Projetos",
+      "dreams": "Sonhos",
       "today": "Hoje",
       "yesterday": "Ontem",
       "earlier": "Anteriores",

--- a/webui/src/i18n/locales/pt-BR/common.json
+++ b/webui/src/i18n/locales/pt-BR/common.json
@@ -893,6 +893,7 @@
   },
   "thread": {
     "loadingConversation": "Carregando conversa…",
+    "readOnlySession": "Esta sessão é somente leitura.",
     "empty": {
       "greetings": {
         "workOn": "Em que vamos trabalhar?",

--- a/webui/src/i18n/locales/vi/common.json
+++ b/webui/src/i18n/locales/vi/common.json
@@ -839,6 +839,7 @@
       "pinned": "Pinned",
       "all": "Chủ đề",
       "projects": "Projects",
+      "dreams": "Giấc mơ",
       "today": "Today",
       "yesterday": "Yesterday",
       "earlier": "Earlier",

--- a/webui/src/i18n/locales/vi/common.json
+++ b/webui/src/i18n/locales/vi/common.json
@@ -879,6 +879,7 @@
   },
   "thread": {
     "loadingConversation": "Đang tải cuộc trò chuyện…",
+    "readOnlySession": "Phiên này chỉ có thể đọc.",
     "empty": {
       "greetings": {
         "workOn": "Mình cùng làm gì tiếp?",

--- a/webui/src/i18n/locales/zh-CN/common.json
+++ b/webui/src/i18n/locales/zh-CN/common.json
@@ -853,6 +853,7 @@
       "pinned": "置顶",
       "all": "话题",
       "projects": "项目",
+      "dreams": "梦境",
       "today": "今天",
       "yesterday": "昨天",
       "earlier": "更早",

--- a/webui/src/i18n/locales/zh-CN/common.json
+++ b/webui/src/i18n/locales/zh-CN/common.json
@@ -893,6 +893,7 @@
   },
   "thread": {
     "loadingConversation": "正在加载话题…",
+    "readOnlySession": "此会话为只读。",
     "empty": {
       "greetings": {
         "workOn": "我们要一起做点什么？",

--- a/webui/src/i18n/locales/zh-TW/common.json
+++ b/webui/src/i18n/locales/zh-TW/common.json
@@ -879,6 +879,7 @@
   },
   "thread": {
     "loadingConversation": "正在載入話題…",
+    "readOnlySession": "此工作階段為唯讀。",
     "empty": {
       "greetings": {
         "workOn": "我們要一起做點什麼？",

--- a/webui/src/i18n/locales/zh-TW/common.json
+++ b/webui/src/i18n/locales/zh-TW/common.json
@@ -839,6 +839,7 @@
       "pinned": "置頂",
       "all": "話題",
       "projects": "專案",
+      "dreams": "夢境",
       "today": "今天",
       "yesterday": "昨天",
       "earlier": "更早",

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -139,6 +139,8 @@ export async function listSessions(
     preview?: string;
     model_preset?: string | null;
     run_started_at?: number | null;
+    read_only?: boolean;
+    kind?: string;
     workspace_scope?: WorkspaceScopePayload | null;
   };
   const body = await request<{ sessions: Row[] }>(
@@ -156,6 +158,8 @@ export async function listSessions(
     preview: s.preview ?? "",
     modelPreset: s.model_preset ?? null,
     runStartedAt: s.run_started_at ?? null,
+    readOnly: s.read_only === true,
+    kind: s.kind,
     workspaceScope: s.workspace_scope ?? null,
   }));
 }

--- a/webui/src/lib/chat-groups.ts
+++ b/webui/src/lib/chat-groups.ts
@@ -8,7 +8,7 @@ export interface SessionGroup {
   id: string;
   label: string;
   sessions: ChatSummary[];
-  kind?: "project";
+  kind?: "project" | "dream";
   projectPath?: string;
   projectKey?: string;
   updatedAt?: string | null;
@@ -22,6 +22,7 @@ export interface ChatGroupLabels {
   earlier: string;
   archived: string;
   projects: string;
+  dreams: string;
   fallbackTitle: string;
 }
 
@@ -54,8 +55,13 @@ export function groupSessions(
   const pinnedSessions: ChatSummary[] = [];
   const archivedSessions: ChatSummary[] = [];
   const normalSessions: ChatSummary[] = [];
+  const dreamSessions: ChatSummary[] = [];
 
   for (const session of sessions) {
+    if (session.kind === "dream") {
+      dreamSessions.push(session);
+      continue;
+    }
     if (archived.has(session.key)) {
       if (options.showArchived) archivedSessions.push(session);
       continue;
@@ -90,6 +96,15 @@ export function groupSessions(
       ),
     }))
     .filter((group) => group.sessions.length > 0);
+
+  if (dreamSessions.length) {
+    groups.push({
+      id: "dream",
+      label: labels.dreams,
+      kind: "dream",
+      sessions: sortSessions(dreamSessions, options.sort, options.titleOverrides),
+    });
+  }
 
   if (options.sort === "title_asc" && normalSessions.length) {
     groups.push({
@@ -176,6 +191,7 @@ export function isCollapsedProject(
   group: SessionGroup,
   collapsedGroups: Record<string, boolean>,
 ): boolean {
+  if (group.kind === "dream") return collapsedGroups[group.id] !== false;
   return group.kind === "project" && Boolean(collapsedGroups[group.id]);
 }
 
@@ -224,11 +240,12 @@ export function displayTitle(
 
 function groupSessionsByProject(
   sessions: ChatSummary[],
-  labels: Pick<ChatGroupLabels, "all">,
+  labels: Pick<ChatGroupLabels, "all" | "dreams">,
   options: ChatGroupingOptions,
 ): SessionGroup[] {
   const archived = new Set(options.archivedKeys);
   const conversations: ChatSummary[] = [];
+  const dreamSessions: ChatSummary[] = [];
   const buckets = new Map<string, {
     path?: string;
     label: string;
@@ -238,6 +255,10 @@ function groupSessionsByProject(
 
   for (const session of sessions) {
     if (archived.has(session.key) && !options.showArchived) {
+      continue;
+    }
+    if (session.kind === "dream") {
+      dreamSessions.push(session);
       continue;
     }
     const scope = session.workspaceScope;
@@ -300,6 +321,23 @@ function groupSessionsByProject(
         pinned,
         archived,
       ),
+    });
+  }
+
+  if (dreamSessions.length) {
+    const dreamsUpdatedAt = dreamSessions.reduce<string | null>(
+      (best, s) => {
+        const candidate = s.updatedAt ?? s.createdAt ?? null;
+        return isNewerDate(candidate, best) ? candidate : best;
+      },
+      null,
+    );
+    groups.push({
+      id: "dream",
+      label: labels.dreams,
+      kind: "dream",
+      updatedAt: dreamsUpdatedAt,
+      sessions: sortSessions(dreamSessions, options.sort, options.titleOverrides),
     });
   }
 

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -251,6 +251,9 @@ export interface ChatSummary {
   modelPreset?: string | null;
   /** Unix epoch seconds when this session currently has a turn in flight. */
   runStartedAt?: number | null;
+  /** Internal sessions such as Dream are visible for inspection but not writable. */
+  readOnly?: boolean;
+  kind?: string;
   workspaceScope?: WorkspaceScopePayload | null;
 }
 

--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -1366,6 +1366,36 @@ describe("App layout", () => {
     );
   });
 
+  it("localizes the Dream session header instead of using its API title", async () => {
+    await i18n.changeLanguage("zh-CN");
+    const dreamKey = "dream:20260727-175801";
+    mockSessions = [
+      {
+        key: dreamKey,
+        channel: "dream",
+        chatId: "20260727-175801",
+        createdAt: "2026-07-27T17:58:01Z",
+        updatedAt: "2026-07-27T17:58:01Z",
+        title: "Dream",
+        preview: "Consolidate memory",
+        kind: "dream",
+        readOnly: true,
+      },
+    ];
+    window.history.replaceState(
+      null,
+      "",
+      `/#/chat/${encodeURIComponent(dreamKey)}`,
+    );
+
+    render(<App />);
+
+    await waitFor(() => expect(connectSpy).toHaveBeenCalled());
+    await waitFor(() => expect(document.title).toBe("梦境 · nanobot"));
+    expect(within(screen.getByRole("main")).getByText("梦境")).toBeInTheDocument();
+    expect(screen.getByText("此会话为只读。")).toBeInTheDocument();
+  });
+
   it("opens the settings view from the sidebar footer", async () => {
     mockSessions = [
       {

--- a/webui/src/tests/chat-list.test.tsx
+++ b/webui/src/tests/chat-list.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { ChatList } from "@/components/ChatList";
+import { fmtDateTime } from "@/lib/format";
 import type { ChatSummary } from "@/lib/types";
 
 function session(overrides: Partial<ChatSummary>): ChatSummary {
@@ -83,6 +84,46 @@ describe("ChatList", () => {
     expect(
       within(screen.getByRole("region", { name: "Earlier" })).queryByTitle("Pinned"),
     ).not.toBeInTheDocument();
+  });
+
+  it("keeps Dream sessions in a separate collapsible folder", () => {
+    const sessions = [
+      session({ chatId: "normal", title: "Normal chat" }),
+      session({
+        key: "dream:20260727-141409",
+        channel: "dream",
+        chatId: "20260727-141409",
+        createdAt: "2026-07-27T14:14:09Z",
+        updatedAt: "2026-07-27T14:14:09Z",
+        title: "Dream",
+        kind: "dream",
+        readOnly: true,
+      }),
+    ];
+
+    render(
+      <ChatList
+        sessions={sessions}
+        activeKey={null}
+        onSelect={vi.fn()}
+        onRequestDelete={vi.fn()}
+        onTogglePin={vi.fn()}
+        onRequestRename={vi.fn()}
+        onToggleArchive={vi.fn()}
+        collapsedGroups={{ dream: false }}
+      />,
+    );
+
+    const dreamRegion = screen.getByRole("region", { name: "Dream" });
+    expect(dreamRegion).toHaveTextContent("Dream");
+    expect(within(dreamRegion).queryByLabelText(/actions/i)).not.toBeInTheDocument();
+    const dreamFolder = within(dreamRegion).getAllByRole("button", { name: "Dream" });
+    expect(dreamFolder).toHaveLength(1);
+    expect(within(dreamRegion).getAllByText("Dream")).toHaveLength(1);
+    expect(within(dreamRegion).getByText(fmtDateTime("2026-07-27T14:14:09Z")))
+      .toBeInTheDocument();
+    expect(within(screen.getByRole("region", { name: "Earlier" })).getByText("Normal chat"))
+      .toBeInTheDocument();
   });
 
   it("groups WebUI chats by workspace project while preserving in-project sorting and activity", () => {

--- a/webui/src/tests/message-bubble.test.tsx
+++ b/webui/src/tests/message-bubble.test.tsx
@@ -95,20 +95,23 @@ const SLASH_COMMANDS: SlashCommand[] = [
 ];
 
 describe("MessageBubble", () => {
-  it("renders user messages as right-aligned pills", () => {
+  it("renders user messages as right-aligned Markdown pills", async () => {
     const message: UIMessage = {
       id: "u1",
       role: "user",
-      content: "hello",
+      content: "**hello**",
       createdAt: Date.now(),
     };
 
     const { container } = render(<MessageBubble message={message} />);
     const row = container.firstElementChild;
-    const pill = screen.getByText("hello");
+    const pill = row?.firstElementChild;
 
     expect(row).toHaveClass("ml-auto", "flex");
+    expect(pill).not.toBeNull();
     expect(pill).toHaveClass("ml-auto", "w-fit", "rounded-[18px]");
+    await waitFor(() => expect(screen.getByText("hello")).toBeInTheDocument());
+    expect(screen.getByText("hello").tagName).toBe("STRONG");
     expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Fork" })).not.toBeInTheDocument();
   });

--- a/webui/src/tests/thread-shell.test.tsx
+++ b/webui/src/tests/thread-shell.test.tsx
@@ -304,6 +304,32 @@ describe("ThreadShell", () => {
     );
   });
 
+  it("keeps read-only sessions free of session management controls", async () => {
+    const client = makeClient();
+
+    render(wrap(
+      client,
+      <ThreadShell
+        session={{
+          ...session("dream"),
+          kind: "dream" as const,
+          readOnly: true,
+        }}
+        title="Dream"
+        onToggleSidebar={() => {}}
+      />,
+    ));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("readonly-session-banner")).toHaveTextContent(
+        "This session is read-only.",
+      );
+      expect(
+        screen.queryByRole("button", { name: "Session details" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it("keeps inferred file paths non-interactive when the availability probe fails", async () => {
     await preloadMarkdownText();
     const client = makeClient();


### PR DESCRIPTION
## Summary

- expose Dream runs in the WebUI as a separate, localized, read-only, collapsible session group with date/time labels
- record and replay Dream reasoning, tool calls, file edits, streaming output, and file previews through the same thread UI as regular sessions
- render user messages as Markdown and preserve complete Dream history prompts without per-entry truncation
- allow Dream's restricted `write_file` tool to update only the canonical memory files when patch-based edits cannot apply

## Testing

- `python -m pytest tests/agent/test_dream.py tests/agent/test_turn_hooks.py tests/utils/test_webui_transcript.py -q`
- `python -m pytest tests/command/test_builtin_dream.py -q`
- `python -m pytest nanobot/channels/websocket/tests/test_websocket_channel.py::test_handle_file_preview_returns_workspace_file nanobot/channels/websocket/tests/test_websocket_channel.py::test_handle_file_preview_returns_workspace_file_for_dream_session -q`
- `npm run test -- --run src/tests/i18n.test.tsx src/tests/chat-list.test.tsx`
- focused Ruff checks on the changed Python surfaces

## Notes

- Browser verification is intentionally left for manual validation while this PR is in draft.