### PR TITLE
fix(ci): scope PR path detection to head changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,20 @@ jobs:
         id: paths
         shell: bash
         env:
+          EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-          HEAD_SHA: ${{ github.sha }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
           python_required=true
 
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            diff_range="${BASE_SHA}...${HEAD_SHA}"
+          else
+            diff_range="${BASE_SHA}..${HEAD_SHA}"
+          fi
+
           if git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null &&
-            changed_files="$(git diff --name-only --no-renames "$BASE_SHA" "$HEAD_SHA")" &&
+            changed_files="$(git diff --name-only --no-renames "$diff_range")" &&
             [[ -n "$changed_files" ]] &&
             ! grep -qvE '^(webui/|nanobot/channels/[^/]+/webui/|docs/)' <<< "$changed_files"; then
             python_required=false


### PR DESCRIPTION
## Summary

- compare pull request changes against the PR head SHA instead of GitHub's synthetic merge commit
- use a three-dot range for pull requests so concurrent base-branch updates are excluded
- retain the existing two-dot comparison for pushes and the conservative fallback that runs Python CI when the diff cannot be classified

## Root cause

Observed on #5143. The workflow event recorded base `76ab04ac`, but `actions/checkout` resolved a synthetic merge commit whose base parent had already advanced to `24a392b6`. Comparing the old event base directly to that merge commit pulled newly merged backend files into the path set, so a WebUI-only PR incorrectly ran the Python matrix.

## Verification

Exercised the classifier against the real commits from #5143:

- stale event base + WebUI PR head: `python_required=false`
- advanced current base + WebUI PR head: `python_required=false`
- backend push: `python_required=true`
- empty push diff: `python_required=true` (fail-safe)

Also confirmed the resulting PR diff remains limited to `.github/workflows/ci.yml` and passes `git diff --check`.