### PR TITLE
fix(cron): prevent store reload from rolling back manual run_job completion (#5163)

### DIFF
--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -164,6 +164,7 @@ class CronService:
         self._timer_task: asyncio.Task[None] | None = None
         self._running = False
         self._timer_active = False
+        self._manual_running = 0
         self.max_sleep_ms = max_sleep_ms
 
     def _is_unbound_agent_job(self, job: CronJob) -> bool:
@@ -294,7 +295,7 @@ class CronService:
           load (during ``start``) can return ``None`` to signal an unrecoverable
           state to the caller.
         """
-        if self._timer_active and self._store:
+        if (self._timer_active or self._manual_running > 0) and self._store:
             return self._store
         loaded = self._load_jobs()
         if loaded is None:
@@ -788,6 +789,7 @@ class CronService:
         """Manually run a job without disturbing the service's running state."""
         was_running = self._running
         self._running = True
+        self._manual_running += 1
         try:
             store = self._require_store()
             for job in store.jobs:
@@ -803,6 +805,7 @@ class CronService:
                     return True
             return False
         finally:
+            self._manual_running -= 1
             self._running = was_running
             if was_running:
                 self._arm_timer()

--- a/tests/cron/test_cron_service.py
+++ b/tests/cron/test_cron_service.py
@@ -858,6 +858,34 @@ async def test_timer_execution_is_not_rolled_back_by_list_jobs_reload(tmp_path):
     assert loaded.state.next_run_at_ms > loaded.state.last_run_at_ms
 
 
+async def test_run_job_completion_is_not_rolled_back_by_list_jobs_reload(tmp_path):
+    """Regression: manual run_job() must not lose its completion state when
+    list_jobs() (WebUI polling) reloads the store mid-execution (#5163)."""
+    store_path = tmp_path / "cron" / "jobs.json"
+
+    async def on_job(_job):
+        service.list_jobs(include_disabled=True)
+        await asyncio.sleep(0)
+
+    service = CronService(store_path, on_job=on_job)
+    job = service.add_job(
+        name="manual-poll-race",
+        schedule=CronSchedule(kind="every", every_ms=60_000),
+        message="hello",
+        **_bound_chat(),
+    )
+
+    result = await service.run_job(job.id)
+    assert result is True
+
+    raw = json.loads(store_path.read_text(encoding="utf-8"))
+    state = raw["jobs"][0]["state"]
+    assert state["lastStatus"] == "ok"
+    assert state["lastError"] is None
+    assert len(state["runHistory"]) == 1
+    assert state["runHistory"][0]["status"] == "ok"
+
+
 # ── update_job tests ──
 
 


### PR DESCRIPTION
## Summary

When `run_job()` executes a callback that calls `list_jobs()` (e.g. WebUI polling), `_load_store()` replaces the in-memory store with the stale on-disk snapshot, discarding the completion state written by `_execute_job()`.

The existing guard in `_load_store()` only checks `_timer_active`, leaving the manual `run_job()` path unprotected.

## Changes

- Added `_manual_running` counter in `CronService.__init__`
- Extended the reload guard: `if (self._timer_active or self._manual_running > 0) and self._store`
- Wrapped `run_job()` execution with `_manual_running += 1` / `-= 1` in `try/finally`
- Added regression test `test_run_job_completion_is_not_rolled_back_by_list_jobs_reload`

## Verification

- Reproducer from the issue: `persisted_last_status=None` → `ok`, `run_history_count=0` → `1`
- New regression test passes
- Full cron test suite: 110 passed, 0 failed