### PR TITLE
fix(pairing): handle null approved map safely in get_approved

### DIFF
--- a/nanobot/pairing/store.py
+++ b/nanobot/pairing/store.py
@@ -261,7 +261,8 @@ def get_approved(channel: str) -> list[str]:
     """Return all approved sender IDs for *channel*."""
     with _LOCK:
         data = _load()
-        return sorted(data.get("approved", {}).get(channel, set()))
+        approved = data.get("approved") or {}
+        return sorted(approved.get(channel, set()))
 
 
 def format_pairing_reply(code: str) -> str:

--- a/tests/pairing/test_store.py
+++ b/tests/pairing/test_store.py
@@ -304,3 +304,11 @@ def test_pending_gc_drops_malformed_entries(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(store, "_store_path", lambda: path)
     assert store.list_pending() == []
+
+def test_get_approved_handles_null_approved_map(monkeypatch):
+    """get_approved must return an empty list without raising AttributeError if approved map is null.
+
+    Prevents AttributeError: 'NoneType' object has no attribute 'get' when data has approved: null.
+    """
+    monkeypatch.setattr(store, "_load", lambda: {"approved": None, "pending": {}})
+    assert store.get_approved("telegram") == []


### PR DESCRIPTION
Fix `get_approved` in the pairing store when the `approved` map is `None`.

If the pairing store JSON file contains `"approved": null`, `data.get("approved", {})` evaluated to `None` because the key was present in the dictionary, causing `get_approved(channel)` to raise `AttributeError: 'NoneType' object has no attribute 'get'`.

This update safely normalizes null or missing approved maps to an empty dictionary before accessing channel senders.