### PR TITLE
fix(exec): preserve wait targets across response truncation

### DIFF
--- a/nanobot/agent/tools/exec_session.py
+++ b/nanobot/agent/tools/exec_session.py
@@ -660,7 +660,7 @@ class WriteStdinTool(Tool):
                 close_stdin=close_stdin if first else False,
                 terminate=terminate if first else False,
                 yield_time_ms=step_ms,
-                max_output_chars=max_output_chars,
+                max_output_chars=MAX_OUTPUT_CHARS,
                 owner_session_key=current_request_session_key(),
             )
             first = False

--- a/tests/tools/test_exec_session_tools.py
+++ b/tests/tools/test_exec_session_tools.py
@@ -16,11 +16,13 @@ from nanobot.agent import context as agent_context
 from nanobot.agent.loop import AgentLoop
 from nanobot.agent.tools.context import RequestContext, bind_request_context, reset_request_context
 from nanobot.agent.tools.exec_session import (
+    MAX_OUTPUT_CHARS,
     ExecSessionManager,
     ListExecSessionsTool,
     WriteStdinTool,
     _BoundedOutputBuffer,
     _SessionPoll,
+    _truncate_output,
 )
 from nanobot.agent.tools.registry import is_tool_error_result
 from nanobot.agent.tools.shell import ExecTool
@@ -224,6 +226,52 @@ def test_write_stdin_wait_for_keeps_aggregate_within_output_budget():
     assert result.startswith("HEAD")
     assert "TARGET" in result
     assert "(796 chars truncated from output)" in result
+    assert len(result) < 1100
+
+
+def test_write_stdin_wait_for_searches_before_response_truncation():
+    async def run() -> tuple[str, list[int]]:
+        output = "A" * 1500 + "TARGET" + "B" * 1500
+        observed_limits: list[int] = []
+
+        async def write(
+            *,
+            session_id: str,
+            chars: str | None,
+            close_stdin: bool,
+            terminate: bool,
+            yield_time_ms: int,
+            max_output_chars: int,
+            owner_session_key: str | None,
+        ) -> _SessionPoll:
+            del session_id, chars, close_stdin, terminate, yield_time_ms, owner_session_key
+            observed_limits.append(max_output_chars)
+            visible, truncated = _truncate_output(output, max_output_chars)
+            return _SessionPoll(
+                output=visible,
+                done=True,
+                exit_code=0,
+                truncated_chars=truncated,
+            )
+
+        manager = SimpleNamespace(write=AsyncMock(side_effect=write))
+        tool = WriteStdinTool(manager=manager)
+        result = await tool._wait_for_output(
+            session_id="session",
+            chars=None,
+            close_stdin=False,
+            terminate=False,
+            wait_for="TARGET",
+            wait_timeout_ms=1000,
+            max_output_chars=1000,
+        )
+        return result, observed_limits
+
+    result, observed_limits = asyncio.run(run())
+
+    assert observed_limits == [MAX_OUTPUT_CHARS]
+    assert "Wait target not observed" not in result
+    assert "(2,006 chars truncated from output)" in result
     assert len(result) < 1100
 
 


### PR DESCRIPTION
## Summary

- search `wait_for` against the exec session's existing bounded internal output limit
- keep the returned response bounded by the caller's `max_output_chars`
- add regression coverage for a target omitted by head/tail response truncation

## Problem

`write_stdin(wait_for=...)` passed the caller's response limit into every session poll. The poll applies head/tail truncation before returning, so a target in the omitted middle could be produced successfully but never reach the wait search. The command could exit normally while the tool incorrectly reported `Wait target not observed`.

## Approach

Poll with the existing `MAX_OUTPUT_CHARS` internal retention limit while waiting for a target. The existing `_BoundedOutputBuffer(max_output_chars)` still enforces the caller's response budget, so the change does not introduce an unbounded buffer or alter the public API.

## Testing

- TDD Red: the regression test observed a 1,000-character manager poll and reproduced the missed target
- Green: the focused regression and all 37 exec-session tool tests pass
- mutation check: restoring the old poll limit makes the regression test fail again
- real `ExecTool -> WriteStdinTool -> ExecSessionManager` smoke test observes the target, reports output truncation, and exits with code 0
- `python -m ruff check .`
- BasedPyright on the changed files: 0 errors, 0 warnings
- full pytest: 5,933 passed, 35 skipped; 7 unrelated network-mocking tests fail identically on unchanged `origin/main` in this local dependency environment

## Scope

This change only separates the bounded internal search window from the smaller caller-facing response window. Output retained beyond the existing 50,000-character session limit remains intentionally out of scope.