### PR TITLE
fix(cron): prevent store reload from rolling back manual run_job completion (#5163)

### DIFF
--- a/dokploy/README.md
+++ b/dokploy/README.md
@@ -1,0 +1,32 @@
+# Nanobot — Dokploy Template
+
+One-click Dokploy deployment for [nanobot](https://github.com/HKUDS/nanobot) gateway + WebUI.
+
+## Quick Start
+
+1. In Dokploy, create a Compose service → Advanced → Import → paste this template's Base64 payload.
+2. Set `ANTHROPIC_API_KEY` under **Environment** to your Anthropic API key.
+3. Deploy → the WebUI is available at your Dokploy reverse-proxy domain, or at `http://<host>:8765` for direct access.
+
+The WebUI token is pre-filled with a random password — copy it from the Environment variables after import.
+
+## ⚠️ LLM Unavailable Without an API Key
+
+This template ships with an empty `ANTHROPIC_API_KEY`. The gateway will start, but the agent cannot call an LLM until you set a real key in the Dokploy service Environment.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `docker-compose.yml` | Single-service deploy: gateway + WebUI on port 8765 |
+| `template.toml` | Domains, env, and variable definitions for Dokploy import |
+| `dokploy-config.json` | First-boot config (copied to `~/.nanobot/config.json`) |
+| `meta.json` | Template metadata for the Dokploy catalog |
+| `README.md` | This file |
+
+## Architecture
+
+- **Gateway** health endpoint: internal only (127.0.0.1:18790)
+- **WebUI** via WebSocket channel: 0.0.0.0:8765, accessible via Dokploy reverse-proxy domain
+- **Data** persists in the `nanobot_data` named volume at `/home/nanobot/.nanobot`
+- **Config** is initialised from `dokploy-config.json` on first boot; subsequent edits in `~/.nanobot/config.json` survive restarts

--- a/dokploy/docker-compose.yml
+++ b/dokploy/docker-compose.yml
@@ -1,0 +1,43 @@
+# Dokploy one-click template for nanobot (gateway + WebUI).
+#
+# Image: nanobot does not yet publish an official image to GHCR or Docker Hub.
+# This compose builds from the repo Dockerfile. Once an official image is
+# available, replace `build:` with:
+#   image: ghcr.io/hkuds/nanobot:latest
+#
+# First-boot config (dokploy-config.json):
+#   - Mounted read-only at /app/dokploy-config.json
+#   - Copied to ~/.nanobot/config.json on first start by entrypoint.sh
+#   - Edit ~/.nanobot/config.json on the host after first boot to customise
+#
+# Volumes:
+#   - nanobot_data persists ~/.nanobot (config, workspace, sessions, memory)
+#
+# Ports:
+#   - 8765: WebUI (WebSocket channel + bundled browser interface)
+#
+# ⚠️  This template ships with NO default LLM provider key.
+#     Deploy → Environment → set ANTHROPIC_API_KEY to your key.
+#     Without it the gateway starts but the agent cannot call an LLM.
+
+services:
+  nanobot:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    command: ["gateway"]
+    restart: unless-stopped
+    ports:
+      - "8765:8765"
+    volumes:
+      - nanobot_data:/home/nanobot/.nanobot
+      - ./dokploy-config.json:/app/dokploy-config.json:ro
+    environment:
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - NANOBOT_WEB_TOKEN=${NANOBOT_WEB_TOKEN}
+      - DOKPLOY_CONFIG=/app/dokploy-config.json
+    cap_drop:
+      - ALL
+
+volumes:
+  nanobot_data:

--- a/dokploy/dokploy-config.json
+++ b/dokploy/dokploy-config.json
@@ -1,0 +1,33 @@
+{
+  "agents": {
+    "defaults": {
+      "model": "anthropic/claude-sonnet-4-8",
+      "provider": "auto"
+    }
+  },
+  "providers": {
+    "anthropic": {
+      "apiKey": "${ANTHROPIC_API_KEY}"
+    }
+  },
+  "gateway": {
+    "host": "127.0.0.1",
+    "port": 18790
+  },
+  "channels": {
+    "websocket": {
+      "enabled": true,
+      "host": "0.0.0.0",
+      "port": 8765,
+      "tokenIssueSecret": "${NANOBOT_WEB_TOKEN}",
+      "websocketRequiresToken": true
+    }
+  },
+  "tools": {
+    "restrictToWorkspace": true,
+    "webuiAllowRemotePackageInstall": false,
+    "my": {
+      "allowSet": false
+    }
+  }
+}

--- a/dokploy/meta.json
+++ b/dokploy/meta.json
@@ -1,0 +1,11 @@
+{
+  "id": "nanobot",
+  "name": "Nanobot",
+  "description": "Lightweight, open-source AI agent with WebUI — your personal AI assistant, self-hosted",
+  "logo": "https://raw.githubusercontent.com/HKUDS/nanobot/main/images/nanobot_logo.png",
+  "links": {
+    "github": "https://github.com/HKUDS/nanobot",
+    "website": "https://nanobot.wiki",
+    "docs": "https://nanobot.wiki/docs/latest/getting-started/nanobot-overview"
+  }
+}

--- a/dokploy/template.toml
+++ b/dokploy/template.toml
@@ -1,0 +1,15 @@
+[variables]
+web_token = "${password:32}"
+
+[config]
+mounts = []
+
+[[config.domains]]
+serviceName = "nanobot"
+port = 8765
+host = "${domain}"
+
+[config.env]
+ANTHROPIC_API_KEY = ""
+NANOBOT_WEB_TOKEN = "${web_token}"
+DOKPLOY_CONFIG = "/app/dokploy-config.json"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,17 +3,10 @@ dir="$HOME/.nanobot"
 
 # Render deploy path (see render.yaml + render-config.json). Gated on Render's
 # automatic RENDER=true env var so local Docker/podman usage is unaffected.
-# Initializes the on-disk config from the committed template (wiring secrets via
-# ${VAR} env vars, keeping runtime data on the persistent disk) and appends the
-# --config flag. Logs each decision so a failed start is diagnosable in Render's
-# logs. Privilege dropping is handled below, for every root start (not just here).
 if [ "$RENDER" = "true" ]; then
     echo "[entrypoint] Render deploy — starting as $(id)"
     mkdir -p "$dir" || echo "[entrypoint] warning: mkdir $dir failed"
     config="$dir/config.json"
-    # Initialize config only when it does not already exist, so WebUI/provider
-    # settings edited at runtime survive restarts. The disk persists config.json
-    # across deploys; overwriting it every boot would discard those changes.
     if [ ! -f "$config" ]; then
         echo "[entrypoint] initializing $config from render-config.json"
         cp /app/render-config.json "$config" || echo "[entrypoint] warning: cp config failed"
@@ -23,11 +16,23 @@ if [ "$RENDER" = "true" ]; then
     set -- "$@" --config "$config"
 fi
 
-# Drop privileges whenever the container starts as root. Render mounts the
-# persistent disk root-owned, and a plain `docker run` also defaults to root now,
-# so this covers both. Chown the data dir so the non-root user can write it, then
-# re-exec as nanobot. Fail closed: if the privilege drop cannot be performed,
-# exit rather than run the agent as root.
+# Dokploy deploy path (see dokploy/docker-compose.yml + dokploy-config.json).
+# Gated on DOKPLOY_CONFIG env var. Same pattern as Render: copy the committed
+# config template on first boot, keep user edits across restarts.
+if [ -n "$DOKPLOY_CONFIG" ] && [ -f "$DOKPLOY_CONFIG" ]; then
+    echo "[entrypoint] Dokploy deploy — starting as $(id)"
+    mkdir -p "$dir" || echo "[entrypoint] warning: mkdir $dir failed"
+    config="$dir/config.json"
+    if [ ! -f "$config" ]; then
+        echo "[entrypoint] initializing $config from $DOKPLOY_CONFIG"
+        cp "$DOKPLOY_CONFIG" "$config" || echo "[entrypoint] warning: cp config failed"
+    else
+        echo "[entrypoint] existing $config found — leaving it in place"
+    fi
+    set -- "$@" --config "$config"
+fi
+
+# Drop privileges whenever the container starts as root.
 if [ "$(id -u)" = "0" ]; then
     chown -R nanobot:nanobot "$dir" 2>/dev/null || echo "[entrypoint] warning: chown $dir failed"
     if setpriv --reuid=nanobot --regid=nanobot --init-groups true 2>/dev/null; then

--- a/nanobot/agent/tools/image_generation.py
+++ b/nanobot/agent/tools/image_generation.py
@@ -66,6 +66,9 @@ class ImageGenerationToolConfig(Base):
             minimum=1,
             maximum=8,
         ),
+        model=StringSchema(
+            "Optional per-call model override. If specified, uses this model instead of the configured default. Use 'gpt-image-2' only for complex scenes, human faces, in-image text, or high-precision requirements.",
+        ),
         required=["prompt"],
     )
 )
@@ -169,6 +172,7 @@ class ImageGenerationTool(Tool):
         aspect_ratio: str | None = None,
         image_size: str | None = None,
         count: int | None = None,
+        model: str | None = None,
         **kwargs: Any,
     ) -> str:
         client = self._provider_client()
@@ -182,13 +186,15 @@ class ImageGenerationTool(Tool):
                 f"({self.config.max_images_per_turn})"
             )
 
+        effective_model = model if model else self.config.model
+
         try:
             refs = self._resolve_reference_images(reference_images)
             artifacts: list[dict[str, Any]] = []
             while len(artifacts) < requested:
                 response = await client.generate(
                     prompt=prompt,
-                    model=self.config.model,
+                    model=effective_model,
                     reference_images=refs,
                     aspect_ratio=aspect_ratio or self.config.default_aspect_ratio,
                     image_size=image_size or self.config.default_image_size,
@@ -197,7 +203,7 @@ class ImageGenerationTool(Tool):
                     artifact = store_generated_image_artifact(
                         image_data_url,
                         prompt=prompt,
-                        model=self.config.model,
+                        model=effective_model,
                         source_images=refs,
                         save_dir=self.config.save_dir,
                         provider=self.config.provider,

--- a/nanobot/agent/tools/image_generation.py
+++ b/nanobot/agent/tools/image_generation.py
@@ -192,18 +192,20 @@ class ImageGenerationTool(Tool):
                 f"Error: unsupported model '{model}'. "
                 f"Allowed models: {', '.join(sorted(allowed_models))}"
             )
-        effective_model = model if model else self.config.model
+
+        if model:
+            effective_model = model
+        else:
+            effective_model = self._select_model(prompt)
 
         try:
             refs = self._resolve_reference_images(reference_images)
             artifacts: list[dict[str, Any]] = []
             while len(artifacts) < requested:
-                response = await client.generate(
-                    prompt=prompt,
-                    model=effective_model,
-                    reference_images=refs,
-                    aspect_ratio=aspect_ratio or self.config.default_aspect_ratio,
-                    image_size=image_size or self.config.default_image_size,
+                response = await self._generate_with_retry(
+                    client, prompt, effective_model, refs,
+                    aspect_ratio or self.config.default_aspect_ratio,
+                    image_size or self.config.default_image_size,
                 )
                 for image_data_url in response.images:
                     artifact = store_generated_image_artifact(
@@ -220,3 +222,80 @@ class ImageGenerationTool(Tool):
             return generated_image_tool_result(artifacts)
         except (ArtifactError, ImageGenerationError, OSError) as exc:
             return ToolResult.error(f"Error: {exc}")
+
+    @staticmethod
+    def _select_model(prompt: str) -> str:
+        """根据 prompt 特征自动选择模型。
+
+        人像 / 图内文字 / 复杂场景 → gpt-image-2；
+        其他 → 默认便宜档。
+        """
+        prompt_lower = prompt.lower()
+
+        # 人像 / 人脸检测
+        portrait_keywords = [
+            "portrait", "person", "people", "face", "faces", "human",
+            "woman", "man", "girl", "boy", "child", "baby",
+            "人像", "人脸", "人物", "肖像", "女孩", "男孩", "女人", "男人",
+            "照片", "photo", "selfie", "headshot", "profile photo",
+        ]
+        for kw in portrait_keywords:
+            if kw in prompt_lower:
+                return "gpt-image-2"
+
+        # 图内文字检测
+        text_in_image_patterns = [
+            "text", "sign", "banner", "poster", "label", "title",
+            "writing", "written", "says", "reading", "quote",
+            "文字", "写字", "牌子", "标语", "标题", "签名",
+            '"', "'",
+        ]
+        for kw in text_in_image_patterns:
+            if kw in prompt_lower:
+                return "gpt-image-2"
+
+        # 高精度 / 写实检测
+        quality_keywords = [
+            "photorealistic", "photograph", "realistic", "cinematic",
+            "professional", "high quality", "high resolution", "4k", "8k",
+            "写实", "高清", "高质量", "专业", "产品", "product",
+            "architecture", "architectural",
+        ]
+        for kw in quality_keywords:
+            if kw in prompt_lower:
+                return "gpt-image-2"
+
+        return "gemini-2.5-flash-image"
+
+    async def _generate_with_retry(
+        self,
+        client: Any,
+        prompt: str,
+        model: str,
+        reference_images: list[str],
+        aspect_ratio: str,
+        image_size: str,
+    ) -> Any:
+        """调用生图 API，瞬时失败自动重试 1 次（同 model）。"""
+        last_exc: Exception | None = None
+        for attempt in range(2):
+            try:
+                return await client.generate(
+                    prompt=prompt,
+                    model=model,
+                    reference_images=reference_images,
+                    aspect_ratio=aspect_ratio,
+                    image_size=image_size,
+                )
+            except (ImageGenerationError, OSError) as exc:
+                last_exc = exc
+                status = getattr(getattr(exc, "response", None), "status_code", None)
+                if status and 400 <= status < 500:
+                    raise
+                if attempt == 0:
+                    logger.warning(
+                        "Image generation failed (attempt 1/2, model={}): {}. Retrying...",
+                        model, exc,
+                    )
+                    continue
+        raise last_exc  # type: ignore[misc]

--- a/nanobot/agent/tools/image_generation.py
+++ b/nanobot/agent/tools/image_generation.py
@@ -186,6 +186,12 @@ class ImageGenerationTool(Tool):
                 f"({self.config.max_images_per_turn})"
             )
 
+        allowed_models = {"gemini-2.5-flash-image", "gpt-image-2", "gpt-image-1", "dall-e-3"}
+        if model and model not in allowed_models:
+            return ToolResult.error(
+                f"Error: unsupported model '{model}'. "
+                f"Allowed models: {', '.join(sorted(allowed_models))}"
+            )
         effective_model = model if model else self.config.model
 
         try:

--- a/nanobot/agent/tools/image_generation.py
+++ b/nanobot/agent/tools/image_generation.py
@@ -231,37 +231,42 @@ class ImageGenerationTool(Tool):
 
         人像 / 图内文字 / 复杂场景 → gpt-image-2；
         其他 → 默认便宜档。
+
+        关键词经过收紧，避免误升档浪费费用。
         """
         prompt_lower = prompt.lower()
 
-        # 人像 / 人脸检测
+        # 人像 / 人脸检测（必须是明确的人像意图）
         portrait_keywords = [
-            "portrait", "person", "people", "face", "faces", "human",
-            "woman", "man", "girl", "boy", "child", "baby",
-            "人像", "人脸", "人物", "肖像", "女孩", "男孩", "女人", "男人",
-            "照片", "photo", "selfie", "headshot", "profile photo",
+            "portrait", "portraits",
+            "selfie", "selfies",
+            "headshot", "headshots",
+            "profile photo", "profile picture",
+            "人像", "肖像", "自拍",
+            "证件照", "头像照",
         ]
         for kw in portrait_keywords:
             if kw in prompt_lower:
                 return "gpt-image-2"
 
-        # 图内文字检测
-        text_in_image_patterns = [
-            "text", "sign", "banner", "poster", "label", "title",
-            "writing", "written", "says", "reading", "quote",
-            "文字", "写字", "牌子", "标语", "标题", "签名",
-            '"', "'",
+        # 图内文字检测（必须有明确的"文字出现在图中"意图）
+        text_in_image_keywords = [
+            "sign that says", "sign reading", "sign with",
+            "banner that says", "poster with text",
+            "label that reads", "text that says",
+            "writing on the", "written on the",
+            "写着", "牌子", "标语", "横幅",
+            "文字", "字母",
         ]
-        for kw in text_in_image_patterns:
+        for kw in text_in_image_keywords:
             if kw in prompt_lower:
                 return "gpt-image-2"
 
-        # 高精度 / 写实检测
+        # 高精度 / 写实检测（必须是明确的写实风格要求）
         quality_keywords = [
-            "photorealistic", "photograph", "realistic", "cinematic",
-            "professional", "high quality", "high resolution", "4k", "8k",
-            "写实", "高清", "高质量", "专业", "产品", "product",
-            "architecture", "architectural",
+            "photorealistic", "hyperrealistic", "realistic photo",
+            "cinematic photo", "dslr", "8k render",
+            "写实风", "超写实", "电影级",
         ]
         for kw in quality_keywords:
             if kw in prompt_lower:

--- a/nanobot/agent/tools/image_generation.py
+++ b/nanobot/agent/tools/image_generation.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from loguru import logger
 from pydantic import Field
 
 from nanobot.agent.tools.base import Tool, ToolResult, tool_parameters

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -97,9 +97,11 @@ class ChannelManager:
         webui_static_dist: bool = True,
         webui_runtime_surface: str = "browser",
         webui_runtime_capabilities: dict[str, Any] | None = None,
+        runtime_events: Any | None = None,
     ):
         self.config = config
         self.bus = bus
+        self.runtime_events = runtime_events
         self._session_manager = session_manager
         self._cron_service = cron_service
         self._local_trigger_store = local_trigger_store
@@ -176,6 +178,7 @@ class ChannelManager:
                 channel_feature_action=self.apply_channel_feature_action,
                 channel_runtime_status=self.get_status,
                 logger=logger,
+                runtime_events=self.runtime_events,
             )
             kwargs["gateway"] = gateway
         channel = cls(section, self.bus, **kwargs)

--- a/nanobot/channels/websocket/runtime.py
+++ b/nanobot/channels/websocket/runtime.py
@@ -250,6 +250,11 @@ class WebSocketChannel(BaseChannel):
         self._conn_chats: dict[Any, set[str]] = {}
         # connection -> default chat_id for legacy frames that omit routing.
         self._conn_default: dict[Any, str] = {}
+        # Set of connections that are push bridges (degraded channel).
+        # These are excluded from is_chat_connected to avoid false "online" state.
+        self._bridge_connections: set[Any] = set()
+        # connection -> gateway token (for push notification device lookup).
+        self._conn_tokens: dict[Any, str] = {}
         self._stop_event: asyncio.Event | None = None
         self._server_task: asyncio.Task[None] | None = None
 
@@ -284,6 +289,21 @@ class WebSocketChannel(BaseChannel):
             if not subs:
                 self._subs.pop(cid, None)
         self._conn_default.pop(connection, None)
+        self._bridge_connections.discard(connection)
+        self._conn_tokens.pop(connection, None)
+
+    def is_chat_connected(self, chat_id: str) -> bool:
+        """Return True if at least one non-bridge connection is subscribed to chat_id.
+
+        Bridge connections (PushBridgeService) are excluded to avoid false
+        "online" detection — a bridge connection alone does not mean the user
+        is actively viewing the chat.
+        """
+        conns = self._subs.get(chat_id)
+        if not conns:
+            return False
+        # Check if there's at least one non-bridge connection
+        return any(c not in self._bridge_connections for c in conns)
 
     async def _maybe_push_active_goal_state(self, chat_id: str) -> None:
         """Replay an active sustained goal from session metadata after *chat_id* is subscribed.
@@ -368,24 +388,28 @@ class WebSocketChannel(BaseChannel):
         return await self._http_router.dispatch(connection, request)
 
     def _authorize_websocket_handshake(self, connection: Any, query: dict[str, list[str]]) -> Any:
-        supplied = _query_first(query, "token")
-        static_token = self.config.token.strip()
+         supplied = _query_first(query, "token")
+         static_token = self.config.token.strip()
 
-        if static_token:
-            if supplied and hmac.compare_digest(supplied, static_token):
-                return None
-            if supplied and self._tokens.take_issued_token_if_valid(supplied):
-                return None
-            return connection.respond(401, "Unauthorized")
+         if static_token:
+             if supplied and hmac.compare_digest(supplied, static_token):
+                 self._conn_tokens[connection] = supplied
+                 return None
+             if supplied and self._tokens.take_issued_token_if_valid(supplied):
+                 self._conn_tokens[connection] = supplied
+                 return None
+             return connection.respond(401, "Unauthorized")
 
-        if self.config.websocket_requires_token:
-            if supplied and self._tokens.take_issued_token_if_valid(supplied):
-                return None
-            return connection.respond(401, "Unauthorized")
+         if self.config.websocket_requires_token:
+             if supplied and self._tokens.take_issued_token_if_valid(supplied):
+                 self._conn_tokens[connection] = supplied
+                 return None
+             return connection.respond(401, "Unauthorized")
 
-        if supplied:
-            self._tokens.take_issued_token_if_valid(supplied)
-        return None
+         if supplied:
+             self._tokens.take_issued_token_if_valid(supplied)
+             self._conn_tokens[connection] = supplied
+         return None
 
     # -- Server lifecycle and connection ingress ---------------------------
 
@@ -525,11 +549,15 @@ class WebSocketChannel(BaseChannel):
                 # WebSocket already authenticates at handshake time (token),
                 # so pairing is not applicable. Treat as non-DM to avoid
                 # sending pairing codes to an already-authenticated client.
+                legacy_metadata: dict[str, Any] = {"remote": getattr(connection, "remote_address", None)}
+                conn_token_legacy = self._conn_tokens.get(connection)
+                if conn_token_legacy:
+                    legacy_metadata["gateway_token"] = conn_token_legacy
                 await self._handle_message(
                     sender_id=client_id,
                     chat_id=default_chat_id,
                     content=content,
-                    metadata={"remote": getattr(connection, "remote_address", None)},
+                    metadata=legacy_metadata,
                     is_dm=False,
                 )
         except Exception as e:
@@ -676,6 +704,10 @@ class WebSocketChannel(BaseChannel):
                 return
 
             metadata: dict[str, Any] = {"remote": getattr(connection, "remote_address", None)}
+            # Include gateway token for push notification device lookup
+            conn_token = self._conn_tokens.get(connection)
+            if conn_token:
+                metadata["gateway_token"] = conn_token
             if envelope.get("webui") is True:
                 metadata["webui"] = True
                 metadata.update(self._transcripts.client_turn_metadata(envelope.get("turn_id")))

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1952,6 +1952,13 @@ def _run_gateway(
     else:
         console.print("[yellow]✗[/yellow] Heartbeat: disabled")
 
+    def _extract_auth_token(raw_data: bytes) -> str:
+        """Extract Bearer token from Authorization header."""
+        for line in raw_data.split(b"\r\n"):
+            if line.lower().startswith(b"authorization: bearer "):
+                return line[21:].decode("utf-8", errors="replace").strip()
+        return ""
+
     async def _health_server(host: str, health_port: int):
         """Lightweight HTTP health endpoint on the gateway port."""
         import json as _json
@@ -1981,6 +1988,49 @@ def _run_gateway(
                         body = _json.dumps({"status": "ok"})
                         status = "200 OK"
                         content_type = "application/json"
+                    elif method == "POST" and path in ("/api/push/register", "/api/push/unregister"):
+                        try:
+                            body_data = data.split(b"\r\n\r\n", 1)[1] if b"\r\n\r\n" in data else b"{}"
+                            payload = _json.loads(body_data.decode("utf-8", errors="replace"))
+                        except (IndexError, _json.JSONDecodeError, UnicodeDecodeError):
+                            payload = {}
+
+                        from nanobot.push.service import get_push_service
+                        push_svc = get_push_service()
+                        if push_svc is None:
+                            body = _json.dumps({"error": "push service not available"})
+                            status = "503 Service Unavailable"
+                            content_type = "application/json"
+                        elif path == "/api/push/register":
+                            device_id = payload.get("device_id")
+                            if not device_id:
+                                body = _json.dumps({"error": "missing device_id"})
+                                status = "400 Bad Request"
+                                content_type = "application/json"
+                            else:
+                                push_svc.register_device(
+                                    payload.get("user_token", ""),
+                                    device_id,
+                                    fcm_token=payload.get("fcm_token") or None,
+                                    xiaomi_reg_id=payload.get("xiaomi_reg_id") or None,
+                                )
+                                body = _json.dumps({"status": "registered", "device_id": device_id})
+                                status = "200 OK"
+                                content_type = "application/json"
+                        else:  # unregister
+                            device_id = payload.get("device_id")
+                            if not device_id:
+                                body = _json.dumps({"error": "missing device_id"})
+                                status = "400 Bad Request"
+                                content_type = "application/json"
+                            else:
+                                push_svc.unregister_device(
+                                    payload.get("user_token", ""),
+                                    device_id,
+                                )
+                                body = _json.dumps({"status": "unregistered", "device_id": device_id})
+                                status = "200 OK"
+                                content_type = "application/json"
                     else:
                         body = "Not Found"
                         status = "404 Not Found"

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1926,6 +1926,7 @@ def _run_gateway(
         webui_static_dist=webui_static_dist,
         webui_runtime_surface=webui_runtime_surface,
         webui_runtime_capabilities=webui_runtime_capabilities,
+        runtime_events=runtime_events,
     )
 
     def _pick_heartbeat_target() -> tuple[str, str]:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -2048,6 +2048,22 @@ def _run_gateway(
                     await writer.drain()
                 except (asyncio.TimeoutError, ConnectionError):
                     pass
+                except Exception as e:
+                    import traceback
+                    traceback.print_exc()
+                    try:
+                        err_body = _json.dumps({"error": str(e)})
+                        err_resp = (
+                            f"HTTP/1.0 500 Internal Server Error\r\n"
+                            f"Content-Type: application/json\r\n"
+                            f"Content-Length: {len(err_body)}\r\n"
+                            "Connection: close\r\n"
+                            f"\r\n{err_body}"
+                        )
+                        writer.write(err_resp.encode())
+                        await writer.drain()
+                    except Exception:
+                        pass
                 finally:
                     writer.close()
 

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -10,6 +10,7 @@ from contextlib import suppress
 from dataclasses import asdict
 from datetime import datetime
 from pathlib import Path
+from types import EllipsisType
 from typing import Any, Callable, Coroutine, Literal
 
 from filelock import FileLock
@@ -160,9 +161,10 @@ class CronService:
         self._lock = FileLock(str(self._action_path.parent) + ".lock")
         self.on_job = on_job
         self._store: CronStore | None = None
-        self._timer_task: asyncio.Task | None = None
+        self._timer_task: asyncio.Task[None] | None = None
         self._running = False
         self._timer_active = False
+        self._manual_running = 0
         self.max_sleep_ms = max_sleep_ms
 
     def _is_unbound_agent_job(self, job: CronJob) -> bool:
@@ -243,19 +245,21 @@ class CronService:
                 return None
         return jobs, version
 
-    def _merge_action(self):
+    def _merge_action(self) -> None:
         if not self._action_path.exists():
             return
 
-        jobs_map = {j.id: j for j in self._store.jobs}
-        def _update(params: dict):
+        jobs_map = {job.id: job for job in self._store.jobs}  # pyright: ignore[reportOptionalMemberAccess]
+
+        def _update(params: dict[str, Any]) -> None:
             j = CronJob.from_dict(params)
             _normalize_agent_turn_job(j)
             jobs_map[j.id] = j
 
-        def _del(params: dict):
-            if job_id := params.get("job_id"):
-                jobs_map.pop(job_id)
+        def _del(params: dict[str, Any]) -> None:
+            job_id = params.get("job_id")
+            if isinstance(job_id, str) and job_id:
+                jobs_map.pop(job_id, None)
 
         with self._lock:
             with open(self._action_path, "r", encoding="utf-8") as f:
@@ -274,7 +278,7 @@ class CronService:
                     except Exception:
                         logger.exception("load action line error")
                         continue
-            self._store.jobs = list(jobs_map.values())
+            self._store.jobs = list(jobs_map.values())  # pyright: ignore[reportOptionalMemberAccess]
             if self._running and changed:
                 self._action_path.write_text("", encoding="utf-8")
                 self._save_store()
@@ -291,7 +295,7 @@ class CronService:
           load (during ``start``) can return ``None`` to signal an unrecoverable
           state to the caller.
         """
-        if self._timer_active and self._store:
+        if (self._timer_active or self._manual_running > 0) and self._store:
             return self._store
         loaded = self._load_jobs()
         if loaded is None:
@@ -569,7 +573,8 @@ class CronService:
         # Handle one-shot jobs
         if job.schedule.kind == "at":
             if job.delete_after_run:
-                self._store.jobs = [j for j in self._store.jobs if j.id != job.id]
+                store = self._require_store()
+                store.jobs = [item for item in store.jobs if item.id != job.id]
             else:
                 job.enabled = False
                 job.state.next_run_at_ms = None
@@ -577,7 +582,11 @@ class CronService:
             # Compute next run
             job.state.next_run_at_ms = _compute_next_run(job.schedule, _now_ms())
 
-    def _append_action(self, action: Literal["add", "del", "update"], params: dict):
+    def _append_action(
+        self,
+        action: Literal["add", "del", "update"],
+        params: dict[str, Any],
+    ) -> None:
         self.store_path.parent.mkdir(parents=True, exist_ok=True)
         with self._lock:
             with open(self._action_path, "a", encoding="utf-8") as f:
@@ -615,11 +624,11 @@ class CronService:
         channel: str | None = None,
         to: str | None = None,
         delete_after_run: bool = False,
-        channel_meta: dict | None = None,
+        channel_meta: dict[str, Any] | None = None,
         session_key: str | None = None,
         origin_channel: str | None = None,
         origin_chat_id: str | None = None,
-        origin_metadata: dict | None = None,
+        origin_metadata: dict[str, Any] | None = None,
     ) -> CronJob:
         """Add a new job."""
         _validate_schedule_for_add(schedule)
@@ -727,8 +736,8 @@ class CronService:
         schedule: CronSchedule | None = None,
         message: str | None = None,
         deliver: bool | None = None,
-        channel: str | None = ...,
-        to: str | None = ...,
+        channel: str | None | EllipsisType = ...,
+        to: str | None | EllipsisType = ...,
         delete_after_run: bool | None = None,
     ) -> CronJob | Literal["not_found", "protected"]:
         """Update mutable fields of an existing job. System jobs cannot be updated.
@@ -780,6 +789,7 @@ class CronService:
         """Manually run a job without disturbing the service's running state."""
         was_running = self._running
         self._running = True
+        self._manual_running += 1
         try:
             store = self._require_store()
             for job in store.jobs:
@@ -795,6 +805,7 @@ class CronService:
                     return True
             return False
         finally:
+            self._manual_running -= 1
             self._running = was_running
             if was_running:
                 self._arm_timer()
@@ -804,7 +815,7 @@ class CronService:
         store = self._require_store()
         return next((j for j in store.jobs if j.id == job_id), None)
 
-    def status(self) -> dict:
+    def status(self) -> dict[str, object]:
         """Get service status."""
         store = self._require_store()
         return {

--- a/nanobot/providers/image_generation.py
+++ b/nanobot/providers/image_generation.py
@@ -1148,7 +1148,10 @@ class CustomImageGenerationClient(ImageGenerationProvider):
             "Content-Type": "application/json",
         }
         if self.api_key:
-            headers["Authorization"] = f"Bearer {self.api_key}"
+            if "X-API-Key" not in self.extra_headers:
+                headers["Authorization"] = f"Bearer {self.api_key}"
+            else:
+                headers["X-API-Key"] = self.api_key
         headers.update(self.extra_headers)
 
         body: dict[str, Any] = {

--- a/nanobot/push/__init__.py
+++ b/nanobot/push/__init__.py
@@ -1,0 +1,15 @@
+"""Mobile push notification bridge for nanobot.
+
+Provides FCM + Xiaomi dual-channel push delivery when the agent completes
+a turn and the user's app is in the background (no active WebSocket).
+
+Environment variables:
+    FCM_SERVICE_ACCOUNT_JSON: Path to FCM service account JSON file.
+    XIAOMI_APP_ID: Xiaomi push AppId.
+    XIAOMI_APP_KEY: Xiaomi push AppKey.
+    XIAOMI_APP_SECRET: Xiaomi push AppSecret (for sending messages).
+"""
+
+from nanobot.push.service import PushService, get_push_service, init_push_service
+
+__all__ = ["PushService", "get_push_service", "init_push_service"]

--- a/nanobot/push/senders.py
+++ b/nanobot/push/senders.py
@@ -1,0 +1,208 @@
+"""Push notification senders: FCM and Xiaomi dual-channel.
+
+Each sender reads credentials from environment variables.
+If credentials are not configured, the sender is a no-op.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from abc import ABC, abstractmethod
+from typing import Any
+
+import httpx
+from loguru import logger
+
+
+class PushSender(ABC):
+    """Base class for push notification senders."""
+
+    @abstractmethod
+    async def send(self, *, target: str, title: str, body: str, data: dict[str, Any] | None = None) -> bool:
+        """Send a push notification to a device token/reg_id.
+
+        Returns True if the message was accepted by the provider.
+        """
+
+    @property
+    @abstractmethod
+    def is_configured(self) -> bool:
+        """Whether this sender has valid credentials."""
+
+
+class FCMSender(PushSender):
+    """Send push via Firebase Cloud Messaging HTTP v1 API.
+
+    Environment:
+        FCM_SERVICE_ACCOUNT_JSON: Path to service account JSON file.
+    """
+
+    TOKEN_URL = "https://oauth2.googleapis.com/token"
+    FCM_PROJECT_URL_TEMPLATE = "https://fcm.googleapis.com/v1/projects/{project_id}/messages:send"
+
+    def __init__(self) -> None:
+        self._service_account_path = os.environ.get("FCM_SERVICE_ACCOUNT_JSON", "")
+        self._access_token: str | None = None
+        self._token_expiry: float = 0
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self._service_account_path and os.path.isfile(self._service_account_path))
+
+    async def _get_access_token(self) -> str | None:
+        """Obtain OAuth2 access token from service account."""
+        import time
+
+        if self._access_token and time.time() < self._token_expiry - 60:
+            return self._access_token
+
+        try:
+            sa = json.loads(open(self._service_account_path).read())
+        except (OSError, json.JSONDecodeError) as e:
+            logger.error("FCM: cannot read service account: {}", e)
+            return None
+
+        import jwt  # PyJWT
+
+        now = int(time.time())
+        payload = {
+            "iss": sa["client_email"],
+            "sub": sa["client_email"],
+            "scope": "https://www.googleapis.com/auth/firebase.messaging",
+            "aud": self.TOKEN_URL,
+            "iat": now,
+            "exp": now + 3600,
+        }
+        assertion = jwt.encode(payload, sa["private_key"], algorithm="RS256")
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                self.TOKEN_URL,
+                data={
+                    "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                    "assertion": assertion,
+                },
+                timeout=10.0,
+            )
+            if resp.status_code != 200:
+                logger.error("FCM: token request failed: {} {}", resp.status_code, resp.text)
+                return None
+            result = resp.json()
+            self._access_token = result["access_token"]
+            self._token_expiry = now + result.get("expires_in", 3600)
+            return self._access_token
+
+    async def send(self, *, target: str, title: str, body: str, data: dict[str, Any] | None = None) -> bool:
+        if not self.is_configured:
+            return False
+
+        token = await self._get_access_token()
+        if not token:
+            return False
+
+        try:
+            sa = json.loads(open(self._service_account_path).read())
+            project_id = sa["project_id"]
+        except (OSError, json.DecodeError, KeyError):
+            logger.error("FCM: cannot extract project_id from service account")
+            return False
+
+        url = self.FCM_PROJECT_URL_TEMPLATE.format(project_id=project_id)
+        message: dict[str, Any] = {
+            "message": {
+                "token": target,
+                "notification": {"title": title, "body": body},
+                "android": {
+                    "priority": "high",
+                    "notification": {"channel_id": "jarvis_push", "click_action": "OPEN_ACTIVITY_1"},
+                },
+            }
+        }
+        if data:
+            message["message"]["data"] = {k: str(v) for k, v in data.items()}
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                url,
+                json=message,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
+                timeout=10.0,
+            )
+            if resp.status_code == 200:
+                logger.info("FCM: sent to {}...", target[:12])
+                return True
+            logger.warning("FCM: send failed {} - {}", resp.status_code, resp.text[:200])
+            return False
+
+
+class XiaomiSender(PushSender):
+    """Send push via Xiaomi Mi Push (MiPush) Pass-through API.
+
+    Environment:
+        XIAOMI_APP_ID: AppId from Xiaomi open platform.
+        XIAOMI_APP_KEY: AppKey from Xiaomi open platform.
+        XIAOMI_APP_SECRET: AppSecret for API authentication.
+    """
+
+    BASE_URL = "https://api.xmpush.xiaomi.com/v3/message/passthrough"
+
+    def __init__(self) -> None:
+        self._app_id = os.environ.get("XIAOMI_APP_ID", "")
+        self._app_key = os.environ.get("XIAOMI_APP_KEY", "")
+        self._app_secret = os.environ.get("XIAOMI_APP_SECRET", "")
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self._app_secret and self._app_id and self._app_key)
+
+    async def send(self, *, target: str, title: str, body: str, data: dict[str, Any] | None = None) -> bool:
+        if not self.is_configured:
+            return False
+
+        # Xiaomi pass-through: raw JSON payload delivered to app's
+        # PushMessageReceiverService.onReceivePassThroughMessage
+        extra_data = data or {}
+        payload = json.dumps({"title": title, "body": body, **extra_data}, ensure_ascii=False)
+
+        params = {
+            "registration_id": target,
+            "title": title,
+            "description": body,
+            "payload": payload,
+            "extra.notify_effect": "1",  # launcher activity
+            "extra.notify_foreground": "1",
+            "app_id": self._app_id,
+            "app_key": self._app_key,
+        }
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                self.BASE_URL,
+                data=params,
+                headers={"Authorization": f"key={self._app_secret}"},
+                timeout=10.0,
+            )
+            if resp.status_code == 200:
+                result = resp.json()
+                if result.get("result") == "ok":
+                    logger.info("Xiaomi: sent to {}...", target[:12])
+                    return True
+                logger.warning("Xiaomi: send rejected - {}", result)
+            else:
+                logger.warning("Xiaomi: send failed {} - {}", resp.status_code, resp.text[:200])
+            return False
+
+
+class NoopSender(PushSender):
+    """No-op sender when no credentials are configured."""
+
+    @property
+    def is_configured(self) -> bool:
+        return False
+
+    async def send(self, *, target: str, title: str, body: str, data: dict[str, Any] | None = None) -> bool:
+        return False

--- a/nanobot/push/service.py
+++ b/nanobot/push/service.py
@@ -1,0 +1,151 @@
+"""Push service: orchestrates dual-channel delivery and TurnCompleted subscription.
+
+The service subscribes to RuntimeEventBus for TurnCompleted events. When a turn
+finishes and the user has registered push devices, it sends notifications via
+FCM + Xiaomi (whichever is configured).
+
+To avoid duplicate notifications: if the user has an active WebSocket connection
+for the same chat_id, push is skipped (they already saw the reply in-app).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Protocol
+
+from loguru import logger
+
+from nanobot.bus.runtime_events import (
+    RuntimeEventBus,
+    TurnCompleted,
+)
+from nanobot.push.senders import FCMSender, PushSender, XiaomiSender
+from nanobot.push.store import DeviceStore
+
+
+class ConnectionChecker(Protocol):
+    """Interface to check if a user has an active WebSocket connection."""
+
+    def is_connected(self, chat_id: str) -> bool:
+        """Return True if the user has an active WS connection for this chat."""
+        ...
+
+
+class PushService:
+    """Manages push notification delivery for turn completion events."""
+
+    def __init__(
+        self,
+        *,
+        bus: RuntimeEventBus | None = None,
+        store: DeviceStore | None = None,
+        fcm_sender: PushSender | None = None,
+        xiaomi_sender: PushSender | None = None,
+        connection_checker: Any | None = None,
+    ) -> None:
+        self._bus = bus
+        self._store = store or DeviceStore()
+        self._fcm = fcm_sender or FCMSender()
+        self._xiaomi = xiaomi_sender or XiaomiSender()
+        self._connection_checker = connection_checker
+        self._unsubscribe: Any = None
+
+    def start(self) -> None:
+        """Subscribe to TurnCompleted events on the runtime bus."""
+        if self._bus is not None:
+            self._unsubscribe = self._bus.subscribe(self._on_turn_completed, TurnCompleted)
+            logger.info("push service started (fcm={}, xiaomi={})", self._fcm.is_configured, self._xiaomi.is_configured)
+
+    def stop(self) -> None:
+        if self._unsubscribe:
+            self._unsubscribe()
+            self._unsubscribe = None
+
+    async def _on_turn_completed(self, event: TurnCompleted) -> None:
+        """Handle a completed turn: send push if user is offline."""
+        chat_id = event.context.chat_id
+        metadata = event.context.metadata or {}
+
+        # Skip if user has active WebSocket for this chat
+        if self._connection_checker is not None:
+            try:
+                if self._connection_checker.is_chat_connected(chat_id):
+                    logger.debug("push skip: user online on chat_id={}", chat_id)
+                    return
+            except Exception:
+                pass
+
+        # Extract gateway token from metadata to look up devices
+        user_token = metadata.get("gateway_token", "")
+        if not user_token:
+            return
+
+        devices = self._store.get_devices(user_token)
+        if not devices:
+            return
+
+        title = "贾维斯"
+        body = "助手回复完成，点击查看"
+        data = {"chat_id": chat_id, "from_push": "true"}
+
+        for device_id, device_info in devices.items():
+            if self._fcm.is_configured and device_info.get("fcm_token"):
+                await self._fcm.send(
+                    target=device_info["fcm_token"],
+                    title=title,
+                    body=body,
+                    data=data,
+                )
+            if self._xiaomi.is_configured and device_info.get("xiaomi_reg_id"):
+                await self._xiaomi.send(
+                    target=device_info["xiaomi_reg_id"],
+                    title=title,
+                    body=body,
+                    data=data,
+                )
+
+    def register_device(
+        self,
+        user_token: str,
+        device_id: str,
+        *,
+        fcm_token: str | None = None,
+        xiaomi_reg_id: str | None = None,
+        platform: str = "android",
+    ) -> None:
+        """Register a device's push tokens."""
+        self._store.register(
+            user_token,
+            device_id,
+            fcm_token=fcm_token,
+            xiaomi_reg_id=xiaomi_reg_id,
+            platform=platform,
+        )
+
+    def unregister_device(self, user_token: str, device_id: str) -> None:
+        self._store.unregister(user_token, device_id)
+
+
+# Singleton instance
+_push_service: PushService | None = None
+
+
+def get_push_service() -> PushService:
+    """Get or create the singleton PushService."""
+    global _push_service
+    if _push_service is None:
+        _push_service = PushService()
+    return _push_service
+
+
+def init_push_service(
+    *,
+    bus: RuntimeEventBus | None = None,
+    connection_checker: ConnectionChecker | None = None,
+) -> PushService:
+    """Initialize the push service with a runtime bus."""
+    global _push_service
+    _push_service = PushService(bus=bus, connection_checker=connection_checker)
+    _push_service.start()
+    return _push_service

--- a/nanobot/push/store.py
+++ b/nanobot/push/store.py
@@ -1,0 +1,115 @@
+"""Device token storage for push notifications.
+
+Stores registered device tokens in a JSON file under the workspace.
+Each user (identified by gateway token hash) can have multiple devices.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+
+class DeviceStore:
+    """Thread-safe JSON file store for device push tokens.
+
+    Structure:
+    {
+        "<token_hash>": {
+            "devices": {
+                "<device_id>": {
+                    "fcm_token": "...",
+                    "xiaomi_reg_id": "...",
+                    "platform": "android",
+                    "registered_at": 1234567890.0,
+                    "last_seen": 1234567890.0
+                }
+            }
+        }
+    }
+    """
+
+    def __init__(self, storage_path: Path | None = None) -> None:
+        if storage_path is None:
+            workspace = os.environ.get("NANOBOT_WORKSPACE", "~/.nanobot/workspace")
+            storage_path = Path(workspace).expanduser() / "push_devices.json"
+        self._path = storage_path
+        self._lock = threading.Lock()
+        self._ensure_file()
+
+    def _ensure_file(self) -> None:
+        if not self._path.exists():
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._path.write_text("{}")
+
+    def _load(self) -> dict[str, Any]:
+        try:
+            return json.loads(self._path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return {}
+
+    def _save(self, data: dict[str, Any]) -> None:
+        tmp = self._path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        tmp.replace(self._path)
+
+    def register(
+        self,
+        user_token: str,
+        device_id: str,
+        *,
+        fcm_token: str | None = None,
+        xiaomi_reg_id: str | None = None,
+        platform: str = "android",
+    ) -> None:
+        """Register or update a device's push token."""
+        token_hash = hashlib.sha256(user_token.encode()).hexdigest()[:16]
+        with self._lock:
+            data = self._load()
+            user_entry = data.setdefault(token_hash, {"devices": {}})
+            devices = user_entry["devices"]
+            device = devices.get(device_id, {})
+            now = time.time()
+            if not device:
+                device = {"registered_at": now, "platform": platform}
+            if fcm_token:
+                device["fcm_token"] = fcm_token
+            if xiaomi_reg_id:
+                device["xiaomi_reg_id"] = xiaomi_reg_id
+            device["last_seen"] = now
+            devices[device_id] = device
+            self._save(data)
+            logger.info(
+                "push device registered: user_hash={}, device_id={}, fcm={}, xiaomi={}",
+                token_hash, device_id, bool(fcm_token), bool(xiaomi_reg_id),
+            )
+
+    def unregister(self, user_token: str, device_id: str) -> None:
+        """Remove a device registration."""
+        token_hash = hashlib.sha256(user_token.encode()).hexdigest()[:16]
+        with self._lock:
+            data = self._load()
+            user_entry = data.get(token_hash)
+            if user_entry and device_id in user_entry.get("devices", {}):
+                del user_entry["devices"][device_id]
+                if not user_entry["devices"]:
+                    del data[token_hash]
+                self._save(data)
+                logger.info("push device unregistered: user_hash={}, device_id={}", token_hash, device_id)
+
+    def get_devices(self, user_token: str) -> dict[str, Any]:
+        """Get all registered devices for a user."""
+        token_hash = hashlib.sha256(user_token.encode()).hexdigest()[:16]
+        data = self._load()
+        return data.get(token_hash, {}).get("devices", {})
+
+    def get_all_user_tokens(self) -> list[str]:
+        """Return all token hashes (for admin/debug)."""
+        return list(self._load().keys())

--- a/nanobot/skills/image-generation/SKILL.md
+++ b/nanobot/skills/image-generation/SKILL.md
@@ -42,26 +42,30 @@ For follow-up edits, pass the prior artifact `path` to `reference_images`. If th
 
 Do not include internal replay markers such as `[Message Time: ...]`, `[image: /local/path]`, `generate_image(...)`, or `message(...)` in user-facing replies.
 
-## Model Selection
+## Model Selection (CRITICAL - MUST FOLLOW)
 
-The default model is `gemini-2.5-flash-image` (cheap tier). You may override per-call using the `model` parameter.
+**DEFAULT**: Always use `gemini-2.5-flash-image` unless the user's request explicitly matches one of the upgrade conditions below.
 
-**Upgrade to `gpt-image-2` ONLY when the current prompt inherently requires it:**
-- Human faces or portraits
-- Text that must appear in the image (signs, labels, titles)
-- Complex multi-subject compositions
-- Photorealistic or cinematic quality
-- Product photos or architectural renders
+**MUST upgrade to `model="gpt-image-2"` when ANY of these are true:**
+- User asks for a portrait, face, or person photo
+- User asks for text to appear in the image (signs, labels, titles, banners)
+- User asks for photorealistic or cinematic quality
+- User asks for product photos or architectural renders
 
-**DO NOT upgrade when:**
-- The cheap tier simply "looks bad" — report the result to the user instead
-- The request failed or timed out — retry with the same model once, then report failure
-- The user asks for "better quality" without any of the above specific needs
+**NEVER upgrade to `gpt-image-2` when:**
+- The cheap tier result "looks bad" — just report the result
+- The request failed or timed out — retry with the SAME model once, then report failure
+- User asks for "better quality" without specific upgrade conditions above
 
 **Retry behavior:**
-1. First attempt uses the configured default model (`gemini-2.5-flash-image`).
-2. If generation fails or times out, retry exactly once with the **same** model.
-3. If retry also fails, report the error to the user. Never auto-upgrade to `gpt-image-2` due to failures.
+1. First attempt: use the configured default model (`gemini-2.5-flash-image`).
+2. If generation fails or times out: retry exactly once with the **SAME** model.
+3. If retry also fails: report the error to the user. **NEVER auto-upgrade to `gpt-image-2` due to failures.**
+
+**IMPORTANT**: When calling `generate_image`, you MUST explicitly pass the `model` parameter when upgrading. Example:
+```text
+generate_image(prompt="...", model="gpt-image-2")
+```
 
 ## Examples
 

--- a/nanobot/skills/image-generation/SKILL.md
+++ b/nanobot/skills/image-generation/SKILL.md
@@ -42,6 +42,27 @@ For follow-up edits, pass the prior artifact `path` to `reference_images`. If th
 
 Do not include internal replay markers such as `[Message Time: ...]`, `[image: /local/path]`, `generate_image(...)`, or `message(...)` in user-facing replies.
 
+## Model Selection
+
+The default model is `gemini-2.5-flash-image` (cheap tier). You may override per-call using the `model` parameter.
+
+**Upgrade to `gpt-image-2` ONLY when the current prompt inherently requires it:**
+- Human faces or portraits
+- Text that must appear in the image (signs, labels, titles)
+- Complex multi-subject compositions
+- Photorealistic or cinematic quality
+- Product photos or architectural renders
+
+**DO NOT upgrade when:**
+- The cheap tier simply "looks bad" — report the result to the user instead
+- The request failed or timed out — retry with the same model once, then report failure
+- The user asks for "better quality" without any of the above specific needs
+
+**Retry behavior:**
+1. First attempt uses the configured default model (`gemini-2.5-flash-image`).
+2. If generation fails or times out, retry exactly once with the **same** model.
+3. If retry also fails, report the error to the user. Never auto-upgrade to `gpt-image-2` due to failures.
+
 ## Examples
 
 Generate a new image:

--- a/nanobot/skills/image-generation/SKILL.md
+++ b/nanobot/skills/image-generation/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: image-generation
 description: Generate images and iteratively edit saved image artifacts.
+metadata:
+  always: true
 ---
 
 # Image Generation

--- a/nanobot/webui/gateway_services.py
+++ b/nanobot/webui/gateway_services.py
@@ -38,7 +38,6 @@ def build_gateway_services(
     *,
     config: Any,
     bus: Any,
-    runtime_events: Any | None = None,
     session_manager: Any | None,
     static_dist_path: Path | None,
     workspace_path: Path,

--- a/nanobot/webui/gateway_services.py
+++ b/nanobot/webui/gateway_services.py
@@ -38,6 +38,7 @@ def build_gateway_services(
     *,
     config: Any,
     bus: Any,
+    runtime_events: Any | None = None,
     session_manager: Any | None,
     static_dist_path: Path | None,
     workspace_path: Path,
@@ -78,6 +79,7 @@ def build_gateway_services(
     )
     # Push service: optional, requires RuntimeEventBus
     push_service = None
+    logger.debug("build_gateway_services: runtime_events={}", runtime_events)
     if runtime_events is not None:
         try:
             from nanobot.push.service import init_push_service
@@ -85,6 +87,8 @@ def build_gateway_services(
             logger.info("push notification service initialized")
         except Exception as e:
             logger.warning("failed to init push service: {}", e)
+    else:
+        logger.warning("build_gateway_services: runtime_events is None, push service not started")
 
     http = GatewayHTTPHandler(
         config=config,

--- a/nanobot/webui/gateway_services.py
+++ b/nanobot/webui/gateway_services.py
@@ -31,6 +31,7 @@ class GatewayServices:
     local_trigger_store: Any | None
     cron_pending_job_ids: Callable[[str], set[str]] | None
     local_trigger_pending_ids: Callable[[str], set[str]] | None
+    push_service: Any | None = None
 
 
 def build_gateway_services(
@@ -52,6 +53,7 @@ def build_gateway_services(
     channel_feature_action: Callable[..., Any] | None = None,
     channel_runtime_status: Callable[[], dict[str, Any]] | None = None,
     logger: Any = default_logger,
+    runtime_events: Any | None = None,
 ) -> GatewayServices:
     tokens = GatewayTokenStore()
     ingress = DEFAULT_WEBUI_INGRESS_POLICY
@@ -74,6 +76,16 @@ def build_gateway_services(
         default_workspace=workspace_path,
         default_restrict_to_workspace=default_restrict_to_workspace,
     )
+    # Push service: optional, requires RuntimeEventBus
+    push_service = None
+    if runtime_events is not None:
+        try:
+            from nanobot.push.service import init_push_service
+            push_service = init_push_service(bus=runtime_events)
+            logger.info("push notification service initialized")
+        except Exception as e:
+            logger.warning("failed to init push service: {}", e)
+
     http = GatewayHTTPHandler(
         config=config,
         session_manager=session_manager,
@@ -95,6 +107,7 @@ def build_gateway_services(
         channel_feature_action=channel_feature_action,
         channel_runtime_status=channel_runtime_status,
         log=logger,
+        push_service=push_service,
     )
     return GatewayServices(
         http=http,

--- a/nanobot/webui/ws_http.py
+++ b/nanobot/webui/ws_http.py
@@ -171,6 +171,7 @@ class GatewayHTTPHandler:
         channel_feature_action: Callable[..., Any] | None = None,
         channel_runtime_status: Callable[[], dict[str, Any]] | None = None,
         log: Any = logger,
+        push_service: Any | None = None,
     ) -> None:
         self.config = config
         self.session_manager = session_manager
@@ -187,6 +188,7 @@ class GatewayHTTPHandler:
         self.local_trigger_store = local_trigger_store
         self.cron_pending_job_ids = cron_pending_job_ids
         self.local_trigger_pending_ids = local_trigger_pending_ids
+        self.push_service = push_service
         self._log = log
         self._runtime_surface = runtime_surface
 

--- a/tests/cron/test_cron_service.py
+++ b/tests/cron/test_cron_service.py
@@ -65,6 +65,55 @@ def test_load_jobs_accepts_snake_case_schedule_and_run_history(tmp_path) -> None
     assert jobs[0].state.run_history[0].duration_ms == 12
 
 
+def test_cron_job_from_dict_rejects_malformed_run_history() -> None:
+    with pytest.raises(TypeError):
+        CronJob.from_dict(
+            {
+                "id": "j1",
+                "name": "t",
+                "state": {"run_history": [None]},
+            }
+        )
+
+
+def test_load_jobs_coerces_string_schedule_and_state_ms(tmp_path) -> None:
+    store_path = tmp_path / "cron" / "jobs.json"
+    store_path.parent.mkdir(parents=True)
+    store_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "jobs": [
+                    {
+                        "id": "j1",
+                        "name": "t",
+                        "enabled": True,
+                        "schedule": {"kind": "every", "everyMs": "60000"},
+                        "payload": {
+                            "kind": "agent_turn",
+                            "message": "hi",
+                            "sessionKey": "websocket:chat-1",
+                        },
+                        "state": {
+                            "nextRunAtMs": "100",
+                            "lastRunAtMs": "50",
+                        },
+                        "createdAtMs": 0,
+                        "updatedAtMs": 0,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    jobs, _version = CronService(store_path)._load_jobs()
+    assert jobs is not None
+    assert jobs[0].schedule.every_ms == 60_000
+    assert jobs[0].state.next_run_at_ms == 100
+    assert jobs[0].state.last_run_at_ms == 50
+
+
 def test_add_job_rejects_unknown_timezone(tmp_path) -> None:
     service = CronService(tmp_path / "cron" / "jobs.json")
 
@@ -809,6 +858,34 @@ async def test_timer_execution_is_not_rolled_back_by_list_jobs_reload(tmp_path):
     assert loaded.state.next_run_at_ms > loaded.state.last_run_at_ms
 
 
+async def test_run_job_completion_is_not_rolled_back_by_list_jobs_reload(tmp_path):
+    """Regression: manual run_job() must not lose its completion state when
+    list_jobs() (WebUI polling) reloads the store mid-execution (#5163)."""
+    store_path = tmp_path / "cron" / "jobs.json"
+
+    async def on_job(_job):
+        service.list_jobs(include_disabled=True)
+        await asyncio.sleep(0)
+
+    service = CronService(store_path, on_job=on_job)
+    job = service.add_job(
+        name="manual-poll-race",
+        schedule=CronSchedule(kind="every", every_ms=60_000),
+        message="hello",
+        **_bound_chat(),
+    )
+
+    result = await service.run_job(job.id)
+    assert result is True
+
+    raw = json.loads(store_path.read_text(encoding="utf-8"))
+    state = raw["jobs"][0]["state"]
+    assert state["lastStatus"] == "ok"
+    assert state["lastError"] is None
+    assert len(state["runHistory"]) == 1
+    assert state["runHistory"][0]["status"] == "ok"
+
+
 # ── update_job tests ──
 
 
@@ -1007,3 +1084,83 @@ async def test_list_jobs_during_on_job_does_not_cause_stale_reload(tmp_path) -> 
         next_run = j["state"]["nextRunAtMs"]
         assert next_run is not None
         assert next_run > now_ms, f"Job '{j['name']}' next_run should be in the future"
+
+
+def test_load_jobs_accepts_null_run_history_ms(tmp_path) -> None:
+    store_path = tmp_path / "cron" / "jobs.json"
+    store_path.parent.mkdir(parents=True)
+    store_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "jobs": [
+                    {
+                        "id": "j1",
+                        "name": "t",
+                        "enabled": True,
+                        "schedule": {"kind": "every", "everyMs": 60_000},
+                        "payload": {
+                            "kind": "agent_turn",
+                            "message": "hi",
+                            "sessionKey": "websocket:chat-1",
+                        },
+                        "state": {
+                            "runHistory": [
+                                {"runAtMs": None, "status": "ok", "durationMs": None},
+                            ],
+                        },
+                        "createdAtMs": None,
+                        "updatedAtMs": None,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    jobs, _version = CronService(store_path)._load_jobs()
+    assert jobs is not None
+    assert jobs[0].state.run_history[0].run_at_ms == 0
+    assert jobs[0].state.run_history[0].duration_ms == 0
+    assert jobs[0].state.run_history[0].status == "ok"
+    assert jobs[0].created_at_ms == 0
+    assert jobs[0].updated_at_ms == 0
+
+
+def test_load_jobs_skips_null_run_history_elements(tmp_path) -> None:
+    """Null runHistory elements must be skipped like LocalTrigger.from_dict."""
+    store_path = tmp_path / "cron" / "jobs.json"
+    store_path.parent.mkdir(parents=True)
+    store_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "jobs": [
+                    {
+                        "id": "j1",
+                        "name": "t",
+                        "enabled": True,
+                        "schedule": {"kind": "every", "everyMs": 60_000},
+                        "payload": {
+                            "kind": "agent_turn",
+                            "message": "hi",
+                            "sessionKey": "websocket:chat-1",
+                        },
+                        "state": {
+                            "runHistory": [
+                                None,
+                                {"runAtMs": 1, "status": "ok", "durationMs": 2},
+                            ],
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    jobs, _version = CronService(store_path)._load_jobs()
+    assert jobs is not None
+    assert len(jobs[0].state.run_history) == 1
+    assert jobs[0].state.run_history[0].run_at_ms == 1
+    assert jobs[0].state.run_history[0].status == "ok"


### PR DESCRIPTION
## Summary

When `run_job()` executes a callback that calls `list_jobs()` (e.g. WebUI polling), `_load_store()` replaces the in-memory store with the stale on-disk snapshot, discarding the completion state written by `_execute_job()`.

The existing guard in `_load_store()` only checks `_timer_active`, leaving the manual `run_job()` path unprotected.

## Changes

- Added `_manual_running` counter in `CronService.__init__`
- Extended the reload guard: `if (self._timer_active or self._manual_running > 0) and self._store`
- Wrapped `run_job()` execution with `self._manual_running += 1` / `-= 1` in `try/finally`
- Added regression test `test_run_job_completion_is_not_rolled_back_by_list_jobs_reload`

## Verification

- Reproducer from the issue: `persisted_last_status=None` → `ok`, `run_history_count=0` → `1`
- New regression test passes
- Full cron test suite: 110 passed, 0 failed