### PR TITLE
docs(readme): add one-click deployment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 | Connect Telegram, Discord, WeChat, Slack, Email, Mattermost, or another chat app | [Chat Apps](./docs/chat-apps.md) |
 | Configure providers, fallback models, Langfuse, MCP, web tools, or security | [Docs](./docs/README.md) and [Configuration](./docs/configuration.md) |
 | Understand or extend the internals | [Architecture](./docs/architecture.md) and [Development](./docs/development.md) |
-| Deploy to the cloud or keep nanobot running as a service | [Deployment](./docs/deployment.md), including [one-click Render setup](./docs/deployment.md#render) |
+| Deploy to the cloud or keep nanobot running as a service | [Deployment](./docs/deployment.md) · [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/HKUDS/nanobot) |
 
 ## What can nanobot do?
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 | Connect Telegram, Discord, WeChat, Slack, Email, Mattermost, or another chat app | [Chat Apps](./docs/chat-apps.md) |
 | Configure providers, fallback models, Langfuse, MCP, web tools, or security | [Docs](./docs/README.md) and [Configuration](./docs/configuration.md) |
 | Understand or extend the internals | [Architecture](./docs/architecture.md) and [Development](./docs/development.md) |
-| Deploy to the cloud or keep nanobot running as a service | [Deployment](./docs/deployment.md) · [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/HKUDS/nanobot) |
+| Deploy to the cloud or keep nanobot running as a service | [Deployment](./docs/deployment.md) |
 
 ## What can nanobot do?
 
@@ -222,6 +222,20 @@ If nanobot worked for you, a star on GitHub is the simplest way to support the p
 - Want to run locally? See [Ollama](./docs/providers.md#ollama), [vLLM or another local OpenAI-compatible server](./docs/providers.md#vllm-or-other-local-openai-compatible-server), and the full [provider reference](./docs/configuration.md#providers).
 - Want to run nanobot in chat apps like Telegram, Discord, WeChat or Feishu? See [Chat Apps](./docs/chat-apps.md)
 - Want Docker or Linux service deployment? See [Deployment](./docs/deployment.md)
+
+## ☁️ Deploy
+
+**Render — one click**
+
+Deploy nanobot's gateway and bundled WebUI from the repository's ready-to-use Blueprint:
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/HKUDS/nanobot)
+
+Render will ask for the model credential and WebUI access secret, then provision persistent storage for sessions, memory, and WebUI history. Persistent disks require a paid Render service.
+
+**Self-host**
+
+Prefer your own infrastructure? Follow the [deployment guide](./docs/deployment.md) for Docker, Docker Compose, Linux services, and macOS LaunchAgent setup.
 
 ## 🌐 WebUI
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ If nanobot worked for you, a star on GitHub is the simplest way to support the p
 - Want to run nanobot in chat apps like Telegram, Discord, WeChat or Feishu? See [Chat Apps](./docs/chat-apps.md)
 - Want Docker or Linux service deployment? See [Deployment](./docs/deployment.md)
 
+<a id="deploy-to-render"></a>
+
 ## ☁️ Deploy
 
 **Render — one click**

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Deploy nanobot's gateway and bundled WebUI from the repository's ready-to-use Bl
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/HKUDS/nanobot)
 
-Render will ask for the model credential and WebUI access secret, then provision persistent storage for sessions, memory, and WebUI history. Persistent disks require a paid Render service.
+Render will ask for `ANTHROPIC_API_KEY` and a private `NANOBOT_WEB_TOKEN`, then provision persistent storage for sessions, memory, and WebUI history. Persistent disks require a paid Render service.
 
 **Self-host**
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -39,6 +39,23 @@ Run nanobot online without managing a server. The blueprint deploys the gateway 
 
 [Review the deployment blueprint](../render.yaml)
 
+### First Deployment
+
+1. Click **Deploy to Render**, sign in, and review the Blueprint. It creates one Starter web service and a 1 GB persistent disk.
+2. Enter your `ANTHROPIC_API_KEY`. Set `NANOBOT_WEB_TOKEN` to a new random value and save it in your password manager; this is the password for the public WebUI.
+3. Create the Blueprint and wait for the service status to become **Live**. The first build can take several minutes.
+4. Open the generated `onrender.com` URL. The **Authentication required** page means the gateway is running: enter the same `NANOBOT_WEB_TOKEN` value to open the WebUI.
+
+The model API key is used by nanobot to call Anthropic. The Web token only protects access to this deployment; do not share it in issues, screenshots, or chat.
+
+### Updates and Data
+
+The Blueprint disables automatic deploys so upstream repository changes do not unexpectedly restart your agent. To update, open the service in the Render Dashboard and choose **Manual Deploy → Deploy latest commit**.
+
+The persistent disk keeps `config.json`, sessions, memory, WebUI history, cron state, media, and logs across restarts and updates. The deployment initializes `config.json` only when it does not already exist, so settings changed later in the WebUI are not replaced on every boot.
+
+If deployment fails, open the service **Logs** page first. A missing model key fails provider requests after startup, while an incorrect Web token leaves you on the authentication page.
+
 ## Docker
 
 > [!TIP]


### PR DESCRIPTION
## Summary

- add a dedicated Deploy section after Quick Start
- present Render first as the one-click hosted option using the official deployment button
- keep the Start Here table provider-neutral and link self-hosters to Docker, Compose, Linux service, and macOS guidance
- document the complete first-deploy flow, including required secrets and the WebUI authentication screen
- explain manual updates, persistent data behavior, and first-line troubleshooting

## Why this layout

The deployment button now has enough context to be useful without turning the Start Here navigation table into a provider promotion. Render is the first quick path, while the section remains extensible for future deployment options.

## Validation

- `python ~/.codex/skills/beautify-github-readme/scripts/audit_readme.py README.md`
- `git diff --check`
- verified the documented service plan, disk, secrets, authentication flow, update policy, and persisted paths against `render.yaml`, `render-config.json`, and `entrypoint.sh`
- verified the official Render button asset and explicit repository deployment target

