### PR TITLE
fix(webui): support well-known skills.sh sources

### DIFF
--- a/nanobot/webui/skills_marketplace.py
+++ b/nanobot/webui/skills_marketplace.py
@@ -42,6 +42,11 @@ _SOURCE_RE = re.compile(
     r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?/"
     r"[A-Za-z0-9](?:[A-Za-z0-9_.-]{0,98}[A-Za-z0-9])?$"
 )
+_WELL_KNOWN_SOURCE_RE = re.compile(
+    r"^(?=.{1,253}$)"
+    r"(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+"
+    r"[A-Za-z](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"
+)
 _SKILL_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 _VERSION_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._+-]{0,63})$")
 _ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
@@ -351,7 +356,8 @@ async def _install_skills_sh_skill(
     skill_id: str,
     workspace_path: Path,
 ) -> dict[str, Any]:
-    if not _SOURCE_RE.fullmatch(source):
+    install_source = _skills_sh_install_source(source)
+    if install_source is None:
         raise SkillsMarketplaceError("invalid skill source")
     if not _valid_skill_id(skill_id):
         raise SkillsMarketplaceError("invalid skill name")
@@ -386,7 +392,7 @@ async def _install_skills_sh_skill(
         "--yes",
         "skills@latest",
         "add",
-        source,
+        install_source,
         "--skill",
         skill_id,
         "--agent",
@@ -755,7 +761,7 @@ def _marketplace_skill(
 ) -> dict[str, Any] | None:
     source = row.get("source")
     skill_id = row.get("skillId")
-    if not isinstance(source, str) or not _SOURCE_RE.fullmatch(source):
+    if not isinstance(source, str) or _skills_sh_install_source(source) is None:
         return None
     if not isinstance(skill_id, str) or not _valid_skill_id(skill_id):
         return None
@@ -889,7 +895,11 @@ def _valid_skill_refs(skill_ids: list[str]) -> list[tuple[str, str]]:
             continue
         source, skill_id = value.rsplit("/", 1)
         ref = (source, skill_id)
-        if _SOURCE_RE.fullmatch(source) and _valid_skill_id(skill_id) and ref not in refs:
+        if (
+            _skills_sh_install_source(source) is not None
+            and _valid_skill_id(skill_id)
+            and ref not in refs
+        ):
             refs.append(ref)
     return refs
 
@@ -920,6 +930,14 @@ async def _load_skill_page_trends(
 
 def _valid_skill_id(value: str) -> bool:
     return len(value) <= 64 and _SKILL_RE.fullmatch(value) is not None
+
+
+def _skills_sh_install_source(value: str) -> str | None:
+    if _SOURCE_RE.fullmatch(value):
+        return value
+    if _WELL_KNOWN_SOURCE_RE.fullmatch(value):
+        return f"https://{value}"
+    return None
 
 
 def _valid_provider(value: str, *, allow_all: bool = True) -> str:

--- a/nanobot/webui/skills_marketplace.py
+++ b/nanobot/webui/skills_marketplace.py
@@ -18,7 +18,7 @@ from urllib.parse import quote, urlparse
 import httpx
 
 from nanobot.agent.skills import SkillsLoader
-from nanobot.security.network import PinnedDNSAsyncTransport
+from nanobot.security.network import PinnedDNSAsyncTransport, validate_url_target
 from nanobot.security.workspace_policy import WorkspaceBoundaryError, require_path_within
 
 _PROVIDER_ALL = "all"
@@ -384,6 +384,14 @@ async def _install_skills_sh_skill(
             "Node.js with npx is required to install skills",
             status=503,
         )
+
+    # GitHub shorthand is resolved by the CLI against a fixed public host. A
+    # well-known source is an arbitrary catalog-provided hostname, so reject
+    # private or otherwise unsafe DNS targets before delegating to the CLI.
+    if install_source.startswith("https://"):
+        allowed, _ = await asyncio.to_thread(validate_url_target, install_source)
+        if not allowed:
+            raise SkillsMarketplaceError("skill source is not publicly reachable")
 
     env = os.environ.copy()
     env["DISABLE_TELEMETRY"] = "1"

--- a/tests/webui/test_skills_marketplace.py
+++ b/tests/webui/test_skills_marketplace.py
@@ -41,6 +41,12 @@ async def test_search_marketplace_skills_filters_and_marks_installed(
                         "source": "acme/agent-skills",
                         "installs": 42,
                     },
+                    {
+                        "name": "Anti UI Slop",
+                        "skillId": "anti-ui-slop",
+                        "source": "uizze.com",
+                        "installs": 62063,
+                    },
                     {"skillId": "../escape", "source": "acme/agent-skills"},
                     {"skillId": "valid-name", "source": "not-a-repository"},
                 ]
@@ -91,7 +97,19 @@ async def test_search_marketplace_skills_filters_and_marks_installed(
                 "installed": True,
                 "install_supported": True,
                 "metric": "installs_total",
-            }
+            },
+            {
+                "id": "uizze.com/anti-ui-slop",
+                "skill_id": "anti-ui-slop",
+                "name": "Anti UI Slop",
+                "source": "uizze.com",
+                "provider": "skills_sh",
+                "installs": 62063,
+                "url": "https://skills.sh/uizze.com/anti-ui-slop",
+                "installed": False,
+                "install_supported": True,
+                "metric": "installs_total",
+            },
         ],
     }
 
@@ -252,6 +270,7 @@ async def test_marketplace_skill_trends_returns_history_separately(
     async def weekly_installs(_client: object) -> dict[tuple[str, str], list[int]]:
         return {
             ("acme/skills", "first"): [2, 4, 3, 8],
+            ("uizze.com", "anti-ui-slop"): [13, 21, 34],
         }
 
     monkeypatch.setattr(
@@ -267,12 +286,14 @@ async def test_marketplace_skill_trends_returns_history_separately(
         [
             "acme/skills/first",
             "other/skills/second",
+            "uizze.com/anti-ui-slop",
             "invalid",
         ]
     ) == {
         "trends": {
             "acme/skills/first": [2, 4, 3, 8],
             "other/skills/second": [3, 5, 8, 13],
+            "uizze.com/anti-ui-slop": [13, 21, 34],
         }
     }
 
@@ -305,7 +326,16 @@ async def test_search_marketplace_skills_returns_safe_upstream_error(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("source", "cli_source"),
+    [
+        ("acme/agent-skills", "acme/agent-skills"),
+        ("uizze.com", "https://uizze.com"),
+    ],
+)
 async def test_install_marketplace_skill_uses_official_cli_and_workspace(
+    source: str,
+    cli_source: str,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -340,7 +370,7 @@ async def test_install_marketplace_skill_uses_official_cli_and_workspace(
     )
 
     result = await install_marketplace_skill(
-        "acme/agent-skills",
+        source,
         "react-testing",
         tmp_path,
     )
@@ -355,7 +385,7 @@ async def test_install_marketplace_skill_uses_official_cli_and_workspace(
         "--yes",
         "skills@latest",
         "add",
-        "acme/agent-skills",
+        cli_source,
         "--skill",
         "react-testing",
         "--agent",
@@ -365,6 +395,26 @@ async def test_install_marketplace_skill_uses_official_cli_and_workspace(
     )
     assert seen["cwd"] == str(tmp_path.resolve())
     assert seen["env"]["DISABLE_TELEMETRY"] == "1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "source",
+    [
+        "https://uizze.com",
+        "uizze.com/path",
+        "uizze.com:443",
+        "localhost",
+        "127.0.0.1",
+        "uizze",
+    ],
+)
+async def test_install_marketplace_skill_rejects_malformed_well_known_sources(
+    source: str,
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(SkillsMarketplaceError, match="invalid skill source"):
+        await install_marketplace_skill(source, "react-testing", tmp_path)
 
 
 @pytest.mark.asyncio

--- a/tests/webui/test_skills_marketplace.py
+++ b/tests/webui/test_skills_marketplace.py
@@ -1,8 +1,10 @@
+import asyncio
 import hashlib
 import io
 import zipfile
 from pathlib import Path
 from typing import Any
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
@@ -365,6 +367,10 @@ async def test_install_marketplace_skill_uses_official_cli_and_workspace(
         lambda executable: "/usr/local/bin/npx" if executable == "npx" else None,
     )
     monkeypatch.setattr(
+        "nanobot.webui.skills_marketplace.validate_url_target",
+        lambda _url: (True, ""),
+    )
+    monkeypatch.setattr(
         "nanobot.webui.skills_marketplace.asyncio.create_subprocess_exec",
         create_subprocess_exec,
     )
@@ -415,6 +421,28 @@ async def test_install_marketplace_skill_rejects_malformed_well_known_sources(
 ) -> None:
     with pytest.raises(SkillsMarketplaceError, match="invalid skill source"):
         await install_marketplace_skill(source, "react-testing", tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_install_marketplace_skill_rejects_private_well_known_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "nanobot.webui.skills_marketplace.shutil.which",
+        lambda executable: "/usr/local/bin/npx" if executable == "npx" else None,
+    )
+    monkeypatch.setattr(
+        "nanobot.webui.skills_marketplace.validate_url_target",
+        lambda _url: (False, "private network target"),
+    )
+    create_process = AsyncMock()
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_process)
+
+    with pytest.raises(SkillsMarketplaceError, match="not publicly reachable"):
+        await install_marketplace_skill("internal.example.com", "react-testing", tmp_path)
+
+    create_process.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

skills.sh returns both GitHub repository sources such as `owner/repo` and
well-known discovery hosts such as `uizze.com`. Nanobot accepted only the
repository form, so well-known skills were omitted from search and trending
results. Their trend references were dropped, and direct installation rejected
them.

This change accepts either a repository source or a bounded DNS hostname.
Hostnames are converted to `https://<hostname>` when passed to the official
skills CLI. Schemes, paths, ports, IP addresses, localhost, and single-label
names are still rejected.

The official CLI remains responsible for fetching and validating the
well-known index. Related to #2571.

## Verification

- old behavior: the `uizze.com` search, trend, and CLI install cases produced
  `3 failed, 1 passed`
- `tests/webui/test_skills_marketplace.py`: 23 passed, 1 skipped
- `tests/webui`: 194 passed, 2 skipped
- restoring the repository-only checks makes the 3 regression tests fail again
- `npx --yes skills@latest add https://uizze.com --list` found 4 skills,
  including `anti-ui-slop`
- Ruff, BasedPyright, and `git diff --check` passed
