### PR TITLE
fix(webui): open threads at latest message

### DIFF
--- a/webui/src/components/thread/ThreadViewport.tsx
+++ b/webui/src/components/thread/ThreadViewport.tsx
@@ -738,7 +738,7 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
           <Button
             variant="outline"
             size="icon"
-            onClick={() => scrollToBottom(true, { force: true })}
+            onClick={() => scrollToBottom(false, { force: true })}
             className={cn(
               "h-8 w-8 rounded-full shadow-md",
               "bg-background/90 backdrop-blur",

--- a/webui/src/components/thread/ThreadViewport.tsx
+++ b/webui/src/components/thread/ThreadViewport.tsx
@@ -738,7 +738,7 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
           <Button
             variant="outline"
             size="icon"
-            onClick={() => scrollToBottom(false, { force: true })}
+            onClick={() => scrollToBottom(true, { force: true })}
             className={cn(
               "h-8 w-8 rounded-full shadow-md",
               "bg-background/90 backdrop-blur",

--- a/webui/src/components/thread/thread-camera.ts
+++ b/webui/src/components/thread/thread-camera.ts
@@ -186,12 +186,20 @@ export class ThreadCameraController {
     }
 
     const deltaSeconds = deltaMs / 1000;
-    const nextTop = easeOutChase(
+    const easedTop = easeOutChase(
       current,
       this.target,
       deltaSeconds,
       motion,
     );
+    // Some browsers quantize scrollTop writes to whole pixels. Keep the
+    // ease-out curve, but never let its subpixel tail round back to the same
+    // position forever.
+    const minimumStep = Math.min(1, Math.abs(remainingDistance));
+    const nextTop =
+      Math.abs(easedTop - current) < minimumStep
+        ? current + Math.sign(remainingDistance) * minimumStep
+        : easedTop;
     const settled = Math.abs(this.target - nextTop) <= motion.settleDistancePx;
     this.write(viewport, settled ? this.target : nextTop);
 

--- a/webui/src/components/thread/thread-motion.ts
+++ b/webui/src/components/thread/thread-motion.ts
@@ -5,6 +5,7 @@ import type {
 
 type ThreadMotionMode =
   | "idle"
+  | "follow-latest"
   | "anchor-prompt"
   | "follow-output"
   | "follow-completion"
@@ -14,6 +15,7 @@ type ThreadMotionMode =
 
 type AutomaticThreadMotionMode =
   | "idle"
+  | "follow-latest"
   | "anchor-prompt"
   | "follow-output";
 
@@ -37,6 +39,11 @@ const THREAD_MOTION_TRANSITIONS: Readonly<
 > = {
   idle: {
     "navigate-latest": "navigating-latest",
+    "navigate-history": "navigating-history",
+    "user-scroll": "browsing-history",
+    "resume-follow": "current-automatic-mode",
+  },
+  "follow-latest": {
     "navigate-history": "navigating-history",
     "user-scroll": "browsing-history",
   },
@@ -350,7 +357,7 @@ export class ThreadMotionCoordinator {
   }
 
   private automaticMode(): AutomaticThreadMotionMode {
-    if (!this.turn.id) return "idle";
+    if (!this.turn.id) return "follow-latest";
     return this.promptPositioned && this.turn.hasOutput
       ? "follow-output"
       : "anchor-prompt";
@@ -406,6 +413,12 @@ export class ThreadMotionCoordinator {
     }
     if (this.mode === "follow-completion") {
       this.followGeometry(geometry);
+      return;
+    }
+    if (this.mode === "follow-latest") {
+      if (geometry.maxScrollTop - geometry.scrollTop > GEOMETRY_EPSILON_PX) {
+        this.camera.jumpTo(geometry.maxScrollTop);
+      }
       return;
     }
     if (this.isHistoryMode() || !this.turn.id) return;

--- a/webui/src/tests/thread-camera.test.ts
+++ b/webui/src/tests/thread-camera.test.ts
@@ -86,6 +86,24 @@ describe("ThreadCameraController", () => {
     expect(viewport.scrollTop).toBeLessThan(1_000);
   });
 
+  it("settles exactly when the viewport quantizes subpixel tail movement", () => {
+    const { camera, viewport, advance } = cameraHarness();
+    let quantizedTop = 0;
+    Object.defineProperty(viewport, "scrollTop", {
+      configurable: true,
+      get: () => quantizedTop,
+      set: (value: number) => {
+        quantizedTop = Math.floor(value);
+      },
+    });
+
+    expect(camera.navigateTo(10)).toBe("started");
+    for (let frame = 0; frame < 60; frame += 1) advance(16);
+
+    expect(camera.isFollowing()).toBe(false);
+    expect(viewport.scrollTop).toBe(10);
+  });
+
   it("gives an immediate jump command priority over an active follow", () => {
     const { camera, viewport, scheduler, frames } = cameraHarness();
 

--- a/webui/src/tests/thread-motion.test.ts
+++ b/webui/src/tests/thread-motion.test.ts
@@ -343,6 +343,43 @@ describe("ThreadMotionCoordinator", () => {
     expect(camera.followTo).toHaveBeenCalledWith(1_600);
   });
 
+  it("keeps an explicitly resumed idle thread pinned to its latest bottom without animating", () => {
+    const {
+      camera,
+      coordinator,
+      advanceFrame,
+      setGeometry,
+    } = motionHarness();
+
+    coordinator.resumeAutoFollow();
+    advanceFrame();
+    expect(camera.jumpTo).toHaveBeenLastCalledWith(1_400);
+    expect(coordinator.snapshot().mode).toBe("follow-latest");
+
+    camera.jumpTo.mockClear();
+    setGeometry({
+      scrollTop: 1_400,
+      scrollHeight: 2_000,
+    });
+    coordinator.invalidateGeometry();
+    advanceFrame();
+
+    expect(camera.jumpTo).toHaveBeenCalledWith(1_500);
+    expect(camera.followTo).not.toHaveBeenCalled();
+
+    coordinator.takeUserControl();
+    camera.jumpTo.mockClear();
+    setGeometry({
+      scrollTop: 300,
+      scrollHeight: 2_100,
+    });
+    coordinator.invalidateGeometry();
+    advanceFrame();
+
+    expect(camera.jumpTo).not.toHaveBeenCalled();
+    expect(coordinator.snapshot().mode).toBe("browsing-history");
+  });
+
   it("treats scroll events as observations until explicit user intent takes control", () => {
     const {
       camera,
@@ -539,7 +576,17 @@ describe("ThreadMotionCoordinator", () => {
     setGeometry({ scrollTop: 1_800 });
     setCameraFollowing(false);
     expect(coordinator.observeScroll(true)).toBe("navigation");
-    expect(coordinator.snapshot().mode).toBe("idle");
+    expect(coordinator.snapshot().mode).toBe("follow-latest");
+
+    camera.jumpTo.mockClear();
+    setGeometry({
+      scrollTop: 1_800,
+      scrollHeight: 2_400,
+    });
+    coordinator.invalidateGeometry();
+    advanceFrame();
+
+    expect(camera.jumpTo).toHaveBeenCalledWith(1_900);
   });
 
   it("pins a waiting prompt to the exact lower boundary across all layout changes", () => {

--- a/webui/src/tests/thread-viewport.test.tsx
+++ b/webui/src/tests/thread-viewport.test.tsx
@@ -820,11 +820,12 @@ describe("ThreadViewport", () => {
     }
   });
 
-  it("gives smooth scroll-to-bottom navigation ownership of the latest target", () => {
-    const navigateLatestTo = vi.spyOn(
+  it("gives direct scroll-to-bottom ownership of the latest target", () => {
+    const resumeAutoFollow = vi.spyOn(
       ThreadMotionCoordinator.prototype,
-      "navigateLatestTo",
-    ).mockReturnValue("started");
+      "resumeAutoFollow",
+    );
+    const jumpTo = vi.spyOn(ThreadCameraController.prototype, "jumpTo");
     const { container } = render(
       <ThreadViewport
         messages={messages}
@@ -844,7 +845,8 @@ describe("ThreadViewport", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "Scroll to bottom" }));
 
-    expect(navigateLatestTo).toHaveBeenCalledWith(1_800);
+    expect(resumeAutoFollow).toHaveBeenCalled();
+    expect(jumpTo).toHaveBeenCalledWith(1_800);
   });
 
   it("pins the waiting boundary across composer and grid-track growth", async () => {
@@ -1635,6 +1637,125 @@ describe("ThreadViewport", () => {
     );
 
     await waitFor(() => expect(scroller.scrollTop).toBe(1800));
+  });
+
+  it("pins an opened conversation to late layout growth without animating", async () => {
+    const resizeObserver = stubResizeObserver();
+    const jumpTo = vi.spyOn(ThreadCameraController.prototype, "jumpTo");
+    const followTo = vi.spyOn(ThreadCameraController.prototype, "followTo");
+
+    try {
+      const { container, rerender } = render(
+        <ThreadViewport
+          messages={messages}
+          isStreaming={false}
+          composer={<div />}
+          conversationKey="chat-a"
+        />,
+      );
+      const scroller = getScroller(container);
+      Object.defineProperties(scroller, {
+        scrollHeight: { configurable: true, value: 2400 },
+        clientHeight: { configurable: true, value: 600 },
+        scrollTop: { configurable: true, writable: true, value: 300 },
+      });
+      act(() => {
+        dispatchUserScroll(scroller);
+      });
+
+      rerender(
+        <ThreadViewport
+          messages={messages}
+          isStreaming={false}
+          composer={<div />}
+          conversationKey="chat-b"
+        />,
+      );
+      await waitFor(() => expect(scroller.scrollTop).toBe(1800));
+      jumpTo.mockClear();
+      followTo.mockClear();
+
+      const messageRegion = screen.getByTestId("thread-message-region");
+      const messageContent = messageRegion.firstElementChild;
+      expect(messageContent).not.toBeNull();
+      const contentObserver = resizeObserver.observers.find(
+        (observer) => observer.elements.includes(messageContent!),
+      );
+      expect(contentObserver).toBeDefined();
+
+      Object.defineProperty(scroller, "scrollHeight", {
+        configurable: true,
+        value: 3000,
+      });
+      act(() => {
+        contentObserver!.callback([], contentObserver as unknown as ResizeObserver);
+      });
+      await flushAnimationFrame();
+
+      expect(jumpTo).toHaveBeenCalledWith(2400);
+      expect(scroller.scrollTop).toBe(2400);
+      expect(followTo).not.toHaveBeenCalled();
+    } finally {
+      jumpTo.mockRestore();
+      followTo.mockRestore();
+      resizeObserver.restore();
+    }
+  });
+
+  it("jumps to the bottom button target and pins later layout growth without animating", async () => {
+    const resizeObserver = stubResizeObserver();
+    const jumpTo = vi.spyOn(ThreadCameraController.prototype, "jumpTo");
+    const followTo = vi.spyOn(ThreadCameraController.prototype, "followTo");
+
+    try {
+      const { container } = render(
+        <ThreadViewport
+          messages={messages}
+          isStreaming={false}
+          composer={<div />}
+          conversationKey="chat-a"
+        />,
+      );
+      const scroller = getScroller(container);
+      Object.defineProperties(scroller, {
+        scrollHeight: { configurable: true, value: 2400 },
+        clientHeight: { configurable: true, value: 600 },
+        scrollTop: { configurable: true, writable: true, value: 300 },
+      });
+      act(() => {
+        dispatchUserScroll(scroller);
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Scroll to bottom" }));
+      expect(scroller.scrollTop).toBe(1800);
+      jumpTo.mockClear();
+      followTo.mockClear();
+
+      const messageRegion = screen.getByTestId("thread-message-region");
+      const messageContent = messageRegion.firstElementChild;
+      expect(messageContent).not.toBeNull();
+      const contentObserver = resizeObserver.observers.find(
+        (observer) => observer.elements.includes(messageContent!),
+      );
+      expect(contentObserver).toBeDefined();
+
+      Object.defineProperty(scroller, "scrollHeight", {
+        configurable: true,
+        value: 3000,
+      });
+      act(() => {
+        contentObserver!.callback([], contentObserver as unknown as ResizeObserver);
+      });
+      await flushAnimationFrame();
+
+      expect(jumpTo).toHaveBeenCalledWith(2400);
+      expect(scroller.scrollTop).toBe(2400);
+      expect(followTo).not.toHaveBeenCalled();
+    } finally {
+      jumpTo.mockRestore();
+      followTo.mockRestore();
+      resizeObserver.restore();
+    }
   });
 
   it("waits for the next conversation's transcript before restoring its bottom", async () => {

--- a/webui/src/tests/thread-viewport.test.tsx
+++ b/webui/src/tests/thread-viewport.test.tsx
@@ -820,12 +820,11 @@ describe("ThreadViewport", () => {
     }
   });
 
-  it("gives direct scroll-to-bottom ownership of the latest target", () => {
-    const resumeAutoFollow = vi.spyOn(
+  it("gives smooth scroll-to-bottom navigation ownership of the latest target", () => {
+    const navigateLatestTo = vi.spyOn(
       ThreadMotionCoordinator.prototype,
-      "resumeAutoFollow",
-    );
-    const jumpTo = vi.spyOn(ThreadCameraController.prototype, "jumpTo");
+      "navigateLatestTo",
+    ).mockReturnValue("started");
     const { container } = render(
       <ThreadViewport
         messages={messages}
@@ -845,8 +844,7 @@ describe("ThreadViewport", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "Scroll to bottom" }));
 
-    expect(resumeAutoFollow).toHaveBeenCalled();
-    expect(jumpTo).toHaveBeenCalledWith(1_800);
+    expect(navigateLatestTo).toHaveBeenCalledWith(1_800);
   });
 
   it("pins the waiting boundary across composer and grid-track growth", async () => {
@@ -1702,8 +1700,12 @@ describe("ThreadViewport", () => {
     }
   });
 
-  it("jumps to the bottom button target and pins later layout growth without animating", async () => {
+  it("animates the bottom button target and pins later layout growth", async () => {
     const resizeObserver = stubResizeObserver();
+    const navigateLatestTo = vi.spyOn(
+      ThreadMotionCoordinator.prototype,
+      "navigateLatestTo",
+    );
     const jumpTo = vi.spyOn(ThreadCameraController.prototype, "jumpTo");
     const followTo = vi.spyOn(ThreadCameraController.prototype, "followTo");
 
@@ -1726,10 +1728,12 @@ describe("ThreadViewport", () => {
         dispatchUserScroll(scroller);
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "Scroll to bottom" }));
-      expect(scroller.scrollTop).toBe(1800);
+      navigateLatestTo.mockClear();
       jumpTo.mockClear();
       followTo.mockClear();
+      fireEvent.click(screen.getByRole("button", { name: "Scroll to bottom" }));
+      expect(navigateLatestTo).toHaveBeenCalledWith(1800);
+      expect(scroller.scrollTop).toBe(300);
 
       const messageRegion = screen.getByTestId("thread-message-region");
       const messageContent = messageRegion.firstElementChild;
@@ -1746,12 +1750,30 @@ describe("ThreadViewport", () => {
       act(() => {
         contentObserver!.callback([], contentObserver as unknown as ResizeObserver);
       });
+      await waitFor(() => expect(scroller.scrollTop).toBe(2400));
+
+      expect(jumpTo).not.toHaveBeenCalled();
+      expect(followTo).not.toHaveBeenCalled();
+
+      act(() => {
+        scroller.dispatchEvent(new Event("scroll"));
+      });
+      await flushAnimationFrame();
+      jumpTo.mockClear();
+
+      Object.defineProperty(scroller, "scrollHeight", {
+        configurable: true,
+        value: 3400,
+      });
+      act(() => {
+        contentObserver!.callback([], contentObserver as unknown as ResizeObserver);
+      });
       await flushAnimationFrame();
 
-      expect(jumpTo).toHaveBeenCalledWith(2400);
-      expect(scroller.scrollTop).toBe(2400);
-      expect(followTo).not.toHaveBeenCalled();
+      expect(jumpTo).toHaveBeenCalledWith(2800);
+      expect(scroller.scrollTop).toBe(2800);
     } finally {
+      navigateLatestTo.mockRestore();
       jumpTo.mockRestore();
       followTo.mockRestore();
       resizeObserver.restore();


### PR DESCRIPTION
## Summary
- open restored topics directly at the latest message without a visible scroll animation, and keep them pinned through delayed layout
- preserve smooth animation for the explicit scroll-to-bottom control while retargeting the moving bottom if content grows
- converge exactly despite browser `scrollTop` quantization, then retain bottom ownership until the user browses history

## Testing
- `npm run test -- src/tests/thread-camera.test.ts src/tests/thread-motion.test.ts src/tests/thread-viewport.test.tsx src/tests/thread-shell.test.tsx` (115 passed)
- `npm run test` (858 passed)
- `npm run lint -- --no-warn-ignored`
- `npm run build`
- real gateway + Playwright with a 64-turn session:
  - opening the long session: 0 intermediate scroll writes, 0 px final bottom distance
  - scroll button + 1400 px message-content growth during animation: 64 distinct writes, retargeted and settled at 0 px bottom distance
  - another 600 px of growth after animation: retained ownership and settled with 1 write at 0 px bottom distance
  - browser console: 0 errors, 0 warnings