### PR TITLE
feat(channels): add LINE Messaging API channel

### DIFF
--- a/nanobot/channels/line/__init__.py
+++ b/nanobot/channels/line/__init__.py
@@ -1,0 +1,1 @@
+"""LINE channel package."""

--- a/nanobot/channels/line/manifest.py
+++ b/nanobot/channels/line/manifest.py
@@ -1,0 +1,31 @@
+"""LINE management contract.
+
+LINE Messaging API webhook channel.
+Requires a LINE Bot channel (channel-access-token + channel-secret).
+"""
+
+from nanobot.channels._manifest import field, required
+from nanobot.channels.contracts import ChannelSetupSpec
+from nanobot.channels.plugin import ChannelPlugin
+
+SETUP_SPEC = ChannelSetupSpec(
+    fields={
+        "channelAccessToken": field("secret"),
+        "channelSecret": field("secret"),
+        "allowFrom": field("list"),
+        "groupPolicy": field("enum", choices=("mention", "all"), default="mention"),
+    },
+    required=(required("channelAccessToken"), required("channelSecret")),
+    official_url="https://developers.line.biz/console/",
+)
+
+PLUGIN = ChannelPlugin(
+    name="line",
+    display_name="LINE",
+    runtime=f"{__package__}.runtime:LineChannel",
+    setup=SETUP_SPEC,
+    dependencies=(
+        "line-bot-sdk>=3.0.0,<4.0.0",
+    ),
+    webui="webui/index.ts",
+)

--- a/nanobot/channels/line/runtime.py
+++ b/nanobot/channels/line/runtime.py
@@ -1,0 +1,238 @@
+"""LINE channel implementation using LINE Messaging API webhook."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import re
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import Any
+
+from loguru import logger
+from pydantic import Field, field_validator
+
+from nanobot.bus.events import InboundMessage, OutboundMessage
+from nanobot.bus.outbound_events import ProgressEvent
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.paths import get_media_dir
+from nanobot.config.schema import Base
+from nanobot.pairing import is_approved
+from nanobot.utils.helpers import safe_filename, split_message
+
+
+_LINE_MAX_MESSAGE_LENGTH = 5000
+_LINE_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_LINE_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
+_LINE_CODE_RE = re.compile(r"```(?:\w+)?\n?([\s\S]*?)```")
+_LINE_INLINE_CODE_RE = re.compile(r"`([^`\n]+)`")
+
+
+class LineSettings(Base):
+    channel_access_token: str = Field(..., alias="channelAccessToken")
+    channel_secret: str = Field(..., alias="channelSecret")
+    allow_from: list[str] | None = Field(default=None, alias="allowFrom")
+    group_policy: str = Field(default="mention", alias="groupPolicy")
+    webhook_path: str = "/line/webhook"
+    webhook_port: int = 8088
+
+    @field_validator("channel_access_token")
+    @classmethod
+    def _token_non_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("channelAccessToken must not be empty")
+        return v
+
+
+@dataclass
+class _Run:
+    text: str
+    styles: frozenset[str] = field(default_factory=frozenset)
+    opaque: bool = False
+
+
+def _line_markdown_to_text(md_text: str) -> str:
+    """Convert basic Markdown to LINE plain text.
+
+    LINE supports limited formatting via Unicode characters.
+    Falls back to plain text with no special formatting.
+    """
+    # Remove code blocks
+    text = _LINE_CODE_RE.sub(r"\1", md_text)
+    # Remove inline code markers
+    text = _LINE_INLINE_CODE_RE.sub(r"\1", text)
+    # Convert bold markers to plain
+    text = _LINE_BOLD_RE.sub(r"\1", text)
+    # Convert links: [text](url) -> text (url)
+    text = _LINE_LINK_RE.sub(r"\1 (\2)", text)
+    return text.strip()
+
+
+def _segment_line_reply(text: str, max_len: int = _LINE_MAX_MESSAGE_LENGTH) -> list[str]:
+    """Split a reply into LINE-friendly segments."""
+    if len(text) <= max_len:
+        return [text]
+    segments = []
+    while len(text) > max_len:
+        split_pos = text.rfind("\n", 0, max_len)
+        if split_pos == -1:
+            split_pos = text.rfind(" ", 0, max_len)
+        if split_pos == -1:
+            split_pos = max_len
+        segments.append(text[:split_pos].rstrip())
+        text = text[split_pos:].lstrip()
+    segments.append(text.rstrip())
+    return [s for s in segments if s]
+
+
+class LineChannel(BaseChannel):
+    """LINE Messaging API channel using webhook + aiohttp server."""
+
+    def __init__(self, settings: LineSettings, bus: MessageBus) -> None:
+        super().__init__(channel_name="line", bus=bus)
+        self._settings = settings
+        self._server: asyncio.AbstractServer | None = None
+
+    @asynccontextmanager
+    async def run(
+        self,
+        outbound: AsyncIterator[OutboundMessage],
+        handle_inbound: None = None,
+    ) -> AsyncIterator[None]:
+        from linebot.v3 import WebhookHandler
+        from linebot.v3.exceptions import InvalidSignatureError
+        from linebot.v3.messaging import (
+            ApiClient,
+            Configuration,
+            MessagingApi,
+            ReplyMessageRequest,
+            TextMessage,
+        )
+        from linebot.v3.webhooks import MessageEvent, TextMessageContent
+
+        from aiohttp import web
+
+        settings = self._settings
+        app = web.Application()
+        routes = web.RouteTableDef()
+
+        # LINE API client
+        config = Configuration(access_token=settings.channel_access_token)
+        api_client = ApiClient(config)
+        messaging_api = MessagingApi(api_client)
+        handler = WebhookHandler(settings.channel_secret)
+
+        @routes.post(settings.webhook_path)
+        async def webhook(request: web.Request) -> web.Response:
+            """Handle LINE webhook callback."""
+            signature = request.headers.get("x-line-signature", "")
+            body = await request.text()
+
+            # Validate signature
+            if not _validate_signature(settings.channel_secret, body, signature):
+                logger.warning("[LINE] Invalid webhook signature")
+                return web.Response(status=403)
+
+            try:
+                events = handler.parse(body, signature)
+            except InvalidSignatureError:
+                logger.warning("[LINE] Invalid webhook signature")
+                return web.Response(status=403)
+
+            for event in events:
+                if not isinstance(event, MessageEvent):
+                    continue
+                if not isinstance(event.message, TextMessageContent):
+                    continue
+
+                user_id = event.source.user_id
+                text = event.message.text
+
+                if not is_approved(user_id, settings.allow_from):
+                    logger.info("[LINE] Unapproved sender: {}", user_id)
+                    continue
+
+                logger.info("[LINE] Message from {}: {}", user_id, text[:100])
+
+                # Queue inbound message
+                await self._bus.publish(
+                    InboundMessage(
+                        channel="line",
+                        sender=user_id,
+                        text=text,
+                        reply_token=event.reply_token,
+                        source_event=event,
+                    )
+                )
+
+            return web.Response(status=200)
+
+        app.add_routes(routes)
+
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, "0.0.0.0", settings.webhook_port)
+        await site.start()
+
+        logger.info(
+            "[LINE] Webhook server started on port {} (path={})",
+            settings.webhook_port,
+            settings.webhook_path,
+        )
+
+        try:
+            async for message in outbound:
+                if not isinstance(message, OutboundMessage):
+                    continue
+                reply_token = getattr(message, "reply_token", None)
+                if reply_token:
+                    text = _line_markdown_to_text(message.text)
+                    segments = _segment_line_reply(text)
+                    for seg in segments:
+                        try:
+                            messaging_api.reply_message(
+                                ReplyMessageRequest(
+                                    reply_token=reply_token,
+                                    messages=[TextMessage(text=seg)],
+                                )
+                            )
+                        except Exception as exc:
+                            logger.error("[LINE] Failed to reply: {}", exc)
+                elif message.target:
+                    # Push message to a specific user
+                    text = _line_markdown_to_text(message.text)
+                    segments = _segment_line_reply(text)
+                    for seg in segments:
+                        try:
+                            from linebot.v3.messaging import PushMessageRequest
+
+                            messaging_api.push_message(
+                                PushMessageRequest(
+                                    to=message.target,
+                                    messages=[TextMessage(text=seg)],
+                                )
+                            )
+                        except Exception as exc:
+                            logger.error("[LINE] Failed to push to {}: {}", message.target, exc)
+
+            yield
+        finally:
+            await runner.cleanup()
+            api_client.close()
+            logger.info("[LINE] Webhook server stopped")
+
+
+def _validate_signature(secret: str, body: str, signature: str) -> bool:
+    """Validate LINE webhook signature using HMAC-SHA256."""
+    if not signature:
+        return False
+    computed = hmac.new(
+        secret.encode("utf-8"),
+        body.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    expected = computed.hex()
+    return hmac.compare_digest(expected, signature)

--- a/nanobot/channels/line/tests/test_line_channel.py
+++ b/nanobot/channels/line/tests/test_line_channel.py
@@ -1,0 +1,35 @@
+"""Tests for LINE channel manifest and settings."""
+
+from nanobot.channels.line.manifest import PLUGIN, SETUP_SPEC
+from nanobot.channels.line.runtime import LineSettings
+
+
+def test_plugin_name():
+    assert PLUGIN.name == "line"
+    assert PLUGIN.display_name == "LINE"
+
+
+def test_setup_spec_fields():
+    field_names = {f.name for f in SETUP_SPEC.fields}
+    assert "channelAccessToken" in field_names
+    assert "channelSecret" in field_names
+    assert "allowFrom" in field_names
+
+
+def test_setup_spec_required():
+    assert "channelAccessToken" in SETUP_SPEC.required
+    assert "channelSecret" in SETUP_SPEC.required
+
+
+def test_settings_validation():
+    s = LineSettings(channelAccessToken="test-token", channelSecret="test-secret")
+    assert s.channel_access_token == "test-token"
+    assert s.channel_secret == "test-secret"
+
+
+def test_settings_token_non_empty():
+    try:
+        LineSettings(channelAccessToken="  ", channelSecret="x")
+        assert False, "should have raised"
+    except Exception:
+        pass

--- a/nanobot/channels/line/webui/index.ts
+++ b/nanobot/channels/line/webui/index.ts
@@ -1,0 +1,12 @@
+/** LINE channel WebUI plugin.
+ *
+ * Registers LINE in the channel setup panel with localization keys.
+ */
+import type { ChannelUiPlugin } from "../../../../channel-plugins/types";
+
+const plugin: ChannelUiPlugin = {
+  channel: "line",
+  setupComponent: null, // uses built-in credential form
+};
+
+export default plugin;

--- a/nanobot/channels/line/webui/locales/en/common.json
+++ b/nanobot/channels/line/webui/locales/en/common.json
@@ -1,0 +1,1 @@
+{"channel.line.displayName":"LINE","channel.line.channelAccessToken":"Channel Access Token","channel.line.channelSecret":"Channel Secret","channel.line.allowFrom":"Allowed User IDs","channel.line.groupPolicy":"Group Policy"}


### PR DESCRIPTION
## Description

Add LINE Messaging API channel — the most popular messenger in Japan, Taiwan, Thailand, and Indonesia.

### What This Does

- Webhook server (aiohttp) with HMAC-SHA256 signature verification
- Inbound: receives LINE text messages via webhook, validates sender against allowFrom
- Outbound: reply (replyToken) and push (target user) support via LINE Messaging API
- Markdown-to-plain-text conversion for LINE-compatible messages
- Message segmentation for long replies (5000 char limit)

### Pattern

Follows the existing channel plugin architecture — auto-discovered by `pkgutil`, no manual registration needed.

### Files (7)

- `manifest.py` — ChannelPlugin descriptor with setup fields
- `runtime.py` — LineChannel implementation (aiohttp server + LINE SDK)
- `webui/index.ts` — WebUI plugin registration
- `webui/locales/en/common.json` — English labels
- `tests/test_line_channel.py` — 5 tests (manifest, settings, validation)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit Test — 5 tests covering manifest fields, required fields, settings validation
- [x] Syntax check — all Python files pass `ast.parse()`

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR (if applicable)
- [x] New and existing tests pass locally