### PR TITLE
feat(webui): support remote Codex OAuth login

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -150,7 +150,7 @@ If you need a known-good snippet instead of diagnosis, use [`provider-cookbook.m
 | Bedrock validation error | Check AWS region, credentials, model access, model ID, and whether the model supports Converse. |
 | OAuth provider fails | Run the matching login command: `openai-codex`, `xai-grok`, or `github-copilot`, normally with `--set-main`. |
 | Codex OAuth needs a proxy | Set `providers.openaiCodex.proxy` before running the login command. The proxy applies to login, token refresh, and Codex API requests. |
-| Codex login runs on a remote/headless machine | Open the printed URL in a local browser, then paste the final `http://localhost:1455/auth/callback?...` URL back into the terminal. |
+| Codex login runs on a remote/headless machine | In the WebUI, open ChatGPT in your local browser; when the localhost callback page cannot load, copy the full `http://localhost:1455/auth/callback?...` URL from the address bar and paste it into the WebUI dialog. From the CLI, open the printed URL locally and paste the same callback URL back into the terminal. |
 | Codex login runs in Docker | Start the container with `docker run -it` so the OAuth flow has an interactive terminal. |
 | Codex says a model is not supported with a ChatGPT account | Use provider `openai_codex` with a Codex model such as `openai-codex/gpt-5.6-sol`. Do not use the direct-API `openai/...` prefix with Codex OAuth. |
 | Config says `providers.openai_codex` conflicts with the built-in provider | Under `providers`, keep only the canonical `openaiCodex` settings key and remove a duplicate `openai_codex` key. A model preset's `provider` value remains `openai_codex`. |

--- a/nanobot/providers/openai_codex_oauth.py
+++ b/nanobot/providers/openai_codex_oauth.py
@@ -1,0 +1,494 @@
+"""Non-blocking OpenAI Codex OAuth flow for browser and remote WebUI login."""
+
+# oauth-cli-kit does not publish type stubs.
+# pyright: reportMissingTypeStubs=false
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import queue
+import secrets
+import socket
+import threading
+import time
+from contextlib import suppress
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, cast
+from urllib.parse import parse_qs, urlencode, urlsplit
+
+import httpx
+from oauth_cli_kit.models import OAuthProviderConfig, OAuthToken
+from oauth_cli_kit.providers import OPENAI_CODEX_PROVIDER
+from oauth_cli_kit.storage import FileTokenStorage
+
+_HTTP_TIMEOUT_S = 30.0
+_CALLBACK_PATH = "/auth/callback"
+_CALLBACK_PORT = 1455
+
+
+class OpenAICodexOAuthError(RuntimeError):
+    """An actionable Codex OAuth failure that contains no credential material."""
+
+
+class OpenAICodexOAuthInputError(OpenAICodexOAuthError):
+    """A recoverable error in a callback URL pasted by the user."""
+
+
+@dataclass(frozen=True)
+class _CallbackResult:
+    code: str | None = None
+    state: str | None = None
+    error: str | None = None
+
+
+class OpenAICodexOAuthLoginFlow:
+    """Pending Codex OAuth login completed by loopback or a pasted callback URL."""
+
+    def __init__(
+        self,
+        *,
+        authorization_url: str,
+        verifier: str,
+        state: str,
+        proxy: str | None,
+        result_queue: queue.Queue[_CallbackResult],
+        server: ThreadingHTTPServer | None,
+        timeout_s: float,
+    ) -> None:
+        self.authorization_url = authorization_url
+        self._verifier = verifier
+        self._state = state
+        self._proxy = proxy
+        self._result_queue = result_queue
+        self._server = server
+        self._expires_at = time.monotonic() + timeout_s
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._token: OAuthToken | None = None
+        self._error: Exception | None = None
+        self._closed = False
+        self._server_thread: threading.Thread | None = None
+        if server is not None:
+            self._server_thread = threading.Thread(
+                target=_serve_callback_server,
+                args=(server, self._stop_event),
+                name="nanobot-openai-codex-oauth-callback",
+                daemon=True,
+            )
+            self._server_thread.start()
+        self._timeout_timer = threading.Timer(timeout_s, self._expire)
+        self._timeout_timer.daemon = True
+        self._timeout_timer.start()
+
+    @property
+    def expired(self) -> bool:
+        return time.monotonic() >= self._expires_at
+
+    @property
+    def remaining_seconds(self) -> int:
+        return max(0, int(self._expires_at - time.monotonic()))
+
+    def complete(self, callback_url: str | None = None) -> OAuthToken | None:
+        """Complete the login or return ``None`` while loopback is still pending."""
+        with self._lock:
+            if self._token is not None:
+                return self._token
+            self._raise_if_finished()
+
+        callback: _CallbackResult | None
+        if callback_url is not None:
+            callback = _parse_callback_url(callback_url)
+        else:
+            try:
+                callback = self._result_queue.get_nowait()
+            except queue.Empty:
+                callback = None
+        if callback is None:
+            with self._lock:
+                if self._token is not None:
+                    return self._token
+                self._raise_if_finished()
+                if self.expired:
+                    self._expire_locked()
+                    self._raise_if_finished()
+            return None
+        return self._finish(callback)
+
+    def cancel(self) -> None:
+        """Stop the callback listener for an abandoned flow."""
+        with self._lock:
+            if self._token is None and self._error is None:
+                self._error = OpenAICodexOAuthError("OpenAI Codex sign-in was cancelled.")
+            self._close_locked()
+
+    def _finish(self, callback: _CallbackResult) -> OAuthToken:
+        with self._lock:
+            if self._token is not None:
+                return self._token
+            self._raise_if_finished()
+            self._close_locked()
+            try:
+                if callback.error:
+                    raise OpenAICodexOAuthError(
+                        f"OpenAI Codex sign-in was not completed: {callback.error}"
+                    )
+                if not callback.code:
+                    raise OpenAICodexOAuthError(
+                        "OpenAI Codex sign-in returned no authorization code."
+                    )
+                if not callback.state or not hmac.compare_digest(callback.state, self._state):
+                    raise OpenAICodexOAuthError(
+                        "OpenAI Codex sign-in failed because the OAuth state did not match."
+                    )
+                token = _exchange_code(
+                    callback.code,
+                    verifier=self._verifier,
+                    proxy=self._proxy,
+                )
+                _token_storage().save(token)
+            except Exception as exc:
+                self._error = exc
+                raise
+            self._token = token
+            return token
+
+    def _expire(self) -> None:
+        with self._lock:
+            if self._token is not None or self._error is not None:
+                return
+            self._expire_locked()
+
+    def _expire_locked(self) -> None:
+        self._error = OpenAICodexOAuthError(
+            "OpenAI Codex sign-in expired. Start a new sign-in flow."
+        )
+        self._close_locked()
+
+    def _raise_if_finished(self) -> None:
+        if self._token is not None:
+            return
+        if self._error is not None:
+            raise self._error
+
+    def _close_locked(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._timeout_timer.cancel()
+        self._stop_event.set()
+        server_thread = self._server_thread
+        if server_thread is not None and threading.current_thread() is not server_thread:
+            server_thread.join(timeout=2)
+
+
+def start_openai_codex_oauth_login(
+    *,
+    proxy: str | None = None,
+    timeout_s: float = 600,
+) -> OpenAICodexOAuthLoginFlow:
+    """Create a non-blocking PKCE flow for loopback or remote callback completion."""
+    verifier, challenge = _generate_pkce()
+    state = secrets.token_urlsafe(32)
+    result_queue: queue.Queue[_CallbackResult] = queue.Queue(maxsize=1)
+    server = _make_callback_server(state, result_queue)
+    authorization_url = _build_authorization_url(
+        OPENAI_CODEX_PROVIDER,
+        challenge=challenge,
+        state=state,
+    )
+    return OpenAICodexOAuthLoginFlow(
+        authorization_url=authorization_url,
+        verifier=verifier,
+        state=state,
+        proxy=proxy,
+        result_queue=result_queue,
+        server=server,
+        timeout_s=timeout_s,
+    )
+
+
+def complete_openai_codex_oauth_login(
+    flow: OpenAICodexOAuthLoginFlow,
+    callback_url: str | None = None,
+) -> OAuthToken | None:
+    """Complete a pending Codex login from loopback or a full callback URL."""
+    return flow.complete(callback_url)
+
+
+def _generate_pkce() -> tuple[str, str]:
+    verifier = _base64url(secrets.token_bytes(32))
+    challenge = _base64url(hashlib.sha256(verifier.encode("ascii")).digest())
+    return verifier, challenge
+
+
+def _base64url(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _build_authorization_url(
+    provider: OAuthProviderConfig,
+    *,
+    challenge: str,
+    state: str,
+) -> str:
+    params = {
+        "response_type": "code",
+        "client_id": provider.client_id,
+        "redirect_uri": provider.redirect_uri,
+        "scope": provider.scope,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+        "id_token_add_organizations": "true",
+        "codex_cli_simplified_flow": "true",
+        "originator": provider.default_originator,
+    }
+    return f"{provider.authorize_url}?{urlencode(params)}"
+
+
+def _parse_callback_url(raw: str) -> _CallbackResult:
+    value = raw.strip()
+    if not value:
+        raise OpenAICodexOAuthInputError("Paste the full callback URL from your browser.")
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError as exc:
+        raise OpenAICodexOAuthInputError(
+            "The callback URL is invalid. Copy the full URL from your browser's address bar."
+        ) from exc
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname not in {"localhost", "127.0.0.1", "::1"}
+        or port != _CALLBACK_PORT
+        or parsed.path != _CALLBACK_PATH
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        raise OpenAICodexOAuthInputError(
+            "Paste the full callback URL from your browser "
+            "(http://localhost:1455/auth/callback?...)."
+        )
+    params = parse_qs(parsed.query)
+    code = _first(params, "code")
+    state = _first(params, "state")
+    error = _first(params, "error_description") or _first(params, "error")
+    if not state:
+        raise OpenAICodexOAuthInputError(
+            "The callback URL is missing OAuth state. Copy the entire browser address."
+        )
+    if not code and not error:
+        raise OpenAICodexOAuthInputError(
+            "The callback URL has no authorization result. Finish signing in, then copy it again."
+        )
+    return _CallbackResult(code=code, state=state, error=error)
+
+
+def _make_callback_server(
+    expected_state: str,
+    result_queue: queue.Queue[_CallbackResult],
+) -> ThreadingHTTPServer | None:
+    class CallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            parsed = urlsplit(self.path)
+            if parsed.path != _CALLBACK_PATH:
+                self.send_error(HTTPStatus.NOT_FOUND)
+                return
+            params = parse_qs(parsed.query)
+            code = _first(params, "code")
+            received_state = _first(params, "state")
+            error = _first(params, "error_description") or _first(params, "error")
+            if code and received_state and hmac.compare_digest(received_state, expected_state):
+                result = _CallbackResult(code=code, state=received_state)
+                title = "Signed in to OpenAI Codex"
+                message = "You can close this tab and return to nanobot."
+            elif code:
+                result = _CallbackResult(error="OAuth state mismatch", state=received_state)
+                title = "Sign-in failed"
+                message = "Return to nanobot and start a new sign-in."
+            else:
+                result = _CallbackResult(
+                    error=error or "access denied",
+                    state=received_state,
+                )
+                title = "Access denied"
+                message = "Return to nanobot and try signing in again."
+            with suppress(queue.Full):
+                result_queue.put_nowait(result)
+            self._send_callback_page(title, message)
+
+        def _send_callback_page(self, title: str, message: str) -> None:
+            encoded = _callback_page(title, message).encode("utf-8")
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'")
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.end_headers()
+            self.wfile.write(encoded)
+
+        def log_message(self, format: str, *_args: Any) -> None:  # noqa: A002
+            # Callback request targets contain a short-lived authorization code.
+            return
+
+    try:
+        addrinfos = socket.getaddrinfo("localhost", _CALLBACK_PORT, type=socket.SOCK_STREAM)
+    except OSError:
+        return None
+    for family, _socket_type, _protocol, _canonical_name, sockaddr in addrinfos:
+        try:
+            class CallbackServer(ThreadingHTTPServer):
+                address_family = family
+
+            server_address = cast(
+                tuple[str, int] | tuple[str, int, int, int],
+                sockaddr,
+            )
+            return CallbackServer(server_address, CallbackHandler)
+        except OSError:
+            continue
+    return None
+
+
+def _serve_callback_server(
+    server: ThreadingHTTPServer,
+    stop_event: threading.Event,
+) -> None:
+    server.timeout = 0.2
+    try:
+        while not stop_event.is_set():
+            server.handle_request()
+    finally:
+        server.server_close()
+
+
+def _callback_page(title: str, message: str) -> str:
+    return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">
+<title>{title}</title><style>
+body{{margin:0;min-height:100vh;display:grid;place-items:center;background:#f5f7fb;color:#172033;
+font:16px/1.5 system-ui,sans-serif}}main{{max-width:30rem;margin:1.5rem;padding:2rem;border:1px solid #dfe4ee;
+border-radius:18px;background:white;box-shadow:0 16px 50px #17203318}}h1{{margin:0 0 .65rem;font-size:1.5rem}}
+p{{margin:0;color:#526078}}</style></head><body><main><h1>{title}</h1><p>{message}</p></main></body></html>"""
+
+
+def _exchange_code(
+    code: str,
+    *,
+    verifier: str,
+    proxy: str | None,
+) -> OAuthToken:
+    provider = OPENAI_CODEX_PROVIDER
+    try:
+        with _http_client(proxy) as client:
+            response = client.post(
+                provider.token_url,
+                data={
+                    "grant_type": "authorization_code",
+                    "client_id": provider.client_id,
+                    "code": code,
+                    "code_verifier": verifier,
+                    "redirect_uri": provider.redirect_uri,
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+    except httpx.HTTPError as exc:
+        raise OpenAICodexOAuthError(
+            f"Could not exchange the OpenAI Codex sign-in code: {type(exc).__name__}."
+        ) from exc
+    if not response.is_success:
+        raise _oauth_http_error(response, "token exchange")
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise OpenAICodexOAuthError(
+            "OpenAI Codex sign-in returned an invalid token response."
+        ) from exc
+    if not isinstance(payload, dict):
+        raise OpenAICodexOAuthError("OpenAI Codex sign-in returned no access token.")
+    token_payload = cast(dict[str, Any], payload)
+    access = token_payload.get("access_token")
+    refresh = token_payload.get("refresh_token")
+    expires_in = token_payload.get("expires_in")
+    if (
+        not isinstance(access, str)
+        or not access
+        or not isinstance(refresh, str)
+        or not refresh
+        or not isinstance(expires_in, int)
+    ):
+        raise OpenAICodexOAuthError(
+            "OpenAI Codex sign-in returned incomplete token credentials."
+        )
+    return OAuthToken(
+        access=access,
+        refresh=refresh,
+        expires=int(time.time() * 1000 + expires_in * 1000),
+        account_id=_decode_account_id(access, provider),
+    )
+
+
+def _decode_account_id(
+    access_token: str,
+    provider: OAuthProviderConfig,
+) -> str | None:
+    if not provider.jwt_claim_path or not provider.account_id_claim:
+        return None
+    parts = access_token.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        padding = "=" * (-len(parts[1]) % 4)
+        raw_payload: object = json.loads(
+            base64.urlsafe_b64decode(parts[1] + padding).decode("utf-8")
+        )
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(raw_payload, dict):
+        return None
+    payload = cast(dict[str, object], raw_payload)
+    auth = payload.get(provider.jwt_claim_path)
+    if not isinstance(auth, dict):
+        return None
+    account_id = cast(dict[str, object], auth).get(provider.account_id_claim)
+    return account_id if isinstance(account_id, str) and account_id else None
+
+
+def _oauth_http_error(response: httpx.Response, action: str) -> OpenAICodexOAuthError:
+    code: str | None = None
+    description: str | None = None
+    with suppress(ValueError):
+        payload = response.json()
+        if isinstance(payload, dict):
+            error_payload = cast(dict[str, Any], payload)
+            raw_code = error_payload.get("error")
+            raw_description = error_payload.get("error_description") or error_payload.get("message")
+            code = raw_code[:80] if isinstance(raw_code, str) else None
+            description = raw_description[:200] if isinstance(raw_description, str) else None
+    detail = ": ".join(value for value in (code, description) if value)
+    suffix = f" ({detail})" if detail else ""
+    return OpenAICodexOAuthError(
+        f"OpenAI Codex OAuth {action} failed with HTTP {response.status_code}{suffix}."
+    )
+
+
+def _http_client(proxy: str | None) -> httpx.Client:
+    kwargs: dict[str, Any] = {"timeout": _HTTP_TIMEOUT_S}
+    if proxy:
+        kwargs.update(proxy=proxy, trust_env=False)
+    return httpx.Client(**kwargs)
+
+
+def _token_storage() -> FileTokenStorage:
+    return FileTokenStorage(token_filename=OPENAI_CODEX_PROVIDER.token_filename)
+
+
+def _first(params: dict[str, list[str]], key: str) -> str | None:
+    values = params.get(key)
+    return values[0] if values else None

--- a/nanobot/providers/openai_codex_oauth.py
+++ b/nanobot/providers/openai_codex_oauth.py
@@ -1,17 +1,22 @@
-"""Thin WebUI adapter around oauth-cli-kit's interactive Codex login."""
+"""WebUI adapter around oauth-cli-kit's interactive Codex login."""
 
 # oauth-cli-kit does not publish type stubs.
 # pyright: reportMissingTypeStubs=false
 
 from __future__ import annotations
 
+import hmac
 import queue
 import re
 import threading
 import time
+from collections.abc import Callable
 from concurrent.futures import Future
 from contextlib import suppress
-from urllib.parse import parse_qs, urlsplit
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, cast
+from urllib.parse import parse_qs, urlsplit, urlunsplit
 
 from oauth_cli_kit import login_oauth_interactive
 from oauth_cli_kit.models import OAuthToken
@@ -20,7 +25,13 @@ from oauth_cli_kit.providers import OPENAI_CODEX_PROVIDER
 _AUTHORIZATION_URL_TIMEOUT_S = 5.0
 _CALLBACK = urlsplit(OPENAI_CODEX_PROVIDER.redirect_uri)
 _CALLBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
+_CALLBACK_PORT = _CALLBACK.port or 1455
 _TOKEN_EXCHANGE_STATUS = re.compile(r"Token exchange failed:\s*(\d{3})\b")
+_CALLBACK_RECEIVED_HTML = b"""<!doctype html>
+<meta charset="utf-8">
+<title>OpenAI Codex sign-in</title>
+<p>Callback received. You can return to nanobot.</p>
+"""
 
 
 class OpenAICodexOAuthError(RuntimeError):
@@ -31,22 +42,98 @@ class OpenAICodexOAuthInputError(OpenAICodexOAuthError):
     """A recoverable error in a callback URL pasted by the user."""
 
 
+# The WebUI opens the browser itself. oauth-cli-kit closes its listener in that
+# headless mode, so this relay preserves automatic local callbacks without
+# taking ownership of PKCE, token exchange, or credential storage.
+class _CallbackRelayHandler(BaseHTTPRequestHandler):
+    """Relay the fixed loopback callback into oauth-cli-kit's prompt."""
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urlsplit(self.path)
+        if parsed.path != _CALLBACK.path:
+            self._send(HTTPStatus.NOT_FOUND, b"Not found")
+            return
+        callback_url = urlunsplit(
+            (_CALLBACK.scheme, _CALLBACK.netloc, _CALLBACK.path, parsed.query, "")
+        )
+        try:
+            cast(_CallbackRelayServer, self.server).submit_callback(callback_url)
+        except OpenAICodexOAuthError:
+            self._send(HTTPStatus.BAD_REQUEST, b"Invalid OAuth callback")
+            return
+        self._send(HTTPStatus.OK, _CALLBACK_RECEIVED_HTML, "text/html; charset=utf-8")
+
+    def _send(
+        self,
+        status: HTTPStatus,
+        body: bytes,
+        content_type: str = "text/plain; charset=utf-8",
+    ) -> None:
+        self.close_connection = True
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        with suppress(OSError):
+            self.wfile.write(body)
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
+        return
+
+
+class _CallbackRelayServer(ThreadingHTTPServer):
+    daemon_threads = True
+    block_on_close = False
+
+    def __init__(self, submit_callback: Callable[[str], object]) -> None:
+        self.submit_callback = submit_callback
+        super().__init__(("127.0.0.1", _CALLBACK_PORT), _CallbackRelayHandler)
+
+
+def _start_callback_relay(
+    submit_callback: Callable[[str], object],
+) -> _CallbackRelayServer | None:
+    try:
+        server = _CallbackRelayServer(submit_callback)
+    except OSError:
+        return None
+    thread = threading.Thread(
+        target=server.serve_forever,
+        name="nanobot-openai-codex-oauth-callback",
+        daemon=True,
+    )
+    thread.start()
+    return server
+
+
 class OpenAICodexOAuthLoginFlow:
     """Expose oauth-cli-kit's blocking prompt as a two-stage WebUI flow."""
 
-    def __init__(self, *, proxy: str | None, timeout_s: float) -> None:
+    def __init__(
+        self,
+        *,
+        proxy: str | None,
+        timeout_s: float,
+        listen_for_callback: bool,
+    ) -> None:
         self.authorization_url = ""
+        self._expected_state = ""
         self._proxy = proxy
         self._expires_at = time.monotonic() + timeout_s
         self._callback_input: queue.Queue[str] = queue.Queue(maxsize=1)
         self._result: Future[OAuthToken] = Future()
         self._ready = threading.Event()
         self._submission_lock = threading.Lock()
+        self._callback_server_lock = threading.Lock()
         self._submitted = False
         self._thread = threading.Thread(
             target=self._run,
             name="nanobot-openai-codex-oauth",
             daemon=True,
+        )
+        self._callback_server = (
+            _start_callback_relay(self.complete) if listen_for_callback else None
         )
 
     @property
@@ -92,7 +179,11 @@ class OpenAICodexOAuthLoginFlow:
         if callback_url is None:
             return None
 
-        authorization_failed = _validate_callback_url(callback_url)
+        callback_state, authorization_failed = _validate_callback_url(callback_url)
+        if not hmac.compare_digest(callback_state, self._expected_state):
+            raise OpenAICodexOAuthInputError(
+                "The callback URL does not belong to this sign-in flow. Copy the latest URL."
+            )
         if authorization_failed:
             error = OpenAICodexOAuthError(
                 "OpenAI Codex sign-in was not completed by the authorization server."
@@ -132,6 +223,7 @@ class OpenAICodexOAuthLoginFlow:
             with suppress(Exception):
                 self._result.set_result(token)
         finally:
+            self._stop_callback_relay()
             self._ready.set()
 
     def _capture_output(self, message: str) -> None:
@@ -140,7 +232,11 @@ class OpenAICodexOAuthLoginFlow:
         if start < 0:
             return
         candidate = raw[start:].split(maxsplit=1)[0]
+        state = _first(parse_qs(urlsplit(candidate).query), "state")
+        if not state:
+            return
         self.authorization_url = candidate
+        self._expected_state = state
         self._ready.set()
 
     def _prompt_for_callback(self, _prompt: str) -> str:
@@ -162,19 +258,35 @@ class OpenAICodexOAuthLoginFlow:
         try:
             self._result.set_exception(error)
         except Exception:
-            return
-        with suppress(queue.Full):
-            self._callback_input.put_nowait("")
+            pass
+        else:
+            with suppress(queue.Full):
+                self._callback_input.put_nowait("")
         self._ready.set()
+        self._stop_callback_relay()
+
+    def _stop_callback_relay(self) -> None:
+        with self._callback_server_lock:
+            server = self._callback_server
+            self._callback_server = None
+        if server is None:
+            return
+        server.shutdown()
+        server.server_close()
 
 
 def start_openai_codex_oauth_login(
     *,
     proxy: str | None = None,
     timeout_s: float = 600,
+    listen_for_callback: bool = True,
 ) -> OpenAICodexOAuthLoginFlow:
     """Start a non-blocking wrapper around oauth-cli-kit's Codex login."""
-    return OpenAICodexOAuthLoginFlow(proxy=proxy, timeout_s=timeout_s).start()
+    return OpenAICodexOAuthLoginFlow(
+        proxy=proxy,
+        timeout_s=timeout_s,
+        listen_for_callback=listen_for_callback,
+    ).start()
 
 
 def complete_openai_codex_oauth_login(
@@ -185,7 +297,7 @@ def complete_openai_codex_oauth_login(
     return flow.complete(callback_url)
 
 
-def _validate_callback_url(raw: str) -> bool:
+def _validate_callback_url(raw: str) -> tuple[str, bool]:
     value = raw.strip()
     if not value:
         raise OpenAICodexOAuthInputError("Paste the full callback URL from your browser.")
@@ -219,7 +331,7 @@ def _validate_callback_url(raw: str) -> bool:
         raise OpenAICodexOAuthInputError(
             "The callback URL has no authorization result. Finish signing in, then copy it again."
         )
-    return error is not None
+    return state, error is not None
 
 
 def _safe_login_error(exc: Exception) -> OpenAICodexOAuthError:

--- a/nanobot/providers/openai_codex_oauth.py
+++ b/nanobot/providers/openai_codex_oauth.py
@@ -10,13 +10,9 @@ import queue
 import re
 import threading
 import time
-from collections.abc import Callable
 from concurrent.futures import Future
 from contextlib import suppress
-from http import HTTPStatus
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any, cast
-from urllib.parse import parse_qs, urlsplit, urlunsplit
+from urllib.parse import parse_qs, urlsplit
 
 from oauth_cli_kit import login_oauth_interactive
 from oauth_cli_kit.models import OAuthToken
@@ -25,13 +21,7 @@ from oauth_cli_kit.providers import OPENAI_CODEX_PROVIDER
 _AUTHORIZATION_URL_TIMEOUT_S = 5.0
 _CALLBACK = urlsplit(OPENAI_CODEX_PROVIDER.redirect_uri)
 _CALLBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
-_CALLBACK_PORT = _CALLBACK.port or 1455
 _TOKEN_EXCHANGE_STATUS = re.compile(r"Token exchange failed:\s*(\d{3})\b")
-_CALLBACK_RECEIVED_HTML = b"""<!doctype html>
-<meta charset="utf-8">
-<title>OpenAI Codex sign-in</title>
-<p>Callback received. You can return to nanobot.</p>
-"""
 
 
 class OpenAICodexOAuthError(RuntimeError):
@@ -42,71 +32,6 @@ class OpenAICodexOAuthInputError(OpenAICodexOAuthError):
     """A recoverable error in a callback URL pasted by the user."""
 
 
-# The WebUI opens the browser itself. oauth-cli-kit closes its listener in that
-# headless mode, so this relay preserves automatic local callbacks without
-# taking ownership of PKCE, token exchange, or credential storage.
-class _CallbackRelayHandler(BaseHTTPRequestHandler):
-    """Relay the fixed loopback callback into oauth-cli-kit's prompt."""
-
-    def do_GET(self) -> None:  # noqa: N802
-        parsed = urlsplit(self.path)
-        if parsed.path != _CALLBACK.path:
-            self._send(HTTPStatus.NOT_FOUND, b"Not found")
-            return
-        callback_url = urlunsplit(
-            (_CALLBACK.scheme, _CALLBACK.netloc, _CALLBACK.path, parsed.query, "")
-        )
-        try:
-            cast(_CallbackRelayServer, self.server).submit_callback(callback_url)
-        except OpenAICodexOAuthError:
-            self._send(HTTPStatus.BAD_REQUEST, b"Invalid OAuth callback")
-            return
-        self._send(HTTPStatus.OK, _CALLBACK_RECEIVED_HTML, "text/html; charset=utf-8")
-
-    def _send(
-        self,
-        status: HTTPStatus,
-        body: bytes,
-        content_type: str = "text/plain; charset=utf-8",
-    ) -> None:
-        self.close_connection = True
-        self.send_response(status)
-        self.send_header("Content-Type", content_type)
-        self.send_header("Content-Length", str(len(body)))
-        self.send_header("Connection", "close")
-        self.end_headers()
-        with suppress(OSError):
-            self.wfile.write(body)
-
-    def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
-        return
-
-
-class _CallbackRelayServer(ThreadingHTTPServer):
-    daemon_threads = True
-    block_on_close = False
-
-    def __init__(self, submit_callback: Callable[[str], object]) -> None:
-        self.submit_callback = submit_callback
-        super().__init__(("127.0.0.1", _CALLBACK_PORT), _CallbackRelayHandler)
-
-
-def _start_callback_relay(
-    submit_callback: Callable[[str], object],
-) -> _CallbackRelayServer | None:
-    try:
-        server = _CallbackRelayServer(submit_callback)
-    except OSError:
-        return None
-    thread = threading.Thread(
-        target=server.serve_forever,
-        name="nanobot-openai-codex-oauth-callback",
-        daemon=True,
-    )
-    thread.start()
-    return server
-
-
 class OpenAICodexOAuthLoginFlow:
     """Expose oauth-cli-kit's blocking prompt as a two-stage WebUI flow."""
 
@@ -115,25 +40,22 @@ class OpenAICodexOAuthLoginFlow:
         *,
         proxy: str | None,
         timeout_s: float,
-        listen_for_callback: bool,
+        open_browser: bool,
     ) -> None:
         self.authorization_url = ""
         self._expected_state = ""
         self._proxy = proxy
+        self._open_browser = open_browser
         self._expires_at = time.monotonic() + timeout_s
         self._callback_input: queue.Queue[str] = queue.Queue(maxsize=1)
         self._result: Future[OAuthToken] = Future()
         self._ready = threading.Event()
         self._submission_lock = threading.Lock()
-        self._callback_server_lock = threading.Lock()
         self._submitted = False
         self._thread = threading.Thread(
             target=self._run,
             name="nanobot-openai-codex-oauth",
             daemon=True,
-        )
-        self._callback_server = (
-            _start_callback_relay(self.complete) if listen_for_callback else None
         )
 
     @property
@@ -214,7 +136,7 @@ class OpenAICodexOAuthLoginFlow:
                 prompt_fn=self._prompt_for_callback,
                 provider=OPENAI_CODEX_PROVIDER,
                 proxy=self._proxy,
-                open_browser=False,
+                open_browser=self._open_browser,
             )
         except Exception as exc:
             with suppress(Exception):
@@ -223,7 +145,6 @@ class OpenAICodexOAuthLoginFlow:
             with suppress(Exception):
                 self._result.set_result(token)
         finally:
-            self._stop_callback_relay()
             self._ready.set()
 
     def _capture_output(self, message: str) -> None:
@@ -263,29 +184,19 @@ class OpenAICodexOAuthLoginFlow:
             with suppress(queue.Full):
                 self._callback_input.put_nowait("")
         self._ready.set()
-        self._stop_callback_relay()
-
-    def _stop_callback_relay(self) -> None:
-        with self._callback_server_lock:
-            server = self._callback_server
-            self._callback_server = None
-        if server is None:
-            return
-        server.shutdown()
-        server.server_close()
 
 
 def start_openai_codex_oauth_login(
     *,
     proxy: str | None = None,
     timeout_s: float = 600,
-    listen_for_callback: bool = True,
+    open_browser: bool = True,
 ) -> OpenAICodexOAuthLoginFlow:
     """Start a non-blocking wrapper around oauth-cli-kit's Codex login."""
     return OpenAICodexOAuthLoginFlow(
         proxy=proxy,
         timeout_s=timeout_s,
-        listen_for_callback=listen_for_callback,
+        open_browser=open_browser,
     ).start()
 
 

--- a/nanobot/providers/openai_codex_oauth.py
+++ b/nanobot/providers/openai_codex_oauth.py
@@ -1,34 +1,26 @@
-"""Non-blocking OpenAI Codex OAuth flow for browser and remote WebUI login."""
+"""Thin WebUI adapter around oauth-cli-kit's interactive Codex login."""
 
 # oauth-cli-kit does not publish type stubs.
 # pyright: reportMissingTypeStubs=false
 
 from __future__ import annotations
 
-import base64
-import hashlib
-import hmac
-import json
 import queue
-import secrets
-import socket
+import re
 import threading
 import time
+from concurrent.futures import Future
 from contextlib import suppress
-from dataclasses import dataclass
-from http import HTTPStatus
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any, cast
-from urllib.parse import parse_qs, urlencode, urlsplit
+from urllib.parse import parse_qs, urlsplit
 
-import httpx
-from oauth_cli_kit.models import OAuthProviderConfig, OAuthToken
+from oauth_cli_kit import login_oauth_interactive
+from oauth_cli_kit.models import OAuthToken
 from oauth_cli_kit.providers import OPENAI_CODEX_PROVIDER
-from oauth_cli_kit.storage import FileTokenStorage
 
-_HTTP_TIMEOUT_S = 30.0
-_CALLBACK_PATH = "/auth/callback"
-_CALLBACK_PORT = 1455
+_AUTHORIZATION_URL_TIMEOUT_S = 5.0
+_CALLBACK = urlsplit(OPENAI_CODEX_PROVIDER.redirect_uri)
+_CALLBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
+_TOKEN_EXCHANGE_STATUS = re.compile(r"Token exchange failed:\s*(\d{3})\b")
 
 
 class OpenAICodexOAuthError(RuntimeError):
@@ -39,51 +31,23 @@ class OpenAICodexOAuthInputError(OpenAICodexOAuthError):
     """A recoverable error in a callback URL pasted by the user."""
 
 
-@dataclass(frozen=True)
-class _CallbackResult:
-    code: str | None = None
-    state: str | None = None
-    error: str | None = None
-
-
 class OpenAICodexOAuthLoginFlow:
-    """Pending Codex OAuth login completed by loopback or a pasted callback URL."""
+    """Expose oauth-cli-kit's blocking prompt as a two-stage WebUI flow."""
 
-    def __init__(
-        self,
-        *,
-        authorization_url: str,
-        verifier: str,
-        state: str,
-        proxy: str | None,
-        result_queue: queue.Queue[_CallbackResult],
-        server: ThreadingHTTPServer | None,
-        timeout_s: float,
-    ) -> None:
-        self.authorization_url = authorization_url
-        self._verifier = verifier
-        self._state = state
+    def __init__(self, *, proxy: str | None, timeout_s: float) -> None:
+        self.authorization_url = ""
         self._proxy = proxy
-        self._result_queue = result_queue
-        self._server = server
         self._expires_at = time.monotonic() + timeout_s
-        self._lock = threading.Lock()
-        self._stop_event = threading.Event()
-        self._token: OAuthToken | None = None
-        self._error: Exception | None = None
-        self._closed = False
-        self._server_thread: threading.Thread | None = None
-        if server is not None:
-            self._server_thread = threading.Thread(
-                target=_serve_callback_server,
-                args=(server, self._stop_event),
-                name="nanobot-openai-codex-oauth-callback",
-                daemon=True,
-            )
-            self._server_thread.start()
-        self._timeout_timer = threading.Timer(timeout_s, self._expire)
-        self._timeout_timer.daemon = True
-        self._timeout_timer.start()
+        self._callback_input: queue.Queue[str] = queue.Queue(maxsize=1)
+        self._result: Future[OAuthToken] = Future()
+        self._ready = threading.Event()
+        self._submission_lock = threading.Lock()
+        self._submitted = False
+        self._thread = threading.Thread(
+            target=self._run,
+            name="nanobot-openai-codex-oauth",
+            daemon=True,
+        )
 
     @property
     def expired(self) -> bool:
@@ -93,97 +57,115 @@ class OpenAICodexOAuthLoginFlow:
     def remaining_seconds(self) -> int:
         return max(0, int(self._expires_at - time.monotonic()))
 
-    def complete(self, callback_url: str | None = None) -> OAuthToken | None:
-        """Complete the login or return ``None`` while loopback is still pending."""
-        with self._lock:
-            if self._token is not None:
-                return self._token
-            self._raise_if_finished()
+    def start(self) -> OpenAICodexOAuthLoginFlow:
+        self._thread.start()
+        wait_s = min(
+            _AUTHORIZATION_URL_TIMEOUT_S,
+            max(0.0, self._expires_at - time.monotonic()),
+        )
+        if not self._ready.wait(wait_s):
+            error = OpenAICodexOAuthError(
+                "OpenAI Codex sign-in could not create an authorization URL."
+            )
+            self._fail(error)
+            raise error
+        if self._result.done():
+            self._result.result()
+        if self.authorization_url:
+            return self
+        error = OpenAICodexOAuthError(
+            "OpenAI Codex sign-in returned no authorization URL."
+        )
+        self._fail(error)
+        raise error
 
-        callback: _CallbackResult | None
-        if callback_url is not None:
-            callback = _parse_callback_url(callback_url)
-        else:
-            try:
-                callback = self._result_queue.get_nowait()
-            except queue.Empty:
-                callback = None
-        if callback is None:
-            with self._lock:
-                if self._token is not None:
-                    return self._token
-                self._raise_if_finished()
-                if self.expired:
-                    self._expire_locked()
-                    self._raise_if_finished()
+    def complete(self, callback_url: str | None = None) -> OAuthToken | None:
+        """Submit a full callback URL, or return ``None`` while waiting for one."""
+        if self._result.done():
+            return self._result.result()
+        if self.expired:
+            error = OpenAICodexOAuthError(
+                "OpenAI Codex sign-in expired. Start a new sign-in flow."
+            )
+            self._fail(error)
+            raise error
+        if callback_url is None:
             return None
-        return self._finish(callback)
+
+        authorization_failed = _validate_callback_url(callback_url)
+        if authorization_failed:
+            error = OpenAICodexOAuthError(
+                "OpenAI Codex sign-in was not completed by the authorization server."
+            )
+            self._fail(error)
+            raise error
+
+        with self._submission_lock:
+            if self._submitted:
+                return None
+            self._submitted = True
+            try:
+                self._callback_input.put_nowait(callback_url.strip())
+            except queue.Full:
+                return None
+        return self._result.result() if self._result.done() else None
 
     def cancel(self) -> None:
-        """Stop the callback listener for an abandoned flow."""
-        with self._lock:
-            if self._token is None and self._error is None:
-                self._error = OpenAICodexOAuthError("OpenAI Codex sign-in was cancelled.")
-            self._close_locked()
+        """Unblock an abandoned interactive login."""
+        self._fail(OpenAICodexOAuthError("OpenAI Codex sign-in was cancelled."))
+        if threading.current_thread() is not self._thread:
+            self._thread.join(timeout=0.5)
 
-    def _finish(self, callback: _CallbackResult) -> OAuthToken:
-        with self._lock:
-            if self._token is not None:
-                return self._token
-            self._raise_if_finished()
-            self._close_locked()
-            try:
-                if callback.error:
-                    raise OpenAICodexOAuthError(
-                        f"OpenAI Codex sign-in was not completed: {callback.error}"
-                    )
-                if not callback.code:
-                    raise OpenAICodexOAuthError(
-                        "OpenAI Codex sign-in returned no authorization code."
-                    )
-                if not callback.state or not hmac.compare_digest(callback.state, self._state):
-                    raise OpenAICodexOAuthError(
-                        "OpenAI Codex sign-in failed because the OAuth state did not match."
-                    )
-                token = _exchange_code(
-                    callback.code,
-                    verifier=self._verifier,
-                    proxy=self._proxy,
-                )
-                _token_storage().save(token)
-            except Exception as exc:
-                self._error = exc
-                raise
-            self._token = token
-            return token
+    def _run(self) -> None:
+        try:
+            token = login_oauth_interactive(
+                print_fn=self._capture_output,
+                prompt_fn=self._prompt_for_callback,
+                provider=OPENAI_CODEX_PROVIDER,
+                proxy=self._proxy,
+                open_browser=False,
+            )
+        except Exception as exc:
+            with suppress(Exception):
+                self._result.set_exception(_safe_login_error(exc))
+        else:
+            with suppress(Exception):
+                self._result.set_result(token)
+        finally:
+            self._ready.set()
 
-    def _expire(self) -> None:
-        with self._lock:
-            if self._token is not None or self._error is not None:
-                return
-            self._expire_locked()
-
-    def _expire_locked(self) -> None:
-        self._error = OpenAICodexOAuthError(
-            "OpenAI Codex sign-in expired. Start a new sign-in flow."
-        )
-        self._close_locked()
-
-    def _raise_if_finished(self) -> None:
-        if self._token is not None:
+    def _capture_output(self, message: str) -> None:
+        raw = str(message)
+        start = raw.find(OPENAI_CODEX_PROVIDER.authorize_url)
+        if start < 0:
             return
-        if self._error is not None:
-            raise self._error
+        candidate = raw[start:].split(maxsplit=1)[0]
+        self.authorization_url = candidate
+        self._ready.set()
 
-    def _close_locked(self) -> None:
-        if self._closed:
+    def _prompt_for_callback(self, _prompt: str) -> str:
+        remaining = max(0.0, self._expires_at - time.monotonic())
+        try:
+            value = self._callback_input.get(timeout=remaining)
+        except queue.Empty as exc:
+            raise OpenAICodexOAuthError(
+                "OpenAI Codex sign-in expired. Start a new sign-in flow."
+            ) from exc
+        if not value:
+            error = self._result.exception() if self._result.done() else None
+            if error is not None:
+                raise error
+            raise OpenAICodexOAuthError("OpenAI Codex sign-in was cancelled.")
+        return value
+
+    def _fail(self, error: OpenAICodexOAuthError) -> None:
+        try:
+            self._result.set_exception(error)
+        except Exception:
             return
-        self._closed = True
-        self._timeout_timer.cancel()
-        self._stop_event.set()
-        server_thread = self._server_thread
-        if server_thread is not None and threading.current_thread() is not server_thread:
-            server_thread.join(timeout=2)
+        with suppress(queue.Full):
+            self._callback_input.put_nowait("")
+        self._ready.set()
 
 
 def start_openai_codex_oauth_login(
@@ -191,67 +173,19 @@ def start_openai_codex_oauth_login(
     proxy: str | None = None,
     timeout_s: float = 600,
 ) -> OpenAICodexOAuthLoginFlow:
-    """Create a non-blocking PKCE flow for loopback or remote callback completion."""
-    verifier, challenge = _generate_pkce()
-    state = secrets.token_urlsafe(32)
-    result_queue: queue.Queue[_CallbackResult] = queue.Queue(maxsize=1)
-    server = _make_callback_server(state, result_queue)
-    authorization_url = _build_authorization_url(
-        OPENAI_CODEX_PROVIDER,
-        challenge=challenge,
-        state=state,
-    )
-    return OpenAICodexOAuthLoginFlow(
-        authorization_url=authorization_url,
-        verifier=verifier,
-        state=state,
-        proxy=proxy,
-        result_queue=result_queue,
-        server=server,
-        timeout_s=timeout_s,
-    )
+    """Start a non-blocking wrapper around oauth-cli-kit's Codex login."""
+    return OpenAICodexOAuthLoginFlow(proxy=proxy, timeout_s=timeout_s).start()
 
 
 def complete_openai_codex_oauth_login(
     flow: OpenAICodexOAuthLoginFlow,
     callback_url: str | None = None,
 ) -> OAuthToken | None:
-    """Complete a pending Codex login from loopback or a full callback URL."""
+    """Complete a pending Codex login from a full callback URL."""
     return flow.complete(callback_url)
 
 
-def _generate_pkce() -> tuple[str, str]:
-    verifier = _base64url(secrets.token_bytes(32))
-    challenge = _base64url(hashlib.sha256(verifier.encode("ascii")).digest())
-    return verifier, challenge
-
-
-def _base64url(value: bytes) -> str:
-    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
-
-
-def _build_authorization_url(
-    provider: OAuthProviderConfig,
-    *,
-    challenge: str,
-    state: str,
-) -> str:
-    params = {
-        "response_type": "code",
-        "client_id": provider.client_id,
-        "redirect_uri": provider.redirect_uri,
-        "scope": provider.scope,
-        "code_challenge": challenge,
-        "code_challenge_method": "S256",
-        "state": state,
-        "id_token_add_organizations": "true",
-        "codex_cli_simplified_flow": "true",
-        "originator": provider.default_originator,
-    }
-    return f"{provider.authorize_url}?{urlencode(params)}"
-
-
-def _parse_callback_url(raw: str) -> _CallbackResult:
+def _validate_callback_url(raw: str) -> bool:
     value = raw.strip()
     if not value:
         raise OpenAICodexOAuthInputError("Paste the full callback URL from your browser.")
@@ -263,21 +197,20 @@ def _parse_callback_url(raw: str) -> _CallbackResult:
             "The callback URL is invalid. Copy the full URL from your browser's address bar."
         ) from exc
     if (
-        parsed.scheme != "http"
-        or parsed.hostname not in {"localhost", "127.0.0.1", "::1"}
-        or port != _CALLBACK_PORT
-        or parsed.path != _CALLBACK_PATH
+        parsed.scheme != _CALLBACK.scheme
+        or parsed.hostname not in _CALLBACK_HOSTS
+        or port != _CALLBACK.port
+        or parsed.path != _CALLBACK.path
         or parsed.username is not None
         or parsed.password is not None
     ):
         raise OpenAICodexOAuthInputError(
-            "Paste the full callback URL from your browser "
-            "(http://localhost:1455/auth/callback?...)."
+            f"Paste the full callback URL from your browser ({OPENAI_CODEX_PROVIDER.redirect_uri}?...)."
         )
     params = parse_qs(parsed.query)
     code = _first(params, "code")
     state = _first(params, "state")
-    error = _first(params, "error_description") or _first(params, "error")
+    error = _first(params, "error")
     if not state:
         raise OpenAICodexOAuthInputError(
             "The callback URL is missing OAuth state. Copy the entire browser address."
@@ -286,207 +219,29 @@ def _parse_callback_url(raw: str) -> _CallbackResult:
         raise OpenAICodexOAuthInputError(
             "The callback URL has no authorization result. Finish signing in, then copy it again."
         )
-    return _CallbackResult(code=code, state=state, error=error)
+    return error is not None
 
 
-def _make_callback_server(
-    expected_state: str,
-    result_queue: queue.Queue[_CallbackResult],
-) -> ThreadingHTTPServer | None:
-    class CallbackHandler(BaseHTTPRequestHandler):
-        def do_GET(self) -> None:  # noqa: N802
-            parsed = urlsplit(self.path)
-            if parsed.path != _CALLBACK_PATH:
-                self.send_error(HTTPStatus.NOT_FOUND)
-                return
-            params = parse_qs(parsed.query)
-            code = _first(params, "code")
-            received_state = _first(params, "state")
-            error = _first(params, "error_description") or _first(params, "error")
-            if code and received_state and hmac.compare_digest(received_state, expected_state):
-                result = _CallbackResult(code=code, state=received_state)
-                title = "Signed in to OpenAI Codex"
-                message = "You can close this tab and return to nanobot."
-            elif code:
-                result = _CallbackResult(error="OAuth state mismatch", state=received_state)
-                title = "Sign-in failed"
-                message = "Return to nanobot and start a new sign-in."
-            else:
-                result = _CallbackResult(
-                    error=error or "access denied",
-                    state=received_state,
-                )
-                title = "Access denied"
-                message = "Return to nanobot and try signing in again."
-            with suppress(queue.Full):
-                result_queue.put_nowait(result)
-            self._send_callback_page(title, message)
-
-        def _send_callback_page(self, title: str, message: str) -> None:
-            encoded = _callback_page(title, message).encode("utf-8")
-            self.send_response(HTTPStatus.OK)
-            self.send_header("Content-Type", "text/html; charset=utf-8")
-            self.send_header("Content-Length", str(len(encoded)))
-            self.send_header("Cache-Control", "no-store")
-            self.send_header("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'")
-            self.send_header("X-Content-Type-Options", "nosniff")
-            self.end_headers()
-            self.wfile.write(encoded)
-
-        def log_message(self, format: str, *_args: Any) -> None:  # noqa: A002
-            # Callback request targets contain a short-lived authorization code.
-            return
-
-    try:
-        addrinfos = socket.getaddrinfo("localhost", _CALLBACK_PORT, type=socket.SOCK_STREAM)
-    except OSError:
-        return None
-    for family, _socket_type, _protocol, _canonical_name, sockaddr in addrinfos:
-        try:
-            class CallbackServer(ThreadingHTTPServer):
-                address_family = family
-
-            server_address = cast(
-                tuple[str, int] | tuple[str, int, int, int],
-                sockaddr,
-            )
-            return CallbackServer(server_address, CallbackHandler)
-        except OSError:
-            continue
-    return None
-
-
-def _serve_callback_server(
-    server: ThreadingHTTPServer,
-    stop_event: threading.Event,
-) -> None:
-    server.timeout = 0.2
-    try:
-        while not stop_event.is_set():
-            server.handle_request()
-    finally:
-        server.server_close()
-
-
-def _callback_page(title: str, message: str) -> str:
-    return f"""<!doctype html>
-<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">
-<title>{title}</title><style>
-body{{margin:0;min-height:100vh;display:grid;place-items:center;background:#f5f7fb;color:#172033;
-font:16px/1.5 system-ui,sans-serif}}main{{max-width:30rem;margin:1.5rem;padding:2rem;border:1px solid #dfe4ee;
-border-radius:18px;background:white;box-shadow:0 16px 50px #17203318}}h1{{margin:0 0 .65rem;font-size:1.5rem}}
-p{{margin:0;color:#526078}}</style></head><body><main><h1>{title}</h1><p>{message}</p></main></body></html>"""
-
-
-def _exchange_code(
-    code: str,
-    *,
-    verifier: str,
-    proxy: str | None,
-) -> OAuthToken:
-    provider = OPENAI_CODEX_PROVIDER
-    try:
-        with _http_client(proxy) as client:
-            response = client.post(
-                provider.token_url,
-                data={
-                    "grant_type": "authorization_code",
-                    "client_id": provider.client_id,
-                    "code": code,
-                    "code_verifier": verifier,
-                    "redirect_uri": provider.redirect_uri,
-                },
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
-            )
-    except httpx.HTTPError as exc:
-        raise OpenAICodexOAuthError(
-            f"Could not exchange the OpenAI Codex sign-in code: {type(exc).__name__}."
-        ) from exc
-    if not response.is_success:
-        raise _oauth_http_error(response, "token exchange")
-    try:
-        payload = response.json()
-    except ValueError as exc:
-        raise OpenAICodexOAuthError(
-            "OpenAI Codex sign-in returned an invalid token response."
-        ) from exc
-    if not isinstance(payload, dict):
-        raise OpenAICodexOAuthError("OpenAI Codex sign-in returned no access token.")
-    token_payload = cast(dict[str, Any], payload)
-    access = token_payload.get("access_token")
-    refresh = token_payload.get("refresh_token")
-    expires_in = token_payload.get("expires_in")
-    if (
-        not isinstance(access, str)
-        or not access
-        or not isinstance(refresh, str)
-        or not refresh
-        or not isinstance(expires_in, int)
-    ):
-        raise OpenAICodexOAuthError(
-            "OpenAI Codex sign-in returned incomplete token credentials."
+def _safe_login_error(exc: Exception) -> OpenAICodexOAuthError:
+    if isinstance(exc, OpenAICodexOAuthError):
+        return exc
+    message = str(exc).strip()
+    if message == "State validation failed.":
+        return OpenAICodexOAuthError(
+            "OpenAI Codex sign-in failed because the OAuth state did not match."
         )
-    return OAuthToken(
-        access=access,
-        refresh=refresh,
-        expires=int(time.time() * 1000 + expires_in * 1000),
-        account_id=_decode_account_id(access, provider),
-    )
-
-
-def _decode_account_id(
-    access_token: str,
-    provider: OAuthProviderConfig,
-) -> str | None:
-    if not provider.jwt_claim_path or not provider.account_id_claim:
-        return None
-    parts = access_token.split(".")
-    if len(parts) != 3:
-        return None
-    try:
-        padding = "=" * (-len(parts[1]) % 4)
-        raw_payload: object = json.loads(
-            base64.urlsafe_b64decode(parts[1] + padding).decode("utf-8")
+    if message == "Authorization code not found.":
+        return OpenAICodexOAuthError(
+            "OpenAI Codex sign-in returned no authorization code."
         )
-    except (ValueError, TypeError):
-        return None
-    if not isinstance(raw_payload, dict):
-        return None
-    payload = cast(dict[str, object], raw_payload)
-    auth = payload.get(provider.jwt_claim_path)
-    if not isinstance(auth, dict):
-        return None
-    account_id = cast(dict[str, object], auth).get(provider.account_id_claim)
-    return account_id if isinstance(account_id, str) and account_id else None
-
-
-def _oauth_http_error(response: httpx.Response, action: str) -> OpenAICodexOAuthError:
-    code: str | None = None
-    description: str | None = None
-    with suppress(ValueError):
-        payload = response.json()
-        if isinstance(payload, dict):
-            error_payload = cast(dict[str, Any], payload)
-            raw_code = error_payload.get("error")
-            raw_description = error_payload.get("error_description") or error_payload.get("message")
-            code = raw_code[:80] if isinstance(raw_code, str) else None
-            description = raw_description[:200] if isinstance(raw_description, str) else None
-    detail = ": ".join(value for value in (code, description) if value)
-    suffix = f" ({detail})" if detail else ""
+    status = _TOKEN_EXCHANGE_STATUS.search(message)
+    if status:
+        return OpenAICodexOAuthError(
+            f"OpenAI Codex OAuth token exchange failed with HTTP {status.group(1)}."
+        )
     return OpenAICodexOAuthError(
-        f"OpenAI Codex OAuth {action} failed with HTTP {response.status_code}{suffix}."
+        f"OpenAI Codex sign-in failed ({type(exc).__name__})."
     )
-
-
-def _http_client(proxy: str | None) -> httpx.Client:
-    kwargs: dict[str, Any] = {"timeout": _HTTP_TIMEOUT_S}
-    if proxy:
-        kwargs.update(proxy=proxy, trust_env=False)
-    return httpx.Client(**kwargs)
-
-
-def _token_storage() -> FileTokenStorage:
-    return FileTokenStorage(token_filename=OPENAI_CODEX_PROVIDER.token_filename)
 
 
 def _first(params: dict[str, list[str]], key: str) -> str | None:

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -1830,7 +1830,7 @@ def login_oauth_provider(query: QueryParams) -> dict[str, Any]:
             flow = start_openai_codex_oauth_login(
                 proxy=proxy,
                 timeout_s=_WEBUI_OAUTH_TIMEOUT_S,
-                listen_for_callback=not remote_browser,
+                open_browser=not remote_browser,
             )
         except Exception as e:
             raise WebUISettingsError(f"OpenAI Codex OAuth login failed: {e}", status=502) from e

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -1820,10 +1820,17 @@ def login_oauth_provider(query: QueryParams) -> dict[str, Any]:
             proxy = resolve_config_env_vars(load_config()).providers.openai_codex.proxy or None
         except ValueError as e:
             raise WebUISettingsError(str(e), status=400) from e
+        remote_browser_value = _query_first(query, "remote_browser")
+        remote_browser = (
+            _parse_bool(remote_browser_value, "remote_browser")
+            if remote_browser_value is not None
+            else False
+        )
         try:
             flow = start_openai_codex_oauth_login(
                 proxy=proxy,
                 timeout_s=_WEBUI_OAUTH_TIMEOUT_S,
+                listen_for_callback=not remote_browser,
             )
         except Exception as e:
             raise WebUISettingsError(f"OpenAI Codex OAuth login failed: {e}", status=502) from e

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -131,10 +131,10 @@ _IMAGE_GENERATION_ASPECT_RATIOS = {
 }
 _CONTEXT_WINDOW_TOKEN_OPTIONS = {65_536, 200_000, 262_144, 500_000, 1_048_576}
 _OAUTH_PROXY_PROVIDERS = {"openai_codex", "xai_grok"}
-_XAI_WEBUI_OAUTH_TIMEOUT_S = 600
-_XAI_WEBUI_OAUTH_MAX_FLOWS = 8
-_xai_webui_oauth_flows: dict[str, Any] = {}
-_xai_webui_oauth_flows_lock = threading.Lock()
+_WEBUI_OAUTH_TIMEOUT_S = 600
+_WEBUI_OAUTH_MAX_FLOWS = 8
+_webui_oauth_flows: dict[str, tuple[str, Any]] = {}
+_webui_oauth_flows_lock = threading.Lock()
 _MODEL_CONFIGURATION_SLUG_RE = re.compile(r"[^a-z0-9_-]+")
 _ENV_REF_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
 
@@ -1810,7 +1810,7 @@ def login_oauth_provider(query: QueryParams) -> dict[str, Any]:
 
     if spec.name == "openai_codex":
         try:
-            from oauth_cli_kit import get_token, login_oauth_interactive
+            from nanobot.providers.openai_codex_oauth import start_openai_codex_oauth_login
         except ImportError:
             raise WebUISettingsError(
                 "oauth_cli_kit not installed. Run: pip install oauth-cli-kit", status=500
@@ -1820,19 +1820,23 @@ def login_oauth_provider(query: QueryParams) -> dict[str, Any]:
             proxy = resolve_config_env_vars(load_config()).providers.openai_codex.proxy or None
         except ValueError as e:
             raise WebUISettingsError(str(e), status=400) from e
-        token = None
-        with suppress(Exception):
-            token = get_token(proxy=proxy)
-        if not (token and token.access):
-            messages: list[str] = []
-            token = login_oauth_interactive(
-                print_fn=lambda message: messages.append(str(message)),
-                prompt_fn=lambda _prompt: "",
+        try:
+            flow = start_openai_codex_oauth_login(
                 proxy=proxy,
+                timeout_s=_WEBUI_OAUTH_TIMEOUT_S,
             )
-        if not (token and token.access):
-            raise WebUISettingsError("OAuth login failed", status=401)
-        return settings_payload()
+        except Exception as e:
+            raise WebUISettingsError(f"OpenAI Codex OAuth login failed: {e}", status=502) from e
+        flow_id = secrets.token_urlsafe(24)
+        _register_webui_oauth_flow(spec.name, flow_id, flow)
+        return {
+            "status": "authorization_required",
+            "provider": spec.name,
+            "flow_id": flow_id,
+            "authorization_url": flow.authorization_url,
+            "expires_in": flow.remaining_seconds,
+            "completion_input": "callback_url",
+        }
 
     if spec.name == "github_copilot":
         try:
@@ -1862,18 +1866,19 @@ def login_oauth_provider(query: QueryParams) -> dict[str, Any]:
         try:
             flow = start_xai_oauth_login(
                 proxy=proxy,
-                timeout_s=_XAI_WEBUI_OAUTH_TIMEOUT_S,
+                timeout_s=_WEBUI_OAUTH_TIMEOUT_S,
             )
         except Exception as e:
             raise WebUISettingsError(f"xAI OAuth login failed: {e}", status=502) from e
         flow_id = secrets.token_urlsafe(24)
-        _register_xai_webui_oauth_flow(flow_id, flow)
+        _register_webui_oauth_flow(spec.name, flow_id, flow)
         return {
             "status": "authorization_required",
             "provider": spec.name,
             "flow_id": flow_id,
             "authorization_url": flow.authorization_url,
             "expires_in": flow.remaining_seconds,
+            "completion_input": "authorization_code",
         }
 
     raise WebUISettingsError("OAuth login is not supported for this provider")
@@ -1881,34 +1886,47 @@ def login_oauth_provider(query: QueryParams) -> dict[str, Any]:
 
 def complete_oauth_provider(
     query: QueryParams,
-    authorization_code: str | None = None,
+    authorization_response: str | None = None,
 ) -> dict[str, Any]:
     provider_name = (_query_first(query, "provider") or "").strip()
     flow_id = (_query_first(query, "flow_id") or "").strip()
     spec = find_by_name(provider_name)
-    if spec is None or spec.name != "xai_grok":
+    if spec is None or spec.name not in {"openai_codex", "xai_grok"}:
         raise WebUISettingsError("OAuth completion is not supported for this provider")
     if not flow_id:
         raise WebUISettingsError("flow_id is required")
 
-    flow = _get_xai_webui_oauth_flow(flow_id)
+    flow = _get_webui_oauth_flow(spec.name, flow_id)
     if flow is None:
-        raise WebUISettingsError("xAI sign-in expired. Start again.", status=410)
-
-    from nanobot.providers.xai_oauth import complete_xai_oauth_login
+        raise WebUISettingsError(f"{spec.label} sign-in expired. Start again.", status=410)
 
     try:
-        token = complete_xai_oauth_login(flow, authorization_code)
+        if spec.name == "openai_codex":
+            from nanobot.providers.openai_codex_oauth import (
+                OpenAICodexOAuthInputError,
+                complete_openai_codex_oauth_login,
+            )
+
+            try:
+                token = complete_openai_codex_oauth_login(flow, authorization_response)
+            except OpenAICodexOAuthInputError as e:
+                raise WebUISettingsError(str(e), status=400) from e
+        else:
+            from nanobot.providers.xai_oauth import complete_xai_oauth_login
+
+            token = complete_xai_oauth_login(flow, authorization_response)
+    except WebUISettingsError:
+        raise
     except Exception as e:
-        _remove_xai_webui_oauth_flow(flow_id, flow)
-        raise WebUISettingsError(f"xAI OAuth login failed: {e}", status=502) from e
+        _remove_webui_oauth_flow(spec.name, flow_id, flow)
+        raise WebUISettingsError(f"{spec.label} OAuth login failed: {e}", status=502) from e
     if token is None:
         return {
             "status": "pending",
             "provider": spec.name,
             "flow_id": flow_id,
         }
-    _remove_xai_webui_oauth_flow(flow_id, flow, cancel=False)
+    _remove_webui_oauth_flow(spec.name, flow_id, flow, cancel=False)
     if not token.access:
         raise WebUISettingsError("OAuth login failed", status=401)
     return settings_payload()
@@ -1930,6 +1948,7 @@ def logout_oauth_provider(query: QueryParams) -> dict[str, Any]:
             raise WebUISettingsError(
                 "oauth_cli_kit not installed. Run: pip install oauth-cli-kit", status=500
             ) from None
+        _clear_webui_oauth_flows(spec.name)
         token_path = FileTokenStorage(token_filename=OPENAI_CODEX_PROVIDER.token_filename).get_token_path()
     elif spec.name == "github_copilot":
         try:
@@ -1942,7 +1961,7 @@ def logout_oauth_provider(query: QueryParams) -> dict[str, Any]:
     elif spec.name == "xai_grok":
         from nanobot.providers.xai_oauth import logout_xai_oauth
 
-        _clear_xai_webui_oauth_flows()
+        _clear_webui_oauth_flows(spec.name)
         logout_xai_oauth()
         return settings_payload()
     else:
@@ -1954,47 +1973,60 @@ def logout_oauth_provider(query: QueryParams) -> dict[str, Any]:
     return settings_payload()
 
 
-def _register_xai_webui_oauth_flow(flow_id: str, flow: Any) -> None:
+def _register_webui_oauth_flow(provider_name: str, flow_id: str, flow: Any) -> None:
     discarded: list[Any] = []
-    with _xai_webui_oauth_flows_lock:
-        for existing_id, existing in list(_xai_webui_oauth_flows.items()):
+    with _webui_oauth_flows_lock:
+        for existing_id, (_provider_name, existing) in list(_webui_oauth_flows.items()):
             if existing.expired:
-                discarded.append(_xai_webui_oauth_flows.pop(existing_id))
-        while len(_xai_webui_oauth_flows) >= _XAI_WEBUI_OAUTH_MAX_FLOWS:
-            oldest_id = next(iter(_xai_webui_oauth_flows))
-            discarded.append(_xai_webui_oauth_flows.pop(oldest_id))
-        _xai_webui_oauth_flows[flow_id] = flow
+                discarded.append(_webui_oauth_flows.pop(existing_id)[1])
+        while len(_webui_oauth_flows) >= _WEBUI_OAUTH_MAX_FLOWS:
+            oldest_id = next(iter(_webui_oauth_flows))
+            discarded.append(_webui_oauth_flows.pop(oldest_id)[1])
+        _webui_oauth_flows[flow_id] = (provider_name, flow)
     for existing in discarded:
         existing.cancel()
 
 
-def _get_xai_webui_oauth_flow(flow_id: str) -> Any | None:
-    with _xai_webui_oauth_flows_lock:
-        flow = _xai_webui_oauth_flows.get(flow_id)
-        if flow is None or not flow.expired:
+def _get_webui_oauth_flow(provider_name: str, flow_id: str) -> Any | None:
+    with _webui_oauth_flows_lock:
+        registered = _webui_oauth_flows.get(flow_id)
+        if registered is None or registered[0] != provider_name:
+            return None
+        flow = registered[1]
+        if not flow.expired:
             return flow
-        _xai_webui_oauth_flows.pop(flow_id, None)
+        _webui_oauth_flows.pop(flow_id, None)
     flow.cancel()
     return None
 
 
-def _remove_xai_webui_oauth_flow(
+def _remove_webui_oauth_flow(
+    provider_name: str,
     flow_id: str,
     flow: Any,
     *,
     cancel: bool = True,
 ) -> None:
-    with _xai_webui_oauth_flows_lock:
-        if _xai_webui_oauth_flows.get(flow_id) is flow:
-            _xai_webui_oauth_flows.pop(flow_id)
+    with _webui_oauth_flows_lock:
+        registered = _webui_oauth_flows.get(flow_id)
+        if (
+            registered is not None
+            and registered[0] == provider_name
+            and registered[1] is flow
+        ):
+            _webui_oauth_flows.pop(flow_id)
     if cancel:
         flow.cancel()
 
 
-def _clear_xai_webui_oauth_flows() -> None:
-    with _xai_webui_oauth_flows_lock:
-        flows = list(_xai_webui_oauth_flows.values())
-        _xai_webui_oauth_flows.clear()
+def _clear_webui_oauth_flows(provider_name: str) -> None:
+    with _webui_oauth_flows_lock:
+        flow_ids = [
+            flow_id
+            for flow_id, (registered_provider, _flow) in _webui_oauth_flows.items()
+            if registered_provider == provider_name
+        ]
+        flows = [_webui_oauth_flows.pop(flow_id)[1] for flow_id in flow_ids]
     for flow in flows:
         flow.cancel()
 

--- a/nanobot/webui/settings_routes.py
+++ b/nanobot/webui/settings_routes.py
@@ -85,7 +85,8 @@ _CHANNEL_VALUES_HEADER_MAX_BYTES = 64 * 1024
 _API_SERVICE_VALUES_HEADER = "X-Nanobot-API-Service-Values"
 _API_SERVICE_VALUES_HEADER_MAX_BYTES = 8 * 1024
 _OAUTH_CODE_HEADER = "X-Nanobot-OAuth-Code"
-_OAUTH_CODE_HEADER_MAX_BYTES = 8 * 1024
+_OAUTH_CALLBACK_HEADER = "X-Nanobot-OAuth-Callback"
+_OAUTH_RESPONSE_HEADER_MAX_BYTES = 8 * 1024
 
 _SKIP_FIELD = object()
 _CHANNEL_CONNECT_ACTIONS = frozenset({"start", "poll", "cancel"})
@@ -471,16 +472,22 @@ class WebUISettingsRouter:
             if action == "login":
                 payload = await asyncio.to_thread(login_oauth_provider, query)
             elif action == "complete":
-                authorization_code = case_insensitive_header(
+                authorization_response = case_insensitive_header(
+                    request.headers,
+                    _OAUTH_CALLBACK_HEADER,
+                ) or case_insensitive_header(
                     request.headers,
                     _OAUTH_CODE_HEADER,
                 )
-                if len(authorization_code.encode("utf-8")) > _OAUTH_CODE_HEADER_MAX_BYTES:
-                    raise WebUISettingsError("OAuth authorization code is too large")
+                if (
+                    len(authorization_response.encode("utf-8"))
+                    > _OAUTH_RESPONSE_HEADER_MAX_BYTES
+                ):
+                    raise WebUISettingsError("OAuth authorization response is too large")
                 payload = await asyncio.to_thread(
                     complete_oauth_provider,
                     query,
-                    authorization_code or None,
+                    authorization_response or None,
                 )
             else:
                 payload = await asyncio.to_thread(logout_oauth_provider, query)

--- a/tests/providers/test_openai_codex_oauth.py
+++ b/tests/providers/test_openai_codex_oauth.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable
-from http.client import HTTPConnection
 from urllib.parse import parse_qs, urlencode, urlsplit
 
 import pytest
@@ -51,7 +50,8 @@ def _fake_interactive_login(
         )
         print_fn("Open this URL:")
         print_fn(_authorization_url())
-        captured["callback_url"] = prompt_fn("Paste callback URL")
+        if not open_browser:
+            captured["callback_url"] = prompt_fn("Paste callback URL")
         if error is not None:
             raise error
         return OAuthToken(
@@ -67,7 +67,7 @@ def _fake_interactive_login(
 def test_authorization_url_comes_from_oauth_cli_kit() -> None:
     flow = start_openai_codex_oauth_login(
         timeout_s=2,
-        listen_for_callback=False,
+        open_browser=False,
     )
     try:
         params = parse_qs(urlsplit(flow.authorization_url).query)
@@ -81,41 +81,28 @@ def test_authorization_url_comes_from_oauth_cli_kit() -> None:
         flow.cancel()
 
 
-def test_local_flow_relays_loopback_callback_to_public_oauth_cli_kit(
+def test_local_flow_delegates_browser_and_callback_to_public_oauth_cli_kit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, object] = {}
-    monkeypatch.setattr(codex_oauth, "_CALLBACK_PORT", 0)
     monkeypatch.setattr(
         codex_oauth,
         "login_oauth_interactive",
         _fake_interactive_login(captured),
     )
     flow = start_openai_codex_oauth_login(timeout_s=5)
-    callback_url = (
-        "http://localhost:1455/auth/callback?"
-        + urlencode({"code": "authorization-code", "state": "expected-state"})
-    )
-    server = flow._callback_server
-    assert server is not None
 
     try:
-        callback = urlsplit(callback_url)
-        connection = HTTPConnection("127.0.0.1", server.server_port, timeout=2)
-        try:
-            connection.request("GET", callback.path + "?" + callback.query)
-            response = connection.getresponse()
-            assert response.status == 200
-            response.read()
-        finally:
-            connection.close()
         token = _wait_for_completion(flow)
     finally:
         flow.cancel()
 
     assert token.account_id == "acct-test"
-    assert captured["callback_url"] == callback_url
-    assert captured["open_browser"] is False
+    assert captured == {
+        "provider": codex_oauth.OPENAI_CODEX_PROVIDER,
+        "proxy": None,
+        "open_browser": True,
+    }
 
 
 def test_remote_flow_delegates_pasted_callback_to_public_oauth_cli_kit(
@@ -130,7 +117,7 @@ def test_remote_flow_delegates_pasted_callback_to_public_oauth_cli_kit(
     flow = start_openai_codex_oauth_login(
         proxy="http://127.0.0.1:7890",
         timeout_s=5,
-        listen_for_callback=False,
+        open_browser=False,
     )
     callback_url = (
         "http://localhost:1455/auth/callback?"
@@ -167,7 +154,7 @@ def test_remote_flow_rejects_callback_from_another_login(
     )
     flow = start_openai_codex_oauth_login(
         timeout_s=5,
-        listen_for_callback=False,
+        open_browser=False,
     )
     callback_url = (
         "http://localhost:1455/auth/callback?"
@@ -192,7 +179,7 @@ def test_remote_flow_reports_authorization_denial_without_exchanging_code(
     )
     flow = start_openai_codex_oauth_login(
         timeout_s=5,
-        listen_for_callback=False,
+        open_browser=False,
     )
     callback_url = (
         "http://localhost:1455/auth/callback?"
@@ -221,7 +208,7 @@ def test_dependency_error_is_bounded_and_does_not_expose_callback(
     )
     flow = start_openai_codex_oauth_login(
         timeout_s=5,
-        listen_for_callback=False,
+        open_browser=False,
     )
     callback_url = (
         "http://localhost:1455/auth/callback?"
@@ -249,7 +236,7 @@ def test_remote_flow_expires_while_waiting_for_callback(
     )
     flow = start_openai_codex_oauth_login(
         timeout_s=0.05,
-        listen_for_callback=False,
+        open_browser=False,
     )
     try:
         time.sleep(0.08)

--- a/tests/providers/test_openai_codex_oauth.py
+++ b/tests/providers/test_openai_codex_oauth.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import base64
+import json
+import queue
+import socket
+import time
+from urllib.parse import parse_qs, urlencode, urlsplit
+
+import httpx
+import pytest
+from oauth_cli_kit.models import OAuthToken
+from oauth_cli_kit.storage import FileTokenStorage
+
+import nanobot.providers.openai_codex_oauth as codex_oauth
+from nanobot.providers.openai_codex_oauth import (
+    OpenAICodexOAuthError,
+    OpenAICodexOAuthInputError,
+    _build_authorization_url,
+    _exchange_code,
+    _generate_pkce,
+    complete_openai_codex_oauth_login,
+    start_openai_codex_oauth_login,
+)
+
+
+def _jwt(payload: dict[str, object]) -> str:
+    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+    return f"header.{encoded}.signature"
+
+
+def test_authorization_url_matches_codex_pkce_contract() -> None:
+    verifier, challenge = _generate_pkce()
+
+    url = _build_authorization_url(
+        codex_oauth.OPENAI_CODEX_PROVIDER,
+        challenge=challenge,
+        state="state-value",
+    )
+
+    params = parse_qs(urlsplit(url).query)
+    assert len(verifier) >= 43
+    assert params == {
+        "response_type": ["code"],
+        "client_id": [codex_oauth.OPENAI_CODEX_PROVIDER.client_id],
+        "redirect_uri": ["http://localhost:1455/auth/callback"],
+        "scope": ["openid profile email offline_access"],
+        "code_challenge": [challenge],
+        "code_challenge_method": ["S256"],
+        "state": ["state-value"],
+        "id_token_add_organizations": ["true"],
+        "codex_cli_simplified_flow": ["true"],
+        "originator": ["nanobot"],
+    }
+
+
+def test_remote_flow_requires_full_callback_url_and_persists_token(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setattr(codex_oauth, "_make_callback_server", lambda _state, _queue: None)
+    storage = FileTokenStorage(
+        token_filename="codex.json",
+        data_dir=tmp_path,
+        import_codex_cli=False,
+    )
+    monkeypatch.setattr(codex_oauth, "_token_storage", lambda: storage)
+    exchanged: dict[str, object] = {}
+
+    def fake_exchange(code: str, *, verifier: str, proxy: str | None) -> OAuthToken:
+        exchanged.update(code=code, verifier=verifier, proxy=proxy)
+        return OAuthToken(
+            access="access-token",
+            refresh="refresh-token",
+            expires=2_000_000_000_000,
+            account_id="acct-test",
+        )
+
+    monkeypatch.setattr(codex_oauth, "_exchange_code", fake_exchange)
+    flow = start_openai_codex_oauth_login(
+        proxy="http://127.0.0.1:7890",
+        timeout_s=5,
+    )
+    try:
+        state = parse_qs(urlsplit(flow.authorization_url).query)["state"][0]
+        with pytest.raises(OpenAICodexOAuthInputError, match="full callback URL"):
+            complete_openai_codex_oauth_login(flow, "authorization-code")
+
+        callback_url = (
+            "http://localhost:1455/auth/callback?"
+            + urlencode({"code": "authorization-code", "state": state})
+        )
+        token = complete_openai_codex_oauth_login(flow, callback_url)
+    finally:
+        flow.cancel()
+
+    assert token is not None
+    assert token.account_id == "acct-test"
+    assert exchanged["code"] == "authorization-code"
+    assert exchanged["verifier"]
+    assert exchanged["proxy"] == "http://127.0.0.1:7890"
+    assert storage.load() == token
+
+
+def test_remote_flow_rejects_callback_with_wrong_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(codex_oauth, "_make_callback_server", lambda _state, _queue: None)
+    monkeypatch.setattr(
+        codex_oauth,
+        "_exchange_code",
+        lambda *_args, **_kwargs: pytest.fail("token exchange must not run"),
+    )
+    flow = start_openai_codex_oauth_login(timeout_s=5)
+    callback_url = (
+        "http://localhost:1455/auth/callback?"
+        + urlencode({"code": "authorization-code", "state": "wrong-state"})
+    )
+    try:
+        with pytest.raises(OpenAICodexOAuthError, match="state did not match"):
+            complete_openai_codex_oauth_login(flow, callback_url)
+    finally:
+        flow.cancel()
+
+
+def test_local_callback_server_completes_flow_automatically(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        callback_port = listener.getsockname()[1]
+    monkeypatch.setattr(codex_oauth, "_CALLBACK_PORT", callback_port)
+
+    result_queue: queue.Queue[codex_oauth._CallbackResult] = queue.Queue(maxsize=1)
+    server = codex_oauth._make_callback_server("expected-state", result_queue)
+    assert server is not None
+
+    storage = FileTokenStorage(
+        token_filename="codex.json",
+        data_dir=tmp_path,
+        import_codex_cli=False,
+    )
+    monkeypatch.setattr(codex_oauth, "_token_storage", lambda: storage)
+    monkeypatch.setattr(
+        codex_oauth,
+        "_exchange_code",
+        lambda code, *, verifier, proxy: OAuthToken(
+            access=f"access-{code}",
+            refresh=f"refresh-{verifier}",
+            expires=2_000_000_000_000,
+            account_id=proxy,
+        ),
+    )
+    flow = codex_oauth.OpenAICodexOAuthLoginFlow(
+        authorization_url="https://auth.openai.com/oauth/authorize",
+        verifier="test-verifier",
+        state="expected-state",
+        proxy=None,
+        result_queue=result_queue,
+        server=server,
+        timeout_s=5,
+    )
+    try:
+        host = server.server_address[0]
+        request_host = f"[{host}]" if ":" in host else host
+        with httpx.Client(trust_env=False) as client:
+            response = client.get(
+                f"http://{request_host}:{callback_port}/auth/callback",
+                params={"code": "local-code", "state": "expected-state"},
+            )
+        assert response.status_code == 200
+        assert "Signed in to OpenAI Codex" in response.text
+        assert "local-code" not in response.text
+
+        token = None
+        deadline = time.monotonic() + 2
+        while token is None and time.monotonic() < deadline:
+            token = complete_openai_codex_oauth_login(flow)
+            if token is None:
+                time.sleep(0.01)
+    finally:
+        flow.cancel()
+
+    assert token is not None
+    assert token.access == "access-local-code"
+    assert storage.load() == token
+
+
+def test_token_exchange_saves_account_identity_without_exposing_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = "acct-codex"
+    access_token = _jwt(
+        {
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": account_id,
+            }
+        }
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url == codex_oauth.OPENAI_CODEX_PROVIDER.token_url
+        form = parse_qs(request.content.decode())
+        assert form["code"] == ["authorization-code"]
+        assert form["code_verifier"] == ["verifier"]
+        assert form["redirect_uri"] == ["http://localhost:1455/auth/callback"]
+        return httpx.Response(
+            200,
+            json={
+                "access_token": access_token,
+                "refresh_token": "refresh-token",
+                "expires_in": 3600,
+            },
+        )
+
+    monkeypatch.setattr(
+        codex_oauth,
+        "_http_client",
+        lambda _proxy: httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+
+    token = _exchange_code("authorization-code", verifier="verifier", proxy=None)
+
+    assert token.access == access_token
+    assert token.refresh == "refresh-token"
+    assert token.account_id == account_id
+
+
+def test_token_exchange_reports_bounded_upstream_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={
+                "error": "invalid_grant",
+                "error_description": "The authorization code has expired.",
+            },
+        )
+
+    monkeypatch.setattr(
+        codex_oauth,
+        "_http_client",
+        lambda _proxy: httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+
+    with pytest.raises(
+        OpenAICodexOAuthError,
+        match=r"HTTP 400 \(invalid_grant: The authorization code has expired\.\)",
+    ):
+        _exchange_code("secret-code", verifier="secret-verifier", proxy=None)

--- a/tests/providers/test_openai_codex_oauth.py
+++ b/tests/providers/test_openai_codex_oauth.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable
+from http.client import HTTPConnection
 from urllib.parse import parse_qs, urlencode, urlsplit
 
 import pytest
@@ -64,7 +65,10 @@ def _fake_interactive_login(
 
 
 def test_authorization_url_comes_from_oauth_cli_kit() -> None:
-    flow = start_openai_codex_oauth_login(timeout_s=2)
+    flow = start_openai_codex_oauth_login(
+        timeout_s=2,
+        listen_for_callback=False,
+    )
     try:
         params = parse_qs(urlsplit(flow.authorization_url).query)
         assert params["response_type"] == ["code"]
@@ -77,7 +81,44 @@ def test_authorization_url_comes_from_oauth_cli_kit() -> None:
         flow.cancel()
 
 
-def test_remote_flow_delegates_callback_to_public_oauth_cli_kit(
+def test_local_flow_relays_loopback_callback_to_public_oauth_cli_kit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(codex_oauth, "_CALLBACK_PORT", 0)
+    monkeypatch.setattr(
+        codex_oauth,
+        "login_oauth_interactive",
+        _fake_interactive_login(captured),
+    )
+    flow = start_openai_codex_oauth_login(timeout_s=5)
+    callback_url = (
+        "http://localhost:1455/auth/callback?"
+        + urlencode({"code": "authorization-code", "state": "expected-state"})
+    )
+    server = flow._callback_server
+    assert server is not None
+
+    try:
+        callback = urlsplit(callback_url)
+        connection = HTTPConnection("127.0.0.1", server.server_port, timeout=2)
+        try:
+            connection.request("GET", callback.path + "?" + callback.query)
+            response = connection.getresponse()
+            assert response.status == 200
+            response.read()
+        finally:
+            connection.close()
+        token = _wait_for_completion(flow)
+    finally:
+        flow.cancel()
+
+    assert token.account_id == "acct-test"
+    assert captured["callback_url"] == callback_url
+    assert captured["open_browser"] is False
+
+
+def test_remote_flow_delegates_pasted_callback_to_public_oauth_cli_kit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -89,6 +130,7 @@ def test_remote_flow_delegates_callback_to_public_oauth_cli_kit(
     flow = start_openai_codex_oauth_login(
         proxy="http://127.0.0.1:7890",
         timeout_s=5,
+        listen_for_callback=False,
     )
     callback_url = (
         "http://localhost:1455/auth/callback?"
@@ -114,42 +156,29 @@ def test_remote_flow_delegates_callback_to_public_oauth_cli_kit(
     }
 
 
-def test_remote_flow_delegates_state_validation_to_public_oauth_cli_kit(
+def test_remote_flow_rejects_callback_from_another_login(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, object] = {}
-
-    def login(
-        *,
-        print_fn,
-        prompt_fn,
-        provider,
-        proxy,
-        open_browser,
-    ) -> OAuthToken:
-        print_fn(_authorization_url())
-        callback_url = prompt_fn("Paste callback URL")
-        captured["callback_url"] = callback_url
-        state = parse_qs(urlsplit(callback_url).query).get("state")
-        if state != ["expected-state"]:
-            raise RuntimeError("State validation failed.")
-        raise AssertionError("expected a mismatched state")
-
-    monkeypatch.setattr(codex_oauth, "login_oauth_interactive", login)
-    flow = start_openai_codex_oauth_login(timeout_s=5)
+    monkeypatch.setattr(
+        codex_oauth,
+        "login_oauth_interactive",
+        _fake_interactive_login(captured),
+    )
+    flow = start_openai_codex_oauth_login(
+        timeout_s=5,
+        listen_for_callback=False,
+    )
     callback_url = (
         "http://localhost:1455/auth/callback?"
         + urlencode({"code": "authorization-code", "state": "wrong-state"})
     )
     try:
-        with pytest.raises(OpenAICodexOAuthError, match="state did not match"):
-            token = complete_openai_codex_oauth_login(flow, callback_url)
-            if token is None:
-                _wait_for_completion(flow)
+        with pytest.raises(OpenAICodexOAuthInputError, match="does not belong"):
+            complete_openai_codex_oauth_login(flow, callback_url)
+        assert "callback_url" not in captured
     finally:
         flow.cancel()
-
-    assert captured["callback_url"] == callback_url
 
 
 def test_remote_flow_reports_authorization_denial_without_exchanging_code(
@@ -161,7 +190,10 @@ def test_remote_flow_reports_authorization_denial_without_exchanging_code(
         "login_oauth_interactive",
         _fake_interactive_login(captured),
     )
-    flow = start_openai_codex_oauth_login(timeout_s=5)
+    flow = start_openai_codex_oauth_login(
+        timeout_s=5,
+        listen_for_callback=False,
+    )
     callback_url = (
         "http://localhost:1455/auth/callback?"
         + urlencode({"error": "access_denied", "state": "expected-state"})
@@ -187,7 +219,10 @@ def test_dependency_error_is_bounded_and_does_not_expose_callback(
             error=RuntimeError("Token exchange failed: 400 secret-code upstream-body"),
         ),
     )
-    flow = start_openai_codex_oauth_login(timeout_s=5)
+    flow = start_openai_codex_oauth_login(
+        timeout_s=5,
+        listen_for_callback=False,
+    )
     callback_url = (
         "http://localhost:1455/auth/callback?"
         + urlencode({"code": "secret-code", "state": "expected-state"})
@@ -212,7 +247,10 @@ def test_remote_flow_expires_while_waiting_for_callback(
         "login_oauth_interactive",
         _fake_interactive_login({}),
     )
-    flow = start_openai_codex_oauth_login(timeout_s=0.05)
+    flow = start_openai_codex_oauth_login(
+        timeout_s=0.05,
+        listen_for_callback=False,
+    )
     try:
         time.sleep(0.08)
         with pytest.raises(OpenAICodexOAuthError, match="expired"):

--- a/tests/providers/test_openai_codex_oauth.py
+++ b/tests/providers/test_openai_codex_oauth.py
@@ -1,74 +1,58 @@
 from __future__ import annotations
 
-import base64
-import json
-import queue
-import socket
 import time
+from collections.abc import Callable
 from urllib.parse import parse_qs, urlencode, urlsplit
 
-import httpx
 import pytest
 from oauth_cli_kit.models import OAuthToken
-from oauth_cli_kit.storage import FileTokenStorage
 
 import nanobot.providers.openai_codex_oauth as codex_oauth
 from nanobot.providers.openai_codex_oauth import (
     OpenAICodexOAuthError,
     OpenAICodexOAuthInputError,
-    _build_authorization_url,
-    _exchange_code,
-    _generate_pkce,
     complete_openai_codex_oauth_login,
     start_openai_codex_oauth_login,
 )
 
 
-def _jwt(payload: dict[str, object]) -> str:
-    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
-    return f"header.{encoded}.signature"
+def _authorization_url(state: str = "expected-state") -> str:
+    return f"{codex_oauth.OPENAI_CODEX_PROVIDER.authorize_url}?{urlencode({'state': state})}"
 
 
-def test_authorization_url_matches_codex_pkce_contract() -> None:
-    verifier, challenge = _generate_pkce()
-
-    url = _build_authorization_url(
-        codex_oauth.OPENAI_CODEX_PROVIDER,
-        challenge=challenge,
-        state="state-value",
-    )
-
-    params = parse_qs(urlsplit(url).query)
-    assert len(verifier) >= 43
-    assert params == {
-        "response_type": ["code"],
-        "client_id": [codex_oauth.OPENAI_CODEX_PROVIDER.client_id],
-        "redirect_uri": ["http://localhost:1455/auth/callback"],
-        "scope": ["openid profile email offline_access"],
-        "code_challenge": [challenge],
-        "code_challenge_method": ["S256"],
-        "state": ["state-value"],
-        "id_token_add_organizations": ["true"],
-        "codex_cli_simplified_flow": ["true"],
-        "originator": ["nanobot"],
-    }
+def _wait_for_completion(flow) -> OAuthToken:
+    deadline = time.monotonic() + 1
+    while time.monotonic() < deadline:
+        token = complete_openai_codex_oauth_login(flow)
+        if token is not None:
+            return token
+        time.sleep(0.01)
+    pytest.fail("OAuth flow did not finish")
 
 
-def test_remote_flow_requires_full_callback_url_and_persists_token(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path,
-) -> None:
-    monkeypatch.setattr(codex_oauth, "_make_callback_server", lambda _state, _queue: None)
-    storage = FileTokenStorage(
-        token_filename="codex.json",
-        data_dir=tmp_path,
-        import_codex_cli=False,
-    )
-    monkeypatch.setattr(codex_oauth, "_token_storage", lambda: storage)
-    exchanged: dict[str, object] = {}
-
-    def fake_exchange(code: str, *, verifier: str, proxy: str | None) -> OAuthToken:
-        exchanged.update(code=code, verifier=verifier, proxy=proxy)
+def _fake_interactive_login(
+    captured: dict[str, object],
+    *,
+    error: Exception | None = None,
+) -> Callable[..., OAuthToken]:
+    def login(
+        *,
+        print_fn,
+        prompt_fn,
+        provider,
+        proxy,
+        open_browser,
+    ) -> OAuthToken:
+        captured.update(
+            provider=provider,
+            proxy=proxy,
+            open_browser=open_browser,
+        )
+        print_fn("Open this URL:")
+        print_fn(_authorization_url())
+        captured["callback_url"] = prompt_fn("Paste callback URL")
+        if error is not None:
+            raise error
         return OAuthToken(
             access="access-token",
             refresh="refresh-token",
@@ -76,41 +60,82 @@ def test_remote_flow_requires_full_callback_url_and_persists_token(
             account_id="acct-test",
         )
 
-    monkeypatch.setattr(codex_oauth, "_exchange_code", fake_exchange)
+    return login
+
+
+def test_authorization_url_comes_from_oauth_cli_kit() -> None:
+    flow = start_openai_codex_oauth_login(timeout_s=2)
+    try:
+        params = parse_qs(urlsplit(flow.authorization_url).query)
+        assert params["response_type"] == ["code"]
+        assert params["client_id"] == [codex_oauth.OPENAI_CODEX_PROVIDER.client_id]
+        assert params["redirect_uri"] == [codex_oauth.OPENAI_CODEX_PROVIDER.redirect_uri]
+        assert params["code_challenge_method"] == ["S256"]
+        assert params["code_challenge"]
+        assert params["state"]
+    finally:
+        flow.cancel()
+
+
+def test_remote_flow_delegates_callback_to_public_oauth_cli_kit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        codex_oauth,
+        "login_oauth_interactive",
+        _fake_interactive_login(captured),
+    )
     flow = start_openai_codex_oauth_login(
         proxy="http://127.0.0.1:7890",
         timeout_s=5,
     )
+    callback_url = (
+        "http://localhost:1455/auth/callback?"
+        + urlencode({"code": "authorization-code", "state": "expected-state"})
+    )
     try:
-        state = parse_qs(urlsplit(flow.authorization_url).query)["state"][0]
+        assert complete_openai_codex_oauth_login(flow) is None
         with pytest.raises(OpenAICodexOAuthInputError, match="full callback URL"):
             complete_openai_codex_oauth_login(flow, "authorization-code")
-
-        callback_url = (
-            "http://localhost:1455/auth/callback?"
-            + urlencode({"code": "authorization-code", "state": state})
-        )
         token = complete_openai_codex_oauth_login(flow, callback_url)
+        if token is None:
+            token = _wait_for_completion(flow)
     finally:
         flow.cancel()
 
     assert token is not None
     assert token.account_id == "acct-test"
-    assert exchanged["code"] == "authorization-code"
-    assert exchanged["verifier"]
-    assert exchanged["proxy"] == "http://127.0.0.1:7890"
-    assert storage.load() == token
+    assert captured == {
+        "provider": codex_oauth.OPENAI_CODEX_PROVIDER,
+        "proxy": "http://127.0.0.1:7890",
+        "open_browser": False,
+        "callback_url": callback_url,
+    }
 
 
-def test_remote_flow_rejects_callback_with_wrong_state(
+def test_remote_flow_delegates_state_validation_to_public_oauth_cli_kit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(codex_oauth, "_make_callback_server", lambda _state, _queue: None)
-    monkeypatch.setattr(
-        codex_oauth,
-        "_exchange_code",
-        lambda *_args, **_kwargs: pytest.fail("token exchange must not run"),
-    )
+    captured: dict[str, object] = {}
+
+    def login(
+        *,
+        print_fn,
+        prompt_fn,
+        provider,
+        proxy,
+        open_browser,
+    ) -> OAuthToken:
+        print_fn(_authorization_url())
+        callback_url = prompt_fn("Paste callback URL")
+        captured["callback_url"] = callback_url
+        state = parse_qs(urlsplit(callback_url).query).get("state")
+        if state != ["expected-state"]:
+            raise RuntimeError("State validation failed.")
+        raise AssertionError("expected a mismatched state")
+
+    monkeypatch.setattr(codex_oauth, "login_oauth_interactive", login)
     flow = start_openai_codex_oauth_login(timeout_s=5)
     callback_url = (
         "http://localhost:1455/auth/callback?"
@@ -118,135 +143,79 @@ def test_remote_flow_rejects_callback_with_wrong_state(
     )
     try:
         with pytest.raises(OpenAICodexOAuthError, match="state did not match"):
+            token = complete_openai_codex_oauth_login(flow, callback_url)
+            if token is None:
+                _wait_for_completion(flow)
+    finally:
+        flow.cancel()
+
+    assert captured["callback_url"] == callback_url
+
+
+def test_remote_flow_reports_authorization_denial_without_exchanging_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        codex_oauth,
+        "login_oauth_interactive",
+        _fake_interactive_login(captured),
+    )
+    flow = start_openai_codex_oauth_login(timeout_s=5)
+    callback_url = (
+        "http://localhost:1455/auth/callback?"
+        + urlencode({"error": "access_denied", "state": "expected-state"})
+    )
+    try:
+        with pytest.raises(OpenAICodexOAuthError, match="authorization server"):
             complete_openai_codex_oauth_login(flow, callback_url)
     finally:
         flow.cancel()
 
+    assert "callback_url" not in captured
 
-def test_local_callback_server_completes_flow_automatically(
+
+def test_dependency_error_is_bounded_and_does_not_expose_callback(
     monkeypatch: pytest.MonkeyPatch,
-    tmp_path,
 ) -> None:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
-        listener.bind(("127.0.0.1", 0))
-        callback_port = listener.getsockname()[1]
-    monkeypatch.setattr(codex_oauth, "_CALLBACK_PORT", callback_port)
-
-    result_queue: queue.Queue[codex_oauth._CallbackResult] = queue.Queue(maxsize=1)
-    server = codex_oauth._make_callback_server("expected-state", result_queue)
-    assert server is not None
-
-    storage = FileTokenStorage(
-        token_filename="codex.json",
-        data_dir=tmp_path,
-        import_codex_cli=False,
-    )
-    monkeypatch.setattr(codex_oauth, "_token_storage", lambda: storage)
+    captured: dict[str, object] = {}
     monkeypatch.setattr(
         codex_oauth,
-        "_exchange_code",
-        lambda code, *, verifier, proxy: OAuthToken(
-            access=f"access-{code}",
-            refresh=f"refresh-{verifier}",
-            expires=2_000_000_000_000,
-            account_id=proxy,
+        "login_oauth_interactive",
+        _fake_interactive_login(
+            captured,
+            error=RuntimeError("Token exchange failed: 400 secret-code upstream-body"),
         ),
     )
-    flow = codex_oauth.OpenAICodexOAuthLoginFlow(
-        authorization_url="https://auth.openai.com/oauth/authorize",
-        verifier="test-verifier",
-        state="expected-state",
-        proxy=None,
-        result_queue=result_queue,
-        server=server,
-        timeout_s=5,
+    flow = start_openai_codex_oauth_login(timeout_s=5)
+    callback_url = (
+        "http://localhost:1455/auth/callback?"
+        + urlencode({"code": "secret-code", "state": "expected-state"})
     )
     try:
-        host = server.server_address[0]
-        request_host = f"[{host}]" if ":" in host else host
-        with httpx.Client(trust_env=False) as client:
-            response = client.get(
-                f"http://{request_host}:{callback_port}/auth/callback",
-                params={"code": "local-code", "state": "expected-state"},
-            )
-        assert response.status_code == 200
-        assert "Signed in to OpenAI Codex" in response.text
-        assert "local-code" not in response.text
-
-        token = None
-        deadline = time.monotonic() + 2
-        while token is None and time.monotonic() < deadline:
-            token = complete_openai_codex_oauth_login(flow)
+        with pytest.raises(OpenAICodexOAuthError) as exc:
+            token = complete_openai_codex_oauth_login(flow, callback_url)
             if token is None:
-                time.sleep(0.01)
+                _wait_for_completion(flow)
     finally:
         flow.cancel()
 
-    assert token is not None
-    assert token.access == "access-local-code"
-    assert storage.load() == token
+    assert str(exc.value) == "OpenAI Codex OAuth token exchange failed with HTTP 400."
+    assert "secret-code" not in str(exc.value)
 
 
-def test_token_exchange_saves_account_identity_without_exposing_tokens(
+def test_remote_flow_expires_while_waiting_for_callback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    account_id = "acct-codex"
-    access_token = _jwt(
-        {
-            "https://api.openai.com/auth": {
-                "chatgpt_account_id": account_id,
-            }
-        }
-    )
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        assert request.url == codex_oauth.OPENAI_CODEX_PROVIDER.token_url
-        form = parse_qs(request.content.decode())
-        assert form["code"] == ["authorization-code"]
-        assert form["code_verifier"] == ["verifier"]
-        assert form["redirect_uri"] == ["http://localhost:1455/auth/callback"]
-        return httpx.Response(
-            200,
-            json={
-                "access_token": access_token,
-                "refresh_token": "refresh-token",
-                "expires_in": 3600,
-            },
-        )
-
     monkeypatch.setattr(
         codex_oauth,
-        "_http_client",
-        lambda _proxy: httpx.Client(transport=httpx.MockTransport(handler)),
+        "login_oauth_interactive",
+        _fake_interactive_login({}),
     )
-
-    token = _exchange_code("authorization-code", verifier="verifier", proxy=None)
-
-    assert token.access == access_token
-    assert token.refresh == "refresh-token"
-    assert token.account_id == account_id
-
-
-def test_token_exchange_reports_bounded_upstream_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    def handler(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            400,
-            json={
-                "error": "invalid_grant",
-                "error_description": "The authorization code has expired.",
-            },
-        )
-
-    monkeypatch.setattr(
-        codex_oauth,
-        "_http_client",
-        lambda _proxy: httpx.Client(transport=httpx.MockTransport(handler)),
-    )
-
-    with pytest.raises(
-        OpenAICodexOAuthError,
-        match=r"HTTP 400 \(invalid_grant: The authorization code has expired\.\)",
-    ):
-        _exchange_code("secret-code", verifier="secret-verifier", proxy=None)
+    flow = start_openai_codex_oauth_login(timeout_s=0.05)
+    try:
+        time.sleep(0.08)
+        with pytest.raises(OpenAICodexOAuthError, match="expired"):
+            complete_openai_codex_oauth_login(flow)
+    finally:
+        flow.cancel()

--- a/tests/webui/test_settings_api.py
+++ b/tests/webui/test_settings_api.py
@@ -1465,11 +1465,11 @@ def test_openai_codex_oauth_login_passes_configured_proxy(
         def cancel(self) -> None:
             captured["cancelled"] = True
 
-    def fake_start(*, proxy=None, timeout_s=None, listen_for_callback=None):
+    def fake_start(*, proxy=None, timeout_s=None, open_browser=None):
         captured.update(
             proxy=proxy,
             timeout_s=timeout_s,
-            listen_for_callback=listen_for_callback,
+            open_browser=open_browser,
         )
         return FakeFlow()
 
@@ -1483,7 +1483,7 @@ def test_openai_codex_oauth_login_passes_configured_proxy(
     assert captured == {
         "proxy": proxy,
         "timeout_s": 600,
-        "listen_for_callback": True,
+        "open_browser": True,
     }
     assert payload["status"] == "authorization_required"
     assert payload["provider"] == "openai_codex"
@@ -1527,7 +1527,7 @@ def test_openai_codex_oauth_login_passes_configured_proxy(
     ]
 
 
-def test_openai_codex_remote_login_disables_loopback_listener(
+def test_openai_codex_remote_login_uses_headless_dependency_mode(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1561,7 +1561,7 @@ def test_openai_codex_remote_login_disables_loopback_listener(
         _clear_webui_oauth_flows("openai_codex")
 
     assert payload["completion_input"] == "callback_url"
-    assert captured["listen_for_callback"] is False
+    assert captured["open_browser"] is False
     assert captured["cancelled"] is True
 
 

--- a/tests/webui/test_settings_api.py
+++ b/tests/webui/test_settings_api.py
@@ -1454,25 +1454,68 @@ def test_openai_codex_oauth_login_passes_configured_proxy(
     )
     monkeypatch.setenv("CODEX_PROXY_TEST", proxy)
     monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+    captured: dict[str, object] = {}
 
-    import oauth_cli_kit
+    class FakeFlow:
+        authorization_url = "https://auth.openai.com/oauth/authorize?state=test"
+        remaining_seconds = 600
+        expired = False
 
-    captured: dict[str, str | None] = {}
+        def cancel(self) -> None:
+            captured["cancelled"] = True
 
-    def fake_get_token(*, proxy=None):
-        captured["get_proxy"] = proxy
-        raise RuntimeError("no-token")
+    def fake_start(*, proxy=None, timeout_s=None):
+        captured.update(proxy=proxy, timeout_s=timeout_s)
+        return FakeFlow()
 
-    def fake_login(*, print_fn, prompt_fn, proxy=None):
-        captured["login_proxy"] = proxy
-        return SimpleNamespace(access="access-token", account_id="acct-test")
+    monkeypatch.setattr(
+        "nanobot.providers.openai_codex_oauth.start_openai_codex_oauth_login",
+        fake_start,
+    )
 
-    monkeypatch.setattr(oauth_cli_kit, "get_token", fake_get_token)
-    monkeypatch.setattr(oauth_cli_kit, "login_oauth_interactive", fake_login)
+    payload = login_oauth_provider({"provider": ["openai-codex"]})
 
-    login_oauth_provider({"provider": ["openai-codex"]})
+    assert captured == {"proxy": proxy, "timeout_s": 600}
+    assert payload["status"] == "authorization_required"
+    assert payload["provider"] == "openai_codex"
+    assert payload["authorization_url"] == FakeFlow.authorization_url
+    assert payload["completion_input"] == "callback_url"
 
-    assert captured == {"get_proxy": proxy, "login_proxy": proxy}
+    callbacks: list[str | None] = []
+
+    def fake_complete(_flow, callback):
+        callbacks.append(callback)
+        if callback is None:
+            return None
+        return SimpleNamespace(access="access-token")
+
+    monkeypatch.setattr(
+        "nanobot.providers.openai_codex_oauth.complete_openai_codex_oauth_login",
+        fake_complete,
+    )
+    monkeypatch.setattr(
+        "nanobot.webui.settings_api.settings_payload",
+        lambda: {"settings": "ready"},
+    )
+
+    pending = complete_oauth_provider(
+        {"provider": ["openai-codex"], "flow_id": [payload["flow_id"]]},
+    )
+    completed = complete_oauth_provider(
+        {"provider": ["openai-codex"], "flow_id": [payload["flow_id"]]},
+        "http://localhost:1455/auth/callback?code=secret&state=test",
+    )
+
+    assert pending == {
+        "status": "pending",
+        "provider": "openai_codex",
+        "flow_id": payload["flow_id"],
+    }
+    assert completed == {"settings": "ready"}
+    assert callbacks == [
+        None,
+        "http://localhost:1455/auth/callback?code=secret&state=test",
+    ]
 
 
 def test_openai_codex_oauth_login_reports_missing_oauth_cli_kit(
@@ -1481,7 +1524,7 @@ def test_openai_codex_oauth_login_reports_missing_oauth_cli_kit(
     real_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
-        if name == "oauth_cli_kit":
+        if name == "nanobot.providers.openai_codex_oauth":
             raise ImportError("missing")
         return real_import(name, *args, **kwargs)
 
@@ -1542,6 +1585,7 @@ def test_xai_grok_login_starts_fresh_browser_flow_with_proxy(
     assert payload["status"] == "authorization_required"
     assert payload["provider"] == "xai_grok"
     assert payload["authorization_url"] == FakeFlow.authorization_url
+    assert payload["completion_input"] == "authorization_code"
     assert payload["flow_id"]
 
     callbacks: list[str | None] = []

--- a/tests/webui/test_settings_api.py
+++ b/tests/webui/test_settings_api.py
@@ -12,6 +12,7 @@ from nanobot.config.schema import Config, InlineFallbackConfig, ModelPresetConfi
 from nanobot.providers.registry import find_by_name
 from nanobot.webui.settings_api import (
     WebUISettingsError,
+    _clear_webui_oauth_flows,
     _docs_version,
     _model_catalog_kind,
     _oauth_provider_status,
@@ -1464,8 +1465,12 @@ def test_openai_codex_oauth_login_passes_configured_proxy(
         def cancel(self) -> None:
             captured["cancelled"] = True
 
-    def fake_start(*, proxy=None, timeout_s=None):
-        captured.update(proxy=proxy, timeout_s=timeout_s)
+    def fake_start(*, proxy=None, timeout_s=None, listen_for_callback=None):
+        captured.update(
+            proxy=proxy,
+            timeout_s=timeout_s,
+            listen_for_callback=listen_for_callback,
+        )
         return FakeFlow()
 
     monkeypatch.setattr(
@@ -1475,7 +1480,11 @@ def test_openai_codex_oauth_login_passes_configured_proxy(
 
     payload = login_oauth_provider({"provider": ["openai-codex"]})
 
-    assert captured == {"proxy": proxy, "timeout_s": 600}
+    assert captured == {
+        "proxy": proxy,
+        "timeout_s": 600,
+        "listen_for_callback": True,
+    }
     assert payload["status"] == "authorization_required"
     assert payload["provider"] == "openai_codex"
     assert payload["authorization_url"] == FakeFlow.authorization_url
@@ -1516,6 +1525,44 @@ def test_openai_codex_oauth_login_passes_configured_proxy(
         None,
         "http://localhost:1455/auth/callback?code=secret&state=test",
     ]
+
+
+def test_openai_codex_remote_login_disables_loopback_listener(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    save_config(Config(), config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+    captured: dict[str, object] = {}
+
+    class FakeFlow:
+        authorization_url = "https://auth.openai.com/oauth/authorize?state=test"
+        remaining_seconds = 600
+        expired = False
+
+        def cancel(self) -> None:
+            captured["cancelled"] = True
+
+    def fake_start(**kwargs):
+        captured.update(kwargs)
+        return FakeFlow()
+
+    monkeypatch.setattr(
+        "nanobot.providers.openai_codex_oauth.start_openai_codex_oauth_login",
+        fake_start,
+    )
+
+    try:
+        payload = login_oauth_provider(
+            {"provider": ["openai-codex"], "remote_browser": ["true"]}
+        )
+    finally:
+        _clear_webui_oauth_flows("openai_codex")
+
+    assert payload["completion_input"] == "callback_url"
+    assert captured["listen_for_callback"] is False
+    assert captured["cancelled"] is True
 
 
 def test_openai_codex_oauth_login_reports_missing_oauth_cli_kit(

--- a/tests/webui/test_settings_routes.py
+++ b/tests/webui/test_settings_routes.py
@@ -27,15 +27,31 @@ def _router(*, authorized: bool = True) -> WebUISettingsRouter:
     )
 
 
+@pytest.mark.parametrize(
+    ("provider", "header_name", "authorization_response"),
+    [
+        ("xai_grok", "X-Nanobot-OAuth-Code", "secret"),
+        (
+            "openai_codex",
+            "X-Nanobot-OAuth-Callback",
+            "http://localhost:1455/auth/callback?code=secret&state=test",
+        ),
+    ],
+)
 @pytest.mark.asyncio
-async def test_xai_oauth_completion_reads_code_from_private_header(monkeypatch) -> None:
+async def test_oauth_completion_reads_private_response_header(
+    monkeypatch,
+    provider: str,
+    header_name: str,
+    authorization_response: str,
+) -> None:
     captured: dict[str, object] = {}
 
-    def complete(query, authorization_code=None):
-        captured.update(query=query, authorization_code=authorization_code)
+    def complete(query, authorization_response=None):
+        captured.update(query=query, authorization_response=authorization_response)
         return {
             "status": "pending",
-            "provider": "xai_grok",
+            "provider": provider,
             "flow_id": "flow-123",
         }
 
@@ -44,13 +60,13 @@ async def test_xai_oauth_completion_reads_code_from_private_header(monkeypatch) 
     request = SimpleNamespace(
         path=(
             "/api/settings/provider/oauth-login/complete"
-            "?provider=xai_grok&flow_id=flow-123"
+            f"?provider={provider}&flow_id=flow-123"
         ),
         headers=Headers(
             [
                 (
-                    "X-Nanobot-OAuth-Code",
-                    "secret",
+                    header_name,
+                    authorization_response,
                 )
             ]
         ),
@@ -66,14 +82,14 @@ async def test_xai_oauth_completion_reads_code_from_private_header(monkeypatch) 
     assert response.status_code == 200
     assert json.loads(response.body) == {
         "status": "pending",
-        "provider": "xai_grok",
+        "provider": provider,
         "flow_id": "flow-123",
     }
     assert captured == {
-        "query": {"provider": ["xai_grok"], "flow_id": ["flow-123"]},
-        "authorization_code": "secret",
+        "query": {"provider": [provider], "flow_id": ["flow-123"]},
+        "authorization_response": authorization_response,
     }
-    assert "secret" not in request.path
+    assert authorization_response not in request.path
 
 
 @pytest.mark.parametrize(

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -661,11 +661,12 @@ export function SettingsView({
   const [nanobotFeatureConfirm, setNanobotFeatureConfirm] = useState<NanobotFeatureInfo | null>(null);
   const [mcpPresetAction, setMcpPresetAction] = useState<string | null>(null);
   const [providerSaving, setProviderSaving] = useState<string | null>(null);
-  const [xaiOAuthFlow, setXaiOAuthFlow] =
+  const [providerOAuthFlow, setProviderOAuthFlow] =
     useState<ProviderOAuthAuthorizationRequired | null>(null);
-  const xaiOAuthFlowRef = useRef<ProviderOAuthAuthorizationRequired | null>(null);
-  const [xaiOAuthCode, setXaiOAuthCode] = useState("");
-  const [xaiOAuthCompleting, setXaiOAuthCompleting] = useState(false);
+  const providerOAuthFlowRef = useRef<ProviderOAuthAuthorizationRequired | null>(null);
+  const [providerOAuthResponse, setProviderOAuthResponse] = useState("");
+  const [providerOAuthCompleting, setProviderOAuthCompleting] = useState(false);
+  const [providerOAuthDialogError, setProviderOAuthDialogError] = useState<string | null>(null);
   const [webSearchSaving, setWebSearchSaving] = useState(false);
   const [imageGenerationSaving, setImageGenerationSaving] = useState(false);
   const [transcriptionSaving, setTranscriptionSaving] = useState(false);
@@ -765,37 +766,44 @@ export function SettingsView({
     [onSettingsChange],
   );
 
-  const closeXaiOAuthFlow = useCallback(() => {
-    xaiOAuthFlowRef.current = null;
-    setXaiOAuthFlow(null);
-    setXaiOAuthCode("");
-    setXaiOAuthCompleting(false);
+  const closeProviderOAuthFlow = useCallback(() => {
+    providerOAuthFlowRef.current = null;
+    setProviderOAuthFlow(null);
+    setProviderOAuthResponse("");
+    setProviderOAuthCompleting(false);
+    setProviderOAuthDialogError(null);
   }, []);
 
   useEffect(() => {
-    if (!xaiOAuthFlow) return;
+    if (!providerOAuthFlow) return;
     let cancelled = false;
     let timer: number | null = null;
     const poll = async () => {
       try {
         const payload = await completeProviderOAuth(
           getToken(),
-          xaiOAuthFlow.provider,
-          xaiOAuthFlow.flow_id,
+          providerOAuthFlow.provider,
+          providerOAuthFlow.flow_id,
         );
-        if (cancelled || xaiOAuthFlowRef.current?.flow_id !== xaiOAuthFlow.flow_id) return;
+        if (
+          cancelled
+          || providerOAuthFlowRef.current?.flow_id !== providerOAuthFlow.flow_id
+        ) return;
         if (isProviderOAuthPending(payload)) {
           timer = window.setTimeout(() => void poll(), 1000);
           return;
         }
         applyPayload(payload);
-        setExpandedProvider(xaiOAuthFlow.provider);
+        setExpandedProvider(providerOAuthFlow.provider);
         setError(null);
-        closeXaiOAuthFlow();
+        closeProviderOAuthFlow();
       } catch (err) {
-        if (cancelled || xaiOAuthFlowRef.current?.flow_id !== xaiOAuthFlow.flow_id) return;
+        if (
+          cancelled
+          || providerOAuthFlowRef.current?.flow_id !== providerOAuthFlow.flow_id
+        ) return;
         setError((err as Error).message);
-        closeXaiOAuthFlow();
+        closeProviderOAuthFlow();
       }
     };
     timer = window.setTimeout(() => void poll(), 1000);
@@ -803,7 +811,7 @@ export function SettingsView({
       cancelled = true;
       if (timer !== null) window.clearTimeout(timer);
     };
-  }, [applyPayload, closeXaiOAuthFlow, getToken, xaiOAuthFlow]);
+  }, [applyPayload, closeProviderOAuthFlow, getToken, providerOAuthFlow]);
 
   useEffect(() => {
     if (!initialSettings || settings !== null) return;
@@ -1612,7 +1620,11 @@ export function SettingsView({
   const runProviderOAuth = async (providerName: string, action: "login" | "logout") => {
     if (providerSaving) return;
     let popup: Window | null = null;
-    if (action === "login" && providerName === "xai_grok" && !remoteBrowserAccess) {
+    if (
+      action === "login"
+      && (providerName === "xai_grok" || providerName === "openai_codex")
+      && !remoteBrowserAccess
+    ) {
       try {
         popup = window.open("about:blank", "_blank");
         if (popup) popup.opener = null;
@@ -1632,15 +1644,16 @@ export function SettingsView({
         } catch {
           // The dialog keeps the authorization link available when the popup was closed.
         }
-        xaiOAuthFlowRef.current = payload;
-        setXaiOAuthFlow(payload);
-        setXaiOAuthCode("");
+        providerOAuthFlowRef.current = payload;
+        setProviderOAuthFlow(payload);
+        setProviderOAuthResponse("");
+        setProviderOAuthDialogError(null);
         setExpandedProvider(providerName);
         setError(null);
         return;
       }
       popup?.close();
-      closeXaiOAuthFlow();
+      closeProviderOAuthFlow();
       applyPayload(payload);
       setExpandedProvider(providerName);
       setError(null);
@@ -1652,31 +1665,31 @@ export function SettingsView({
     }
   };
 
-  const completeXaiOAuth = async () => {
-    const flow = xaiOAuthFlowRef.current;
-    const authorizationCode = xaiOAuthCode.trim();
-    if (!flow || !authorizationCode || xaiOAuthCompleting) return;
-    setXaiOAuthCompleting(true);
+  const completeProviderOAuthResponse = async () => {
+    const flow = providerOAuthFlowRef.current;
+    const authorizationResponse = providerOAuthResponse.trim();
+    if (!flow || !authorizationResponse || providerOAuthCompleting) return;
+    setProviderOAuthCompleting(true);
+    setProviderOAuthDialogError(null);
     try {
       const payload = await completeProviderOAuth(
         token,
         flow.provider,
         flow.flow_id,
-        authorizationCode,
+        authorizationResponse,
       );
-      if (xaiOAuthFlowRef.current?.flow_id !== flow.flow_id) return;
+      if (providerOAuthFlowRef.current?.flow_id !== flow.flow_id) return;
       if (isProviderOAuthPending(payload)) return;
       applyPayload(payload);
       setExpandedProvider(flow.provider);
       setError(null);
-      closeXaiOAuthFlow();
+      closeProviderOAuthFlow();
     } catch (err) {
-      if (xaiOAuthFlowRef.current?.flow_id === flow.flow_id) {
-        setError((err as Error).message);
-        closeXaiOAuthFlow();
+      if (providerOAuthFlowRef.current?.flow_id === flow.flow_id) {
+        setProviderOAuthDialogError((err as Error).message);
       }
     } finally {
-      setXaiOAuthCompleting(false);
+      setProviderOAuthCompleting(false);
     }
   };
 
@@ -2317,19 +2330,33 @@ export function SettingsView({
         onConfirm={handleDeleteModelConfiguration}
       />
 
-      <XaiOAuthLoginDialog
-        flow={xaiOAuthFlow}
-        authorizationCode={xaiOAuthCode}
-        completing={xaiOAuthCompleting}
+      <ProviderOAuthLoginDialog
+        flow={providerOAuthFlow}
+        providerLabel={
+          providerOAuthFlow
+            ? settings?.providers.find((provider) => provider.name === providerOAuthFlow.provider)
+              ?.label ?? providerOAuthFlow.provider
+            : ""
+        }
+        authorizationResponse={providerOAuthResponse}
+        completing={providerOAuthCompleting}
+        error={providerOAuthDialogError}
         remoteBrowserAccess={remoteBrowserAccess}
-        onAuthorizationCodeChange={setXaiOAuthCode}
+        onAuthorizationResponseChange={(value) => {
+          setProviderOAuthResponse(value);
+          setProviderOAuthDialogError(null);
+        }}
         onOpenAuthorization={() => {
-          if (!xaiOAuthFlow) return;
-          const opened = window.open(xaiOAuthFlow.authorization_url, "_blank", "noopener,noreferrer");
+          if (!providerOAuthFlow) return;
+          const opened = window.open(
+            providerOAuthFlow.authorization_url,
+            "_blank",
+            "noopener,noreferrer",
+          );
           if (opened) opened.opener = null;
         }}
-        onComplete={() => void completeXaiOAuth()}
-        onClose={closeXaiOAuthFlow}
+        onComplete={() => void completeProviderOAuthResponse()}
+        onClose={closeProviderOAuthFlow}
       />
 
       <NanobotFeatureInstallDialog
@@ -2980,26 +3007,35 @@ function AppearanceSettings({
   );
 }
 
-function XaiOAuthLoginDialog({
+function ProviderOAuthLoginDialog({
   flow,
-  authorizationCode,
+  providerLabel,
+  authorizationResponse,
   completing,
+  error,
   remoteBrowserAccess,
-  onAuthorizationCodeChange,
+  onAuthorizationResponseChange,
   onOpenAuthorization,
   onComplete,
   onClose,
 }: {
   flow: ProviderOAuthAuthorizationRequired | null;
-  authorizationCode: string;
+  providerLabel: string;
+  authorizationResponse: string;
   completing: boolean;
+  error: string | null;
   remoteBrowserAccess: boolean;
-  onAuthorizationCodeChange: (value: string) => void;
+  onAuthorizationResponseChange: (value: string) => void;
   onOpenAuthorization: () => void;
   onComplete: () => void;
   onClose: () => void;
 }) {
   const { t } = useTranslation();
+  const expectsCallbackUrl = flow?.completion_input === "callback_url";
+  const inputId = expectsCallbackUrl ? "provider-oauth-callback" : "provider-oauth-code";
+  const inputLabel = expectsCallbackUrl
+    ? t("settings.oauth.callbackUrl")
+    : t("settings.oauth.authorizationCode");
 
   return (
     <Dialog
@@ -3017,36 +3053,67 @@ function XaiOAuthLoginDialog({
           }}
         >
           <DialogHeader>
-            <DialogTitle>xAI Grok</DialogTitle>
+            <DialogTitle>{providerLabel}</DialogTitle>
             <DialogDescription>
-              {remoteBrowserAccess
-                ? t("settings.oauth.remoteCodeHelp")
-                : t("settings.oauth.localCodeHelp")}
+              {expectsCallbackUrl
+                ? remoteBrowserAccess
+                  ? t("settings.oauth.remoteCallbackHelp")
+                  : t("settings.oauth.localCallbackHelp")
+                : remoteBrowserAccess
+                  ? t("settings.oauth.remoteCodeHelp")
+                  : t("settings.oauth.localCodeHelp")}
             </DialogDescription>
           </DialogHeader>
+          <div className="flex items-center gap-2 rounded-[14px] border border-border/45 bg-muted/35 px-3 py-2.5 text-[12px] text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" aria-hidden />
+            <span>{t("settings.oauth.waitingForCallback")}</span>
+          </div>
           <div className="space-y-2">
             <label
-              htmlFor="xai-oauth-code"
+              htmlFor={inputId}
               className="block text-xs font-medium text-foreground"
             >
-              {t("settings.oauth.authorizationCode")}
+              {inputLabel}
             </label>
-            <Input
-              id="xai-oauth-code"
-              value={authorizationCode}
-              onChange={(event) => onAuthorizationCodeChange(event.target.value)}
-              placeholder={t("settings.oauth.authorizationCode")}
-              aria-label={t("settings.oauth.authorizationCode")}
-              autoComplete="off"
-              spellCheck={false}
-            />
+            {expectsCallbackUrl ? (
+              <Textarea
+                id={inputId}
+                value={authorizationResponse}
+                onChange={(event) => onAuthorizationResponseChange(event.target.value)}
+                placeholder={t("settings.oauth.callbackUrlPlaceholder")}
+                aria-label={inputLabel}
+                autoComplete="off"
+                spellCheck={false}
+                className="min-h-[88px] resize-none break-all font-mono text-[12px] leading-5"
+              />
+            ) : (
+              <Input
+                id={inputId}
+                value={authorizationResponse}
+                onChange={(event) => onAuthorizationResponseChange(event.target.value)}
+                placeholder={inputLabel}
+                aria-label={inputLabel}
+                autoComplete="off"
+                spellCheck={false}
+              />
+            )}
           </div>
+          {error ? (
+            <p
+              role="alert"
+              className="rounded-[14px] border border-destructive/20 bg-destructive/5 px-3 py-2.5 text-[12px] text-destructive"
+            >
+              {error}
+            </p>
+          ) : null}
           <DialogFooter className="gap-2 sm:space-x-0">
             <Button type="button" variant="outline" onClick={onOpenAuthorization}>
               <ExternalLink className="mr-2 h-4 w-4" aria-hidden />
-              {t("settings.oauth.signIn")}
+              {expectsCallbackUrl
+                ? t("settings.oauth.openChatGPT")
+                : t("settings.oauth.signIn")}
             </Button>
-            <Button type="submit" disabled={!authorizationCode.trim() || completing}>
+            <Button type="submit" disabled={!authorizationResponse.trim() || completing}>
               {completing ? t("settings.oauth.signingIn") : t("settings.oauth.finishSignIn")}
             </Button>
           </DialogFooter>
@@ -4255,7 +4322,12 @@ function ProvidersSettings({
                             account: provider.oauth_account || provider.label,
                             defaultValue: "Signed in as {{account}}",
                           })
-                        : provider.name === "xai_grok" && remoteBrowserAccess
+                        : provider.name === "openai_codex" && remoteBrowserAccess
+                          ? tx(
+                              "settings.oauth.codexRemoteSignInHelp",
+                              "Sign in through this browser, then paste the full localhost callback URL back into nanobot.",
+                            )
+                          : provider.name === "xai_grok" && remoteBrowserAccess
                           ? tx(
                               "settings.oauth.remoteSignInHelp",
                               "Select Sign in to open xAI on your computer, then paste the authorization code shown after login.",

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -1622,7 +1622,7 @@ export function SettingsView({
     let popup: Window | null = null;
     if (
       action === "login"
-      && (providerName === "xai_grok" || providerName === "openai_codex")
+      && providerName === "xai_grok"
       && !remoteBrowserAccess
     ) {
       try {

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -3056,17 +3056,23 @@ function ProviderOAuthLoginDialog({
             <DialogTitle>{providerLabel}</DialogTitle>
             <DialogDescription>
               {expectsCallbackUrl
-                ? remoteBrowserAccess
-                  ? t("settings.oauth.remoteCallbackHelp")
-                  : t("settings.oauth.localCallbackHelp")
+                ? t("settings.oauth.remoteCallbackHelp")
                 : remoteBrowserAccess
                   ? t("settings.oauth.remoteCodeHelp")
                   : t("settings.oauth.localCodeHelp")}
             </DialogDescription>
           </DialogHeader>
           <div className="flex items-center gap-2 rounded-[14px] border border-border/45 bg-muted/35 px-3 py-2.5 text-[12px] text-muted-foreground">
-            <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" aria-hidden />
-            <span>{t("settings.oauth.waitingForCallback")}</span>
+            {expectsCallbackUrl ? (
+              <Clipboard className="h-3.5 w-3.5 shrink-0" aria-hidden />
+            ) : (
+              <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" aria-hidden />
+            )}
+            <span>
+              {expectsCallbackUrl
+                ? t("settings.oauth.pasteCallbackToContinue")
+                : t("settings.oauth.waitingForCallback")}
+            </span>
           </div>
           <div className="space-y-2">
             <label

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -1636,7 +1636,12 @@ export function SettingsView({
     try {
       const payload =
         action === "login"
-          ? await loginProviderOAuth(token, providerName)
+          ? await loginProviderOAuth(
+              token,
+              providerName,
+              "",
+              providerName === "openai_codex" && remoteBrowserAccess,
+            )
           : await logoutProviderOAuth(token, providerName);
       if (isProviderOAuthAuthorizationRequired(payload)) {
         try {
@@ -3056,20 +3061,22 @@ function ProviderOAuthLoginDialog({
             <DialogTitle>{providerLabel}</DialogTitle>
             <DialogDescription>
               {expectsCallbackUrl
-                ? t("settings.oauth.remoteCallbackHelp")
+                ? remoteBrowserAccess
+                  ? t("settings.oauth.remoteCallbackHelp")
+                  : t("settings.oauth.localCallbackHelp")
                 : remoteBrowserAccess
                   ? t("settings.oauth.remoteCodeHelp")
                   : t("settings.oauth.localCodeHelp")}
             </DialogDescription>
           </DialogHeader>
           <div className="flex items-center gap-2 rounded-[14px] border border-border/45 bg-muted/35 px-3 py-2.5 text-[12px] text-muted-foreground">
-            {expectsCallbackUrl ? (
+            {expectsCallbackUrl && remoteBrowserAccess ? (
               <Clipboard className="h-3.5 w-3.5 shrink-0" aria-hidden />
             ) : (
               <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" aria-hidden />
             )}
             <span>
-              {expectsCallbackUrl
+              {expectsCallbackUrl && remoteBrowserAccess
                 ? t("settings.oauth.pasteCallbackToContinue")
                 : t("settings.oauth.waitingForCallback")}
             </span>

--- a/webui/src/i18n/locales/en/common.json
+++ b/webui/src/i18n/locales/en/common.json
@@ -783,6 +783,7 @@
       "saveProxy": "Save proxy",
       "localCodeHelp": "Complete sign-in in your browser. Nanobot usually finishes automatically; if it does not, paste the authorization code below.",
       "remoteCodeHelp": "Select Sign in to open xAI on your computer. After signing in, paste the authorization code shown by xAI below.",
+      "localCallbackHelp": "Complete sign-in in your browser. Nanobot usually finishes automatically; if it does not, copy the full localhost callback URL from the address bar and paste it below.",
       "remoteCallbackHelp": "Open ChatGPT in this browser and finish signing in. When the localhost page fails to load, copy the full URL from the address bar and paste it below.",
       "authorizationCode": "Authorization code",
       "callbackUrl": "Full callback URL",

--- a/webui/src/i18n/locales/en/common.json
+++ b/webui/src/i18n/locales/en/common.json
@@ -773,6 +773,7 @@
       "signedInAs": "Signed in as {{account}}",
       "signInHelp": "Sign in from this device; no API key is stored in config.",
       "remoteSignInHelp": "Select Sign in to open xAI on your computer, then paste the authorization code shown after login.",
+      "codexRemoteSignInHelp": "Sign in through this browser, then paste the full localhost callback URL back into nanobot.",
       "signInRequired": "Sign in required",
       "signInBeforeSaving": "Sign in before saving this provider in the preset.",
       "signedIn": "Signed in",
@@ -782,7 +783,13 @@
       "saveProxy": "Save proxy",
       "localCodeHelp": "Complete sign-in in your browser. Nanobot usually finishes automatically; if it does not, paste the authorization code below.",
       "remoteCodeHelp": "Select Sign in to open xAI on your computer. After signing in, paste the authorization code shown by xAI below.",
+      "localCallbackHelp": "Complete sign-in in your browser. Nanobot usually finishes automatically; if it does not, copy the full localhost callback URL from the address bar and paste it below.",
+      "remoteCallbackHelp": "Open ChatGPT in this browser and finish signing in. When the localhost page fails to load, copy the full URL from the address bar and paste it below.",
       "authorizationCode": "Authorization code",
+      "callbackUrl": "Full callback URL",
+      "callbackUrlPlaceholder": "http://localhost:1455/auth/callback?code=…&state=…",
+      "openChatGPT": "Open ChatGPT",
+      "waitingForCallback": "Waiting for the browser callback…",
       "finishSignIn": "Finish sign-in"
     },
     "skills": {

--- a/webui/src/i18n/locales/en/common.json
+++ b/webui/src/i18n/locales/en/common.json
@@ -783,12 +783,12 @@
       "saveProxy": "Save proxy",
       "localCodeHelp": "Complete sign-in in your browser. Nanobot usually finishes automatically; if it does not, paste the authorization code below.",
       "remoteCodeHelp": "Select Sign in to open xAI on your computer. After signing in, paste the authorization code shown by xAI below.",
-      "localCallbackHelp": "Complete sign-in in your browser. Nanobot usually finishes automatically; if it does not, copy the full localhost callback URL from the address bar and paste it below.",
       "remoteCallbackHelp": "Open ChatGPT in this browser and finish signing in. When the localhost page fails to load, copy the full URL from the address bar and paste it below.",
       "authorizationCode": "Authorization code",
       "callbackUrl": "Full callback URL",
       "callbackUrlPlaceholder": "http://localhost:1455/auth/callback?code=…&state=…",
       "openChatGPT": "Open ChatGPT",
+      "pasteCallbackToContinue": "Paste the callback URL to continue.",
       "waitingForCallback": "Waiting for the browser callback…",
       "finishSignIn": "Finish sign-in"
     },

--- a/webui/src/i18n/locales/es/common.json
+++ b/webui/src/i18n/locales/es/common.json
@@ -770,12 +770,12 @@
       "saveProxy": "Guardar proxy",
       "localCodeHelp": "Completa el inicio de sesión en el navegador. nanobot suele finalizar automáticamente; si no lo hace, pega el código de autorización abajo.",
       "remoteCodeHelp": "Selecciona Iniciar sesión para abrir xAI en tu computadora. Después de iniciar sesión, pega abajo el código de autorización que muestra xAI.",
-      "localCallbackHelp": "Completa el inicio de sesión en el navegador. nanobot suele finalizar automáticamente; si no lo hace, copia de la barra de direcciones la URL completa de devolución de localhost y pégala abajo.",
       "remoteCallbackHelp": "Abre ChatGPT en este navegador y completa el inicio de sesión. Cuando la página de localhost no cargue, copia la URL completa de la barra de direcciones y pégala abajo.",
       "authorizationCode": "Código de autorización",
       "callbackUrl": "URL completa de devolución",
       "callbackUrlPlaceholder": "http://localhost:1455/auth/callback?code=…&state=…",
       "openChatGPT": "Abrir ChatGPT",
+      "pasteCallbackToContinue": "Pega la URL de devolución para continuar.",
       "waitingForCallback": "Esperando la devolución del navegador…",
       "finishSignIn": "Completar inicio de sesión"
     },

--- a/webui/src/i18n/locales/es/common.json
+++ b/webui/src/i18n/locales/es/common.json
@@ -770,6 +770,7 @@
       "saveProxy": "Guardar proxy",
       "localCodeHelp": "Completa el inicio de sesión en el navegador. nanobot suele finalizar automáticamente; si no lo hace, pega el código de autorización abajo.",
       "remoteCodeHelp": "Selecciona Iniciar sesión para abrir xAI en tu computadora. Después de iniciar sesión, pega abajo el código de autorización que muestra xAI.",
+      "localCallbackHelp": "Completa el inicio de sesión en el navegador. nanobot suele finalizar automáticamente; si no lo hace, copia de la barra de direcciones la URL completa de devolución de localhost y pégala abajo.",
       "remoteCallbackHelp": "Abre ChatGPT en este navegador y completa el inicio de sesión. Cuando la página de localhost no cargue, copia la URL completa de la barra de direcciones y pégala abajo.",
       "authorizationCode": "Código de autorización",
       "callbackUrl": "URL completa de devolución",

--- a/webui/src/i18n/locales/es/common.json
+++ b/webui/src/i18n/locales/es/common.json
@@ -760,6 +760,7 @@
       "signedInAs": "Sesión iniciada como {{account}}",
       "signInHelp": "Inicia sesión desde este dispositivo; no se guarda API key en config.",
       "remoteSignInHelp": "Selecciona Iniciar sesión para abrir xAI en tu computadora y luego pega el código de autorización que se muestra tras iniciar sesión.",
+      "codexRemoteSignInHelp": "Inicia sesión en este navegador y pega en nanobot la URL completa de devolución de localhost.",
       "signInRequired": "Inicio de sesión requerido",
       "signInBeforeSaving": "Inicia sesión en este proveedor antes de guardar el preajuste.",
       "signedIn": "Sesión iniciada",
@@ -769,7 +770,13 @@
       "saveProxy": "Guardar proxy",
       "localCodeHelp": "Completa el inicio de sesión en el navegador. nanobot suele finalizar automáticamente; si no lo hace, pega el código de autorización abajo.",
       "remoteCodeHelp": "Selecciona Iniciar sesión para abrir xAI en tu computadora. Después de iniciar sesión, pega abajo el código de autorización que muestra xAI.",
+      "localCallbackHelp": "Completa el inicio de sesión en el navegador. nanobot suele finalizar automáticamente; si no lo hace, copia de la barra de direcciones la URL completa de devolución de localhost y pégala abajo.",
+      "remoteCallbackHelp": "Abre ChatGPT en este navegador y completa el inicio de sesión. Cuando la página de localhost no cargue, copia la URL completa de la barra de direcciones y pégala abajo.",
       "authorizationCode": "Código de autorización",
+      "callbackUrl": "URL completa de devolución",
+      "callbackUrlPlaceholder": "http://localhost:1455/auth/callback?code=…&state=…",
+      "openChatGPT": "Abrir ChatGPT",
+      "waitingForCallback": "Esperando la devolución del navegador…",
       "finishSignIn": "Completar inicio de sesión"
     },
     "skills": {

--- a/webui/src/i18n/locales/fr/common.json
+++ b/webui/src/i18n/locales/fr/common.json
@@ -759,6 +759,7 @@
       "signedInAs": "Connecté en tant que {{account}}",
       "signInHelp": "Inicia sesión desde este dispositivo; no se guarda API key en config.",
       "remoteSignInHelp": "Sélectionnez Se connecter pour ouvrir xAI sur votre ordinateur, puis collez le code d’autorisation affiché après la connexion.",
+      "codexRemoteSignInHelp": "Connectez-vous dans ce navigateur, puis recollez dans nanobot l’URL complète de rappel localhost.",
       "signInRequired": "Connexion requise",
       "signInBeforeSaving": "Connectez-vous à ce fournisseur avant d’enregistrer le préréglage.",
       "signedIn": "Connecté",
@@ -768,7 +769,13 @@
       "saveProxy": "Enregistrer le proxy",
       "localCodeHelp": "Terminez la connexion dans votre navigateur. nanobot termine généralement automatiquement ; sinon, collez le code d’autorisation ci-dessous.",
       "remoteCodeHelp": "Sélectionnez Se connecter pour ouvrir xAI sur votre ordinateur. Après la connexion, collez ci-dessous le code d’autorisation affiché par xAI.",
+      "localCallbackHelp": "Terminez la connexion dans votre navigateur. nanobot termine généralement automatiquement ; sinon, copiez l’URL complète de rappel localhost depuis la barre d’adresse et collez-la ci-dessous.",
+      "remoteCallbackHelp": "Ouvrez ChatGPT dans ce navigateur et terminez la connexion. Lorsque la page localhost ne se charge pas, copiez l’URL complète de la barre d’adresse et collez-la ci-dessous.",
       "authorizationCode": "Code d’autorisation",
+      "callbackUrl": "URL complète de rappel",
+      "callbackUrlPlaceholder": "http://localhost:1455/auth/callback?code=…&state=…",
+      "openChatGPT": "Ouvrir ChatGPT",
+      "waitingForCallback": "En attente du rappel du navigateur…",
       "finishSignIn": "Terminer la connexion"
     },
     "skills": {

--- a/webui/src/i18n/locales/fr/common.json
+++ b/webui/src/i18n/locales/fr/common.json
@@ -769,6 +769,7 @@
       "saveProxy": "Enregistrer le proxy",
       "localCodeHelp": "Terminez la connexion dans votre navigateur. nanobot termine généralement automatiquement ; sinon, collez le code d’autorisation ci-dessous.",
       "remoteCodeHelp": "Sélectionnez Se connecter pour ouvrir xAI sur votre ordinateur. Après la connexion, collez ci-dessous le code d’autorisation affiché par xAI.",
+      "localCallbackHelp": "Terminez la connexion dans votre navigateur. nanobot termine généralement automatiquement ; sinon, copiez l’URL complète de rappel localhost depuis la barre d’adresse et collez-la ci-dessous.",
       "remoteCallbackHelp": "Ouvrez ChatGPT dans ce navigateur et terminez la connexion. Lorsque la page localhost ne se charge pas, copiez l’URL complète de la barre d’adresse et collez-la ci-dessous.",
       "authorizationCode": "Code d’autorisation",
       "callbackUrl": "URL complète de rappel",

--- a/webui/src/i18n/locales/fr/common.json
+++ b/webui/src/i18n/locales/fr/common.json
@@ -769,12 +769,12 @@
       "saveProxy": "Enregistrer le proxy",
       "localCodeHelp": "Terminez la connexion dans votre navigateur. nanobot termine généralement automatiquement ; sinon, collez le code d’autorisation ci-dessous.",
       "remoteCodeHelp": "Sélectionnez Se connecter pour ouvrir xAI sur votre ordinateur. Après la connexion, collez ci-dessous le code d’autorisation affiché par xAI.",
-      "localCallbackHelp": "Terminez la connexion dans votre navigateur. nanobot termine généralement automatiquement ; sinon, copiez l’URL complète de rappel localhost depuis la barre d’adresse et collez-la ci-dessous.",
       "remoteCallbackHelp": "Ouvrez ChatGPT dans ce navigateur et terminez la connexion. Lorsque la page localhost ne se charge pas, copiez l’URL complète de la barre d’adresse et collez-la ci-dessous.",
       "authorizationCode": "Code d’autorisation",
       "callbackUrl": "URL complète de rappel",
       "callbackUrlPlaceholder": "http://localhost:1455/auth/callback?code=…&state=…",
       "openChatGPT": "Ouvrir ChatGPT",
+      "pasteCallbackToContinue": "Collez l’URL de rappel pour continuer.",
       "waitingForCallback": "En attente du rappel du navigateur…",
       "finishSignIn": "Terminer la connexion"
     },

--- a/webui/src/i18n/locales/id/common.json
+++ b/webui/src/i18n/locales/id/common.json
@@ -769,12 +769,12 @@
       "saveProxy": "Simpan proksi",
       "localCodeHelp": "Selesaikan proses masuk di browser. nanobot biasanya menyelesaikannya secara otomatis; jika tidak, tempel kode otorisasi di bawah.",
       "remoteCodeHelp": "Pilih Masuk untuk membuka xAI di komputer Anda. Setelah masuk, tempel kode otorisasi yang ditampilkan xAI di bawah.",
-      "localCallbackHelp": "Selesaikan proses masuk di browser. nanobot biasanya menyelesaikannya secara otomatis; jika tidak, salin URL callback localhost lengkap dari bilah alamat dan tempel di bawah.",
       "remoteCallbackHelp": "Buka ChatGPT di browser ini dan selesaikan proses masuk. Saat halaman localhost gagal dimuat, salin URL lengkap dari bilah alamat dan tempel di bawah.",
       "authorizationCode": "Kode otorisasi",
       "callbackUrl": "URL callback lengkap",
       "callbackUrlPlaceholder": "http://localhost:1455/auth/callback?code=…&state=…",
       "openChatGPT": "Buka ChatGPT",
+      "pasteCallbackToContinue": "Tempel URL callback untuk melanjutkan.",
       "waitingForCallback": "Menunggu callback browser…",
       "finishSignIn": "Selesaikan masuk"
     },

--- a/webui/src/i18n/locales/id/common.json
+++ b/webui/src/i18n/locales/id/common.json
@@ -759,6 +759,7 @@
       "signedInAs": "Masuk sebagai {{account}}",
       "signInHelp": "Inicia sesión desde este dispositivo; no se guarda API key en config.",
       "remoteSignInHelp": "Pilih Masuk untuk membuka xAI di komputer Anda, lalu tempel kode otorisasi yang ditampilkan setelah masuk.",
+      "codexRemoteSignInHelp": "Masuk melalui browser ini, lalu tempel URL callback localhost lengkap kembali ke nanobot.",
       "signInRequired": "Perlu masuk",
       "signInBeforeSaving": "Masuk ke penyedia ini sebelum menyimpan preset.",
       "signedIn": "Sudah masuk",
@@ -768,7 +769,13 @@
       "saveProxy": "Simpan proksi",
       "localCodeHelp": "Selesaikan proses masuk di browser. nanobot biasanya menyelesaikannya secara otomatis; jika tidak, tempel kode otorisasi di bawah.",
       "remoteCodeHelp": "Pilih Masuk untuk membuka xAI di komputer Anda. Setelah masuk, tempel kode otorisasi yang ditampilkan xAI di bawah.",
+      "localCallbackHelp": "Selesaikan proses masuk di browser. nanobot biasanya menyelesaikannya secara otomatis; jika tidak, salin URL callback localhost lengkap dari bilah alamat dan tempel di bawah.",
+      "remoteCallbackHelp": "Buka ChatGPT di browser ini dan selesaikan proses masuk. Saat halaman localhost gagal dimuat, salin URL lengkap dari bilah alamat dan tempel di bawah.",
       "authorizationCode": "Kode otorisasi",
+      "callbackUrl": "URL callback lengkap",
+      "callbackUrlPlaceholder": "http://localhost:1455/auth/callback?code=…&state=…",
+      "openChatGPT": "Buka ChatGPT",
+      "waitingForCallback": "Menunggu callback browser…",
       "finishSignIn": "Selesaikan masuk"
     },
     "skills": {

--- a/webui/src/i18n/locales/id/common.json
+++ b/webui/src/i18n/locales/id/common.json
@@ -769,6 +769,7 @@
       "saveProxy": "Simpan proksi",
       "localCodeHelp": "Selesaikan proses masuk di browser. nanobot biasanya menyelesaikannya secara otomatis; jika tidak, tempel kode otorisasi di bawah.",
       "remoteCodeHelp": "Pilih Masuk untuk membuka xAI di komputer Anda. Setelah masuk, tempel kode otorisasi yang ditampilkan xAI di bawah.",
+      "localCallbackHelp": "Selesaikan proses masuk di browser. nanobot biasanya menyelesaikannya secara otomatis; jika tidak, salin URL callback localhost lengkap dari bilah alamat dan tempel di bawah.",
       "remoteCallbackHelp": "Buka ChatGPT di browser ini dan selesaikan proses masuk. Saat halaman localhost gagal dimuat, salin URL lengkap dari bilah alamat dan tempel di bawah.",
       "authorizationCode": "Kode otorisasi",
       "callbackUrl": "URL callback lengkap",

--- a/webui/src/i18n/locales/ja/common.json
+++ b/webui/src/i18n/locales/ja/common.json
@@ -769,6 +769,7 @@
       "saveProxy": "プロキシを保存",
       "localCodeHelp": "ブラウザーでサインインを完了してください。通常は nanobot が自動で完了します。完了しない場合は、認証コードを下に貼り付けてください。",
       "remoteCodeHelp": "「サインイン」を選択して自分のコンピューターで xAI を開いてください。サインイン後、xAI に表示された認証コードを下に貼り付けてください。",
+      "localCallbackHelp": "ブラウザーでサインインを完了してください。通常は nanobot が自動で完了します。完了しない場合は、アドレスバーから localhost の完全なコールバック URL をコピーして下に貼り付けてください。",
       "remoteCallbackHelp": "このブラウザーで ChatGPT を開いてサインインを完了してください。localhost ページを開けない場合は、アドレスバーの完全な URL をコピーして下に貼り付けてください。",
       "authorizationCode": "認証コード",
       "callbackUrl": "完全なコールバック URL",

--- a/webui/src/i18n/locales/ja/common.json
+++ b/webui/src/i18n/locales/ja/common.json
@@ -759,6 +759,7 @@
       "signedInAs": "{{account}} としてサインイン済み",
       "signInHelp": "このデバイスからサインインします。API key は config に保存されません。",
       "remoteSignInHelp": "「サインイン」を選択して自分のコンピューターで xAI を開き、サインイン後に表示される認証コードを貼り付けてください。",
+      "codexRemoteSignInHelp": "このブラウザーでサインインし、localhost の完全なコールバック URL を nanobot に貼り付けてください。",
       "signInRequired": "サインインが必要です",
       "signInBeforeSaving": "プリセットを保存する前に、このプロバイダーへサインインしてください。",
       "signedIn": "サインイン済み",
@@ -768,7 +769,13 @@
       "saveProxy": "プロキシを保存",
       "localCodeHelp": "ブラウザーでサインインを完了してください。通常は nanobot が自動で完了します。完了しない場合は、認証コードを下に貼り付けてください。",
       "remoteCodeHelp": "「サインイン」を選択して自分のコンピューターで xAI を開いてください。サインイン後、xAI に表示された認証コードを下に貼り付けてください。",
+      "localCallbackHelp": "ブラウザーでサインインを完了してください。通常は nanobot が自動で完了します。完了しない場合は、アドレスバーから localhost の完全なコールバック URL をコピーして下に貼り付けてください。",
+      "remoteCallbackHelp": "このブラウザーで ChatGPT を開いてサインインを完了してください。localhost ページを開けない場合は、アドレスバーの完全な URL をコピーして下に貼り付けてください。",
       "authorizationCode": "認証コード",
+      "callbackUrl": "完全なコールバック URL",
+      "callbackUrlPlaceholder": "http://localhost:1455/auth/callback?code=…&state=…",
+      "openChatGPT": "ChatGPT を開く",
+      "waitingForCallback": "ブラウザーのコールバックを待機中…",
       "finishSignIn": "サインインを完了"
     },
     "skills": {

--- a/webui/src/i18n/locales/ja/common.json
+++ b/webui/src/i18n/locales/ja/common.json
@@ -769,12 +769,12 @@
       "saveProxy": "プロキシを保存",
       "localCodeHelp": "ブラウザーでサインインを完了してください。通常は nanobot が自動で完了します。完了しない場合は、認証コードを下に貼り付けてください。",
       "remoteCodeHelp": "「サインイン」を選択して自分のコンピューターで xAI を開いてください。サインイン後、xAI に表示された認証コードを下に貼り付けてください。",
-      "localCallbackHelp": "ブラウザーでサインインを完了してください。通常は nanobot が自動で完了します。完了しない場合は、アドレスバーから localhost の完全なコールバック URL をコピーして下に貼り付けてください。",
       "remoteCallbackHelp": "このブラウザーで ChatGPT を開いてサインインを完了してください。localhost ページを開けない場合は、アドレスバーの完全な URL をコピーして下に貼り付けてください。",
       "authorizationCode": "認証コード",
       "callbackUrl": "完全なコールバック URL",
       "callbackUrlPlaceholder": "http://localhost:1455/auth/callback?code=…&state=…",
       "openChatGPT": "ChatGPT を開く",
+      "pasteCallbackToContinue": "続行するにはコールバック URL を貼り付けてください。",
       "waitingForCallback": "ブラウザーのコールバックを待機中…",
       "finishSignIn": "サインインを完了"
     },

--- a/webui/src/i18n/locales/ko/common.json
+++ b/webui/src/i18n/locales/ko/common.json
@@ -769,12 +769,12 @@
       "saveProxy": "프록시 저장",
       "localCodeHelp": "브라우저에서 로그인을 완료하세요. 일반적으로 nanobot이 자동으로 완료합니다. 완료되지 않으면 인증 코드를 아래에 붙여 넣으세요.",
       "remoteCodeHelp": "로그인을 선택하여 사용자 컴퓨터에서 xAI를 여세요. 로그인 후 xAI에 표시된 인증 코드를 아래에 붙여 넣으세요.",
-      "localCallbackHelp": "브라우저에서 로그인을 완료하세요. 일반적으로 nanobot이 자동으로 완료합니다. 완료되지 않으면 주소 표시줄에서 전체 localhost 콜백 URL을 복사해 아래에 붙여 넣으세요.",
       "remoteCallbackHelp": "이 브라우저에서 ChatGPT를 열고 로그인을 완료하세요. localhost 페이지가 열리지 않으면 주소 표시줄의 전체 URL을 복사해 아래에 붙여 넣으세요.",
       "authorizationCode": "인증 코드",
       "callbackUrl": "전체 콜백 URL",
       "callbackUrlPlaceholder": "http://localhost:1455/auth/callback?code=…&state=…",
       "openChatGPT": "ChatGPT 열기",
+      "pasteCallbackToContinue": "계속하려면 콜백 URL을 붙여 넣으세요.",
       "waitingForCallback": "브라우저 콜백 대기 중…",
       "finishSignIn": "로그인 완료"
     },

--- a/webui/src/i18n/locales/ko/common.json
+++ b/webui/src/i18n/locales/ko/common.json
@@ -759,6 +759,7 @@
       "signedInAs": "{{account}}로 로그인됨",
       "signInHelp": "이 기기에서 로그인합니다. API key는 config에 저장되지 않습니다.",
       "remoteSignInHelp": "로그인을 선택하여 사용자 컴퓨터에서 xAI를 연 다음, 로그인 후 표시되는 인증 코드를 붙여 넣으세요.",
+      "codexRemoteSignInHelp": "이 브라우저에서 로그인한 다음 전체 localhost 콜백 URL을 nanobot에 붙여 넣으세요.",
       "signInRequired": "로그인이 필요합니다",
       "signInBeforeSaving": "프리셋을 저장하기 전에 이 제공자에 로그인하세요.",
       "signedIn": "로그인됨",
@@ -768,7 +769,13 @@
       "saveProxy": "프록시 저장",
       "localCodeHelp": "브라우저에서 로그인을 완료하세요. 일반적으로 nanobot이 자동으로 완료합니다. 완료되지 않으면 인증 코드를 아래에 붙여 넣으세요.",
       "remoteCodeHelp": "로그인을 선택하여 사용자 컴퓨터에서 xAI를 여세요. 로그인 후 xAI에 표시된 인증 코드를 아래에 붙여 넣으세요.",
+      "localCallbackHelp": "브라우저에서 로그인을 완료하세요. 일반적으로 nanobot이 자동으로 완료합니다. 완료되지 않으면 주소 표시줄에서 전체 localhost 콜백 URL을 복사해 아래에 붙여 넣으세요.",
+      "remoteCallbackHelp": "이 브라우저에서 ChatGPT를 열고 로그인을 완료하세요. localhost 페이지가 열리지 않으면 주소 표시줄의 전체 URL을 복사해 아래에 붙여 넣으세요.",
       "authorizationCode": "인증 코드",
+      "callbackUrl": "전체 콜백 URL",
+      "callbackUrlPlaceholder": "http://localhost:1455/auth/callback?code=…&state=…",
+      "openChatGPT": "ChatGPT 열기",
+      "waitingForCallback": "브라우저 콜백 대기 중…",
       "finishSignIn": "로그인 완료"
     },
     "skills": {

--- a/webui/src/i18n/locales/ko/common.json
+++ b/webui/src/i18n/locales/ko/common.json
@@ -769,6 +769,7 @@
       "saveProxy": "프록시 저장",
       "localCodeHelp": "브라우저에서 로그인을 완료하세요. 일반적으로 nanobot이 자동으로 완료합니다. 완료되지 않으면 인증 코드를 아래에 붙여 넣으세요.",
       "remoteCodeHelp": "로그인을 선택하여 사용자 컴퓨터에서 xAI를 여세요. 로그인 후 xAI에 표시된 인증 코드를 아래에 붙여 넣으세요.",
+      "localCallbackHelp": "브라우저에서 로그인을 완료하세요. 일반적으로 nanobot이 자동으로 완료합니다. 완료되지 않으면 주소 표시줄에서 전체 localhost 콜백 URL을 복사해 아래에 붙여 넣으세요.",
       "remoteCallbackHelp": "이 브라우저에서 ChatGPT를 열고 로그인을 완료하세요. localhost 페이지가 열리지 않으면 주소 표시줄의 전체 URL을 복사해 아래에 붙여 넣으세요.",
       "authorizationCode": "인증 코드",
       "callbackUrl": "전체 콜백 URL",

--- a/webui/src/i18n/locales/pt-BR/common.json
+++ b/webui/src/i18n/locales/pt-BR/common.json
@@ -783,6 +783,7 @@
       "saveProxy": "Salvar proxy",
       "localCodeHelp": "Conclua o login no navegador. O nanobot geralmente termina automaticamente; caso contrário, cole o código de autorização abaixo.",
       "remoteCodeHelp": "Selecione Entrar para abrir a xAI no seu computador. Após o login, cole abaixo o código de autorização exibido pela xAI.",
+      "localCallbackHelp": "Conclua o login no navegador. O nanobot geralmente termina automaticamente; caso contrário, copie da barra de endereço a URL completa de callback do localhost e cole abaixo.",
       "remoteCallbackHelp": "Abra o ChatGPT neste navegador e conclua o login. Quando a página localhost não carregar, copie a URL completa da barra de endereço e cole abaixo.",
       "authorizationCode": "Código de autorização",
       "callbackUrl": "URL completa de callback",

--- a/webui/src/i18n/locales/pt-BR/common.json
+++ b/webui/src/i18n/locales/pt-BR/common.json
@@ -783,12 +783,12 @@
       "saveProxy": "Salvar proxy",
       "localCodeHelp": "Conclua o login no navegador. O nanobot geralmente termina automaticamente; caso contrário, cole o código de autorização abaixo.",
       "remoteCodeHelp": "Selecione Entrar para abrir a xAI no seu computador. Após o login, cole abaixo o código de autorização exibido pela xAI.",
-      "localCallbackHelp": "Conclua o login no navegador. O nanobot geralmente termina automaticamente; caso contrário, copie da barra de endereço a URL completa de callback do localhost e cole abaixo.",
       "remoteCallbackHelp": "Abra o ChatGPT neste navegador e conclua o login. Quando a página localhost não carregar, copie a URL completa da barra de endereço e cole abaixo.",
       "authorizationCode": "Código de autorização",
       "callbackUrl": "URL completa de callback",
       "callbackUrlPlaceholder": "http://localhost:1455/auth/callback?code=…&state=…",
       "openChatGPT": "Abrir ChatGPT",
+      "pasteCallbackToContinue": "Cole a URL de callback para continuar.",
       "waitingForCallback": "Aguardando o callback do navegador…",
       "finishSignIn": "Concluir login"
     },

--- a/webui/src/i18n/locales/pt-BR/common.json
+++ b/webui/src/i18n/locales/pt-BR/common.json
@@ -773,6 +773,7 @@
       "signedInAs": "Conectado como {{account}}",
       "signInHelp": "Entre por este dispositivo; nenhuma chave de API é armazenada em config.",
       "remoteSignInHelp": "Selecione Entrar para abrir a xAI no seu computador e depois cole o código de autorização exibido após o login.",
+      "codexRemoteSignInHelp": "Entre por este navegador e cole no nanobot a URL completa de callback do localhost.",
       "signInRequired": "Login necessário",
       "signInBeforeSaving": "Entre neste provedor antes de salvar a predefinição.",
       "signedIn": "Conectado",
@@ -782,7 +783,13 @@
       "saveProxy": "Salvar proxy",
       "localCodeHelp": "Conclua o login no navegador. O nanobot geralmente termina automaticamente; caso contrário, cole o código de autorização abaixo.",
       "remoteCodeHelp": "Selecione Entrar para abrir a xAI no seu computador. Após o login, cole abaixo o código de autorização exibido pela xAI.",
+      "localCallbackHelp": "Conclua o login no navegador. O nanobot geralmente termina automaticamente; caso contrário, copie da barra de endereço a URL completa de callback do localhost e cole abaixo.",
+      "remoteCallbackHelp": "Abra o ChatGPT neste navegador e conclua o login. Quando a página localhost não carregar, copie a URL completa da barra de endereço e cole abaixo.",
       "authorizationCode": "Código de autorização",
+      "callbackUrl": "URL completa de callback",
+      "callbackUrlPlaceholder": "http://localhost:1455/auth/callback?code=…&state=…",
+      "openChatGPT": "Abrir ChatGPT",
+      "waitingForCallback": "Aguardando o callback do navegador…",
       "finishSignIn": "Concluir login"
     },
     "skills": {

--- a/webui/src/i18n/locales/vi/common.json
+++ b/webui/src/i18n/locales/vi/common.json
@@ -769,12 +769,12 @@
       "saveProxy": "Lưu proxy",
       "localCodeHelp": "Hoàn tất đăng nhập trong trình duyệt. nanobot thường tự động hoàn tất; nếu không, hãy dán mã ủy quyền bên dưới.",
       "remoteCodeHelp": "Chọn Đăng nhập để mở xAI trên máy tính của bạn. Sau khi đăng nhập, hãy dán mã ủy quyền do xAI hiển thị bên dưới.",
-      "localCallbackHelp": "Hoàn tất đăng nhập trong trình duyệt. nanobot thường tự động hoàn tất; nếu không, hãy sao chép URL callback localhost đầy đủ từ thanh địa chỉ và dán vào bên dưới.",
       "remoteCallbackHelp": "Mở ChatGPT trong trình duyệt này và hoàn tất đăng nhập. Khi trang localhost không tải được, hãy sao chép URL đầy đủ từ thanh địa chỉ và dán vào bên dưới.",
       "authorizationCode": "Mã ủy quyền",
       "callbackUrl": "URL callback đầy đủ",
       "callbackUrlPlaceholder": "http://localhost:1455/auth/callback?code=…&state=…",
       "openChatGPT": "Mở ChatGPT",
+      "pasteCallbackToContinue": "Dán URL callback để tiếp tục.",
       "waitingForCallback": "Đang chờ callback từ trình duyệt…",
       "finishSignIn": "Hoàn tất đăng nhập"
     },

--- a/webui/src/i18n/locales/vi/common.json
+++ b/webui/src/i18n/locales/vi/common.json
@@ -769,6 +769,7 @@
       "saveProxy": "Lưu proxy",
       "localCodeHelp": "Hoàn tất đăng nhập trong trình duyệt. nanobot thường tự động hoàn tất; nếu không, hãy dán mã ủy quyền bên dưới.",
       "remoteCodeHelp": "Chọn Đăng nhập để mở xAI trên máy tính của bạn. Sau khi đăng nhập, hãy dán mã ủy quyền do xAI hiển thị bên dưới.",
+      "localCallbackHelp": "Hoàn tất đăng nhập trong trình duyệt. nanobot thường tự động hoàn tất; nếu không, hãy sao chép URL callback localhost đầy đủ từ thanh địa chỉ và dán vào bên dưới.",
       "remoteCallbackHelp": "Mở ChatGPT trong trình duyệt này và hoàn tất đăng nhập. Khi trang localhost không tải được, hãy sao chép URL đầy đủ từ thanh địa chỉ và dán vào bên dưới.",
       "authorizationCode": "Mã ủy quyền",
       "callbackUrl": "URL callback đầy đủ",

--- a/webui/src/i18n/locales/vi/common.json
+++ b/webui/src/i18n/locales/vi/common.json
@@ -759,6 +759,7 @@
       "signedInAs": "Đã đăng nhập bằng {{account}}",
       "signInHelp": "Inicia sesión desde este dispositivo; no se guarda API key en config.",
       "remoteSignInHelp": "Chọn Đăng nhập để mở xAI trên máy tính của bạn, sau đó dán mã ủy quyền được hiển thị sau khi đăng nhập.",
+      "codexRemoteSignInHelp": "Đăng nhập trong trình duyệt này, sau đó dán lại URL callback localhost đầy đủ vào nanobot.",
       "signInRequired": "Cần đăng nhập",
       "signInBeforeSaving": "Hãy đăng nhập nhà cung cấp này trước khi lưu cấu hình đặt trước.",
       "signedIn": "Đã đăng nhập",
@@ -768,7 +769,13 @@
       "saveProxy": "Lưu proxy",
       "localCodeHelp": "Hoàn tất đăng nhập trong trình duyệt. nanobot thường tự động hoàn tất; nếu không, hãy dán mã ủy quyền bên dưới.",
       "remoteCodeHelp": "Chọn Đăng nhập để mở xAI trên máy tính của bạn. Sau khi đăng nhập, hãy dán mã ủy quyền do xAI hiển thị bên dưới.",
+      "localCallbackHelp": "Hoàn tất đăng nhập trong trình duyệt. nanobot thường tự động hoàn tất; nếu không, hãy sao chép URL callback localhost đầy đủ từ thanh địa chỉ và dán vào bên dưới.",
+      "remoteCallbackHelp": "Mở ChatGPT trong trình duyệt này và hoàn tất đăng nhập. Khi trang localhost không tải được, hãy sao chép URL đầy đủ từ thanh địa chỉ và dán vào bên dưới.",
       "authorizationCode": "Mã ủy quyền",
+      "callbackUrl": "URL callback đầy đủ",
+      "callbackUrlPlaceholder": "http://localhost:1455/auth/callback?code=…&state=…",
+      "openChatGPT": "Mở ChatGPT",
+      "waitingForCallback": "Đang chờ callback từ trình duyệt…",
       "finishSignIn": "Hoàn tất đăng nhập"
     },
     "skills": {

--- a/webui/src/i18n/locales/zh-CN/common.json
+++ b/webui/src/i18n/locales/zh-CN/common.json
@@ -773,6 +773,7 @@
       "signedInAs": "已登录为 {{account}}",
       "signInHelp": "从这台设备登录；不会在配置中保存 API key。",
       "remoteSignInHelp": "点击“登录”在你的电脑上打开 xAI，完成登录后粘贴页面显示的授权码。",
+      "codexRemoteSignInHelp": "在此浏览器中登录，然后将完整的 localhost 回调 URL 粘贴回 nanobot。",
       "signInRequired": "需要登录",
       "signInBeforeSaving": "请先登录此提供商，再保存模型预设。",
       "signedIn": "已登录",
@@ -782,7 +783,13 @@
       "saveProxy": "保存代理",
       "localCodeHelp": "请在浏览器中完成登录。nanobot 通常会自动完成；若未自动完成，请将授权码粘贴到下方。",
       "remoteCodeHelp": "点击“登录”在你的电脑上打开 xAI。完成登录后，请将 xAI 显示的授权码粘贴到下方。",
+      "localCallbackHelp": "请在浏览器中完成登录。nanobot 通常会自动完成；若未自动完成，请复制地址栏中的完整 localhost 回调 URL 并粘贴到下方。",
+      "remoteCallbackHelp": "在此浏览器中打开 ChatGPT 并完成登录。当 localhost 页面无法打开时，请复制地址栏中的完整 URL 并粘贴到下方。",
       "authorizationCode": "授权码",
+      "callbackUrl": "完整回调 URL",
+      "callbackUrlPlaceholder": "http://localhost:1455/auth/callback?code=…&state=…",
+      "openChatGPT": "打开 ChatGPT",
+      "waitingForCallback": "正在等待浏览器回调…",
       "finishSignIn": "完成登录"
     },
     "skills": {

--- a/webui/src/i18n/locales/zh-CN/common.json
+++ b/webui/src/i18n/locales/zh-CN/common.json
@@ -783,12 +783,12 @@
       "saveProxy": "保存代理",
       "localCodeHelp": "请在浏览器中完成登录。nanobot 通常会自动完成；若未自动完成，请将授权码粘贴到下方。",
       "remoteCodeHelp": "点击“登录”在你的电脑上打开 xAI。完成登录后，请将 xAI 显示的授权码粘贴到下方。",
-      "localCallbackHelp": "请在浏览器中完成登录。nanobot 通常会自动完成；若未自动完成，请复制地址栏中的完整 localhost 回调 URL 并粘贴到下方。",
       "remoteCallbackHelp": "在此浏览器中打开 ChatGPT 并完成登录。当 localhost 页面无法打开时，请复制地址栏中的完整 URL 并粘贴到下方。",
       "authorizationCode": "授权码",
       "callbackUrl": "完整回调 URL",
       "callbackUrlPlaceholder": "http://localhost:1455/auth/callback?code=…&state=…",
       "openChatGPT": "打开 ChatGPT",
+      "pasteCallbackToContinue": "粘贴回调 URL 以继续。",
       "waitingForCallback": "正在等待浏览器回调…",
       "finishSignIn": "完成登录"
     },

--- a/webui/src/i18n/locales/zh-CN/common.json
+++ b/webui/src/i18n/locales/zh-CN/common.json
@@ -783,6 +783,7 @@
       "saveProxy": "保存代理",
       "localCodeHelp": "请在浏览器中完成登录。nanobot 通常会自动完成；若未自动完成，请将授权码粘贴到下方。",
       "remoteCodeHelp": "点击“登录”在你的电脑上打开 xAI。完成登录后，请将 xAI 显示的授权码粘贴到下方。",
+      "localCallbackHelp": "请在浏览器中完成登录。nanobot 通常会自动完成；若未自动完成，请复制地址栏中的完整 localhost 回调 URL 并粘贴到下方。",
       "remoteCallbackHelp": "在此浏览器中打开 ChatGPT 并完成登录。当 localhost 页面无法打开时，请复制地址栏中的完整 URL 并粘贴到下方。",
       "authorizationCode": "授权码",
       "callbackUrl": "完整回调 URL",

--- a/webui/src/i18n/locales/zh-TW/common.json
+++ b/webui/src/i18n/locales/zh-TW/common.json
@@ -769,6 +769,7 @@
       "saveProxy": "儲存代理",
       "localCodeHelp": "請在瀏覽器中完成登入。nanobot 通常會自動完成；若未自動完成，請將授權碼貼到下方。",
       "remoteCodeHelp": "點擊「登入」在你的電腦上開啟 xAI。完成登入後，請將 xAI 顯示的授權碼貼到下方。",
+      "localCallbackHelp": "請在瀏覽器中完成登入。nanobot 通常會自動完成；若未自動完成，請複製網址列中的完整 localhost 回呼 URL 並貼到下方。",
       "remoteCallbackHelp": "請在此瀏覽器中開啟 ChatGPT 並完成登入。當 localhost 頁面無法開啟時，請複製網址列中的完整 URL 並貼到下方。",
       "authorizationCode": "授權碼",
       "callbackUrl": "完整回呼 URL",

--- a/webui/src/i18n/locales/zh-TW/common.json
+++ b/webui/src/i18n/locales/zh-TW/common.json
@@ -759,6 +759,7 @@
       "signedInAs": "已使用 {{account}} 登入",
       "signInHelp": "請從這臺裝置登入；系統不會將 API 金鑰儲存在設定中。",
       "remoteSignInHelp": "點擊「登入」在你的電腦上開啟 xAI，完成登入後貼上頁面顯示的授權碼。",
+      "codexRemoteSignInHelp": "請在此瀏覽器中登入，然後將完整的 localhost 回呼 URL 貼回 nanobot。",
       "signInRequired": "需要登入",
       "signInBeforeSaving": "請先登入此供應商，再儲存模型預設。",
       "signedIn": "已登入",
@@ -768,7 +769,13 @@
       "saveProxy": "儲存代理",
       "localCodeHelp": "請在瀏覽器中完成登入。nanobot 通常會自動完成；若未自動完成，請將授權碼貼到下方。",
       "remoteCodeHelp": "點擊「登入」在你的電腦上開啟 xAI。完成登入後，請將 xAI 顯示的授權碼貼到下方。",
+      "localCallbackHelp": "請在瀏覽器中完成登入。nanobot 通常會自動完成；若未自動完成，請複製網址列中的完整 localhost 回呼 URL 並貼到下方。",
+      "remoteCallbackHelp": "請在此瀏覽器中開啟 ChatGPT 並完成登入。當 localhost 頁面無法開啟時，請複製網址列中的完整 URL 並貼到下方。",
       "authorizationCode": "授權碼",
+      "callbackUrl": "完整回呼 URL",
+      "callbackUrlPlaceholder": "http://localhost:1455/auth/callback?code=…&state=…",
+      "openChatGPT": "開啟 ChatGPT",
+      "waitingForCallback": "正在等待瀏覽器回呼…",
       "finishSignIn": "完成登入"
     },
     "skills": {

--- a/webui/src/i18n/locales/zh-TW/common.json
+++ b/webui/src/i18n/locales/zh-TW/common.json
@@ -769,12 +769,12 @@
       "saveProxy": "儲存代理",
       "localCodeHelp": "請在瀏覽器中完成登入。nanobot 通常會自動完成；若未自動完成，請將授權碼貼到下方。",
       "remoteCodeHelp": "點擊「登入」在你的電腦上開啟 xAI。完成登入後，請將 xAI 顯示的授權碼貼到下方。",
-      "localCallbackHelp": "請在瀏覽器中完成登入。nanobot 通常會自動完成；若未自動完成，請複製網址列中的完整 localhost 回呼 URL 並貼到下方。",
       "remoteCallbackHelp": "請在此瀏覽器中開啟 ChatGPT 並完成登入。當 localhost 頁面無法開啟時，請複製網址列中的完整 URL 並貼到下方。",
       "authorizationCode": "授權碼",
       "callbackUrl": "完整回呼 URL",
       "callbackUrlPlaceholder": "http://localhost:1455/auth/callback?code=…&state=…",
       "openChatGPT": "開啟 ChatGPT",
+      "pasteCallbackToContinue": "貼上回呼 URL 以繼續。",
       "waitingForCallback": "正在等待瀏覽器回呼…",
       "finishSignIn": "完成登入"
     },

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -993,9 +993,11 @@ export async function loginProviderOAuth(
   token: string,
   provider: string,
   base: string = "",
+  remoteBrowserAccess: boolean = false,
 ): Promise<ProviderOAuthLoginResult> {
   const query = new URLSearchParams();
   query.set("provider", provider);
+  if (remoteBrowserAccess) query.set("remote_browser", "true");
   return request<ProviderOAuthLoginResult>(
     `${base}/api/settings/provider/oauth-login?${query}`,
     token,

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -61,6 +61,7 @@ function isSlashCommandLifecycle(value: unknown): value is SlashCommandLifecycle
 const CHANNEL_VALUES_HEADER = "X-Nanobot-Channel-Values";
 const API_SERVICE_VALUES_HEADER = "X-Nanobot-API-Service-Values";
 const OAUTH_CODE_HEADER = "X-Nanobot-OAuth-Code";
+const OAUTH_CALLBACK_HEADER = "X-Nanobot-OAuth-Callback";
 const PROVIDER_VALUES_HEADER = "X-Nanobot-Provider-Values";
 
 export class ApiError extends Error {
@@ -1006,13 +1007,18 @@ export async function completeProviderOAuth(
   token: string,
   provider: string,
   flowId: string,
-  authorizationCode?: string,
+  authorizationResponse?: string,
   base: string = "",
 ): Promise<ProviderOAuthCompletionResult> {
   const query = new URLSearchParams();
   query.set("provider", provider);
   query.set("flow_id", flowId);
-  const headers = authorizationCode ? { [OAUTH_CODE_HEADER]: authorizationCode } : undefined;
+  const responseHeader = provider === "openai_codex"
+    ? OAUTH_CALLBACK_HEADER
+    : OAUTH_CODE_HEADER;
+  const headers = authorizationResponse
+    ? { [responseHeader]: authorizationResponse }
+    : undefined;
   return request<ProviderOAuthCompletionResult>(
     `${base}/api/settings/provider/oauth-login/complete?${query}`,
     token,

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -458,6 +458,7 @@ export interface ProviderOAuthAuthorizationRequired {
   flow_id: string;
   authorization_url: string;
   expires_in: number;
+  completion_input?: "authorization_code" | "callback_url";
 }
 
 export interface ProviderOAuthPending {

--- a/webui/src/tests/api.test.ts
+++ b/webui/src/tests/api.test.ts
@@ -651,6 +651,14 @@ describe("webui API helpers", () => {
       }),
     );
 
+    await loginProviderOAuth("tok", "openai_codex", "", true);
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/settings/provider/oauth-login?provider=openai_codex&remote_browser=true",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer tok" },
+      }),
+    );
+
     await completeProviderOAuth("tok", "xai_grok", "flow-123");
     expect(fetch).toHaveBeenCalledWith(
       "/api/settings/provider/oauth-login/complete?provider=xai_grok&flow_id=flow-123",

--- a/webui/src/tests/api.test.ts
+++ b/webui/src/tests/api.test.ts
@@ -675,6 +675,23 @@ describe("webui API helpers", () => {
       }),
     );
 
+    await completeProviderOAuth(
+      "tok",
+      "openai_codex",
+      "flow-codex",
+      "http://localhost:1455/auth/callback?code=secret&state=test",
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/settings/provider/oauth-login/complete?provider=openai_codex&flow_id=flow-codex",
+      expect.objectContaining({
+        headers: {
+          Authorization: "Bearer tok",
+          "X-Nanobot-OAuth-Callback":
+            "http://localhost:1455/auth/callback?code=secret&state=test",
+        },
+      }),
+    );
+
     await logoutProviderOAuth("tok", "openai_codex");
     expect(fetch).toHaveBeenCalledWith(
       "/api/settings/provider/oauth-logout?provider=openai_codex",

--- a/webui/src/tests/settings-view.test.tsx
+++ b/webui/src/tests/settings-view.test.tsx
@@ -2847,6 +2847,7 @@ describe("SettingsView Apps catalog", () => {
           "Open ChatGPT in this browser and finish signing in. When the localhost page fails to load, copy the full URL from the address bar and paste it below.",
         ),
       ).toBeInTheDocument();
+      expect(within(dialog).getByText("Paste the callback URL to continue.")).toBeInTheDocument();
       const callbackInput = within(dialog).getByRole("textbox", {
         name: "Full callback URL",
       });

--- a/webui/src/tests/settings-view.test.tsx
+++ b/webui/src/tests/settings-view.test.tsx
@@ -2753,6 +2753,90 @@ describe("SettingsView Apps catalog", () => {
     }
   });
 
+  it("polls local OpenAI Codex sign-in until the loopback callback completes", async () => {
+    const base = settingsPayload();
+    const codexProvider = {
+      name: "openai_codex",
+      label: "OpenAI Codex",
+      configured: false,
+      auth_type: "oauth" as const,
+      api_key_required: false,
+      api_key_hint: null,
+      api_base: null,
+      default_api_base: "https://chatgpt.com/backend-api",
+      model_catalog: "builtin",
+      oauth_account: null,
+      oauth_expires_at: null,
+      oauth_login_supported: true,
+    };
+    const payload: SettingsPayload = { ...base, providers: [codexProvider] };
+    const signedIn: SettingsPayload = {
+      ...payload,
+      providers: [{ ...codexProvider, configured: true, oauth_account: "acct-codex" }],
+    };
+    const authorization = {
+      status: "authorization_required",
+      provider: "openai_codex",
+      flow_id: "flow-codex-local",
+      authorization_url: "https://auth.openai.com/oauth/authorize?state=local",
+      expires_in: 600,
+      completion_input: "callback_url",
+    };
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/settings") return jsonResponse(payload);
+      if (url === "/api/settings/provider/oauth-login?provider=openai_codex") {
+        return jsonResponse(authorization);
+      }
+      if (
+        url ===
+        "/api/settings/provider/oauth-login/complete?provider=openai_codex&flow_id=flow-codex-local"
+      ) {
+        expect(init?.headers).not.toHaveProperty("X-Nanobot-OAuth-Callback");
+        return jsonResponse(signedIn);
+      }
+      if (url === "/api/settings/cli-apps") {
+        return jsonResponse({ apps: [], installed_count: 0 });
+      }
+      if (url === "/api/settings/mcp-presets") {
+        return jsonResponse({ presets: [], installed_count: 0 });
+      }
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const popup = {
+      opener: window,
+      location: { href: "about:blank" },
+      close: vi.fn(),
+    };
+    vi.stubGlobal("open", vi.fn(() => popup));
+
+    renderSettingsView({ initialSection: "models", initialSettings: payload });
+
+    await chooseProviderToConfigure("OpenAI Codex");
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+    const dialog = await screen.findByRole("dialog");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/settings/provider/oauth-login?provider=openai_codex",
+      expect.objectContaining({ headers: { Authorization: "Bearer tok" } }),
+    );
+    expect(popup.location.href).toBe(authorization.authorization_url);
+    expect(
+      within(dialog).getByText(
+        "Complete sign-in in your browser. Nanobot usually finishes automatically; if it does not, copy the full localhost callback URL from the address bar and paste it below.",
+      ),
+    ).toBeInTheDocument();
+    expect(within(dialog).getByText("Waiting for the browser callback…")).toBeInTheDocument();
+    expect(
+      within(dialog).queryByText("Paste the callback URL to continue."),
+    ).not.toBeInTheDocument();
+
+    expect(
+      await screen.findByText("Signed in as acct-codex", {}, { timeout: 2500 }),
+    ).toBeInTheDocument();
+  });
+
   it("completes remote OpenAI Codex sign-in with the full callback URL", async () => {
     const happyWindow = window as typeof window & {
       happyDOM: { setURL: (url: string) => void };
@@ -2794,7 +2878,10 @@ describe("SettingsView Apps catalog", () => {
       const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = String(input);
         if (url === "/api/settings") return jsonResponse(payload);
-        if (url === "/api/settings/provider/oauth-login?provider=openai_codex") {
+        if (
+          url ===
+          "/api/settings/provider/oauth-login?provider=openai_codex&remote_browser=true"
+        ) {
           return jsonResponse(authorization);
         }
         if (

--- a/webui/src/tests/settings-view.test.tsx
+++ b/webui/src/tests/settings-view.test.tsx
@@ -2804,12 +2804,8 @@ describe("SettingsView Apps catalog", () => {
       return jsonResponse({});
     });
     vi.stubGlobal("fetch", fetchMock);
-    const popup = {
-      opener: window,
-      location: { href: "about:blank" },
-      close: vi.fn(),
-    };
-    vi.stubGlobal("open", vi.fn(() => popup));
+    const openMock = vi.fn();
+    vi.stubGlobal("open", openMock);
 
     renderSettingsView({ initialSection: "models", initialSettings: payload });
 
@@ -2821,7 +2817,7 @@ describe("SettingsView Apps catalog", () => {
       "/api/settings/provider/oauth-login?provider=openai_codex",
       expect.objectContaining({ headers: { Authorization: "Bearer tok" } }),
     );
-    expect(popup.location.href).toBe(authorization.authorization_url);
+    expect(openMock).not.toHaveBeenCalled();
     expect(
       within(dialog).getByText(
         "Complete sign-in in your browser. Nanobot usually finishes automatically; if it does not, copy the full localhost callback URL from the address bar and paste it below.",

--- a/webui/src/tests/settings-view.test.tsx
+++ b/webui/src/tests/settings-view.test.tsx
@@ -2753,6 +2753,135 @@ describe("SettingsView Apps catalog", () => {
     }
   });
 
+  it("completes remote OpenAI Codex sign-in with the full callback URL", async () => {
+    const happyWindow = window as typeof window & {
+      happyDOM: { setURL: (url: string) => void };
+    };
+    const originalUrl = window.location.href;
+    happyWindow.happyDOM.setURL("http://203.0.113.10:18887/#/settings?section=models");
+
+    try {
+      const base = settingsPayload();
+      const codexProvider = {
+        name: "openai_codex",
+        label: "OpenAI Codex",
+        configured: false,
+        auth_type: "oauth" as const,
+        api_key_required: false,
+        api_key_hint: null,
+        api_base: null,
+        default_api_base: "https://chatgpt.com/backend-api",
+        model_catalog: "builtin",
+        oauth_account: null,
+        oauth_expires_at: null,
+        oauth_login_supported: true,
+      };
+      const payload: SettingsPayload = { ...base, providers: [codexProvider] };
+      const signedIn: SettingsPayload = {
+        ...payload,
+        providers: [{ ...codexProvider, configured: true, oauth_account: "acct-codex" }],
+      };
+      const authorization = {
+        status: "authorization_required",
+        provider: "openai_codex",
+        flow_id: "flow-codex",
+        authorization_url: "https://auth.openai.com/oauth/authorize?state=test",
+        expires_in: 600,
+        completion_input: "callback_url",
+      };
+      const callbackUrl =
+        "http://localhost:1455/auth/callback?code=secret&state=test";
+      const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url === "/api/settings") return jsonResponse(payload);
+        if (url === "/api/settings/provider/oauth-login?provider=openai_codex") {
+          return jsonResponse(authorization);
+        }
+        if (
+          url ===
+          "/api/settings/provider/oauth-login/complete?provider=openai_codex&flow_id=flow-codex"
+        ) {
+          const headers = init?.headers as Record<string, string>;
+          if (headers?.["X-Nanobot-OAuth-Callback"]) {
+            expect(headers["X-Nanobot-OAuth-Callback"]).toBe(callbackUrl);
+            return jsonResponse(signedIn);
+          }
+          return jsonResponse({
+            status: "pending",
+            provider: "openai_codex",
+            flow_id: "flow-codex",
+          });
+        }
+        if (url === "/api/settings/cli-apps") {
+          return jsonResponse({ apps: [], installed_count: 0 });
+        }
+        if (url === "/api/settings/mcp-presets") {
+          return jsonResponse({ presets: [], installed_count: 0 });
+        }
+        return jsonResponse({});
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const popup = {
+        opener: window,
+        location: { href: "about:blank" },
+        close: vi.fn(),
+      };
+      const openMock = vi.fn(() => popup);
+      vi.stubGlobal("open", openMock);
+
+      renderSettingsView({ initialSection: "models", initialSettings: payload });
+
+      await chooseProviderToConfigure("OpenAI Codex");
+      expect(
+        screen.getByText(
+          "Sign in through this browser, then paste the full localhost callback URL back into nanobot.",
+        ),
+      ).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+      const dialog = await screen.findByRole("dialog");
+
+      expect(openMock).not.toHaveBeenCalled();
+      expect(
+        within(dialog).getByText(
+          "Open ChatGPT in this browser and finish signing in. When the localhost page fails to load, copy the full URL from the address bar and paste it below.",
+        ),
+      ).toBeInTheDocument();
+      const callbackInput = within(dialog).getByRole("textbox", {
+        name: "Full callback URL",
+      });
+      expect(callbackInput).toHaveAttribute(
+        "placeholder",
+        "http://localhost:1455/auth/callback?code=…&state=…",
+      );
+
+      fireEvent.click(within(dialog).getByRole("button", { name: "Open ChatGPT" }));
+      expect(openMock).toHaveBeenCalledWith(
+        authorization.authorization_url,
+        "_blank",
+        "noopener,noreferrer",
+      );
+      expect(popup.opener).toBeNull();
+
+      fireEvent.change(callbackInput, { target: { value: callbackUrl } });
+      fireEvent.click(within(dialog).getByRole("button", { name: "Finish sign-in" }));
+
+      await waitFor(() =>
+        expect(fetchMock).toHaveBeenCalledWith(
+          "/api/settings/provider/oauth-login/complete?provider=openai_codex&flow_id=flow-codex",
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              "X-Nanobot-OAuth-Callback": callbackUrl,
+            }),
+          }),
+        ),
+      );
+      expect(await screen.findByText("Signed in as acct-codex")).toBeInTheDocument();
+    } finally {
+      happyWindow.happyDOM.setURL(originalUrl);
+    }
+  });
+
   it("saves scoped proxies for xAI and OpenAI Codex OAuth providers", async () => {
     const base = settingsPayload();
     const providers: SettingsPayload["providers"] = [


### PR DESCRIPTION
## Summary

- expose `oauth-cli-kit`'s interactive Codex login through a bounded, non-blocking WebUI adapter
- preserve automatic localhost callback completion when the WebUI is opened locally by using `oauth-cli-kit`'s browser/listener mode directly
- use the remote-friendly fallback only for remote/headless access: open ChatGPT locally, then paste the full localhost callback URL
- leave browser launch, loopback callback handling, PKCE, authoritative OAuth state validation, token exchange, account decoding, and token persistence to `oauth-cli-kit`; nanobot only coordinates start/poll/paste/timeout and selects local or headless mode
- keep pasted callbacks out of query strings and gateway logs, and update the dialog copy, locales, tests, and troubleshooting docs

## Security

- enables `oauth-cli-kit`'s localhost callback listener only for local WebUI access; remote/headless access uses its manual callback mode
- only accepts pasted `http://localhost|127.0.0.1|::1:1455/auth/callback` responses for the active flow
- sends pasted callback URLs through `X-Nanobot-OAuth-Callback`, bounds pending flows and expiry, and sanitizes dependency failures before returning them
- `oauth-cli-kit` remains responsible for the authoritative state check and token exchange

## Testing

- `uv run --with pytest --with pytest-asyncio python -m pytest tests/providers/test_openai_codex_oauth.py -q` (7 passed)
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/webui/test_settings_api.py -q -k openai_codex` (8 passed, 75 deselected)
- `cd webui && bun run test -- src/tests/settings-view.test.tsx -t "OpenAI Codex"` (3 passed, 55 skipped)
- `cd webui && bun run lint`
- `uv run ruff check nanobot/providers/openai_codex_oauth.py nanobot/webui/settings_api.py tests/providers/test_openai_codex_oauth.py tests/webui/test_settings_api.py`

Per maintainer request, no gateway/Playwright or live OpenAI account verification was run; the maintainer will verify both browser flows manually.
