### PR TITLE
fix(webui): prevent composer resize scroll jitter

### DIFF
--- a/webui/src/components/thread/ThreadViewport.tsx
+++ b/webui/src/components/thread/ThreadViewport.tsx
@@ -513,14 +513,7 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
     invalidateGeometry();
     const observer = typeof ResizeObserver === "undefined"
       ? null
-      : new ResizeObserver((entries) => {
-          threadMotionRef.current?.invalidateGeometry({
-            preserveScrollPosition: Boolean(
-              composerDock
-              && entries.some((entry) => entry.target === composerDock),
-            ),
-          });
-        });
+      : new ResizeObserver(invalidateGeometry);
     observer?.observe(el);
     if (content) observer?.observe(content);
     if (messageRegion) observer?.observe(messageRegion);
@@ -671,6 +664,11 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
           <div
             ref={composerDockRef}
             data-testid="thread-composer-dock"
+            onInputCapture={(event) => {
+              if (event.target instanceof HTMLTextAreaElement) {
+                threadMotionRef.current?.handleComposerInput();
+              }
+            }}
             className={cn(
               "row-start-2 z-10 w-full",
               hasMessages ? "sticky bottom-0 bg-background" : "relative self-center",

--- a/webui/src/components/thread/ThreadViewport.tsx
+++ b/webui/src/components/thread/ThreadViewport.tsx
@@ -513,7 +513,14 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
     invalidateGeometry();
     const observer = typeof ResizeObserver === "undefined"
       ? null
-      : new ResizeObserver(invalidateGeometry);
+      : new ResizeObserver((entries) => {
+          threadMotionRef.current?.invalidateGeometry({
+            preserveScrollPosition: Boolean(
+              composerDock
+              && entries.some((entry) => entry.target === composerDock),
+            ),
+          });
+        });
     observer?.observe(el);
     if (content) observer?.observe(content);
     if (messageRegion) observer?.observe(messageRegion);

--- a/webui/src/components/thread/thread-motion.ts
+++ b/webui/src/components/thread/thread-motion.ts
@@ -110,6 +110,10 @@ interface ThreadMotionCoordinatorOptions {
   scheduler?: ThreadMotionScheduler;
 }
 
+interface ThreadMotionInvalidationOptions {
+  preserveScrollPosition?: boolean;
+}
+
 const GEOMETRY_EPSILON_PX = 0.5;
 
 type ThreadScrollOwner = "automatic" | "navigation" | "user";
@@ -141,6 +145,7 @@ export class ThreadMotionCoordinator {
   private promptPositioned = false;
   private measurementFrameId: number | null = null;
   private geometryDirty = false;
+  private preserveScrollPositionPending = false;
 
   constructor(options: ThreadMotionCoordinatorOptions) {
     this.camera = options.camera;
@@ -195,8 +200,10 @@ export class ThreadMotionCoordinator {
     this.invalidateGeometry();
   }
 
-  invalidateGeometry(): void {
+  invalidateGeometry(options?: ThreadMotionInvalidationOptions): void {
     this.geometryDirty = true;
+    this.preserveScrollPositionPending ||=
+      options?.preserveScrollPosition === true;
     if (this.measurementFrameId !== null) return;
     this.measurementFrameId = this.scheduler.request(this.flushGeometry);
   }
@@ -273,6 +280,7 @@ export class ThreadMotionCoordinator {
       this.measurementFrameId = null;
     }
     this.geometryDirty = false;
+    this.preserveScrollPositionPending = false;
     this.camera.cancel();
     this.turn = { id: null, promptId: null, hasOutput: false };
     this.mode = "idle";
@@ -328,6 +336,8 @@ export class ThreadMotionCoordinator {
     this.measurementFrameId = null;
     if (!this.geometryDirty) return;
     this.geometryDirty = false;
+    const preserveScrollPosition = this.preserveScrollPositionPending;
+    this.preserveScrollPositionPending = false;
 
     const needsPromptGeometry =
       !this.isHistoryMode()
@@ -336,6 +346,21 @@ export class ThreadMotionCoordinator {
     const geometry = this.measure(needsPromptGeometry ? this.turn.promptId : null);
     if (!geometry) return;
     this.onGeometry?.(geometry);
+
+    if (
+      preserveScrollPosition
+      && !this.isHistoryMode()
+      && (this.turn.id === null || this.promptPositioned)
+    ) {
+      // A focused textarea asks the browser to preserve the caret's viewport
+      // position while its sticky composer grows. Any simultaneous camera
+      // write fights that adjustment and makes the transcript bounce between
+      // two scroll positions. Measure the new geometry, but leave scrolling
+      // untouched until message output or an explicit navigation invalidates
+      // it again.
+      this.camera.cancel();
+      return;
+    }
 
     if (this.mode === "follow-completion") {
       this.followGeometry(geometry);

--- a/webui/src/components/thread/thread-motion.ts
+++ b/webui/src/components/thread/thread-motion.ts
@@ -21,6 +21,7 @@ type ThreadMotionEvent =
   | "navigation-settled"
   | "user-scroll"
   | "boundary-scroll"
+  | "composer-input"
   | "turn-completed"
   | "resume-follow";
 
@@ -49,6 +50,7 @@ const THREAD_MOTION_TRANSITIONS: Readonly<
   "follow-completion": {
     "navigate-history": "navigating-history",
     "user-scroll": "browsing-history",
+    "composer-input": "idle",
   },
   "navigating-history": {
     "navigate-history": "navigating-history",
@@ -110,10 +112,6 @@ interface ThreadMotionCoordinatorOptions {
   scheduler?: ThreadMotionScheduler;
 }
 
-interface ThreadMotionInvalidationOptions {
-  preserveScrollPosition?: boolean;
-}
-
 const GEOMETRY_EPSILON_PX = 0.5;
 
 type ThreadScrollOwner = "automatic" | "navigation" | "user";
@@ -145,7 +143,7 @@ export class ThreadMotionCoordinator {
   private promptPositioned = false;
   private measurementFrameId: number | null = null;
   private geometryDirty = false;
-  private preserveScrollPositionPending = false;
+  private composerInputDuringTurn = false;
 
   constructor(options: ThreadMotionCoordinatorOptions) {
     this.camera = options.camera;
@@ -175,6 +173,7 @@ export class ThreadMotionCoordinator {
     this.turn = turn;
     if (isNewTurn) {
       this.camera.cancel();
+      this.composerInputDuringTurn = false;
       this.promptPositioned = turn.entry === "restored";
       this.mode = this.promptPositioned && turn.hasOutput
         ? "follow-output"
@@ -192,20 +191,34 @@ export class ThreadMotionCoordinator {
     }
     // Protocol completion can share a React commit with the last large text
     // batch and begins the run-drawer exit. Keep camera ownership through
-    // those final layout changes; only a new turn or explicit user navigation
-    // may end completion follow.
+    // those final layout changes; only a new turn, explicit user navigation,
+    // or input for the next prompt may end completion follow.
     this.transition("turn-completed");
+    if (
+      this.composerInputDuringTurn
+      && this.transition("composer-input")
+    ) {
+      this.camera.cancel();
+    }
     this.turn = { id: null, promptId: null, hasOutput: false };
+    this.composerInputDuringTurn = false;
     this.promptPositioned = false;
     this.invalidateGeometry();
   }
 
-  invalidateGeometry(options?: ThreadMotionInvalidationOptions): void {
+  invalidateGeometry(): void {
     this.geometryDirty = true;
-    this.preserveScrollPositionPending ||=
-      options?.preserveScrollPosition === true;
     if (this.measurementFrameId !== null) return;
     this.measurementFrameId = this.scheduler.request(this.flushGeometry);
+  }
+
+  handleComposerInput(): void {
+    // Input and protocol completion can arrive in either order. Remember
+    // editing that starts just before turn_end so the completion drawer
+    // cannot reacquire the camera a few milliseconds later.
+    if (this.turn.id) this.composerInputDuringTurn = true;
+    if (!this.transition("composer-input")) return;
+    this.camera.cancel();
   }
 
   takeUserControl(): void {
@@ -280,9 +293,9 @@ export class ThreadMotionCoordinator {
       this.measurementFrameId = null;
     }
     this.geometryDirty = false;
-    this.preserveScrollPositionPending = false;
     this.camera.cancel();
     this.turn = { id: null, promptId: null, hasOutput: false };
+    this.composerInputDuringTurn = false;
     this.mode = "idle";
     this.promptPositioned = false;
   }
@@ -336,8 +349,6 @@ export class ThreadMotionCoordinator {
     this.measurementFrameId = null;
     if (!this.geometryDirty) return;
     this.geometryDirty = false;
-    const preserveScrollPosition = this.preserveScrollPositionPending;
-    this.preserveScrollPositionPending = false;
 
     const needsPromptGeometry =
       !this.isHistoryMode()
@@ -346,21 +357,6 @@ export class ThreadMotionCoordinator {
     const geometry = this.measure(needsPromptGeometry ? this.turn.promptId : null);
     if (!geometry) return;
     this.onGeometry?.(geometry);
-
-    if (
-      preserveScrollPosition
-      && !this.isHistoryMode()
-      && (this.turn.id === null || this.promptPositioned)
-    ) {
-      // A focused textarea asks the browser to preserve the caret's viewport
-      // position while its sticky composer grows. Any simultaneous camera
-      // write fights that adjustment and makes the transcript bounce between
-      // two scroll positions. Measure the new geometry, but leave scrolling
-      // untouched until message output or an explicit navigation invalidates
-      // it again.
-      this.camera.cancel();
-      return;
-    }
 
     if (this.mode === "follow-completion") {
       this.followGeometry(geometry);

--- a/webui/src/tests/thread-motion.test.ts
+++ b/webui/src/tests/thread-motion.test.ts
@@ -192,6 +192,38 @@ describe("ThreadMotionCoordinator", () => {
     expect(camera.followTo).toHaveBeenLastCalledWith(1_950);
   });
 
+  it("preserves the viewport instead of easing composer growth after completion", () => {
+    const {
+      camera,
+      coordinator,
+      advanceFrame,
+      setGeometry,
+    } = motionHarness();
+    coordinator.updateTurn({
+      id: "turn-1",
+      promptId: "prompt-1",
+      hasOutput: true,
+    });
+    advanceFrame();
+    coordinator.completeTurn();
+    camera.jumpTo.mockClear();
+    camera.followTo.mockClear();
+    camera.cancel.mockClear();
+
+    setGeometry({
+      scrollTop: 1_400,
+      scrollHeight: 1_940,
+      composerHeight: 160,
+    });
+    coordinator.invalidateGeometry({ preserveScrollPosition: true });
+    advanceFrame();
+
+    expect(camera.cancel).toHaveBeenCalledTimes(1);
+    expect(camera.jumpTo).not.toHaveBeenCalled();
+    expect(camera.followTo).not.toHaveBeenCalled();
+    expect(coordinator.snapshot().mode).toBe("follow-completion");
+  });
+
   it("keeps turn identity stable when canonical replay replaces DOM ids", () => {
     const {
       camera,
@@ -261,15 +293,17 @@ describe("ThreadMotionCoordinator", () => {
       hasOutput: true,
     });
     advanceFrame();
+    camera.jumpTo.mockClear();
     camera.followTo.mockClear();
     onGeometry.mockClear();
 
     coordinator.takeUserControl();
     setGeometry({ scrollTop: 200, scrollHeight: 2_100 });
-    coordinator.invalidateGeometry();
+    coordinator.invalidateGeometry({ preserveScrollPosition: true });
     advanceFrame();
 
     expect(onGeometry).toHaveBeenCalledTimes(1);
+    expect(camera.jumpTo).not.toHaveBeenCalled();
     expect(camera.followTo).not.toHaveBeenCalled();
     expect(coordinator.snapshot().mode).toBe("browsing-history");
 

--- a/webui/src/tests/thread-motion.test.ts
+++ b/webui/src/tests/thread-motion.test.ts
@@ -192,7 +192,7 @@ describe("ThreadMotionCoordinator", () => {
     expect(camera.followTo).toHaveBeenLastCalledWith(1_950);
   });
 
-  it("preserves the viewport instead of easing composer growth after completion", () => {
+  it("releases completion follow when composer editing begins", () => {
     const {
       camera,
       coordinator,
@@ -210,18 +210,51 @@ describe("ThreadMotionCoordinator", () => {
     camera.followTo.mockClear();
     camera.cancel.mockClear();
 
+    coordinator.handleComposerInput();
     setGeometry({
       scrollTop: 1_400,
       scrollHeight: 1_940,
       composerHeight: 160,
     });
-    coordinator.invalidateGeometry({ preserveScrollPosition: true });
+    coordinator.invalidateGeometry();
     advanceFrame();
 
     expect(camera.cancel).toHaveBeenCalledTimes(1);
     expect(camera.jumpTo).not.toHaveBeenCalled();
     expect(camera.followTo).not.toHaveBeenCalled();
-    expect(coordinator.snapshot().mode).toBe("follow-completion");
+    expect(coordinator.snapshot().mode).toBe("idle");
+  });
+
+  it("remembers composer editing that begins before turn completion", () => {
+    const {
+      camera,
+      coordinator,
+      advanceFrame,
+      setGeometry,
+    } = motionHarness();
+    coordinator.updateTurn({
+      id: "turn-1",
+      promptId: "prompt-1",
+      hasOutput: true,
+    });
+    advanceFrame();
+    camera.followTo.mockClear();
+    camera.cancel.mockClear();
+
+    coordinator.handleComposerInput();
+    expect(coordinator.snapshot().mode).toBe("follow-output");
+
+    coordinator.completeTurn();
+    setGeometry({
+      scrollTop: 1_400,
+      scrollHeight: 1_940,
+      composerHeight: 160,
+    });
+    advanceFrame();
+
+    expect(camera.cancel).toHaveBeenCalledTimes(1);
+    expect(camera.followTo).not.toHaveBeenCalled();
+    expect(coordinator.snapshot().mode).toBe("idle");
   });
 
   it("keeps turn identity stable when canonical replay replaces DOM ids", () => {
@@ -293,17 +326,15 @@ describe("ThreadMotionCoordinator", () => {
       hasOutput: true,
     });
     advanceFrame();
-    camera.jumpTo.mockClear();
     camera.followTo.mockClear();
     onGeometry.mockClear();
 
     coordinator.takeUserControl();
     setGeometry({ scrollTop: 200, scrollHeight: 2_100 });
-    coordinator.invalidateGeometry({ preserveScrollPosition: true });
+    coordinator.invalidateGeometry();
     advanceFrame();
 
     expect(onGeometry).toHaveBeenCalledTimes(1);
-    expect(camera.jumpTo).not.toHaveBeenCalled();
     expect(camera.followTo).not.toHaveBeenCalled();
     expect(coordinator.snapshot().mode).toBe("browsing-history");
 

--- a/webui/src/tests/thread-viewport.test.tsx
+++ b/webui/src/tests/thread-viewport.test.tsx
@@ -772,7 +772,7 @@ describe("ThreadViewport", () => {
     }
   });
 
-  it("preserves the waiting viewport across composer and grid-track growth", async () => {
+  it("pins the waiting boundary across composer and grid-track growth", async () => {
     const resizeObserver = stubResizeObserver();
     const jumpTo = vi.spyOn(ThreadCameraController.prototype, "jumpTo");
 
@@ -845,64 +845,47 @@ describe("ThreadViewport", () => {
         value: 1228,
       });
       act(() => {
-        composerObserver!.callback(
-          [{ target: composerDock }] as ResizeObserverEntry[],
-          composerObserver as unknown as ResizeObserver,
-        );
+        composerObserver!.callback([], composerObserver as unknown as ResizeObserver);
       });
       await flushAnimationFrame();
 
-      expect(jumpTo).not.toHaveBeenCalled();
-      expect(scroller.scrollTop).toBe(700);
+      expect(jumpTo).toHaveBeenCalledWith(728);
 
+      jumpTo.mockClear();
       Object.defineProperty(scroller, "scrollHeight", {
         configurable: true,
         value: 1268,
       });
       act(() => {
-        composerObserver!.callback(
-          [{ target: composerDock }] as ResizeObserverEntry[],
-          composerObserver as unknown as ResizeObserver,
-        );
+        composerObserver!.callback([], composerObserver as unknown as ResizeObserver);
       });
       await flushAnimationFrame();
 
-      expect(jumpTo).not.toHaveBeenCalled();
-      expect(scroller.scrollTop).toBe(700);
+      expect(jumpTo).toHaveBeenCalledWith(768);
     } finally {
       resizeObserver.restore();
     }
   });
 
-  it("preserves completed threads when the composer grows", async () => {
+  it("releases completion follow when single-line input starts before completion", async () => {
     const resizeObserver = stubResizeObserver();
     const jumpTo = vi.spyOn(ThreadCameraController.prototype, "jumpTo");
     const followTo = vi.spyOn(ThreadCameraController.prototype, "followTo");
 
     try {
       const threaded: UIMessage[] = [
-        {
-          id: "u1",
-          role: "user",
-          content: "question",
-          turnId: "turn-1",
-          createdAt: 1,
-        },
-        {
-          id: "a1",
-          role: "assistant",
-          content: "answer",
-          turnId: "turn-1",
-          createdAt: 2,
-        },
+        { id: "u1", role: "user", content: "question", turnId: "turn-1", createdAt: 1 },
+        { id: "a1", role: "assistant", content: "answer", turnId: "turn-1", createdAt: 2 },
       ];
-      const { container, rerender } = render(
+      const viewport = (isStreaming: boolean, activeTurnId?: string) => (
         <ThreadViewport
           messages={threaded}
-          isStreaming
-          composer={<div>composer</div>}
-        />,
+          isStreaming={isStreaming}
+          composer={<textarea aria-label="Message input" />}
+          activeTurnId={activeTurnId}
+        />
       );
+      const { container, rerender } = render(viewport(true));
       const scroller = container.firstElementChild?.firstElementChild as HTMLElement;
       Object.defineProperties(scroller, {
         scrollHeight: { configurable: true, value: 1_200 },
@@ -910,22 +893,7 @@ describe("ThreadViewport", () => {
         scrollTop: { configurable: true, writable: true, value: 700 },
       });
 
-      rerender(
-        <ThreadViewport
-          messages={threaded}
-          isStreaming
-          composer={<div>composer</div>}
-          activeTurnId="turn-1"
-        />,
-      );
-      await flushAnimationFrame();
-      rerender(
-        <ThreadViewport
-          messages={threaded}
-          isStreaming={false}
-          composer={<div>composer</div>}
-        />,
-      );
+      rerender(viewport(true, "turn-1"));
       await flushAnimationFrame();
       jumpTo.mockClear();
       followTo.mockClear();
@@ -948,9 +916,31 @@ describe("ThreadViewport", () => {
       });
       await flushAnimationFrame();
 
+      expect(followTo).toHaveBeenCalled();
+
+      followTo.mockClear();
+      fireEvent.input(screen.getByLabelText("Message input"), {
+        target: { value: "x" },
+      });
+      const scrollTopAfterInput = scroller.scrollTop;
+      rerender(viewport(false));
+      await flushAnimationFrame();
+      expect(followTo).not.toHaveBeenCalled();
+      Object.defineProperty(scroller, "scrollHeight", {
+        configurable: true,
+        value: 1_280,
+      });
+      act(() => {
+        composerObserver!.callback(
+          [{ target: composerDock }] as ResizeObserverEntry[],
+          composerObserver as unknown as ResizeObserver,
+        );
+      });
+      await flushAnimationFrame();
+
       expect(jumpTo).not.toHaveBeenCalled();
       expect(followTo).not.toHaveBeenCalled();
-      expect(scroller.scrollTop).toBe(700);
+      expect(scroller.scrollTop).toBe(scrollTopAfterInput);
     } finally {
       resizeObserver.restore();
     }

--- a/webui/src/tests/thread-viewport.test.tsx
+++ b/webui/src/tests/thread-viewport.test.tsx
@@ -772,7 +772,7 @@ describe("ThreadViewport", () => {
     }
   });
 
-  it("pins the waiting boundary across composer and grid-track growth", async () => {
+  it("preserves the waiting viewport across composer and grid-track growth", async () => {
     const resizeObserver = stubResizeObserver();
     const jumpTo = vi.spyOn(ThreadCameraController.prototype, "jumpTo");
 
@@ -845,23 +845,112 @@ describe("ThreadViewport", () => {
         value: 1228,
       });
       act(() => {
-        composerObserver!.callback([], composerObserver as unknown as ResizeObserver);
+        composerObserver!.callback(
+          [{ target: composerDock }] as ResizeObserverEntry[],
+          composerObserver as unknown as ResizeObserver,
+        );
       });
       await flushAnimationFrame();
 
-      expect(jumpTo).toHaveBeenCalledWith(728);
+      expect(jumpTo).not.toHaveBeenCalled();
+      expect(scroller.scrollTop).toBe(700);
 
-      jumpTo.mockClear();
       Object.defineProperty(scroller, "scrollHeight", {
         configurable: true,
         value: 1268,
       });
       act(() => {
-        composerObserver!.callback([], composerObserver as unknown as ResizeObserver);
+        composerObserver!.callback(
+          [{ target: composerDock }] as ResizeObserverEntry[],
+          composerObserver as unknown as ResizeObserver,
+        );
       });
       await flushAnimationFrame();
 
-      expect(jumpTo).toHaveBeenCalledWith(768);
+      expect(jumpTo).not.toHaveBeenCalled();
+      expect(scroller.scrollTop).toBe(700);
+    } finally {
+      resizeObserver.restore();
+    }
+  });
+
+  it("preserves completed threads when the composer grows", async () => {
+    const resizeObserver = stubResizeObserver();
+    const jumpTo = vi.spyOn(ThreadCameraController.prototype, "jumpTo");
+    const followTo = vi.spyOn(ThreadCameraController.prototype, "followTo");
+
+    try {
+      const threaded: UIMessage[] = [
+        {
+          id: "u1",
+          role: "user",
+          content: "question",
+          turnId: "turn-1",
+          createdAt: 1,
+        },
+        {
+          id: "a1",
+          role: "assistant",
+          content: "answer",
+          turnId: "turn-1",
+          createdAt: 2,
+        },
+      ];
+      const { container, rerender } = render(
+        <ThreadViewport
+          messages={threaded}
+          isStreaming
+          composer={<div>composer</div>}
+        />,
+      );
+      const scroller = container.firstElementChild?.firstElementChild as HTMLElement;
+      Object.defineProperties(scroller, {
+        scrollHeight: { configurable: true, value: 1_200 },
+        clientHeight: { configurable: true, value: 500 },
+        scrollTop: { configurable: true, writable: true, value: 700 },
+      });
+
+      rerender(
+        <ThreadViewport
+          messages={threaded}
+          isStreaming
+          composer={<div>composer</div>}
+          activeTurnId="turn-1"
+        />,
+      );
+      await flushAnimationFrame();
+      rerender(
+        <ThreadViewport
+          messages={threaded}
+          isStreaming={false}
+          composer={<div>composer</div>}
+        />,
+      );
+      await flushAnimationFrame();
+      jumpTo.mockClear();
+      followTo.mockClear();
+
+      const composerDock = screen.getByTestId("thread-composer-dock");
+      const composerObserver = resizeObserver.observers.find(
+        (observer) => observer.elements.includes(composerDock),
+      );
+      expect(composerObserver).toBeDefined();
+      Object.defineProperty(scroller, "scrollHeight", {
+        configurable: true,
+        value: 1_240,
+      });
+
+      act(() => {
+        composerObserver!.callback(
+          [{ target: composerDock }] as ResizeObserverEntry[],
+          composerObserver as unknown as ResizeObserver,
+        );
+      });
+      await flushAnimationFrame();
+
+      expect(jumpTo).not.toHaveBeenCalled();
+      expect(followTo).not.toHaveBeenCalled();
+      expect(scroller.scrollTop).toBe(700);
     } finally {
       resizeObserver.restore();
     }


### PR DESCRIPTION
## Summary

- release completion auto-follow on actual textarea input instead of inferring user intent from composer resize events
- remember input that starts just before `turn_end`, so completion cannot reacquire the scroll camera a few milliseconds later
- preserve normal completion following and geometry updates when the user has not started the next prompt
- add state-machine and viewport regressions for both input/completion event orders

## Root cause

After a response completes, the thread motion coordinator remains in `follow-completion` while the final response layout and the composer status drawer settle. The drawer closes through a 600 ms height transition, so the thread's lower scroll boundary keeps changing even when the textarea stays on one line.

If the user starts typing during that window, browser layout/caret handling and the automatic scroll camera can both write the viewport position. Their frame timing can differ, producing visible up/down feedback. The issue is intermittent because the input event can arrive just before or just after `turn_end`, and because typing must overlap the drawer transition.

The final fix treats input as an explicit motion-state event. Input after completion releases `follow-completion` immediately; input just before completion is latched and releases it when `turn_end` arrives. Composer resize remains a normal geometry signal, so layout changes without user input still follow the lower boundary as designed.

## Verification

- `bun run test -- src/tests/thread-motion.test.ts src/tests/thread-viewport.test.tsx` (48 passed)
- `bun run test` (51 files, 787 passed)
- `bun run lint`
- `bun run build`
- real gateway at a 390×844 viewport with 30 seeded turns:
  - typed `x` → `xy` → `xyz` → `typing`, with no newline and a constant 50 px textarea height
  - input began 700.6 ms before completion
  - the composer dock still animated from 157.375 px to 122 px after completion
  - 250 frame samples and 29 scroll events produced 0 direction reversals
