### PR TITLE
fix(webui): animate reasoning drawer transitions

### DIFF
--- a/webui/src/components/thread/activity/ThinkingReasoningShell.tsx
+++ b/webui/src/components/thread/activity/ThinkingReasoningShell.tsx
@@ -47,8 +47,8 @@ export function ThinkingReasoningShell({
         </span>
         <ChevronDown
           className={cn(
-            "h-3 w-3 shrink-0 text-muted-foreground/60 transition-[transform,color] duration-200",
-            "group-hover:text-muted-foreground motion-reduce:transition-none",
+            "h-3 w-3 shrink-0 text-muted-foreground/60 transition-[transform,color] [transition-duration:600ms] ease-out",
+            "group-hover:text-muted-foreground motion-reduce:[transition-duration:220ms]",
             expanded && "rotate-180",
           )}
           strokeWidth={1.8}
@@ -58,7 +58,7 @@ export function ThinkingReasoningShell({
 
       <div
         className={cn(
-          "grid transition-[grid-template-rows,opacity] duration-300 motion-reduce:transition-none",
+          "grid transition-[grid-template-rows,opacity] [transition-duration:600ms] ease-out motion-reduce:[transition-duration:220ms]",
           expanded
             ? "grid-rows-[1fr] opacity-100"
             : "pointer-events-none grid-rows-[0fr] opacity-0",

--- a/webui/src/components/thread/activity/ThinkingReasoningShell.tsx
+++ b/webui/src/components/thread/activity/ThinkingReasoningShell.tsx
@@ -45,15 +45,22 @@ export function ThinkingReasoningShell({
         >
           {label}
         </span>
-        <ChevronDown
+        <span
           className={cn(
-            "h-3 w-3 shrink-0 text-muted-foreground/60 transition-[transform,color] [transition-duration:600ms] ease-out",
-            "group-hover:text-muted-foreground motion-reduce:[transition-duration:220ms]",
+            "inline-flex shrink-0 transition-transform [transition-duration:600ms] ease-out",
+            "motion-reduce:[transition-duration:220ms]",
             expanded && "rotate-180",
           )}
-          strokeWidth={1.8}
-          aria-hidden
-        />
+        >
+          <ChevronDown
+            className={cn(
+              "h-3 w-3 text-muted-foreground/60 transition-colors duration-200",
+              "group-hover:text-muted-foreground motion-reduce:transition-none",
+            )}
+            strokeWidth={1.8}
+            aria-hidden
+          />
+        </span>
       </button>
 
       <div

--- a/webui/src/tests/agent-activity-cluster.test.tsx
+++ b/webui/src/tests/agent-activity-cluster.test.tsx
@@ -350,6 +350,31 @@ describe("AgentActivityCluster", () => {
     }
   });
 
+  it("keeps chevron color feedback faster than the drawer rotation", () => {
+    render(
+      <AgentActivityCluster
+        messages={[{
+          id: "r-motion",
+          role: "assistant",
+          content: "",
+          reasoning: "checking motion",
+          createdAt: 1,
+        }]}
+        isTurnStreaming={false}
+        hasBodyBelow
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Thought" });
+    const chevron = button.querySelector("svg");
+    expect(chevron).toBeInTheDocument();
+    expect(chevron).toHaveClass("transition-colors", "duration-200");
+    expect(chevron?.parentElement).toHaveClass(
+      "transition-transform",
+      "[transition-duration:600ms]",
+    );
+  });
+
   it("uses persisted turn latency for completed history instead of replay timestamps", () => {
     render(
       <AgentActivityCluster


### PR DESCRIPTION
## Summary

- align the shared reasoning/tool activity drawer expansion and collapse with the running drawer's 600ms ease-out motion
- keep chevron rotation synchronized at 600ms while preserving the existing 200ms hover color feedback
- shorten the transition to 220ms under reduced-motion preferences, matching the running drawer behavior
- cover the split rotation/color transition timing with a regression test

The shared drawer applies to reasoning and regular tool activity, including generic tools, CLI runs, MCP runs, and web searches. File-edit-only activity continues to render outside this drawer.

## Testing

- `bun run test -- src/tests/agent-activity-cluster.test.tsx` (50 passed)
- `bun run build`
- `bun run lint`