### PR TITLE
fix(webui): drop malformed token-usage day keys

### DIFF
--- a/nanobot/webui/token_usage.py
+++ b/nanobot/webui/token_usage.py
@@ -159,6 +159,13 @@ def normalize_token_usage_state(raw: Any) -> dict[str, Any]:
         if not isinstance(date, str) or len(date) != 10 or not isinstance(row_value, dict):
             continue
         row = cast(dict[str, Any], row_value)
+        try:
+            datetime.fromisoformat(date)
+        except ValueError:
+            # A hand-edited or foreign day key that is not a real date would
+            # otherwise reach token_usage_payload's date parsing and fail every
+            # settings request; drop it like any other malformed row.
+            continue
         normalized = _normalize_usage_row(row)
         if normalized["total_tokens"] <= 0 and normalized["requests"] <= 0:
             continue

--- a/tests/webui/test_token_usage.py
+++ b/tests/webui/test_token_usage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
@@ -12,6 +13,60 @@ from nanobot.webui.token_usage import (
     record_token_usage,
     token_usage_payload,
 )
+
+
+def _write_state(tmp_path, days: dict) -> None:
+    state_dir = tmp_path / "webui"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "token-usage.json").write_text(
+        json.dumps({"days": days}), encoding="utf-8"
+    )
+
+
+def test_payload_tolerates_malformed_persisted_day_keys(tmp_path, monkeypatch) -> None:
+    """Day keys that are not real dates must not break settings payloads.
+
+    normalize_token_usage_state only length-checks day keys, so a hand-edited
+    10-char key survives reads and atomic rewrites; token_usage_payload then
+    parsed it with an unguarded fromisoformat, failing every /api/settings and
+    /api/settings/usage request until the file was fixed by hand.
+    """
+    monkeypatch.setattr("nanobot.webui.token_usage.get_webui_dir", lambda: tmp_path / "webui")
+    _write_state(tmp_path, {
+        "not-a-dat3": {"total_tokens": 7, "requests": 1},
+        "2026-13-01": {"total_tokens": 9, "requests": 1},
+        "2026-06-02": {"total_tokens": 5, "requests": 1},
+    })
+
+    payload = token_usage_payload(
+        timezone_name="UTC",
+        now=datetime(2026, 6, 3, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert payload["total_tokens"] == 5
+    assert payload["total_tokens_30d"] == 5
+    assert payload["requests_30d"] == 1
+    assert payload["active_days_30d"] == 1
+
+
+def test_record_scrubs_malformed_day_keys(tmp_path, monkeypatch) -> None:
+    """Rewrites drop malformed day keys instead of persisting them forever."""
+    monkeypatch.setattr("nanobot.webui.token_usage.get_webui_dir", lambda: tmp_path / "webui")
+    _write_state(tmp_path, {
+        "not-a-dat3": {"total_tokens": 7, "requests": 1},
+        "2026-06-02": {"total_tokens": 5, "requests": 1},
+    })
+
+    record_token_usage(
+        {"prompt_tokens": 1, "completion_tokens": 1},
+        timezone_name="UTC",
+        now=datetime(2026, 6, 3, 12, 0, tzinfo=timezone.utc),
+    )
+
+    raw = json.loads((tmp_path / "webui" / "token-usage.json").read_text(encoding="utf-8"))
+    assert "not-a-dat3" not in raw["days"]
+    assert "2026-06-02" in raw["days"]
+    assert "2026-06-03" in raw["days"]
 
 
 def test_record_token_usage_aggregates_by_local_day(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- validate persisted token-usage day keys in `normalize_token_usage_state`
- stop one malformed key from failing every `/api/settings` and
  `/api/settings/usage` request

## Problem

`normalize_token_usage_state` only length-checks day keys, so a hand-edited or
foreign 10-char key (e.g. `"not-a-dat3"` or `"2026-13-01"`) in
`token-usage.json` survives reads and atomic rewrites. `token_usage_payload`
then parses every day key with an unguarded `datetime.fromisoformat`, so one
such key raises `ValueError` on each settings request (`ws_http.dispatch` has
no exception handler on this path). The WebUI Settings page and Overview usage
card stay broken until the file is repaired by hand.

## Root cause

The day-key check at the normalize boundary admits strings that the payload's
date parsing later rejects. Every other parse in the module is guarded; this
was the single gap.

## Fix

Validate the key with the same parser at the normalize boundary that every
read, record, and rewrite already funnels through, and drop malformed keys
like other malformed rows. The next write scrubs them from the file. Valid
state is unchanged; no public API or configuration changes.

## Validation

- `uv run pytest tests/webui/test_token_usage.py -q` — 8 passed
- `uv run pytest tests/webui -q` — 163 passed
- old-behavior mutation: keeping the malformed key makes both regression tests fail
- `uv run ruff check nanobot/webui/token_usage.py tests/webui/test_token_usage.py`
- `git diff --check`