### PR TITLE
fix(telegram): recover from silently stalled polling

### DIFF
--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -516,6 +516,7 @@ class TelegramChannel(BaseChannel):
         self._rich_send_disabled: bool = False  # Latch off if Bot API < 10.1
         self._last_poll_ok: float = 0.0  # monotonic time of last getUpdates round trip
         self._app_ready = asyncio.Event()  # cleared while the app is being rebuilt
+        self._teardown_lock = asyncio.Lock()
 
     def _require_app(self) -> TelegramApplication:
         if self._app is None:
@@ -768,21 +769,22 @@ class TelegramChannel(BaseChannel):
 
     async def _teardown_app(self) -> None:
         """Shut down the application, tolerating partially started state."""
-        app, self._app = self._app, None
-        self._app_ready.clear()
-        if not app:
-            return
-        for step in (cast(Any, app.updater).stop, app.stop, app.shutdown):
+        async with self._teardown_lock:
+            app, self._app = self._app, None
+            self._app_ready.clear()
+            if not app:
+                return
+            for step in (cast(Any, app.updater).stop, app.stop, app.shutdown):
+                try:
+                    await step()
+                except Exception as e:
+                    self.logger.debug("teardown step failed: {}", e)
+            # Application.shutdown() skips the HTTPX pools unless initialize()
+            # finished, so a failed startup leaks one per retry. This is idempotent.
             try:
-                await step()
+                await app.bot.shutdown()
             except Exception as e:
-                self.logger.debug("teardown step failed: {}", e)
-        # Application.shutdown() skips the HTTPX pools unless initialize()
-        # finished, so a failed startup leaks one per retry. This is idempotent.
-        try:
-            await app.bot.shutdown()
-        except Exception as e:
-            self.logger.debug("bot shutdown failed: {}", e)
+                self.logger.debug("bot shutdown failed: {}", e)
 
     async def stop(self) -> None:
         """Stop the Telegram bot."""
@@ -804,7 +806,9 @@ class TelegramChannel(BaseChannel):
 
         if self._app:
             self.logger.info("Stopping bot...")
-            await self._teardown_app()
+        # Join an in-flight supervisor teardown before ChannelManager cancels
+        # start(), otherwise cancellation can strand the old HTTPX pools.
+        await self._teardown_app()
 
     @staticmethod
     def _get_media_type(path: str) -> str:

--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -25,9 +25,9 @@ from telegram import (
     Update,
     User,
 )
-from telegram.error import BadRequest, NetworkError, TimedOut
+from telegram.error import BadRequest, InvalidToken, NetworkError, TimedOut
 from telegram.ext import Application, CallbackQueryHandler, ContextTypes, MessageHandler, filters
-from telegram.request import HTTPXRequest
+from telegram.request import BaseRequest, HTTPXRequest
 
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.outbound_events import ProgressEvent
@@ -38,6 +38,7 @@ from nanobot.config.paths import get_media_dir
 from nanobot.config.schema import Base
 from nanobot.security.network import validate_url_target
 from nanobot.utils.helpers import split_message
+from nanobot.utils.logging_bridge import redirect_lib_logging
 
 TELEGRAM_MAX_MESSAGE_LEN = 4000  # Telegram message character limit
 # Telegram's actual API limit is 4096; we split raw markdown at 4000 as a
@@ -52,6 +53,39 @@ TELEGRAM_REPLY_CONTEXT_MAX_LEN = TELEGRAM_MAX_MESSAGE_LEN  # Max length for repl
 # explicit rather than allowing unspecialized generics to spread Unknown.
 TelegramApplication: TypeAlias = Application[Any, Any, Any, Any, Any, Any]
 _T = TypeVar("_T")
+
+# A healthy getUpdates long poll completes every ~10s even with no traffic;
+# PTB retries timeouts silently, so stalls must be detected here.
+POLL_STALE_SECONDS = 120.0
+POLL_WATCH_INTERVAL = 1.0
+RESTART_BACKOFF_INITIAL_SECONDS = 5.0
+RESTART_BACKOFF_MAX_SECONDS = 300.0
+
+
+class _LivenessTrackedRequest(BaseRequest):
+    """Wrap the getUpdates request pool, reporting each completed round trip."""
+
+    __slots__ = ("inner", "_on_round_trip")
+
+    def __init__(self, inner: BaseRequest, on_round_trip: Callable[[], None]) -> None:
+        super().__init__()
+        self.inner = inner
+        self._on_round_trip = on_round_trip
+
+    @property
+    def read_timeout(self) -> float | None:
+        return self.inner.read_timeout
+
+    async def initialize(self) -> None:
+        await self.inner.initialize()
+
+    async def shutdown(self) -> None:
+        await self.inner.shutdown()
+
+    async def do_request(self, *args: Any, **kwargs: Any) -> tuple[int, bytes]:
+        result = await self.inner.do_request(*args, **kwargs)
+        self._on_round_trip()
+        return result
 
 
 def _split_telegram_markdown(content: str, max_len: int) -> list[str]:
@@ -477,6 +511,7 @@ class TelegramChannel(BaseChannel):
         self._inbound_buffers: dict[str, list[_QueuedTelegramUpdate]] = {}
         self._inbound_workers: dict[str, asyncio.Task[None]] = {}
         self._rich_send_disabled: bool = False  # Latch off if Bot API < 10.1
+        self._last_poll_ok: float = 0.0  # monotonic time of last getUpdates round trip
 
     def _require_app(self) -> TelegramApplication:
         if self._app is None:
@@ -516,13 +551,56 @@ class TelegramChannel(BaseChannel):
         return content
 
     async def start(self) -> None:
-        """Start the Telegram bot."""
+        """Start the Telegram bot, rebuilding the app whenever polling stalls."""
         if not self.config.token:
             self.logger.error("bot token not configured")
             return
 
-        self._running = True
+        redirect_lib_logging("telegram")
+        redirect_lib_logging("httpx", level="WARNING")
 
+        self._running = True
+        backoff = RESTART_BACKOFF_INITIAL_SECONDS
+        while self._running:
+            try:
+                await self._start_app()
+            except InvalidToken as e:
+                # A rejected token is a config error, not a transient network
+                # failure — retrying forever would only spam the log.
+                await self._teardown_app()
+                self.logger.error("bot token rejected: {}", self._format_telegram_error(e))
+                return
+            except Exception as e:
+                await self._teardown_app()
+                if not self._running:
+                    break
+                self.logger.error(
+                    "startup failed: {}; retrying in {:.0f}s",
+                    self._format_telegram_error(e),
+                    backoff,
+                )
+                await self._idle(backoff)
+                backoff = min(backoff * 2, RESTART_BACKOFF_MAX_SECONDS)
+                continue
+
+            backoff = RESTART_BACKOFF_INITIAL_SECONDS
+            if not self._running:
+                # stop() ran while _start_app() was mid-flight and tore down the
+                # previous (possibly None) app; this one would leak otherwise.
+                await self._teardown_app()
+                break
+            stalled = await self._watch_polling()
+            if not stalled or not self._running:
+                break
+            self.logger.warning(
+                "polling stalled: no getUpdates round trip for {:.0f}s; "
+                "rebuilding connection pools and restarting",
+                time.monotonic() - self._last_poll_ok,
+            )
+            await self._teardown_app()
+
+    async def _start_app(self) -> None:
+        """Build, initialize and start the Telegram application."""
         proxy = self.config.proxy or None
 
         # Separate pools so long-polling (getUpdates) never starves outbound sends.
@@ -544,7 +622,7 @@ class TelegramChannel(BaseChannel):
             Application.builder()
             .token(self.config.token)
             .request(api_request)
-            .get_updates_request(poll_request)
+            .get_updates_request(_LivenessTrackedRequest(poll_request, self._note_poll_ok))
         )
         self._app = builder.build()
         self._app.add_error_handler(self._on_error)
@@ -621,16 +699,43 @@ class TelegramChannel(BaseChannel):
                 max_connections=self.config.webhook_max_connections,
             )
         else:
-            # Start polling (this runs until stopped)
+            self._last_poll_ok = time.monotonic()
             await cast(Any, self._app.updater).start_polling(
                 allowed_updates=allowed_updates,
                 drop_pending_updates=False,  # Process pending messages on startup
                 error_callback=self._on_polling_error,
             )
 
-        # Keep running until stopped
+    def _note_poll_ok(self) -> None:
+        # HTTP error statuses count too: the watchdog detects transport stalls,
+        # not logical failures.
+        self._last_poll_ok = time.monotonic()
+
+    async def _watch_polling(self) -> bool:
+        """Idle until stop(); in polling mode, return True when getUpdates goes stale."""
+        watch = self.config.mode != "webhook"
         while self._running:
-            await asyncio.sleep(1)
+            await asyncio.sleep(POLL_WATCH_INTERVAL)
+            if watch and time.monotonic() - self._last_poll_ok > POLL_STALE_SECONDS:
+                return True
+        return False
+
+    async def _idle(self, seconds: float) -> None:
+        """Sleep in short steps so stop() stays responsive."""
+        deadline = time.monotonic() + seconds
+        while self._running and time.monotonic() < deadline:
+            await asyncio.sleep(POLL_WATCH_INTERVAL)
+
+    async def _teardown_app(self) -> None:
+        """Shut down the application, tolerating partially started state."""
+        app, self._app = self._app, None
+        if not app:
+            return
+        for step in (cast(Any, app.updater).stop, app.stop, app.shutdown):
+            try:
+                await step()
+            except Exception as e:
+                self.logger.debug("teardown step failed: {}", e)
 
     async def stop(self) -> None:
         """Stop the Telegram bot."""
@@ -652,10 +757,7 @@ class TelegramChannel(BaseChannel):
 
         if self._app:
             self.logger.info("Stopping bot...")
-            await cast(Any, self._app.updater).stop()
-            await self._app.stop()
-            await self._app.shutdown()
-            self._app = None
+            await self._teardown_app()
 
     @staticmethod
     def _get_media_type(path: str) -> str:

--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -60,6 +60,9 @@ POLL_STALE_SECONDS = 120.0
 POLL_WATCH_INTERVAL = 1.0
 RESTART_BACKOFF_INITIAL_SECONDS = 5.0
 RESTART_BACKOFF_MAX_SECONDS = 300.0
+# How long a send waits out a rebuild; short because ChannelManager dispatches
+# every channel from one serial loop.
+APP_RESTART_SEND_WAIT_SECONDS = 2.0
 
 
 class _LivenessTrackedRequest(BaseRequest):
@@ -512,6 +515,7 @@ class TelegramChannel(BaseChannel):
         self._inbound_workers: dict[str, asyncio.Task[None]] = {}
         self._rich_send_disabled: bool = False  # Latch off if Bot API < 10.1
         self._last_poll_ok: float = 0.0  # monotonic time of last getUpdates round trip
+        self._app_ready = asyncio.Event()  # cleared while the app is being rebuilt
 
     def _require_app(self) -> TelegramApplication:
         if self._app is None:
@@ -564,16 +568,23 @@ class TelegramChannel(BaseChannel):
         while self._running:
             try:
                 await self._start_app()
-            except InvalidToken as e:
-                # A rejected token is a config error, not a transient network
-                # failure — retrying forever would only spam the log.
+            except InvalidToken:
+                # A config error, not a blip: fail the channel. The scrubbed
+                # re-raise keeps PTB's token-bearing message out of the log.
                 await self._teardown_app()
-                self.logger.error("bot token rejected: {}", self._format_telegram_error(e))
-                return
+                self._running = False
+                self.logger.error("bot token rejected by Telegram")
+                raise RuntimeError("Telegram bot token was rejected by the server") from None
             except Exception as e:
                 await self._teardown_app()
                 if not self._running:
                     break
+                if not self._is_transient_startup_error(e):
+                    # Never heals on its own: fail instead of retrying forever
+                    # while ChannelManager keeps reporting the channel running.
+                    self._running = False
+                    self.logger.error("startup failed: {}", self._format_telegram_error(e))
+                    raise
                 self.logger.error(
                     "startup failed: {}; retrying in {:.0f}s",
                     self._format_telegram_error(e),
@@ -706,6 +717,35 @@ class TelegramChannel(BaseChannel):
                 error_callback=self._on_polling_error,
             )
 
+        self._app_ready.set()
+
+    @staticmethod
+    def _is_transient_startup_error(exc: Exception) -> bool:
+        """Report whether a startup failure is worth retrying.
+
+        HTTPXRequest wraps every httpx failure into NetworkError/TimedOut, so
+        anything else is terminal: a bad proxy raises ValueError, an already
+        bound webhook port raises OSError.
+        """
+        return isinstance(exc, NetworkError | TimedOut | asyncio.TimeoutError)
+
+    async def _wait_for_app(self) -> TelegramApplication | None:
+        """Return the live app, briefly waiting out an in-flight rebuild.
+
+        Returning quietly while ``start()`` rebuilds would let the manager count
+        the message as delivered, so raise once the wait runs out. None means the
+        channel is stopped: nothing left to deliver.
+        """
+        if self._app is not None:
+            return self._app
+        if not self._running:
+            return None
+        with suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(self._app_ready.wait(), APP_RESTART_SEND_WAIT_SECONDS)
+        if self._app is None:
+            raise RuntimeError("Telegram application is restarting; message not delivered")
+        return self._app
+
     def _note_poll_ok(self) -> None:
         # HTTP error statuses count too: the watchdog detects transport stalls,
         # not logical failures.
@@ -729,6 +769,7 @@ class TelegramChannel(BaseChannel):
     async def _teardown_app(self) -> None:
         """Shut down the application, tolerating partially started state."""
         app, self._app = self._app, None
+        self._app_ready.clear()
         if not app:
             return
         for step in (cast(Any, app.updater).stop, app.stop, app.shutdown):
@@ -736,6 +777,12 @@ class TelegramChannel(BaseChannel):
                 await step()
             except Exception as e:
                 self.logger.debug("teardown step failed: {}", e)
+        # Application.shutdown() skips the HTTPX pools unless initialize()
+        # finished, so a failed startup leaks one per retry. This is idempotent.
+        try:
+            await app.bot.shutdown()
+        except Exception as e:
+            self.logger.debug("bot shutdown failed: {}", e)
 
     async def stop(self) -> None:
         """Stop the Telegram bot."""
@@ -848,7 +895,8 @@ class TelegramChannel(BaseChannel):
 
     async def send(self, msg: OutboundMessage) -> None:
         """Send a message through Telegram."""
-        if not self._app:
+        app = await self._wait_for_app()
+        if app is None:
             self.logger.warning("bot not running")
             return
 
@@ -887,11 +935,11 @@ class TelegramChannel(BaseChannel):
             try:
                 media_type = self._get_media_type(media_path)
                 sender = {
-                    "photo": self._app.bot.send_photo,
-                    "video": self._app.bot.send_video,
-                    "voice": self._app.bot.send_voice,
-                    "audio": self._app.bot.send_audio,
-                }.get(media_type, self._app.bot.send_document)
+                    "photo": app.bot.send_photo,
+                    "video": app.bot.send_video,
+                    "voice": app.bot.send_voice,
+                    "audio": app.bot.send_audio,
+                }.get(media_type, app.bot.send_document)
                 param = {
                     "photo": "photo",
                     "video": "video",
@@ -931,7 +979,7 @@ class TelegramChannel(BaseChannel):
             except Exception:
                 filename = media_path.rsplit("/", 1)[-1]
                 self.logger.exception("Failed to send media {}", media_path)
-                await self._app.bot.send_message(
+                await app.bot.send_message(
                     chat_id=chat_id,
                     text=f"[Failed to send: {filename}]",
                     reply_parameters=reply_params,
@@ -1059,7 +1107,8 @@ class TelegramChannel(BaseChannel):
         merge_next: bool = False,
     ) -> None:
         """Progressive message editing: send on first delta, edit on subsequent ones."""
-        if not self._app:
+        app = await self._wait_for_app()
+        if app is None:
             return
         meta = metadata or {}
         int_chat_id = int(chat_id)
@@ -1098,7 +1147,7 @@ class TelegramChannel(BaseChannel):
                     # Delete the streaming preview message
                     try:
                         await self._call_with_retry(
-                            self._app.bot.delete_message,
+                            app.bot.delete_message,
                             chat_id=int_chat_id, message_id=buf.message_id,
                         )
                     except Exception:
@@ -1112,7 +1161,7 @@ class TelegramChannel(BaseChannel):
             extra_html_chunks = html_chunks[1:]
             try:
                 await self._call_with_retry(
-                    self._app.bot.edit_message_text,
+                    app.bot.edit_message_text,
                     chat_id=int_chat_id, message_id=buf.message_id,
                     text=primary_html, parse_mode="HTML",
                 )
@@ -1129,7 +1178,7 @@ class TelegramChannel(BaseChannel):
                 primary_plain = split_message(raw_text, TELEGRAM_MAX_MESSAGE_LEN)[0] if len(raw_text) > TELEGRAM_MAX_MESSAGE_LEN else raw_text
                 try:
                     await self._call_with_retry(
-                        self._app.bot.edit_message_text,
+                        app.bot.edit_message_text,
                         chat_id=int_chat_id, message_id=buf.message_id,
                         text=primary_plain,
                     )
@@ -1142,7 +1191,7 @@ class TelegramChannel(BaseChannel):
             for extra_html_chunk in extra_html_chunks:
                 try:
                     await self._call_with_retry(
-                        self._app.bot.send_message,
+                        app.bot.send_message,
                         chat_id=int_chat_id, text=extra_html_chunk,
                         parse_mode="HTML",
                         **thread_kwargs,
@@ -1172,7 +1221,7 @@ class TelegramChannel(BaseChannel):
             preview = _strip_md_block(buf.text)
             try:
                 sent = await self._call_with_retry(
-                    self._app.bot.send_message,
+                    app.bot.send_message,
                     chat_id=int_chat_id, text=preview,
                     **stream_thread_kwargs,
                 )
@@ -1189,7 +1238,7 @@ class TelegramChannel(BaseChannel):
             preview = _strip_md_block(buf.text)
             try:
                 await self._call_with_retry(
-                    self._app.bot.edit_message_text,
+                    app.bot.edit_message_text,
                     chat_id=int_chat_id, message_id=buf.message_id,
                     text=preview,
                 )

--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -736,13 +736,13 @@ class TelegramChannel(BaseChannel):
         the message as delivered, so raise once the wait runs out. None means the
         channel is stopped: nothing left to deliver.
         """
-        if self._app is not None:
+        if self._app_ready.is_set() and self._app is not None:
             return self._app
         if not self._running:
             return None
         with suppress(asyncio.TimeoutError):
             await asyncio.wait_for(self._app_ready.wait(), APP_RESTART_SEND_WAIT_SECONDS)
-        if self._app is None:
+        if not self._app_ready.is_set() or self._app is None:
             raise RuntimeError("Telegram application is restarting; message not delivered")
         return self._app
 

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -61,6 +61,10 @@ class _FakeBot:
         self.sent_messages: list[dict] = []
         self.sent_media: list[dict] = []
         self.get_me_calls = 0
+        self.shutdown_calls = 0
+
+    async def shutdown(self) -> None:
+        self.shutdown_calls += 1
 
     async def get_me(self):
         self.get_me_calls += 1
@@ -450,11 +454,49 @@ async def test_startup_failure_retries_with_backoff(monkeypatch) -> None:
     assert apps[0].updater.start_polling_kwargs is None
     assert apps[1].updater.start_polling_kwargs is None
     assert apps[2].updater.start_polling_kwargs is not None
+    # Pools must be closed via the bot: app.shutdown() skips them here.
+    assert apps[0].bot.shutdown_calls == 1
+    assert apps[1].bot.shutdown_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_startup_error_is_not_retried(monkeypatch) -> None:
+    """Config errors (bad proxy, bound webhook port) must fail the channel."""
+    _FakeHTTPXRequest.clear()
+    config = TelegramConfig(enabled=True, token="123:abc", allow_from=["*"])
+    bus = MessageBus()
+    channel = TelegramChannel(config, bus)
+
+    apps: list[_FakeApp] = []
+
+    def make_builder():
+        app = _FakeApp(lambda: None)
+
+        async def _fail() -> None:
+            raise ValueError("Unknown scheme for proxy URL")
+
+        app.initialize = _fail
+        apps.append(app)
+        return _FakeBuilder(app)
+
+    monkeypatch.setattr("nanobot.channels.telegram.runtime.HTTPXRequest", _FakeHTTPXRequest)
+    monkeypatch.setattr(
+        "nanobot.channels.telegram.runtime.Application",
+        SimpleNamespace(builder=make_builder),
+    )
+    monkeypatch.setattr("nanobot.channels.telegram.runtime.RESTART_BACKOFF_INITIAL_SECONDS", 0.0)
+
+    with pytest.raises(ValueError, match="proxy URL"):
+        await channel.start()
+
+    assert len(apps) == 1  # no retry loop
+    assert channel._app is None
+    assert channel.is_running is False
 
 
 @pytest.mark.asyncio
 async def test_invalid_token_stops_without_retry(monkeypatch) -> None:
-    """A rejected token is a config error: log it and give up instead of retrying."""
+    """A rejected token is a config error: fail the channel instead of retrying."""
     from telegram.error import InvalidToken
 
     _FakeHTTPXRequest.clear()
@@ -481,10 +523,13 @@ async def test_invalid_token_stops_without_retry(monkeypatch) -> None:
     )
     monkeypatch.setattr("nanobot.channels.telegram.runtime.RESTART_BACKOFF_INITIAL_SECONDS", 0.0)
 
-    await channel.start()
+    with pytest.raises(RuntimeError) as excinfo:
+        await channel.start()
 
     assert len(apps) == 1
     assert channel._app is None
+    assert channel.is_running is False
+    assert "123:abc" not in str(excinfo.value)  # token must not reach the log
 
 
 @pytest.mark.asyncio
@@ -508,6 +553,52 @@ async def test_stop_during_startup_does_not_leak_app(monkeypatch) -> None:
     await channel.start()
 
     assert channel._app is None  # torn down, not leaked
+
+
+@pytest.mark.asyncio
+async def test_send_during_rebuild_fails_instead_of_dropping(monkeypatch) -> None:
+    """A send that cannot reach Telegram must raise so the manager can retry."""
+    monkeypatch.setattr("nanobot.channels.telegram.runtime.APP_RESTART_SEND_WAIT_SECONDS", 0.0)
+    config = TelegramConfig(enabled=True, token="123:abc", allow_from=["*"])
+    channel = TelegramChannel(config, MessageBus())
+
+    # Mid-rebuild: still running, but no app to send through.
+    channel._running = True
+    channel._app = None
+
+    msg = OutboundMessage(channel="telegram", chat_id="123", content="hello")
+    with pytest.raises(RuntimeError, match="restarting"):
+        await channel.send(msg)
+    with pytest.raises(RuntimeError, match="restarting"):
+        await channel.send_delta("123", "hello", stream_id="s1")
+
+    # Stopped: nothing to deliver, so stay quiet.
+    channel._running = False
+    await channel.send(msg)
+    await channel.send_delta("123", "hello", stream_id="s1")
+
+
+@pytest.mark.asyncio
+async def test_send_waits_for_rebuild_to_finish(monkeypatch) -> None:
+    """A fast rebuild is waited out rather than surfaced as a delivery failure."""
+    monkeypatch.setattr("nanobot.channels.telegram.runtime.APP_RESTART_SEND_WAIT_SECONDS", 5.0)
+    config = TelegramConfig(enabled=True, token="123:abc", allow_from=["*"])
+    channel = TelegramChannel(config, MessageBus())
+
+    app = _FakeApp(lambda: None)
+    channel._running = True
+    channel._app = None
+
+    async def _finish_rebuild() -> None:
+        await asyncio.sleep(0)
+        channel._app = app
+        channel._app_ready.set()
+
+    rebuild = asyncio.create_task(_finish_rebuild())
+    await channel.send(OutboundMessage(channel="telegram", chat_id="123", content="hello"))
+    await rebuild
+
+    assert [m["text"] for m in app.bot.sent_messages] == ["hello"]
 
 
 @pytest.mark.asyncio

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -337,7 +337,7 @@ async def test_start_creates_separate_pools_with_proxy(monkeypatch) -> None:
     assert api_req.kwargs["connection_pool_size"] == 32
     assert poll_req.kwargs["connection_pool_size"] == 4
     assert builder.request_value is api_req
-    assert builder.get_updates_request_value is poll_req
+    assert builder.get_updates_request_value.inner is poll_req
     assert callable(app.updater.start_polling_kwargs["error_callback"])
     assert any(cmd.command == "status" for cmd in app.bot.commands)
     assert any(cmd.command == "history" for cmd in app.bot.commands)
@@ -376,6 +376,161 @@ async def test_start_respects_custom_pool_config(monkeypatch) -> None:
     assert api_req.kwargs["connection_pool_size"] == 32
     assert api_req.kwargs["pool_timeout"] == 10.0
     assert poll_req.kwargs["pool_timeout"] == 10.0
+
+
+@pytest.mark.asyncio
+async def test_stalled_polling_triggers_pool_rebuild(monkeypatch) -> None:
+    """When no getUpdates round trip completes for too long, the app is rebuilt."""
+    _FakeHTTPXRequest.clear()
+    config = TelegramConfig(enabled=True, token="123:abc", allow_from=["*"])
+    bus = MessageBus()
+    channel = TelegramChannel(config, bus)
+
+    apps: list[_FakeApp] = []
+
+    def on_start_polling() -> None:
+        if len(apps) >= 2:
+            channel._running = False
+
+    def make_builder():
+        app = _FakeApp(on_start_polling)
+        apps.append(app)
+        return _FakeBuilder(app)
+
+    monkeypatch.setattr("nanobot.channels.telegram.runtime.HTTPXRequest", _FakeHTTPXRequest)
+    monkeypatch.setattr(
+        "nanobot.channels.telegram.runtime.Application",
+        SimpleNamespace(builder=make_builder),
+    )
+    monkeypatch.setattr("nanobot.channels.telegram.runtime.POLL_STALE_SECONDS", -1.0)
+    monkeypatch.setattr("nanobot.channels.telegram.runtime.POLL_WATCH_INTERVAL", 0.0)
+
+    await channel.start()
+
+    assert len(apps) == 2
+    assert apps[0].updater.start_polling_kwargs is not None
+    assert apps[1].updater.start_polling_kwargs is not None
+    # 2 fresh pools per app
+    assert len(_FakeHTTPXRequest.instances) == 4
+
+
+@pytest.mark.asyncio
+async def test_startup_failure_retries_with_backoff(monkeypatch) -> None:
+    """Transient startup failures back off and retry until the app comes up."""
+    from telegram.error import NetworkError
+
+    _FakeHTTPXRequest.clear()
+    config = TelegramConfig(enabled=True, token="123:abc", allow_from=["*"])
+    bus = MessageBus()
+    channel = TelegramChannel(config, bus)
+
+    apps: list[_FakeApp] = []
+
+    def make_builder():
+        app = _FakeApp(lambda: setattr(channel, "_running", False))
+        if len(apps) < 2:
+            async def _fail() -> None:
+                raise NetworkError("connect failed")
+
+            app.initialize = _fail
+        apps.append(app)
+        return _FakeBuilder(app)
+
+    monkeypatch.setattr("nanobot.channels.telegram.runtime.HTTPXRequest", _FakeHTTPXRequest)
+    monkeypatch.setattr(
+        "nanobot.channels.telegram.runtime.Application",
+        SimpleNamespace(builder=make_builder),
+    )
+    monkeypatch.setattr("nanobot.channels.telegram.runtime.POLL_WATCH_INTERVAL", 0.0)
+    monkeypatch.setattr("nanobot.channels.telegram.runtime.RESTART_BACKOFF_INITIAL_SECONDS", 0.0)
+
+    await channel.start()
+
+    assert len(apps) == 3
+    assert apps[0].updater.start_polling_kwargs is None
+    assert apps[1].updater.start_polling_kwargs is None
+    assert apps[2].updater.start_polling_kwargs is not None
+
+
+@pytest.mark.asyncio
+async def test_invalid_token_stops_without_retry(monkeypatch) -> None:
+    """A rejected token is a config error: log it and give up instead of retrying."""
+    from telegram.error import InvalidToken
+
+    _FakeHTTPXRequest.clear()
+    config = TelegramConfig(enabled=True, token="123:abc", allow_from=["*"])
+    bus = MessageBus()
+    channel = TelegramChannel(config, bus)
+
+    apps: list[_FakeApp] = []
+
+    def make_builder():
+        app = _FakeApp(lambda: None)
+
+        async def _reject() -> None:
+            raise InvalidToken("token rejected by Telegram")
+
+        app.initialize = _reject
+        apps.append(app)
+        return _FakeBuilder(app)
+
+    monkeypatch.setattr("nanobot.channels.telegram.runtime.HTTPXRequest", _FakeHTTPXRequest)
+    monkeypatch.setattr(
+        "nanobot.channels.telegram.runtime.Application",
+        SimpleNamespace(builder=make_builder),
+    )
+    monkeypatch.setattr("nanobot.channels.telegram.runtime.RESTART_BACKOFF_INITIAL_SECONDS", 0.0)
+
+    await channel.start()
+
+    assert len(apps) == 1
+    assert channel._app is None
+
+
+@pytest.mark.asyncio
+async def test_stop_during_startup_does_not_leak_app(monkeypatch) -> None:
+    """stop() landing while _start_app() is mid-flight must not leave the app running."""
+    _FakeHTTPXRequest.clear()
+    config = TelegramConfig(enabled=True, token="123:abc", allow_from=["*"])
+    bus = MessageBus()
+    channel = TelegramChannel(config, bus)
+
+    # Simulate stop() winning the race just before start_polling returns.
+    app = _FakeApp(lambda: setattr(channel, "_running", False))
+    builder = _FakeBuilder(app)
+
+    monkeypatch.setattr("nanobot.channels.telegram.runtime.HTTPXRequest", _FakeHTTPXRequest)
+    monkeypatch.setattr(
+        "nanobot.channels.telegram.runtime.Application",
+        SimpleNamespace(builder=lambda: builder),
+    )
+
+    await channel.start()
+
+    assert channel._app is None  # torn down, not leaked
+
+
+@pytest.mark.asyncio
+async def test_liveness_tracked_request_stamps_on_round_trip() -> None:
+    from nanobot.channels.telegram.runtime import _LivenessTrackedRequest
+
+    stamps: list[int] = []
+
+    class _Inner:
+        read_timeout = 5.0
+
+        async def initialize(self) -> None:
+            pass
+
+        async def shutdown(self) -> None:
+            pass
+
+        async def do_request(self, *args, **kwargs):
+            return 200, b"{}"
+
+    wrapped = _LivenessTrackedRequest(_Inner(), lambda: stamps.append(1))
+    assert await wrapped.do_request(url="https://example.org", method="POST") == (200, b"{}")
+    assert stamps == [1]
 
 
 def test_webhook_config_requires_https_url_and_secret() -> None:

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -564,6 +564,46 @@ async def test_stop_during_startup_does_not_leak_app(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_stop_waits_for_inflight_watchdog_teardown(monkeypatch) -> None:
+    """Manager cancellation after stop() must not interrupt an active teardown."""
+    _FakeHTTPXRequest.clear()
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
+        MessageBus(),
+    )
+    teardown_started = asyncio.Event()
+    finish_teardown = asyncio.Event()
+    app = _FakeApp(lambda: None)
+
+    async def slow_updater_stop() -> None:
+        teardown_started.set()
+        await finish_teardown.wait()
+
+    app.updater.stop = slow_updater_stop
+    monkeypatch.setattr("nanobot.channels.telegram.runtime.HTTPXRequest", _FakeHTTPXRequest)
+    monkeypatch.setattr(
+        "nanobot.channels.telegram.runtime.Application",
+        SimpleNamespace(builder=lambda: _FakeBuilder(app)),
+    )
+    monkeypatch.setattr("nanobot.channels.telegram.runtime.POLL_STALE_SECONDS", -1.0)
+    monkeypatch.setattr("nanobot.channels.telegram.runtime.POLL_WATCH_INTERVAL", 0.0)
+
+    start_task = asyncio.create_task(channel.start())
+    await teardown_started.wait()
+    assert channel._app is None
+
+    stop_task = asyncio.create_task(channel.stop())
+    await asyncio.sleep(0)
+    assert not stop_task.done()
+
+    finish_teardown.set()
+    await stop_task
+    await start_task
+
+    assert app.bot.shutdown_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_send_during_rebuild_fails_instead_of_dropping(monkeypatch) -> None:
     """A send that cannot reach Telegram must raise so the manager can retry."""
     monkeypatch.setattr("nanobot.channels.telegram.runtime.APP_RESTART_SEND_WAIT_SECONDS", 0.0)

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -157,6 +157,14 @@ class _FakeBuilder:
         return self.app
 
 
+def _install_ready_app(channel: TelegramChannel) -> _FakeApp:
+    """Install the ready app state expected by ordinary send tests."""
+    app = _FakeApp(lambda: None)
+    channel._app = app
+    channel._app_ready.set()
+    return app
+
+
 def _make_telegram_update(
     *,
     chat_type: str = "group",
@@ -602,6 +610,29 @@ async def test_send_waits_for_rebuild_to_finish(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_send_waits_for_partially_initialized_app(monkeypatch) -> None:
+    """A built app is not available for sends until startup marks it ready."""
+    monkeypatch.setattr("nanobot.channels.telegram.runtime.APP_RESTART_SEND_WAIT_SECONDS", 5.0)
+    config = TelegramConfig(enabled=True, token="123:abc", allow_from=["*"])
+    channel = TelegramChannel(config, MessageBus())
+
+    app = _FakeApp(lambda: None)
+    channel._running = True
+    channel._app = app
+
+    send_task = asyncio.create_task(
+        channel.send(OutboundMessage(channel="telegram", chat_id="123", content="hello"))
+    )
+    await asyncio.sleep(0)
+    assert not send_task.done()
+
+    channel._app_ready.set()
+    await send_task
+
+    assert [m["text"] for m in app.bot.sent_messages] == ["hello"]
+
+
+@pytest.mark.asyncio
 async def test_liveness_tracked_request_stamps_on_round_trip() -> None:
     from nanobot.channels.telegram.runtime import _LivenessTrackedRequest
 
@@ -725,7 +756,7 @@ async def test_send_text_retries_on_timeout() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
 
     call_count = 0
     original_send = channel._app.bot.send_message
@@ -760,7 +791,7 @@ async def test_send_text_gives_up_after_max_retries() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
 
     async def always_timeout(**kwargs):
         raise TimedOut()
@@ -787,7 +818,7 @@ async def test_send_rich_capability_error_latches_and_falls_back() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_messages=True),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     channel._app.bot.do_api_request = AsyncMock(side_effect=BadRequest("Method not found"))
 
     await channel.send(OutboundMessage(channel="telegram", chat_id="123", content="**hello**"))
@@ -806,7 +837,7 @@ async def test_send_rich_bad_request_does_not_latch_capability() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_messages=True),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     channel._app.bot.do_api_request = AsyncMock(
         side_effect=BadRequest("Bad Request: message to reply not found")
     )
@@ -825,7 +856,7 @@ async def test_rich_messages_default_skips_send_rich_message() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     channel._app.bot.do_api_request = AsyncMock()
 
     await channel.send(OutboundMessage(channel="telegram", chat_id="123", content="**hello**"))
@@ -912,7 +943,7 @@ async def test_send_delta_stream_end_raises_and_keeps_buffer_on_failure() -> Non
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     channel._app.bot.edit_message_text = AsyncMock(side_effect=RuntimeError("boom"))
     channel._stream_bufs["123"] = _StreamBuf(text="hello", message_id=7, last_edit=0.0)
 
@@ -928,7 +959,7 @@ async def test_send_delta_merge_next_preserves_buffer() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     channel._app.bot.edit_message_text = AsyncMock()
     channel._stream_bufs["123"] = _StreamBuf(
         text="first-",
@@ -957,7 +988,7 @@ async def test_send_delta_stream_end_treats_not_modified_as_success() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     channel._app.bot.edit_message_text = AsyncMock(side_effect=BadRequest("Message is not modified"))
     channel._stream_bufs["123"] = _StreamBuf(text="hello", message_id=7, last_edit=0.0, stream_id="s:0")
 
@@ -977,7 +1008,7 @@ async def test_send_delta_stream_end_does_not_fallback_on_network_timeout(
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     monkeypatch.setattr("nanobot.channels.telegram.runtime._SEND_RETRY_BASE_DELAY", 0)
     # _call_with_retry retries TimedOut up to 3 times, so the mock will be called
     # multiple times – but all calls must be with parse_mode="HTML" (no plain fallback).
@@ -1005,7 +1036,7 @@ async def test_send_delta_stream_end_does_not_fallback_on_network_error() -> Non
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     channel._app.bot.edit_message_text = AsyncMock(side_effect=NetworkError("connection reset"))
     channel._stream_bufs["123"] = _StreamBuf(text="hello", message_id=7, last_edit=0.0)
 
@@ -1029,7 +1060,7 @@ async def test_send_delta_stream_end_falls_back_on_bad_request() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
 
     # First call (HTML) raises BadRequest, second call (plain) succeeds
     channel._app.bot.edit_message_text = AsyncMock(
@@ -1061,7 +1092,7 @@ async def test_send_delta_stream_end_splits_oversized_reply() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     channel._app.bot.edit_message_text = AsyncMock()
     channel._app.bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=99))
 
@@ -1095,7 +1126,7 @@ async def test_send_delta_stream_end_html_expansion_does_not_overflow() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     channel._app.bot.edit_message_text = AsyncMock()
     channel._app.bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=99))
 
@@ -1126,7 +1157,7 @@ async def test_send_delta_stream_end_splits_long_code_block_before_html_renderin
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     channel._app.bot.edit_message_text = AsyncMock()
     channel._app.bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=99))
 
@@ -1155,7 +1186,7 @@ async def test_send_delta_new_stream_id_replaces_stale_buffer() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     channel._stream_bufs["123"] = _StreamBuf(
         text="hello",
         message_id=7,
@@ -1179,7 +1210,7 @@ async def test_send_delta_incremental_edit_treats_not_modified_as_success() -> N
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     channel._stream_bufs["123"] = _StreamBuf(text="hello", message_id=7, last_edit=0.0, stream_id="s:0")
     channel._app.bot.edit_message_text = AsyncMock(side_effect=BadRequest("Message is not modified"))
 
@@ -1197,7 +1228,7 @@ async def test_send_delta_incremental_edit_splits_oversized_buffer() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     channel._app.bot.edit_message_text = AsyncMock()
     channel._app.bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=99))
 
@@ -1234,7 +1265,7 @@ async def test_send_delta_incremental_html_expansion_does_not_overflow() -> None
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     channel._app.bot.edit_message_text = AsyncMock()
     channel._app.bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=99))
 
@@ -1268,7 +1299,7 @@ async def test_send_delta_incremental_html_parse_failure_falls_back_to_plain() -
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     channel._app.bot.edit_message_text = AsyncMock(
         side_effect=[BadRequest("Can't parse entities"), None]
     )
@@ -1302,7 +1333,7 @@ async def test_send_delta_initial_send_keeps_message_in_thread() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
 
     await channel.send_delta(
         "123",
@@ -1375,7 +1406,7 @@ def test_is_allowed_rejects_invalid_legacy_telegram_sender_shapes() -> None:
 async def test_send_progress_keeps_message_in_topic() -> None:
     config = TelegramConfig(enabled=True, token="123:abc", allow_from=["*"])
     channel = TelegramChannel(config, MessageBus())
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
 
     await channel.send(
         OutboundMessage(
@@ -1394,7 +1425,7 @@ async def test_send_progress_keeps_message_in_topic() -> None:
 async def test_send_reply_infers_topic_from_message_id_cache() -> None:
     config = TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], reply_to_message=True)
     channel = TelegramChannel(config, MessageBus())
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     channel._message_threads[("123", 10)] = 42
 
     await channel.send(
@@ -1416,7 +1447,7 @@ async def test_send_remote_media_url_after_security_validation(monkeypatch) -> N
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     monkeypatch.setattr("nanobot.channels.telegram.runtime.validate_url_target", lambda url: (True, ""))
 
     await channel.send(
@@ -1444,7 +1475,7 @@ async def test_send_local_media_preserves_filename(tmp_path: Path) -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     attachment = tmp_path / "report.final.md"
     attachment.write_bytes(b"# Report\n")
 
@@ -1474,7 +1505,7 @@ async def test_send_blocks_unsafe_remote_media_url(monkeypatch) -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     monkeypatch.setattr(
         "nanobot.channels.telegram.runtime.validate_url_target",
         lambda url: (False, "Blocked: example.com resolves to private/internal address 127.0.0.1"),
@@ -1505,7 +1536,7 @@ async def test_group_policy_mention_ignores_unmentioned_group_message() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], group_policy="mention"),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
 
     handled = []
 
@@ -1527,7 +1558,7 @@ async def test_group_policy_mention_accepts_text_mention_and_caches_bot_identity
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], group_policy="mention"),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
 
     handled = []
 
@@ -1551,7 +1582,7 @@ async def test_group_policy_mention_accepts_caption_mention() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], group_policy="mention"),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
 
     handled = []
 
@@ -1577,7 +1608,7 @@ async def test_group_policy_mention_accepts_reply_to_bot() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], group_policy="mention"),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
 
     handled = []
 
@@ -1599,7 +1630,7 @@ async def test_group_policy_open_accepts_plain_group_message() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], group_policy="open"),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
 
     handled = []
 
@@ -1627,7 +1658,7 @@ async def test_extract_reply_context_no_reply() -> None:
 async def test_extract_reply_context_with_text() -> None:
     """When reply has text, return prefixed string."""
     channel = TelegramChannel(TelegramConfig(enabled=True, token="123:abc"), MessageBus())
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     reply = SimpleNamespace(text="Hello world", caption=None, from_user=SimpleNamespace(id=2, username="testuser", first_name="Test"))
     message = SimpleNamespace(reply_to_message=reply)
     assert await channel._extract_reply_context(message) == "[Reply to @testuser: Hello world]"
@@ -1637,7 +1668,7 @@ async def test_extract_reply_context_with_text() -> None:
 async def test_extract_reply_context_with_caption_only() -> None:
     """When reply has only caption (no text), caption is used."""
     channel = TelegramChannel(TelegramConfig(enabled=True, token="123:abc"), MessageBus())
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     reply = SimpleNamespace(text=None, caption="Photo caption", from_user=SimpleNamespace(id=2, username=None, first_name="Test"))
     message = SimpleNamespace(reply_to_message=reply)
     assert await channel._extract_reply_context(message) == "[Reply to Test: Photo caption]"
@@ -1647,7 +1678,7 @@ async def test_extract_reply_context_with_caption_only() -> None:
 async def test_extract_reply_context_truncation() -> None:
     """Reply text is truncated at TELEGRAM_REPLY_CONTEXT_MAX_LEN."""
     channel = TelegramChannel(TelegramConfig(enabled=True, token="123:abc"), MessageBus())
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     long_text = "x" * (TELEGRAM_REPLY_CONTEXT_MAX_LEN + 100)
     reply = SimpleNamespace(text=long_text, caption=None, from_user=SimpleNamespace(id=2, username=None, first_name=None))
     message = SimpleNamespace(reply_to_message=reply)
@@ -1674,7 +1705,7 @@ async def test_on_message_includes_reply_context() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], group_policy="open"),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     handled = []
     async def capture_handle(**kwargs) -> None:
         handled.append(kwargs)
@@ -1706,7 +1737,7 @@ async def test_download_message_media_returns_path_when_download_succeeds(
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     channel._app.bot.get_file = AsyncMock(
         return_value=SimpleNamespace(download_to_drive=AsyncMock(return_value=None))
     )
@@ -1833,7 +1864,7 @@ async def test_on_message_reply_to_media_fallback_when_download_fails() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], group_policy="open"),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     channel._app.bot.get_file = None
     handled = []
     async def capture_handle(**kwargs) -> None:
@@ -1916,7 +1947,7 @@ async def test_forward_command_does_not_inject_reply_context() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], group_policy="open"),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     handled = []
     async def capture_handle(**kwargs) -> None:
         handled.append(kwargs)
@@ -1936,7 +1967,7 @@ async def test_forward_command_pairs_unauthorized_private_user(monkeypatch) -> N
         TelegramConfig(enabled=True, token="123:abc", allow_from=["999"], group_policy="open"),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     monkeypatch.setattr(
         "nanobot.channels.base.generate_code", lambda _ch, _sid: "ABCD-EFGH"
     )
@@ -1953,7 +1984,7 @@ async def test_forward_command_preserves_dream_log_args_and_strips_bot_suffix() 
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], group_policy="open"),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     handled = []
 
     async def capture_handle(**kwargs) -> None:
@@ -1974,7 +2005,7 @@ async def test_forward_command_normalizes_telegram_safe_dream_aliases() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], group_policy="open"),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     handled = []
 
     async def capture_handle(**kwargs) -> None:
@@ -2049,7 +2080,7 @@ async def test_on_start_sends_pairing_code_to_unauthorized_private_user(monkeypa
         TelegramConfig(enabled=True, token="123:abc", allow_from=["999"], group_policy="open"),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     update = _make_telegram_update(text="/start", chat_type="private")
     update.message.reply_text = AsyncMock()
     monkeypatch.setattr(
@@ -2069,7 +2100,7 @@ async def test_on_help_sends_pairing_code_to_unauthorized_private_user(monkeypat
         TelegramConfig(enabled=True, token="123:abc", allow_from=["999"], group_policy="open"),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     update = _make_telegram_update(text="/help", chat_type="private")
     update.message.reply_text = AsyncMock()
     monkeypatch.setattr(
@@ -2091,7 +2122,7 @@ async def test_on_message_pairs_unauthorized_private_user_before_side_effects(
         TelegramConfig(enabled=True, token="123:abc", allow_from=["999"], group_policy="open"),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     started_typing: list[str] = []
     channel._start_typing = lambda chat_id: started_typing.append(chat_id)
     channel._add_reaction = AsyncMock(return_value=None)
@@ -2116,7 +2147,7 @@ async def test_on_message_location_content() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], group_policy="open"),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     handled = []
     async def capture_handle(**kwargs) -> None:
         handled.append(kwargs)
@@ -2138,7 +2169,7 @@ async def test_on_message_location_with_text() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], group_policy="open"),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     handled = []
     async def capture_handle(**kwargs) -> None:
         handled.append(kwargs)
@@ -2202,7 +2233,7 @@ async def test_send_text_does_not_fallback_on_network_timeout() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
 
     call_count = 0
 
@@ -2239,7 +2270,7 @@ async def test_send_text_does_not_fallback_on_network_error() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
 
     call_count = 0
 
@@ -2276,7 +2307,7 @@ async def test_send_text_falls_back_on_bad_request() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
 
     original_send = channel._app.bot.send_message
     html_call_count = 0
@@ -2314,7 +2345,7 @@ async def test_send_text_bad_request_plain_fallback_exhausted() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
 
     call_count = 0
 
@@ -2437,7 +2468,7 @@ async def test_send_delta_mid_stream_strips_markdown() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
     channel._app.bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=42))
     channel._app.bot.edit_message_text = AsyncMock()
 
@@ -2538,7 +2569,7 @@ async def test_send_falls_back_buttons_to_inline_text_when_flag_off() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], inline_keyboards=False),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
 
     await channel.send(
         OutboundMessage(
@@ -2566,7 +2597,7 @@ async def test_send_uses_native_keyboard_when_flag_on() -> None:
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], inline_keyboards=True),
         MessageBus(),
     )
-    channel._app = _FakeApp(lambda: None)
+    _install_ready_app(channel)
 
     await channel.send(
         OutboundMessage(


### PR DESCRIPTION
Fixes #5171

## Problem

After transient network blips on the path to Telegram (e.g. an unstable proxy), the bot can stop receiving messages permanently while the process keeps running and the log stays completely silent. Observed in production:

```
22:58:46 | WARNING | telegram | polling network issue: httpx.RemoteProtocolError: Server disconnected without sending a response.
23:30:59 | WARNING | telegram | polling network issue: httpx.ConnectError:
(no telegram log lines ever again; messages pile up server-side — a manual getUpdates returns 200 with a backlog instead of 409)
```

## Root cause

Two things combine into a silent, permanent stall:

1. PTB's `network_retry_loop` treats `TimedOut` as a normal long-poll expiry: it retries immediately, never calls `error_callback`, and logs only at DEBUG. When a blip leaves the 4-connection getUpdates pool wedged (half-open connections that never release their slots), every subsequent poll fails with `PoolTimeout` → `TimedOut` → an invisible infinite retry loop that never recovers, even after the network is healthy again.
2. The channel had no way to notice: the stdlib logging of python-telegram-bot was not bridged into loguru (unlike the feishu/matrix/qq channels), and `start()` ended in a bare `while self._running: sleep(1)` keep-alive with no health check.

## Fix

- **Liveness tracking**: wrap the getUpdates request pool (`_LivenessTrackedRequest`) to timestamp every completed HTTP round trip. A healthy long poll completes one every ~10s even with zero traffic, so staleness is a reliable stall signal that cannot be confused with a quiet chat.
- **Supervisor loop**: `start()` now watches that timestamp; if no round trip completes for 120s it logs a WARNING, tears the application down (discarding the wedged HTTPX pools), and rebuilds it. Startup failures retry with exponential backoff (5s → 300s), so the bot self-heals as soon as the network path recovers. Webhook mode is unaffected.
- **Observability**: bridge `telegram` (and `httpx` at WARNING) stdlib logging into loguru so PTB's own errors surface in nanobot logs.

`drop_pending_updates=False` is preserved on restart, so messages that piled up during a stall are delivered after recovery.

## Testing

- `pytest nanobot/channels/telegram/tests -q` — 122 passed, including watchdog rebuild, liveness tracking, startup retry/cleanup, and concurrent stop/teardown coverage.
- `ruff check nanobot/channels/telegram/` — clean.
