### PR TITLE
refactor(cli): narrow Pyright suppressions

### DIFF
--- a/nanobot/cli/gateway.py
+++ b/nanobot/cli/gateway.py
@@ -1,7 +1,5 @@
 """Typer commands for foreground and background gateway control."""
 
-# pyright: reportUnusedFunction=false
-
 from __future__ import annotations
 
 import subprocess
@@ -135,8 +133,9 @@ def create_gateway_app(
             console.print()
             console.print(result.content)
 
+    # Typer consumes these callbacks through decorator registration.
     @gateway_app.callback(invoke_without_command=True)
-    def gateway(
+    def gateway(  # pyright: ignore[reportUnusedFunction]
         ctx: typer.Context,
         port: int | None = typer.Option(None, "--port", "-p", help="Gateway port"),
         workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace directory"),
@@ -191,7 +190,7 @@ def create_gateway_app(
             )
 
     @gateway_app.command("status")
-    def gateway_status(
+    def gateway_status(  # pyright: ignore[reportUnusedFunction]
         workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace directory"),
         config: str | None = typer.Option(None, "--config", "-c", help="Path to config file"),
     ) -> None:
@@ -199,7 +198,7 @@ def create_gateway_app(
         print_status(runtime_for_instance(workspace=workspace, config=config).status())
 
     @gateway_app.command("logs")
-    def gateway_logs(
+    def gateway_logs(  # pyright: ignore[reportUnusedFunction]
         tail: int = typer.Option(200, "--tail", help="Number of recent lines to show"),
         follow: bool = typer.Option(True, "--follow/--no-follow", help="Follow new log output"),
         workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace directory"),
@@ -217,7 +216,7 @@ def create_gateway_app(
             console.print(line)
 
     @gateway_app.command("stop")
-    def gateway_stop(
+    def gateway_stop(  # pyright: ignore[reportUnusedFunction]
         timeout: int = typer.Option(20, "--timeout", help="Stop timeout in seconds"),
         workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace directory"),
         config: str | None = typer.Option(None, "--config", "-c", help="Path to config file"),
@@ -233,7 +232,7 @@ def create_gateway_app(
             raise typer.Exit(1)
 
     @gateway_app.command("restart")
-    def gateway_restart(
+    def gateway_restart(  # pyright: ignore[reportUnusedFunction]
         port: int | None = typer.Option(None, "--port", "-p", help="Gateway port"),
         workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace directory"),
         verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),
@@ -266,7 +265,7 @@ def create_gateway_app(
         raise typer.Exit(1)
 
     @gateway_app.command("install-service")
-    def gateway_install_service(
+    def gateway_install_service(  # pyright: ignore[reportUnusedFunction]
         port: int | None = typer.Option(None, "--port", "-p", help="Gateway port"),
         workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace directory"),
         verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),
@@ -302,7 +301,7 @@ def create_gateway_app(
         raise typer.Exit(1)
 
     @gateway_app.command("uninstall-service")
-    def gateway_uninstall_service(
+    def gateway_uninstall_service(  # pyright: ignore[reportUnusedFunction]
         name: str = typer.Option("nanobot-gateway", "--name", help="Service name"),
         manager: ServiceManagerKind = typer.Option("auto", "--manager", help="auto, systemd, or launchd"),
         dry_run: bool = typer.Option(False, "--dry-run", help="Print actions without uninstalling"),

--- a/nanobot/cli/onboard.py
+++ b/nanobot/cli/onboard.py
@@ -1,7 +1,5 @@
 """Interactive onboarding questionnaire for nanobot."""
 
-# pyright: reportMissingTypeStubs=false, reportUnusedFunction=false
-
 import asyncio
 import json
 import types
@@ -206,35 +204,36 @@ def _select_with_back(
     # Key bindings
     bindings = KeyBindings()
 
+    # KeyBindings consumes these handlers through decorator registration.
     @bindings.add(Keys.Up)
-    def _up(event: KeyPressEvent) -> None:
+    def _up(event: KeyPressEvent) -> None:  # pyright: ignore[reportUnusedFunction]
         nonlocal selected_index
         selected_index = (selected_index - 1) % len(choices)
         event.app.invalidate()
 
     @bindings.add(Keys.Down)
-    def _down(event: KeyPressEvent) -> None:
+    def _down(event: KeyPressEvent) -> None:  # pyright: ignore[reportUnusedFunction]
         nonlocal selected_index
         selected_index = (selected_index + 1) % len(choices)
         event.app.invalidate()
 
     @bindings.add(Keys.Enter)
-    def _enter(event: KeyPressEvent) -> None:
+    def _enter(event: KeyPressEvent) -> None:  # pyright: ignore[reportUnusedFunction]
         state["result"] = choices[selected_index]
         event.app.exit()
 
     @bindings.add("escape")
-    def _escape(event: KeyPressEvent) -> None:
+    def _escape(event: KeyPressEvent) -> None:  # pyright: ignore[reportUnusedFunction]
         state["result"] = _BACK_PRESSED
         event.app.exit()
 
     @bindings.add(Keys.Left)
-    def _left(event: KeyPressEvent) -> None:
+    def _left(event: KeyPressEvent) -> None:  # pyright: ignore[reportUnusedFunction]
         state["result"] = _BACK_PRESSED
         event.app.exit()
 
     @bindings.add(Keys.ControlC)
-    def _ctrl_c(event: KeyPressEvent) -> None:
+    def _ctrl_c(event: KeyPressEvent) -> None:  # pyright: ignore[reportUnusedFunction]
         state["result"] = None
         event.app.exit()
 
@@ -532,8 +531,9 @@ def _input_back_key_bindings() -> KeyBindings:
     """Return key bindings that make Escape behave like a local back action."""
     bindings = KeyBindings()
 
+    # KeyBindings consumes this handler through decorator registration.
     @bindings.add("escape")
-    def _escape(event: KeyPressEvent) -> None:
+    def _escape(event: KeyPressEvent) -> None:  # pyright: ignore[reportUnusedFunction]
         event.app.exit(result=_BACK_PRESSED)
 
     return bindings
@@ -1668,7 +1668,11 @@ def _quick_start_oauth_login(config: Config, provider_name: str) -> bool:
         return False
 
     try:
-        from oauth_cli_kit import get_token, login_oauth_interactive
+        # oauth-cli-kit does not publish type information.
+        from oauth_cli_kit import (  # pyright: ignore[reportMissingTypeStubs]
+            get_token,
+            login_oauth_interactive,
+        )
     except ImportError:
         console.print("[red]oauth_cli_kit not installed. Run: pip install oauth-cli-kit[/red]")
         return False
@@ -1709,7 +1713,8 @@ def _quick_start_oauth_is_authenticated(config: Config, provider_name: str) -> b
     if provider_name != "openai_codex":
         return False
     try:
-        from oauth_cli_kit import get_token
+        # oauth-cli-kit does not publish type information.
+        from oauth_cli_kit import get_token  # pyright: ignore[reportMissingTypeStubs]
 
         proxy = _quick_start_codex_proxy(config)
         token = get_token(proxy=proxy)


### PR DESCRIPTION
## Summary

- replace the gateway module's file-level `reportUnusedFunction` suppression with line-level ignores limited to Typer-registered callbacks
- replace the onboarding module's file-level suppressions with line-level ignores limited to `KeyBindings` handlers and the untyped `oauth-cli-kit` imports
- reduce the current file-level Pyright directive count from 32 to 30 without changing the runtime AST

## Why

File-level directives hide future diagnostics of the same category anywhere in a module. These two CLI modules only need exceptions at decorator-driven registration points and at two imports from a dependency that does not publish type information.

This is a reviewable CLI-sized step toward #5161. It does not close the umbrella issue.

## Testing

- Red: removing both file-level directives produced 16 strict BasedPyright errors at the dynamically registered callbacks and untyped imports
- Green: `uv run --no-sync basedpyright nanobot/cli/gateway.py nanobot/cli/onboard.py` -> 0 errors
- Mutation: removing the `gateway_status` line-level ignore restored exactly one `reportUnusedFunction` error; the ignore was then restored
- Full strict check in the CI Python 3.14 environment: `uv run --no-sync basedpyright` -> 0 errors
- Closest tests: 237 passed, 1 skipped
- `uv run --no-sync ruff check nanobot tests conftest.py`
- `git diff --check`