### PR TITLE
fix(webui): soften model selector emphasis

### DIFF
--- a/webui/src/components/thread/ModelPresetBadge.tsx
+++ b/webui/src/components/thread/ModelPresetBadge.tsx
@@ -359,7 +359,7 @@ function PresetPill({
       data-preset-offset={offset}
       title={fallbackModelName || title || undefined}
       className={cn(
-        "composer-model-badge composer-model-pill inline-flex h-full w-fit max-w-full min-w-0 shrink-0 items-center rounded-full border border-border/55 bg-card font-semibold text-foreground/58",
+        "composer-model-badge composer-model-pill inline-flex h-full w-fit max-w-full min-w-0 shrink-0 items-center rounded-full border border-border/55 bg-card font-medium text-foreground/70",
         offset === undefined && "shadow-[0_2px_8px_rgba(15,23,42,0.045)]",
         "transition-[color,background-color,border-color,transform] duration-150 ease-out group-focus-visible/model-badge:ring-2 group-focus-visible/model-badge:ring-ring/45",
         needsSetup && "border-amber-500/35 bg-amber-50/70 text-amber-900 dark:bg-amber-500/10 dark:text-amber-200",

--- a/webui/src/tests/thread-composer.test.tsx
+++ b/webui/src/tests/thread-composer.test.tsx
@@ -446,6 +446,9 @@ describe("ThreadComposer", () => {
     );
 
     expect(screen.getByText("gpt-4o")).toBeInTheDocument();
+    const modelPill = screen.getByText("gpt-4o").closest(".composer-model-pill");
+    expect(modelPill).toHaveClass("font-medium", "text-foreground/70");
+    expect(modelPill).not.toHaveClass("font-semibold");
     expect(screen.getByTestId("composer-model-logo-openai")).toBeInTheDocument();
     const input = screen.getByPlaceholderText("Type your message...");
     expect(input.className).toContain("min-h-[50px]");


### PR DESCRIPTION
## Summary

- reduce the model selector label from semibold to medium weight
- replace the unsupported `/58` foreground opacity with the generated `/70` token so the intended emphasis reaches production CSS
- add regression coverage for the selector typography classes

## Testing

- `cd webui && bun run test -- src/tests/thread-composer.test.tsx` (67 passed)
- `cd webui && bun run lint`
- `cd webui && bun run build`
- verified the built WebUI through an isolated real gateway in light and dark modes (`Connected`)