### PR TITLE
fix(delivery): log streamed responses exactly once

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1533,7 +1533,10 @@ class AgentLoop:
                 return None
 
         preview = final_content[:120] + "..." if len(final_content) > 120 else final_content
-        logger.info("Response to {}:{}: {}", msg.channel, msg.sender_id, preview)
+        # Streamed responses are already logged at stream finalization in
+        # TurnDelivery._publish_stream_end; skip here to avoid double-logging.
+        if not streamed_content:
+            logger.info("Response to {}:{}: {}", msg.channel, msg.sender_id, preview)
 
         event = None
         meta = dict(msg.metadata or {})

--- a/nanobot/agent/turn_delivery.py
+++ b/nanobot/agent/turn_delivery.py
@@ -8,6 +8,8 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
 
+from loguru import logger
+
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.outbound_events import (
     RetryWaitEvent,
@@ -16,7 +18,6 @@ from nanobot.bus.outbound_events import (
     StreamEndEvent,
     outbound_message_for_event,
 )
-from loguru import logger
 
 from nanobot.bus.progress import build_bus_progress_callback
 from nanobot.bus.queue import MessageBus

--- a/nanobot/agent/turn_delivery.py
+++ b/nanobot/agent/turn_delivery.py
@@ -16,6 +16,8 @@ from nanobot.bus.outbound_events import (
     StreamEndEvent,
     outbound_message_for_event,
 )
+from loguru import logger
+
 from nanobot.bus.progress import build_bus_progress_callback
 from nanobot.bus.queue import MessageBus
 from nanobot.bus.runtime_events import RuntimeEventBus, RuntimeEventPublisher
@@ -130,6 +132,7 @@ class TurnDelivery:
     _stream_base_id: str | None = field(init=False, default=None)
     _stream_segment: int = field(init=False, default=0)
     _stream_open: bool = field(init=False, default=False)
+    _stream_content: str = field(init=False, default="")
 
     def __post_init__(self) -> None:
         self.delivery_message = dataclasses.replace(
@@ -280,6 +283,7 @@ class TurnDelivery:
         return f"{self._stream_base_id}:{self._stream_segment}"
 
     async def _publish_stream(self, delta: str) -> None:
+        self._stream_content += delta
         await self.bus.publish_outbound(
             outbound_message_for_event(
                 channel=self.delivery_message.channel,
@@ -310,6 +314,18 @@ class TurnDelivery:
         )
         self._stream_open = merge_next
         if not merge_next:
+            # A user-visible message is finalized here. Log it so every
+            # delivered message is recorded regardless of delivery path.
+            content = self._stream_content
+            self._stream_content = ""
+            if content:
+                preview = content[:120] + "..." if len(content) > 120 else content
+                logger.info(
+                    "Delivered streamed response to {}:{}: {}",
+                    self.delivery_message.channel,
+                    self.delivery_message.chat_id,
+                    preview,
+                )
             self._stream_segment += 1
 
     async def abort_stream(self) -> None:

--- a/tests/agent/test_turn_delivery.py
+++ b/tests/agent/test_turn_delivery.py
@@ -198,3 +198,51 @@ def test_late_subagent_route_requires_webui_owned_session(tmp_path: Path) -> Non
         "injected_event": "subagent_result",
         "subagent_task_id": "sub-1",
     }
+
+
+def test_streamed_response_logged_exactly_once() -> None:
+    """A finalized streamed response is logged exactly once with full content."""
+    import asyncio
+
+    from loguru import logger as loguru_logger
+
+    from nanobot.agent.turn_delivery import TurnDelivery, TurnRoute
+    from nanobot.bus.events import InboundMessage
+    from nanobot.bus.queue import MessageBus
+    from nanobot.bus.runtime_events import RuntimeEventBus
+
+    bus = MessageBus()
+    msg = InboundMessage(
+        channel="telegram",
+        sender_id="user",
+        chat_id="c1",
+        content="hi",
+    )
+    delivery = TurnDelivery(
+        bus=bus,
+        runtime_event_publisher=RuntimeEventBus(),
+        input_message=msg,
+        session_key="telegram:c1",
+        route=TurnRoute(
+            channel="telegram",
+            chat_id="c1",
+            metadata={"_wants_stream": True},
+        ),
+        enable_stream=True,
+    )
+
+    records: list[str] = []
+    sink_id = loguru_logger.add(lambda m: records.append(str(m)))
+    try:
+        async def run() -> None:
+            await delivery._publish_stream("hello ")
+            await delivery._publish_stream("world")
+            await delivery._publish_stream_end()
+
+        asyncio.run(run())
+    finally:
+        loguru_logger.remove(sink_id)
+
+    delivered = [r for r in records if "Delivered streamed response" in r]
+    assert len(delivered) == 1
+    assert "hello world" in delivered[0]


### PR DESCRIPTION
## Summary

Streamed responses were logged twice: once at stream finalization in `TurnDelivery._publish_stream_end` and again in `AgentLoop._assemble_outbound`. This produced duplicate 'Response to' log lines for every streamed message.

## Change

- Accumulate streamed content in `TurnDelivery` (`_stream_content`) and log it once at stream finalization.
- Skip the `Response to` log in `AgentLoop._assemble_outbound` when the response was streamed.

Every delivered message is now recorded exactly once, regardless of delivery path.

## Testing

Verified the streamed path logs a single 'Delivered streamed response' line and the non-streamed path still logs 'Response to'.