### PR TITLE
fix(agent): prevent gateway crash when stopping active tasks

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -760,7 +760,7 @@ class AgentLoop:
 
         Returns the total number of cancelled tasks + subagents.
         """
-        tasks = self._active_tasks.pop(key, set())
+        tasks = tuple(self._active_tasks.pop(key, set()))
         cancelled = sum(1 for t in tasks if not t.done() and t.cancel())
         for t in tasks:
             with suppress(asyncio.CancelledError, Exception):

--- a/tests/agent/test_task_cancel.py
+++ b/tests/agent/test_task_cancel.py
@@ -73,7 +73,9 @@ class TestHandleStop:
 
         task = asyncio.create_task(slow_task())
         await asyncio.sleep(0)
-        loop._active_tasks["test:c1"] = {task}
+        active_tasks = {task}
+        loop._active_tasks["test:c1"] = active_tasks
+        task.add_done_callback(active_tasks.discard)
 
         msg = InboundMessage(channel="test", sender_id="u1", chat_id="c1", content="/stop")
         ctx = CommandContext(msg=msg, session=None, key=msg.session_key, raw="/stop", loop=loop)


### PR DESCRIPTION
## Summary

- snapshot a session's tracked tasks before cancelling and awaiting them
- exercise the real `active_tasks.discard` done callback in the `/stop` regression test

## Root cause

#5127 changed per-session task tracking from a list to a set and registered `active_tasks.discard` as each task's done callback. `_cancel_active_tasks()` popped that same set, then iterated it while awaiting cancelled tasks. Completion callbacks mutated the popped set during iteration, raising `RuntimeError: Set changed size during iteration` out of the priority `/stop` path and crashing the gateway runtime.

Converting the popped set to a tuple gives cancellation a stable snapshot while preserving set-based tracking for active tasks.

## Testing

- pre-fix regression test: reproduced `RuntimeError: Set changed size during iteration`
- `pytest tests/agent/test_task_cancel.py tests/command/test_stop_pending_queue.py tests/agent/test_unified_session.py -q` (44 passed)
- `pytest nanobot/channels/websocket/tests/test_websocket_channel.py::test_webui_stop_control_message_is_not_persisted_as_user_bubble -q` (1 passed)
- `ruff check nanobot/agent/loop.py tests/agent/test_task_cancel.py`
- `bun run test -- src/tests/thread-composer.test.tsx src/tests/useNanobotStream.test.tsx` (127 passed)
- `bun run build`
- real built WebUI + gateway smoke test: an active WebSocket turn returned `Stopped 1 task(s).`; bootstrap and health remained HTTP 200; the agent loop then processed `/model` successfully; no traceback or runtime error was logged