### PR TITLE
fix(shell): preserve UTF-8 native input on PowerShell 5

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -555,6 +555,7 @@ class ExecTool(Tool):
             command = ExecTool._normalize_powershell_command(command)
             command = (
                 "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)\n"
+                "if ($PSVersionTable.PSVersion.Major -lt 6) { $OutputEncoding = [Console]::OutputEncoding }\n"
                 "$PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'\n"
                 f"{command}\n"
                 "if ($LASTEXITCODE -ne $null) { exit $LASTEXITCODE }"

--- a/tests/tools/test_exec_platform.py
+++ b/tests/tools/test_exec_platform.py
@@ -230,8 +230,8 @@ class TestSpawnWindows:
         assert "if ($LASTEXITCODE -ne $null) { exit $LASTEXITCODE }" in command
 
     @pytest.mark.asyncio
-    async def test_powershell_configures_utf8_output(self):
-        """PowerShell should emit UTF-8 for captured output and redirections."""
+    async def test_powershell_configures_utf8_io(self):
+        """PowerShell should use UTF-8 for captured output, native input, and redirections."""
         env = {"PATH": ""}
         with (
             patch("nanobot.agent.tools.shell._IS_WINDOWS", True),
@@ -242,7 +242,10 @@ class TestSpawnWindows:
 
         command = mock_exec.call_args[0][-1]
         assert "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)" in command
-        assert "$OutputEncoding =" not in command
+        assert (
+            "if ($PSVersionTable.PSVersion.Major -lt 6) { "
+            "$OutputEncoding = [Console]::OutputEncoding }"
+        ) in command
         assert "$PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'" in command
 
     @pytest.mark.asyncio
@@ -820,6 +823,20 @@ class TestWindowsRealExec:
         data = (tmp_path / "marker.txt").read_bytes()
         assert b"\x00" not in data
         assert data.decode("utf-8-sig").strip() == "file café λ 你好"
+
+    @pytest.mark.asyncio
+    async def test_windows_powershell_native_pipeline_input_is_utf8(self):
+        python = sys.executable.replace("'", "''")
+        result = await ExecTool(timeout=10).execute(
+            command=(
+                f"[string][char]0x4F1A | & '{python}' "
+                '-c "import sys; print(sys.stdin.buffer.read().hex())"'
+            ),
+            shell="powershell",
+        )
+
+        assert "e4bc9a0d0a" in result
+        assert "Exit code: 0" in result
 
     @pytest.mark.asyncio
     async def test_windows_powershell_session_output_is_utf8(self):

--- a/tests/tools/test_exec_platform.py
+++ b/tests/tools/test_exec_platform.py
@@ -827,7 +827,7 @@ class TestWindowsRealExec:
     @pytest.mark.asyncio
     async def test_windows_powershell_native_pipeline_input_is_utf8(self):
         python = sys.executable.replace("'", "''")
-        result = await ExecTool(timeout=10).execute(
+        result = await ExecTool(timeout=180).execute(
             command=(
                 f"[string][char]0x4F1A | & '{python}' "
                 '-c "import sys; print(sys.stdin.buffer.read().hex())"'


### PR DESCRIPTION
## Summary
- configure `$OutputEncoding` from the UTF-8 console encoding only on Windows PowerShell 5.1
- leave PowerShell 7 native pipeline defaults unchanged
- add a Windows integration regression test that asserts the raw UTF-8 bytes received by a native process

## Root cause
Windows PowerShell 5.1 defaults `$OutputEncoding` to US-ASCII, so non-ASCII PowerShell strings are replaced with `?` before native pipeline consumers receive them. The existing prelude configured captured output and redirections, but not this input direction.

## Testing
- `uv run --extra dev pytest tests/tools/test_exec_platform.py -q --basetemp .tmp-pytest-5159` (`48 passed, 1 skipped`)
- `uv run --extra dev ruff check nanobot/ tests/tools/test_exec_platform.py`
- issue reproduction now returns `e4bc9a0d0a` instead of `3f0d0a`

Closes #5159