### PR TITLE
feat(session): migrate session storage from JSONL to SQLite

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -182,7 +182,13 @@ Dream is implemented in `nanobot/agent/memory.py` and scheduled by the runtime w
 
 On first startup after upgrading, canonical files under `<workspace>/sessions/`
 are imported into SQLite in one transaction. The JSONL files remain as a
-rollback backup; runtime session reads and writes use only `sessions.db`.
+rollback backup; runtime session reads and writes use only `sessions.db`. During
+the migration window, startup checks the backup content hashes and fails closed
+if a rollback wrote new JSONL data, so divergent histories are never silently
+overwritten.
+Session metadata is stored as an extensible JSON object, while provider-owned
+continuation state is isolated in a private JSON envelope that is not returned
+by session or WebUI APIs.
 
 ## Security Boundaries
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,7 +142,7 @@ Defaults:
 |---|---|
 | Config | `~/.nanobot/config.json` |
 | Workspace | `~/.nanobot/workspace/` |
-| Sessions | `<workspace>/sessions/*.jsonl` |
+| Sessions | `<workspace>/sessions.db` |
 | Memory | `<workspace>/memory/` |
 | Cron store | `<workspace>/cron/jobs.json` |
 | WebUI/media/log runtime data | config directory subdirectories such as `webui/`, `media/`, and `logs/` |
@@ -173,12 +173,16 @@ Session history is the near-term conversation replay. Memory is the longer-term 
 
 | Store | File area |
 |---|---|
-| Session JSONL files | `<workspace>/sessions/` |
+| Session database | `<workspace>/sessions.db` |
 | Long-term memory | `<workspace>/memory/MEMORY.md` |
 | Consolidation source history | `<workspace>/memory/history.jsonl` |
 | Bootstrap identity files | `<workspace>/SOUL.md`, `<workspace>/USER.md`, templates under `nanobot/templates/` |
 
 Dream is implemented in `nanobot/agent/memory.py` and scheduled by the runtime when enabled.
+
+On first startup after upgrading, canonical files under `<workspace>/sessions/`
+are imported into SQLite in one transaction. The JSONL files remain as a
+rollback backup; runtime session reads and writes use only `sessions.db`.
 
 ## Security Boundaries
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -125,7 +125,7 @@ nanobot uses two related stores:
 
 | Store | Location | Purpose |
 |---|---|---|
-| Sessions | `<workspace>/sessions/*.jsonl` | Recent conversation turns replayed into context |
+| Sessions | `<workspace>/sessions.db` | Recent conversation turns replayed into context |
 | Memory | `<workspace>/memory/MEMORY.md` and `<workspace>/memory/history.jsonl` | Long-term facts and consolidated history |
 
 Dream is a periodic consolidation job. It reads accumulated history and updates workspace memory so useful context can survive beyond short session replay.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2200,11 +2200,11 @@ How it works:
 4. **Restart-safe resume**: The summary is also mirrored into session metadata so it can still be recovered after a process restart.
 
 > [!NOTE]
-> Mental model: "summarize older context, keep the freshest live turns, **and overwrite the session file with the compact form.**" It is not a full `session.clear()`, but it is a write — not a soft cursor move.
+> Mental model: "summarize older context, keep the freshest live turns, **and overwrite the persisted session with the compact form.**" It is not a full `session.clear()`, but it is a write — not a soft cursor move.
 >
-> Concretely, auto compact rewrites `sessions/<key>.jsonl` in place: older messages (including their structured `tool_calls` / `tool_call_id` / `reasoning_content`) are replaced by just the retained recent suffix (currently 8 messages), while the archived prefix is preserved only as a plain-text summary appended to `memory/history.jsonl` (or a `[RAW] ...` flattened dump if LLM summarization fails). The original structured JSON of those turns is no longer recoverable from the session file.
+> Concretely, auto compact replaces the session row in `sessions.db`: older messages (including their structured `tool_calls` / `tool_call_id` / `reasoning_content`) are replaced by just the retained recent suffix (currently 8 messages), while the archived prefix is preserved only as a plain-text summary appended to `memory/history.jsonl` (or a `[RAW] ...` flattened dump if LLM summarization fails). The original structured JSON of those turns is no longer recoverable from the active session database.
 >
-> This differs from the **token-driven soft consolidation** that fires when a prompt exceeds the context budget: that path only advances an internal `last_consolidated` cursor and leaves the session file untouched, so the raw tool-call trail stays on disk and can still be replayed or audited. If you rely on that trail for debugging or auditing, set `idleCompactAfterMinutes` to `0` and let only the token-driven path run.
+> This differs from the **token-driven soft consolidation** that fires when a prompt exceeds the context budget: that path only advances an internal `last_consolidated` cursor and leaves persisted messages untouched, so the raw tool-call trail stays on disk and can still be replayed or audited. If you rely on that trail for debugging or auditing, set `idleCompactAfterMinutes` to `0` and let only the token-driven path run.
 
 ## Timezone
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -313,7 +313,7 @@ See [`chat-apps.md`](./chat-apps.md) for channel-specific setup.
 |---|---|
 | Conversation context seems wrong | Confirm the active workspace and session. WebUI chats and chat app threads may use different sessions. |
 | Memory does not update immediately | Dream consolidation is periodic; recent turns still live in session history. |
-| Old sessions appear after moving config | Session files are stored under `<workspace>/sessions/`; verify the workspace path. |
+| Old sessions appear after moving config | Sessions are stored in `<workspace>/sessions.db`; verify the workspace path. |
 | You want one shared session across devices | Set `agents.defaults.unifiedSession` intentionally; otherwise keep separate sessions. |
 
 ## Collect Useful Evidence

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -770,28 +770,20 @@ class MemoryStore:
         return f"{prefix}\n\n{diff_body}"
 
     @staticmethod
-    def prune_dream_sessions(sessions_dir: Path, *, keep: int = 10) -> None:
-        """Remove the oldest Dream session files, keeping only the N most recent.
-
-        Only current base64url-encoded Dream session keys are considered.
-        Non-dream session files are never touched.
-        """
-        dream_files: list[Path] = []
-        for path in sessions_dir.glob("*.jsonl"):
-            decoded_key = SessionManager.decode_storage_key(path.stem)
-            if decoded_key is not None and decoded_key.startswith("dream:"):
-                dream_files.append(path)
-        dream_files.sort(key=lambda p: p.stat().st_mtime)
-        if len(dream_files) <= keep:
+    def prune_dream_sessions(sessions: SessionManager, *, keep: int = 10) -> None:
+        """Remove the oldest Dream sessions, keeping only the N most recent."""
+        dream_sessions = [
+            info
+            for info in sessions.list_sessions()
+            if info["key"].startswith("dream:")
+        ]
+        dream_sessions.sort(key=lambda info: (info["updated_at"], info["key"]))
+        if len(dream_sessions) <= keep:
             return
 
-        to_remove = dream_files[: len(dream_files) - keep]
-        for path in to_remove:
-            try:
-                path.unlink()
-                logger.debug("Pruned old dream session: {}", path.stem)
-            except OSError:
-                logger.warning("Failed to prune dream session {}", path)
+        for info in dream_sessions[: len(dream_sessions) - max(keep, 0)]:
+            if sessions.delete_session(info["key"]):
+                logger.debug("Pruned old dream session: {}", info["key"])
 
 
 # ---------------------------------------------------------------------------

--- a/nanobot/channels/websocket/tests/test_websocket_http_routes.py
+++ b/nanobot/channels/websocket/tests/test_websocket_http_routes.py
@@ -2296,8 +2296,7 @@ async def test_session_delete_removes_file(
         token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
-        path = sm._get_session_path("websocket:doomed")
-        assert path.exists()
+        assert sm.read_session_file("websocket:doomed") is not None
         webui_path = tmp_path / "webui" / f"{SessionManager.safe_key('websocket:doomed')}.jsonl"
         assert webui_path.is_file()
         resp = await _http_get(
@@ -2306,7 +2305,7 @@ async def test_session_delete_removes_file(
         )
         assert resp.status_code == 200
         assert resp.json()["deleted"] is True
-        assert not path.exists()
+        assert sm.read_session_file("websocket:doomed") is None
         assert not webui_path.exists()
     finally:
         await channel.stop()
@@ -2666,7 +2665,6 @@ async def test_session_delete_blocks_when_bound_automation_exists(
         token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
-        path = sm._get_session_path("websocket:doomed")
         resp = await _http_get(
             "http://127.0.0.1:29915/api/sessions/websocket:doomed/delete",
             headers=auth,
@@ -2677,7 +2675,7 @@ async def test_session_delete_blocks_when_bound_automation_exists(
         assert body["deleted"] is False
         assert body["blocked_by_automations"] is True
         assert [job["name"] for job in body["automations"]] == ["Daily check"]
-        assert path.exists()
+        assert sm.read_session_file("websocket:doomed") is not None
         assert cron.list_bound_cron_jobs_for_session("websocket:doomed")
     finally:
         await channel.stop()
@@ -2758,7 +2756,6 @@ async def test_session_delete_can_cascade_bound_automations(
         token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
-        path = sm._get_session_path("websocket:doomed")
         resp = await _http_get(
             "http://127.0.0.1:29916/api/sessions/websocket:doomed/delete?delete_automations=true",
             headers=auth,
@@ -2766,7 +2763,7 @@ async def test_session_delete_can_cascade_bound_automations(
 
         assert resp.status_code == 200
         assert resp.json()["deleted"] is True
-        assert not path.exists()
+        assert sm.read_session_file("websocket:doomed") is None
         assert cron.list_bound_cron_jobs_for_session("websocket:doomed") == []
         assert cron.list_jobs(include_disabled=True) == []
     finally:
@@ -2800,7 +2797,6 @@ async def test_session_delete_blocks_origin_automation_when_unified_enabled(
         token = channel.gateway.tokens.issue_api_token(300)
         auth = {"Authorization": f"Bearer {token}"}
 
-        path = sm._get_session_path("websocket:doomed")
         resp = await _http_get(
             "http://127.0.0.1:29918/api/sessions/websocket:doomed/delete",
             headers=auth,
@@ -2811,7 +2807,7 @@ async def test_session_delete_blocks_origin_automation_when_unified_enabled(
         assert body["deleted"] is False
         assert body["blocked_by_automations"] is True
         assert [job["name"] for job in body["automations"]] == ["Chat daily check"]
-        assert path.exists()
+        assert sm.read_session_file("websocket:doomed") is not None
         assert [job.name for job in cron.list_bound_cron_jobs_for_session("websocket:doomed")] == [
             "Chat daily check"
         ]
@@ -2838,15 +2834,14 @@ async def test_session_routes_accept_percent_encoded_websocket_keys(
         assert msgs.status_code == 200
         assert msgs.json()["key"] == "websocket:encoded-key"
 
-        path = sm._get_session_path("websocket:encoded-key")
-        assert path.exists()
+        assert sm.read_session_file("websocket:encoded-key") is not None
         deleted = await _http_get(
             "http://127.0.0.1:29910/api/sessions/websocket%3Aencoded-key/delete",
             headers=auth,
         )
         assert deleted.status_code == 200
         assert deleted.json()["deleted"] is True
-        assert not path.exists()
+        assert sm.read_session_file("websocket:encoded-key") is None
     finally:
         await channel.stop()
         await server_task
@@ -2982,14 +2977,13 @@ async def test_session_routes_reject_non_websocket_keys(
         )
         assert msgs.status_code == 404
 
-        doomed = sm._get_session_path("slack:C123")
-        assert doomed.exists()
+        assert sm.read_session_file("slack:C123") is not None
         deny_delete = await _http_get(
             "http://127.0.0.1:29909/api/sessions/slack:C123/delete",
             headers=auth,
         )
         assert deny_delete.status_code == 404
-        assert doomed.exists()
+        assert sm.read_session_file("slack:C123") is not None
     finally:
         await channel.stop()
         await server_task

--- a/nanobot/cli/gateway_runtime.py
+++ b/nanobot/cli/gateway_runtime.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import signal
-from collections.abc import Awaitable, Callable, Coroutine, Iterable
+from collections.abc import Awaitable, Callable, Coroutine, Iterable, Mapping
 from contextlib import suppress
 from pathlib import Path
 from typing import Any, cast
@@ -154,14 +154,15 @@ def _heartbeat_has_active_tasks(content: str) -> bool:
 def _pick_heartbeat_target_from_sessions(
     *,
     enabled_channels: Iterable[str],
-    sessions: Iterable[dict[str, Any]],
+    sessions: Iterable[Mapping[str, object]],
     archived_keys: Iterable[str],
     unified_session_metadata: dict[str, Any] | None = None,
 ) -> tuple[str, str]:
     enabled = set(enabled_channels)
     archived = set(archived_keys)
     for item in sessions:
-        key = item.get("key") or ""
+        value = item.get("key")
+        key = value if isinstance(value, str) else ""
         if key in archived:
             continue
         if key == UNIFIED_SESSION_KEY:
@@ -475,7 +476,7 @@ def _run_gateway(
                 if sha:
                     logger.info("Dream commit: {}", sha)
                 store.compact_history()
-                prune_dream_sessions(agent.sessions.sessions_dir)
+                prune_dream_sessions(agent.sessions)
             return None
 
         # Heartbeat is a system job that checks HEARTBEAT.md for active tasks.

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -490,7 +490,7 @@ async def cmd_dream(ctx: CommandContext) -> OutboundMessage:
                 if sha:
                     content += f" (commit {sha})"
             store.compact_history()
-            prune_dream_sessions(loop.sessions.sessions_dir)
+            prune_dream_sessions(loop.sessions)
         await loop.bus.publish_outbound(OutboundMessage(
             channel=msg.channel, chat_id=msg.chat_id, content=content,
         ))

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -186,7 +186,7 @@ class ProviderConversationState:
         )
 
     def to_private_record(self) -> dict[str, Any]:
-        """Serialize for the private session sidecar, never for public history."""
+        """Serialize for private session storage, never for public history."""
         return {
             "kind": self.kind,
             "provider": self.provider,
@@ -201,7 +201,7 @@ class ProviderConversationState:
         cls,
         value: object,
     ) -> ProviderConversationState | None:
-        """Validate and deserialize a private session-sidecar value."""
+        """Validate and deserialize a private session storage value."""
         if not isinstance(value, dict):
             return None
         data = cast(dict[str, Any], value)

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -5,12 +5,15 @@ import errno
 import json
 import os
 import re
+import sqlite3
 from collections import OrderedDict
-from contextlib import suppress
+from collections.abc import Generator
+from contextlib import contextmanager, suppress
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
+from time import monotonic, sleep
 from typing import Any, Callable, Protocol, TypedDict, cast
 from weakref import WeakValueDictionary
 
@@ -48,6 +51,8 @@ _PROVIDER_STATE_RECORD_TYPE = "provider_state"
 _PROVIDER_STATE_RECORD_PREFIX_RE = re.compile(
     r'^\s*\{\s*"_type"\s*:\s*"provider_state"\s*(?:,|\})'
 )
+_SQLITE_DB_NAME = "sessions.db"
+_SQLITE_SCHEMA_VERSION = 1
 _FORK_VOLATILE_METADATA_KEYS = {
     "goal_state",
     "pending_user_turn",
@@ -950,6 +955,334 @@ class JsonlSessionStore:
                     )
                 continue
         return sorted(sessions, key=lambda item: item["updated_at"], reverse=True)
+
+
+class SQLiteSessionStore:
+    """SQLite implementation of session persistence."""
+
+    def __init__(self, workspace: Path):
+        self.db_path = ensure_dir(workspace) / _SQLITE_DB_NAME
+        self._initialize()
+
+    @contextmanager
+    def _connection(self, *, durable: bool = False) -> Generator[sqlite3.Connection]:
+        connection = sqlite3.connect(self.db_path, timeout=5.0)
+        try:
+            connection.execute("PRAGMA foreign_keys = ON")
+            connection.execute("PRAGMA busy_timeout = 5000")
+            connection.execute(
+                "PRAGMA synchronous = FULL" if durable else "PRAGMA synchronous = NORMAL"
+            )
+            yield connection
+        finally:
+            connection.close()
+
+    def _initialize(self) -> None:
+        with self._connection(durable=True) as connection:
+            deadline = monotonic() + 5.0
+            while True:
+                try:
+                    journal_mode: object = connection.execute(
+                        "PRAGMA journal_mode = WAL"
+                    ).fetchone()
+                    if journal_mode != ("wal",):
+                        raise RuntimeError(f"Failed to enable SQLite WAL mode: {journal_mode!r}")
+                    break
+                except sqlite3.OperationalError as exc:
+                    error_code = exc.sqlite_errorcode & 0xFF
+                    if (
+                        error_code not in (sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED)
+                        or monotonic() >= deadline
+                    ):
+                        raise
+                    sleep(0.05)
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+                raw_version: object = connection.execute("PRAGMA user_version").fetchone()
+                if not isinstance(raw_version, tuple):
+                    raise RuntimeError("Failed to read SQLite session schema version")
+                version_row = cast(tuple[object, ...], raw_version)
+                if len(version_row) != 1 or not isinstance(version_row[0], int):
+                    raise RuntimeError("Failed to read SQLite session schema version")
+                version = version_row[0]
+                if version not in (0, _SQLITE_SCHEMA_VERSION):
+                    raise RuntimeError(
+                        f"Unsupported SQLite session schema version {version}; "
+                        f"expected {_SQLITE_SCHEMA_VERSION}"
+                    )
+                if version == _SQLITE_SCHEMA_VERSION:
+                    connection.commit()
+                    return
+
+                connection.execute(
+                    """
+                    CREATE TABLE sessions (
+                        key TEXT PRIMARY KEY,
+                        created_at TEXT NOT NULL,
+                        updated_at TEXT NOT NULL,
+                        metadata TEXT NOT NULL,
+                        last_consolidated INTEGER NOT NULL DEFAULT 0
+                            CHECK (last_consolidated >= 0)
+                    )
+                    """
+                )
+                connection.execute(
+                    """
+                    CREATE TABLE messages (
+                        session_key TEXT NOT NULL,
+                        position INTEGER NOT NULL CHECK (position >= 0),
+                        payload TEXT NOT NULL,
+                        PRIMARY KEY (session_key, position),
+                        FOREIGN KEY (session_key) REFERENCES sessions(key) ON DELETE CASCADE
+                    )
+                    """
+                )
+                connection.execute(
+                    "CREATE INDEX sessions_updated_at ON sessions(updated_at DESC)"
+                )
+                connection.execute(f"PRAGMA user_version = {_SQLITE_SCHEMA_VERSION}")
+                connection.commit()
+            except BaseException:
+                connection.rollback()
+                raise
+
+    @staticmethod
+    def _encode_json(value: object) -> str:
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+    @staticmethod
+    def _decode_json_object(value: object) -> dict[str, Any]:
+        if not isinstance(value, str):
+            raise ValueError("SQLite session JSON must be text")
+        return _json_object(json.loads(value))
+
+    @classmethod
+    def _decode_session_row(
+        cls,
+        row: object,
+    ) -> tuple[str, str, str, dict[str, Any], int]:
+        if not isinstance(row, tuple):
+            raise ValueError("Invalid SQLite session row")
+        values = cast(tuple[object, ...], row)
+        if len(values) != 5:
+            raise ValueError("Invalid SQLite session row")
+        key, created_at, updated_at, metadata_json, last_consolidated = values
+        if (
+            not isinstance(key, str)
+            or not isinstance(created_at, str)
+            or not isinstance(updated_at, str)
+            or not isinstance(last_consolidated, int)
+            or isinstance(last_consolidated, bool)
+        ):
+            raise ValueError("Invalid SQLite session fields")
+        return (
+            key,
+            created_at,
+            updated_at,
+            cls._decode_json_object(metadata_json),
+            last_consolidated,
+        )
+
+    @classmethod
+    def _read_messages(
+        cls,
+        connection: sqlite3.Connection,
+        key: str,
+    ) -> list[dict[str, Any]]:
+        messages: list[dict[str, Any]] = []
+        rows = connection.execute(
+            "SELECT payload FROM messages WHERE session_key = ? ORDER BY position",
+            (key,),
+        )
+        for raw_row in rows:
+            row: object = raw_row
+            if not isinstance(row, tuple):
+                raise ValueError("Invalid SQLite message row")
+            values = cast(tuple[object, ...], row)
+            if len(values) != 1:
+                raise ValueError("Invalid SQLite message row")
+            messages.append(cls._decode_json_object(values[0]))
+        return messages
+
+    @classmethod
+    def _preview(
+        cls,
+        connection: sqlite3.Connection,
+        key: str,
+    ) -> str:
+        preview = ""
+        fallback_preview = ""
+        scanned_chars = 0
+        rows = connection.execute(
+            """
+            SELECT payload
+            FROM messages
+            WHERE session_key = ?
+            ORDER BY position
+            LIMIT ?
+            """,
+            (key, _SESSION_LIST_PREVIEW_MAX_RECORDS + 1),
+        )
+        for index, raw_row in enumerate(rows, start=1):
+            row: object = raw_row
+            if not isinstance(row, tuple):
+                raise ValueError("Invalid SQLite message row")
+            values = cast(tuple[object, ...], row)
+            if len(values) != 1 or not isinstance(values[0], str):
+                raise ValueError("Invalid SQLite message row")
+            payload = values[0]
+            scanned_chars += len(payload) + 1
+            if (
+                index > _SESSION_LIST_PREVIEW_MAX_RECORDS
+                or scanned_chars > _SESSION_LIST_PREVIEW_MAX_CHARS
+            ):
+                break
+            message = cls._decode_json_object(payload)
+            text = _message_preview_text(message)
+            if not text:
+                continue
+            if message.get("role") == "user":
+                preview = text
+                break
+            if not fallback_preview and message.get("role") == "assistant":
+                fallback_preview = text
+        return preview or fallback_preview
+
+    def load(self, key: str) -> Session | None:
+        with self._connection() as connection, connection:
+            connection.execute("BEGIN")
+            row: object = connection.execute(
+                """
+                SELECT key, created_at, updated_at, metadata, last_consolidated
+                FROM sessions
+                WHERE key = ?
+                """,
+                (key,),
+            ).fetchone()
+            if row is None:
+                return None
+            try:
+                stored_key, created_at, updated_at, metadata, last_consolidated = (
+                    self._decode_session_row(row)
+                )
+                messages = self._read_messages(connection, stored_key)
+                return Session(
+                    key=stored_key,
+                    messages=messages,
+                    created_at=datetime.fromisoformat(created_at),
+                    updated_at=datetime.fromisoformat(updated_at),
+                    metadata=metadata,
+                    last_consolidated=last_consolidated,
+                )
+            except _SESSION_DATA_ERRORS as exc:
+                logger.warning("Failed to load SQLite session {}: {}", key, exc)
+                return None
+
+    def save(self, session: Session, *, fsync: bool = False) -> None:
+        metadata_json = self._encode_json(session.metadata)
+        message_rows = [
+            (session.key, position, self._encode_json(message))
+            for position, message in enumerate(session.messages)
+        ]
+        with self._connection(durable=fsync) as connection, connection:
+            connection.execute(
+                """
+                INSERT INTO sessions (
+                    key, created_at, updated_at, metadata, last_consolidated
+                )
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(key) DO UPDATE SET
+                    created_at = excluded.created_at,
+                    updated_at = excluded.updated_at,
+                    metadata = excluded.metadata,
+                    last_consolidated = excluded.last_consolidated
+                """,
+                (
+                    session.key,
+                    session.created_at.isoformat(),
+                    session.updated_at.isoformat(),
+                    metadata_json,
+                    session.last_consolidated,
+                ),
+            )
+            connection.execute("DELETE FROM messages WHERE session_key = ?", (session.key,))
+            connection.executemany(
+                """
+                INSERT INTO messages (session_key, position, payload)
+                VALUES (?, ?, ?)
+                """,
+                message_rows,
+            )
+
+    def delete(self, key: str) -> bool:
+        with self._connection() as connection, connection:
+            cursor = connection.execute("DELETE FROM sessions WHERE key = ?", (key,))
+            return cursor.rowcount > 0
+
+    def read(self, key: str) -> SessionPayload | None:
+        session = self.load(key)
+        if session is None:
+            return None
+        return {
+            "key": session.key,
+            "created_at": session.created_at.isoformat(),
+            "updated_at": session.updated_at.isoformat(),
+            "metadata": session.metadata,
+            "messages": session.messages,
+        }
+
+    def read_metadata(self, key: str) -> SessionMetadataPayload | None:
+        with self._connection() as connection:
+            row: object = connection.execute(
+                """
+                SELECT key, created_at, updated_at, metadata, last_consolidated
+                FROM sessions
+                WHERE key = ?
+                """,
+                (key,),
+            ).fetchone()
+            if row is None:
+                return None
+            try:
+                stored_key, created_at, updated_at, metadata, _ = self._decode_session_row(row)
+            except _SESSION_DATA_ERRORS as exc:
+                logger.warning("Failed to read SQLite session metadata {}: {}", key, exc)
+                return None
+            return {
+                "key": stored_key,
+                "created_at": created_at,
+                "updated_at": updated_at,
+                "metadata": metadata,
+            }
+
+    def list_sessions(self) -> list[SessionInfo]:
+        sessions: list[SessionInfo] = []
+        with self._connection() as connection, connection:
+            connection.execute("BEGIN")
+            rows = connection.execute(
+                """
+                SELECT key, created_at, updated_at, metadata, last_consolidated
+                FROM sessions
+                ORDER BY updated_at DESC, key
+                """
+            )
+            for raw_row in rows:
+                row: object = raw_row
+                try:
+                    key, created_at, updated_at, metadata, _ = self._decode_session_row(row)
+                    sessions.append(
+                        {
+                            "key": key,
+                            "created_at": created_at,
+                            "updated_at": updated_at,
+                            "title": _metadata_title(metadata),
+                            "preview": self._preview(connection, key),
+                            "path": str(self.db_path),
+                        }
+                    )
+                except _SESSION_DATA_ERRORS as exc:
+                    logger.warning("Failed to list SQLite session: {}", exc)
+        return sessions
 
 
 class SessionManager:

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -1,9 +1,7 @@
 """Session management for conversation history."""
 
 import base64
-import errno
 import json
-import os
 import re
 import sqlite3
 from collections import OrderedDict
@@ -25,6 +23,8 @@ from nanobot.runtime_context import (
     RUNTIME_CONTEXT_HISTORY_META,
     public_history_message,
 )
+from nanobot.session.history_visibility import is_hidden_history_message
+from nanobot.session.model_selection import model_preset_from_metadata
 from nanobot.utils.helpers import (
     content_with_media_breadcrumbs,
     ensure_dir,
@@ -53,6 +53,7 @@ _PROVIDER_STATE_RECORD_PREFIX_RE = re.compile(
 )
 _SQLITE_DB_NAME = "sessions.db"
 _SQLITE_SCHEMA_VERSION = 1
+_SQLITE_JSONL_MIGRATION_KEY = "jsonl_import_v1"
 _FORK_VOLATILE_METADATA_KEYS = {
     "goal_state",
     "pending_user_turn",
@@ -469,6 +470,7 @@ class SessionInfo(TypedDict):
     updated_at: str
     title: str
     preview: str
+    model_preset: str | None
     path: str
 
 
@@ -486,8 +488,8 @@ class SessionStore(Protocol):
     def list_sessions(self) -> list[SessionInfo]: ...
 
 
-class JsonlSessionStore:
-    """JSONL implementation of session persistence."""
+class JsonlSessionFiles:
+    """Read and clean up JSONL files during SQLite migration."""
 
     def __init__(self, workspace: Path):
         self.sessions_dir = ensure_dir(workspace / "sessions")
@@ -527,7 +529,15 @@ class JsonlSessionStore:
     def get_legacy_session_path(self, key: str) -> Path:
         return self.legacy_sessions_dir / f"{self.safe_key(key)}.jsonl"
 
-    def load(self, key: str) -> Session | None:
+    def session_files(self) -> list[tuple[str, Path]]:
+        files: list[tuple[str, Path]] = []
+        for path in sorted(self.sessions_dir.glob("*.jsonl")):
+            key = self.session_key_from_path(path)
+            if key is not None:
+                files.append((key, path))
+        return files
+
+    def load_for_migration(self, key: str) -> Session | None:
         path = self.get_session_path(key)
         if not path.exists():
             return None
@@ -593,7 +603,7 @@ class JsonlSessionStore:
             )
         except _SESSION_DATA_ERRORS as e:
             logger.warning("Failed to load session {}: {}", key, e)
-            repaired = self.repair(key)
+            repaired = self._repair(key)
             if repaired is not None:
                 logger.info(
                     "Recovered session {} from corrupt file ({} messages)",
@@ -602,7 +612,7 @@ class JsonlSessionStore:
                 )
             return repaired
 
-    def repair(self, key: str, *, path: Path | None = None) -> Session | None:
+    def _repair(self, key: str, *, path: Path | None = None) -> Session | None:
         if path is None:
             path = self.get_session_path(key)
         if not path.exists():
@@ -684,60 +694,7 @@ class JsonlSessionStore:
             logger.warning("Repair failed for session {}: {}", key, e)
             return None
 
-    @staticmethod
-    def session_payload(session: Session) -> SessionPayload:
-        return {
-            "key": session.key,
-            "created_at": session.created_at.isoformat(),
-            "updated_at": session.updated_at.isoformat(),
-            "metadata": session.metadata,
-            "messages": session.messages,
-        }
-
-    def save(self, session: Session, *, fsync: bool = False) -> None:
-        path = self.get_session_path(session.key)
-        tmp_path = path.with_suffix(".jsonl.tmp")
-
-        try:
-            with open(tmp_path, "w", encoding="utf-8") as f:
-                metadata_line = {
-                    "_type": "metadata",
-                    "key": session.key,
-                    "created_at": session.created_at.isoformat(),
-                    "updated_at": session.updated_at.isoformat(),
-                    "metadata": session.metadata,
-                    "last_consolidated": session.last_consolidated,
-                }
-                f.write(json.dumps(metadata_line, ensure_ascii=False) + "\n")
-                if session.provider_state is not None:
-                    provider_state_line = {
-                        "_type": _PROVIDER_STATE_RECORD_TYPE,
-                        "state": session.provider_state.to_private_record(),
-                    }
-                    f.write(json.dumps(provider_state_line, ensure_ascii=False) + "\n")
-                for msg in session.messages:
-                    f.write(json.dumps(msg, ensure_ascii=False) + "\n")
-                if fsync:
-                    f.flush()
-                    os.fsync(f.fileno())
-
-            os.replace(tmp_path, path)
-
-            if fsync:
-                with suppress(PermissionError):
-                    fd = os.open(str(path.parent), os.O_RDONLY)
-                    try:
-                        os.fsync(fd)
-                    except OSError as exc:
-                        if exc.errno != errno.EINVAL:
-                            raise
-                    finally:
-                        os.close(fd)
-        except BaseException:
-            tmp_path.unlink(missing_ok=True)
-            raise
-
-    def delete(self, key: str) -> bool:
+    def delete_backups(self, key: str) -> bool:
         paths = [
             self.get_session_path(key),
             self.get_legacy_lossy_path(key),
@@ -753,209 +710,6 @@ class JsonlSessionStore:
             except OSError as e:
                 logger.warning("Failed to delete session file {}: {}", path, e)
         return deleted
-
-    def read(self, key: str) -> SessionPayload | None:
-        path = self.get_session_path(key)
-        if not path.exists():
-            return None
-        try:
-            messages: list[dict[str, Any]] = []
-            metadata: dict[str, Any] = {}
-            created_at: str | None = None
-            updated_at: str | None = None
-            stored_key: str | None = None
-            with open(path, encoding="utf-8") as f:
-                for line in f:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    raw_data: object = json.loads(line)
-                    data = _json_object(raw_data)
-                    record_type = data.get("_type")
-                    if record_type == "metadata":
-                        metadata_value = cast(object, data.get("metadata", {}))
-                        metadata = (
-                            cast(dict[str, Any], metadata_value)
-                            if isinstance(metadata_value, dict)
-                            else {}
-                        )
-                        created_at_value = cast(object, data.get("created_at"))
-                        updated_at_value = cast(object, data.get("updated_at"))
-                        stored_key_value = cast(object, data.get("key"))
-                        created_at = (
-                            created_at_value if isinstance(created_at_value, str) else None
-                        )
-                        updated_at = (
-                            updated_at_value if isinstance(updated_at_value, str) else None
-                        )
-                        stored_key = (
-                            stored_key_value if isinstance(stored_key_value, str) else None
-                        )
-                    elif record_type == _PROVIDER_STATE_RECORD_TYPE:
-                        continue
-                    else:
-                        messages.append(data)
-            return {
-                "key": stored_key or key,
-                "created_at": created_at,
-                "updated_at": updated_at,
-                "metadata": metadata,
-                "messages": messages,
-            }
-        except _SESSION_DATA_ERRORS as e:
-            logger.warning("Failed to read session {}: {}", key, e)
-            repaired = self.repair(key, path=path)
-            if repaired is not None:
-                logger.info("Recovered read-only session view {} from corrupt file", key)
-                return self.session_payload(repaired)
-            return None
-
-    def read_metadata(self, key: str) -> SessionMetadataPayload | None:
-        path = self.get_session_path(key)
-        if not path.exists():
-            return None
-        try:
-            with open(path, encoding="utf-8") as f:
-                for line in f:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    raw_data: object = json.loads(line)
-                    data = _json_object(raw_data)
-                    if data.get("_type") != "metadata":
-                        return None
-                    metadata_value = cast(object, data.get("metadata", {}))
-                    key_value = cast(object, data.get("key"))
-                    created_at_value = cast(object, data.get("created_at"))
-                    updated_at_value = cast(object, data.get("updated_at"))
-                    return {
-                        "key": key_value if isinstance(key_value, str) and key_value else key,
-                        "created_at": (
-                            created_at_value if isinstance(created_at_value, str) else None
-                        ),
-                        "updated_at": (
-                            updated_at_value if isinstance(updated_at_value, str) else None
-                        ),
-                        "metadata": (
-                            cast(dict[str, Any], metadata_value)
-                            if isinstance(metadata_value, dict)
-                            else {}
-                        ),
-                    }
-            return None
-        except _SESSION_DATA_ERRORS as e:
-            logger.warning("Failed to read session metadata {}: {}", key, e)
-            repaired = self.repair(key, path=path)
-            if repaired is not None:
-                logger.info("Recovered read-only session metadata {} from corrupt file", key)
-                return {
-                    "key": repaired.key,
-                    "created_at": repaired.created_at.isoformat(),
-                    "updated_at": repaired.updated_at.isoformat(),
-                    "metadata": repaired.metadata,
-                }
-            return None
-
-    def list_sessions(self) -> list[SessionInfo]:
-        sessions: list[SessionInfo] = []
-
-        for path in self.sessions_dir.glob("*.jsonl"):
-            storage_key = self.session_key_from_path(path)
-            if storage_key is None:
-                continue
-            try:
-                with open(path, encoding="utf-8") as f:
-                    first_line = f.readline().strip()
-                    if first_line:
-                        raw_data: object = json.loads(first_line)
-                        data = _json_object(raw_data)
-                        if data.get("_type") == "metadata":
-                            key_value = cast(object, data.get("key"))
-                            key = (
-                                key_value
-                                if isinstance(key_value, str) and key_value
-                                else storage_key
-                            )
-                            metadata = cast(object, data.get("metadata", {}))
-                            title = _metadata_title(metadata)
-                            preview = ""
-                            fallback_preview = ""
-                            scanned_records = 0
-                            scanned_chars = 0
-                            for line in f:
-                                if not line.strip():
-                                    continue
-                                if _is_provider_state_record_line(line):
-                                    continue
-                                scanned_records += 1
-                                scanned_chars += len(line)
-                                if (
-                                    scanned_records > _SESSION_LIST_PREVIEW_MAX_RECORDS
-                                    or scanned_chars > _SESSION_LIST_PREVIEW_MAX_CHARS
-                                ):
-                                    break
-                                raw_item: object = json.loads(line)
-                                item = _json_object(raw_item)
-                                if item.get("_type") in {
-                                    "metadata",
-                                    _PROVIDER_STATE_RECORD_TYPE,
-                                }:
-                                    continue
-                                text = _message_preview_text(item)
-                                if not text:
-                                    continue
-                                if item.get("role") == "user":
-                                    preview = text
-                                    break
-                                if not fallback_preview and item.get("role") == "assistant":
-                                    fallback_preview = text
-                            preview = preview or fallback_preview
-                            fallback_time = datetime.fromtimestamp(path.stat().st_mtime).isoformat()
-                            created_at = cast(object, data.get("created_at"))
-                            updated_at = cast(object, data.get("updated_at"))
-                            sessions.append(
-                                {
-                                    "key": key,
-                                    "created_at": (
-                                        created_at
-                                        if isinstance(created_at, str) and created_at
-                                        else fallback_time
-                                    ),
-                                    "updated_at": (
-                                        updated_at
-                                        if isinstance(updated_at, str) and updated_at
-                                        else fallback_time
-                                    ),
-                                    "title": title,
-                                    "preview": preview,
-                                    "path": str(path),
-                                }
-                            )
-            except FileNotFoundError:
-                continue
-            except _SESSION_DATA_ERRORS:
-                repaired = self.repair(storage_key, path=path)
-                if repaired is not None:
-                    sessions.append(
-                        {
-                            "key": repaired.key,
-                            "created_at": repaired.created_at.isoformat(),
-                            "updated_at": repaired.updated_at.isoformat(),
-                            "title": _metadata_title(repaired.metadata),
-                            "preview": next(
-                                (
-                                    text
-                                    for msg in repaired.messages
-                                    if (text := _message_preview_text(msg))
-                                ),
-                                "",
-                            ),
-                            "path": str(path),
-                        }
-                    )
-                continue
-        return sorted(sessions, key=lambda item: item["updated_at"], reverse=True)
-
 
 class SQLiteSessionStore:
     """SQLite implementation of session persistence."""
@@ -1011,6 +765,14 @@ class SQLiteSessionStore:
                         f"expected {_SQLITE_SCHEMA_VERSION}"
                     )
                 if version == _SQLITE_SCHEMA_VERSION:
+                    connection.execute(
+                        """
+                        CREATE TABLE IF NOT EXISTS store_metadata (
+                            key TEXT PRIMARY KEY,
+                            value TEXT NOT NULL
+                        )
+                        """
+                    )
                     return
 
                 connection.execute(
@@ -1039,7 +801,55 @@ class SQLiteSessionStore:
                 connection.execute(
                     "CREATE INDEX sessions_updated_at ON sessions(updated_at DESC)"
                 )
+                connection.execute(
+                    """
+                    CREATE TABLE store_metadata (
+                        key TEXT PRIMARY KEY,
+                        value TEXT NOT NULL
+                    )
+                    """
+                )
                 connection.execute(f"PRAGMA user_version = {_SQLITE_SCHEMA_VERSION}")
+
+    def migrate_from_jsonl(self, source: JsonlSessionFiles) -> int:
+        migrated_count = 0
+        with self._connection(durable=True) as connection, connection:
+            connection.execute("BEGIN IMMEDIATE")
+            migrated = connection.execute(
+                "SELECT value FROM store_metadata WHERE key = ?",
+                (_SQLITE_JSONL_MIGRATION_KEY,),
+            ).fetchone()
+            if migrated is not None:
+                return 0
+
+            files = source.session_files()
+            existing_keys = {
+                row[0]
+                for row in connection.execute("SELECT key FROM sessions")
+                if isinstance(row[0], str)
+            }
+            conflicts = sorted(existing_keys.intersection(key for key, _ in files))
+            if conflicts:
+                raise RuntimeError(
+                    "Cannot migrate JSONL sessions because SQLite already contains "
+                    f"{len(conflicts)} matching session key(s)"
+                )
+
+            for key, path in files:
+                session = source.load_for_migration(key)
+                if session is None:
+                    raise RuntimeError(f"Failed to migrate JSONL session {path}")
+                self._save(connection, session)
+
+            connection.execute(
+                "INSERT INTO store_metadata (key, value) VALUES (?, ?)",
+                (_SQLITE_JSONL_MIGRATION_KEY, str(len(files))),
+            )
+            migrated_count = len(files)
+
+        if migrated_count:
+            logger.info("Migrated {} JSONL session(s) to SQLite", migrated_count)
+        return migrated_count
 
     @staticmethod
     def _encode_json(value: object) -> str:
@@ -1132,6 +942,8 @@ class SQLiteSessionStore:
             ):
                 break
             message = cls._decode_json_object(payload)
+            if is_hidden_history_message(message):
+                continue
             text = _message_preview_text(message)
             if not text:
                 continue
@@ -1172,40 +984,43 @@ class SQLiteSessionStore:
                 return None
 
     def save(self, session: Session, *, fsync: bool = False) -> None:
+        with self._connection(durable=fsync) as connection, connection:
+            self._save(connection, session)
+
+    def _save(self, connection: sqlite3.Connection, session: Session) -> None:
         metadata_json = self._encode_json(session.metadata)
         message_rows = [
             (session.key, position, self._encode_json(message))
             for position, message in enumerate(session.messages)
         ]
-        with self._connection(durable=fsync) as connection, connection:
-            connection.execute(
-                """
-                INSERT INTO sessions (
-                    key, created_at, updated_at, metadata, last_consolidated
-                )
-                VALUES (?, ?, ?, ?, ?)
-                ON CONFLICT(key) DO UPDATE SET
-                    created_at = excluded.created_at,
-                    updated_at = excluded.updated_at,
-                    metadata = excluded.metadata,
-                    last_consolidated = excluded.last_consolidated
-                """,
-                (
-                    session.key,
-                    session.created_at.isoformat(),
-                    session.updated_at.isoformat(),
-                    metadata_json,
-                    session.last_consolidated,
-                ),
+        connection.execute(
+            """
+            INSERT INTO sessions (
+                key, created_at, updated_at, metadata, last_consolidated
             )
-            connection.execute("DELETE FROM messages WHERE session_key = ?", (session.key,))
-            connection.executemany(
-                """
-                INSERT INTO messages (session_key, position, payload)
-                VALUES (?, ?, ?)
-                """,
-                message_rows,
-            )
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(key) DO UPDATE SET
+                created_at = excluded.created_at,
+                updated_at = excluded.updated_at,
+                metadata = excluded.metadata,
+                last_consolidated = excluded.last_consolidated
+            """,
+            (
+                session.key,
+                session.created_at.isoformat(),
+                session.updated_at.isoformat(),
+                metadata_json,
+                session.last_consolidated,
+            ),
+        )
+        connection.execute("DELETE FROM messages WHERE session_key = ?", (session.key,))
+        connection.executemany(
+            """
+            INSERT INTO messages (session_key, position, payload)
+            VALUES (?, ?, ?)
+            """,
+            message_rows,
+        )
 
     def delete(self, key: str) -> bool:
         with self._connection() as connection, connection:
@@ -1263,18 +1078,21 @@ class SQLiteSessionStore:
                 row: object = raw_row
                 try:
                     key, created_at, updated_at, metadata, _ = self._decode_session_row(row)
-                    sessions.append(
-                        {
-                            "key": key,
-                            "created_at": created_at,
-                            "updated_at": updated_at,
-                            "title": _metadata_title(metadata),
-                            "preview": self._preview(connection, key),
-                            "path": str(self.db_path),
-                        }
-                    )
+                    preview = self._preview(connection, key)
                 except _SESSION_DATA_ERRORS as exc:
                     logger.warning("Failed to list SQLite session: {}", exc)
+                    continue
+                sessions.append(
+                    {
+                        "key": key,
+                        "created_at": created_at,
+                        "updated_at": updated_at,
+                        "title": _metadata_title(metadata),
+                        "preview": preview,
+                        "model_preset": model_preset_from_metadata(metadata),
+                        "path": str(self.db_path),
+                    }
+                )
         return sessions
 
 
@@ -1283,10 +1101,13 @@ class SessionManager:
 
     def __init__(self, workspace: Path, *, store: SessionStore | None = None):
         self.workspace = workspace
-        self._jsonl_store = JsonlSessionStore(workspace)
-        self._store: SessionStore = store if store is not None else self._jsonl_store
-        self.sessions_dir = self._jsonl_store.sessions_dir
-        self.legacy_sessions_dir = self._jsonl_store.legacy_sessions_dir
+        self._jsonl_files = JsonlSessionFiles(workspace)
+        if store is None:
+            sqlite_store = SQLiteSessionStore(workspace)
+            sqlite_store.migrate_from_jsonl(self._jsonl_files)
+            self._store: SessionStore = sqlite_store
+        else:
+            self._store = store
         self._cache: OrderedDict[str, Session] = OrderedDict()
         # Preserve identity for sessions held by active callers without retaining idle ones.
         self._overflow_cache: WeakValueDictionary[str, Session] = WeakValueDictionary()
@@ -1324,39 +1145,7 @@ class SessionManager:
     @staticmethod
     def safe_key(key: str) -> str:
         """Public helper used by HTTP handlers to map an arbitrary key to a stable filename stem."""
-        return JsonlSessionStore.safe_key(key)
-
-    @staticmethod
-    def _storage_key(key: str) -> str:
-        """Collision-resistant encoding for internal session storage filenames."""
-        return JsonlSessionStore.storage_key(key)
-
-    @staticmethod
-    def _decode_storage_key(stem: str) -> str | None:
-        """Reverse _storage_key(): decode a base64url (no-padding) stem back to the original key."""
-        return JsonlSessionStore.decode_storage_key(stem)
-
-    @staticmethod
-    def decode_storage_key(stem: str) -> str | None:
-        """Public decoder for components that inspect canonical session filenames."""
-        return SessionManager._decode_storage_key(stem)
-
-    @classmethod
-    def _session_key_from_path(cls, path: Path) -> str | None:
-        """Decode a session key only from a canonical collision-resistant filename."""
-        return JsonlSessionStore.session_key_from_path(path)
-
-    def _get_session_path(self, key: str) -> Path:
-        """Get the collision-resistant workspace path for a session."""
-        return self._jsonl_store.get_session_path(key)
-
-    def _get_legacy_lossy_path(self, key: str) -> Path:
-        """Previous workspace session path using lossy ':' to '_' replacement."""
-        return self._jsonl_store.get_legacy_lossy_path(key)
-
-    def _get_legacy_session_path(self, key: str) -> Path:
-        """Legacy global session path (~/.nanobot/sessions/)."""
-        return self._jsonl_store.get_legacy_session_path(key)
+        return JsonlSessionFiles.safe_key(key)
 
     def get_or_create(self, key: str) -> Session:
         """
@@ -1381,14 +1170,6 @@ class SessionManager:
 
     def _load(self, key: str) -> Session | None:
         return self._store.load(key)
-
-    def _repair(self, key: str, *, path: Path | None = None) -> Session | None:
-        """Attempt to recover a session from a corrupt JSONL file."""
-        return self._jsonl_store.repair(key, path=path)
-
-    @staticmethod
-    def _session_payload(session: Session) -> SessionPayload:
-        return JsonlSessionStore.session_payload(session)
 
     def save(self, session: Session, *, fsync: bool = False) -> None:
         """Persist a session and retain it in the cache."""
@@ -1430,7 +1211,8 @@ class SessionManager:
     def delete_session(self, key: str) -> bool:
         """Delete a persisted session and invalidate its cache entry."""
         self.invalidate(key)
-        return self._store.delete(key)
+        deleted = self._store.delete(key)
+        return self._jsonl_files.delete_backups(key) or deleted
 
     def fork_session_before_user_index(
         self,
@@ -1496,5 +1278,5 @@ class SessionManager:
         """Read session metadata without loading the transcript."""
         return cast(dict[str, Any] | None, self._store.read_metadata(key))
 
-    def list_sessions(self) -> list[dict[str, Any]]:
-        return cast(list[dict[str, Any]], self._store.list_sessions())
+    def list_sessions(self) -> list[SessionInfo]:
+        return self._store.list_sessions()

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -996,7 +996,7 @@ class SQLiteSessionStore:
                     ):
                         raise
                     sleep(0.05)
-            try:
+            with connection:
                 connection.execute("BEGIN IMMEDIATE")
                 raw_version: object = connection.execute("PRAGMA user_version").fetchone()
                 if not isinstance(raw_version, tuple):
@@ -1011,7 +1011,6 @@ class SQLiteSessionStore:
                         f"expected {_SQLITE_SCHEMA_VERSION}"
                     )
                 if version == _SQLITE_SCHEMA_VERSION:
-                    connection.commit()
                     return
 
                 connection.execute(
@@ -1041,10 +1040,6 @@ class SQLiteSessionStore:
                     "CREATE INDEX sessions_updated_at ON sessions(updated_at DESC)"
                 )
                 connection.execute(f"PRAGMA user_version = {_SQLITE_SCHEMA_VERSION}")
-                connection.commit()
-            except BaseException:
-                connection.rollback()
-                raise
 
     @staticmethod
     def _encode_json(value: object) -> str:
@@ -1110,7 +1105,6 @@ class SQLiteSessionStore:
         connection: sqlite3.Connection,
         key: str,
     ) -> str:
-        preview = ""
         fallback_preview = ""
         scanned_chars = 0
         rows = connection.execute(
@@ -1142,11 +1136,10 @@ class SQLiteSessionStore:
             if not text:
                 continue
             if message.get("role") == "user":
-                preview = text
-                break
+                return text
             if not fallback_preview and message.get("role") == "assistant":
                 fallback_preview = text
-        return preview or fallback_preview
+        return fallback_preview
 
     def load(self, key: str) -> Session | None:
         with self._connection() as connection, connection:

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -50,7 +50,7 @@ _SESSION_LIST_PREVIEW_MAX_CHARS = 1_000_000
 _SESSION_DATA_ERRORS = (ValueError, TypeError, AttributeError, KeyError)
 _PROVIDER_STATE_RECORD_TYPE = "provider_state"
 _SQLITE_DB_NAME = "sessions.db"
-_SQLITE_SCHEMA_VERSION = 2
+_SQLITE_SCHEMA_VERSION = 1
 _SQLITE_BUSY_TIMEOUT_SECONDS = 5.0
 _SQLITE_STARTUP_BUSY_TIMEOUT_SECONDS = 60.0
 # TODO(0.3.2): Remove JSONL migration; v0.3.1 is the upgrade window.
@@ -820,7 +820,7 @@ class SQLiteSessionStore:
                 if len(version_row) != 1 or not isinstance(version_row[0], int):
                     raise RuntimeError("Failed to read SQLite session schema version")
                 version = version_row[0]
-                if version not in (0, 1, _SQLITE_SCHEMA_VERSION):
+                if version not in (0, _SQLITE_SCHEMA_VERSION):
                     raise RuntimeError(
                         f"Unsupported SQLite session schema version {version}; "
                         f"expected {_SQLITE_SCHEMA_VERSION}"
@@ -853,23 +853,6 @@ class SQLiteSessionStore:
                     connection.execute(
                         "CREATE INDEX sessions_updated_at ON sessions(updated_at DESC)"
                     )
-                elif version == 1:
-                    columns: set[str] = set()
-                    for raw_column in connection.execute("PRAGMA table_info(sessions)"):
-                        column: object = raw_column
-                        if not isinstance(column, tuple):
-                            continue
-                        values = cast(tuple[object, ...], column)
-                        if len(values) > 1 and isinstance(values[1], str):
-                            columns.add(values[1])
-                    if "private_metadata" not in columns:
-                        connection.execute(
-                            """
-                            ALTER TABLE sessions
-                            ADD COLUMN private_metadata TEXT NOT NULL DEFAULT '{}'
-                            """
-                        )
-
                 connection.execute(
                     """
                     CREATE TABLE IF NOT EXISTS store_metadata (
@@ -935,10 +918,7 @@ class SQLiteSessionStore:
     @staticmethod
     def _decode_migration_manifest(
         value: str,
-    ) -> dict[str, _JsonlFileSignature] | None:
-        # The original PR marker only stored the imported file count.
-        if value.isdecimal():
-            return None
+    ) -> dict[str, _JsonlFileSignature]:
         try:
             data = _json_object(json.loads(value))
             version = cast(object, data.get("version"))
@@ -1024,78 +1004,6 @@ class SQLiteSessionStore:
             signatures[key] = after
         return prepared, signatures
 
-    @classmethod
-    def _validate_legacy_migration_marker(
-        cls,
-        connection: sqlite3.Connection,
-        prepared: list[_PreparedSession],
-        expected_count: int,
-    ) -> None:
-        changed: list[str] = []
-        prepared_keys = {session.key for session in prepared}
-        stored_keys = {
-            row[0]
-            for row in connection.execute("SELECT key FROM sessions")
-            if isinstance(row[0], str)
-        }
-        if expected_count != len(prepared) or stored_keys != prepared_keys:
-            raise RuntimeError(
-                "JSONL session backups may have changed after SQLite migration. "
-                "Refusing to start to avoid losing rollback writes; preserve "
-                "sessions.db and the JSONL files before recovery."
-            )
-        for session in prepared:
-            row: object = connection.execute(
-                """
-                SELECT
-                    key,
-                    created_at,
-                    updated_at,
-                    metadata,
-                    private_metadata,
-                    last_consolidated
-                FROM sessions
-                WHERE key = ?
-                """,
-                (session.key,),
-            ).fetchone()
-            try:
-                (
-                    _,
-                    stored_created_at,
-                    stored_updated_at,
-                    stored_metadata,
-                    stored_last_consolidated,
-                    stored_provider_state,
-                ) = cls._decode_loaded_session_row(row)
-                source_metadata = cls._decode_json_object(session.metadata_json)
-                source_private = cls._decode_json_object(session.private_metadata_json)
-                source_provider_state = ProviderConversationState.from_private_record(
-                    source_private.get(_PROVIDER_STATE_RECORD_TYPE)
-                )
-                source_messages = [
-                    cls._decode_json_object(payload)
-                    for _, _, payload in session.message_rows
-                ]
-                stored_messages = cls._read_messages(connection, session.key)
-                if (
-                    session.created_at != stored_created_at
-                    or session.updated_at != stored_updated_at
-                    or source_metadata != stored_metadata
-                    or session.last_consolidated != stored_last_consolidated
-                    or source_provider_state != stored_provider_state
-                    or stored_messages != source_messages
-                ):
-                    changed.append(session.key)
-            except _SESSION_DATA_ERRORS:
-                changed.append(session.key)
-        if changed:
-            raise RuntimeError(
-                "JSONL session backups may have changed after SQLite migration for "
-                f"{len(changed)} session(s). Refusing to start to avoid losing "
-                "rollback writes; preserve sessions.db and the JSONL files before recovery."
-            )
-
     def migrate_from_jsonl(self, source: JsonlSessionFiles) -> int:
         with self._connection(
             timeout=_SQLITE_STARTUP_BUSY_TIMEOUT_SECONDS,
@@ -1103,10 +1011,9 @@ class SQLiteSessionStore:
             marker = self._read_migration_marker(connection)
             if marker is not None:
                 manifest = self._decode_migration_manifest(marker)
-                if manifest is not None:
-                    current = self._current_jsonl_signatures(source)
-                    self._assert_backups_unchanged(connection, current, manifest)
-                    return 0
+                current = self._current_jsonl_signatures(source)
+                self._assert_backups_unchanged(connection, current, manifest)
+                return 0
 
         prepared, signatures = self._prepare_jsonl_sessions(source)
         self._assert_prepared_sources_unchanged(source, signatures)
@@ -1119,22 +1026,7 @@ class SQLiteSessionStore:
             marker = self._read_migration_marker(connection)
             if marker is not None:
                 manifest = self._decode_migration_manifest(marker)
-                if manifest is not None:
-                    self._assert_backups_unchanged(connection, signatures, manifest)
-                    return 0
-
-                self._validate_legacy_migration_marker(
-                    connection,
-                    prepared,
-                    int(marker),
-                )
-                connection.execute(
-                    "UPDATE store_metadata SET value = ? WHERE key = ?",
-                    (
-                        self._encode_migration_manifest(signatures),
-                        _SQLITE_JSONL_MIGRATION_KEY,
-                    ),
-                )
+                self._assert_backups_unchanged(connection, signatures, manifest)
                 return 0
 
             existing_keys = {
@@ -1424,7 +1316,7 @@ class SQLiteSessionStore:
             marker = self._read_migration_marker(connection)
             if marker is not None:
                 manifest = self._decode_migration_manifest(marker)
-                if manifest is not None and key in manifest:
+                if key in manifest:
                     updated_manifest = dict(manifest)
                     updated_manifest.pop(key)
                     connection.execute(

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager, suppress
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime
+from hashlib import sha256
 from pathlib import Path
 from time import monotonic, sleep
 from typing import Any, Callable, Protocol, TypedDict, cast
@@ -48,13 +49,13 @@ _SESSION_LIST_PREVIEW_MAX_RECORDS = 200
 _SESSION_LIST_PREVIEW_MAX_CHARS = 1_000_000
 _SESSION_DATA_ERRORS = (ValueError, TypeError, AttributeError, KeyError)
 _PROVIDER_STATE_RECORD_TYPE = "provider_state"
-_PROVIDER_STATE_RECORD_PREFIX_RE = re.compile(
-    r'^\s*\{\s*"_type"\s*:\s*"provider_state"\s*(?:,|\})'
-)
 _SQLITE_DB_NAME = "sessions.db"
-_SQLITE_SCHEMA_VERSION = 1
+_SQLITE_SCHEMA_VERSION = 2
+_SQLITE_BUSY_TIMEOUT_SECONDS = 5.0
+_SQLITE_STARTUP_BUSY_TIMEOUT_SECONDS = 60.0
 # TODO(0.3.2): Remove JSONL migration; v0.3.1 is the upgrade window.
 _SQLITE_JSONL_MIGRATION_KEY = "jsonl_import_v1"
+_SQLITE_JSONL_MANIFEST_VERSION = 1
 _FORK_VOLATILE_METADATA_KEYS = {
     "goal_state",
     "pending_user_turn",
@@ -70,11 +71,6 @@ def _json_object(value: object) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError("session records must be JSON objects")
     return cast(dict[str, Any], value)
-
-
-def _is_provider_state_record_line(line: str) -> bool:
-    """Recognize the canonical private record without decoding its opaque payload."""
-    return _PROVIDER_STATE_RECORD_PREFIX_RE.match(line) is not None
 
 
 def replay_max_messages_for_context(context_window_tokens: int | None) -> int:
@@ -475,6 +471,22 @@ class SessionInfo(TypedDict):
     path: str
 
 
+@dataclass(frozen=True)
+class _JsonlFileSignature:
+    sha256: str
+
+
+@dataclass(frozen=True)
+class _PreparedSession:
+    key: str
+    created_at: str
+    updated_at: str
+    metadata_json: str
+    private_metadata_json: str
+    last_consolidated: int
+    message_rows: tuple[tuple[str, int, str], ...]
+
+
 class SessionStore(Protocol):
     def load(self, key: str) -> Session | None: ...
 
@@ -525,7 +537,7 @@ class JsonlSessionFiles:
         return self.sessions_dir / f"{self.storage_key(key)}.jsonl"
 
     def get_legacy_lossy_path(self, key: str) -> Path:
-        return self.sessions_dir / f"{safe_filename(key.replace(':', '_'))}.jsonl"
+        return self.sessions_dir / f"{self.safe_key(key)}.jsonl"
 
     def get_legacy_session_path(self, key: str) -> Path:
         return self.legacy_sessions_dir / f"{self.safe_key(key)}.jsonl"
@@ -537,6 +549,26 @@ class JsonlSessionFiles:
             if key is not None:
                 files.append((key, path))
         return files
+
+    @staticmethod
+    def _metadata_record_key(path: Path) -> str | None:
+        try:
+            with open(path, encoding="utf-8") as file:
+                for line in file:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    raw_data: object = json.loads(line)
+                    if not isinstance(raw_data, dict):
+                        continue
+                    data = cast(dict[object, object], raw_data)
+                    if data.get("_type") != "metadata":
+                        continue
+                    key = data.get("key")
+                    return key if isinstance(key, str) else None
+        except (OSError, *_SESSION_DATA_ERRORS):
+            return None
+        return None
 
     def load_for_migration(self, key: str) -> Session | None:
         path = self.get_session_path(key)
@@ -562,6 +594,10 @@ class JsonlSessionFiles:
 
                     record_type = data.get("_type")
                     if record_type == "metadata":
+                        if data.get("key") != key:
+                            raise ValueError(
+                                "session metadata key does not match its canonical filename"
+                            )
                         metadata_value = cast(object, data.get("metadata", {}))
                         metadata = (
                             cast(dict[str, Any], metadata_value)
@@ -613,9 +649,8 @@ class JsonlSessionFiles:
                 )
             return repaired
 
-    def _repair(self, key: str, *, path: Path | None = None) -> Session | None:
-        if path is None:
-            path = self.get_session_path(key)
+    def _repair(self, key: str) -> Session | None:
+        path = self.get_session_path(key)
         if not path.exists():
             return None
 
@@ -645,6 +680,12 @@ class JsonlSessionFiles:
 
                     record_type = data.get("_type")
                     if record_type == "metadata":
+                        if data.get("key") != key:
+                            logger.warning(
+                                "Session metadata key does not match canonical key {}",
+                                key,
+                            )
+                            return None
                         metadata_value = cast(object, data.get("metadata", {}))
                         metadata = (
                             cast(dict[str, Any], metadata_value)
@@ -696,11 +737,20 @@ class JsonlSessionFiles:
             return None
 
     def delete_backups(self, key: str) -> bool:
-        paths = [
-            self.get_session_path(key),
-            self.get_legacy_lossy_path(key),
-            self.get_legacy_session_path(key),
-        ]
+        canonical_path = self.get_session_path(key)
+        lossy_path = self.get_legacy_lossy_path(key)
+        paths = [canonical_path]
+        if lossy_path != canonical_path and lossy_path.exists():
+            canonical_owner = self.session_key_from_path(lossy_path)
+            if canonical_owner is None or canonical_owner == key:
+                paths.append(lossy_path)
+            else:
+                metadata_owner = self._metadata_record_key(lossy_path)
+                if metadata_owner != canonical_owner:
+                    raise RuntimeError(
+                        f"Refusing to delete ambiguous legacy session file {lossy_path}"
+                    )
+        paths.append(self.get_legacy_session_path(key))
         deleted = False
         for path in paths:
             if not path.exists():
@@ -710,7 +760,9 @@ class JsonlSessionFiles:
                 deleted = True
             except OSError as e:
                 logger.warning("Failed to delete session file {}: {}", path, e)
+                raise
         return deleted
+
 
 class SQLiteSessionStore:
     """SQLite implementation of session persistence."""
@@ -720,11 +772,16 @@ class SQLiteSessionStore:
         self._initialize()
 
     @contextmanager
-    def _connection(self, *, durable: bool = False) -> Generator[sqlite3.Connection]:
-        connection = sqlite3.connect(self.db_path, timeout=5.0)
+    def _connection(
+        self,
+        *,
+        durable: bool = False,
+        timeout: float = _SQLITE_BUSY_TIMEOUT_SECONDS,
+    ) -> Generator[sqlite3.Connection]:
+        connection = sqlite3.connect(self.db_path, timeout=timeout)
         try:
             connection.execute("PRAGMA foreign_keys = ON")
-            connection.execute("PRAGMA busy_timeout = 5000")
+            connection.execute(f"PRAGMA busy_timeout = {int(timeout * 1000)}")
             connection.execute(
                 "PRAGMA synchronous = FULL" if durable else "PRAGMA synchronous = NORMAL"
             )
@@ -733,8 +790,11 @@ class SQLiteSessionStore:
             connection.close()
 
     def _initialize(self) -> None:
-        with self._connection(durable=True) as connection:
-            deadline = monotonic() + 5.0
+        with self._connection(
+            durable=True,
+            timeout=_SQLITE_STARTUP_BUSY_TIMEOUT_SECONDS,
+        ) as connection:
+            deadline = monotonic() + _SQLITE_STARTUP_BUSY_TIMEOUT_SECONDS
             while True:
                 try:
                     journal_mode: object = connection.execute(
@@ -760,93 +820,348 @@ class SQLiteSessionStore:
                 if len(version_row) != 1 or not isinstance(version_row[0], int):
                     raise RuntimeError("Failed to read SQLite session schema version")
                 version = version_row[0]
-                if version not in (0, _SQLITE_SCHEMA_VERSION):
+                if version not in (0, 1, _SQLITE_SCHEMA_VERSION):
                     raise RuntimeError(
                         f"Unsupported SQLite session schema version {version}; "
                         f"expected {_SQLITE_SCHEMA_VERSION}"
                     )
-                if version == _SQLITE_SCHEMA_VERSION:
+                if version == 0:
                     connection.execute(
                         """
-                        CREATE TABLE IF NOT EXISTS store_metadata (
+                        CREATE TABLE sessions (
                             key TEXT PRIMARY KEY,
-                            value TEXT NOT NULL
+                            created_at TEXT NOT NULL,
+                            updated_at TEXT NOT NULL,
+                            metadata TEXT NOT NULL,
+                            private_metadata TEXT NOT NULL DEFAULT '{}',
+                            last_consolidated INTEGER NOT NULL DEFAULT 0
+                                CHECK (last_consolidated >= 0)
                         )
                         """
                     )
-                    return
+                    connection.execute(
+                        """
+                        CREATE TABLE messages (
+                            session_key TEXT NOT NULL,
+                            position INTEGER NOT NULL CHECK (position >= 0),
+                            payload TEXT NOT NULL,
+                            PRIMARY KEY (session_key, position),
+                            FOREIGN KEY (session_key) REFERENCES sessions(key) ON DELETE CASCADE
+                        )
+                        """
+                    )
+                    connection.execute(
+                        "CREATE INDEX sessions_updated_at ON sessions(updated_at DESC)"
+                    )
+                elif version == 1:
+                    columns: set[str] = set()
+                    for raw_column in connection.execute("PRAGMA table_info(sessions)"):
+                        column: object = raw_column
+                        if not isinstance(column, tuple):
+                            continue
+                        values = cast(tuple[object, ...], column)
+                        if len(values) > 1 and isinstance(values[1], str):
+                            columns.add(values[1])
+                    if "private_metadata" not in columns:
+                        connection.execute(
+                            """
+                            ALTER TABLE sessions
+                            ADD COLUMN private_metadata TEXT NOT NULL DEFAULT '{}'
+                            """
+                        )
 
                 connection.execute(
                     """
-                    CREATE TABLE sessions (
-                        key TEXT PRIMARY KEY,
-                        created_at TEXT NOT NULL,
-                        updated_at TEXT NOT NULL,
-                        metadata TEXT NOT NULL,
-                        last_consolidated INTEGER NOT NULL DEFAULT 0
-                            CHECK (last_consolidated >= 0)
-                    )
-                    """
-                )
-                connection.execute(
-                    """
-                    CREATE TABLE messages (
-                        session_key TEXT NOT NULL,
-                        position INTEGER NOT NULL CHECK (position >= 0),
-                        payload TEXT NOT NULL,
-                        PRIMARY KEY (session_key, position),
-                        FOREIGN KEY (session_key) REFERENCES sessions(key) ON DELETE CASCADE
-                    )
-                    """
-                )
-                connection.execute(
-                    "CREATE INDEX sessions_updated_at ON sessions(updated_at DESC)"
-                )
-                connection.execute(
-                    """
-                    CREATE TABLE store_metadata (
+                    CREATE TABLE IF NOT EXISTS store_metadata (
                         key TEXT PRIMARY KEY,
                         value TEXT NOT NULL
                     )
                     """
                 )
-                connection.execute(f"PRAGMA user_version = {_SQLITE_SCHEMA_VERSION}")
+                if version != _SQLITE_SCHEMA_VERSION:
+                    connection.execute(f"PRAGMA user_version = {_SQLITE_SCHEMA_VERSION}")
+
+    @staticmethod
+    def _file_signature(path: Path) -> _JsonlFileSignature:
+        try:
+            digest = sha256()
+            with open(path, "rb") as file:
+                while chunk := file.read(1024 * 1024):
+                    digest.update(chunk)
+        except OSError as exc:
+            raise RuntimeError(f"Failed to inspect JSONL session backup {path}") from exc
+        return _JsonlFileSignature(sha256=digest.hexdigest())
+
+    @classmethod
+    def _current_jsonl_signatures(
+        cls,
+        source: JsonlSessionFiles,
+    ) -> dict[str, _JsonlFileSignature]:
+        return {
+            key: cls._file_signature(path)
+            for key, path in source.session_files()
+        }
+
+    @staticmethod
+    def _read_migration_marker(connection: sqlite3.Connection) -> str | None:
+        row: object = connection.execute(
+            "SELECT value FROM store_metadata WHERE key = ?",
+            (_SQLITE_JSONL_MIGRATION_KEY,),
+        ).fetchone()
+        if row is None:
+            return None
+        if not isinstance(row, tuple):
+            raise RuntimeError("Invalid JSONL migration marker")
+        values = cast(tuple[object, ...], row)
+        if len(values) != 1 or not isinstance(values[0], str):
+            raise RuntimeError("Invalid JSONL migration marker")
+        return values[0]
+
+    @classmethod
+    def _encode_migration_manifest(
+        cls,
+        signatures: dict[str, _JsonlFileSignature],
+    ) -> str:
+        return cls._encode_json(
+            {
+                "version": _SQLITE_JSONL_MANIFEST_VERSION,
+                "files": {
+                    key: {"sha256": signature.sha256}
+                    for key, signature in sorted(signatures.items())
+                },
+            }
+        )
+
+    @staticmethod
+    def _decode_migration_manifest(
+        value: str,
+    ) -> dict[str, _JsonlFileSignature] | None:
+        # The original PR marker only stored the imported file count.
+        if value.isdecimal():
+            return None
+        try:
+            data = _json_object(json.loads(value))
+            version = cast(object, data.get("version"))
+            files = cast(object, data.get("files"))
+            if (
+                not isinstance(version, int)
+                or isinstance(version, bool)
+                or version != _SQLITE_JSONL_MANIFEST_VERSION
+                or not isinstance(files, dict)
+            ):
+                raise ValueError("unsupported JSONL migration manifest")
+
+            signatures: dict[str, _JsonlFileSignature] = {}
+            for raw_key, raw_signature in cast(dict[object, object], files).items():
+                if not isinstance(raw_key, str) or not isinstance(raw_signature, dict):
+                    raise ValueError("invalid JSONL migration manifest entry")
+                signature_data = cast(dict[object, object], raw_signature)
+                digest = signature_data.get("sha256")
+                if (
+                    not isinstance(digest, str)
+                    or re.fullmatch(r"[0-9a-f]{64}", digest) is None
+                ):
+                    raise ValueError("invalid JSONL migration file signature")
+                signatures[raw_key] = _JsonlFileSignature(sha256=digest)
+            return signatures
+        except _SESSION_DATA_ERRORS as exc:
+            raise RuntimeError("Invalid JSONL migration marker") from exc
+
+    @staticmethod
+    def _assert_backups_unchanged(
+        connection: sqlite3.Connection,
+        current: dict[str, _JsonlFileSignature],
+        expected: dict[str, _JsonlFileSignature],
+    ) -> None:
+        changed = {
+            key
+            for key, signature in current.items()
+            if expected.get(key) != signature
+        }
+        live_keys = {
+            row[0]
+            for row in connection.execute("SELECT key FROM sessions")
+            if isinstance(row[0], str)
+        }
+        changed.update((expected.keys() - current.keys()).intersection(live_keys))
+        if changed:
+            raise RuntimeError(
+                "JSONL session backups changed after SQLite migration for "
+                f"{len(changed)} session(s). Refusing to start to avoid losing "
+                "rollback writes; preserve sessions.db and the JSONL files before recovery."
+            )
+
+    @classmethod
+    def _assert_prepared_sources_unchanged(
+        cls,
+        source: JsonlSessionFiles,
+        expected: dict[str, _JsonlFileSignature],
+    ) -> None:
+        if cls._current_jsonl_signatures(source) != expected:
+            raise RuntimeError(
+                "JSONL session files changed while migration was being prepared; "
+                "retry startup after session writers have stopped."
+            )
+
+    def _prepare_jsonl_sessions(
+        self,
+        source: JsonlSessionFiles,
+    ) -> tuple[list[_PreparedSession], dict[str, _JsonlFileSignature]]:
+        prepared: list[_PreparedSession] = []
+        signatures: dict[str, _JsonlFileSignature] = {}
+        for key, path in source.session_files():
+            before = self._file_signature(path)
+            session = source.load_for_migration(key)
+            if session is None:
+                raise RuntimeError(f"Failed to migrate JSONL session {path}")
+            prepared_session = self._prepare_session(session)
+            after = self._file_signature(path)
+            if before != after:
+                raise RuntimeError(
+                    f"JSONL session file changed while it was being read: {path}"
+                )
+            prepared.append(prepared_session)
+            signatures[key] = after
+        return prepared, signatures
+
+    @classmethod
+    def _validate_legacy_migration_marker(
+        cls,
+        connection: sqlite3.Connection,
+        prepared: list[_PreparedSession],
+        expected_count: int,
+    ) -> None:
+        changed: list[str] = []
+        prepared_keys = {session.key for session in prepared}
+        stored_keys = {
+            row[0]
+            for row in connection.execute("SELECT key FROM sessions")
+            if isinstance(row[0], str)
+        }
+        if expected_count != len(prepared) or stored_keys != prepared_keys:
+            raise RuntimeError(
+                "JSONL session backups may have changed after SQLite migration. "
+                "Refusing to start to avoid losing rollback writes; preserve "
+                "sessions.db and the JSONL files before recovery."
+            )
+        for session in prepared:
+            row: object = connection.execute(
+                """
+                SELECT
+                    key,
+                    created_at,
+                    updated_at,
+                    metadata,
+                    private_metadata,
+                    last_consolidated
+                FROM sessions
+                WHERE key = ?
+                """,
+                (session.key,),
+            ).fetchone()
+            try:
+                (
+                    _,
+                    stored_created_at,
+                    stored_updated_at,
+                    stored_metadata,
+                    stored_last_consolidated,
+                    stored_provider_state,
+                ) = cls._decode_loaded_session_row(row)
+                source_metadata = cls._decode_json_object(session.metadata_json)
+                source_private = cls._decode_json_object(session.private_metadata_json)
+                source_provider_state = ProviderConversationState.from_private_record(
+                    source_private.get(_PROVIDER_STATE_RECORD_TYPE)
+                )
+                source_messages = [
+                    cls._decode_json_object(payload)
+                    for _, _, payload in session.message_rows
+                ]
+                stored_messages = cls._read_messages(connection, session.key)
+                if (
+                    session.created_at != stored_created_at
+                    or session.updated_at != stored_updated_at
+                    or source_metadata != stored_metadata
+                    or session.last_consolidated != stored_last_consolidated
+                    or source_provider_state != stored_provider_state
+                    or stored_messages != source_messages
+                ):
+                    changed.append(session.key)
+            except _SESSION_DATA_ERRORS:
+                changed.append(session.key)
+        if changed:
+            raise RuntimeError(
+                "JSONL session backups may have changed after SQLite migration for "
+                f"{len(changed)} session(s). Refusing to start to avoid losing "
+                "rollback writes; preserve sessions.db and the JSONL files before recovery."
+            )
 
     def migrate_from_jsonl(self, source: JsonlSessionFiles) -> int:
+        with self._connection(
+            timeout=_SQLITE_STARTUP_BUSY_TIMEOUT_SECONDS,
+        ) as connection:
+            marker = self._read_migration_marker(connection)
+            if marker is not None:
+                manifest = self._decode_migration_manifest(marker)
+                if manifest is not None:
+                    current = self._current_jsonl_signatures(source)
+                    self._assert_backups_unchanged(connection, current, manifest)
+                    return 0
+
+        prepared, signatures = self._prepare_jsonl_sessions(source)
+        self._assert_prepared_sources_unchanged(source, signatures)
         migrated_count = 0
-        with self._connection(durable=True) as connection, connection:
+        with self._connection(
+            durable=True,
+            timeout=_SQLITE_STARTUP_BUSY_TIMEOUT_SECONDS,
+        ) as connection, connection:
             connection.execute("BEGIN IMMEDIATE")
-            migrated = connection.execute(
-                "SELECT value FROM store_metadata WHERE key = ?",
-                (_SQLITE_JSONL_MIGRATION_KEY,),
-            ).fetchone()
-            if migrated is not None:
+            marker = self._read_migration_marker(connection)
+            if marker is not None:
+                manifest = self._decode_migration_manifest(marker)
+                if manifest is not None:
+                    self._assert_backups_unchanged(connection, signatures, manifest)
+                    return 0
+
+                self._validate_legacy_migration_marker(
+                    connection,
+                    prepared,
+                    int(marker),
+                )
+                connection.execute(
+                    "UPDATE store_metadata SET value = ? WHERE key = ?",
+                    (
+                        self._encode_migration_manifest(signatures),
+                        _SQLITE_JSONL_MIGRATION_KEY,
+                    ),
+                )
                 return 0
 
-            files = source.session_files()
             existing_keys = {
                 row[0]
                 for row in connection.execute("SELECT key FROM sessions")
                 if isinstance(row[0], str)
             }
-            conflicts = sorted(existing_keys.intersection(key for key, _ in files))
+            conflicts = sorted(
+                existing_keys.intersection(session.key for session in prepared)
+            )
             if conflicts:
                 raise RuntimeError(
                     "Cannot migrate JSONL sessions because SQLite already contains "
                     f"{len(conflicts)} matching session key(s)"
                 )
 
-            for key, path in files:
-                session = source.load_for_migration(key)
-                if session is None:
-                    raise RuntimeError(f"Failed to migrate JSONL session {path}")
-                self._save(connection, session)
+            for session in prepared:
+                self._save_prepared(connection, session)
 
             connection.execute(
                 "INSERT INTO store_metadata (key, value) VALUES (?, ?)",
-                (_SQLITE_JSONL_MIGRATION_KEY, str(len(files))),
+                (
+                    _SQLITE_JSONL_MIGRATION_KEY,
+                    self._encode_migration_manifest(signatures),
+                ),
             )
-            migrated_count = len(files)
+            migrated_count = len(prepared)
 
         if migrated_count:
             logger.info("Migrated {} JSONL session(s) to SQLite", migrated_count)
@@ -890,6 +1205,42 @@ class SQLiteSessionStore:
         )
 
     @classmethod
+    def _decode_loaded_session_row(
+        cls,
+        row: object,
+    ) -> tuple[
+        str,
+        str,
+        str,
+        dict[str, Any],
+        int,
+        ProviderConversationState | None,
+    ]:
+        if not isinstance(row, tuple):
+            raise ValueError("Invalid SQLite session row")
+        values = cast(tuple[object, ...], row)
+        if len(values) != 6:
+            raise ValueError("Invalid SQLite session row")
+        key, created_at, updated_at, metadata_json, private_metadata_json, offset = values
+        stored_key, created_at_text, updated_at_text, metadata, last_consolidated = (
+            cls._decode_session_row(
+                (key, created_at, updated_at, metadata_json, offset)
+            )
+        )
+        private_metadata = cls._decode_json_object(private_metadata_json)
+        provider_state = ProviderConversationState.from_private_record(
+            private_metadata.get(_PROVIDER_STATE_RECORD_TYPE)
+        )
+        return (
+            stored_key,
+            created_at_text,
+            updated_at_text,
+            metadata,
+            last_consolidated,
+            provider_state,
+        )
+
+    @classmethod
     def _read_messages(
         cls,
         connection: sqlite3.Connection,
@@ -926,9 +1277,9 @@ class SQLiteSessionStore:
             ORDER BY position
             LIMIT ?
             """,
-            (key, _SESSION_LIST_PREVIEW_MAX_RECORDS + 1),
+            (key, _SESSION_LIST_PREVIEW_MAX_RECORDS),
         )
-        for index, raw_row in enumerate(rows, start=1):
+        for raw_row in rows:
             row: object = raw_row
             if not isinstance(row, tuple):
                 raise ValueError("Invalid SQLite message row")
@@ -937,10 +1288,7 @@ class SQLiteSessionStore:
                 raise ValueError("Invalid SQLite message row")
             payload = values[0]
             scanned_chars += len(payload) + 1
-            if (
-                index > _SESSION_LIST_PREVIEW_MAX_RECORDS
-                or scanned_chars > _SESSION_LIST_PREVIEW_MAX_CHARS
-            ):
+            if scanned_chars > _SESSION_LIST_PREVIEW_MAX_CHARS:
                 break
             message = cls._decode_json_object(payload)
             if is_hidden_history_message(message):
@@ -959,7 +1307,13 @@ class SQLiteSessionStore:
             connection.execute("BEGIN")
             row: object = connection.execute(
                 """
-                SELECT key, created_at, updated_at, metadata, last_consolidated
+                SELECT
+                    key,
+                    created_at,
+                    updated_at,
+                    metadata,
+                    private_metadata,
+                    last_consolidated
                 FROM sessions
                 WHERE key = ?
                 """,
@@ -968,9 +1322,14 @@ class SQLiteSessionStore:
             if row is None:
                 return None
             try:
-                stored_key, created_at, updated_at, metadata, last_consolidated = (
-                    self._decode_session_row(row)
-                )
+                (
+                    stored_key,
+                    created_at,
+                    updated_at,
+                    metadata,
+                    last_consolidated,
+                    provider_state,
+                ) = self._decode_loaded_session_row(row)
                 messages = self._read_messages(connection, stored_key)
                 return Session(
                     key=stored_key,
@@ -979,38 +1338,74 @@ class SQLiteSessionStore:
                     updated_at=datetime.fromisoformat(updated_at),
                     metadata=metadata,
                     last_consolidated=last_consolidated,
+                    provider_state=provider_state,
                 )
             except _SESSION_DATA_ERRORS as exc:
                 logger.warning("Failed to load SQLite session {}: {}", key, exc)
-                return None
+                raise RuntimeError(f"Failed to load SQLite session {key}") from exc
 
     def save(self, session: Session, *, fsync: bool = False) -> None:
+        prepared = self._prepare_session(session)
         with self._connection(durable=fsync) as connection, connection:
-            self._save(connection, session)
+            self._save_prepared(connection, prepared)
 
-    def _save(self, connection: sqlite3.Connection, session: Session) -> None:
-        metadata_json = self._encode_json(session.metadata)
-        message_rows = [
-            (session.key, position, self._encode_json(message))
+    @classmethod
+    def _prepare_session(cls, session: Session) -> _PreparedSession:
+        metadata_json = cls._encode_json(session.metadata)
+        private_metadata_json = cls._encode_json(
+            {
+                _PROVIDER_STATE_RECORD_TYPE: session.provider_state.to_private_record()
+            }
+            if session.provider_state is not None
+            else {}
+        )
+        message_rows = tuple(
+            (
+                session.key,
+                position,
+                cls._encode_json(_json_object(cast(object, message))),
+            )
             for position, message in enumerate(session.messages)
-        ]
+        )
+        return _PreparedSession(
+            key=session.key,
+            created_at=session.created_at.isoformat(),
+            updated_at=session.updated_at.isoformat(),
+            metadata_json=metadata_json,
+            private_metadata_json=private_metadata_json,
+            last_consolidated=session.last_consolidated,
+            message_rows=message_rows,
+        )
+
+    @staticmethod
+    def _save_prepared(
+        connection: sqlite3.Connection,
+        session: _PreparedSession,
+    ) -> None:
         connection.execute(
             """
             INSERT INTO sessions (
-                key, created_at, updated_at, metadata, last_consolidated
+                key,
+                created_at,
+                updated_at,
+                metadata,
+                private_metadata,
+                last_consolidated
             )
-            VALUES (?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?)
             ON CONFLICT(key) DO UPDATE SET
                 created_at = excluded.created_at,
                 updated_at = excluded.updated_at,
                 metadata = excluded.metadata,
+                private_metadata = excluded.private_metadata,
                 last_consolidated = excluded.last_consolidated
             """,
             (
                 session.key,
-                session.created_at.isoformat(),
-                session.updated_at.isoformat(),
-                metadata_json,
+                session.created_at,
+                session.updated_at,
+                session.metadata_json,
+                session.private_metadata_json,
                 session.last_consolidated,
             ),
         )
@@ -1020,11 +1415,25 @@ class SQLiteSessionStore:
             INSERT INTO messages (session_key, position, payload)
             VALUES (?, ?, ?)
             """,
-            message_rows,
+            session.message_rows,
         )
 
     def delete(self, key: str) -> bool:
         with self._connection() as connection, connection:
+            connection.execute("BEGIN IMMEDIATE")
+            marker = self._read_migration_marker(connection)
+            if marker is not None:
+                manifest = self._decode_migration_manifest(marker)
+                if manifest is not None and key in manifest:
+                    updated_manifest = dict(manifest)
+                    updated_manifest.pop(key)
+                    connection.execute(
+                        "UPDATE store_metadata SET value = ? WHERE key = ?",
+                        (
+                            self._encode_migration_manifest(updated_manifest),
+                            _SQLITE_JSONL_MIGRATION_KEY,
+                        ),
+                    )
             cursor = connection.execute("DELETE FROM sessions WHERE key = ?", (key,))
             return cursor.rowcount > 0
 
@@ -1056,7 +1465,9 @@ class SQLiteSessionStore:
                 stored_key, created_at, updated_at, metadata, _ = self._decode_session_row(row)
             except _SESSION_DATA_ERRORS as exc:
                 logger.warning("Failed to read SQLite session metadata {}: {}", key, exc)
-                return None
+                raise RuntimeError(
+                    f"Failed to read SQLite session metadata {key}"
+                ) from exc
             return {
                 "key": stored_key,
                 "created_at": created_at,
@@ -1082,7 +1493,7 @@ class SQLiteSessionStore:
                     preview = self._preview(connection, key)
                 except _SESSION_DATA_ERRORS as exc:
                     logger.warning("Failed to list SQLite session: {}", exc)
-                    continue
+                    raise RuntimeError("Failed to list SQLite sessions") from exc
                 sessions.append(
                     {
                         "key": key,
@@ -1212,8 +1623,9 @@ class SessionManager:
     def delete_session(self, key: str) -> bool:
         """Delete a persisted session and invalidate its cache entry."""
         self.invalidate(key)
+        backup_deleted = self._jsonl_files.delete_backups(key)
         deleted = self._store.delete(key)
-        return self._jsonl_files.delete_backups(key) or deleted
+        return backup_deleted or deleted
 
     def fork_session_before_user_index(
         self,

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -53,7 +53,7 @@ _PROVIDER_STATE_RECORD_PREFIX_RE = re.compile(
 )
 _SQLITE_DB_NAME = "sessions.db"
 _SQLITE_SCHEMA_VERSION = 1
-# TODO(0.3.2): Remove JSONL migration after v0.3.1 users have upgraded.
+# TODO(0.3.2): Remove JSONL migration; v0.3.1 is the upgrade window.
 _SQLITE_JSONL_MIGRATION_KEY = "jsonl_import_v1"
 _FORK_VOLATILE_METADATA_KEYS = {
     "goal_state",

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -53,6 +53,7 @@ _PROVIDER_STATE_RECORD_PREFIX_RE = re.compile(
 )
 _SQLITE_DB_NAME = "sessions.db"
 _SQLITE_SCHEMA_VERSION = 1
+# TODO(0.3.2): Remove JSONL migration after v0.3.1 users have upgraded.
 _SQLITE_JSONL_MIGRATION_KEY = "jsonl_import_v1"
 _FORK_VOLATILE_METADATA_KEYS = {
     "goal_state",

--- a/nanobot/webui/session_list_index.py
+++ b/nanobot/webui/session_list_index.py
@@ -13,12 +13,10 @@ from loguru import logger
 from nanobot.config.paths import get_webui_dir
 from nanobot.session.history_visibility import is_hidden_history_message
 from nanobot.session.manager import (
-    _PROVIDER_STATE_RECORD_TYPE,  # pyright: ignore[reportPrivateUsage]
     _SESSION_LIST_PREVIEW_MAX_CHARS,  # pyright: ignore[reportPrivateUsage]
     _SESSION_LIST_PREVIEW_MAX_RECORDS,  # pyright: ignore[reportPrivateUsage]
     SessionInfo,
     SessionManager,
-    _is_provider_state_record_line,  # pyright: ignore[reportPrivateUsage]
     _message_preview_text,  # pyright: ignore[reportPrivateUsage]
 )
 
@@ -55,13 +53,11 @@ def _reconcile_index(session_manager: SessionManager) -> tuple[list[dict[str, An
 
     for stored in session_manager.list_sessions():
         key = stored["key"]
-        model_preset = stored["model_preset"]
         activity_signature = _webui_activity_signature(key)
         row = existing_by_key.get(key)
         if row is not None and _indexed_row_matches(
             row,
             stored,
-            model_preset,
             activity_signature,
         ):
             rows.append(row)
@@ -85,13 +81,10 @@ def _reconcile_index(session_manager: SessionManager) -> tuple[list[dict[str, An
             _indexed_row(
                 stored,
                 messages,
-                model_preset,
                 activity_signature,
             )
         )
 
-    if set(existing_by_key) != {row["key"] for row in rows}:
-        changed = True
     if existing_rows is not None and rows != existing_rows:
         changed = True
     return rows, changed
@@ -138,7 +131,6 @@ def _write_index_rows(sessions_dir: Path, rows: list[dict[str, Any]]) -> None:
 def _indexed_row_matches(
     row: dict[str, Any],
     stored: SessionInfo,
-    model_preset: str | None,
     activity_signature: dict[str, int],
 ) -> bool:
     text_fields = (
@@ -160,7 +152,7 @@ def _indexed_row_matches(
         and row.get("title") == stored["title"]
         and row.get(_STORED_PREVIEW) == stored["preview"]
         and row.get("path") == stored["path"]
-        and row.get(_MODEL_PRESET_FIELD) == model_preset
+        and row.get(_MODEL_PRESET_FIELD) == stored["model_preset"]
         and row.get(_WEBUI_ACTIVITY_MTIME_NS)
         == activity_signature[_WEBUI_ACTIVITY_MTIME_NS]
         and row.get(_WEBUI_ACTIVITY_SIZE) == activity_signature[_WEBUI_ACTIVITY_SIZE]
@@ -274,7 +266,6 @@ def _visible_activity_updated_at(
 def _indexed_row(
     stored: SessionInfo,
     messages: list[dict[str, Any]],
-    model_preset: str | None,
     activity_signature: dict[str, int],
 ) -> dict[str, Any]:
     return {
@@ -287,7 +278,7 @@ def _indexed_row(
         ),
         "title": stored["title"],
         "preview": _preview_from_messages(messages),
-        _MODEL_PRESET_FIELD: model_preset,
+        _MODEL_PRESET_FIELD: stored["model_preset"],
         "path": stored["path"],
         _STORED_UPDATED_AT: stored["updated_at"],
         _STORED_PREVIEW: stored["preview"],

--- a/nanobot/webui/session_list_index.py
+++ b/nanobot/webui/session_list_index.py
@@ -1,9 +1,4 @@
-"""Cache-only WebUI session list index.
-
-The core ``SessionManager`` owns durable conversation history. This module owns
-the WebUI sidebar optimization so core session writes stay independent from UI
-presentation caches.
-"""
+"""Cache-only WebUI session list index."""
 
 from __future__ import annotations
 
@@ -21,61 +16,81 @@ from nanobot.session.manager import (
     _PROVIDER_STATE_RECORD_TYPE,  # pyright: ignore[reportPrivateUsage]
     _SESSION_LIST_PREVIEW_MAX_CHARS,  # pyright: ignore[reportPrivateUsage]
     _SESSION_LIST_PREVIEW_MAX_RECORDS,  # pyright: ignore[reportPrivateUsage]
-    Session,
+    SessionInfo,
     SessionManager,
     _is_provider_state_record_line,  # pyright: ignore[reportPrivateUsage]
     _message_preview_text,  # pyright: ignore[reportPrivateUsage]
-    _metadata_title,  # pyright: ignore[reportPrivateUsage]
 )
-from nanobot.session.model_selection import model_preset_from_metadata
 
-_INDEX_VERSION = 4
+_INDEX_VERSION = 5
 _INDEX_FILENAME = ".webui_session_index.json"
 _MODEL_PRESET_FIELD = "model_preset"
+_STORED_UPDATED_AT = "stored_updated_at"
+_STORED_PREVIEW = "stored_preview"
 _WEBUI_ACTIVITY_MTIME_NS = "webui_activity_mtime_ns"
 _WEBUI_ACTIVITY_SIZE = "webui_activity_size"
 _VISIBLE_TRANSCRIPT_ROLES = {"user", "assistant"}
 
 
 def list_webui_sessions(session_manager: SessionManager) -> list[dict[str, Any]]:
-    """Return session rows for the WebUI sidebar, backed by a rebuildable cache."""
+    index_dir = session_manager.workspace / "sessions"
     rows, changed = _reconcile_index(session_manager)
     if changed:
         try:
-            _write_index_rows(session_manager.sessions_dir, rows)
+            _write_index_rows(index_dir, rows)
         except Exception as e:
             logger.debug("Failed to write WebUI session list index: {}", e)
-    sessions = [_public_row(session_manager.sessions_dir, row) for row in rows]
-    return sorted(sessions, key=lambda row: row.get("updated_at", ""), reverse=True)
+    return sorted((_public_row(row) for row in rows), key=lambda row: row["updated_at"], reverse=True)
 
 
 def _reconcile_index(session_manager: SessionManager) -> tuple[list[dict[str, Any]], bool]:
-    existing_rows = _read_index_rows(session_manager.sessions_dir)
-    existing_by_file = {
-        row.get("file"): row
+    existing_rows = _read_index_rows(session_manager.workspace / "sessions")
+    existing_by_key = {
+        row.get("key"): row
         for row in existing_rows or []
-        if isinstance(row.get("file"), str)
+        if isinstance(row.get("key"), str)
     }
-    paths = sorted(
-        path
-        for path in session_manager.sessions_dir.glob("*.jsonl")
-        if SessionManager._session_key_from_path(path) is not None  # pyright: ignore[reportPrivateUsage]
-    )
     rows: list[dict[str, Any]] = []
     changed = existing_rows is None
 
-    for path in paths:
-        row = existing_by_file.get(path.name)
-        if row is not None and _indexed_row_matches_file(row, path):
+    for stored in session_manager.list_sessions():
+        key = stored["key"]
+        model_preset = stored["model_preset"]
+        activity_signature = _webui_activity_signature(key)
+        row = existing_by_key.get(key)
+        if row is not None and _indexed_row_matches(
+            row,
+            stored,
+            model_preset,
+            activity_signature,
+        ):
             rows.append(row)
             continue
 
         changed = True
-        scanned = _scan_session_row(session_manager, path)
-        if scanned is not None:
-            rows.append(scanned)
+        payload = session_manager.read_session_file(key)
+        if payload is None:
+            continue
+        raw_messages: object = payload.get("messages", [])
+        messages = (
+            [
+                cast(dict[str, Any], message)
+                for message in cast(list[object], raw_messages)
+                if isinstance(message, dict)
+            ]
+            if isinstance(raw_messages, list)
+            else []
+        )
+        rows.append(
+            _indexed_row(
+                stored,
+                messages,
+                model_preset,
+                activity_signature,
+            )
+        )
 
-    if set(existing_by_file) != {path.name for path in paths}:
+    if set(existing_by_key) != {row["key"] for row in rows}:
         changed = True
     if existing_rows is not None and rows != existing_rows:
         changed = True
@@ -91,21 +106,21 @@ def _read_index_rows(sessions_dir: Path) -> list[dict[str, Any]] | None:
     if not path.is_file():
         return None
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
+        raw_data: object = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
-    if not isinstance(data, dict):
+    if not isinstance(raw_data, dict):
         return None
-    index_data = cast(dict[str, Any], data)
-    if index_data.get("version") != _INDEX_VERSION:
+    data = cast(dict[str, Any], raw_data)
+    if data.get("version") != _INDEX_VERSION:
         return None
-    rows = index_data.get("sessions")
-    if not isinstance(rows, list):
+    raw_rows: object = data.get("sessions")
+    if not isinstance(raw_rows, list):
         return None
-    index_rows = cast(list[Any], rows)
-    if not all(isinstance(row, dict) for row in index_rows):
+    rows = cast(list[object], raw_rows)
+    if not all(isinstance(row, dict) for row in rows):
         return None
-    return [cast(dict[str, Any], row) for row in index_rows]
+    return [cast(dict[str, Any], row) for row in rows]
 
 
 def _write_index_rows(sessions_dir: Path, rows: list[dict[str, Any]]) -> None:
@@ -120,32 +135,39 @@ def _write_index_rows(sessions_dir: Path, rows: list[dict[str, Any]]) -> None:
         raise
 
 
-def _file_signature(path: Path) -> dict[str, int]:
-    stat = path.stat()
-    return {"mtime_ns": stat.st_mtime_ns, "size": stat.st_size}
-
-
-def _indexed_row_matches_file(row: dict[str, Any], path: Path) -> bool:
-    if not all(isinstance(row.get(key), str) for key in ("key", "created_at", "updated_at")):
+def _indexed_row_matches(
+    row: dict[str, Any],
+    stored: SessionInfo,
+    model_preset: str | None,
+    activity_signature: dict[str, int],
+) -> bool:
+    text_fields = (
+        "key",
+        "created_at",
+        "updated_at",
+        "title",
+        "preview",
+        "path",
+        _STORED_UPDATED_AT,
+        _STORED_PREVIEW,
+    )
+    if not all(isinstance(row.get(field), str) for field in text_fields):
         return False
-    if not isinstance(row.get("title", ""), str) or not isinstance(row.get("preview", ""), str):
-        return False
-    if row.get("file") != path.name:
-        return False
-    try:
-        signature = _file_signature(path)
-    except OSError:
-        return False
-    activity_signature = _webui_activity_signature(str(row.get("key")))
     return (
-        row.get("mtime_ns") == signature["mtime_ns"]
-        and row.get("size") == signature["size"]
-        and row.get(_WEBUI_ACTIVITY_MTIME_NS) == activity_signature[_WEBUI_ACTIVITY_MTIME_NS]
+        row.get("key") == stored["key"]
+        and row.get("created_at") == stored["created_at"]
+        and row.get(_STORED_UPDATED_AT) == stored["updated_at"]
+        and row.get("title") == stored["title"]
+        and row.get(_STORED_PREVIEW) == stored["preview"]
+        and row.get("path") == stored["path"]
+        and row.get(_MODEL_PRESET_FIELD) == model_preset
+        and row.get(_WEBUI_ACTIVITY_MTIME_NS)
+        == activity_signature[_WEBUI_ACTIVITY_MTIME_NS]
         and row.get(_WEBUI_ACTIVITY_SIZE) == activity_signature[_WEBUI_ACTIVITY_SIZE]
     )
 
 
-def _public_row(sessions_dir: Path, row: dict[str, Any]) -> dict[str, Any]:
+def _public_row(row: dict[str, Any]) -> dict[str, Any]:
     return {
         "key": row.get("key"),
         "created_at": row.get("created_at"),
@@ -153,7 +175,7 @@ def _public_row(sessions_dir: Path, row: dict[str, Any]) -> dict[str, Any]:
         "title": row.get("title", ""),
         "preview": row.get("preview", ""),
         _MODEL_PRESET_FIELD: row.get(_MODEL_PRESET_FIELD),
-        "path": str(sessions_dir / str(row.get("file", ""))),
+        "path": row.get("path", ""),
     }
 
 
@@ -184,10 +206,7 @@ def _preview_from_messages(messages: list[dict[str, Any]]) -> str:
 def _webui_activity_paths(session_key: str) -> list[Path]:
     stem = SessionManager.safe_key(session_key)
     webui_dir = get_webui_dir()
-    return [
-        webui_dir / f"{stem}.jsonl",
-        webui_dir / f"{stem}.json",
-    ]
+    return [webui_dir / f"{stem}.jsonl", webui_dir / f"{stem}.json"]
 
 
 def _webui_activity_signature(session_key: str) -> dict[str, int]:
@@ -231,9 +250,7 @@ def _latest_updated_at(stored: str | None, activity: str | None) -> str | None:
 
 
 def _visible_message_timestamp(item: dict[str, Any]) -> str | None:
-    if is_hidden_history_message(item):
-        return None
-    if item.get("role") not in _VISIBLE_TRANSCRIPT_ROLES:
+    if is_hidden_history_message(item) or item.get("role") not in _VISIBLE_TRANSCRIPT_ROLES:
         return None
     timestamp = item.get("timestamp")
     return timestamp if isinstance(timestamp, str) else None
@@ -242,9 +259,7 @@ def _visible_message_timestamp(item: dict[str, Any]) -> str | None:
 def _last_visible_message_at(messages: list[dict[str, Any]]) -> str | None:
     latest: str | None = None
     for item in messages:
-        timestamp = _visible_message_timestamp(item)
-        if timestamp is not None:
-            latest = _latest_updated_at(latest, timestamp)
+        latest = _latest_updated_at(latest, _visible_message_timestamp(item))
     return latest
 
 
@@ -256,108 +271,25 @@ def _visible_activity_updated_at(
     return _latest_updated_at(visible_message_at, webui_activity) or stored
 
 
-def _indexed_row_for_session(session: Session, path: Path) -> dict[str, Any]:
-    signature = _file_signature(path)
-    activity_signature = _webui_activity_signature(session.key)
-    activity_updated_at = _webui_activity_updated_at(activity_signature)
-    visible_message_at = _last_visible_message_at(session.messages)
+def _indexed_row(
+    stored: SessionInfo,
+    messages: list[dict[str, Any]],
+    model_preset: str | None,
+    activity_signature: dict[str, int],
+) -> dict[str, Any]:
     return {
-        "key": session.key,
-        "created_at": session.created_at.isoformat(),
+        "key": stored["key"],
+        "created_at": stored["created_at"],
         "updated_at": _visible_activity_updated_at(
-            session.updated_at.isoformat(),
-            visible_message_at,
-            activity_updated_at,
+            stored["updated_at"],
+            _last_visible_message_at(messages),
+            _webui_activity_updated_at(activity_signature),
         ),
-        "title": _metadata_title(session.metadata),
-        "preview": _preview_from_messages(session.messages),
-        _MODEL_PRESET_FIELD: model_preset_from_metadata(session.metadata),
-        "file": path.name,
-        "mtime_ns": signature["mtime_ns"],
-        "size": signature["size"],
+        "title": stored["title"],
+        "preview": _preview_from_messages(messages),
+        _MODEL_PRESET_FIELD: model_preset,
+        "path": stored["path"],
+        _STORED_UPDATED_AT: stored["updated_at"],
+        _STORED_PREVIEW: stored["preview"],
         **activity_signature,
     }
-
-
-def _scan_session_row(session_manager: SessionManager, path: Path) -> dict[str, Any] | None:
-    storage_key = SessionManager._session_key_from_path(path)  # pyright: ignore[reportPrivateUsage]
-    if storage_key is None:
-        return None
-    try:
-        with open(path, encoding="utf-8") as f:
-            first_line = f.readline().strip()
-            if not first_line:
-                return None
-            data = json.loads(first_line)
-            if data.get("_type") != "metadata":
-                return None
-            preview = ""
-            fallback_preview = ""
-            visible_message_at = None
-            preview_done = False
-            scanned_records = 0
-            scanned_chars = 0
-            for line in f:
-                if not line.strip():
-                    continue
-                if _is_provider_state_record_line(line):
-                    continue
-                item = json.loads(line)
-                if item.get("_type") == _PROVIDER_STATE_RECORD_TYPE:
-                    continue
-                timestamp = _visible_message_timestamp(item)
-                if timestamp is not None:
-                    visible_message_at = _latest_updated_at(visible_message_at, timestamp)
-                if not preview_done:
-                    scanned_records += 1
-                    scanned_chars += len(line)
-                    if (
-                        scanned_records > _SESSION_LIST_PREVIEW_MAX_RECORDS
-                        or scanned_chars > _SESSION_LIST_PREVIEW_MAX_CHARS
-                    ):
-                        preview_done = True
-                        continue
-                    if item.get("_type") == "metadata":
-                        continue
-                    if is_hidden_history_message(item):
-                        continue
-                    text = _message_preview_text(item)
-                    if not text:
-                        continue
-                    if item.get("role") == "user":
-                        preview = text
-                        preview_done = True
-                        continue
-                    if not fallback_preview and item.get("role") == "assistant":
-                        fallback_preview = text
-            signature = _file_signature(path)
-            created_at_s = data.get("created_at")
-            updated_at_s = data.get("updated_at")
-            if not created_at_s or not updated_at_s:
-                fallback_time = datetime.fromtimestamp(signature["mtime_ns"] / 1e9).isoformat()
-                created_at_s = created_at_s or fallback_time
-                updated_at_s = updated_at_s or fallback_time
-            key = data.get("key") or storage_key
-            activity_signature = _webui_activity_signature(key)
-            activity_updated_at = _webui_activity_updated_at(activity_signature)
-            return {
-                "key": key,
-                "created_at": created_at_s,
-                "updated_at": _visible_activity_updated_at(
-                    updated_at_s,
-                    visible_message_at,
-                    activity_updated_at,
-                ),
-                "title": _metadata_title(data.get("metadata", {})),
-                "preview": preview or fallback_preview,
-                _MODEL_PRESET_FIELD: model_preset_from_metadata(data.get("metadata", {})),
-                "file": path.name,
-                "mtime_ns": signature["mtime_ns"],
-                "size": signature["size"],
-                **activity_signature,
-            }
-    except Exception:
-        repaired = session_manager._repair(storage_key)  # pyright: ignore[reportPrivateUsage]
-        if repaired is None:
-            return None
-        return _indexed_row_for_session(repaired, path)

--- a/tests/agent/test_auto_compact.py
+++ b/tests/agent/test_auto_compact.py
@@ -856,15 +856,14 @@ class TestProactiveAutoCompact:
         healthy.add_message("user", "keep me")
         loop.sessions.save(healthy)
 
-        removed_path = loop.sessions._get_session_path(removed.key)
-        original_open = open
+        original_list = loop.sessions.list_sessions
 
-        def remove_before_open(path, *args, **kwargs):
-            if Path(path) == removed_path:
-                removed_path.unlink()
-            return original_open(path, *args, **kwargs)
+        def remove_after_listing():
+            rows = original_list()
+            loop.sessions.delete_session(removed.key)
+            return rows
 
-        monkeypatch.setattr("builtins.open", remove_before_open)
+        monkeypatch.setattr(loop.sessions, "list_sessions", remove_after_listing)
 
         async def idle_once():
             loop._running = False
@@ -874,7 +873,7 @@ class TestProactiveAutoCompact:
 
         await loop.run()
 
-        assert [row["key"] for row in loop.sessions.list_sessions()] == ["cli:healthy"]
+        assert [row["key"] for row in original_list()] == ["cli:healthy"]
 
     @pytest.mark.asyncio
     async def test_no_check_when_ttl_disabled(self, tmp_path):

--- a/tests/agent/test_dream_session.py
+++ b/tests/agent/test_dream_session.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from unittest.mock import patch
 
 from nanobot.agent.memory import MemoryStore
-from nanobot.session.manager import SessionManager
+from nanobot.session.manager import Session, SessionManager
 
 
 class TestDreamSessionKey:
@@ -26,79 +26,54 @@ class TestDreamSessionKey:
 
 class TestPruneDreamSessions:
     def test_keeps_n_most_recent(self, tmp_path):
-        import os
-        import time
-
-        sessions_dir = tmp_path / "sessions"
-        sessions_dir.mkdir()
-
-        base_time = time.time() - 100
-        dream_paths = []
-
+        manager = SessionManager(tmp_path)
         for i in range(15):
             key = f"dream:20260528-{100000 + i:06d}"
-            path = sessions_dir / f"{SessionManager._storage_key(key)}.jsonl"
-            path.write_text(
-                f'{{"_type": "metadata", "key": "{key}", '
-                f'"created_at": "2026-05-28T10:00:{i:02d}", '
-                f'"updated_at": "2026-05-28T10:00:{i:02d}"}}\n',
-                encoding="utf-8",
+            manager.save(
+                Session(
+                    key=key,
+                    created_at=datetime(2026, 5, 28, 10, 0, i),
+                    updated_at=datetime(2026, 5, 28, 10, 0, i),
+                )
             )
-            os.utime(path, (base_time + i, base_time + i))
-            dream_paths.append(path)
+        manager.save(Session(key="telegram:123"))
 
-        normal_path = sessions_dir / "telegram_123.jsonl"
-        normal_path.write_text('{"_type": "metadata"}\n', encoding="utf-8")
+        MemoryStore.prune_dream_sessions(manager, keep=10)
 
-        MemoryStore.prune_dream_sessions(sessions_dir, keep=10)
+        keys = {row["key"] for row in manager.list_sessions()}
+        assert keys == {
+            "telegram:123",
+            *(f"dream:20260528-{100000 + i:06d}" for i in range(5, 15)),
+        }
 
-        assert [path.exists() for path in dream_paths] == [False] * 5 + [True] * 10
-        assert normal_path.exists()
-
-    def test_ignores_legacy_dream_filenames(self, tmp_path):
-        import os
-        import time
-
-        sessions_dir = tmp_path / "sessions"
-        sessions_dir.mkdir()
-        base_time = time.time() - 100
-        current_paths = []
-
+    def test_ignores_non_dream_session_keys(self, tmp_path):
+        manager = SessionManager(tmp_path)
         for i in range(2):
             key = f"dream:20260713-{100000 + i:06d}"
-            path = sessions_dir / f"{SessionManager._storage_key(key)}.jsonl"
-            path.write_text(
-                f'{{"_type": "metadata", "key": "{key}"}}\n',
-                encoding="utf-8",
+            manager.save(
+                Session(
+                    key=key,
+                    updated_at=datetime(2026, 7, 13, 10, 0, i),
+                )
             )
-            os.utime(path, (base_time + i, base_time + i))
-            current_paths.append(path)
+        manager.save(Session(key="dream_20260713-095959"))
 
-        legacy_path = sessions_dir / "dream_20260713-095959.jsonl"
-        legacy_path.write_text(
-            '{"_type": "metadata", "key": "dream:20260713-095959"}\n',
-            encoding="utf-8",
-        )
-        os.utime(legacy_path, (base_time - 1, base_time - 1))
+        MemoryStore.prune_dream_sessions(manager, keep=1)
 
-        MemoryStore.prune_dream_sessions(sessions_dir, keep=1)
-
-        assert [path.exists() for path in current_paths] == [False, True]
-        assert legacy_path.exists()
+        assert manager.read_session_file("dream:20260713-100000") is None
+        assert manager.read_session_file("dream:20260713-100001") is not None
+        assert manager.read_session_file("dream_20260713-095959") is not None
 
     def test_noop_when_under_limit(self, tmp_path):
-        sessions_dir = tmp_path / "sessions"
-        sessions_dir.mkdir()
+        manager = SessionManager(tmp_path)
         for i in range(3):
             key = f"dream:20260528-{100000 + i:06d}"
-            path = sessions_dir / f"{SessionManager._storage_key(key)}.jsonl"
-            path.write_text("{}", encoding="utf-8")
+            manager.save(Session(key=key))
 
-        MemoryStore.prune_dream_sessions(sessions_dir, keep=10)
-        assert len(list(sessions_dir.glob("*.jsonl"))) == 3
+        MemoryStore.prune_dream_sessions(manager, keep=10)
+        assert len(manager.list_sessions()) == 3
 
     def test_empty_dir_noop(self, tmp_path):
-        sessions_dir = tmp_path / "sessions"
-        sessions_dir.mkdir()
-        MemoryStore.prune_dream_sessions(sessions_dir, keep=10)
-        assert list(sessions_dir.iterdir()) == []
+        manager = SessionManager(tmp_path)
+        MemoryStore.prune_dream_sessions(manager, keep=10)
+        assert manager.list_sessions() == []

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -771,8 +771,9 @@ async def test_runtime_checkpoint_keeps_provider_state_out_of_public_metadata(
     public_payload = loop.sessions.read_session_file(session.key)
     assert public_payload is not None
     assert "private-checkpoint-blob" not in json.dumps(public_payload)
-    raw = loop.sessions._get_session_path(session.key).read_text(encoding="utf-8")
-    assert "private-checkpoint-blob" in raw
+    loop.sessions.invalidate(session.key)
+    persisted = loop.sessions.get_or_create(session.key)
+    assert persisted.provider_state == state
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_session_atomic.py
+++ b/tests/agent/test_session_atomic.py
@@ -1,396 +1,147 @@
-"""Tests for atomic session save and corrupt-file repair."""
+"""Session persistence and JSONL recovery tests."""
 
 import json
 from datetime import datetime
 from pathlib import Path
 
-from nanobot.providers.base import ProviderConversationState
-from nanobot.session.manager import Session, SessionManager
+import pytest
+
+from nanobot.session.manager import JsonlSessionFiles, Session, SessionManager
 
 
-class TestAtomicSave:
-    def test_save_creates_valid_jsonl(self, tmp_path: Path):
-        mgr = SessionManager(tmp_path)
-        session = Session(key="test:1")
-        session.add_message("user", "hello")
-        session.add_message("assistant", "hi")
+def _write_jsonl(workspace: Path, key: str, lines: list[str]) -> Path:
+    path = JsonlSessionFiles(workspace).get_session_path(key)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
 
-        mgr.save(session)
 
-        path = mgr._get_session_path("test:1")
-        lines = path.read_text(encoding="utf-8").strip().split("\n")
-        assert len(lines) == 3
+def test_manager_saves_only_to_sqlite(tmp_path: Path) -> None:
+    manager = SessionManager(tmp_path)
+    session = Session(key="test:sqlite")
+    session.add_message("user", "hello")
 
-        meta = json.loads(lines[0])
-        assert meta["_type"] == "metadata"
-        assert meta["key"] == "test:1"
+    manager.save(session)
 
-        msg1 = json.loads(lines[1])
-        assert msg1["role"] == "user"
-        assert msg1["content"] == "hello"
+    assert (tmp_path / "sessions.db").is_file()
+    assert not list((tmp_path / "sessions").glob("*.jsonl"))
+    assert SessionManager(tmp_path).get_or_create(session.key) == session
 
-    def test_no_tmp_file_left_after_successful_save(self, tmp_path: Path):
-        mgr = SessionManager(tmp_path)
-        session = Session(key="test:clean")
-        mgr.save(session)
 
-        tmp_files = list(mgr.sessions_dir.glob("*.tmp"))
-        assert tmp_files == []
-
-    def test_tmp_file_cleaned_up_on_write_failure(self, tmp_path: Path):
-        mgr = SessionManager(tmp_path)
-        session = Session(key="test:fail")
-        path = mgr._get_session_path("test:fail")
-        tmp_path_file = path.with_suffix(".jsonl.tmp")
-
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path_file.write_text("stale")
-
-        class BadMessage:
-            def __init__(self, data):
-                self.data = data
-
-        original_dumps = json.dumps
-
-        def failing_dumps(obj, **kwargs):
-            if isinstance(obj, dict) and obj.get("role") == "assistant":
-                raise OSError("simulated disk full")
-            return original_dumps(obj, **kwargs)
-
-        session = Session(key="test:fail")
-        session.messages = [
-            {"role": "user", "content": "ok"},
-            {"role": "assistant", "content": "will fail"},
-        ]
-
-        import unittest.mock
-        with unittest.mock.patch("nanobot.session.manager.json.dumps", side_effect=failing_dumps):
-            try:
-                mgr.save(session)
-            except OSError:
-                pass
-
-        assert not tmp_path_file.exists()
-
-    def test_overwrite_preserves_latest_data(self, tmp_path: Path):
-        mgr = SessionManager(tmp_path)
-        session = Session(key="test:overwrite")
-
-        session.add_message("user", "first")
-        mgr.save(session)
-
-        session.add_message("user", "second")
-        mgr.save(session)
-
-        mgr.invalidate("test:overwrite")
-        loaded = mgr.get_or_create("test:overwrite")
-        assert len(loaded.messages) == 2
-        assert loaded.messages[0]["content"] == "first"
-        assert loaded.messages[1]["content"] == "second"
-
-    def test_consecutive_saves_are_consistent(self, tmp_path: Path):
-        mgr = SessionManager(tmp_path)
-        session = Session(key="test:consistency")
-
-        for i in range(5):
-            session.add_message("user", f"msg{i}")
-            mgr.save(session)
-
-        mgr.invalidate("test:consistency")
-        loaded = mgr.get_or_create("test:consistency")
-        assert len(loaded.messages) == 5
-        for i in range(5):
-            assert loaded.messages[i]["content"] == f"msg{i}"
-
-    def test_provider_state_round_trips_in_private_record_only(self, tmp_path: Path):
-        mgr = SessionManager(tmp_path)
-        secret = "encrypted-reasoning-blob"
-        session = Session(
-            key="test:provider-state",
-            provider_state=ProviderConversationState(
-                kind="openai_responses",
-                provider="openai:https://api.openai.com/v1",
-                model="gpt-5.6",
-                version=1,
-                payload={
-                    "items": [
-                        {
-                            "type": "reasoning",
-                            "encrypted_content": secret,
-                        }
-                    ]
-                },
-                pending_messages=[{"role": "user", "content": "continue"}],
+def test_truncated_jsonl_is_repaired_during_migration(tmp_path: Path) -> None:
+    key = "test:truncated"
+    _write_jsonl(
+        tmp_path,
+        key,
+        [
+            json.dumps(
+                {
+                    "_type": "metadata",
+                    "key": key,
+                    "created_at": datetime.now().isoformat(),
+                    "updated_at": datetime.now().isoformat(),
+                    "metadata": {},
+                    "last_consolidated": 0,
+                }
             ),
-        )
-        session.add_message("user", "hello")
-        mgr.save(session)
-
-        records = [
-            json.loads(line)
-            for line in mgr._get_session_path(session.key)
-            .read_text(encoding="utf-8")
-            .splitlines()
-        ]
-        assert [record.get("_type") for record in records] == [
-            "metadata",
-            "provider_state",
-            None,
-        ]
-        assert secret in records[1]["state"]["payload"]["items"][0]["encrypted_content"]
-
-        mgr.invalidate(session.key)
-        loaded = mgr.get_or_create(session.key)
-        assert loaded.provider_state is not None
-        assert loaded.provider_state.to_private_record() == session.provider_state.to_private_record()
-
-        public_payload = mgr.read_session_file(session.key)
-        assert public_payload is not None
-        assert public_payload["messages"] == [session.messages[0]]
-        assert secret not in json.dumps(public_payload)
-        assert secret not in json.dumps(mgr.list_sessions())
-
-    def test_provider_state_does_not_consume_list_preview_budget(
-        self,
-        tmp_path: Path,
-        monkeypatch,
-    ):
-        import nanobot.session.manager as session_manager
-
-        monkeypatch.setattr(session_manager, "_SESSION_LIST_PREVIEW_MAX_CHARS", 100)
-        mgr = SessionManager(tmp_path)
-        session = Session(
-            key="test:provider-state-preview",
-            provider_state=ProviderConversationState(
-                kind="openai_responses",
-                provider="openai:test",
-                model="test-model",
-                version=1,
-                payload={"items": [{"encrypted_content": "x" * 200}]},
-            ),
-        )
-        session.add_message("user", "visible preview")
-        mgr.save(session)
-
-        assert mgr.list_sessions()[0]["preview"] == "visible preview"
-
-    def test_clear_and_fork_discard_provider_state(self, tmp_path: Path):
-        mgr = SessionManager(tmp_path)
-        state = ProviderConversationState(
-            kind="openai_responses",
-            provider="openai:test",
-            model="gpt-5.6",
-            version=1,
-            payload={"items": []},
-        )
-        source = Session(key="test:state-source", provider_state=state)
-        source.add_message("user", "hello")
-        mgr.save(source)
-
-        fork = mgr.fork_session_before_user_index(
-            source.key,
-            "test:state-fork",
-            1,
-        )
-        assert fork is not None
-        assert fork.provider_state is None
-
-        source.clear()
-        assert source.provider_state is None
-
-    def test_invalid_provider_state_record_is_not_public_history(self, tmp_path: Path):
-        mgr = SessionManager(tmp_path)
-        path = mgr._get_session_path("test:bad-provider-state")
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(
-            "\n".join(
-                [
-                    json.dumps(
-                        {
-                            "_type": "metadata",
-                            "key": "test:bad-provider-state",
-                            "created_at": datetime.now().isoformat(),
-                            "updated_at": datetime.now().isoformat(),
-                            "metadata": {},
-                            "last_consolidated": 0,
-                        }
-                    ),
-                    json.dumps(
-                        {
-                            "_type": "provider_state",
-                            "state": {"kind": "openai_responses"},
-                        }
-                    ),
-                    json.dumps({"role": "user", "content": "safe"}),
-                ]
-            )
-            + "\n",
-            encoding="utf-8",
-        )
-
-        loaded = mgr._load("test:bad-provider-state")
-        assert loaded is not None
-        assert loaded.provider_state is None
-        assert loaded.messages == [{"role": "user", "content": "safe"}]
-
-
-class TestRepairCorruptFile:
-    def _write_corrupt_jsonl(self, path: Path, lines: list[str]) -> None:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-    def test_truncated_last_line_recovered(self, tmp_path: Path):
-        mgr = SessionManager(tmp_path)
-        path = mgr._get_session_path("test:trunc")
-
-        valid_meta = json.dumps({
-            "_type": "metadata",
-            "key": "test:trunc",
-            "created_at": datetime.now().isoformat(),
-            "updated_at": datetime.now().isoformat(),
-            "metadata": {},
-            "last_consolidated": 0,
-        })
-        valid_msg = json.dumps({"role": "user", "content": "hello"})
-
-        self._write_corrupt_jsonl(path, [
-            valid_meta,
-            valid_msg,
-            '{"role": "assistant", "content": "partial...',
-        ])
-
-        session = mgr._load("test:trunc")
-        assert session is not None
-        assert len(session.messages) == 1
-        assert session.messages[0]["content"] == "hello"
-
-    def test_corrupt_metadata_line_skipped(self, tmp_path: Path):
-        mgr = SessionManager(tmp_path)
-        path = mgr._get_session_path("test:badmeta")
-
-        self._write_corrupt_jsonl(path, [
-            "NOT VALID JSON!!!",
-            '{"role": "user", "content": "survived"}',
-        ])
-
-        session = mgr._load("test:badmeta")
-        assert session is not None
-        assert len(session.messages) == 1
-        assert session.messages[0]["content"] == "survived"
-
-    def test_all_corrupt_lines_returns_none(self, tmp_path: Path):
-        mgr = SessionManager(tmp_path)
-        path = mgr._get_session_path("test:allbad")
-
-        self._write_corrupt_jsonl(path, [
-            "garbage line 1",
-            "garbage line 2",
-            "{{invalid json",
-        ])
-
-        session = mgr._load("test:allbad")
-        assert session is None
-
-    def test_empty_file_returns_empty_session(self, tmp_path: Path):
-        mgr = SessionManager(tmp_path)
-        path = mgr._get_session_path("test:empty")
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text("", encoding="utf-8")
-
-        session = mgr._load("test:empty")
-        assert session is not None
-        assert session.messages == []
-        assert session.key == "test:empty"
-
-    def test_repair_preserves_valid_messages_amid_corruption(self, tmp_path: Path):
-        mgr = SessionManager(tmp_path)
-        path = mgr._get_session_path("test:mixed")
-
-        self._write_corrupt_jsonl(path, [
-            json.dumps({"_type": "metadata", "key": "test:mixed",
-                        "created_at": datetime.now().isoformat(),
-                        "updated_at": datetime.now().isoformat(),
-                        "metadata": {}, "last_consolidated": 0}),
-            "BROKEN",
-            json.dumps({"role": "user", "content": "msg1"}),
-            '{"role": "assistant", "content": "broken',
-            json.dumps({"role": "user", "content": "msg2"}),
-        ])
-
-        session = mgr._load("test:mixed")
-        assert session is not None
-        assert len(session.messages) == 2
-        assert session.messages[0]["content"] == "msg1"
-        assert session.messages[1]["content"] == "msg2"
-
-    def test_repair_with_bad_timestamp_uses_fallback(self, tmp_path: Path):
-        mgr = SessionManager(tmp_path)
-        path = mgr._get_session_path("test:badts")
-
-        self._write_corrupt_jsonl(path, [
-            json.dumps({"_type": "metadata", "key": "test:badts",
-                        "created_at": "not-a-date",
-                        "updated_at": "also-bad",
-                        "metadata": {}, "last_consolidated": 5}),
-            json.dumps({"role": "user", "content": "hi"}),
-        ])
-
-        session = mgr._load("test:badts")
-        assert session is not None
-        # offset 5 exceeds the single loaded message; reset to avoid hiding history (#4066)
-        assert session.last_consolidated == 0
-        assert isinstance(session.created_at, datetime)
-
-    def test_read_session_file_repairs_corrupt_jsonl(self, tmp_path: Path):
-        mgr = SessionManager(tmp_path)
-        path = mgr._get_session_path("test:read-repair")
-
-        self._write_corrupt_jsonl(path, [
-            json.dumps({
-                "_type": "metadata",
-                "key": "test:read-repair",
-                "created_at": datetime.now().isoformat(),
-                "updated_at": datetime.now().isoformat(),
-                "metadata": {"source": "repair"},
-                "last_consolidated": 0,
-            }),
-            json.dumps({"role": "user", "content": "survived"}),
-            '{"role": "assistant", "content": "partial...',
-        ])
-
-        payload = mgr.read_session_file("test:read-repair")
-        assert payload is not None
-        assert payload["key"] == "test:read-repair"
-        assert payload["metadata"] == {"source": "repair"}
-        assert payload["messages"] == [{"role": "user", "content": "survived"}]
-
-    def test_list_sessions_keeps_repaired_corrupt_file(self, tmp_path: Path):
-        mgr = SessionManager(tmp_path)
-        path = mgr._get_session_path("test:list-repair")
-
-        self._write_corrupt_jsonl(path, [
-            "NOT VALID JSON",
-            json.dumps({
-                "_type": "metadata",
-                "key": "test:list-repair",
-                "created_at": datetime.now().isoformat(),
-                "updated_at": datetime.now().isoformat(),
-                "metadata": {},
-                "last_consolidated": 0,
-            }),
             json.dumps({"role": "user", "content": "hello"}),
-        ])
+            '{"role": "assistant", "content": "partial...',
+        ],
+    )
 
-        sessions = mgr.list_sessions()
-        assert any(s["key"] == "test:list-repair" for s in sessions)
+    session = SessionManager(tmp_path).get_or_create(key)
 
-    def test_get_or_create_returns_new_session_for_corrupt_file(self, tmp_path: Path):
-        mgr = SessionManager(tmp_path)
-        path = mgr._get_session_path("test:fallback")
+    assert session.messages == [{"role": "user", "content": "hello"}]
 
-        self._write_corrupt_jsonl(path, ["{{{{"])
 
-        session = mgr.get_or_create("test:fallback")
-        assert session is not None
-        assert session.messages == []
-        assert session.key == "test:fallback"
+def test_jsonl_repair_preserves_valid_records(tmp_path: Path) -> None:
+    key = "test:mixed"
+    _write_jsonl(
+        tmp_path,
+        key,
+        [
+            "BROKEN",
+            json.dumps({"role": "user", "content": "first"}),
+            '{"role": "assistant", "content": "broken',
+            json.dumps({"role": "user", "content": "second"}),
+        ],
+    )
+
+    session = SessionManager(tmp_path).get_or_create(key)
+
+    assert [message["content"] for message in session.messages] == ["first", "second"]
+
+
+def test_all_corrupt_jsonl_blocks_migration_without_removing_source(tmp_path: Path) -> None:
+    path = _write_jsonl(tmp_path, "test:all-bad", ["garbage", "{{invalid json"])
+
+    with pytest.raises(RuntimeError, match="Failed to migrate JSONL session"):
+        SessionManager(tmp_path)
+
+    assert path.is_file()
+
+
+def test_empty_jsonl_migrates_as_empty_session(tmp_path: Path) -> None:
+    key = "test:empty"
+    path = JsonlSessionFiles(tmp_path).get_session_path(key)
+    path.write_text("", encoding="utf-8")
+
+    session = SessionManager(tmp_path).get_or_create(key)
+
+    assert session.key == key
+    assert session.messages == []
+
+
+def test_bad_jsonl_timestamp_uses_fallback_and_clamps_offset(tmp_path: Path) -> None:
+    key = "test:bad-time"
+    _write_jsonl(
+        tmp_path,
+        key,
+        [
+            json.dumps(
+                {
+                    "_type": "metadata",
+                    "key": key,
+                    "created_at": "not-a-date",
+                    "updated_at": "also-bad",
+                    "metadata": {},
+                    "last_consolidated": 5,
+                }
+            ),
+            json.dumps({"role": "user", "content": "hi"}),
+        ],
+    )
+
+    session = SessionManager(tmp_path).get_or_create(key)
+
+    assert session.last_consolidated == 0
+    assert isinstance(session.created_at, datetime)
+
+
+def test_repaired_jsonl_is_available_through_read_and_list(tmp_path: Path) -> None:
+    key = "test:read-repair"
+    _write_jsonl(
+        tmp_path,
+        key,
+        [
+            "NOT VALID JSON",
+            json.dumps(
+                {
+                    "_type": "metadata",
+                    "key": key,
+                    "created_at": datetime.now().isoformat(),
+                    "updated_at": datetime.now().isoformat(),
+                    "metadata": {"source": "repair"},
+                    "last_consolidated": 0,
+                }
+            ),
+            json.dumps({"role": "user", "content": "survived"}),
+        ],
+    )
+    manager = SessionManager(tmp_path)
+
+    payload = manager.read_session_file(key)
+
+    assert payload is not None
+    assert payload["metadata"] == {"source": "repair"}
+    assert payload["messages"] == [{"role": "user", "content": "survived"}]
+    assert [row["key"] for row in manager.list_sessions()] == [key]

--- a/tests/agent/test_session_collision.py
+++ b/tests/agent/test_session_collision.py
@@ -1,19 +1,10 @@
-"""Regression tests for collision-resistant session filenames."""
+"""Regression tests for session keys that collide under legacy filenames."""
 
 import json
 from datetime import datetime
 from pathlib import Path
 
-from nanobot.session.manager import Session, SessionManager
-from nanobot.utils.helpers import safe_filename
-
-
-def _manager(tmp_path: Path, monkeypatch) -> SessionManager:
-    monkeypatch.setattr(
-        "nanobot.session.manager.get_legacy_sessions_dir",
-        lambda: tmp_path / "legacy_sessions",
-    )
-    return SessionManager(tmp_path / "workspace")
+from nanobot.session.manager import JsonlSessionFiles, Session, SessionManager
 
 
 def _write_session_file(path: Path, key: str, content: str) -> None:
@@ -33,112 +24,48 @@ def _write_session_file(path: Path, key: str, content: str) -> None:
     )
 
 
-def test_distinct_keys_have_distinct_filenames(tmp_path: Path, monkeypatch) -> None:
-    sm = _manager(tmp_path, monkeypatch)
-
-    first = sm._get_session_path("telegram:a_b")
-    second = sm._get_session_path("telegram:a:b")
-
-    assert first.name != second.name
-    assert sm.safe_key("telegram:a_b") == sm.safe_key("telegram:a:b")
-    assert sm._storage_key("telegram:a_b") != sm._storage_key("telegram:a:b")
-
-
-def test_save_uses_new_path_not_lossy(tmp_path: Path, monkeypatch) -> None:
-    sm = _manager(tmp_path, monkeypatch)
-    key = "telegram:a:b"
-    session = Session(key=key)
-    session.add_message("user", "first")
-    sm.save(session)
-
-    new_path = sm._get_session_path(key)
-    lossy_path = sm._get_legacy_lossy_path(key)
-    _write_session_file(lossy_path, key, "stale lossy content")
-    stale_lossy = lossy_path.read_text(encoding="utf-8")
-
-    session.add_message("assistant", "latest content")
-    sm.save(session)
-
-    assert new_path.exists()
-    assert lossy_path.exists()
-    assert "latest content" in new_path.read_text(encoding="utf-8")
-    assert lossy_path.read_text(encoding="utf-8") == stale_lossy
-
-
-def test_load_ignores_legacy_lossy_path(tmp_path: Path, monkeypatch) -> None:
-    sm = _manager(tmp_path, monkeypatch)
-    key = "telegram:legacy:lossy"
-    lossy_path = sm._get_legacy_lossy_path(key)
-    _write_session_file(lossy_path, key, "loaded from lossy")
-
-    session = sm._load(key)
-
-    assert session is None
-    assert lossy_path.exists()
-    assert not sm._get_session_path(key).exists()
-
-
-def test_load_ignores_legacy_global_path(tmp_path: Path, monkeypatch) -> None:
-    sm = _manager(tmp_path, monkeypatch)
-    key = "telegram:legacy:global"
-    new_path = sm._get_session_path(key)
-    legacy_path = sm._get_legacy_session_path(key)
-    _write_session_file(legacy_path, key, "loaded from global")
-
-    session = sm._load(key)
-
-    assert session is None
-    assert legacy_path.exists()
-    assert not new_path.exists()
-
-
 def test_safe_key_is_lossy() -> None:
     assert SessionManager.safe_key("telegram:a_b") == SessionManager.safe_key("telegram:a:b")
 
 
-def test_storage_key_is_collision_resistant() -> None:
-    encoded = {
-        SessionManager._storage_key("a:b"),
-        SessionManager._storage_key("a_b"),
-        SessionManager._storage_key("a:b:c"),
-    }
-
-    assert len(encoded) == 3
-    assert SessionManager._storage_key("telegram:a_b") != SessionManager._storage_key("telegram:a:b")
-
-
-def test_lossy_path_helper_returns_expected_path(tmp_path: Path, monkeypatch) -> None:
-    sm = _manager(tmp_path, monkeypatch)
-    key = "telegram:a:b"
-    expected = sm.sessions_dir / f"{safe_filename(key.replace(':', '_'))}.jsonl"
-
-    assert sm._get_legacy_lossy_path(key) == expected
-
-
-def test_storage_paths_are_distinct_when_keys_collide_under_safe_key(
+def test_migration_preserves_keys_that_collide_under_legacy_filename(
     tmp_path: Path,
-    monkeypatch,
 ) -> None:
-    sm = _manager(tmp_path, monkeypatch)
-    first = Session(key="telegram:a_b")
-    first.add_message("user", "underscore history")
-    second = Session(key="telegram:a:b")
-    second.add_message("user", "colon history")
+    source = JsonlSessionFiles(tmp_path)
+    first_key = "telegram:a_b"
+    second_key = "telegram:a:b"
+    _write_session_file(source.get_session_path(first_key), first_key, "underscore history")
+    _write_session_file(source.get_session_path(second_key), second_key, "colon history")
 
-    sm.save(first)
-    sm.save(second)
+    manager = SessionManager(tmp_path)
 
-    assert sm.safe_key(first.key) == sm.safe_key(second.key)
-    assert sm._get_session_path(first.key).exists()
-    assert sm._get_session_path(second.key).exists()
-    assert sm._get_session_path(first.key) != sm._get_session_path(second.key)
+    assert manager.read_session_file(first_key)["messages"][0]["content"] == "underscore history"
+    assert manager.read_session_file(second_key)["messages"][0]["content"] == "colon history"
 
-    sm.invalidate(first.key)
-    sm.invalidate(second.key)
-    loaded_first = sm._load(first.key)
-    loaded_second = sm._load(second.key)
 
-    assert loaded_first is not None
-    assert loaded_second is not None
-    assert loaded_first.messages[0]["content"] == "underscore history"
-    assert loaded_second.messages[0]["content"] == "colon history"
+def test_sqlite_save_does_not_touch_legacy_lossy_file(tmp_path: Path) -> None:
+    manager = SessionManager(tmp_path)
+    source = JsonlSessionFiles(tmp_path)
+    key = "telegram:a:b"
+    lossy_path = source.get_legacy_lossy_path(key)
+    _write_session_file(lossy_path, key, "stale lossy content")
+    stale_lossy = lossy_path.read_text(encoding="utf-8")
+    session = Session(key=key)
+    session.add_message("user", "latest content")
+
+    manager.save(session)
+
+    assert manager.read_session_file(key)["messages"][0]["content"] == "latest content"
+    assert lossy_path.read_text(encoding="utf-8") == stale_lossy
+
+
+def test_migration_ignores_legacy_lossy_file(tmp_path: Path) -> None:
+    source = JsonlSessionFiles(tmp_path)
+    key = "telegram:legacy:lossy"
+    lossy_path = source.get_legacy_lossy_path(key)
+    _write_session_file(lossy_path, key, "legacy content")
+
+    manager = SessionManager(tmp_path)
+
+    assert manager.read_session_file(key) is None
+    assert lossy_path.exists()

--- a/tests/agent/test_session_collision.py
+++ b/tests/agent/test_session_collision.py
@@ -4,6 +4,8 @@ import json
 from datetime import datetime
 from pathlib import Path
 
+import pytest
+
 from nanobot.session.manager import JsonlSessionFiles, Session, SessionManager
 
 
@@ -69,3 +71,47 @@ def test_migration_ignores_legacy_lossy_file(tmp_path: Path) -> None:
 
     assert manager.read_session_file(key) is None
     assert lossy_path.exists()
+
+
+def test_migration_rejects_lossy_stem_that_is_canonical_for_another_key(
+    tmp_path: Path,
+) -> None:
+    source = JsonlSessionFiles(tmp_path)
+    lossy_key = "YQ"
+    assert source.session_key_from_path(source.get_legacy_lossy_path(lossy_key)) == "a"
+    _write_session_file(
+        source.get_legacy_lossy_path(lossy_key),
+        lossy_key,
+        "must not migrate under a",
+    )
+
+    with pytest.raises(RuntimeError, match="Failed to migrate JSONL session"):
+        SessionManager(tmp_path)
+
+
+def test_delete_does_not_remove_another_keys_canonical_backup(tmp_path: Path) -> None:
+    source = JsonlSessionFiles(tmp_path)
+    canonical_key = "a"
+    colliding_lossy_key = "YQ"
+    canonical_path = source.get_session_path(canonical_key)
+    assert canonical_path == source.get_legacy_lossy_path(colliding_lossy_key)
+    _write_session_file(canonical_path, canonical_key, "canonical history")
+    manager = SessionManager(tmp_path)
+
+    assert manager.delete_session(colliding_lossy_key) is False
+    assert canonical_path.is_file()
+    assert manager.read_session_file(canonical_key) is not None
+
+
+def test_delete_rejects_ambiguous_lossy_and_canonical_path(tmp_path: Path) -> None:
+    manager = SessionManager(tmp_path)
+    source = JsonlSessionFiles(tmp_path)
+    lossy_key = "YQ"
+    lossy_path = source.get_legacy_lossy_path(lossy_key)
+    assert source.session_key_from_path(lossy_path) == "a"
+    _write_session_file(lossy_path, lossy_key, "ambiguous history")
+
+    with pytest.raises(RuntimeError, match="ambiguous legacy session file"):
+        manager.delete_session(lossy_key)
+
+    assert lossy_path.is_file()

--- a/tests/agent/test_session_delete.py
+++ b/tests/agent/test_session_delete.py
@@ -1,8 +1,9 @@
 """Tests for SessionManager.delete_session and read_session_file."""
 
+import json
 from pathlib import Path
 
-from nanobot.session.manager import Session, SessionManager
+from nanobot.session.manager import JsonlSessionFiles, Session, SessionManager
 
 
 def _seed(workspace: Path, key: str = "telegram:abc") -> SessionManager:
@@ -14,16 +15,15 @@ def _seed(workspace: Path, key: str = "telegram:abc") -> SessionManager:
     return sm
 
 
-def test_delete_session_removes_file_and_invalidates_cache(tmp_path: Path) -> None:
+def test_delete_session_removes_row_and_invalidates_cache(tmp_path: Path) -> None:
     sm = _seed(tmp_path, "telegram:abc")
-    file_path = sm._get_session_path("telegram:abc")
-    assert file_path.exists()
+    assert (tmp_path / "sessions.db").is_file()
     # Populate cache as a real consumer would.
     cached = sm.get_or_create("telegram:abc")
     assert cached.messages
 
     assert sm.delete_session("telegram:abc") is True
-    assert not file_path.exists()
+    assert sm.read_session_file("telegram:abc") is None
     # Subsequent get_or_create returns a fresh, empty Session (no stale cache).
     fresh = sm.get_or_create("telegram:abc")
     assert fresh.messages == []
@@ -58,13 +58,6 @@ def test_read_session_file_missing(tmp_path: Path) -> None:
     assert sm.read_session_file("nope:none") is None
 
 
-def test_storage_key_matches_internal_path(tmp_path: Path) -> None:
-    sm = SessionManager(tmp_path)
-    key = "telegram:abc/def"
-    expected = sm._get_session_path(key).name
-    assert SessionManager._storage_key(key) + ".jsonl" == expected
-
-
 def _write_legacy_session(legacy_dir: Path, key: str, roles: list[str]) -> Path:
     legacy_dir.mkdir(parents=True, exist_ok=True)
     safe = SessionManager.safe_key(key)
@@ -82,6 +75,26 @@ def _write_legacy_session(legacy_dir: Path, key: str, roles: list[str]) -> Path:
     return path
 
 
+def _write_jsonl_session(source: JsonlSessionFiles, session: Session) -> Path:
+    records = [
+        {
+            "_type": "metadata",
+            "key": session.key,
+            "created_at": session.created_at.isoformat(),
+            "updated_at": session.updated_at.isoformat(),
+            "metadata": session.metadata,
+            "last_consolidated": session.last_consolidated,
+        },
+        *session.messages,
+    ]
+    path = source.get_session_path(session.key)
+    path.write_text(
+        "".join(json.dumps(record) + "\n" for record in records),
+        encoding="utf-8",
+    )
+    return path
+
+
 def test_delete_session_cleans_legacy_file(tmp_path: Path, monkeypatch) -> None:
     """A session that only exists at the legacy location must also be deleted."""
     legacy = tmp_path / "legacy_sessions"
@@ -94,8 +107,6 @@ def test_delete_session_cleans_legacy_file(tmp_path: Path, monkeypatch) -> None:
     assert legacy_path.exists()
 
     sm = SessionManager(tmp_path / "workspace")
-    new_path = sm._get_session_path(key)
-    assert not new_path.exists()
 
     assert sm.delete_session(key) is True
     assert not legacy_path.exists(), "legacy session file should have been removed"
@@ -111,18 +122,24 @@ def test_delete_session_cleans_both_locations(tmp_path: Path, monkeypatch) -> No
     workspace = tmp_path / "workspace"
     key = "telegram:both-paths"
     _write_legacy_session(legacy, key, ["user", "assistant"])
+    source = JsonlSessionFiles(workspace)
+    migrated = Session(key=key)
+    migrated.add_message("user", "from jsonl")
+    _write_jsonl_session(source, migrated)
 
     sm = SessionManager(workspace)
     session = Session(key=key)
     session.add_message("user", "recent")
     sm.save(session)
 
-    assert sm._get_session_path(key).exists()
+    assert source.get_session_path(key).exists()
+    assert sm.read_session_file(key) is not None
     assert (legacy / f"{SessionManager.safe_key(key)}.jsonl").exists()
 
     assert sm.delete_session(key) is True
 
-    assert not sm._get_session_path(key).exists()
+    assert not source.get_session_path(key).exists()
+    assert sm.read_session_file(key) is None
     assert not (legacy / f"{SessionManager.safe_key(key)}.jsonl").exists()
 
 

--- a/tests/command/test_builtin_dream.py
+++ b/tests/command/test_builtin_dream.py
@@ -16,6 +16,7 @@ from nanobot.command.builtin import (
     cmd_dream_restore,
 )
 from nanobot.command.router import CommandContext
+from nanobot.session.manager import SessionManager
 from nanobot.utils.gitstore import CommitInfo
 
 
@@ -118,12 +119,10 @@ def _make_dream_ctx(tmp_path) -> tuple[CommandContext, _FakeBus]:
     msg = InboundMessage(channel="cli", sender_id="u1", chat_id="direct", content="/dream")
     store = _FakeStore(_FakeGit(initialized=False), dream_prompt_result=None)
     bus = _FakeBus()
-    sessions_dir = tmp_path / "sessions"
-    sessions_dir.mkdir()
     loop = SimpleNamespace(
         bus=bus,
         context=SimpleNamespace(memory=store, timezone="UTC"),
-        sessions=SimpleNamespace(sessions_dir=sessions_dir),
+        sessions=SessionManager(tmp_path),
     )
     ctx = CommandContext(msg=msg, session=None, key=msg.session_key, raw="/dream", args="", loop=loop)
     return ctx, bus
@@ -169,13 +168,11 @@ async def test_dream_internal_run_silences_progress(tmp_path) -> None:
             metadata={"_stop_reason": "completed"},
         )
 
-    sessions_dir = tmp_path / "sessions"
-    sessions_dir.mkdir()
     dream_runtime = object()
     loop = SimpleNamespace(
         bus=bus,
         context=SimpleNamespace(memory=store, timezone="UTC"),
-        sessions=SimpleNamespace(sessions_dir=sessions_dir),
+        sessions=SessionManager(tmp_path),
         process_direct=process_direct,
         dream_runtime=lambda: dream_runtime,
     )
@@ -224,12 +221,10 @@ def _build_runnable_dream(
         )
 
     bus = _FakeBus()
-    sessions_dir = tmp_path / "sessions"
-    sessions_dir.mkdir()
     loop = SimpleNamespace(
         bus=bus,
         context=SimpleNamespace(memory=store, timezone="UTC"),
-        sessions=SimpleNamespace(sessions_dir=sessions_dir),
+        sessions=SessionManager(tmp_path),
         process_direct=process_direct,
         dream_runtime=lambda: None,
     )
@@ -311,12 +306,10 @@ async def test_dream_noop_batch_unlocks_following_history(tmp_path) -> None:
 
     msg = InboundMessage(channel="cli", sender_id="u1", chat_id="direct", content="/dream")
     bus = _FakeBus()
-    sessions_dir = tmp_path / "sessions"
-    sessions_dir.mkdir()
     loop = SimpleNamespace(
         bus=bus,
         context=SimpleNamespace(memory=store, timezone="UTC"),
-        sessions=SimpleNamespace(sessions_dir=sessions_dir),
+        sessions=SessionManager(tmp_path),
         process_direct=process_direct,
         dream_runtime=lambda: None,
     )

--- a/tests/session/test_consolidated_offset_clamp.py
+++ b/tests/session/test_consolidated_offset_clamp.py
@@ -3,7 +3,7 @@
 import json
 from pathlib import Path
 
-from nanobot.session.manager import Session, SessionManager
+from nanobot.session.manager import JsonlSessionFiles, Session, SessionManager
 
 
 def _session(count: int, last_consolidated: object) -> Session:
@@ -30,8 +30,8 @@ def test_loaded_corrupt_offset_keeps_messages(tmp_path: Path):
     }
 
     for name, offset in offsets.items():
-        manager = SessionManager(tmp_path / name)
-        path = manager._get_session_path("chan:chat")
+        workspace = tmp_path / name
+        path = JsonlSessionFiles(workspace).get_session_path("chan:chat")
         path.parent.mkdir(parents=True, exist_ok=True)
         message = {"role": "user", "content": f"survived {name}"}
         path.write_text(
@@ -47,6 +47,7 @@ def test_loaded_corrupt_offset_keeps_messages(tmp_path: Path):
             encoding="utf-8",
         )
 
+        manager = SessionManager(workspace)
         session = manager.get_or_create("chan:chat")
 
         assert session.messages == [message]
@@ -62,8 +63,7 @@ def test_valid_offset_is_preserved():
 
 def test_loaded_null_metadata_becomes_empty_dict(tmp_path: Path):
     """Session jsonl metadata:null must load as {} so agent .pop/.get work."""
-    manager = SessionManager(tmp_path)
-    path = manager._get_session_path("chan:chat")
+    path = JsonlSessionFiles(tmp_path).get_session_path("chan:chat")
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         json.dumps({
@@ -76,6 +76,7 @@ def test_loaded_null_metadata_becomes_empty_dict(tmp_path: Path):
         }) + "\n",
         encoding="utf-8",
     )
+    manager = SessionManager(tmp_path)
     session = manager.get_or_create("chan:chat")
     assert session.metadata == {}
     session.metadata["title"] = "ok"

--- a/tests/session/test_session_fsync.py
+++ b/tests/session/test_session_fsync.py
@@ -2,17 +2,13 @@
 
 from __future__ import annotations
 
-import errno
-import os
-import sys
 from pathlib import Path
+from typing import cast
 from unittest.mock import patch
 
 import pytest
 
-from nanobot.session.manager import SessionManager
-
-_IS_WINDOWS = sys.platform == "win32"
+from nanobot.session.manager import SessionManager, SQLiteSessionStore
 
 
 @pytest.fixture
@@ -28,74 +24,35 @@ def manager(sessions_dir: Path) -> SessionManager:
 
 
 class TestSaveFsync:
-    """Verify that save(fsync=True) calls os.fsync."""
+    """Verify that durable saves use SQLite FULL synchronous mode."""
 
-    def test_save_without_fsync_does_not_call_fsync(self, manager: SessionManager):
+    def test_save_without_fsync_uses_normal_durability(self, manager: SessionManager):
         session = manager.get_or_create("test:no-fsync")
         session.add_message("user", "hello")
+        store = cast(SQLiteSessionStore, manager._store)  # pyright: ignore[reportPrivateUsage]
 
-        with patch("os.fsync") as mock_fsync:
+        with patch.object(store, "_connection", wraps=store._connection) as connection:
             manager.save(session, fsync=False)
-            mock_fsync.assert_not_called()
+        connection.assert_called_once_with(durable=False)
 
-    def test_save_with_fsync_calls_fsync(self, manager: SessionManager):
+    def test_save_with_fsync_uses_full_durability(self, manager: SessionManager):
         session = manager.get_or_create("test:with-fsync")
         session.add_message("user", "hello")
+        store = cast(SQLiteSessionStore, manager._store)  # pyright: ignore[reportPrivateUsage]
 
-        with patch("os.fsync") as mock_fsync:
+        with patch.object(store, "_connection", wraps=store._connection) as connection:
             manager.save(session, fsync=True)
-            # File fsync always runs; directory fsync only on non-Windows.
-            expected = 1 if _IS_WINDOWS else 2
-            assert mock_fsync.call_count == expected
+        connection.assert_called_once_with(durable=True)
 
     def test_save_default_no_fsync(self, manager: SessionManager):
         """Default save() should not fsync (backward compat)."""
         session = manager.get_or_create("test:default")
         session.add_message("user", "hello")
+        store = cast(SQLiteSessionStore, manager._store)  # pyright: ignore[reportPrivateUsage]
 
-        with patch("os.fsync") as mock_fsync:
+        with patch.object(store, "_connection", wraps=store._connection) as connection:
             manager.save(session)
-            mock_fsync.assert_not_called()
-
-    def test_save_ignores_unsupported_directory_fsync(
-        self, manager: SessionManager
-    ) -> None:
-        """Shared filesystems may open directories but reject directory fsync."""
-        session = manager.get_or_create("test:unsupported-directory-fsync")
-        session.add_message("user", "hello")
-        directory_fd = 987654
-        with (
-            patch("nanobot.session.manager.os.open", return_value=directory_fd) as open_dir,
-            patch(
-                "nanobot.session.manager.os.fsync",
-                side_effect=[None, OSError(errno.EINVAL, "Invalid argument")],
-            ),
-            patch("nanobot.session.manager.os.close") as close_dir,
-        ):
-            manager.save(session, fsync=True)
-
-        assert manager._get_session_path(session.key).exists()
-        open_dir.assert_called_once_with(str(manager.sessions_dir), os.O_RDONLY)
-        close_dir.assert_called_once_with(directory_fd)
-
-    def test_save_propagates_other_directory_fsync_errors(
-        self, manager: SessionManager
-    ) -> None:
-        """Only EINVAL is an expected unsupported-directory-fsync result."""
-        session = manager.get_or_create("test:directory-fsync-io-error")
-        directory_fd = 987654
-        with (
-            patch("nanobot.session.manager.os.open", return_value=directory_fd),
-            patch(
-                "nanobot.session.manager.os.fsync",
-                side_effect=[None, OSError(errno.EIO, "I/O error")],
-            ),
-            patch("nanobot.session.manager.os.close") as close_dir,
-            pytest.raises(OSError, match="I/O error"),
-        ):
-            manager.save(session, fsync=True)
-
-        close_dir.assert_called_once_with(directory_fd)
+        connection.assert_called_once_with(durable=False)
 
 
 class TestFlushAll:
@@ -120,12 +77,11 @@ class TestFlushAll:
         session = manager.get_or_create("test:fsync-check")
         session.add_message("user", "important")
         manager.save(session)
+        store = cast(SQLiteSessionStore, manager._store)  # pyright: ignore[reportPrivateUsage]
 
-        with patch("os.fsync") as mock_fsync:
+        with patch.object(store, "_connection", wraps=store._connection) as connection:
             manager.flush_all()
-            # file fsync always; directory fsync only on non-Windows
-            expected = 1 if _IS_WINDOWS else 2
-            assert mock_fsync.call_count == expected
+        connection.assert_called_once_with(durable=True)
 
     def test_flush_all_continues_on_error(self, manager: SessionManager):
         """One broken session should not prevent others from flushing."""
@@ -188,7 +144,8 @@ class TestLoadErrors:
         writer.save(session)
 
         reader = SessionManager(workspace=sessions_dir)
-        with patch("builtins.open", side_effect=PermissionError("access denied")):
+        store = cast(SQLiteSessionStore, reader._store)  # pyright: ignore[reportPrivateUsage]
+        with patch.object(store, "_connection", side_effect=PermissionError("access denied")):
             with pytest.raises(PermissionError, match="access denied"):
                 if operation == "list_sessions":
                     reader.list_sessions()

--- a/tests/session/test_session_list_repair_legacy.py
+++ b/tests/session/test_session_list_repair_legacy.py
@@ -4,16 +4,14 @@ import json
 from datetime import datetime
 from pathlib import Path
 
-from nanobot.session.manager import SessionManager
+from nanobot.session.manager import JsonlSessionFiles, SessionManager
 
 
 def test_list_sessions_ignores_legacy_stem(tmp_path: Path) -> None:
     manager = SessionManager(tmp_path / "workspace")
 
-    # A legacy lossy-path filename must not be treated as current session storage,
-    # even when the file contains otherwise recoverable records.
     legacy_stem = "telegram_12345"
-    corrupt_path = manager.sessions_dir / f"{legacy_stem}.jsonl"
+    corrupt_path = manager.workspace / "sessions" / f"{legacy_stem}.jsonl"
     corrupt_path.parent.mkdir(parents=True, exist_ok=True)
     metadata = json.dumps({
         "_type": "metadata",
@@ -42,9 +40,10 @@ def test_read_session_methods_ignore_legacy_lossy_stem(
         lambda: tmp_path / "legacy_sessions",
     )
     manager = SessionManager(tmp_path / "workspace")
+    source = JsonlSessionFiles(manager.workspace)
     session_id = "123e4567-e89b-12d3-a456-426614174000"
     key = f"websocket:{session_id}"
-    legacy_path = manager._get_legacy_lossy_path(key)
+    legacy_path = source.get_legacy_lossy_path(key)
     assert legacy_path.name == f"websocket_{session_id}.jsonl"
 
     metadata = {

--- a/tests/session/test_session_store.py
+++ b/tests/session/test_session_store.py
@@ -8,6 +8,7 @@ from nanobot.session.manager import FILE_MAX_MESSAGES, SessionStore
 def test_store_types_are_not_public_session_api() -> None:
     assert not hasattr(session_api, "SessionStore")
     assert not hasattr(session_api, "JsonlSessionStore")
+    assert not hasattr(session_api, "SQLiteSessionStore")
 
 
 def test_manager_delegates_persistence_to_store(tmp_path) -> None:

--- a/tests/session/test_session_store.py
+++ b/tests/session/test_session_store.py
@@ -7,6 +7,7 @@ from nanobot.session.manager import FILE_MAX_MESSAGES, SessionStore
 
 def test_store_types_are_not_public_session_api() -> None:
     assert not hasattr(session_api, "SessionStore")
+    assert not hasattr(session_api, "JsonlSessionFiles")
     assert not hasattr(session_api, "JsonlSessionStore")
     assert not hasattr(session_api, "SQLiteSessionStore")
 
@@ -34,6 +35,7 @@ def test_manager_delegates_persistence_to_store(tmp_path) -> None:
             "updated_at": stored.updated_at.isoformat(),
             "title": "",
             "preview": "hello",
+            "model_preset": None,
             "path": "session.db",
         }
     ]

--- a/tests/session/test_sqlite_store.py
+++ b/tests/session/test_sqlite_store.py
@@ -1,3 +1,4 @@
+import json
 import sqlite3
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
@@ -6,7 +7,7 @@ from threading import Event
 import pytest
 
 from nanobot.session import Session, SessionManager
-from nanobot.session.manager import SQLiteSessionStore
+from nanobot.session.manager import JsonlSessionFiles, SQLiteSessionStore
 
 
 def _session(
@@ -26,6 +27,24 @@ def _session(
     )
 
 
+def _write_jsonl(source: JsonlSessionFiles, session: Session) -> None:
+    records = [
+        {
+            "_type": "metadata",
+            "key": session.key,
+            "created_at": session.created_at.isoformat(),
+            "updated_at": session.updated_at.isoformat(),
+            "metadata": session.metadata,
+            "last_consolidated": session.last_consolidated,
+        },
+        *session.messages,
+    ]
+    source.get_session_path(session.key).write_text(
+        "".join(json.dumps(record, ensure_ascii=False) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
 def test_sqlite_store_round_trips_through_manager(tmp_path) -> None:
     key = "websocket:quote'和中文"
     stored = _session(
@@ -40,12 +59,14 @@ def test_sqlite_store_round_trips_through_manager(tmp_path) -> None:
         ],
         title="SQLite session",
     )
-    manager = SessionManager(tmp_path, store=SQLiteSessionStore(tmp_path))
+    manager = SessionManager(tmp_path)
 
     manager.save(stored, fsync=True)
 
-    reloaded = SessionManager(tmp_path, store=SQLiteSessionStore(tmp_path))
+    reloaded = SessionManager(tmp_path)
     assert reloaded.get_or_create(key) == stored
+    assert (tmp_path / "sessions.db").is_file()
+    assert not list((tmp_path / "sessions").glob("*.jsonl"))
     assert reloaded.read_session_file(key) == {
         "key": key,
         "created_at": stored.created_at.isoformat(),
@@ -61,7 +82,87 @@ def test_sqlite_store_round_trips_through_manager(tmp_path) -> None:
     }
 
 
-def test_sqlite_store_lists_sessions_with_jsonl_projection(tmp_path) -> None:
+def test_manager_migrates_jsonl_once_and_keeps_source_as_backup(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    source = JsonlSessionFiles(tmp_path)
+    stored = _session(
+        "cli:migrate",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "from jsonl"}],
+        title="Migrated",
+    )
+    _write_jsonl(source, stored)
+    source_path = source.get_session_path(stored.key)
+
+    manager = SessionManager(tmp_path)
+
+    assert manager.get_or_create(stored.key) == stored
+    assert source_path.is_file()
+
+    stored.add_message("assistant", "only in sqlite")
+    manager.save(stored)
+
+    def fail_scan(_self) -> None:
+        raise AssertionError("JSONL backups should not be scanned after migration")
+
+    monkeypatch.setattr(JsonlSessionFiles, "session_files", fail_scan)
+    reloaded = SessionManager(tmp_path)
+    assert [message["content"] for message in reloaded.get_or_create(stored.key).messages] == [
+        "from jsonl",
+        "only in sqlite",
+    ]
+
+
+def test_jsonl_migration_rolls_back_on_invalid_session(tmp_path) -> None:
+    source = JsonlSessionFiles(tmp_path)
+    valid = _session(
+        "cli:valid",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "keep me"}],
+        title="Valid",
+    )
+    _write_jsonl(source, valid)
+    invalid_path = source.get_session_path("cli:invalid")
+    invalid_path.write_text("not json\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="Failed to migrate JSONL session"):
+        SessionManager(tmp_path)
+
+    with sqlite3.connect(tmp_path / "sessions.db") as connection:
+        session_count = connection.execute("SELECT COUNT(*) FROM sessions").fetchone()
+        migration_count = connection.execute(
+            "SELECT COUNT(*) FROM store_metadata WHERE key = 'jsonl_import_v1'"
+        ).fetchone()
+    assert session_count == (0,)
+    assert migration_count == (0,)
+    assert source.get_session_path(valid.key).is_file()
+    assert invalid_path.is_file()
+
+
+def test_jsonl_migration_is_safe_under_concurrent_startup(tmp_path) -> None:
+    source = JsonlSessionFiles(tmp_path)
+    stored = _session(
+        "cli:concurrent-migration",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "migrate once"}],
+        title="Concurrent",
+    )
+    _write_jsonl(source, stored)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        managers = list(executor.map(lambda _: SessionManager(tmp_path), range(8)))
+
+    assert all(manager.get_or_create(stored.key) == stored for manager in managers)
+    with sqlite3.connect(tmp_path / "sessions.db") as connection:
+        session_count = connection.execute("SELECT COUNT(*) FROM sessions").fetchone()
+        message_count = connection.execute("SELECT COUNT(*) FROM messages").fetchone()
+    assert session_count == (1,)
+    assert message_count == (1,)
+
+
+def test_sqlite_store_lists_sessions_with_session_projection(tmp_path) -> None:
     store = SQLiteSessionStore(tmp_path)
     older = _session(
         "cli:older",
@@ -86,6 +187,7 @@ def test_sqlite_store_lists_sessions_with_jsonl_projection(tmp_path) -> None:
     assert [row["key"] for row in rows] == ["cli:newer", "cli:older"]
     assert [row["preview"] for row in rows] == ["first user", "assistant fallback"]
     assert [row["title"] for row in rows] == ["Newer", "Older"]
+    assert [row["model_preset"] for row in rows] == [None, None]
     assert {row["path"] for row in rows} == {str(store.db_path)}
 
 

--- a/tests/session/test_sqlite_store.py
+++ b/tests/session/test_sqlite_store.py
@@ -75,65 +75,6 @@ def _write_jsonl(source: JsonlSessionFiles, session: Session) -> None:
     )
 
 
-def _create_v1_database(
-    workspace: Path,
-    session: Session,
-    *,
-    migration_marker: str | None = None,
-) -> None:
-    with sqlite3.connect(workspace / "sessions.db") as connection:
-        connection.executescript(
-            """
-            CREATE TABLE sessions (
-                key TEXT PRIMARY KEY,
-                created_at TEXT NOT NULL,
-                updated_at TEXT NOT NULL,
-                metadata TEXT NOT NULL,
-                last_consolidated INTEGER NOT NULL DEFAULT 0
-            );
-            CREATE TABLE messages (
-                session_key TEXT NOT NULL,
-                position INTEGER NOT NULL,
-                payload TEXT NOT NULL,
-                PRIMARY KEY (session_key, position),
-                FOREIGN KEY (session_key) REFERENCES sessions(key) ON DELETE CASCADE
-            );
-            CREATE TABLE store_metadata (
-                key TEXT PRIMARY KEY,
-                value TEXT NOT NULL
-            );
-            PRAGMA user_version = 1;
-            """
-        )
-        connection.execute(
-            """
-            INSERT INTO sessions (
-                key, created_at, updated_at, metadata, last_consolidated
-            )
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            (
-                session.key,
-                session.created_at.isoformat(),
-                session.updated_at.isoformat(),
-                json.dumps(session.metadata),
-                session.last_consolidated,
-            ),
-        )
-        connection.executemany(
-            "INSERT INTO messages (session_key, position, payload) VALUES (?, ?, ?)",
-            [
-                (session.key, position, json.dumps(message))
-                for position, message in enumerate(session.messages)
-            ],
-        )
-        if migration_marker is not None:
-            connection.execute(
-                "INSERT INTO store_metadata (key, value) VALUES (?, ?)",
-                ("jsonl_import_v1", migration_marker),
-            )
-
-
 def test_sqlite_store_round_trips_through_manager(tmp_path) -> None:
     key = "websocket:quote'和中文"
     stored = _session(
@@ -457,129 +398,30 @@ def test_jsonl_backup_touch_with_same_content_does_not_block_startup(tmp_path) -
     assert SessionManager(tmp_path).get_or_create(stored.key) == stored
 
 
-def test_legacy_count_marker_is_upgraded_without_reimporting_jsonl(tmp_path) -> None:
+def test_non_manifest_migration_marker_fails_closed(tmp_path) -> None:
     source = JsonlSessionFiles(tmp_path)
     stored = _session(
-        "cli:legacy-marker",
+        "cli:invalid-marker",
         updated_at=datetime(2026, 7, 30, 10, 0),
         messages=[{"role": "user", "content": "already imported"}],
-        title="Legacy marker",
+        title="Invalid marker",
     )
     _write_jsonl(source, stored)
-    _create_v1_database(tmp_path, stored, migration_marker="1")
+    SessionManager(tmp_path)
+    with sqlite3.connect(tmp_path / "sessions.db") as connection:
+        connection.execute(
+            "UPDATE store_metadata SET value = '1' WHERE key = 'jsonl_import_v1'"
+        )
 
-    manager = SessionManager(tmp_path)
+    with pytest.raises(RuntimeError, match="Invalid JSONL migration marker"):
+        SessionManager(tmp_path)
 
-    assert manager.get_or_create(stored.key) == stored
+    assert SQLiteSessionStore(tmp_path).load(stored.key) == stored
     with sqlite3.connect(tmp_path / "sessions.db") as connection:
         marker = connection.execute(
             "SELECT value FROM store_metadata WHERE key = 'jsonl_import_v1'"
         ).fetchone()
-        version = connection.execute("PRAGMA user_version").fetchone()
-        private_metadata = connection.execute(
-            "SELECT private_metadata FROM sessions WHERE key = ?",
-            (stored.key,),
-        ).fetchone()
-    assert marker is not None
-    assert json.loads(marker[0])["version"] == 1
-    assert version == (2,)
-    assert private_metadata == ("{}",)
-
-
-def test_legacy_count_marker_rejects_newer_jsonl_backup(tmp_path) -> None:
-    stored = _session(
-        "cli:legacy-marker-rollback",
-        updated_at=datetime(2026, 7, 30, 10, 0),
-        messages=[{"role": "user", "content": "already imported"}],
-        title="Legacy marker",
-    )
-    rollback = _session(
-        stored.key,
-        updated_at=stored.updated_at,
-        messages=[
-            *stored.messages,
-            {"role": "assistant", "content": "written during rollback"},
-        ],
-        title="Legacy marker",
-    )
-    _write_jsonl(JsonlSessionFiles(tmp_path), rollback)
-    _create_v1_database(tmp_path, stored, migration_marker="1")
-
-    with pytest.raises(RuntimeError, match="may have changed after SQLite migration"):
-        SessionManager(tmp_path)
-
-    assert SQLiteSessionStore(tmp_path).load(stored.key) == stored
-
-
-def test_legacy_count_marker_rejects_truncated_jsonl_backup(tmp_path) -> None:
-    stored = _session(
-        "cli:legacy-marker-truncated",
-        updated_at=datetime(2026, 7, 30, 10, 0),
-        messages=[
-            {"role": "user", "content": "first"},
-            {"role": "assistant", "content": "second"},
-        ],
-        title="Legacy marker",
-    )
-    truncated = _session(
-        stored.key,
-        updated_at=stored.updated_at,
-        messages=stored.messages[:1],
-        title="Legacy marker",
-    )
-    truncated.last_consolidated = stored.last_consolidated
-    _write_jsonl(JsonlSessionFiles(tmp_path), truncated)
-    _create_v1_database(tmp_path, stored, migration_marker="1")
-
-    with pytest.raises(RuntimeError, match="may have changed after SQLite migration"):
-        SessionManager(tmp_path)
-
-    assert SQLiteSessionStore(tmp_path).load(stored.key) == stored
-
-
-def test_legacy_count_marker_rejects_missing_jsonl_backup(tmp_path) -> None:
-    keep = _session(
-        "cli:legacy-marker-keep",
-        updated_at=datetime(2026, 7, 30, 10, 0),
-        messages=[{"role": "user", "content": "keep"}],
-        title="Keep",
-    )
-    deleted = _session(
-        "cli:legacy-marker-deleted",
-        updated_at=datetime(2026, 7, 30, 10, 0),
-        messages=[{"role": "user", "content": "deleted during rollback"}],
-        title="Deleted",
-    )
-    _write_jsonl(JsonlSessionFiles(tmp_path), keep)
-    _create_v1_database(tmp_path, keep, migration_marker="2")
-    with sqlite3.connect(tmp_path / "sessions.db") as connection:
-        connection.execute(
-            """
-            INSERT INTO sessions (
-                key, created_at, updated_at, metadata, last_consolidated
-            )
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            (
-                deleted.key,
-                deleted.created_at.isoformat(),
-                deleted.updated_at.isoformat(),
-                json.dumps(deleted.metadata),
-                deleted.last_consolidated,
-            ),
-        )
-        connection.executemany(
-            "INSERT INTO messages (session_key, position, payload) VALUES (?, ?, ?)",
-            [
-                (deleted.key, position, json.dumps(message))
-                for position, message in enumerate(deleted.messages)
-            ],
-        )
-
-    with pytest.raises(RuntimeError, match="may have changed after SQLite migration"):
-        SessionManager(tmp_path)
-
-    assert SQLiteSessionStore(tmp_path).load(deleted.key) == deleted
+    assert marker == ("1",)
 
 
 def test_jsonl_migration_rolls_back_on_invalid_session(tmp_path) -> None:
@@ -985,34 +827,12 @@ def test_concurrent_deletes_do_not_restore_manifest_entries(tmp_path) -> None:
     assert SessionManager(tmp_path).get_or_create(sessions[1].key) == sessions[1]
 
 
-def test_sqlite_store_migrates_v1_schema_in_place(tmp_path) -> None:
-    stored = _session(
-        "cli:schema-v1",
-        updated_at=datetime(2026, 7, 30, 10, 0),
-        messages=[{"role": "user", "content": "keep v1 data"}],
-        title="Schema v1",
-    )
-    _create_v1_database(tmp_path, stored)
-
-    store = SQLiteSessionStore(tmp_path)
-
-    assert store.load(stored.key) == stored
-    with sqlite3.connect(store.db_path) as connection:
-        version = connection.execute("PRAGMA user_version").fetchone()
-        columns = {
-            row[1]
-            for row in connection.execute("PRAGMA table_info(sessions)").fetchall()
-        }
-    assert version == (2,)
-    assert "private_metadata" in columns
-
-
 def test_sqlite_store_rejects_unknown_schema_version(tmp_path) -> None:
     db_path = tmp_path / "sessions.db"
     with sqlite3.connect(db_path) as connection:
-        connection.execute("PRAGMA user_version = 3")
+        connection.execute("PRAGMA user_version = 2")
 
-    with pytest.raises(RuntimeError, match="Unsupported SQLite session schema version 3"):
+    with pytest.raises(RuntimeError, match="Unsupported SQLite session schema version 2"):
         SQLiteSessionStore(tmp_path)
 
 
@@ -1024,7 +844,7 @@ def test_sqlite_store_initializes_concurrently(tmp_path) -> None:
     with sqlite3.connect(stores[0].db_path) as connection:
         version = connection.execute("PRAGMA user_version").fetchone()
         journal_mode = connection.execute("PRAGMA journal_mode").fetchone()
-    assert version == (2,)
+    assert version == (1,)
     assert journal_mode == ("wal",)
 
 

--- a/tests/session/test_sqlite_store.py
+++ b/tests/session/test_sqlite_store.py
@@ -1,0 +1,229 @@
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from threading import Event
+
+import pytest
+
+from nanobot.session import Session, SessionManager
+from nanobot.session.manager import SQLiteSessionStore
+
+
+def _session(
+    key: str,
+    *,
+    updated_at: datetime,
+    messages: list[dict],
+    title: str,
+) -> Session:
+    return Session(
+        key=key,
+        messages=messages,
+        created_at=datetime(2026, 7, 30, 9, 0),
+        updated_at=updated_at,
+        metadata={"title": title, "nested": {"language": "中文"}},
+        last_consolidated=min(1, len(messages)),
+    )
+
+
+def test_sqlite_store_round_trips_through_manager(tmp_path) -> None:
+    key = "websocket:quote'和中文"
+    stored = _session(
+        key,
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "你好"}, {"type": "image", "url": "x"}],
+            },
+        ],
+        title="SQLite session",
+    )
+    manager = SessionManager(tmp_path, store=SQLiteSessionStore(tmp_path))
+
+    manager.save(stored, fsync=True)
+
+    reloaded = SessionManager(tmp_path, store=SQLiteSessionStore(tmp_path))
+    assert reloaded.get_or_create(key) == stored
+    assert reloaded.read_session_file(key) == {
+        "key": key,
+        "created_at": stored.created_at.isoformat(),
+        "updated_at": stored.updated_at.isoformat(),
+        "metadata": stored.metadata,
+        "messages": stored.messages,
+    }
+    assert reloaded.read_session_metadata(key) == {
+        "key": key,
+        "created_at": stored.created_at.isoformat(),
+        "updated_at": stored.updated_at.isoformat(),
+        "metadata": stored.metadata,
+    }
+
+
+def test_sqlite_store_lists_sessions_with_jsonl_projection(tmp_path) -> None:
+    store = SQLiteSessionStore(tmp_path)
+    older = _session(
+        "cli:older",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "assistant", "content": "assistant fallback"}],
+        title="Older",
+    )
+    newer = _session(
+        "cli:newer",
+        updated_at=datetime(2026, 7, 30, 11, 0),
+        messages=[
+            {"role": "assistant", "content": "not selected"},
+            {"role": "user", "content": "first user"},
+        ],
+        title="Newer",
+    )
+    store.save(older)
+    store.save(newer)
+
+    rows = store.list_sessions()
+
+    assert [row["key"] for row in rows] == ["cli:newer", "cli:older"]
+    assert [row["preview"] for row in rows] == ["first user", "assistant fallback"]
+    assert [row["title"] for row in rows] == ["Newer", "Older"]
+    assert {row["path"] for row in rows} == {str(store.db_path)}
+
+
+def test_sqlite_store_replaces_messages_atomically(tmp_path) -> None:
+    store = SQLiteSessionStore(tmp_path)
+    original = _session(
+        "cli:replace",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[
+            {"role": "user", "content": "one"},
+            {"role": "assistant", "content": "two"},
+        ],
+        title="Original",
+    )
+    replacement = _session(
+        original.key,
+        updated_at=datetime(2026, 7, 30, 11, 0),
+        messages=[{"role": "user", "content": "replacement"}],
+        title="Replacement",
+    )
+    store.save(original)
+    store.save(replacement)
+    assert store.load(original.key) == replacement
+
+    invalid = _session(
+        original.key,
+        updated_at=datetime(2026, 7, 30, 12, 0),
+        messages=[{"role": "user", "content": object()}],
+        title="Invalid",
+    )
+    with pytest.raises(TypeError):
+        store.save(invalid)
+
+    assert store.load(original.key) == replacement
+
+    failed = _session(
+        original.key,
+        updated_at=datetime(2026, 7, 30, 13, 0),
+        messages=[{"role": "user", "content": "not committed"}],
+        title="Failed",
+    )
+    with sqlite3.connect(store.db_path) as connection:
+        connection.execute(
+            """
+            CREATE TRIGGER fail_message_insert
+            BEFORE INSERT ON messages
+            WHEN NEW.session_key = 'cli:replace'
+            BEGIN
+                SELECT RAISE(ABORT, 'forced insert failure');
+            END
+            """
+        )
+
+    with pytest.raises(sqlite3.IntegrityError, match="forced insert failure"):
+        store.save(failed)
+
+    assert store.load(original.key) == replacement
+
+
+def test_sqlite_store_delete_cascades_and_is_idempotent(tmp_path) -> None:
+    store = SQLiteSessionStore(tmp_path)
+    session = _session(
+        "cli:delete",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "delete me"}],
+        title="Delete",
+    )
+    store.save(session)
+
+    assert store.delete(session.key) is True
+    assert store.delete(session.key) is False
+    assert store.load(session.key) is None
+    with sqlite3.connect(store.db_path) as connection:
+        count = connection.execute(
+            "SELECT COUNT(*) FROM messages WHERE session_key = ?",
+            (session.key,),
+        ).fetchone()
+    assert count == (0,)
+
+
+def test_sqlite_store_rejects_unknown_schema_version(tmp_path) -> None:
+    db_path = tmp_path / "sessions.db"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("PRAGMA user_version = 2")
+
+    with pytest.raises(RuntimeError, match="Unsupported SQLite session schema version 2"):
+        SQLiteSessionStore(tmp_path)
+
+
+def test_sqlite_store_initializes_concurrently(tmp_path) -> None:
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        stores = list(executor.map(lambda _: SQLiteSessionStore(tmp_path), range(8)))
+
+    assert {store.db_path for store in stores} == {tmp_path / "sessions.db"}
+    with sqlite3.connect(stores[0].db_path) as connection:
+        version = connection.execute("PRAGMA user_version").fetchone()
+        journal_mode = connection.execute("PRAGMA journal_mode").fetchone()
+    assert version == (1,)
+    assert journal_mode == ("wal",)
+
+
+def test_sqlite_store_load_uses_one_snapshot(tmp_path, monkeypatch) -> None:
+    reader = SQLiteSessionStore(tmp_path)
+    writer = SQLiteSessionStore(tmp_path)
+    original = _session(
+        "cli:snapshot",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "before"}],
+        title="Before",
+    )
+    replacement = _session(
+        original.key,
+        updated_at=datetime(2026, 7, 30, 11, 0),
+        messages=[{"role": "user", "content": "after"}],
+        title="After",
+    )
+    reader.save(original)
+    metadata_read = Event()
+    replacement_saved = Event()
+    read_messages = reader._read_messages
+
+    def delayed_read(connection, key):
+        metadata_read.set()
+        assert replacement_saved.wait(timeout=5)
+        return read_messages(connection, key)
+
+    monkeypatch.setattr(reader, "_read_messages", delayed_read)
+
+    def replace_session() -> None:
+        assert metadata_read.wait(timeout=5)
+        writer.save(replacement)
+        replacement_saved.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        loaded_future = executor.submit(reader.load, original.key)
+        replaced_future = executor.submit(replace_session)
+        loaded = loaded_future.result(timeout=10)
+        replaced_future.result(timeout=10)
+
+    assert loaded == original
+    assert writer.load(original.key) == replacement

--- a/tests/session/test_sqlite_store.py
+++ b/tests/session/test_sqlite_store.py
@@ -1,13 +1,35 @@
 import json
+import os
 import sqlite3
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
+from pathlib import Path
 from threading import Event
+from typing import cast
 
 import pytest
 
+from nanobot.providers.base import ProviderConversationState
 from nanobot.session import Session, SessionManager
 from nanobot.session.manager import JsonlSessionFiles, SQLiteSessionStore
+
+
+def _provider_state(secret: str) -> ProviderConversationState:
+    return ProviderConversationState(
+        kind="openai_responses",
+        provider="openai:https://api.openai.com/v1",
+        model="gpt-5.6",
+        version=1,
+        payload={
+            "items": [
+                {
+                    "type": "reasoning",
+                    "encrypted_content": secret,
+                }
+            ]
+        },
+        pending_messages=[{"role": "user", "content": "continue"}],
+    )
 
 
 def _session(
@@ -39,10 +61,77 @@ def _write_jsonl(source: JsonlSessionFiles, session: Session) -> None:
         },
         *session.messages,
     ]
+    if session.provider_state is not None:
+        records.insert(
+            1,
+            {
+                "_type": "provider_state",
+                "state": session.provider_state.to_private_record(),
+            },
+        )
     source.get_session_path(session.key).write_text(
         "".join(json.dumps(record, ensure_ascii=False) + "\n" for record in records),
         encoding="utf-8",
     )
+
+
+def _create_v1_database(
+    workspace: Path,
+    session: Session,
+    *,
+    migration_marker: str | None = None,
+) -> None:
+    with sqlite3.connect(workspace / "sessions.db") as connection:
+        connection.executescript(
+            """
+            CREATE TABLE sessions (
+                key TEXT PRIMARY KEY,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                metadata TEXT NOT NULL,
+                last_consolidated INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE messages (
+                session_key TEXT NOT NULL,
+                position INTEGER NOT NULL,
+                payload TEXT NOT NULL,
+                PRIMARY KEY (session_key, position),
+                FOREIGN KEY (session_key) REFERENCES sessions(key) ON DELETE CASCADE
+            );
+            CREATE TABLE store_metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            PRAGMA user_version = 1;
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO sessions (
+                key, created_at, updated_at, metadata, last_consolidated
+            )
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                session.key,
+                session.created_at.isoformat(),
+                session.updated_at.isoformat(),
+                json.dumps(session.metadata),
+                session.last_consolidated,
+            ),
+        )
+        connection.executemany(
+            "INSERT INTO messages (session_key, position, payload) VALUES (?, ?, ?)",
+            [
+                (session.key, position, json.dumps(message))
+                for position, message in enumerate(session.messages)
+            ],
+        )
+        if migration_marker is not None:
+            connection.execute(
+                "INSERT INTO store_metadata (key, value) VALUES (?, ?)",
+                ("jsonl_import_v1", migration_marker),
+            )
 
 
 def test_sqlite_store_round_trips_through_manager(tmp_path) -> None:
@@ -82,6 +171,159 @@ def test_sqlite_store_round_trips_through_manager(tmp_path) -> None:
     }
 
 
+def test_sqlite_store_keeps_provider_state_private_across_restart(tmp_path) -> None:
+    secret = "encrypted-reasoning-blob"
+    stored = _session(
+        "websocket:private-state",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "hello"}],
+        title="Private state",
+    )
+    stored.provider_state = _provider_state(secret)
+    manager = SessionManager(tmp_path)
+
+    manager.save(stored, fsync=True)
+    reloaded = SessionManager(tmp_path)
+
+    assert reloaded.get_or_create(stored.key).provider_state == stored.provider_state
+    public_payloads = [
+        reloaded.read_session_file(stored.key),
+        reloaded.read_session_metadata(stored.key),
+        reloaded.list_sessions(),
+    ]
+    assert secret not in json.dumps(public_payloads, ensure_ascii=False)
+
+    with sqlite3.connect(tmp_path / "sessions.db") as connection:
+        private_metadata, public_metadata = connection.execute(
+            "SELECT private_metadata, metadata FROM sessions WHERE key = ?",
+            (stored.key,),
+        ).fetchone()
+        message_payloads = connection.execute(
+            "SELECT payload FROM messages WHERE session_key = ?",
+            (stored.key,),
+        ).fetchall()
+    assert json.loads(private_metadata)["provider_state"] == (
+        stored.provider_state.to_private_record()
+    )
+    assert secret not in public_metadata
+    assert all(secret not in payload for (payload,) in message_payloads)
+
+    stored.provider_state = None
+    manager.save(stored)
+
+    assert SessionManager(tmp_path).get_or_create(stored.key).provider_state is None
+    with sqlite3.connect(tmp_path / "sessions.db") as connection:
+        private_metadata = connection.execute(
+            "SELECT private_metadata FROM sessions WHERE key = ?",
+            (stored.key,),
+        ).fetchone()
+    assert private_metadata == ("{}",)
+
+
+def test_session_metadata_remains_extensible_across_migration_restart_and_fork(
+    tmp_path,
+) -> None:
+    future_metadata = {
+        "future_feature": {
+            "nested": [
+                1,
+                None,
+                True,
+                {"language": "中文", "ratio": 0.75},
+            ]
+        }
+    }
+    source = JsonlSessionFiles(tmp_path)
+    stored = _session(
+        "websocket:extensible-metadata",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "preserve metadata"}],
+        title="Extensible",
+    )
+    stored.metadata.update(future_metadata)
+    _write_jsonl(source, stored)
+
+    manager = SessionManager(tmp_path)
+    assert manager.read_session_metadata(stored.key)["metadata"]["future_feature"] == (
+        future_metadata["future_feature"]
+    )
+    assert manager.list_sessions()[0]["key"] == stored.key
+    assert manager.read_session_file(stored.key)["metadata"]["future_feature"] == (
+        future_metadata["future_feature"]
+    )
+
+    reloaded = SessionManager(tmp_path)
+    forked = reloaded.fork_session_before_user_index(
+        stored.key,
+        "websocket:extensible-metadata-fork",
+        1,
+    )
+
+    assert forked is not None
+    assert forked.metadata["future_feature"] == future_metadata["future_feature"]
+    assert SessionManager(tmp_path).get_or_create(forked.key).metadata["future_feature"] == (
+        future_metadata["future_feature"]
+    )
+
+
+def test_jsonl_migration_preserves_provider_state_without_public_leakage(tmp_path) -> None:
+    secret = "migrated-encrypted-state"
+    source = JsonlSessionFiles(tmp_path)
+    stored = _session(
+        "cli:migrate-private-state",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "public history"}],
+        title="Migrated private state",
+    )
+    stored.provider_state = _provider_state(secret)
+    _write_jsonl(source, stored)
+
+    manager = SessionManager(tmp_path)
+    migrated = manager.get_or_create(stored.key)
+
+    assert migrated.provider_state == stored.provider_state
+    assert migrated.messages == stored.messages
+    assert secret not in json.dumps(manager.read_session_file(stored.key))
+    assert secret not in json.dumps(manager.list_sessions())
+
+
+def test_jsonl_migration_drops_invalid_provider_state_from_public_history(tmp_path) -> None:
+    key = "cli:invalid-private-state"
+    source = JsonlSessionFiles(tmp_path)
+    source.get_session_path(key).write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "_type": "metadata",
+                        "key": key,
+                        "created_at": datetime(2026, 7, 30, 9, 0).isoformat(),
+                        "updated_at": datetime(2026, 7, 30, 10, 0).isoformat(),
+                        "metadata": {},
+                        "last_consolidated": 0,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "_type": "provider_state",
+                        "state": {"kind": "openai_responses"},
+                    }
+                ),
+                json.dumps({"role": "user", "content": "safe"}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    manager = SessionManager(tmp_path)
+    migrated = manager.get_or_create(key)
+
+    assert migrated.provider_state is None
+    assert migrated.messages == [{"role": "user", "content": "safe"}]
+    assert manager.read_session_file(key)["messages"] == migrated.messages
+
+
 def test_manager_migrates_jsonl_once_and_keeps_source_as_backup(
     tmp_path,
     monkeypatch,
@@ -104,15 +346,240 @@ def test_manager_migrates_jsonl_once_and_keeps_source_as_backup(
     stored.add_message("assistant", "only in sqlite")
     manager.save(stored)
 
-    def fail_scan(_self) -> None:
-        raise AssertionError("JSONL backups should not be scanned after migration")
+    def fail_reload(_self, _key) -> None:
+        raise AssertionError("JSONL backups should not be re-imported after migration")
 
-    monkeypatch.setattr(JsonlSessionFiles, "session_files", fail_scan)
+    monkeypatch.setattr(JsonlSessionFiles, "load_for_migration", fail_reload)
     reloaded = SessionManager(tmp_path)
     assert [message["content"] for message in reloaded.get_or_create(stored.key).messages] == [
         "from jsonl",
         "only in sqlite",
     ]
+
+
+@pytest.mark.parametrize("change_kind", ["modified", "new"])
+def test_jsonl_backup_changes_after_migration_fail_closed(
+    tmp_path,
+    change_kind,
+) -> None:
+    source = JsonlSessionFiles(tmp_path)
+    stored = _session(
+        "cli:rollback-source",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "before rollback"}],
+        title="Before rollback",
+    )
+    _write_jsonl(source, stored)
+    SessionManager(tmp_path)
+
+    if change_kind == "modified":
+        rollback = _session(
+            stored.key,
+            updated_at=datetime(2026, 7, 30, 11, 0),
+            messages=[
+                *stored.messages,
+                {"role": "assistant", "content": "written during rollback"},
+            ],
+            title="During rollback",
+        )
+    else:
+        rollback = _session(
+            "cli:created-during-rollback",
+            updated_at=datetime(2026, 7, 30, 11, 0),
+            messages=[{"role": "user", "content": "new during rollback"}],
+            title="Created during rollback",
+        )
+    _write_jsonl(source, rollback)
+
+    with pytest.raises(RuntimeError, match="changed after SQLite migration"):
+        SessionManager(tmp_path)
+
+    assert SQLiteSessionStore(tmp_path).load(stored.key) == stored
+    assert source.get_session_path(rollback.key).is_file()
+
+
+def test_jsonl_backup_deletion_after_migration_fails_closed(tmp_path) -> None:
+    source = JsonlSessionFiles(tmp_path)
+    stored = _session(
+        "cli:deleted-during-rollback",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "do not resurrect"}],
+        title="Deleted during rollback",
+    )
+    _write_jsonl(source, stored)
+    SessionManager(tmp_path)
+    source.get_session_path(stored.key).unlink()
+
+    with pytest.raises(RuntimeError, match="changed after SQLite migration"):
+        SessionManager(tmp_path)
+
+    assert SQLiteSessionStore(tmp_path).load(stored.key) == stored
+
+
+def test_jsonl_backup_content_hash_detects_same_stat_rewrite(tmp_path) -> None:
+    source = JsonlSessionFiles(tmp_path)
+    stored = _session(
+        "cli:same-stat-rewrite",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "before"}],
+        title="Same stat",
+    )
+    _write_jsonl(source, stored)
+    SessionManager(tmp_path)
+    path = source.get_session_path(stored.key)
+    original_stat = path.stat()
+    rewritten = path.read_text(encoding="utf-8").replace("before", "during")
+    path.write_text(rewritten, encoding="utf-8")
+    assert path.stat().st_size == original_stat.st_size
+    os.utime(
+        path,
+        ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+    )
+
+    with pytest.raises(RuntimeError, match="changed after SQLite migration"):
+        SessionManager(tmp_path)
+
+    assert SQLiteSessionStore(tmp_path).load(stored.key) == stored
+
+
+def test_jsonl_backup_touch_with_same_content_does_not_block_startup(tmp_path) -> None:
+    source = JsonlSessionFiles(tmp_path)
+    stored = _session(
+        "cli:touched-backup",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "unchanged"}],
+        title="Touched",
+    )
+    _write_jsonl(source, stored)
+    SessionManager(tmp_path)
+    source.get_session_path(stored.key).touch()
+
+    assert SessionManager(tmp_path).get_or_create(stored.key) == stored
+
+
+def test_legacy_count_marker_is_upgraded_without_reimporting_jsonl(tmp_path) -> None:
+    source = JsonlSessionFiles(tmp_path)
+    stored = _session(
+        "cli:legacy-marker",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "already imported"}],
+        title="Legacy marker",
+    )
+    _write_jsonl(source, stored)
+    _create_v1_database(tmp_path, stored, migration_marker="1")
+
+    manager = SessionManager(tmp_path)
+
+    assert manager.get_or_create(stored.key) == stored
+    with sqlite3.connect(tmp_path / "sessions.db") as connection:
+        marker = connection.execute(
+            "SELECT value FROM store_metadata WHERE key = 'jsonl_import_v1'"
+        ).fetchone()
+        version = connection.execute("PRAGMA user_version").fetchone()
+        private_metadata = connection.execute(
+            "SELECT private_metadata FROM sessions WHERE key = ?",
+            (stored.key,),
+        ).fetchone()
+    assert marker is not None
+    assert json.loads(marker[0])["version"] == 1
+    assert version == (2,)
+    assert private_metadata == ("{}",)
+
+
+def test_legacy_count_marker_rejects_newer_jsonl_backup(tmp_path) -> None:
+    stored = _session(
+        "cli:legacy-marker-rollback",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "already imported"}],
+        title="Legacy marker",
+    )
+    rollback = _session(
+        stored.key,
+        updated_at=stored.updated_at,
+        messages=[
+            *stored.messages,
+            {"role": "assistant", "content": "written during rollback"},
+        ],
+        title="Legacy marker",
+    )
+    _write_jsonl(JsonlSessionFiles(tmp_path), rollback)
+    _create_v1_database(tmp_path, stored, migration_marker="1")
+
+    with pytest.raises(RuntimeError, match="may have changed after SQLite migration"):
+        SessionManager(tmp_path)
+
+    assert SQLiteSessionStore(tmp_path).load(stored.key) == stored
+
+
+def test_legacy_count_marker_rejects_truncated_jsonl_backup(tmp_path) -> None:
+    stored = _session(
+        "cli:legacy-marker-truncated",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+        ],
+        title="Legacy marker",
+    )
+    truncated = _session(
+        stored.key,
+        updated_at=stored.updated_at,
+        messages=stored.messages[:1],
+        title="Legacy marker",
+    )
+    truncated.last_consolidated = stored.last_consolidated
+    _write_jsonl(JsonlSessionFiles(tmp_path), truncated)
+    _create_v1_database(tmp_path, stored, migration_marker="1")
+
+    with pytest.raises(RuntimeError, match="may have changed after SQLite migration"):
+        SessionManager(tmp_path)
+
+    assert SQLiteSessionStore(tmp_path).load(stored.key) == stored
+
+
+def test_legacy_count_marker_rejects_missing_jsonl_backup(tmp_path) -> None:
+    keep = _session(
+        "cli:legacy-marker-keep",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "keep"}],
+        title="Keep",
+    )
+    deleted = _session(
+        "cli:legacy-marker-deleted",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "deleted during rollback"}],
+        title="Deleted",
+    )
+    _write_jsonl(JsonlSessionFiles(tmp_path), keep)
+    _create_v1_database(tmp_path, keep, migration_marker="2")
+    with sqlite3.connect(tmp_path / "sessions.db") as connection:
+        connection.execute(
+            """
+            INSERT INTO sessions (
+                key, created_at, updated_at, metadata, last_consolidated
+            )
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                deleted.key,
+                deleted.created_at.isoformat(),
+                deleted.updated_at.isoformat(),
+                json.dumps(deleted.metadata),
+                deleted.last_consolidated,
+            ),
+        )
+        connection.executemany(
+            "INSERT INTO messages (session_key, position, payload) VALUES (?, ?, ?)",
+            [
+                (deleted.key, position, json.dumps(message))
+                for position, message in enumerate(deleted.messages)
+            ],
+        )
+
+    with pytest.raises(RuntimeError, match="may have changed after SQLite migration"):
+        SessionManager(tmp_path)
+
+    assert SQLiteSessionStore(tmp_path).load(deleted.key) == deleted
 
 
 def test_jsonl_migration_rolls_back_on_invalid_session(tmp_path) -> None:
@@ -162,6 +629,78 @@ def test_jsonl_migration_is_safe_under_concurrent_startup(tmp_path) -> None:
     assert message_count == (1,)
 
 
+def test_jsonl_parsing_happens_outside_sqlite_write_lock(tmp_path, monkeypatch) -> None:
+    source = JsonlSessionFiles(tmp_path)
+    stored = _session(
+        "cli:lock-free-prepare",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "prepare outside lock"}],
+        title="Lock free prepare",
+    )
+    _write_jsonl(source, stored)
+    store = SQLiteSessionStore(tmp_path)
+    load_started = Event()
+    release_load = Event()
+    load_for_migration = source.load_for_migration
+
+    def delayed_load(key):
+        load_started.set()
+        assert release_load.wait(timeout=5)
+        return load_for_migration(key)
+
+    monkeypatch.setattr(source, "load_for_migration", delayed_load)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        migration = executor.submit(store.migrate_from_jsonl, source)
+        assert load_started.wait(timeout=5)
+        try:
+            with sqlite3.connect(store.db_path, timeout=0.2) as connection:
+                connection.execute("PRAGMA busy_timeout = 200")
+                connection.execute("BEGIN IMMEDIATE")
+                connection.rollback()
+        finally:
+            release_load.set()
+        assert migration.result(timeout=5) == 1
+
+
+def test_jsonl_hashing_happens_outside_sqlite_write_lock(tmp_path, monkeypatch) -> None:
+    source = JsonlSessionFiles(tmp_path)
+    stored = _session(
+        "cli:lock-free-hash",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "hash outside lock"}],
+        title="Lock free hash",
+    )
+    _write_jsonl(source, stored)
+    store = SQLiteSessionStore(tmp_path)
+    hash_started = Event()
+    release_hash = Event()
+    current_signatures = store._current_jsonl_signatures
+
+    def delayed_hash(_cls, jsonl_source):
+        hash_started.set()
+        assert release_hash.wait(timeout=5)
+        return current_signatures(jsonl_source)
+
+    monkeypatch.setattr(
+        SQLiteSessionStore,
+        "_current_jsonl_signatures",
+        classmethod(delayed_hash),
+    )
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        migration = executor.submit(store.migrate_from_jsonl, source)
+        assert hash_started.wait(timeout=5)
+        try:
+            with sqlite3.connect(store.db_path, timeout=0.2) as connection:
+                connection.execute("PRAGMA busy_timeout = 200")
+                connection.execute("BEGIN IMMEDIATE")
+                connection.rollback()
+        finally:
+            release_hash.set()
+        assert migration.result(timeout=5) == 1
+
+
 def test_sqlite_store_lists_sessions_with_session_projection(tmp_path) -> None:
     store = SQLiteSessionStore(tmp_path)
     older = _session(
@@ -208,6 +747,8 @@ def test_sqlite_store_replaces_messages_atomically(tmp_path) -> None:
         messages=[{"role": "user", "content": "replacement"}],
         title="Replacement",
     )
+    original.provider_state = _provider_state("original-state")
+    replacement.provider_state = _provider_state("replacement-state")
     store.save(original)
     store.save(replacement)
     assert store.load(original.key) == replacement
@@ -229,6 +770,7 @@ def test_sqlite_store_replaces_messages_atomically(tmp_path) -> None:
         messages=[{"role": "user", "content": "not committed"}],
         title="Failed",
     )
+    failed.provider_state = _provider_state("failed-state")
     with sqlite3.connect(store.db_path) as connection:
         connection.execute(
             """
@@ -245,6 +787,95 @@ def test_sqlite_store_replaces_messages_atomically(tmp_path) -> None:
         store.save(failed)
 
     assert store.load(original.key) == replacement
+
+
+def test_sqlite_store_rejects_non_object_message_without_overwrite(tmp_path) -> None:
+    store = SQLiteSessionStore(tmp_path)
+    original = _session(
+        "cli:invalid-dynamic-message",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "preserve me"}],
+        title="Original",
+    )
+    store.save(original)
+    invalid = _session(
+        original.key,
+        updated_at=datetime(2026, 7, 30, 11, 0),
+        messages=[{"role": "user", "content": "replacement"}],
+        title="Invalid",
+    )
+    invalid.messages.append(
+        cast(dict[str, object], cast(object, ["not", "an", "object"]))
+    )
+
+    with pytest.raises(ValueError, match="session records must be JSON objects"):
+        store.save(invalid)
+
+    assert store.load(original.key) == original
+
+
+def test_sqlite_store_corruption_fails_closed_without_replacing_session(tmp_path) -> None:
+    stored = _session(
+        "cli:corrupt-message",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "preserve me"}],
+        title="Corrupt",
+    )
+    store = SQLiteSessionStore(tmp_path)
+    store.save(stored)
+    with sqlite3.connect(store.db_path) as connection:
+        connection.execute(
+            "UPDATE messages SET payload = '[]' WHERE session_key = ?",
+            (stored.key,),
+        )
+
+    manager = SessionManager(tmp_path)
+    with pytest.raises(RuntimeError, match="Failed to load SQLite session"):
+        manager.get_or_create(stored.key)
+
+    assert manager.get_cached(stored.key) is None
+    with sqlite3.connect(store.db_path) as connection:
+        session_count = connection.execute(
+            "SELECT COUNT(*) FROM sessions WHERE key = ?",
+            (stored.key,),
+        ).fetchone()
+        payload = connection.execute(
+            "SELECT payload FROM messages WHERE session_key = ?",
+            (stored.key,),
+        ).fetchone()
+    assert session_count == (1,)
+    assert payload == ("[]",)
+
+
+def test_sqlite_store_metadata_corruption_fails_closed_for_all_reads(tmp_path) -> None:
+    stored = _session(
+        "cli:corrupt-metadata",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "preserve me"}],
+        title="Corrupt metadata",
+    )
+    store = SQLiteSessionStore(tmp_path)
+    store.save(stored)
+    with sqlite3.connect(store.db_path) as connection:
+        connection.execute(
+            "UPDATE sessions SET metadata = '[]' WHERE key = ?",
+            (stored.key,),
+        )
+    manager = SessionManager(tmp_path)
+
+    with pytest.raises(RuntimeError, match="Failed to load SQLite session"):
+        manager.get_or_create(stored.key)
+    with pytest.raises(RuntimeError, match="Failed to read SQLite session metadata"):
+        manager.read_session_metadata(stored.key)
+    with pytest.raises(RuntimeError, match="Failed to list SQLite sessions"):
+        manager.list_sessions()
+
+    with sqlite3.connect(store.db_path) as connection:
+        metadata = connection.execute(
+            "SELECT metadata FROM sessions WHERE key = ?",
+            (stored.key,),
+        ).fetchone()
+    assert metadata == ("[]",)
 
 
 def test_sqlite_store_delete_cascades_and_is_idempotent(tmp_path) -> None:
@@ -268,12 +899,120 @@ def test_sqlite_store_delete_cascades_and_is_idempotent(tmp_path) -> None:
     assert count == (0,)
 
 
+def test_manager_keeps_sqlite_session_when_backup_delete_fails(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    source = JsonlSessionFiles(tmp_path)
+    stored = _session(
+        "cli:locked-backup",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "do not resurrect"}],
+        title="Locked backup",
+    )
+    _write_jsonl(source, stored)
+    manager = SessionManager(tmp_path)
+    backup = source.get_session_path(stored.key)
+    unlink = Path.unlink
+
+    def fail_locked_backup(path, *args, **kwargs):
+        if path == backup:
+            raise PermissionError("backup is locked")
+        return unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_locked_backup)
+
+    with pytest.raises(PermissionError, match="backup is locked"):
+        manager.delete_session(stored.key)
+
+    assert backup.is_file()
+    assert SQLiteSessionStore(tmp_path).load(stored.key) == stored
+
+
+def test_manager_delete_updates_migration_manifest_before_key_reuse(tmp_path) -> None:
+    source = JsonlSessionFiles(tmp_path)
+    stored = _session(
+        "cli:delete-and-reuse",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "old history"}],
+        title="Old history",
+    )
+    _write_jsonl(source, stored)
+    manager = SessionManager(tmp_path)
+
+    assert manager.delete_session(stored.key) is True
+    reloaded = SessionManager(tmp_path)
+    assert reloaded.read_session_file(stored.key) is None
+
+    replacement = _session(
+        stored.key,
+        updated_at=datetime(2026, 7, 30, 11, 0),
+        messages=[{"role": "user", "content": "new history"}],
+        title="New history",
+    )
+    reloaded.save(replacement)
+
+    assert SessionManager(tmp_path).get_or_create(stored.key) == replacement
+
+
+def test_concurrent_deletes_do_not_restore_manifest_entries(tmp_path) -> None:
+    source = JsonlSessionFiles(tmp_path)
+    sessions = [
+        _session(
+            f"cli:concurrent-delete-{index}",
+            updated_at=datetime(2026, 7, 30, 10, index),
+            messages=[{"role": "user", "content": str(index)}],
+            title=f"Delete {index}",
+        )
+        for index in range(2)
+    ]
+    for session in sessions:
+        _write_jsonl(source, session)
+    manager = SessionManager(tmp_path)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        deleted = list(executor.map(manager.delete_session, [s.key for s in sessions]))
+
+    assert deleted == [True, True]
+    with sqlite3.connect(tmp_path / "sessions.db") as connection:
+        marker = connection.execute(
+            "SELECT value FROM store_metadata WHERE key = 'jsonl_import_v1'"
+        ).fetchone()
+    assert marker is not None
+    assert json.loads(marker[0])["files"] == {}
+
+    manager.save(sessions[1])
+    assert SessionManager(tmp_path).get_or_create(sessions[1].key) == sessions[1]
+
+
+def test_sqlite_store_migrates_v1_schema_in_place(tmp_path) -> None:
+    stored = _session(
+        "cli:schema-v1",
+        updated_at=datetime(2026, 7, 30, 10, 0),
+        messages=[{"role": "user", "content": "keep v1 data"}],
+        title="Schema v1",
+    )
+    _create_v1_database(tmp_path, stored)
+
+    store = SQLiteSessionStore(tmp_path)
+
+    assert store.load(stored.key) == stored
+    with sqlite3.connect(store.db_path) as connection:
+        version = connection.execute("PRAGMA user_version").fetchone()
+        columns = {
+            row[1]
+            for row in connection.execute("PRAGMA table_info(sessions)").fetchall()
+        }
+    assert version == (2,)
+    assert "private_metadata" in columns
+
+
 def test_sqlite_store_rejects_unknown_schema_version(tmp_path) -> None:
     db_path = tmp_path / "sessions.db"
     with sqlite3.connect(db_path) as connection:
-        connection.execute("PRAGMA user_version = 2")
+        connection.execute("PRAGMA user_version = 3")
 
-    with pytest.raises(RuntimeError, match="Unsupported SQLite session schema version 2"):
+    with pytest.raises(RuntimeError, match="Unsupported SQLite session schema version 3"):
         SQLiteSessionStore(tmp_path)
 
 
@@ -285,7 +1024,7 @@ def test_sqlite_store_initializes_concurrently(tmp_path) -> None:
     with sqlite3.connect(stores[0].db_path) as connection:
         version = connection.execute("PRAGMA user_version").fetchone()
         journal_mode = connection.execute("PRAGMA journal_mode").fetchone()
-    assert version == (1,)
+    assert version == (2,)
     assert journal_mode == ("wal",)
 
 
@@ -304,6 +1043,8 @@ def test_sqlite_store_load_uses_one_snapshot(tmp_path, monkeypatch) -> None:
         messages=[{"role": "user", "content": "after"}],
         title="After",
     )
+    original.provider_state = _provider_state("before-state")
+    replacement.provider_state = _provider_state("after-state")
     reader.save(original)
     metadata_read = Event()
     replacement_saved = Event()

--- a/tests/webui/test_session_list_index.py
+++ b/tests/webui/test_session_list_index.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from datetime import datetime
 from pathlib import Path
@@ -11,7 +12,7 @@ from nanobot.cron.session_turns import CRON_HISTORY_META
 from nanobot.providers.base import ProviderConversationState
 from nanobot.session.automation_turns import AUTOMATION_HISTORY_META
 from nanobot.session.history_visibility import HIDDEN_HISTORY_META
-from nanobot.session.manager import SessionManager
+from nanobot.session.manager import JsonlSessionFiles, SessionManager
 from nanobot.session.model_selection import SESSION_MODEL_PRESET_METADATA_KEY
 
 
@@ -28,16 +29,33 @@ def test_webui_session_list_reuses_valid_index_without_scanning_files(
     assert list_webui_sessions(manager)[0]["preview"] == "indexed preview"
     assert list_webui_sessions(manager)[0]["model_preset"] == "fast"
 
-    def fail_scan(session_manager: SessionManager, path: Path) -> None:
-        raise AssertionError(f"unexpected session file scan: {path}")
+    def fail_read(key: str) -> None:
+        raise AssertionError(f"unexpected session read: {key}")
 
-    monkeypatch.setattr(session_list_index, "_scan_session_row", fail_scan)
+    monkeypatch.setattr(manager, "read_session_file", fail_read)
 
     rows = list_webui_sessions(manager)
 
     assert rows[0]["key"] == "websocket:indexed"
     assert rows[0]["preview"] == "indexed preview"
     assert rows[0]["model_preset"] == "fast"
+
+
+def test_webui_session_list_rebuilds_invalid_cached_row(tmp_path: Path) -> None:
+    manager = SessionManager(tmp_path)
+    session = manager.get_or_create("websocket:invalid-index")
+    session.add_message("user", "hello")
+    manager.save(session)
+    expected_updated_at = list_webui_sessions(manager)[0]["updated_at"]
+
+    index_path = tmp_path / "sessions" / ".webui_session_index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    index["sessions"][0]["updated_at"] = None
+    index_path.write_text(json.dumps(index), encoding="utf-8")
+
+    row = list_webui_sessions(manager)[0]
+
+    assert row["updated_at"] == expected_updated_at
 
 
 def test_webui_session_list_rejects_invalid_internal_model_preset_metadata(
@@ -71,18 +89,18 @@ def test_webui_session_list_rescans_only_changed_file(tmp_path: Path, monkeypatc
     second.add_message("user", "second after")
     manager.save(second)
 
-    original_scan = session_list_index._scan_session_row
+    original_read = manager.read_session_file
     scanned: list[str] = []
 
-    def record_scan(session_manager: SessionManager, path: Path) -> dict | None:
-        scanned.append(path.name)
-        return original_scan(session_manager, path)
+    def record_read(key: str) -> dict | None:
+        scanned.append(key)
+        return original_read(key)
 
-    monkeypatch.setattr(session_list_index, "_scan_session_row", record_scan)
+    monkeypatch.setattr(manager, "read_session_file", record_read)
 
     rows = list_webui_sessions(manager)
 
-    assert scanned == [manager._get_session_path("websocket:second").name]
+    assert scanned == ["websocket:second"]
     assert {row["preview"] for row in rows} == {"first", "second after"}
 
 
@@ -121,7 +139,7 @@ def test_webui_session_list_drops_deleted_index_rows(tmp_path: Path) -> None:
 
 def test_webui_session_list_ignores_legacy_stem(tmp_path: Path) -> None:
     manager = SessionManager(tmp_path)
-    legacy_path = manager.sessions_dir / "websocket_legacy.jsonl"
+    legacy_path = manager.workspace / "sessions" / "websocket_legacy.jsonl"
     legacy_path.write_text(
         '{"_type":"metadata","key":"websocket:legacy",'
         '"created_at":"2025-01-01T00:00:00",'
@@ -244,18 +262,18 @@ def test_webui_session_list_rescans_when_transcript_changes(
     activity_ns = int(datetime(2026, 6, 15, 12, 30, 0).timestamp() * 1_000_000_000)
     os.utime(transcript, ns=(activity_ns, activity_ns))
 
-    original_scan = session_list_index._scan_session_row
+    original_read = manager.read_session_file
     scanned: list[str] = []
 
-    def record_scan(session_manager: SessionManager, path: Path) -> dict | None:
-        scanned.append(path.name)
-        return original_scan(session_manager, path)
+    def record_read(key: str) -> dict | None:
+        scanned.append(key)
+        return original_read(key)
 
-    monkeypatch.setattr(session_list_index, "_scan_session_row", record_scan)
+    monkeypatch.setattr(manager, "read_session_file", record_read)
 
     rows = list_webui_sessions(manager)
 
-    assert scanned == [manager._get_session_path("websocket:transcript-change").name]
+    assert scanned == ["websocket:transcript-change"]
     assert rows[0]["updated_at"].startswith("2026-06-15T12:30:00")
 
 
@@ -290,13 +308,14 @@ def list_webui_sessions(manager: SessionManager) -> list[dict]:
 
 
 def test_webui_session_list_fallback_time_when_missing(tmp_path: Path) -> None:
-    manager = SessionManager(tmp_path)
-    path = manager._get_session_path("websocket:missing-time")
+    source = JsonlSessionFiles(tmp_path)
+    path = source.get_session_path("websocket:missing-time")
     path.write_text(
         '{"_type": "metadata", "key": "websocket:missing-time"}\n'
         '{"_type": "message", "role": "user", "content": "hello"}\n',
         encoding="utf-8",
     )
+    manager = SessionManager(tmp_path)
 
     rows = list_webui_sessions(manager)
     assert len(rows) == 1
@@ -308,13 +327,14 @@ def test_webui_session_list_fallback_time_when_missing(tmp_path: Path) -> None:
 
 
 def test_session_manager_list_sessions_fallback_time_when_missing(tmp_path: Path) -> None:
-    manager = SessionManager(tmp_path)
-    path = manager._get_session_path("websocket:missing-time2")
+    source = JsonlSessionFiles(tmp_path)
+    path = source.get_session_path("websocket:missing-time2")
     path.write_text(
         '{"_type": "metadata", "key": "websocket:missing-time2"}\n'
         '{"_type": "message", "role": "user", "content": "hello"}\n',
         encoding="utf-8",
     )
+    manager = SessionManager(tmp_path)
 
     sessions = manager.list_sessions()
     assert len(sessions) == 1


### PR DESCRIPTION
## Summary

- make `sessions.db` the only runtime session store
- transactionally import canonical `<workspace>/sessions/*.jsonl` on first startup
- retain JSONL files as rollback backups while runtime reads and writes use SQLite
- route WebUI session listing and Dream pruning through `SessionManager`
- remove the parallel JSONL runtime store and backend selector

## Migration and compatibility safety

- rebase onto main `6a1a45d07` and preserve OpenAI Responses provider continuation state
- use the first released SQLite schema (v1), including the private metadata envelope from initial database creation
- keep public session metadata in an extensible JSON object; unknown nested fields survive migration, restart, listing/read consumers, and fork
- isolate provider-owned continuation state in private JSON that public session/WebUI APIs never return
- parse, validate, and serialize JSONL outside the SQLite write lock; use a bounded startup lock timeout and transactional conflict/marker checks
- record SHA-256 hashes for retained JSONL backups; unchanged `touch` operations are accepted, while rollback additions, edits, truncations, and deletions fail closed instead of silently diverging
- reject malformed migration markers before any session or marker mutation
- reject canonical filename / metadata-key mismatches and ambiguous lossy filename deletion
- fail closed on logical SQLite corruption so a damaged row cannot be treated as a missing session and overwritten
- delete rollback backups before the SQLite row; failures remain visible and keep the live SQLite session intact

The JSONL migration/checking path is limited to the v0.3.1 upgrade window and is marked for removal in v0.3.2.

## Verification

- `$simplify`: PASS; no safe behavior-preserving simplification remained
- `$pr-review`: PASS; final maintainer review found no blocker/high/medium findings
- `$verify`: PASS through a real gateway, authenticated session/messages/thread APIs, and the built React WebUI
- Python: `5779 passed, 40 skipped`
- focused SQLite/session/delete/collision regression suite: `91 passed`
- WebUI: `52` files / `896` tests passed
- production WebUI build passed
- `ruff check nanobot tests conftest.py` passed
- scoped strict `basedpyright`: 0 errors / 0 warnings
- `git diff --check` passed
- black-box evidence: migrated nested metadata and history survived restart and browser refresh; private provider state did not leak; browser console had 0 errors; content-preserving touch restarted successfully; same-length content rewrite exited non-zero with the expected fail-closed migration error