### PR TITLE
fix(dream): advance cursor when durable changes were made

### DIFF
--- a/nanobot/cli/gateway_runtime.py
+++ b/nanobot/cli/gateway_runtime.py
@@ -443,17 +443,29 @@ def _run_gateway(
                     resp,
                     had_tool_errors=progress.had_tool_errors,
                 )
-                if completed:
+                # Advance the cursor when the Dream either reported clean
+                # completion OR actually made durable changes (diff_body). The
+                # _stop_reason check alone is unreliable for ephemeral agent
+                # runs: the agent loop may set a different stop reason even
+                # when the run itself succeeded and produced edits.
+                if completed or diff_body:
                     store.set_last_dream_cursor(last_cursor)
-                    if diff_body:
-                        logger.info(
-                            "Dream cron job completed, cursor advanced to {}",
-                            last_cursor,
-                        )
+                    if completed:
+                        if diff_body:
+                            logger.info(
+                                "Dream cron job completed, cursor advanced to {}",
+                                last_cursor,
+                            )
+                        else:
+                            logger.info(
+                                "Dream cron job completed with no memory changes; "
+                                "cursor advanced to {}",
+                                last_cursor,
+                            )
                     else:
-                        logger.info(
-                            "Dream cron job completed with no memory changes; "
-                            "cursor advanced to {}",
+                        logger.warning(
+                            "Dream cron job advanced cursor to {} despite "
+                            "non-complete stop reason (diff_body present)",
                             last_cursor,
                         )
                 else:


### PR DESCRIPTION
## Summary

The Dream cron job only advanced its history cursor when the agent run reported clean completion. For ephemeral agent runs the loop can set a different stop reason even when the run succeeded and produced edits, so the cursor never moved and history batches were reprocessed repeatedly.

## Change

Advance the cursor when the run either completed cleanly OR produced a real memory diff (`diff_body`). Log a warning for the non-complete-but-changed case so the behavior stays observable.

## Testing

Verified the cursor advances when `diff_body` is present even with a non-complete stop reason, and still advances on clean completion.