### PR TITLE
fix(slack): scope channel thread openers to their own session

### DIFF
--- a/nanobot/channels/slack/runtime.py
+++ b/nanobot/channels/slack/runtime.py
@@ -493,12 +493,11 @@ class SlackChannel(BaseChannel):
         except Exception as e:
             self.logger.debug("reactions_add failed: {}", e)
 
-        # Thread-scoped session key whenever the user is in a real thread
-        # (raw_thread_ts is set). DM threads get their own session, separate
-        # from the DM root, so context doesn't bleed across thread boundaries.
-        session_key = (
-            f"slack:{chat_id}:{thread_ts}" if thread_ts and raw_thread_ts else None
-        )
+        # Thread-scoped session key whenever the turn lives in a thread: either the
+        # message arrived inside one (raw_thread_ts) or reply_in_thread opens a new
+        # thread for this channel message. DM roots have no thread_ts and keep the
+        # default per-chat session, so context doesn't bleed across thread boundaries.
+        session_key = f"slack:{chat_id}:{thread_ts}" if thread_ts else None
         media_paths: list[str] = []
         file_markers: list[str] = []
         for file_info in _as_json_list(event.get("files")) or []:

--- a/nanobot/channels/slack/tests/test_slack_channel.py
+++ b/nanobot/channels/slack/tests/test_slack_channel.py
@@ -555,6 +555,113 @@ async def test_dm_thread_message_keeps_thread_ts_and_threaded_session() -> None:
     assert kwargs["metadata"]["slack"]["thread_ts"] == "1700000000.000100"
 
 
+def _channel_mention_request(envelope_id: str, ts: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        type="events_api",
+        envelope_id=envelope_id,
+        payload={
+            "event": {
+                "type": "app_mention",
+                "user": "U1",
+                "channel": "C123",
+                "text": "<@UBOT> hello",
+                "ts": ts,
+            }
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_channel_root_message_uses_thread_scoped_session() -> None:
+    """A channel mention that opens a thread belongs to that thread's session."""
+    channel = SlackChannel(SlackConfig(enabled=True), MessageBus())
+    channel._bot_user_id = "UBOT"
+    channel._web_client = _FakeAsyncWebClient()
+    channel._handle_message = AsyncMock()  # type: ignore[method-assign]
+    client = SimpleNamespace(send_socket_mode_response=AsyncMock())
+
+    req = _channel_mention_request("env-c1", "1700000000.000100")
+
+    await channel._on_socket_request(client, req)
+
+    channel._handle_message.assert_awaited_once()
+    kwargs = channel._handle_message.await_args.kwargs
+    assert kwargs["session_key"] == "slack:C123:1700000000.000100"
+    assert kwargs["metadata"]["slack"]["thread_ts"] == "1700000000.000100"
+
+
+@pytest.mark.asyncio
+async def test_channel_root_messages_do_not_share_one_session() -> None:
+    """Two threads opened in the same channel must not collapse into one session."""
+    channel = SlackChannel(SlackConfig(enabled=True), MessageBus())
+    channel._bot_user_id = "UBOT"
+    channel._web_client = _FakeAsyncWebClient()
+    channel._handle_message = AsyncMock()  # type: ignore[method-assign]
+    client = SimpleNamespace(send_socket_mode_response=AsyncMock())
+
+    first = _channel_mention_request("env-c1", "1700000000.000100")
+    second = _channel_mention_request("env-c2", "1700000000.000200")
+
+    await channel._on_socket_request(client, first)
+    await channel._on_socket_request(client, second)
+
+    session_keys = [call.kwargs["session_key"] for call in channel._handle_message.await_args_list]
+    assert session_keys == [
+        "slack:C123:1700000000.000100",
+        "slack:C123:1700000000.000200",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_channel_root_message_without_reply_in_thread_uses_channel_session() -> None:
+    """With reply_in_thread disabled no thread is opened, so the channel session is used."""
+    channel = SlackChannel(SlackConfig(enabled=True, reply_in_thread=False), MessageBus())
+    channel._bot_user_id = "UBOT"
+    channel._web_client = _FakeAsyncWebClient()
+    channel._handle_message = AsyncMock()  # type: ignore[method-assign]
+    client = SimpleNamespace(send_socket_mode_response=AsyncMock())
+
+    req = _channel_mention_request("env-c3", "1700000000.000300")
+
+    await channel._on_socket_request(client, req)
+
+    channel._handle_message.assert_awaited_once()
+    kwargs = channel._handle_message.await_args.kwargs
+    assert kwargs["session_key"] is None
+    assert kwargs["metadata"]["slack"]["thread_ts"] is None
+
+
+@pytest.mark.asyncio
+async def test_channel_thread_reply_keeps_thread_session() -> None:
+    """A reply inside a channel thread stays in the session opened by the root message."""
+    channel = SlackChannel(SlackConfig(enabled=True), MessageBus())
+    channel._bot_user_id = "UBOT"
+    channel._web_client = _FakeAsyncWebClient()
+    channel._handle_message = AsyncMock()  # type: ignore[method-assign]
+    channel._with_thread_context = AsyncMock(return_value="hello")  # type: ignore[method-assign]
+    client = SimpleNamespace(send_socket_mode_response=AsyncMock())
+    req = SimpleNamespace(
+        type="events_api",
+        envelope_id="env-c4",
+        payload={
+            "event": {
+                "type": "app_mention",
+                "user": "U1",
+                "channel": "C123",
+                "text": "<@UBOT> follow up",
+                "ts": "1700000000.000400",
+                "thread_ts": "1700000000.000100",
+            }
+        },
+    )
+
+    await channel._on_socket_request(client, req)
+
+    channel._handle_message.assert_awaited_once()
+    kwargs = channel._handle_message.await_args.kwargs
+    assert kwargs["session_key"] == "slack:C123:1700000000.000100"
+
+
 @pytest.mark.asyncio
 async def test_slack_slash_command_skips_thread_context() -> None:
     channel = SlackChannel(SlackConfig(enabled=True, allow_from=[]), MessageBus())


### PR DESCRIPTION
## Summary

A top-level channel message that opens a Slack thread falls back to the channel-wide session. Every new thread therefore begins life in one shared session and only becomes thread-scoped from its first reply onward, so unrelated threads see each other's opening turns.

The session key requires `raw_thread_ts`, which Slack only sets on messages that already arrived *inside* a thread — never on the message that opens one:

```python
session_key = (
    f"slack:{chat_id}:{thread_ts}" if thread_ts and raw_thread_ts else None
)
```

#1048 shipped this correctly with `thread_ts and channel_type != "im"`, so a mention that opened a thread got its own session. Commit 82c5083 (`fix(slack): preserve DM thread routing and strip trailing newlines`) swapped the guard to `raw_thread_ts` so a thread inside a DM would get a session separate from the DM root. That fixed DMs, but channel thread openers stopped qualifying.

## What Changed

Key off `thread_ts` alone. It is already computed just above, and is set precisely when the turn will live in a thread:

| Case | `thread_ts` | Session | Change |
|---|---|---|---|
| Message inside a thread (channel or DM) | `raw_thread_ts` | thread-scoped | unchanged |
| Channel message, `replyInThread` on | `event_ts` — the thread the bot is about to open | thread-scoped | **restored** |
| DM root | none | default per-chat | unchanged (82c5083 preserved) |
| Channel message, `replyInThread` off | none | channel | unchanged |

Because `thread_ts` already encodes the DM-root exception, the fix is a deletion rather than a wider condition. This also matches how `_on_block_action` derives its session key.

## Test plan

Four tests added to `nanobot/channels/slack/tests/test_slack_channel.py`:

- `test_channel_root_message_uses_thread_scoped_session` — an opener gets `slack:C123:{ts}`
- `test_channel_root_messages_do_not_share_one_session` — two openers in one channel get distinct keys
- `test_channel_root_message_without_reply_in_thread_uses_channel_session` — `replyInThread` off still uses the channel session
- `test_channel_thread_reply_keeps_thread_session` — a reply stays in the opener's session

The two existing DM tests from 82c5083 (`test_dm_root_message_has_no_thread_ts_and_no_thread_session`, `test_dm_thread_message_keeps_thread_ts_and_threaded_session`) are unmodified and still pass.

```
pytest nanobot/channels/slack/tests/   # 31 passed
pytest                                 # 5521 passed, 22 skipped
ruff check nanobot/channels/slack/     # clean
basedpyright nanobot/channels/slack/   # 0 errors, 0 warnings
```
