### PR TITLE
fix(cron): handle dataclass instances in CronJob.from_dict

### DIFF
--- a/nanobot/cron/types.py
+++ b/nanobot/cron/types.py
@@ -138,14 +138,36 @@ class CronJob:
 
     @classmethod
     def from_dict(cls, kwargs: dict):
-        state_kwargs = dict(kwargs.get("state", {}))
-        state_kwargs["run_history"] = [
-            record if isinstance(record, CronRunRecord) else CronRunRecord(**record)
-            for record in state_kwargs.get("run_history", [])
-        ]
-        kwargs["schedule"] = CronSchedule(**kwargs.get("schedule", {"kind": "every"}))
-        kwargs["payload"] = CronPayload(**kwargs.get("payload", {}))
-        kwargs["state"] = CronJobState(**state_kwargs)
+        kwargs = dict(kwargs)
+        raw_schedule = kwargs.get("schedule")
+        if isinstance(raw_schedule, CronSchedule):
+            pass
+        elif isinstance(raw_schedule, dict):
+            kwargs["schedule"] = CronSchedule(**raw_schedule)
+        else:
+            kwargs["schedule"] = CronSchedule(kind="every")
+
+        raw_payload = kwargs.get("payload")
+        if isinstance(raw_payload, CronPayload):
+            pass
+        elif isinstance(raw_payload, dict):
+            kwargs["payload"] = CronPayload(**raw_payload)
+        else:
+            kwargs["payload"] = CronPayload()
+
+        raw_state = kwargs.get("state")
+        if isinstance(raw_state, CronJobState):
+            pass
+        elif isinstance(raw_state, dict):
+            state_kwargs = dict(raw_state)
+            state_kwargs["run_history"] = [
+                record if isinstance(record, CronRunRecord) else CronRunRecord(**record)
+                for record in state_kwargs.get("run_history", [])
+            ]
+            kwargs["state"] = CronJobState(**state_kwargs)
+        else:
+            kwargs["state"] = CronJobState()
+
         return cls(**kwargs)
 
     @classmethod

--- a/tests/cron/test_cron_service.py
+++ b/tests/cron/test_cron_service.py
@@ -5,7 +5,7 @@ import time
 import pytest
 
 from nanobot.cron.service import CronJobSkippedError, CronService
-from nanobot.cron.types import CronJob, CronPayload, CronSchedule
+from nanobot.cron.types import CronJob, CronJobState, CronPayload, CronRunRecord, CronSchedule
 
 
 async def _wait_until(predicate, *, timeout: float = 1.0, interval: float = 0.01) -> None:
@@ -1125,3 +1125,27 @@ def test_load_jobs_skips_null_run_history_elements(tmp_path) -> None:
     assert len(jobs[0].state.run_history) == 1
     assert jobs[0].state.run_history[0].run_at_ms == 1
     assert jobs[0].state.run_history[0].status == "ok"
+
+def test_cron_job_from_dict_handles_dataclass_instances() -> None:
+    """CronJob.from_dict must handle pre-instantiated CronSchedule, CronPayload, and CronJobState objects."""
+    schedule = CronSchedule(kind="cron", expr="0 * * * *")
+    payload = CronPayload(kind="agent_turn", message="hello")
+    state = CronJobState(run_history=[CronRunRecord(run_at_ms=100, status="ok")])
+
+    job = CronJob.from_dict({
+        "id": "j-dataclass",
+        "name": "Dataclass test",
+        "schedule": schedule,
+        "payload": payload,
+        "state": state,
+    })
+
+    assert job.id == "j-dataclass"
+    assert job.name == "Dataclass test"
+    assert job.schedule.kind == "cron"
+    assert job.schedule.expr == "0 * * * *"
+    assert job.payload.kind == "agent_turn"
+    assert job.payload.message == "hello"
+    assert len(job.state.run_history) == 1
+    assert job.state.run_history[0].run_at_ms == 100
+    assert job.state.run_history[0].status == "ok"


### PR DESCRIPTION
When schedule, payload, or state was passed as a pre-instantiated dataclass object rather than a dictionary, CronJob.from_dict raised TypeError during dictionary unpack.

Convert dataclass instances or check dictionary types before unpacking in from_dict.