### PR TITLE
fix(config): install timezone data on all platforms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "filelock>=3.25.2",
     "watchfiles>=1.1.1,<2.0.0",
     "packaging>=24.0",
-    "tzdata>=2025.2; sys_platform == 'win32'",
+    "tzdata>=2025.2",
     "defusedxml>=0.7.1,<1.0.0",
     "pypdf>=5.0.0,<6.0.0",
     "python-docx>=1.1.0,<2.0.0",

--- a/tests/channels/test_channel_plugins.py
+++ b/tests/channels/test_channel_plugins.py
@@ -2558,7 +2558,7 @@ def test_optional_dependency_metadata_for_enable():
     ):
         assert not any(dep.startswith(dep_name) for dep in required)
     for dependency in (
-        "tzdata>=2025.2; sys_platform == 'win32'",
+        "tzdata>=2025.2",
         "defusedxml>=0.7.1,<1.0.0",
         "pypdf>=5.0.0,<6.0.0",
         "python-docx>=1.1.0,<2.0.0",

--- a/tests/config/test_model_presets.py
+++ b/tests/config/test_model_presets.py
@@ -1,4 +1,8 @@
 import json
+import os
+import subprocess
+import sys
+import textwrap
 import warnings
 
 import pytest
@@ -40,6 +44,32 @@ def test_model_preset_catalog_missing_env_reports_explicit_config_path(
 def test_agent_timezone_rejects_unknown_iana_name() -> None:
     with pytest.raises(ValueError, match="unknown timezone"):
         Config.model_validate({"agents": {"defaults": {"timezone": "Not/AZone"}}})
+
+
+def test_agent_timezones_use_packaged_data_without_system_database() -> None:
+    script = textwrap.dedent(
+        """\
+        from zoneinfo import TZPATH
+
+        from nanobot.config.schema import Config
+
+        assert not TZPATH
+        for name in ("UTC", "Asia/Shanghai"):
+            config = Config.model_validate({"agents": {"defaults": {"timezone": name}}})
+            serialized = config.model_dump(mode="json", by_alias=True)
+            restored = Config.model_validate(serialized)
+            assert restored.agents.defaults.timezone == name
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=os.environ | {"PYTHONTZPATH": ""},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_provider_api_type_accepts_exact_values_only() -> None:


### PR DESCRIPTION
## Summary

- install `tzdata` as the standard-library `zoneinfo` fallback on every platform
- preserve strict invalid-timezone validation while supporting Termux and other minimal Linux hosts without a system timezone database
- add an isolated subprocess regression for `UTC` and `Asia/Shanghai`, plus direct dependency metadata coverage

## Root cause

`tzdata` was conditioned on `sys_platform == 'win32'`. Termux and other minimal Linux environments can also lack system TZif files, so loading the default `UTC` setting failed before startup. Python's `zoneinfo` already prefers system data and uses the package only as a fallback, so removing the marker does not change the lookup order on hosts with a system database.

## Verification

- focused timezone, dependency, and config checks: 4 passed
- config suite plus dependency contract: 103 passed
- full Python 3.13 suite: 5,964 passed, 11 skipped
- Python 3.14 focused platform checks: 3 passed
- strict BasedPyright: 0 errors
- full CI Ruff target: all checks passed
- dependency consistency: no broken requirements
- installed metadata: `tzdata>=2025.2` without a platform marker
- `git diff --check`

Closes https://github.com/HKUDS/nanobot/issues/5187