### PR TITLE
feat(providers): support DeepSeek Responses API

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -374,8 +374,8 @@ is required. The Responses API is currently not available for `deepseek-v4-pro`.
 DeepSeek's Responses API is stateless: nanobot replays its local conversation state
 instead of using `previous_response_id` or server-side conversations. It supports
 function tools and streamed reasoning/text events, while unsupported OpenAI-specific
-features such as server compaction, `include`, and image/file input are not enabled by
-nanobot for this model.
+features such as server compaction and `include` are not enabled by nanobot for this
+model. DeepSeek does not support image or file input on this API surface.
 
 </details>
 
@@ -388,7 +388,8 @@ conversation, which helps with multi-step tasks. Supported providers can also
 compact long conversations automatically.
 
 nanobot preserves Responses conversation state automatically for OpenAI
-Responses, OpenAI Codex, Azure OpenAI, and compatible GitHub Copilot models.
+Responses, OpenAI Codex, Azure OpenAI, DeepSeek V4 Flash, and compatible GitHub
+Copilot models.
 Native compaction is also automatic when the provider supports it. The
 threshold is derived from the active model's context window and reserved output
 headroom; no provider configuration is required.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -348,31 +348,6 @@ Valid `apiType` values are exactly `auto`, `chat_completions`, and `responses`.
 
 </details>
 
-<details>
-<summary><b>DeepSeek</b></summary>
-
-DeepSeek uses Chat Completions for most models. `deepseek-v4-flash` automatically uses DeepSeek's native Responses API when selected as the active model; no `apiType` setting is required. The Responses API is currently not available for `deepseek-v4-pro`.
-
-```json
-{
-  "providers": {
-    "deepseek": {
-      "apiKey": "${DEEPSEEK_API_KEY}"
-    }
-  },
-  "modelPresets": {
-    "primary": {
-      "provider": "deepseek",
-      "model": "deepseek-v4-flash"
-    }
-  }
-}
-```
-
-DeepSeek's Responses API is stateless: nanobot replays its local conversation state instead of using `previous_response_id` or server-side conversations. It supports function tools and streamed reasoning/text events, while unsupported OpenAI-specific features such as server compaction and `include` are not enabled by nanobot for this model. DeepSeek does not support image or file input on this API surface.
-
-</details>
-
 <a id="responses-state-and-compaction"></a>
 
 ### Responses conversation state and compaction

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -348,6 +348,37 @@ Valid `apiType` values are exactly `auto`, `chat_completions`, and `responses`.
 
 </details>
 
+<details>
+<summary><b>DeepSeek</b></summary>
+
+DeepSeek uses Chat Completions for most models. `deepseek-v4-flash` automatically uses
+DeepSeek's native Responses API when selected as the active model; no `apiType` setting
+is required. The Responses API is currently not available for `deepseek-v4-pro`.
+
+```json
+{
+  "providers": {
+    "deepseek": {
+      "apiKey": "${DEEPSEEK_API_KEY}"
+    }
+  },
+  "modelPresets": {
+    "primary": {
+      "provider": "deepseek",
+      "model": "deepseek-v4-flash"
+    }
+  }
+}
+```
+
+DeepSeek's Responses API is stateless: nanobot replays its local conversation state
+instead of using `previous_response_id` or server-side conversations. It supports
+function tools and streamed reasoning/text events, while unsupported OpenAI-specific
+features such as server compaction, `include`, and image/file input are not enabled by
+nanobot for this model.
+
+</details>
+
 <a id="responses-state-and-compaction"></a>
 
 ### Responses conversation state and compaction

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -351,9 +351,7 @@ Valid `apiType` values are exactly `auto`, `chat_completions`, and `responses`.
 <details>
 <summary><b>DeepSeek</b></summary>
 
-DeepSeek uses Chat Completions for most models. `deepseek-v4-flash` automatically uses
-DeepSeek's native Responses API when selected as the active model; no `apiType` setting
-is required. The Responses API is currently not available for `deepseek-v4-pro`.
+DeepSeek uses Chat Completions for most models. `deepseek-v4-flash` automatically uses DeepSeek's native Responses API when selected as the active model; no `apiType` setting is required. The Responses API is currently not available for `deepseek-v4-pro`.
 
 ```json
 {
@@ -371,11 +369,7 @@ is required. The Responses API is currently not available for `deepseek-v4-pro`.
 }
 ```
 
-DeepSeek's Responses API is stateless: nanobot replays its local conversation state
-instead of using `previous_response_id` or server-side conversations. It supports
-function tools and streamed reasoning/text events, while unsupported OpenAI-specific
-features such as server compaction and `include` are not enabled by nanobot for this
-model. DeepSeek does not support image or file input on this API surface.
+DeepSeek's Responses API is stateless: nanobot replays its local conversation state instead of using `previous_response_id` or server-side conversations. It supports function tools and streamed reasoning/text events, while unsupported OpenAI-specific features such as server compaction and `include` are not enabled by nanobot for this model. DeepSeek does not support image or file input on this API surface.
 
 </details>
 
@@ -387,9 +381,7 @@ Providers that use the Responses API can keep reasoning context across a
 conversation, which helps with multi-step tasks. Supported providers can also
 compact long conversations automatically.
 
-nanobot preserves Responses conversation state automatically for OpenAI
-Responses, OpenAI Codex, Azure OpenAI, DeepSeek V4 Flash, and compatible GitHub
-Copilot models.
+nanobot preserves Responses conversation state automatically for OpenAI Responses, OpenAI Codex, Azure OpenAI, DeepSeek V4 Flash, and compatible GitHub Copilot models.
 Native compaction is also automatic when the provider supports it. The
 threshold is derived from the active model's context window and reserved output
 headroom; no provider configuration is required.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -231,10 +231,7 @@ Arbitrary custom provider names are OpenAI-compatible only; they do not use the 
 
 `providers.openai.apiType` may be set when you need to force a specific OpenAI API surface. Other providers reject `apiType`; leave it unset outside `providers.openai`. Replace the model with a model ID available to your OpenAI account. Direct OpenAI Responses, OpenAI Codex, Azure OpenAI Responses, and eligible GitHub Copilot models share [opaque Responses state retention](./configuration.md#responses-state-and-compaction); native compaction is enabled only where the backend supports it.
 
-DeepSeek is the model-level exception in the OpenAI-compatible provider: `deepseek-v4-flash`
-automatically uses DeepSeek's native Responses API, while `deepseek-v4-pro` remains on Chat
-Completions until DeepSeek enables Responses support for it. See the [DeepSeek configuration
-notes](./configuration.md) for the stateless replay and unsupported-feature details.
+DeepSeek is the model-level exception in the OpenAI-compatible provider: `deepseek-v4-flash` automatically uses DeepSeek's native Responses API, while `deepseek-v4-pro` remains on Chat Completions until DeepSeek enables Responses support for it. See the [DeepSeek configuration notes](./configuration.md) for the stateless replay and unsupported-feature details.
 
 ### Custom OpenAI-Compatible Endpoint
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -231,7 +231,7 @@ Arbitrary custom provider names are OpenAI-compatible only; they do not use the 
 
 `providers.openai.apiType` may be set when you need to force a specific OpenAI API surface. Other providers reject `apiType`; leave it unset outside `providers.openai`. Replace the model with a model ID available to your OpenAI account. Direct OpenAI Responses, OpenAI Codex, Azure OpenAI Responses, and eligible GitHub Copilot models share [opaque Responses state retention](./configuration.md#responses-state-and-compaction); native compaction is enabled only where the backend supports it.
 
-DeepSeek is the model-level exception in the OpenAI-compatible provider: `deepseek-v4-flash` automatically uses DeepSeek's native Responses API, while `deepseek-v4-pro` remains on Chat Completions until DeepSeek enables Responses support for it. See the [DeepSeek configuration notes](./configuration.md) for the stateless replay and unsupported-feature details.
+DeepSeek is the model-level exception in the OpenAI-compatible provider: `deepseek-v4-flash` automatically uses DeepSeek's native Responses API, while `deepseek-v4-pro` remains on Chat Completions.
 
 ### Custom OpenAI-Compatible Endpoint
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -231,6 +231,11 @@ Arbitrary custom provider names are OpenAI-compatible only; they do not use the 
 
 `providers.openai.apiType` may be set when you need to force a specific OpenAI API surface. Other providers reject `apiType`; leave it unset outside `providers.openai`. Replace the model with a model ID available to your OpenAI account. Direct OpenAI Responses, OpenAI Codex, Azure OpenAI Responses, and eligible GitHub Copilot models share [opaque Responses state retention](./configuration.md#responses-state-and-compaction); native compaction is enabled only where the backend supports it.
 
+DeepSeek is the model-level exception in the OpenAI-compatible provider: `deepseek-v4-flash`
+automatically uses DeepSeek's native Responses API, while `deepseek-v4-pro` remains on Chat
+Completions until DeepSeek enables Responses support for it. See the [DeepSeek configuration
+notes](./configuration.md) for the stateless replay and unsupported-feature details.
+
 ### Custom OpenAI-Compatible Endpoint
 
 The `custom` provider fits one OpenAI-compatible endpoint that is not represented by a named provider.

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -1841,6 +1841,7 @@ class OpenAICompatProvider(LLMProvider):
                         _timed_stream(),
                         on_content_delta,
                         on_tool_call_delta=on_tool_call_delta,
+                        on_reasoning_delta=on_thinking_delta,
                         capture=capture,
                     )
                     self._record_responses_success(model, reasoning_effort)

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -958,22 +958,34 @@ class OpenAICompatProvider(LLMProvider):
         model: str | None,
         reasoning_effort: str | None,
     ) -> bool:
-        """Use Responses API only for direct OpenAI requests that benefit from it."""
+        """Choose Responses for providers/models that explicitly support it."""
         if self._api_type == "chat_completions":
             return False
-        if self._spec and self._spec.name not in ("openai", "github_copilot"):
+        spec_name = self._spec.name if self._spec is not None else None
+        model_name = self._request_model_name(model or self.default_model).lower()
+        supported_models = {
+            supported.lower()
+            for supported in getattr(self._spec, "responses_models", ())
+        }
+        model_responses = any(
+            model_name == supported or model_name.endswith(f"/{supported}")
+            for supported in supported_models
+        )
+        provider_responses = spec_name in ("openai", "github_copilot")
+        if not provider_responses and not model_responses:
             return False
         if self._api_type == "responses":
             # Explicit configuration means Responses is mandatory; do not
             # consult the circuit breaker or fall back to Chat Completions.
             return True
-        if self._spec is None or self._spec.name != "github_copilot":
+        if provider_responses and (self._spec is None or self._spec.name != "github_copilot"):
             if not _is_direct_openai_base(self._effective_base):
                 return False
 
-        model_name = (model or self.default_model).lower()
         wants = False
-        if reasoning_effort and reasoning_effort.lower() != "none":
+        if model_responses:
+            wants = True
+        elif reasoning_effort and reasoning_effort.lower() != "none":
             wants = True
         elif any(token in model_name for token in ("gpt-5", "o1", "o3", "o4")):
             wants = True
@@ -1099,11 +1111,13 @@ class OpenAICompatProvider(LLMProvider):
                     self._sanitize_empty_content(sanitized_state.pending_messages)
                 )
             )
+        preserve_reasoning = bool(self._spec and self._spec.name == "deepseek")
         instructions, input_items, replayed = prepare_responses_input(
             sanitized_messages,
             state=sanitized_state,
             provider=self._responses_state_provider(),
             model=model_name,
+            preserve_reasoning=preserve_reasoning,
         )
 
         body: dict[str, Any] = {
@@ -1131,7 +1145,7 @@ class OpenAICompatProvider(LLMProvider):
         if self._supports_temperature(model_name, reasoning_effort):
             body["temperature"] = temperature
 
-        if not self._supports_temperature(model_name, reasoning_effort):
+        if not self._supports_temperature(model_name, reasoning_effort) and not preserve_reasoning:
             body["include"] = ["reasoning.encrypted_content"]
         if reasoning_effort and reasoning_effort.lower() != "none":
             body["reasoning"] = {"effort": reasoning_effort}

--- a/nanobot/providers/openai_responses/converters.py
+++ b/nanobot/providers/openai_responses/converters.py
@@ -12,7 +12,11 @@ def _as_json_object(value: object) -> dict[str, Any] | None:
     return cast(dict[str, Any], value) if isinstance(value, dict) else None
 
 
-def convert_messages(messages: list[dict[str, Any]]) -> tuple[str, list[dict[str, Any]]]:
+def convert_messages(
+    messages: list[dict[str, Any]],
+    *,
+    preserve_reasoning: bool = False,
+) -> tuple[str, list[dict[str, Any]]]:
     """Convert Chat Completions messages to Responses API input items.
 
     Returns ``(system_prompt, input_items)`` where *system_prompt* is extracted
@@ -36,6 +40,13 @@ def convert_messages(messages: list[dict[str, Any]]) -> tuple[str, list[dict[str
             continue
 
         if role == "assistant":
+            if preserve_reasoning:
+                reasoning = msg.get("reasoning_content")
+                if isinstance(reasoning, str) and reasoning:
+                    input_items.append({
+                        "type": "reasoning",
+                        "content": reasoning,
+                    })
             if isinstance(content, str) and content:
                 message_id = _unique_item_id(f"msg_{idx}", used_item_ids)
                 input_items.append({

--- a/nanobot/providers/openai_responses/parsing.py
+++ b/nanobot/providers/openai_responses/parsing.py
@@ -324,20 +324,14 @@ async def consume_sse_with_reasoning(
                 emitted_refusal_text += remaining_text
                 if on_content_delta and remaining_text:
                     await on_content_delta(remaining_text)
-        elif event_type in {
-            "response.reasoning_summary_text.delta",
-            "response.reasoning_text.delta",
-        }:
+        elif event_type == "response.reasoning_summary_text.delta":
             delta_text = event.get("delta") or ""
             if delta_text:
                 reasoning_content = (reasoning_content or "") + delta_text
                 streamed_reasoning = True
                 if on_reasoning_delta:
                     await on_reasoning_delta(delta_text)
-        elif event_type in {
-            "response.reasoning_summary_text.done",
-            "response.reasoning_text.done",
-        }:
+        elif event_type == "response.reasoning_summary_text.done":
             text = event.get("text") or ""
             if text and not streamed_reasoning and not reasoning_content:
                 reasoning_content = text

--- a/nanobot/providers/openai_responses/parsing.py
+++ b/nanobot/providers/openai_responses/parsing.py
@@ -335,6 +335,19 @@ async def consume_sse_with_reasoning(
                 reasoning_content = text
                 if on_reasoning_delta:
                     await on_reasoning_delta(text)
+        elif event_type == "response.reasoning_text.delta":
+            delta_text = event.get("delta") or ""
+            if delta_text:
+                reasoning_content = (reasoning_content or "") + delta_text
+                streamed_reasoning = True
+                if on_reasoning_delta:
+                    await on_reasoning_delta(delta_text)
+        elif event_type == "response.reasoning_text.done":
+            text = event.get("text") or ""
+            if text and not streamed_reasoning and not reasoning_content:
+                reasoning_content = text
+                if on_reasoning_delta:
+                    await on_reasoning_delta(text)
         elif event_type == "response.reasoning_summary_part.done":
             part = _as_json_object(event.get("part")) or {}
             text = part.get("text") if part.get("type") == "summary_text" else None
@@ -444,6 +457,14 @@ def _extract_reasoning_summary_from_output(output: object) -> str | None:
     for item in _response_object_list(output):
         if item.get("type") != "reasoning":
             continue
+        content = item.get("content")
+        if isinstance(content, str) and content:
+            parts.append(content)
+        elif isinstance(content, list):
+            for block in _response_object_list(cast(list[object], content)):
+                text = block.get("text")
+                if isinstance(text, str) and text:
+                    parts.append(text)
         for summary in _response_object_list(item.get("summary")):
             if summary.get("type") == "summary_text" and summary.get("text"):
                 text = summary.get("text")
@@ -483,11 +504,9 @@ def parse_response_output(
                     if isinstance(refusal, str):
                         content_parts.append(refusal)
         elif item_type == "reasoning":
-            for s in _response_object_list(item.get("summary")):
-                if s.get("type") == "summary_text" and s.get("text"):
-                    text = s.get("text")
-                    if isinstance(text, str):
-                        reasoning_content = (reasoning_content or "") + text
+            text = _extract_reasoning_summary_from_output([item])
+            if text:
+                reasoning_content = (reasoning_content or "") + text
         elif item_type == "function_call":
             call_id = item.get("call_id") or ""
             item_id = item.get("id") or "fc_0"

--- a/nanobot/providers/openai_responses/parsing.py
+++ b/nanobot/providers/openai_responses/parsing.py
@@ -69,7 +69,9 @@ def _response_object(value: object) -> dict[str, Any] | None:
         return object_value
     dump = getattr(value, "model_dump", None)
     if callable(dump):
-        return _as_json_object(dump())
+        dumped = _as_json_object(dump())
+        if dumped is not None:
+            return dumped
     try:
         return _as_json_object(vars(value))
     except TypeError:
@@ -322,27 +324,20 @@ async def consume_sse_with_reasoning(
                 emitted_refusal_text += remaining_text
                 if on_content_delta and remaining_text:
                     await on_content_delta(remaining_text)
-        elif event_type == "response.reasoning_summary_text.delta":
+        elif event_type in {
+            "response.reasoning_summary_text.delta",
+            "response.reasoning_text.delta",
+        }:
             delta_text = event.get("delta") or ""
             if delta_text:
                 reasoning_content = (reasoning_content or "") + delta_text
                 streamed_reasoning = True
                 if on_reasoning_delta:
                     await on_reasoning_delta(delta_text)
-        elif event_type == "response.reasoning_summary_text.done":
-            text = event.get("text") or ""
-            if text and not streamed_reasoning and not reasoning_content:
-                reasoning_content = text
-                if on_reasoning_delta:
-                    await on_reasoning_delta(text)
-        elif event_type == "response.reasoning_text.delta":
-            delta_text = event.get("delta") or ""
-            if delta_text:
-                reasoning_content = (reasoning_content or "") + delta_text
-                streamed_reasoning = True
-                if on_reasoning_delta:
-                    await on_reasoning_delta(delta_text)
-        elif event_type == "response.reasoning_text.done":
+        elif event_type in {
+            "response.reasoning_summary_text.done",
+            "response.reasoning_text.done",
+        }:
             text = event.get("text") or ""
             if text and not streamed_reasoning and not reasoning_content:
                 reasoning_content = text
@@ -724,30 +719,11 @@ async def consume_sdk_stream(
                         "total_tokens": int(getattr(usage_obj, "total_tokens", 0) or 0),
                     }
                 if not reasoning_content:
-                    reasoning_parts: list[str] = []
-                    for out_item in cast(list[Any], getattr(resp, "output", None) or []):
-                        if getattr(out_item, "type", None) != "reasoning":
-                            continue
-                        reasoning_item_content = getattr(out_item, "content", None)
-                        if isinstance(reasoning_item_content, str) and reasoning_item_content:
-                            reasoning_parts.append(reasoning_item_content)
-                        elif isinstance(reasoning_item_content, list):
-                            for block in cast(list[Any], reasoning_item_content):
-                                text = getattr(block, "text", None)
-                                if isinstance(text, str) and text:
-                                    reasoning_parts.append(text)
-                        for summary in cast(
-                            list[Any],
-                            getattr(out_item, "summary", None) or [],
-                        ):
-                            if getattr(summary, "type", None) == "summary_text":
-                                text = getattr(summary, "text", None)
-                                if isinstance(text, str) and text:
-                                    reasoning_parts.append(text)
-                    if reasoning_parts:
-                        reasoning_content = "".join(reasoning_parts)
-                        if on_reasoning_delta:
-                            await on_reasoning_delta(reasoning_content)
+                    reasoning_content = _extract_reasoning_summary_from_output(
+                        getattr(resp, "output", None)
+                    )
+                    if reasoning_content and on_reasoning_delta:
+                        await on_reasoning_delta(reasoning_content)
         elif event_type in {"error", "response.failed"}:
             detail = getattr(event, "error", None) or getattr(event, "message", None) or event
             raise RuntimeError(f"Response failed: {str(detail)[:500]}")

--- a/nanobot/providers/openai_responses/parsing.py
+++ b/nanobot/providers/openai_responses/parsing.py
@@ -551,6 +551,7 @@ async def consume_sdk_stream(
     stream: Any,
     on_content_delta: Callable[[str], Awaitable[None]] | None = None,
     on_tool_call_delta: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+    on_reasoning_delta: Callable[[str], Awaitable[None]] | None = None,
     capture: ResponsesStreamCapture | None = None,
 ) -> tuple[str, list[ToolCallRequest], str, dict[str, int], str | None]:
     """Consume an SDK async stream from ``client.responses.create(stream=True)``."""
@@ -561,6 +562,7 @@ async def consume_sdk_stream(
     finish_reason = "stop"
     usage: dict[str, int] = {}
     reasoning_content: str | None = None
+    streamed_reasoning = False
     refusal_seen = False
     refusal_deltas: dict[tuple[str | None, int | None], str] = {}
     emitted_refusal_text = ""
@@ -591,6 +593,19 @@ async def consume_sdk_stream(
             content += delta_text
             if on_content_delta and delta_text:
                 await on_content_delta(delta_text)
+        elif event_type == "response.reasoning_text.delta":
+            delta_text = getattr(event, "delta", "") or ""
+            if delta_text:
+                reasoning_content = (reasoning_content or "") + delta_text
+                streamed_reasoning = True
+                if on_reasoning_delta:
+                    await on_reasoning_delta(delta_text)
+        elif event_type == "response.reasoning_text.done":
+            text = getattr(event, "text", "") or ""
+            if text and not streamed_reasoning and not reasoning_content:
+                reasoning_content = text
+                if on_reasoning_delta:
+                    await on_reasoning_delta(text)
         elif event_type == "response.refusal.delta":
             refusal_seen = True
             delta_text = getattr(event, "delta", None)
@@ -708,13 +723,31 @@ async def consume_sdk_stream(
                         "completion_tokens": int(getattr(usage_obj, "output_tokens", 0) or 0),
                         "total_tokens": int(getattr(usage_obj, "total_tokens", 0) or 0),
                     }
-                for out_item in cast(list[Any], getattr(resp, "output", None) or []):
-                    if getattr(out_item, "type", None) == "reasoning":
-                        for s in cast(list[Any], getattr(out_item, "summary", None) or []):
-                            if getattr(s, "type", None) == "summary_text":
-                                text = getattr(s, "text", None)
-                                if text:
-                                    reasoning_content = (reasoning_content or "") + text
+                if not reasoning_content:
+                    reasoning_parts: list[str] = []
+                    for out_item in cast(list[Any], getattr(resp, "output", None) or []):
+                        if getattr(out_item, "type", None) != "reasoning":
+                            continue
+                        reasoning_item_content = getattr(out_item, "content", None)
+                        if isinstance(reasoning_item_content, str) and reasoning_item_content:
+                            reasoning_parts.append(reasoning_item_content)
+                        elif isinstance(reasoning_item_content, list):
+                            for block in cast(list[Any], reasoning_item_content):
+                                text = getattr(block, "text", None)
+                                if isinstance(text, str) and text:
+                                    reasoning_parts.append(text)
+                        for summary in cast(
+                            list[Any],
+                            getattr(out_item, "summary", None) or [],
+                        ):
+                            if getattr(summary, "type", None) == "summary_text":
+                                text = getattr(summary, "text", None)
+                                if isinstance(text, str) and text:
+                                    reasoning_parts.append(text)
+                    if reasoning_parts:
+                        reasoning_content = "".join(reasoning_parts)
+                        if on_reasoning_delta:
+                            await on_reasoning_delta(reasoning_content)
         elif event_type in {"error", "response.failed"}:
             detail = getattr(event, "error", None) or getattr(event, "message", None) or event
             raise RuntimeError(f"Response failed: {str(detail)[:500]}")

--- a/nanobot/providers/openai_responses/state.py
+++ b/nanobot/providers/openai_responses/state.py
@@ -43,6 +43,7 @@ def prepare_responses_input(
     state: ProviderConversationState | None,
     provider: str,
     model: str,
+    preserve_reasoning: bool = False,
 ) -> tuple[str, list[dict[str, Any]], bool]:
     """Build a request from exact prior items plus only newly appended messages.
 
@@ -50,7 +51,10 @@ def prepare_responses_input(
     When no compatible state exists, it is converted normally as a safe
     fallback.
     """
-    instructions, fallback_items = convert_messages(messages)
+    instructions, fallback_items = convert_messages(
+        messages,
+        preserve_reasoning=preserve_reasoning,
+    )
     if state is None or not responses_state_matches(
         state,
         provider=provider,
@@ -62,7 +66,10 @@ def prepare_responses_input(
     if prior_items is None:
         return instructions, fallback_items, False
 
-    _, delta_items = convert_messages(state.pending_messages)
+    _, delta_items = convert_messages(
+        state.pending_messages,
+        preserve_reasoning=preserve_reasoning,
+    )
     logger.debug(
         "Replaying Responses state: prior_items={} pending_messages={}",
         len(prior_items),

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -111,6 +111,11 @@ class ProviderSpec:
     # Substring match against the wire model name (lowercased).
     implicit_reasoning_models: tuple[str, ...] = ()
 
+    # Models that expose the OpenAI Responses wire format.  This is model-level
+    # because providers may add Responses support incrementally (DeepSeek V4
+    # Flash is supported before V4 Pro).
+    responses_models: tuple[str, ...] = ()
+
     # When the model returns content as a list of {"type":"thinking",...} +
     # {"type":"text",...} blocks, extract the thinking text into
     # reasoning_content. Mistral's Magistral / reasoning-enabled responses use
@@ -461,6 +466,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         backend="openai_compat",
         default_api_base="https://api.deepseek.com",
         thinking_style="thinking_type",
+        responses_models=("deepseek-v4-flash",),
     ),
     # Gemini: Google's OpenAI-compatible endpoint
     ProviderSpec(

--- a/tests/providers/test_openai_responses.py
+++ b/tests/providers/test_openai_responses.py
@@ -87,6 +87,23 @@ class TestConvertUserMessage:
         assert result["content"][0]["type"] == "input_text"
         assert result["content"][1]["type"] == "input_image"
 
+
+def test_convert_messages_preserves_deepseek_reasoning_content():
+    _, items = convert_messages([
+        {"role": "assistant", "reasoning_content": "think first", "content": "answer"},
+    ], preserve_reasoning=True)
+
+    assert items == [
+        {"type": "reasoning", "content": "think first"},
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "answer"}],
+            "status": "completed",
+            "id": "msg_0",
+        },
+    ]
+
     def test_empty_list_falls_back(self):
         result = convert_user_message([])
         assert result["content"] == [{"type": "input_text", "text": ""}]
@@ -538,6 +555,22 @@ class TestParseResponseOutput:
         result = parse_response_output(resp)
         assert result.content == "42"
         assert result.reasoning_content == "I think therefore I am."
+
+    def test_deepseek_reasoning_content_extracted(self):
+        resp = {
+            "output": [
+                {"type": "reasoning", "content": "think first"},
+                {"type": "message", "content": [
+                    {"type": "output_text", "text": "answer"},
+                ]},
+            ],
+            "status": "completed", "usage": {},
+        }
+
+        result = parse_response_output(resp)
+
+        assert result.content == "answer"
+        assert result.reasoning_content == "think first"
 
     def test_empty_output(self):
         resp = {"output": [], "status": "completed", "usage": {}}

--- a/tests/providers/test_openai_responses.py
+++ b/tests/providers/test_openai_responses.py
@@ -87,23 +87,6 @@ class TestConvertUserMessage:
         assert result["content"][0]["type"] == "input_text"
         assert result["content"][1]["type"] == "input_image"
 
-
-def test_convert_messages_preserves_deepseek_reasoning_content():
-    _, items = convert_messages([
-        {"role": "assistant", "reasoning_content": "think first", "content": "answer"},
-    ], preserve_reasoning=True)
-
-    assert items == [
-        {"type": "reasoning", "content": "think first"},
-        {
-            "type": "message",
-            "role": "assistant",
-            "content": [{"type": "output_text", "text": "answer"}],
-            "status": "completed",
-            "id": "msg_0",
-        },
-    ]
-
     def test_empty_list_falls_back(self):
         result = convert_user_message([])
         assert result["content"] == [{"type": "input_text", "text": ""}]
@@ -166,6 +149,22 @@ class TestConvertMessages:
         assert items[0]["role"] == "assistant"
         assert items[0]["content"][0]["type"] == "output_text"
         assert items[0]["content"][0]["text"] == "I'll help"
+
+    def test_preserves_deepseek_reasoning_content(self):
+        _, items = convert_messages([
+            {"role": "assistant", "reasoning_content": "think first", "content": "answer"},
+        ], preserve_reasoning=True)
+
+        assert items == [
+            {"type": "reasoning", "content": "think first"},
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "answer"}],
+                "status": "completed",
+                "id": "msg_0",
+            },
+        ]
 
     def test_assistant_empty_content_skipped(self):
         _, items = convert_messages([{"role": "assistant", "content": ""}])
@@ -1665,6 +1664,30 @@ class TestConsumeSdkStream:
 
         _, _, _, _, reasoning = await consume_sdk_stream(stream())
         assert reasoning == "thinking..."
+
+    @pytest.mark.asyncio
+    async def test_deepseek_reasoning_text_streamed(self):
+        events = [
+            MagicMock(type="response.reasoning_text.delta", delta="step 1 "),
+            MagicMock(type="response.reasoning_text.delta", delta="step 2"),
+            MagicMock(type="response.reasoning_text.done", text="step 1 step 2"),
+        ]
+        emitted: list[str] = []
+
+        async def stream():
+            for event in events:
+                yield event
+
+        async def on_reasoning_delta(delta: str) -> None:
+            emitted.append(delta)
+
+        _, _, _, _, reasoning = await consume_sdk_stream(
+            stream(),
+            on_reasoning_delta=on_reasoning_delta,
+        )
+
+        assert reasoning == "step 1 step 2"
+        assert emitted == ["step 1 ", "step 2"]
 
     @pytest.mark.asyncio
     async def test_error_event_raises(self):

--- a/tests/providers/test_responses_circuit_breaker.py
+++ b/tests/providers/test_responses_circuit_breaker.py
@@ -29,6 +29,32 @@ def test_responses_api_available_by_default(provider):
     assert provider._should_use_responses_api("gpt-5", None) is True
 
 
+def test_deepseek_v4_flash_uses_responses_by_model(provider):
+    provider._spec = type("Spec", (), {
+        "name": "deepseek",
+        "responses_models": ("deepseek-v4-flash",),
+        "strip_model_prefix": False,
+        "strip_model_prefixes": (),
+    })()
+    provider._effective_base = "https://api.deepseek.com"
+    provider.default_model = "deepseek-v4-flash"
+
+    assert provider._should_use_responses_api("deepseek-v4-flash", None) is True
+    assert provider._should_use_responses_api("deepseek-v4-pro", None) is False
+
+
+def test_deepseek_v4_flash_matches_provider_prefixed_model(provider):
+    provider._spec = type("Spec", (), {
+        "name": "deepseek",
+        "responses_models": ("deepseek-v4-flash",),
+        "strip_model_prefix": False,
+        "strip_model_prefixes": (),
+    })()
+    provider._effective_base = "https://api.deepseek.com"
+
+    assert provider._should_use_responses_api("deepseek/deepseek-v4-flash", None) is True
+
+
 def test_direct_openai_enables_server_compaction(provider):
     provider._extra_body = {}
 


### PR DESCRIPTION
## Summary

- route `deepseek-v4-flash` through DeepSeek's native Responses API while keeping other DeepSeek models on Chat Completions
- reuse the existing Responses request, local conversation-state replay, streaming, and function-tool machinery
- preserve DeepSeek plaintext reasoning items and parse `response.reasoning_text.*` events through the public thinking stream
- document the model-level routing and DeepSeek's stateless compatibility limits

## Verification

- `uv run --no-sync pytest tests/providers/test_responses_circuit_breaker.py tests/providers/test_openai_responses.py tests/config/test_model_presets.py -q` (155 passed)
- focused `ruff check` on changed Python files (passed)
- focused `basedpyright` on changed provider files (0 errors)
- real low-volume API smoke using the configured DeepSeek API key:
  - streamed text response returned expected content and usage
  - function-tool request returned `get_weather(city="Shanghai")`
  - thinking-mode stream returned reasoning content and 14 reasoning deltas

## Notes

- DeepSeek currently exposes Responses only for `deepseek-v4-flash`; `deepseek-v4-pro` remains on Chat Completions.
- DeepSeek Responses is stateless, so nanobot replays local response items rather than relying on `previous_response_id` or server compaction.