### PR TITLE
fix: preserve media paths during session consolidation

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -19,10 +19,12 @@ from nanobot.runtime_context import public_history_messages
 from nanobot.session.manager import Session, SessionManager
 from nanobot.utils.gitstore import GitStore
 from nanobot.utils.helpers import (
+    content_with_media_breadcrumbs,
     ensure_dir,
     estimate_message_tokens,
     estimate_prompt_tokens_chain,
     find_legal_message_start,
+    image_placeholder_text,
     recent_message_start_index,
     strip_think,
     truncate_text,
@@ -695,11 +697,16 @@ class MemoryStore:
     def _format_messages(messages: list[dict]) -> str:
         lines = []
         for message in messages:
-            if not message.get("content"):
+            content = content_with_media_breadcrumbs(
+                message.get("role"),
+                message.get("content", ""),
+                message.get("media"),
+            )
+            if not content:
                 continue
             tools = f" [tools: {', '.join(message['tools_used'])}]" if message.get("tools_used") else ""
             lines.append(
-                f"[{message.get('timestamp', '?')[:16]}] {message['role'].upper()}{tools}: {message['content']}"
+                f"[{message.get('timestamp', '?')[:16]}] {message['role'].upper()}{tools}: {content}"
             )
         return "\n".join(lines)
 
@@ -716,6 +723,15 @@ class MemoryStore:
             self._format_messages(public_history_messages(messages)),
             limit,
         )
+        for media_chunk in _archived_media_reference_chunks(messages, existing_text=formatted):
+            self.append_history(
+                media_chunk,
+                max_chars=min(
+                    _HISTORY_ENTRY_HARD_CAP,
+                    max(_ARCHIVE_MEDIA_REFERENCES_MAX_CHARS, len(media_chunk)),
+                ),
+                session_key=session_key,
+            )
         self.append_history(
             f"[RAW] {len(messages)} messages\n"
             f"{formatted}",
@@ -786,7 +802,54 @@ class MemoryStore:
 # that catches any new caller that forgot to set its own cap.
 _RAW_ARCHIVE_MAX_CHARS = 16_000       # fallback dump (LLM failed)
 _ARCHIVE_SUMMARY_MAX_CHARS = 8_000    # LLM-produced consolidation summary
+_ARCHIVE_MEDIA_REFERENCES_MAX_CHARS = 4_000
 _HISTORY_ENTRY_HARD_CAP = 64_000      # emergency cap in append_history
+
+
+def _archived_media_reference_chunks(
+    messages: list[dict],
+    *,
+    existing_text: str = "",
+) -> list[str]:
+    """Return complete, deduplicated media-reference lines in bounded chunks."""
+    references: list[str] = []
+    seen: set[str] = set()
+    for message in messages:
+        if message.get("role") != "user":
+            continue
+        media = message.get("media")
+        if not isinstance(media, list):
+            continue
+        for path in media:
+            breadcrumb = image_placeholder_text(path) if isinstance(path, str) else ""
+            if (
+                isinstance(path, str)
+                and path
+                and path not in seen
+                and breadcrumb not in existing_text
+            ):
+                seen.add(path)
+                references.append(breadcrumb)
+
+    lines = [
+        f"- [ephemeral] Uploaded media remains available at {reference}"
+        for reference in references
+    ]
+    chunks: list[str] = []
+    current: list[str] = []
+    current_size = 0
+    for line in lines:
+        addition = len(line) + (1 if current else 0)
+        if current and current_size + addition > _ARCHIVE_MEDIA_REFERENCES_MAX_CHARS:
+            chunks.append("\n".join(current))
+            current = []
+            current_size = 0
+            addition = len(line)
+        current.append(line)
+        current_size += addition
+    if current:
+        chunks.append("\n".join(current))
+    return chunks
 
 
 class Consolidator:
@@ -1019,13 +1082,38 @@ class Consolidator:
             logger.warning("Consolidation provider returned an error, raw-dumping to history")
             self.store.raw_archive(messages, session_key=session_key)
             return None
-        summary = response.content or "[no summary]"
-        self.store.append_history(
-            summary,
-            max_chars=_ARCHIVE_SUMMARY_MAX_CHARS,
-            session_key=session_key,
+        summary = strip_think(response.content or "[no summary]")
+        persisted_summary = truncate_text(summary.rstrip(), _ARCHIVE_SUMMARY_MAX_CHARS)
+        media_chunks = _archived_media_reference_chunks(
+            messages,
+            existing_text=persisted_summary,
         )
-        return summary
+        for media_chunk in media_chunks:
+            self.store.append_history(
+                media_chunk,
+                max_chars=min(
+                    _HISTORY_ENTRY_HARD_CAP,
+                    max(_ARCHIVE_MEDIA_REFERENCES_MAX_CHARS, len(media_chunk)),
+                ),
+                session_key=session_key,
+            )
+
+        keep_summary = bool(persisted_summary and persisted_summary != "(nothing)")
+        if keep_summary or not media_chunks:
+            self.store.append_history(
+                persisted_summary,
+                max_chars=_ARCHIVE_SUMMARY_MAX_CHARS,
+                session_key=session_key,
+            )
+
+        media_references = "\n".join(media_chunks)
+        if media_references:
+            return (
+                f"{media_references}\n{persisted_summary}"
+                if keep_summary
+                else media_references
+            )
+        return persisted_summary
 
     async def maybe_consolidate_by_tokens(
         self,

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -22,10 +22,10 @@ from nanobot.runtime_context import (
     public_history_message,
 )
 from nanobot.utils.helpers import (
+    content_with_media_breadcrumbs,
     ensure_dir,
     estimate_message_tokens,
     find_legal_message_start,
-    image_placeholder_text,
     recent_message_start_index,
     safe_filename,
     strip_think,
@@ -214,12 +214,7 @@ class Session:
             # image used to be. Without this, an image-only user turn
             # replays as an empty user message — the assistant's reply then
             # looks like it's responding to nothing.
-            media = message.get("media")
-            if role == "user" and isinstance(media, list) and media and isinstance(content, str):
-                breadcrumbs = "\n".join(
-                    image_placeholder_text(p) for p in media if isinstance(p, str) and p
-                )
-                content = f"{content}\n{breadcrumbs}" if content else breadcrumbs
+            content = content_with_media_breadcrumbs(role, content, message.get("media"))
             cli_apps = message.get("cli_apps")
             if (
                 include_runtime_context

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -367,6 +367,31 @@ def image_placeholder_text(path: str | None, *, empty: str = "[image]") -> str:
     return f"[image: {path}]" if path else empty
 
 
+def media_breadcrumb_texts(media: Any) -> list[str]:
+    """Render valid persisted media paths as replay breadcrumbs."""
+    if not isinstance(media, list):
+        return []
+    return [
+        image_placeholder_text(path)
+        for path in media
+        if isinstance(path, str) and path
+    ]
+
+
+def content_with_media_breadcrumbs(
+    role: str | None,
+    content: Any,
+    media: Any,
+) -> Any:
+    """Append persisted user-media breadcrumbs to plain-text content."""
+    if role != "user" or not isinstance(content, str):
+        return content
+    breadcrumbs = "\n".join(media_breadcrumb_texts(media))
+    if not breadcrumbs:
+        return content
+    return f"{content}\n{breadcrumbs}" if content else breadcrumbs
+
+
 def truncate_text(text: str, max_chars: int) -> str:
     """Truncate text with a stable suffix."""
     if max_chars <= 0 or len(text) <= max_chars:

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -75,6 +75,138 @@ def _tool_round(call_id: str) -> list[dict]:
 
 
 class TestConsolidatorSummarize:
+    async def test_archive_persists_media_path_when_summary_omits_it(
+        self, consolidator, mock_provider, store, runtime
+    ):
+        path = "/home/user/.nanobot/media/websocket/upload_photo.png"
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="User uploaded a photo.",
+            finish_reason="stop",
+        )
+
+        result = await consolidator.archive(
+            [{"role": "user", "content": "please inspect this", "media": [path]}],
+            runtime=runtime,
+        )
+
+        prompt = mock_provider.chat_with_retry.call_args.kwargs["messages"][1]["content"]
+        entry = store.read_unprocessed_history(since_cursor=0)[0]["content"]
+        assert path in prompt
+        assert result is not None and path in result
+        assert path in entry
+        assert entry.startswith("- [ephemeral] Uploaded media remains available at")
+
+    async def test_archive_keeps_media_when_model_returns_nothing(
+        self, consolidator, mock_provider, store, runtime
+    ):
+        path = "/home/user/.nanobot/media/websocket/report.pdf"
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="(nothing)",
+            finish_reason="stop",
+        )
+
+        result = await consolidator.archive(
+            [{"role": "user", "content": "", "media": [path]}],
+            runtime=runtime,
+        )
+
+        assert result == f"- [ephemeral] Uploaded media remains available at [image: {path}]"
+        assert path in store.read_unprocessed_history(since_cursor=0)[0]["content"]
+
+    async def test_archive_strips_unclosed_thinking_before_media_manifest(
+        self, consolidator, mock_provider, store, runtime
+    ):
+        path = "/home/user/.nanobot/media/websocket/private.png"
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="<think>internal reasoning",
+            finish_reason="stop",
+        )
+
+        result = await consolidator.archive(
+            [{"role": "user", "content": "", "media": [path]}],
+            runtime=runtime,
+        )
+
+        entry = store.read_unprocessed_history(since_cursor=0)[0]["content"]
+        assert result == f"- [ephemeral] Uploaded media remains available at [image: {path}]"
+        assert "internal reasoning" not in entry
+
+    async def test_archive_manifest_excludes_media_from_retained_summary_context(
+        self, consolidator, mock_provider, store, runtime
+    ):
+        archived_path = "/home/user/.nanobot/media/websocket/archived.png"
+        retained_path = "/home/user/.nanobot/media/websocket/still-live.png"
+        archived = {"role": "user", "content": "old", "media": [archived_path]}
+        retained = {"role": "user", "content": "new", "media": [retained_path]}
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="Summary.",
+            finish_reason="stop",
+        )
+
+        await consolidator.archive(
+            [archived],
+            summary_messages=[archived, retained],
+            runtime=runtime,
+        )
+
+        prompt = mock_provider.chat_with_retry.call_args.kwargs["messages"][1]["content"]
+        entry = store.read_unprocessed_history(since_cursor=0)[0]["content"]
+        assert archived_path in prompt and retained_path in prompt
+        assert archived_path in entry
+        assert retained_path not in entry
+
+    async def test_archive_does_not_duplicate_path_already_in_summary(
+        self, consolidator, mock_provider, store, runtime
+    ):
+        path = "/home/user/.nanobot/media/websocket/already-there.png"
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content=f"- [ephemeral] Uploaded media at [image: {path}]",
+            finish_reason="stop",
+        )
+
+        result = await consolidator.archive(
+            [{"role": "user", "content": "", "media": [path]}],
+            runtime=runtime,
+        )
+
+        entries = store.read_unprocessed_history(since_cursor=0)
+        assert result is not None and result.count(path) == 1
+        assert len(entries) == 1
+        assert entries[0]["content"].count(path) == 1
+
+    async def test_archive_splits_large_media_manifest_without_dropping_paths(
+        self, consolidator, mock_provider, store, runtime
+    ):
+        paths = [
+            f"/home/user/.nanobot/media/websocket/{index:03d}-{'x' * 80}.png"
+            for index in range(80)
+        ]
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="(nothing)",
+            finish_reason="stop",
+        )
+
+        result = await consolidator.archive(
+            [{"role": "user", "content": "", "media": paths}],
+            runtime=runtime,
+        )
+
+        entries = store.read_unprocessed_history(since_cursor=0)
+        persisted = "\n".join(entry["content"] for entry in entries)
+        assert len(entries) > 1
+        assert result is not None
+        for path in paths:
+            assert result.count(path) == 1
+            assert persisted.count(path) == 1
+
+    def test_format_messages_keeps_media_only_user_turn(self):
+        path = "/home/user/.nanobot/media/websocket/clip.mp4"
+        formatted = MemoryStore._format_messages(
+            [{"role": "user", "content": "", "media": [path], "timestamp": "2026-07-27"}]
+        )
+
+        assert formatted == f"[2026-07-27] USER: [image: {path}]"
+
     async def test_archive_excludes_model_only_runtime_context(
         self, consolidator, mock_provider, runtime
     ):
@@ -599,6 +731,35 @@ class TestCompactIdleSession:
         assert reloaded.updated_at == old_ts
 
     @pytest.mark.asyncio
+    async def test_media_path_reaches_idle_compact_session_summary(
+        self, real_consolidator, mock_provider, store, runtime
+    ):
+        path = "/home/user/.nanobot/media/websocket/upload_photo.png"
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="(nothing)",
+            finish_reason="stop",
+        )
+        sessions = real_consolidator.sessions
+        session = sessions.get_or_create("websocket:media")
+        session.add_message("user", "", media=[path])
+        session.add_message("assistant", "photo received")
+        for i in range(12):
+            session.add_message("user", f"user msg {i}")
+            session.add_message("assistant", f"assistant msg {i}")
+        sessions.save(session)
+
+        result = await real_consolidator.compact_idle_session(
+            "websocket:media", runtime=runtime, max_suffix=8
+        )
+
+        reloaded = sessions.get_or_create("websocket:media")
+        summary = reloaded.metadata["_last_summary"]["text"]
+        history = store.read_unprocessed_history(since_cursor=0)[0]["content"]
+        assert result is not None and path in result
+        assert path in summary
+        assert path in history
+
+    @pytest.mark.asyncio
     async def test_summarizes_retained_suffix_not_just_dropped_prefix(
         self, real_consolidator, mock_provider, runtime
     ):
@@ -992,6 +1153,25 @@ class TestRawArchiveTruncation:
         assert len(entries) == 1
         assert "hello" in entries[0]["content"]
 
+    def test_raw_archive_preserves_media_only_path(self, store):
+        path = "/home/user/.nanobot/media/websocket/upload_photo.png"
+        store.raw_archive([{"role": "user", "content": "", "media": [path]}])
+
+        entry = store.read_unprocessed_history(since_cursor=0)[0]["content"]
+        assert path in entry
+
+    def test_raw_archive_preserves_path_after_long_content_is_truncated(self, store):
+        path = "/home/user/.nanobot/media/websocket/upload_photo.png"
+        store.raw_archive(
+            [{"role": "user", "content": "x" * 30_000, "media": [path]}]
+        )
+
+        entries = store.read_unprocessed_history(since_cursor=0)
+        persisted = "\n".join(entry["content"] for entry in entries)
+        assert len(entries) == 2
+        assert persisted.count(path) == 1
+        assert any("[RAW]" in entry["content"] for entry in entries)
+
     def test_raw_archive_excludes_model_only_runtime_context(self, store):
         content, marker = append_runtime_context(
             "ship the feature",
@@ -1024,6 +1204,43 @@ class TestRawArchiveTruncation:
 
 class TestArchiveTruncation:
     """archive() must truncate formatted text before sending to consolidation LLM."""
+
+    async def test_archive_summary_cap_keeps_media_manifest(
+        self, consolidator, mock_provider, store, runtime
+    ):
+        path = "/home/user/.nanobot/media/websocket/upload_photo.png"
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="S" * (_ARCHIVE_SUMMARY_MAX_CHARS * 10),
+            finish_reason="stop",
+        )
+
+        await consolidator.archive(
+            [{"role": "user", "content": "", "media": [path]}],
+            runtime=runtime,
+        )
+
+        entry = store.read_unprocessed_history(since_cursor=0)[0]["content"]
+        assert path in entry
+        assert entry.startswith("- [ephemeral] Uploaded media remains available at")
+
+    async def test_archive_restores_path_beyond_summary_truncation_boundary(
+        self, consolidator, mock_provider, store, runtime
+    ):
+        path = "/home/user/.nanobot/media/websocket/late-path.png"
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content=f"{'S' * (_ARCHIVE_SUMMARY_MAX_CHARS * 2)} [image: {path}]",
+            finish_reason="stop",
+        )
+
+        result = await consolidator.archive(
+            [{"role": "user", "content": "", "media": [path]}],
+            runtime=runtime,
+        )
+
+        entries = store.read_unprocessed_history(since_cursor=0)
+        persisted = "\n".join(entry["content"] for entry in entries)
+        assert result is not None and result.count(path) == 1
+        assert persisted.count(path) == 1
 
     async def test_archive_truncates_large_formatted_text(
         self, consolidator, mock_provider, store, runtime


### PR DESCRIPTION
Fixes #5118

## Summary

- preserve uploaded media path breadcrumbs when user messages are archived during session consolidation
- persist missing media references deterministically instead of relying on the model to repeat paths in its summary
- retain paths across raw-archive fallback, summary truncation, and large media manifests without duplicating references

## Root cause

Uploaded attachments are stored in a user message's `media` field, while consolidation previously formatted only `content`. Once old messages were compacted, the attachment path could disappear from both the summarization prompt and persisted history. Even when a path is included in the prompt, model output is not a reliable persistence boundary because the model can omit it, return `(nothing)`, or place it beyond the summary size limit.

## Implementation

- add shared helpers for rendering user media breadcrumbs and use them in both session replay and memory formatting
- derive a deterministic media reference manifest only from messages actually being removed from the live session
- strip reasoning and apply the summary size limit before checking which references are already persisted
- write missing references as bounded history entries and split large manifests instead of dropping older paths
- recover references removed by raw-archive truncation when the consolidation provider fails
- avoid duplicating a path already present as a complete `[image: path]` breadcrumb


## Validation

- `pytest tests/agent/test_consolidator.py tests/agent/test_session_manager_history.py tests/agent/test_memory_store.py tests/utils/test_helpers.py tests/utils/test_strip_think.py -q` - 216 passed
- `pytest tests/agent tests/session tests/utils -q` - 1758 passed, 1 skipped
- `ruff check nanobot/ tests/agent/test_consolidator.py` - passed
- `git diff --check` - passed
