### PR TITLE
fix(memory): expose media references to session consolidation

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -19,10 +19,12 @@ from nanobot.runtime_context import public_history_messages
 from nanobot.session.manager import Session, SessionManager
 from nanobot.utils.gitstore import GitStore
 from nanobot.utils.helpers import (
+    content_with_media_breadcrumbs,
     ensure_dir,
     estimate_message_tokens,
     estimate_prompt_tokens_chain,
     find_legal_message_start,
+    media_breadcrumb_texts,
     recent_message_start_index,
     strip_think,
     truncate_text,
@@ -695,13 +697,41 @@ class MemoryStore:
     def _format_messages(messages: list[dict]) -> str:
         lines = []
         for message in messages:
-            if not message.get("content"):
+            content = content_with_media_breadcrumbs(
+                message.get("role"),
+                message.get("content", ""),
+                message.get("media"),
+            )
+            if not content:
                 continue
             tools = f" [tools: {', '.join(message['tools_used'])}]" if message.get("tools_used") else ""
             lines.append(
-                f"[{message.get('timestamp', '?')[:16]}] {message['role'].upper()}{tools}: {message['content']}"
+                f"[{message.get('timestamp', '?')[:16]}] "
+                f"{message['role'].upper()}{tools}: {content}"
             )
         return "\n".join(lines)
+
+    def _persist_missing_media_references(
+        self,
+        messages: list[dict],
+        *,
+        existing_text: str,
+        session_key: str | None,
+    ) -> list[str]:
+        chunks = _archived_media_reference_chunks(
+            messages,
+            existing_text=existing_text,
+        )
+        for chunk in chunks:
+            self.append_history(
+                chunk,
+                max_chars=min(
+                    _HISTORY_ENTRY_HARD_CAP,
+                    max(_ARCHIVE_MEDIA_REFERENCES_MAX_CHARS, len(chunk)),
+                ),
+                session_key=session_key,
+            )
+        return chunks
 
     def raw_archive(
         self,
@@ -715,6 +745,11 @@ class MemoryStore:
         formatted = truncate_text(
             self._format_messages(public_history_messages(messages)),
             limit,
+        )
+        self._persist_missing_media_references(
+            messages,
+            existing_text=formatted,
+            session_key=session_key,
         )
         self.append_history(
             f"[RAW] {len(messages)} messages\n"
@@ -786,7 +821,44 @@ class MemoryStore:
 # that catches any new caller that forgot to set its own cap.
 _RAW_ARCHIVE_MAX_CHARS = 16_000       # fallback dump (LLM failed)
 _ARCHIVE_SUMMARY_MAX_CHARS = 8_000    # LLM-produced consolidation summary
+_ARCHIVE_MEDIA_REFERENCES_MAX_CHARS = 4_000
 _HISTORY_ENTRY_HARD_CAP = 64_000      # emergency cap in append_history
+
+
+def _archived_media_reference_chunks(
+    messages: list[dict],
+    *,
+    existing_text: str = "",
+) -> list[str]:
+    """Return missing, deduplicated media references in bounded history chunks."""
+    references: list[str] = []
+    seen: set[str] = set()
+    for message in messages:
+        if message.get("role") != "user":
+            continue
+        for breadcrumb in media_breadcrumb_texts(message.get("media")):
+            if breadcrumb in seen or breadcrumb in existing_text:
+                continue
+            seen.add(breadcrumb)
+            references.append(
+                f"- [ephemeral] Archived media reference: {breadcrumb}"
+            )
+
+    chunks: list[str] = []
+    current: list[str] = []
+    current_size = 0
+    for reference in references:
+        addition = len(reference) + (1 if current else 0)
+        if current and current_size + addition > _ARCHIVE_MEDIA_REFERENCES_MAX_CHARS:
+            chunks.append("\n".join(current))
+            current = []
+            current_size = 0
+            addition = len(reference)
+        current.append(reference)
+        current_size += addition
+    if current:
+        chunks.append("\n".join(current))
+    return chunks
 
 
 class Consolidator:
@@ -1020,12 +1092,32 @@ class Consolidator:
             self.store.raw_archive(messages, session_key=session_key)
             return None
         summary = response.content or "[no summary]"
-        self.store.append_history(
-            summary,
-            max_chars=_ARCHIVE_SUMMARY_MAX_CHARS,
+        persisted_summary = strip_think(
+            truncate_text(summary.rstrip(), _ARCHIVE_SUMMARY_MAX_CHARS)
+        )
+        media_chunks = self.store._persist_missing_media_references(
+            messages,
+            existing_text=persisted_summary,
             session_key=session_key,
         )
-        return summary
+
+        keep_summary = bool(persisted_summary and persisted_summary != "(nothing)")
+        if keep_summary or not media_chunks:
+            self.store.append_history(
+                summary,
+                max_chars=_ARCHIVE_SUMMARY_MAX_CHARS,
+                session_key=session_key,
+            )
+
+        if not media_chunks:
+            return summary
+        summary_parts = [*media_chunks]
+        if keep_summary:
+            summary_parts.append(persisted_summary)
+        return truncate_text(
+            "\n".join(summary_parts),
+            _ARCHIVE_SUMMARY_MAX_CHARS,
+        )
 
     async def maybe_consolidate_by_tokens(
         self,

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -24,7 +24,6 @@ from nanobot.utils.helpers import (
     estimate_message_tokens,
     estimate_prompt_tokens_chain,
     find_legal_message_start,
-    media_breadcrumb_texts,
     recent_message_start_index,
     strip_think,
     truncate_text,
@@ -711,28 +710,6 @@ class MemoryStore:
             )
         return "\n".join(lines)
 
-    def _persist_missing_media_references(
-        self,
-        messages: list[dict],
-        *,
-        existing_text: str,
-        session_key: str | None,
-    ) -> list[str]:
-        chunks = _archived_media_reference_chunks(
-            messages,
-            existing_text=existing_text,
-        )
-        for chunk in chunks:
-            self.append_history(
-                chunk,
-                max_chars=min(
-                    _HISTORY_ENTRY_HARD_CAP,
-                    max(_ARCHIVE_MEDIA_REFERENCES_MAX_CHARS, len(chunk)),
-                ),
-                session_key=session_key,
-            )
-        return chunks
-
     def raw_archive(
         self,
         messages: list[dict],
@@ -745,11 +722,6 @@ class MemoryStore:
         formatted = truncate_text(
             self._format_messages(public_history_messages(messages)),
             limit,
-        )
-        self._persist_missing_media_references(
-            messages,
-            existing_text=formatted,
-            session_key=session_key,
         )
         self.append_history(
             f"[RAW] {len(messages)} messages\n"
@@ -821,44 +793,7 @@ class MemoryStore:
 # that catches any new caller that forgot to set its own cap.
 _RAW_ARCHIVE_MAX_CHARS = 16_000       # fallback dump (LLM failed)
 _ARCHIVE_SUMMARY_MAX_CHARS = 8_000    # LLM-produced consolidation summary
-_ARCHIVE_MEDIA_REFERENCES_MAX_CHARS = 4_000
 _HISTORY_ENTRY_HARD_CAP = 64_000      # emergency cap in append_history
-
-
-def _archived_media_reference_chunks(
-    messages: list[dict],
-    *,
-    existing_text: str = "",
-) -> list[str]:
-    """Return missing, deduplicated media references in bounded history chunks."""
-    references: list[str] = []
-    seen: set[str] = set()
-    for message in messages:
-        if message.get("role") != "user":
-            continue
-        for breadcrumb in media_breadcrumb_texts(message.get("media")):
-            if breadcrumb in seen or breadcrumb in existing_text:
-                continue
-            seen.add(breadcrumb)
-            references.append(
-                f"- [ephemeral] Archived media reference: {breadcrumb}"
-            )
-
-    chunks: list[str] = []
-    current: list[str] = []
-    current_size = 0
-    for reference in references:
-        addition = len(reference) + (1 if current else 0)
-        if current and current_size + addition > _ARCHIVE_MEDIA_REFERENCES_MAX_CHARS:
-            chunks.append("\n".join(current))
-            current = []
-            current_size = 0
-            addition = len(reference)
-        current.append(reference)
-        current_size += addition
-    if current:
-        chunks.append("\n".join(current))
-    return chunks
 
 
 class Consolidator:
@@ -1092,32 +1027,12 @@ class Consolidator:
             self.store.raw_archive(messages, session_key=session_key)
             return None
         summary = response.content or "[no summary]"
-        persisted_summary = strip_think(
-            truncate_text(summary.rstrip(), _ARCHIVE_SUMMARY_MAX_CHARS)
-        )
-        media_chunks = self.store._persist_missing_media_references(
-            messages,
-            existing_text=persisted_summary,
+        self.store.append_history(
+            summary,
+            max_chars=_ARCHIVE_SUMMARY_MAX_CHARS,
             session_key=session_key,
         )
-
-        keep_summary = bool(persisted_summary and persisted_summary != "(nothing)")
-        if keep_summary or not media_chunks:
-            self.store.append_history(
-                summary,
-                max_chars=_ARCHIVE_SUMMARY_MAX_CHARS,
-                session_key=session_key,
-            )
-
-        if not media_chunks:
-            return summary
-        summary_parts = [*media_chunks]
-        if keep_summary:
-            summary_parts.append(persisted_summary)
-        return truncate_text(
-            "\n".join(summary_parts),
-            _ARCHIVE_SUMMARY_MAX_CHARS,
-        )
+        return summary
 
     async def maybe_consolidate_by_tokens(
         self,

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -22,10 +22,10 @@ from nanobot.runtime_context import (
     public_history_message,
 )
 from nanobot.utils.helpers import (
+    content_with_media_breadcrumbs,
     ensure_dir,
     estimate_message_tokens,
     find_legal_message_start,
-    image_placeholder_text,
     recent_message_start_index,
     safe_filename,
     strip_think,
@@ -214,12 +214,11 @@ class Session:
             # image used to be. Without this, an image-only user turn
             # replays as an empty user message — the assistant's reply then
             # looks like it's responding to nothing.
-            media = message.get("media")
-            if role == "user" and isinstance(media, list) and media and isinstance(content, str):
-                breadcrumbs = "\n".join(
-                    image_placeholder_text(p) for p in media if isinstance(p, str) and p
-                )
-                content = f"{content}\n{breadcrumbs}" if content else breadcrumbs
+            content = content_with_media_breadcrumbs(
+                role,
+                content,
+                message.get("media"),
+            )
             cli_apps = message.get("cli_apps")
             if (
                 include_runtime_context

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -367,6 +367,31 @@ def image_placeholder_text(path: str | None, *, empty: str = "[image]") -> str:
     return f"[image: {path}]" if path else empty
 
 
+def media_breadcrumb_texts(media: Any) -> list[str]:
+    """Render valid persisted media paths as single-line replay breadcrumbs."""
+    if not isinstance(media, list):
+        return []
+    return [
+        image_placeholder_text(path.replace("\r", " ").replace("\n", " "))
+        for path in media
+        if isinstance(path, str) and path
+    ]
+
+
+def content_with_media_breadcrumbs(
+    role: str | None,
+    content: Any,
+    media: Any,
+) -> Any:
+    """Append persisted user-media breadcrumbs to plain-text content."""
+    if role != "user" or not isinstance(content, str):
+        return content
+    breadcrumbs = "\n".join(media_breadcrumb_texts(media))
+    if not breadcrumbs:
+        return content
+    return f"{content}\n{breadcrumbs}" if content else breadcrumbs
+
+
 def truncate_text(text: str, max_chars: int) -> str:
     """Truncate text with a stable suffix."""
     if max_chars <= 0 or len(text) <= max_chars:

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -367,26 +367,19 @@ def image_placeholder_text(path: str | None, *, empty: str = "[image]") -> str:
     return f"[image: {path}]" if path else empty
 
 
-def media_breadcrumb_texts(media: Any) -> list[str]:
-    """Render valid persisted media paths as single-line replay breadcrumbs."""
-    if not isinstance(media, list):
-        return []
-    return [
-        image_placeholder_text(path.replace("\r", " ").replace("\n", " "))
-        for path in media
-        if isinstance(path, str) and path
-    ]
-
-
 def content_with_media_breadcrumbs(
     role: str | None,
     content: Any,
     media: Any,
 ) -> Any:
     """Append persisted user-media breadcrumbs to plain-text content."""
-    if role != "user" or not isinstance(content, str):
+    if role != "user" or not isinstance(content, str) or not isinstance(media, list):
         return content
-    breadcrumbs = "\n".join(media_breadcrumb_texts(media))
+    breadcrumbs = "\n".join(
+        image_placeholder_text(path)
+        for path in media
+        if isinstance(path, str) and path
+    )
     if not breadcrumbs:
         return content
     return f"{content}\n{breadcrumbs}" if content else breadcrumbs

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -75,6 +75,131 @@ def _tool_round(call_id: str) -> list[dict]:
 
 
 class TestConsolidatorSummarize:
+    async def test_archive_persists_media_path_when_summary_omits_it(
+        self, consolidator, mock_provider, store, runtime
+    ):
+        path = "/home/user/.nanobot/media/websocket/upload_photo.png"
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="User uploaded a photo.",
+            finish_reason="stop",
+        )
+
+        result = await consolidator.archive(
+            [{"role": "user", "content": "please inspect this", "media": [path]}],
+            runtime=runtime,
+        )
+
+        prompt = mock_provider.chat_with_retry.call_args.kwargs["messages"][1]["content"]
+        persisted = "\n".join(
+            entry["content"]
+            for entry in store.read_unprocessed_history(since_cursor=0)
+        )
+        assert path in prompt
+        assert result is not None and path in result
+        assert path in persisted
+
+    async def test_archive_does_not_duplicate_media_path_already_in_summary(
+        self, consolidator, mock_provider, store, runtime
+    ):
+        path = "/home/user/.nanobot/media/websocket/already-there.png"
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content=f"User uploaded [image: {path}]",
+            finish_reason="stop",
+        )
+
+        result = await consolidator.archive(
+            [{"role": "user", "content": "", "media": [path]}],
+            runtime=runtime,
+        )
+
+        entries = store.read_unprocessed_history(since_cursor=0)
+        assert result is not None and result.count(path) == 1
+        assert len(entries) == 1
+        assert entries[0]["content"].count(path) == 1
+
+    async def test_archive_recovers_path_removed_by_summary_truncation(
+        self, consolidator, mock_provider, store, runtime
+    ):
+        path = "/media/late-path.png"
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content=f"{'S' * (_ARCHIVE_SUMMARY_MAX_CHARS * 2)} [image: {path}]",
+            finish_reason="stop",
+        )
+
+        result = await consolidator.archive(
+            [{"role": "user", "content": "", "media": [path]}],
+            runtime=runtime,
+        )
+
+        persisted = "\n".join(
+            entry["content"]
+            for entry in store.read_unprocessed_history(since_cursor=0)
+        )
+        assert result is not None and path in result
+        assert persisted.count(path) == 1
+
+    async def test_archive_recovers_path_removed_with_unclosed_thinking(
+        self, consolidator, mock_provider, store, runtime
+    ):
+        path = "/media/private.png"
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content=f"<think>internal [image: {path}]",
+            finish_reason="stop",
+        )
+
+        result = await consolidator.archive(
+            [{"role": "user", "content": "", "media": [path]}],
+            runtime=runtime,
+        )
+
+        persisted = "\n".join(
+            entry["content"]
+            for entry in store.read_unprocessed_history(since_cursor=0)
+        )
+        assert result is not None and path in result
+        assert "internal" not in persisted
+
+    async def test_archive_manifest_only_covers_removed_messages(
+        self, consolidator, mock_provider, store, runtime
+    ):
+        archived_path = "/media/archived.png"
+        retained_path = "/media/still-live.png"
+        archived = {"role": "user", "content": "old", "media": [archived_path]}
+        retained = {"role": "user", "content": "new", "media": [retained_path]}
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="Summary.",
+            finish_reason="stop",
+        )
+
+        await consolidator.archive(
+            [archived],
+            summary_messages=[archived, retained],
+            runtime=runtime,
+        )
+
+        prompt = mock_provider.chat_with_retry.call_args.kwargs["messages"][1]["content"]
+        persisted = "\n".join(
+            entry["content"]
+            for entry in store.read_unprocessed_history(since_cursor=0)
+        )
+        assert archived_path in prompt and retained_path in prompt
+        assert archived_path in persisted
+        assert retained_path not in persisted
+
+    def test_format_messages_keeps_media_only_user_turn(self):
+        path = "/home/user/.nanobot/media/websocket/clip.mp4"
+
+        formatted = MemoryStore._format_messages([
+            {
+                "role": "user",
+                "content": "",
+                "media": [path],
+                "timestamp": "2026-07-27",
+            }
+        ])
+
+        assert formatted == f"[2026-07-27] USER: [image: {path}]"
+
     async def test_archive_excludes_model_only_runtime_context(
         self, consolidator, mock_provider, runtime
     ):
@@ -599,6 +724,39 @@ class TestCompactIdleSession:
         assert reloaded.updated_at == old_ts
 
     @pytest.mark.asyncio
+    async def test_media_path_survives_idle_compact(
+        self, real_consolidator, mock_provider, store, runtime
+    ):
+        path = "/home/user/.nanobot/media/websocket/upload_photo.png"
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="User shared a photo.",
+            finish_reason="stop",
+        )
+        sessions = real_consolidator.sessions
+        session = sessions.get_or_create("websocket:media")
+        session.add_message("user", "", media=[path])
+        session.add_message("assistant", "photo received")
+        for i in range(12):
+            session.add_message("user", f"user msg {i}")
+            session.add_message("assistant", f"assistant msg {i}")
+        sessions.save(session)
+
+        result = await real_consolidator.compact_idle_session(
+            "websocket:media",
+            runtime=runtime,
+            max_suffix=8,
+        )
+
+        reloaded = sessions.get_or_create("websocket:media")
+        persisted = "\n".join(
+            entry["content"]
+            for entry in store.read_unprocessed_history(since_cursor=0)
+        )
+        assert result is not None and path in result
+        assert path in reloaded.metadata["_last_summary"]["text"]
+        assert path in persisted
+
+    @pytest.mark.asyncio
     async def test_summarizes_retained_suffix_not_just_dropped_prefix(
         self, real_consolidator, mock_provider, runtime
     ):
@@ -992,6 +1150,19 @@ class TestRawArchiveTruncation:
         assert len(entries) == 1
         assert "hello" in entries[0]["content"]
 
+    def test_raw_archive_recovers_media_path_after_content_truncation(self, store):
+        path = "/home/user/.nanobot/media/websocket/upload_photo.png"
+
+        store.raw_archive([
+            {"role": "user", "content": "x" * 30_000, "media": [path]}
+        ])
+
+        entries = store.read_unprocessed_history(since_cursor=0)
+        persisted = "\n".join(entry["content"] for entry in entries)
+        assert len(entries) == 2
+        assert persisted.count(path) == 1
+        assert any("[RAW]" in entry["content"] for entry in entries)
+
     def test_raw_archive_excludes_model_only_runtime_context(self, store):
         content, marker = append_runtime_context(
             "ship the feature",
@@ -1041,6 +1212,49 @@ class TestArchiveTruncation:
         user_content = call_args.kwargs["messages"][1]["content"]
         # Should be significantly shorter than 100K
         assert len(user_content) < 50_000
+
+    async def test_archive_without_media_keeps_existing_return_contract(
+        self, consolidator, mock_provider, store, runtime
+    ):
+        summary = "S" * (_ARCHIVE_SUMMARY_MAX_CHARS * 2)
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content=summary,
+            finish_reason="stop",
+        )
+
+        result = await consolidator.archive(
+            [{"role": "user", "content": "hello"}],
+            runtime=runtime,
+        )
+
+        persisted = store.read_unprocessed_history(since_cursor=0)[0]["content"]
+        assert result == summary
+        assert len(persisted) <= _ARCHIVE_SUMMARY_MAX_CHARS + 50
+
+    async def test_large_media_manifest_is_durable_but_session_summary_is_bounded(
+        self, consolidator, mock_provider, store, runtime
+    ):
+        paths = [
+            f"/media/{index:03d}-{'x' * 80}.png"
+            for index in range(80)
+        ]
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="(nothing)",
+            finish_reason="stop",
+        )
+
+        result = await consolidator.archive(
+            [{"role": "user", "content": "", "media": paths}],
+            runtime=runtime,
+        )
+
+        entries = store.read_unprocessed_history(since_cursor=0)
+        persisted = "\n".join(entry["content"] for entry in entries)
+        assert len(entries) > 1
+        assert result is not None
+        assert len(result) <= _ARCHIVE_SUMMARY_MAX_CHARS + 50
+        for path in paths:
+            assert persisted.count(path) == 1
 
     async def test_archive_truncates_with_small_token_budget(
         self, consolidator, mock_provider, store, runtime

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -75,12 +75,13 @@ def _tool_round(call_id: str) -> list[dict]:
 
 
 class TestConsolidatorSummarize:
-    async def test_archive_persists_media_path_when_summary_omits_it(
+    async def test_archive_prompt_includes_media_breadcrumb(
         self, consolidator, mock_provider, store, runtime
     ):
         path = "/home/user/.nanobot/media/websocket/upload_photo.png"
+        summary = "User uploaded a photo."
         mock_provider.chat_with_retry.return_value = MagicMock(
-            content="User uploaded a photo.",
+            content=summary,
             finish_reason="stop",
         )
 
@@ -90,101 +91,10 @@ class TestConsolidatorSummarize:
         )
 
         prompt = mock_provider.chat_with_retry.call_args.kwargs["messages"][1]["content"]
-        persisted = "\n".join(
-            entry["content"]
-            for entry in store.read_unprocessed_history(since_cursor=0)
-        )
-        assert path in prompt
-        assert result is not None and path in result
-        assert path in persisted
-
-    async def test_archive_does_not_duplicate_media_path_already_in_summary(
-        self, consolidator, mock_provider, store, runtime
-    ):
-        path = "/home/user/.nanobot/media/websocket/already-there.png"
-        mock_provider.chat_with_retry.return_value = MagicMock(
-            content=f"User uploaded [image: {path}]",
-            finish_reason="stop",
-        )
-
-        result = await consolidator.archive(
-            [{"role": "user", "content": "", "media": [path]}],
-            runtime=runtime,
-        )
-
         entries = store.read_unprocessed_history(since_cursor=0)
-        assert result is not None and result.count(path) == 1
-        assert len(entries) == 1
-        assert entries[0]["content"].count(path) == 1
-
-    async def test_archive_recovers_path_removed_by_summary_truncation(
-        self, consolidator, mock_provider, store, runtime
-    ):
-        path = "/media/late-path.png"
-        mock_provider.chat_with_retry.return_value = MagicMock(
-            content=f"{'S' * (_ARCHIVE_SUMMARY_MAX_CHARS * 2)} [image: {path}]",
-            finish_reason="stop",
-        )
-
-        result = await consolidator.archive(
-            [{"role": "user", "content": "", "media": [path]}],
-            runtime=runtime,
-        )
-
-        persisted = "\n".join(
-            entry["content"]
-            for entry in store.read_unprocessed_history(since_cursor=0)
-        )
-        assert result is not None and path in result
-        assert persisted.count(path) == 1
-
-    async def test_archive_recovers_path_removed_with_unclosed_thinking(
-        self, consolidator, mock_provider, store, runtime
-    ):
-        path = "/media/private.png"
-        mock_provider.chat_with_retry.return_value = MagicMock(
-            content=f"<think>internal [image: {path}]",
-            finish_reason="stop",
-        )
-
-        result = await consolidator.archive(
-            [{"role": "user", "content": "", "media": [path]}],
-            runtime=runtime,
-        )
-
-        persisted = "\n".join(
-            entry["content"]
-            for entry in store.read_unprocessed_history(since_cursor=0)
-        )
-        assert result is not None and path in result
-        assert "internal" not in persisted
-
-    async def test_archive_manifest_only_covers_removed_messages(
-        self, consolidator, mock_provider, store, runtime
-    ):
-        archived_path = "/media/archived.png"
-        retained_path = "/media/still-live.png"
-        archived = {"role": "user", "content": "old", "media": [archived_path]}
-        retained = {"role": "user", "content": "new", "media": [retained_path]}
-        mock_provider.chat_with_retry.return_value = MagicMock(
-            content="Summary.",
-            finish_reason="stop",
-        )
-
-        await consolidator.archive(
-            [archived],
-            summary_messages=[archived, retained],
-            runtime=runtime,
-        )
-
-        prompt = mock_provider.chat_with_retry.call_args.kwargs["messages"][1]["content"]
-        persisted = "\n".join(
-            entry["content"]
-            for entry in store.read_unprocessed_history(since_cursor=0)
-        )
-        assert archived_path in prompt and retained_path in prompt
-        assert archived_path in persisted
-        assert retained_path not in persisted
+        assert f"[image: {path}]" in prompt
+        assert result == summary
+        assert [entry["content"] for entry in entries] == [summary]
 
     def test_format_messages_keeps_media_only_user_turn(self):
         path = "/home/user/.nanobot/media/websocket/clip.mp4"
@@ -724,39 +634,6 @@ class TestCompactIdleSession:
         assert reloaded.updated_at == old_ts
 
     @pytest.mark.asyncio
-    async def test_media_path_survives_idle_compact(
-        self, real_consolidator, mock_provider, store, runtime
-    ):
-        path = "/home/user/.nanobot/media/websocket/upload_photo.png"
-        mock_provider.chat_with_retry.return_value = MagicMock(
-            content="User shared a photo.",
-            finish_reason="stop",
-        )
-        sessions = real_consolidator.sessions
-        session = sessions.get_or_create("websocket:media")
-        session.add_message("user", "", media=[path])
-        session.add_message("assistant", "photo received")
-        for i in range(12):
-            session.add_message("user", f"user msg {i}")
-            session.add_message("assistant", f"assistant msg {i}")
-        sessions.save(session)
-
-        result = await real_consolidator.compact_idle_session(
-            "websocket:media",
-            runtime=runtime,
-            max_suffix=8,
-        )
-
-        reloaded = sessions.get_or_create("websocket:media")
-        persisted = "\n".join(
-            entry["content"]
-            for entry in store.read_unprocessed_history(since_cursor=0)
-        )
-        assert result is not None and path in result
-        assert path in reloaded.metadata["_last_summary"]["text"]
-        assert path in persisted
-
-    @pytest.mark.asyncio
     async def test_summarizes_retained_suffix_not_just_dropped_prefix(
         self, real_consolidator, mock_provider, runtime
     ):
@@ -1150,19 +1027,6 @@ class TestRawArchiveTruncation:
         assert len(entries) == 1
         assert "hello" in entries[0]["content"]
 
-    def test_raw_archive_recovers_media_path_after_content_truncation(self, store):
-        path = "/home/user/.nanobot/media/websocket/upload_photo.png"
-
-        store.raw_archive([
-            {"role": "user", "content": "x" * 30_000, "media": [path]}
-        ])
-
-        entries = store.read_unprocessed_history(since_cursor=0)
-        persisted = "\n".join(entry["content"] for entry in entries)
-        assert len(entries) == 2
-        assert persisted.count(path) == 1
-        assert any("[RAW]" in entry["content"] for entry in entries)
-
     def test_raw_archive_excludes_model_only_runtime_context(self, store):
         content, marker = append_runtime_context(
             "ship the feature",
@@ -1212,49 +1076,6 @@ class TestArchiveTruncation:
         user_content = call_args.kwargs["messages"][1]["content"]
         # Should be significantly shorter than 100K
         assert len(user_content) < 50_000
-
-    async def test_archive_without_media_keeps_existing_return_contract(
-        self, consolidator, mock_provider, store, runtime
-    ):
-        summary = "S" * (_ARCHIVE_SUMMARY_MAX_CHARS * 2)
-        mock_provider.chat_with_retry.return_value = MagicMock(
-            content=summary,
-            finish_reason="stop",
-        )
-
-        result = await consolidator.archive(
-            [{"role": "user", "content": "hello"}],
-            runtime=runtime,
-        )
-
-        persisted = store.read_unprocessed_history(since_cursor=0)[0]["content"]
-        assert result == summary
-        assert len(persisted) <= _ARCHIVE_SUMMARY_MAX_CHARS + 50
-
-    async def test_large_media_manifest_is_durable_but_session_summary_is_bounded(
-        self, consolidator, mock_provider, store, runtime
-    ):
-        paths = [
-            f"/media/{index:03d}-{'x' * 80}.png"
-            for index in range(80)
-        ]
-        mock_provider.chat_with_retry.return_value = MagicMock(
-            content="(nothing)",
-            finish_reason="stop",
-        )
-
-        result = await consolidator.archive(
-            [{"role": "user", "content": "", "media": paths}],
-            runtime=runtime,
-        )
-
-        entries = store.read_unprocessed_history(since_cursor=0)
-        persisted = "\n".join(entry["content"] for entry in entries)
-        assert len(entries) > 1
-        assert result is not None
-        assert len(result) <= _ARCHIVE_SUMMARY_MAX_CHARS + 50
-        for path in paths:
-            assert persisted.count(path) == 1
 
     async def test_archive_truncates_with_small_token_budget(
         self, consolidator, mock_provider, store, runtime

--- a/tests/agent/test_session_manager_history.py
+++ b/tests/agent/test_session_manager_history.py
@@ -405,20 +405,6 @@ def test_get_history_synthesizes_breadcrumb_for_image_only_turn():
     assert history[0] == {"role": "user", "content": "[image: /m/pic.png]"}
 
 
-def test_get_history_preserves_non_image_media_path():
-    session = Session(key="test:non-image-media")
-    session.messages.append(
-        {"role": "user", "content": "review", "media": ["/m/report.pdf"]}
-    )
-
-    history = session.get_history(max_messages=500)
-
-    assert history == [{
-        "role": "user",
-        "content": "review\n[image: /m/report.pdf]",
-    }]
-
-
 def test_get_history_synthesizes_cli_app_attachment_breadcrumb():
     session = Session(key="test:cli-app")
     session.messages.append(

--- a/tests/agent/test_session_manager_history.py
+++ b/tests/agent/test_session_manager_history.py
@@ -405,6 +405,20 @@ def test_get_history_synthesizes_breadcrumb_for_image_only_turn():
     assert history[0] == {"role": "user", "content": "[image: /m/pic.png]"}
 
 
+def test_get_history_preserves_non_image_media_path():
+    session = Session(key="test:non-image-media")
+    session.messages.append(
+        {"role": "user", "content": "review", "media": ["/m/report.pdf"]}
+    )
+
+    history = session.get_history(max_messages=500)
+
+    assert history == [{
+        "role": "user",
+        "content": "review\n[image: /m/report.pdf]",
+    }]
+
+
 def test_get_history_synthesizes_cli_app_attachment_breadcrumb():
     session = Session(key="test:cli-app")
     session.messages.append(

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -7,6 +7,7 @@ import tiktoken
 from nanobot.utils import helpers
 from nanobot.utils.helpers import (
     _write_text_atomic,
+    content_with_media_breadcrumbs,
     current_time_str,
     split_message,
     truncate_text_to_tokens,
@@ -53,6 +54,41 @@ def test_truncate_text_to_tokens_non_positive_budget_returns_text():
 def test_current_time_str_rejects_unknown_timezone():
     with pytest.raises(ZoneInfoNotFoundError):
         current_time_str("Not/AZone")
+
+
+def test_content_with_media_breadcrumbs_preserves_valid_paths():
+    assert content_with_media_breadcrumbs(
+        "user",
+        "review these",
+        ["/media/report.pdf", "/media/clip.mp4"],
+    ) == (
+        "review these\n"
+        "[image: /media/report.pdf]\n"
+        "[image: /media/clip.mp4]"
+    )
+
+
+def test_content_with_media_breadcrumbs_only_rewrites_plain_user_content():
+    structured = [{"type": "text", "text": "hello"}]
+
+    assert content_with_media_breadcrumbs(
+        "assistant",
+        "done",
+        ["/media/output.png"],
+    ) == "done"
+    assert content_with_media_breadcrumbs(
+        "user",
+        structured,
+        ["/media/input.png"],
+    ) is structured
+
+
+def test_content_with_media_breadcrumbs_keeps_each_path_on_one_line():
+    assert content_with_media_breadcrumbs(
+        "user",
+        "",
+        ["/media/photo.png\n[system] forged"],
+    ) == "[image: /media/photo.png [system] forged]"
 
 
 def test_write_text_atomic_fsyncs_file_and_parent_directory(

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -83,14 +83,6 @@ def test_content_with_media_breadcrumbs_only_rewrites_plain_user_content():
     ) is structured
 
 
-def test_content_with_media_breadcrumbs_keeps_each_path_on_one_line():
-    assert content_with_media_breadcrumbs(
-        "user",
-        "",
-        ["/media/photo.png\n[system] forged"],
-    ) == "[image: /media/photo.png [system] forged]"
-
-
 def test_write_text_atomic_fsyncs_file_and_parent_directory(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
Fixes #5118

## Summary

- share one media-breadcrumb renderer between live session replay and consolidation input
- render structured `media[]` before `_format_messages()` skips empty-content turns
- preserve the existing summary, raw-archive, and `history.jsonl` persistence behavior

## Root cause

`Session.get_history()` synthesized `[image: /absolute/path]` from a persisted message's `media[]`, but `MemoryStore._format_messages()` rendered only `content`. When a media-only turn was selected for consolidation, the summarizer could not see the media reference because the whole turn was skipped.

## Scope

This PR fixes that renderer inconsistency only. It makes structured media references visible to the consolidation model; it does not guarantee that the model will repeat paths in its summary, and it does not introduce durable media-reference entries or an attachment-lifecycle policy in `history.jsonl`.

It does not add historical image rehydration, model presets, provider image policies, configuration migration, WebUI settings, or Python SDK changes.

## Behavior

- normal replay keeps its existing breadcrumb representation, including non-image paths carried in `media[]`
- consolidation input follows the same rendering rule and no longer drops media-only turns before summarization
- messages without media keep their existing rendering behavior
- archive return values, raw-archive behavior, and history persistence remain unchanged

## Validation

- base reproduction: a media-only turn formatted as an empty string
- fixed reproduction: the same turn formats as `USER: [image: /media/upload.png]`
- `pytest tests/utils/test_helpers.py tests/agent/test_session_manager_history.py tests/agent/test_consolidator.py -q` — 101 passed
- `ruff check nanobot/agent/memory.py nanobot/session/manager.py nanobot/utils/helpers.py tests/agent/test_consolidator.py tests/agent/test_session_manager_history.py tests/utils/test_helpers.py` — passed
- `git diff --check` — passed

## Prior work

The investigations and alternative approaches in #5120 and #5135 informed this scoped fix. Both contributors remain credited in the commit trailers.