### PR TITLE
fix(gitstore): return real git object ids instead of hex-of-hex

### DIFF
--- a/nanobot/utils/gitstore.py
+++ b/nanobot/utils/gitstore.py
@@ -161,7 +161,10 @@ class GitStore:
             )
             if sha_bytes is None:
                 return None
-            sha = sha_bytes.hex()[:8]
+            # porcelain.commit returns the id as a 40-char hex string that is
+            # already encoded to bytes; .hex() would encode those ASCII bytes
+            # again and produce an id no git command can resolve.
+            sha = sha_bytes.decode()[:8]
             logger.debug("Git auto-commit: {} ({})", sha, message)
             return sha
         except Exception as exc:
@@ -185,7 +188,7 @@ class GitStore:
                     return None
 
                 while sha:
-                    if sha.hex().startswith(short_sha):
+                    if sha.decode().startswith(short_sha):
                         return sha
                     commit = repo[sha]
                     if commit.type_name != b"commit":
@@ -263,7 +266,7 @@ class GitStore:
                     msg = commit.message.decode("utf-8", errors="replace").strip()
                     if message_prefix is None or msg.startswith(message_prefix):
                         entries.append(CommitInfo(
-                            sha=sha.hex()[:8],
+                            sha=sha.decode()[:8],
                             message=msg,
                             timestamp=ts,
                         ))
@@ -466,7 +469,7 @@ class GitStore:
                     with Repo(str(self._workspace)) as repo:
                         commit = repo[full_sha]
                         parent = commit.parents[0] if commit.parents else None
-                    diff = self.diff_commits(parent.hex()[:8], c.sha) if parent else ""
+                    diff = self.diff_commits(parent.decode()[:8], c.sha) if parent else ""
                     return c, diff
             return None
         except Exception as exc:

--- a/tests/utils/test_gitstore.py
+++ b/tests/utils/test_gitstore.py
@@ -310,3 +310,25 @@ class TestNestedRepoProtection:
 
         assert result is False
         assert not (workspace / ".git").exists()
+
+
+class TestCommitIdEncoding:
+    """Commit ids must be usable with git, not hex-of-hex."""
+
+    def test_auto_commit_returns_the_real_short_sha(self, git, tmp_path):
+        (tmp_path / "MEMORY.md").write_text("- a fact\n", encoding="utf-8")
+        sha = git.auto_commit("memory update")
+        expected = subprocess.run(
+            ["git", "-C", str(tmp_path), "log", "-1", "--format=%h", "--abbrev=8"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        assert sha == expected
+
+    def test_a_real_git_sha_resolves(self, git, tmp_path):
+        (tmp_path / "MEMORY.md").write_text("- a fact\n", encoding="utf-8")
+        git.auto_commit("memory update")
+        real = subprocess.run(
+            ["git", "-C", str(tmp_path), "log", "-1", "--format=%h", "--abbrev=8"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        assert git._resolve_sha(real) is not None


### PR DESCRIPTION
dulwich hands back object ids as a 40-character hex string that is **already encoded to bytes** — `porcelain.commit()` returns e.g. `b"bb244606d780..."`, and `repo.refs[b"HEAD"]` behaves the same. `GitStore` calls `.hex()` on those values, which encodes the ASCII a second time.

Every id the memory store produces or displays is therefore hex-of-hex:

```
auto_commit()        -> "62623234"
git log --abbrev=8   -> "bb244606"
```

The module is *self-consistently* wrong, so `/dream-log` and `/dream-restore` still work as long as the id originated from nanobot itself. What breaks is crossing the boundary in either direction:

```
_resolve_sha(id from auto_commit) -> b"bb244606d780..."   # resolves
_resolve_sha(id from git log)     -> None                 # does not
```

So ids printed in logs and command output match nothing in `git log`, and an id copied out of `git log` cannot be fed back into nanobot. In practice this makes the Dream audit trail impossible to cross-reference with git history.

## Change

`.decode()` instead of `.hex()` at the four sites that consume dulwich object ids (`auto_commit`, `_resolve_sha`, the commit listing, and the parent id in `show_commit_diff`).

Nothing persists an id — every caller either displays it or resolves it live against git — so there is no stored state in the old format to migrate.

## Tests

Two regression tests added to `tests/utils/test_gitstore.py`:

- the id returned by `auto_commit` equals `git log --abbrev=8`
- an id taken from `git log` resolves through `_resolve_sha`

Both fail on `main` (`assert "66316261" == "f1baff91"`) and pass with the change. Full `tests/utils/` passes: 267.
