### PR TITLE
feat(webui): support trusted proxy bootstrap auth

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -82,7 +82,7 @@ If deployment fails, open the service **Logs** page first. A missing model key f
 > }
 > ```
 >
-> When the WebSocket `host` is `0.0.0.0`, the channel refuses to start unless `token` or `tokenIssueSecret` is also configured. See [`webui.md#lan-access`](./webui.md#lan-access) for details.
+> When the WebSocket `host` is `0.0.0.0`, the channel refuses to start unless `token`, `tokenIssueSecret`, or a fully configured `trustedProxyAuth` is also configured. See [`webui.md#lan-access`](./webui.md#lan-access) for details.
 > The gateway health route itself is intentionally minimal and unauthenticated. When the
 > container binds it to `0.0.0.0`, publish port `18790` to host loopback only; place any
 > remotely monitored health endpoint behind a firewall or reverse proxy. If another host
@@ -93,7 +93,7 @@ If deployment fails, open the service **Logs** page first. A missing model key f
 
 For a local `cloudflared` process in front of nanobot, Cloudflare Access can
 authenticate the user before forwarding the request and add
-`Cf-Access-Jwt-Assertion`. Opt in to trusted-proxy bootstrap only when the
+`Cf-Access-Jwt-Assertion`. Opt in to trusted-proxy no-token mode only when the
 direct TCP peer is the tunnel process and the assertion is non-empty:
 
 ```json
@@ -113,11 +113,14 @@ direct TCP peer is the tunnel process and the assertion is non-empty:
 ```
 
 This is two-part authorization: a trusted direct loopback peer **and** a
-non-empty Cloudflare Access assertion. A trusted CIDR alone is not a bootstrap
-bypass. Nanobot trusts the assertion but does not cryptographically validate
-the JWT, so configure the tunnel and Access policy carefully and do not expose
-the nanobot listener directly to untrusted clients. Forwarded client headers
-such as `X-Forwarded-For` do not establish proxy trust.
+non-empty Cloudflare Access assertion. A trusted CIDR alone is not a bypass.
+For this flow `/webui/bootstrap` returns connection metadata without a
+bootstrap token or REST API token; the proxy assertion authorizes the WebSocket
+handshake and REST requests directly. Nanobot trusts the assertion but does
+not cryptographically validate the JWT, so configure the tunnel and Access
+policy carefully and do not expose the nanobot listener directly to untrusted
+clients. Forwarded client headers such as `X-Forwarded-For` do not establish
+proxy trust.
 
 ### Docker Compose
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -67,7 +67,7 @@ If deployment fails, open the service **Logs** page first. A missing model key f
 > Official Docker usage currently means building from this repository with the included `Dockerfile`. Docker Hub images under third-party namespaces are not maintained or verified by HKUDS/nanobot; do not mount API keys or bot tokens into them unless you trust the publisher.
 
 > [!IMPORTANT]
-> The gateway and WebSocket channel default to `host: "127.0.0.1"` in `config.json` (set in `nanobot/config/schema.py`). Docker `-p` port forwarding cannot reach a container's loopback interface, so for the host or LAN to reach the exposed ports you must set both binds to `0.0.0.0` in `~/.nanobot/config.json` before starting the container. To serve the bundled WebUI from Docker, bind the WebSocket channel externally and protect bootstrap with a secret:
+> The gateway and WebSocket channel default to `host: "127.0.0.1"` in `config.json` (set in `nanobot/config/schema.py`). Docker `-p` port forwarding cannot reach a container's loopback interface, so for the host or LAN to reach the exposed ports you must set both binds to `0.0.0.0` in `~/.nanobot/config.json` before starting the container. To serve the bundled WebUI from Docker, bind the WebSocket channel externally and protect bootstrap with `tokenIssueSecret`:
 >
 > ```json
 > {
@@ -88,6 +88,36 @@ If deployment fails, open the service **Logs** page first. A missing model key f
 > remotely monitored health endpoint behind a firewall or reverse proxy. If another host
 > must probe it directly, replace `127.0.0.1` in the port mapping with a trusted host
 > interface and restrict inbound traffic to the monitoring system.
+
+### Cloudflare Tunnel + Cloudflare Access
+
+For a local `cloudflared` process in front of nanobot, Cloudflare Access can
+authenticate the user before forwarding the request and add
+`Cf-Access-Jwt-Assertion`. Opt in to trusted-proxy bootstrap only when the
+direct TCP peer is the tunnel process and the assertion is non-empty:
+
+```json
+{
+  "gateway": { "host": "127.0.0.1" },
+  "channels": {
+    "websocket": {
+      "host": "127.0.0.1",
+      "port": 8765,
+      "trustedProxyAuth": {
+        "trustedPeerCidrs": ["127.0.0.1/32", "::1/128"],
+        "assertionHeader": "Cf-Access-Jwt-Assertion"
+      }
+    }
+  }
+}
+```
+
+This is two-part authorization: a trusted direct loopback peer **and** a
+non-empty Cloudflare Access assertion. A trusted CIDR alone is not a bootstrap
+bypass. Nanobot trusts the assertion but does not cryptographically validate
+the JWT, so configure the tunnel and Access policy carefully and do not expose
+the nanobot listener directly to untrusted clients. Forwarded client headers
+such as `X-Forwarded-For` do not establish proxy trust.
 
 ### Docker Compose
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -116,11 +116,13 @@ This is two-part authorization: a trusted direct loopback peer **and** a
 non-empty Cloudflare Access assertion. A trusted CIDR alone is not a bypass.
 For this flow `/webui/bootstrap` returns connection metadata without a
 bootstrap token or REST API token; the proxy assertion authorizes the WebSocket
-handshake and REST requests directly. Nanobot trusts the assertion but does
+handshake and REST requests directly. The assertion header must be generated
+by Cloudflare Access after authentication; routing/client metadata headers such
+as `Host`, `Forwarded`, `X-Forwarded-*`, `X-Real-IP`, and `CF-Connecting-IP`
+are rejected as `assertionHeader` values. Nanobot trusts the assertion but does
 not cryptographically validate the JWT, so configure the tunnel and Access
 policy carefully and do not expose the nanobot listener directly to untrusted
-clients. Forwarded client headers such as `X-Forwarded-For` do not establish
-proxy trust.
+clients. Forwarded client headers do not establish proxy trust.
 
 ### Docker Compose
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -103,6 +103,7 @@ direct TCP peer is the tunnel process and the assertion is non-empty:
     "websocket": {
       "host": "127.0.0.1",
       "port": 8765,
+      "publicWsUrl": "wss://nanobot.example.com/",
       "trustedProxyAuth": {
         "trustedPeerCidrs": ["127.0.0.1/32", "::1/128"],
         "assertionHeader": "Cf-Access-Jwt-Assertion"
@@ -116,7 +117,12 @@ This is two-part authorization: a trusted direct loopback peer **and** a
 non-empty Cloudflare Access assertion. A trusted CIDR alone is not a bypass.
 For this flow `/webui/bootstrap` returns connection metadata without a
 bootstrap token or REST API token; the proxy assertion authorizes the WebSocket
-handshake and REST requests directly. The assertion header must be generated
+handshake and REST requests directly.
+
+Set `publicWsUrl` to the browser-facing `wss://` endpoint when the tunnel sends
+the origin host header (such as `127.0.0.1:8765`); otherwise the WebUI could
+attempt to open its WebSocket directly against the loopback address.
+The assertion header must be generated
 by Cloudflare Access after authentication; routing/client metadata headers such
 as `Host`, `Forwarded`, `X-Forwarded-*`, `X-Real-IP`, and `CF-Connecting-IP`
 are rejected as `assertionHeader` values. Nanobot trusts the assertion but does

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -225,7 +225,10 @@ All fields go under `channels.websocket` in `config.json`.
 | `token` | string | `""` | Static shared secret. When set, clients must provide `?token=<value>` matching this secret (timing-safe comparison). Issued tokens are also accepted as a fallback. |
 | `websocketRequiresToken` | bool | `true` | When `true` and no static `token` is configured, clients must still present a valid issued token. Set to `false` to allow unauthenticated connections (only safe for local/trusted networks). |
 | `tokenIssuePath` | string | `""` | HTTP path for issuing short-lived tokens. Must differ from `path`. See [Token Issuance](#token-issuance). |
-| `tokenIssueSecret` | string | `""` | Secret required to obtain tokens via the issue endpoint. If empty, any client can obtain WebSocket connection tokens from `tokenIssuePath` (logged as a warning). `/webui/bootstrap` still issues WebUI REST API tokens for same-machine localhost browser requests; remote or forwarded bootstrap requires `tokenIssueSecret` or `token`. |
+| `tokenIssueSecret` | string | `""` | Secret required to obtain tokens via the issue endpoint. If empty, any client can obtain WebSocket connection tokens from `tokenIssuePath` (logged as a warning). `/webui/bootstrap` still issues WebUI REST API tokens for same-machine localhost browser requests; remote or forwarded bootstrap requires `tokenIssueSecret`, `token`, or a fully configured `trustedProxyAuth`. |
+| `trustedProxyAuth` | object or `null` | `null` | Optional two-part bootstrap authorization for a directly connected upstream proxy. Both `trustedPeerCidrs` and a non-empty `assertionHeader` value must match; a CIDR alone never authorizes bootstrap. |
+| `trustedProxyAuth.trustedPeerCidrs` | list of CIDR strings | — | Direct TCP peer networks that may present the assertion. IPv4, IPv6, and IPv4-mapped IPv6 peers are supported; universal CIDRs (`0.0.0.0/0`, `::/0`) are rejected. |
+| `trustedProxyAuth.assertionHeader` | string | — | HTTP header whose non-empty value proves the upstream proxy authenticated the request. Nanobot trusts this value but does not cryptographically validate it. |
 | `tokenTtlS` | int | `300` | Time-to-live for issued tokens in seconds (30 – 86,400). |
 
 ### Access Control
@@ -271,9 +274,47 @@ For production deployments where `websocketRequiresToken: true`, use short-lived
 4. The token is consumed (single use) and cannot be reused.
 
 The embedded WebUI's `/webui/bootstrap` route also returns a WebSocket token.
+
 It returns a separate `api_token` for REST routes to same-machine localhost
-browser requests, or after the request proves knowledge of `tokenIssueSecret`
-or the static `token`.
+browser requests, or after the request proves knowledge of `tokenIssueSecret`,
+the static `token`, or the configured trusted proxy assertion.
+
+### Trusted proxy bootstrap
+
+`trustedProxyAuth` is an opt-in alternative for deployments where an
+identity-aware reverse proxy authenticates the user before connecting to nanobot.
+Bootstrap is accepted only when **both** the direct TCP peer matches one of
+`trustedPeerCidrs` and the configured assertion header is present and non-empty.
+A trusted address by itself is never sufficient.
+
+Nanobot deliberately uses only `connection.remote_address` for the peer check.
+It never uses `X-Forwarded-For`, `Forwarded`, `X-Real-IP`, `CF-Connecting-IP`,
+or `X-Forwarded-Host` to decide whether the proxy is trusted. Nanobot trusts the
+assertion supplied by the explicitly trusted peer, but does not cryptographically
+validate or interpret the JWT/assertion contents. Do not enable this option if
+untrusted clients can connect directly to the nanobot listener.
+
+For example, a local Cloudflare Tunnel with Cloudflare Access can validate the
+user at the edge and forward the resulting `Cf-Access-Jwt-Assertion`:
+
+```json
+{
+  "channels": {
+    "websocket": {
+      "host": "127.0.0.1",
+      "trustedProxyAuth": {
+        "trustedPeerCidrs": ["127.0.0.1/32", "::1/128"],
+        "assertionHeader": "Cf-Access-Jwt-Assertion"
+      }
+    }
+  }
+}
+```
+
+This works only when the directly connected `cloudflared` process reaches
+nanobot over the configured loopback address and supplies a non-empty assertion.
+Keep nanobot firewalled from untrusted clients; this configuration is not a
+CIDR-based bootstrap bypass.
 
 ### Example setup
 

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -216,6 +216,7 @@ All fields go under `channels.websocket` in `config.json`.
 | `host` | string | `"127.0.0.1"` | Bind address. Use `"0.0.0.0"` to accept external connections. |
 | `port` | int | `8765` | Listen port. |
 | `path` | string | `"/"` | WebSocket upgrade path. Trailing slashes are normalized (root `/` is preserved). |
+| `publicWsUrl` | string | `""` | Exact public `ws://` or `wss://` endpoint returned by `/webui/bootstrap`. Set this when a reverse proxy forwards requests with an origin `Host` header (for example, `wss://claw.example.com/`); its path must match `path`. |
 | `maxMessageBytes` | int | `37748736` | Maximum inbound message size in bytes (1 KB – 40 MB). Default (36 MB) is sized to accept up to 4 base64-encoded image attachments at 8 MB each; lower it if the channel only carries text. |
 
 ### Authentication
@@ -310,6 +311,7 @@ user at the edge and forward the resulting `Cf-Access-Jwt-Assertion`:
   "channels": {
     "websocket": {
       "host": "127.0.0.1",
+      "publicWsUrl": "wss://nanobot.example.com/",
       "trustedProxyAuth": {
         "trustedPeerCidrs": ["127.0.0.1/32", "::1/128"],
         "assertionHeader": "Cf-Access-Jwt-Assertion"

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -76,7 +76,7 @@ ws://{host}:{port}{path}?client_id={id}&token={token}
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `client_id` | No | Identifier for `allowFrom` authorization. Auto-generated as `anon-xxxxxxxxxxxx` if omitted. Truncated to 128 chars. |
-| `token` | Conditional | Authentication token. Required when `websocketRequiresToken` is `true` or `token` (static secret) is configured. |
+| `token` | Conditional | Authentication token. Required when `websocketRequiresToken` is `true` or `token` (static secret) is configured, unless the request comes through an authenticated `trustedProxyAuth` peer. |
 
 ## Wire Protocol
 
@@ -222,11 +222,11 @@ All fields go under `channels.websocket` in `config.json`.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `token` | string | `""` | Static shared secret. When set, clients must provide `?token=<value>` matching this secret (timing-safe comparison). Issued tokens are also accepted as a fallback. |
-| `websocketRequiresToken` | bool | `true` | When `true` and no static `token` is configured, clients must still present a valid issued token. Set to `false` to allow unauthenticated connections (only safe for local/trusted networks). |
+| `token` | string | `""` | Static shared secret. When set, clients must provide `?token=<value>` matching this secret (timing-safe comparison). Issued tokens are also accepted as a fallback. A trusted proxy assertion bypasses this requirement. |
+| `websocketRequiresToken` | bool | `true` | When `true` and no static `token` is configured, clients must still present a valid issued token, unless `trustedProxyAuth` authenticates the direct proxy peer. Set to `false` to allow unauthenticated connections (only safe for local/trusted networks). |
 | `tokenIssuePath` | string | `""` | HTTP path for issuing short-lived tokens. Must differ from `path`. See [Token Issuance](#token-issuance). |
-| `tokenIssueSecret` | string | `""` | Secret required to obtain tokens via the issue endpoint. If empty, any client can obtain WebSocket connection tokens from `tokenIssuePath` (logged as a warning). `/webui/bootstrap` still issues WebUI REST API tokens for same-machine localhost browser requests; remote or forwarded bootstrap requires `tokenIssueSecret`, `token`, or a fully configured `trustedProxyAuth`. |
-| `trustedProxyAuth` | object or `null` | `null` | Optional two-part bootstrap authorization for a directly connected upstream proxy. Both `trustedPeerCidrs` and a non-empty `assertionHeader` value must match; a CIDR alone never authorizes bootstrap. |
+| `tokenIssueSecret` | string | `""` | Secret required to obtain tokens via the issue endpoint. If empty, any client can obtain WebSocket connection tokens from `tokenIssuePath` (logged as a warning). `/webui/bootstrap` issues tokens for local/secret-authenticated requests; trusted-proxy requests intentionally receive no bootstrap or API token. |
+| `trustedProxyAuth` | object or `null` | `null` | Optional two-part no-token authorization for a directly connected upstream proxy. Both `trustedPeerCidrs` and a non-empty `assertionHeader` value must match; a CIDR alone never authorizes bootstrap or WebSocket/API access. |
 | `trustedProxyAuth.trustedPeerCidrs` | list of CIDR strings | — | Direct TCP peer networks that may present the assertion. IPv4, IPv6, and IPv4-mapped IPv6 peers are supported; universal CIDRs (`0.0.0.0/0`, `::/0`) are rejected. |
 | `trustedProxyAuth.assertionHeader` | string | — | HTTP header whose non-empty value proves the upstream proxy authenticated the request. Nanobot trusts this value but does not cryptographically validate it. |
 | `tokenTtlS` | int | `300` | Time-to-live for issued tokens in seconds (30 – 86,400). |
@@ -273,16 +273,18 @@ For production deployments where `websocketRequiresToken: true`, use short-lived
 3. Client opens WebSocket with `?token=nbwt_aBcDeFg...&client_id=...`.
 4. The token is consumed (single use) and cannot be reused.
 
-The embedded WebUI's `/webui/bootstrap` route also returns a WebSocket token.
+The embedded WebUI's `/webui/bootstrap` route returns a WebSocket token and
+REST `api_token` for local or secret-authenticated requests. When
+`trustedProxyAuth` authenticates the direct proxy peer, it returns connection
+metadata only: no bootstrap token, no REST API token, and no token query
+parameter is required for the WebSocket handshake or subsequent REST requests.
 
-It returns a separate `api_token` for REST routes to same-machine localhost
-browser requests, or after the request proves knowledge of `tokenIssueSecret`,
-the static `token`, or the configured trusted proxy assertion.
-
-### Trusted proxy bootstrap
+### Trusted proxy no-token bootstrap
 
 `trustedProxyAuth` is an opt-in alternative for deployments where an
 identity-aware reverse proxy authenticates the user before connecting to nanobot.
+The proxy assertion becomes the authentication boundary for the entire WebUI
+surface: `/webui/bootstrap`, the WebSocket handshake, and REST API routes.
 Bootstrap is accepted only when **both** the direct TCP peer matches one of
 `trustedPeerCidrs` and the configured assertion header is present and non-empty.
 A trusted address by itself is never sufficient.

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -228,7 +228,7 @@ All fields go under `channels.websocket` in `config.json`.
 | `tokenIssueSecret` | string | `""` | Secret required to obtain tokens via the issue endpoint. If empty, any client can obtain WebSocket connection tokens from `tokenIssuePath` (logged as a warning). `/webui/bootstrap` issues tokens for local/secret-authenticated requests; trusted-proxy requests intentionally receive no bootstrap or API token. |
 | `trustedProxyAuth` | object or `null` | `null` | Optional two-part no-token authorization for a directly connected upstream proxy. Both `trustedPeerCidrs` and a non-empty `assertionHeader` value must match; a CIDR alone never authorizes bootstrap or WebSocket/API access. |
 | `trustedProxyAuth.trustedPeerCidrs` | list of CIDR strings | — | Direct TCP peer networks that may present the assertion. IPv4, IPv6, and IPv4-mapped IPv6 peers are supported; universal CIDRs (`0.0.0.0/0`, `::/0`) are rejected. |
-| `trustedProxyAuth.assertionHeader` | string | — | HTTP header whose non-empty value proves the upstream proxy authenticated the request. Nanobot trusts this value but does not cryptographically validate it. |
+| `trustedProxyAuth.assertionHeader` | string | — | Header injected by the identity-aware proxy after successful authentication. Routing/client metadata headers (`Host`, `Forwarded`, `X-Forwarded-*`, `X-Real-IP`, `CF-Connecting-IP`) are rejected; nanobot trusts the remaining header's non-empty value but does not cryptographically validate it. |
 | `tokenTtlS` | int | `300` | Time-to-live for issued tokens in seconds (30 – 86,400). |
 
 ### Access Control
@@ -295,6 +295,12 @@ or `X-Forwarded-Host` to decide whether the proxy is trusted. Nanobot trusts the
 assertion supplied by the explicitly trusted peer, but does not cryptographically
 validate or interpret the JWT/assertion contents. Do not enable this option if
 untrusted clients can connect directly to the nanobot listener.
+
+The configured assertion header must be a proxy-generated authentication
+assertion, not a routing or client metadata header. Headers such as `Host`,
+`Forwarded`, `X-Forwarded-*`, `X-Real-IP`, and `CF-Connecting-IP` are rejected
+by configuration; use the identity provider's post-authentication assertion
+header instead (for example, `Cf-Access-Jwt-Assertion`).
 
 For example, a local Cloudflare Tunnel with Cloudflare Access can validate the
 user at the edge and forward the resulting `Cf-Access-Jwt-Assertion`:

--- a/nanobot/channels/websocket/runtime.py
+++ b/nanobot/channels/websocket/runtime.py
@@ -93,6 +93,24 @@ from nanobot.webui.websocket_logging import websockets_server_logger
 _WEBUI_HTTP_OPEN_TIMEOUT_S = 360.0
 
 
+_ROUTING_ASSERTION_HEADERS = frozenset(
+    {
+        "host",
+        "forwarded",
+        "x-forwarded-for",
+        "x-forwarded-host",
+        "x-forwarded-proto",
+        "x-real-ip",
+        "cf-connecting-ip",
+    }
+)
+
+
+def _is_routing_assertion_header(value: str) -> bool:
+    normalized = value.casefold()
+    return normalized in _ROUTING_ASSERTION_HEADERS or normalized.startswith("x-forwarded-")
+
+
 class TrustedProxyAuthConfig(Base):
     """Authentication assertions accepted from explicitly trusted proxy peers."""
 
@@ -128,6 +146,11 @@ class TrustedProxyAuthConfig(Base):
         value = value.strip()
         if not value or any(char.isspace() or ord(char) < 0x21 for char in value):
             raise ValueError("assertion_header must be a valid HTTP header name")
+        if _is_routing_assertion_header(value):
+            raise ValueError(
+                "assertion_header must identify a proxy-generated authentication assertion, "
+                "not a routing or client metadata header"
+            )
         return value
 
     @model_validator(mode="after")

--- a/nanobot/channels/websocket/runtime.py
+++ b/nanobot/channels/websocket/runtime.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from contextlib import suppress
 from pathlib import Path
 from typing import Any, Self, TypeGuard, cast
+from urllib.parse import urlsplit, urlunsplit
 
 from pydantic import Field, PrivateAttr, field_validator, model_validator
 from websockets.asyncio.server import ServerConnection, serve, unix_serve
@@ -175,6 +176,8 @@ class WebSocketConfig(Base):
       blocking ``urllib`` or synchronous ``httpx`` from inside a coroutine.
     - ``token_issue_secret``: If non-empty, token requests must send ``Authorization: Bearer <secret>`` or
       ``X-Nanobot-Auth: <secret>``.
+    - ``public_ws_url``: Optional public WebSocket endpoint returned by WebUI bootstrap instead of
+      deriving one from proxy request headers. Its path must match ``path``.
     - ``websocket_requires_token``: If True, the handshake must include a valid token (static or issued and not expired).
     - Each connection has its own session: a unique ``chat_id`` maps to the agent session internally.
     - ``media`` field in outbound messages contains local filesystem paths; remote clients need a
@@ -186,6 +189,7 @@ class WebSocketConfig(Base):
     port: int = 8765
     unix_socket_path: str = ""
     path: str = "/"
+    public_ws_url: str = ""
     token: str = ""
     token_issue_path: str = ""
     token_issue_secret: str = ""
@@ -233,6 +237,32 @@ class WebSocketConfig(Base):
         if not value.startswith("/"):
             raise ValueError('token_issue_path must start with "/"')
         return _normalize_config_path(value)
+
+    @field_validator("public_ws_url")
+    @classmethod
+    def public_ws_url_format(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            return ""
+        parsed = urlsplit(value)
+        if (
+            parsed.scheme not in {"ws", "wss"}
+            or not parsed.netloc
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError("public_ws_url must be an absolute ws:// or wss:// URL without credentials")
+        return urlunsplit(
+            (parsed.scheme, parsed.netloc, _normalize_config_path(parsed.path or "/"), "", "")
+        )
+
+    @model_validator(mode="after")
+    def public_ws_url_matches_path(self) -> Self:
+        if self.public_ws_url and urlsplit(self.public_ws_url).path != _normalize_config_path(self.path):
+            raise ValueError("public_ws_url path must match path")
+        return self
 
     @model_validator(mode="after")
     def token_issue_path_differs_from_ws_path(self) -> Self:

--- a/nanobot/channels/websocket/runtime.py
+++ b/nanobot/channels/websocket/runtime.py
@@ -62,6 +62,9 @@ from nanobot.webui.cli_apps_api import normalize_cli_app_mentions
 from nanobot.webui.forking import handle_webui_fork_chat
 from nanobot.webui.gateway_services import GatewayServices
 from nanobot.webui.http_utils import (
+    is_trusted_proxy_authenticated_request as _is_trusted_proxy_authenticated_request,
+)
+from nanobot.webui.http_utils import (
     normalize_config_path as _normalize_config_path,
 )
 from nanobot.webui.http_utils import (
@@ -220,11 +223,11 @@ class WebSocketConfig(Base):
     def wildcard_host_requires_auth(self) -> Self:
         if self.host not in ("0.0.0.0", "::"):
             return self
-        if self.token.strip() or self.token_issue_secret.strip():
+        if self.token.strip() or self.token_issue_secret.strip() or self.trusted_proxy_auth is not None:
             return self
         raise ValueError(
-            "host is 0.0.0.0 (all interfaces) but neither token nor "
-            "token_issue_secret is set — set one to prevent unauthenticated access"
+            "host is 0.0.0.0 (all interfaces) but neither token, token_issue_secret, "
+            "nor trusted_proxy_auth is set — set one to prevent unauthenticated access"
         )
 
 
@@ -480,16 +483,16 @@ class WebSocketChannel(BaseChannel):
     async def _dispatch_http(self, connection: ServerConnection, request: WsRequest) -> Any:
         """Route an inbound HTTP request to the HTTP handler or WS upgrade."""
         got, query = _parse_request_path(request.path)
+        expected_ws = self._expected_path()
 
         # WebSocket upgrade — channel handles this itself
-        expected_ws = self._expected_path()
         if got == expected_ws and _is_websocket_upgrade(request):
             client_id = _query_first(query, "client_id") or ""
             if len(client_id) > 128:
                 client_id = client_id[:128]
             if not self.is_allowed(client_id):
                 return connection.respond(403, "Forbidden")
-            return self._authorize_websocket_handshake(connection, query)
+            return self._authorize_websocket_handshake(connection, query, request.headers)
 
         # Everything else goes to the HTTP handler
         return await self._http_router.dispatch(connection, request)
@@ -498,7 +501,12 @@ class WebSocketChannel(BaseChannel):
         self,
         connection: ServerConnection,
         query: dict[str, list[str]],
+        headers: Any = None,
     ) -> Any:
+        if _is_trusted_proxy_authenticated_request(connection, headers or {}, self.config):
+            self._webui_connections.add(connection)
+            return None
+
         supplied = _query_first(query, "token")
         static_token = self.config.token.strip()
 

--- a/nanobot/channels/websocket/runtime.py
+++ b/nanobot/channels/websocket/runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import hmac
+import ipaddress
 import json
 import re
 import ssl
@@ -13,7 +14,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any, Self, TypeGuard, cast
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, PrivateAttr, field_validator, model_validator
 from websockets.asyncio.server import ServerConnection, serve, unix_serve
 from websockets.exceptions import ConnectionClosed
 from websockets.http11 import Request as WsRequest
@@ -89,6 +90,51 @@ from nanobot.webui.websocket_logging import websockets_server_logger
 _WEBUI_HTTP_OPEN_TIMEOUT_S = 360.0
 
 
+class TrustedProxyAuthConfig(Base):
+    """Authentication assertions accepted from explicitly trusted proxy peers."""
+
+    trusted_peer_cidrs: list[str] = Field(min_length=1)
+    assertion_header: str = Field(min_length=1)
+    _trusted_peer_networks: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...] = PrivateAttr(
+        default=()
+    )
+
+    @field_validator("trusted_peer_cidrs")
+    @classmethod
+    def validate_trusted_peer_cidrs(cls, values: list[str]) -> list[str]:
+        normalized: list[str] = []
+        for value in values:
+            value = value.strip()
+            try:
+                network = ipaddress.ip_network(value, strict=False)
+            except ValueError as exc:
+                raise ValueError(f"invalid trusted proxy CIDR: {value!r}") from exc
+            if network.prefixlen == 0:
+                raise ValueError("universal trusted proxy CIDRs are not allowed")
+            if isinstance(network, ipaddress.IPv6Network):
+                mapped_start = ipaddress.IPv6Address("::ffff:0:0")
+                mapped_end = ipaddress.IPv6Address("::ffff:ffff:ffff")
+                if mapped_start in network and mapped_end in network:
+                    raise ValueError("trusted proxy CIDRs must not cover all IPv4-mapped addresses")
+            normalized.append(network.with_prefixlen)
+        return normalized
+
+    @field_validator("assertion_header")
+    @classmethod
+    def validate_assertion_header(cls, value: str) -> str:
+        value = value.strip()
+        if not value or any(char.isspace() or ord(char) < 0x21 for char in value):
+            raise ValueError("assertion_header must be a valid HTTP header name")
+        return value
+
+    @model_validator(mode="after")
+    def compile_trusted_peer_networks(self) -> Self:
+        self._trusted_peer_networks = tuple(
+            ipaddress.ip_network(value, strict=False) for value in self.trusted_peer_cidrs
+        )
+        return self
+
+
 class WebSocketConfig(Base):
     """WebSocket server channel configuration.
 
@@ -117,6 +163,7 @@ class WebSocketConfig(Base):
     token: str = ""
     token_issue_path: str = ""
     token_issue_secret: str = ""
+    trusted_proxy_auth: TrustedProxyAuthConfig | None = None
     token_ttl_s: int = Field(default=300, ge=30, le=86_400)
     websocket_requires_token: bool = True
     allow_from: list[str] = Field(default_factory=lambda: ["*"])

--- a/nanobot/channels/websocket/tests/test_websocket_http_routes.py
+++ b/nanobot/channels/websocket/tests/test_websocket_http_routes.py
@@ -3552,6 +3552,40 @@ def test_bootstrap_ws_url_uses_forwarded_https_host(bus: MagicMock) -> None:
     assert body["ws_url"] == "wss://nanobot.example/"
 
 
+def test_bootstrap_ws_url_uses_configured_public_url(bus: MagicMock) -> None:
+    channel = _ch(
+        bus,
+        host="127.0.0.1",
+        port=29931,
+        tokenIssueSecret="s3cret",
+        publicWsUrl="wss://claw.wasapi.xyz/",
+    )
+    resp = channel.gateway.http._handle_bootstrap(
+        _LOCAL,
+        _FakeReq(
+            {
+                "Authorization": "Bearer s3cret",
+                "Host": "127.0.0.1:29931",
+                "X-Forwarded-Proto": "https",
+            }
+        ),
+    )
+    assert resp.status_code == 200
+    assert json.loads(resp.body)["ws_url"] == "wss://claw.wasapi.xyz/"
+
+
+def test_public_ws_url_must_match_configured_path() -> None:
+    from pydantic_core import ValidationError
+
+    with pytest.raises(ValidationError, match="public_ws_url path must match path"):
+        WebSocketConfig.model_validate(
+            {
+                "path": "/socket",
+                "publicWsUrl": "wss://claw.wasapi.xyz/",
+            }
+        )
+
+
 def test_bootstrap_without_auth_rejects_remote_requests(bus: MagicMock) -> None:
     channel = _ch(bus, host="127.0.0.1")
     resp = channel.gateway.http._handle_bootstrap(_REMOTE, _NO_HEADERS)

--- a/nanobot/channels/websocket/tests/test_websocket_http_routes.py
+++ b/nanobot/channels/websocket/tests/test_websocket_http_routes.py
@@ -3321,6 +3321,128 @@ def test_local_browser_request_requires_loopback_host_and_forwarded_origin() -> 
     )
 
 
+def _trusted_proxy_config(
+    cidrs: list[str] | None = None,
+    *,
+    assertion_header: str = "Cf-Access-Jwt-Assertion",
+) -> dict[str, Any]:
+    return {
+        "trustedProxyAuth": {
+            "trustedPeerCidrs": cidrs or ["127.0.0.1/32"],
+            "assertionHeader": assertion_header,
+        }
+    }
+
+
+def test_trusted_proxy_requires_non_empty_assertion(bus: MagicMock) -> None:
+    channel = _ch(bus, **_trusted_proxy_config())
+    for assertion in (None, "", "   "):
+        headers = {"Cf-Access-Jwt-Assertion": assertion} if assertion is not None else {}
+        resp = channel.gateway.http._handle_bootstrap(_LOCAL, _FakeReq(headers))
+        assert resp.status_code == 403
+
+
+def test_trusted_proxy_rejects_untrusted_peer_spoof(bus: MagicMock) -> None:
+    channel = _ch(bus, **_trusted_proxy_config())
+    resp = channel.gateway.http._handle_bootstrap(
+        _REMOTE,
+        _FakeReq({"Cf-Access-Jwt-Assertion": "spoofed"}),
+    )
+    assert resp.status_code == 403
+
+
+def test_trusted_proxy_accepts_assertion_without_forwarded_header_trust(
+    bus: MagicMock,
+) -> None:
+    assertion = "opaque-upstream-assertion"
+    channel = _ch(bus, **_trusted_proxy_config())
+    log = MagicMock()
+    channel.gateway.http._log = log
+    resp = channel.gateway.http._handle_bootstrap(
+        _LOCAL,
+        _FakeReq(
+            {
+                "Host": "nanobot.example",
+                "X-Forwarded-For": "203.0.113.42",
+                "Forwarded": "for=203.0.113.42;host=nanobot.example",
+                "X-Real-IP": "203.0.113.42",
+                "X-Forwarded-Host": "nanobot.example",
+                "Cf-Access-Jwt-Assertion": assertion,
+            }
+        ),
+    )
+    assert resp.status_code == 200
+    body = resp.body.decode()
+    assert assertion not in body
+    assert assertion not in repr(log.mock_calls)
+    payload = json.loads(body)
+    assert payload["token"].startswith("nbwt_")
+    assert payload["api_token"].startswith("nbwt_")
+    assert payload["api_token"] != payload["token"]
+
+
+def test_forwarding_headers_alone_never_authorize_bootstrap(bus: MagicMock) -> None:
+    channel = _ch(bus)
+    resp = channel.gateway.http._handle_bootstrap(
+        _REMOTE,
+        _FakeReq(
+            {
+                "Host": "nanobot.example",
+                "X-Forwarded-For": "127.0.0.1",
+                "Forwarded": "for=127.0.0.1",
+                "X-Real-IP": "127.0.0.1",
+            }
+        ),
+    )
+    assert resp.status_code == 403
+
+
+def test_trusted_proxy_does_not_override_bootstrap_secret(bus: MagicMock) -> None:
+    channel = _ch(
+        bus,
+        tokenIssueSecret="route-secret",
+        **_trusted_proxy_config(),
+    )
+    resp = channel.gateway.http._handle_bootstrap(
+        _LOCAL,
+        _FakeReq({"Cf-Access-Jwt-Assertion": "present"}),
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.parametrize(
+    ("peer", "cidr"),
+    [
+        ("127.0.0.1", "127.0.0.1/32"),
+        ("::1", "::1/128"),
+        ("::ffff:127.0.0.1", "127.0.0.0/24"),
+        ("127.0.0.1", "::ffff:127.0.0.0/120"),
+    ],
+)
+def test_trusted_proxy_matches_ip_versions_and_mapped_peers(
+    bus: MagicMock,
+    peer: str,
+    cidr: str,
+) -> None:
+    from nanobot.webui.http_utils import is_trusted_proxy_authenticated_request
+
+    config = WebSocketConfig.model_validate(_trusted_proxy_config([cidr]))
+    request = _FakeReq({"Cf-Access-Jwt-Assertion": "present"})
+    assert is_trusted_proxy_authenticated_request(_FakeConn((peer, 12345)), request.headers, config)
+
+
+@pytest.mark.parametrize(
+    "cidr",
+    ["not-a-cidr", "0.0.0.0/0", "::/0", "::/1", "::ffff:0:0/96"],
+)
+def test_trusted_proxy_rejects_invalid_or_universal_cidrs(
+    cidr: str,
+) -> None:
+    from pydantic_core import ValidationError
+
+    with pytest.raises(ValidationError):
+        WebSocketConfig.model_validate(_trusted_proxy_config([cidr]))
+
 def test_wildcard_host_without_auth_raises_on_startup(bus: MagicMock) -> None:
     import pytest
     from pydantic_core import ValidationError

--- a/nanobot/channels/websocket/tests/test_websocket_http_routes.py
+++ b/nanobot/channels/websocket/tests/test_websocket_http_routes.py
@@ -3351,7 +3351,7 @@ def test_trusted_proxy_rejects_untrusted_peer_spoof(bus: MagicMock) -> None:
     assert resp.status_code == 403
 
 
-def test_trusted_proxy_accepts_assertion_without_forwarded_header_trust(
+def test_trusted_proxy_bootstrap_has_no_tokens(
     bus: MagicMock,
 ) -> None:
     assertion = "opaque-upstream-assertion"
@@ -3376,9 +3376,36 @@ def test_trusted_proxy_accepts_assertion_without_forwarded_header_trust(
     assert assertion not in body
     assert assertion not in repr(log.mock_calls)
     payload = json.loads(body)
-    assert payload["token"].startswith("nbwt_")
-    assert payload["api_token"].startswith("nbwt_")
-    assert payload["api_token"] != payload["token"]
+    assert "token" not in payload
+    assert "api_token" not in payload
+    assert payload["ws_path"] == "/"
+
+
+@pytest.mark.asyncio
+async def test_trusted_proxy_authorizes_rest_without_api_token(bus: MagicMock) -> None:
+    channel = _ch(bus, **_trusted_proxy_config())
+    response = await channel.gateway.http.dispatch(
+        _LOCAL,
+        _FakeReq(
+            {
+                "Host": "nanobot.example",
+                "Cf-Access-Jwt-Assertion": "present",
+            },
+            path="/api/sessions",
+        ),
+    )
+    assert response.status_code == 503
+
+
+def test_trusted_proxy_authorizes_websocket_without_token(bus: MagicMock) -> None:
+    channel = _ch(bus, **_trusted_proxy_config())
+    response = channel._authorize_websocket_handshake(
+        _LOCAL,
+        {},
+        {"Cf-Access-Jwt-Assertion": "present"},
+    )
+    assert response is None
+    assert _LOCAL in channel._webui_connections
 
 
 def test_forwarding_headers_alone_never_authorize_bootstrap(bus: MagicMock) -> None:
@@ -3397,7 +3424,7 @@ def test_forwarding_headers_alone_never_authorize_bootstrap(bus: MagicMock) -> N
     assert resp.status_code == 403
 
 
-def test_trusted_proxy_does_not_override_bootstrap_secret(bus: MagicMock) -> None:
+def test_trusted_proxy_bypasses_bootstrap_secret_and_tokens(bus: MagicMock) -> None:
     channel = _ch(
         bus,
         tokenIssueSecret="route-secret",
@@ -3407,7 +3434,10 @@ def test_trusted_proxy_does_not_override_bootstrap_secret(bus: MagicMock) -> Non
         _LOCAL,
         _FakeReq({"Cf-Access-Jwt-Assertion": "present"}),
     )
-    assert resp.status_code == 401
+    assert resp.status_code == 200
+    payload = json.loads(resp.body)
+    assert "token" not in payload
+    assert "api_token" not in payload
 
 
 @pytest.mark.parametrize(
@@ -3458,6 +3488,11 @@ def test_wildcard_host_with_token_is_valid(bus: MagicMock) -> None:
 
 def test_wildcard_host_with_secret_is_valid(bus: MagicMock) -> None:
     channel = _ch(bus, host="0.0.0.0", tokenIssueSecret="s3cret")
+    assert channel.config.host == "0.0.0.0"
+
+
+def test_wildcard_host_with_trusted_proxy_auth_is_valid(bus: MagicMock) -> None:
+    channel = _ch(bus, host="0.0.0.0", **_trusted_proxy_config())
     assert channel.config.host == "0.0.0.0"
 
 

--- a/nanobot/channels/websocket/tests/test_websocket_http_routes.py
+++ b/nanobot/channels/websocket/tests/test_websocket_http_routes.py
@@ -3473,6 +3473,16 @@ def test_trusted_proxy_rejects_invalid_or_universal_cidrs(
     with pytest.raises(ValidationError):
         WebSocketConfig.model_validate(_trusted_proxy_config([cidr]))
 
+@pytest.mark.parametrize(
+    "assertion_header",
+    ["Host", "Forwarded", "X-Forwarded-For", "X-Real-IP", "CF-Connecting-IP"],
+)
+def test_trusted_proxy_rejects_routing_headers(assertion_header: str) -> None:
+    from pydantic_core import ValidationError
+
+    with pytest.raises(ValidationError, match="proxy-generated"):
+        WebSocketConfig.model_validate(_trusted_proxy_config(assertion_header=assertion_header))
+
 def test_wildcard_host_without_auth_raises_on_startup(bus: MagicMock) -> None:
     import pytest
     from pydantic_core import ValidationError

--- a/nanobot/webui/http_utils.py
+++ b/nanobot/webui/http_utils.py
@@ -169,6 +169,50 @@ def is_localhost(connection: Any) -> bool:
     return host in {"127.0.0.1", "::1", "localhost"}
 
 
+def _connection_ip(connection: Any) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    addr = getattr(connection, "remote_address", None)
+    host = cast(Any, addr[0] if isinstance(addr, tuple) else addr)
+    if not isinstance(host, str):
+        return None
+    try:
+        return ipaddress.ip_address(host)
+    except ValueError:
+        return None
+
+
+def _address_matches_network(
+    address: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    network: ipaddress.IPv4Network | ipaddress.IPv6Network,
+) -> bool:
+    if isinstance(address, ipaddress.IPv4Address):
+        if isinstance(network, ipaddress.IPv4Network):
+            return address in network
+        return ipaddress.IPv6Address(f"::ffff:{address}") in network
+    if isinstance(network, ipaddress.IPv6Network):
+        return address in network
+    mapped = address.ipv4_mapped
+    return mapped is not None and mapped in network
+
+
+def is_trusted_proxy_authenticated_request(
+    connection: Any,
+    headers: Any,
+    config: Any,
+) -> bool:
+    """Return True when a configured proxy peer presents a non-empty assertion."""
+    trusted_proxy_auth = getattr(config, "trusted_proxy_auth", None)
+    if trusted_proxy_auth is None:
+        return False
+    address = _connection_ip(connection)
+    if address is None:
+        return False
+    networks = getattr(trusted_proxy_auth, "_trusted_peer_networks", ())
+    if not any(_address_matches_network(address, network) for network in networks):
+        return False
+    assertion_header = getattr(trusted_proxy_auth, "assertion_header", "")
+    return bool(case_insensitive_header(headers, assertion_header))
+
+
 def _host_without_port(value: str) -> str:
     value = value.strip().strip('"').strip("'")
     if not value:

--- a/nanobot/webui/ws_http.py
+++ b/nanobot/webui/ws_http.py
@@ -61,6 +61,9 @@ from nanobot.webui.http_utils import (
     is_localhost as _is_localhost,
 )
 from nanobot.webui.http_utils import (
+    is_trusted_proxy_authenticated_request as _is_trusted_proxy_authenticated_request,
+)
+from nanobot.webui.http_utils import (
     issue_route_secret_matches as _issue_route_secret_matches,
 )
 from nanobot.webui.http_utils import (
@@ -372,13 +375,18 @@ class GatewayHTTPHandler:
     def _handle_bootstrap(self, connection: Any, request: Any) -> Response:
         secret = self.config.token_issue_secret.strip() or self.config.token.strip()
         is_local_browser = _is_local_browser_request(connection, request.headers)
+        is_proxy_authenticated = _is_trusted_proxy_authenticated_request(
+            connection,
+            request.headers,
+            self.config,
+        )
         if secret:
             if not _issue_route_secret_matches(request.headers, secret):
                 return _http_error(401, "Unauthorized")
-        elif not is_local_browser:
+        elif not (is_local_browser or is_proxy_authenticated):
             return _http_error(403, "bootstrap is localhost-only")
 
-        api_token_allowed = bool(secret) or is_local_browser
+        api_token_allowed = bool(secret) or is_local_browser or is_proxy_authenticated
         if not self.tokens.can_issue(include_api_token=api_token_allowed):
             return _http_response(
                 json.dumps({"error": "too many outstanding tokens"}).encode("utf-8"),

--- a/nanobot/webui/ws_http.py
+++ b/nanobot/webui/ws_http.py
@@ -266,6 +266,8 @@ class GatewayHTTPHandler:
     # -- Token management ---------------------------------------------------
 
     def check_api_token(self, request: WsRequest) -> bool:
+        if getattr(request, "_nanobot_trusted_proxy_authenticated", False):
+            return True
         return self.tokens.check_api_token(request)
 
     # -- Main dispatch ------------------------------------------------------
@@ -275,6 +277,11 @@ class GatewayHTTPHandler:
         got, _ = _parse_request_path(request.path)
         started = time.perf_counter()
         response: Any | None = None
+        setattr(
+            request,
+            "_nanobot_trusted_proxy_authenticated",
+            _is_trusted_proxy_authenticated_request(connection, request.headers, self.config),
+        )
 
         try:
             response = await self._dispatch_resolved(connection, request, got)
@@ -380,13 +387,27 @@ class GatewayHTTPHandler:
             request.headers,
             self.config,
         )
-        if secret:
-            if not _issue_route_secret_matches(request.headers, secret):
-                return _http_error(401, "Unauthorized")
-        elif not (is_local_browser or is_proxy_authenticated):
-            return _http_error(403, "bootstrap is localhost-only")
+        if not is_proxy_authenticated:
+            if secret:
+                if not _issue_route_secret_matches(request.headers, secret):
+                    return _http_error(401, "Unauthorized")
+            elif not is_local_browser:
+                return _http_error(403, "bootstrap is localhost-only")
 
-        api_token_allowed = bool(secret) or is_local_browser or is_proxy_authenticated
+        if is_proxy_authenticated:
+            payload = {
+                "ws_path": _normalize_config_path(self.config.path),
+                "ws_url": self._bootstrap_ws_url(request),
+                "limits": self.ingress.bootstrap_limits(
+                    max_frame_bytes=self.config.max_message_bytes,
+                ),
+                "model_name": _resolve_bootstrap_model_name(self.runtime_model_name),
+                "runtime_surface": self._runtime_surface,
+                "runtime_capabilities": self._capabilities,
+            }
+            return _http_json_response(payload)
+
+        api_token_allowed = bool(secret) or is_local_browser
         if not self.tokens.can_issue(include_api_token=api_token_allowed):
             return _http_response(
                 json.dumps({"error": "too many outstanding tokens"}).encode("utf-8"),

--- a/nanobot/webui/ws_http.py
+++ b/nanobot/webui/ws_http.py
@@ -441,6 +441,8 @@ class GatewayHTTPHandler:
 
     def _bootstrap_ws_url(self, request: Any) -> str:
         headers = getattr(request, "headers", {}) or {}
+        if self.config.public_ws_url:
+            return self.config.public_ws_url
         host = _safe_host_header(_case_insensitive_header(headers, "Host"))
         if not host:
             host = _host_for_url(self.config.host, self.config.port)

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -70,7 +70,7 @@ type BootState =
       status: "ready";
       client: NanobotClient;
       token: string;
-      tokenExpiresAt: number;
+      tokenExpiresAt: number | null;
       modelName: string | null;
       ingressLimits: BootstrapResponse["limits"] | null;
       runtimeSurface: RuntimeSurface;
@@ -733,7 +733,9 @@ export default function App() {
         ? toRuntimeSurface(boot.runtime_surface)
         : fallbackSurface;
       const runtimeHost = createRuntimeHost(runtimeSurface, boot.runtime_capabilities);
-      const tokenExpiresAt = bootstrapTokenExpiresAt(boot.expires_in);
+      const tokenExpiresAt = boot.expires_in
+        ? bootstrapTokenExpiresAt(boot.expires_in)
+        : null;
       if (runtimeHost.socketFactory) {
         client.updateUrl(url, runtimeHost.socketFactory);
       } else {
@@ -744,7 +746,7 @@ export default function App() {
         current.status === "ready" && current.client === client
           ? {
               ...current,
-              token: boot.api_token,
+              token: boot.api_token ?? "",
               tokenExpiresAt,
               modelName: boot.model_name ?? current.modelName,
               ingressLimits: boot.limits ?? current.ingressLimits,
@@ -752,7 +754,7 @@ export default function App() {
             }
           : current,
       );
-      return { token: boot.api_token, url };
+      return { token: boot.api_token ?? "", url };
     },
     [],
   );
@@ -787,8 +789,10 @@ export default function App() {
           setState({
             status: "ready",
             client,
-            token: boot.api_token,
-            tokenExpiresAt: bootstrapTokenExpiresAt(boot.expires_in),
+            token: boot.api_token ?? "",
+            tokenExpiresAt: boot.expires_in
+              ? bootstrapTokenExpiresAt(boot.expires_in)
+              : null,
             modelName: boot.model_name ?? null,
             ingressLimits: boot.limits ?? null,
             runtimeSurface,
@@ -813,7 +817,7 @@ export default function App() {
   );
 
   useEffect(() => {
-    if (state.status !== "ready") return;
+    if (state.status !== "ready" || state.tokenExpiresAt === null) return;
     const client = state.client;
     const timer = window.setTimeout(async () => {
       try {

--- a/webui/src/lib/bootstrap.ts
+++ b/webui/src/lib/bootstrap.ts
@@ -87,13 +87,8 @@ export async function fetchBootstrap(
     throw new Error(`bootstrap failed: HTTP ${res.status}`);
   }
   const body = (await res.json()) as BootstrapResponse;
-  if (!body.token || !body.ws_path) {
-    throw new Error("bootstrap response missing token or ws_path");
-  }
-  if (!body.api_token) {
-    throw new BootstrapAuthRequiredError(
-      "bootstrap authentication required: missing api_token",
-    );
+  if (!body.ws_path) {
+    throw new Error("bootstrap response missing ws_path");
   }
   return body;
 }
@@ -107,10 +102,10 @@ export async function fetchBootstrap(
  */
 export function deriveWsUrl(
   wsPath: string,
-  token: string,
+  token: string | null | undefined,
   wsUrl?: string | null,
 ): string {
-  const query = `?token=${encodeURIComponent(token)}`;
+  const query = token ? `?token=${encodeURIComponent(token)}` : "";
   const path = wsPath && wsPath.startsWith("/") ? wsPath : `/${wsPath || ""}`;
   if (typeof window !== "undefined" && window.location.port === "5173") {
     const host = window.location.hostname.includes(":")
@@ -127,6 +122,7 @@ export function deriveWsUrl(
     return `${scheme}://${authority}${path}${query}`;
   }
   if (wsUrl && /^(wss?|nanobot-host):\/\//i.test(wsUrl)) {
+    if (!token) return wsUrl;
     const join = wsUrl.includes("?") ? "&" : "?";
     return `${wsUrl}${join}token=${encodeURIComponent(token)}`;
   }

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -390,11 +390,11 @@ export interface SidebarStatePayload {
 }
 
 export interface BootstrapResponse {
-  token: string;
-  api_token: string;
+  token?: string;
+  api_token?: string;
   ws_path: string;
   ws_url?: string | null;
-  expires_in: number;
+  expires_in?: number;
   limits?: WebUIIngressLimits;
   model_name?: string | null;
   runtime_surface?: RuntimeSurface;

--- a/webui/src/tests/bootstrap.test.ts
+++ b/webui/src/tests/bootstrap.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
-  BootstrapAuthRequiredError,
   consumeUrlBootstrapSecret,
   deriveWsUrl,
   fetchBootstrap,
@@ -57,6 +56,12 @@ describe("bootstrap helpers", () => {
     );
   });
 
+  it("does not append a token for trusted-proxy websocket URLs", () => {
+    expect(deriveWsUrl("/", undefined, "wss://proxy.example/")).toBe(
+      "wss://proxy.example/",
+    );
+  });
+
   it("times out when the bootstrap endpoint never responds", async () => {
     vi.useFakeTimers();
     vi.stubGlobal("fetch", vi.fn(() => new Promise<Response>(() => {})));
@@ -69,21 +74,19 @@ describe("bootstrap helpers", () => {
     await pending;
   });
 
-  it("treats bootstrap responses without an API token as auth-required", async () => {
+  it("accepts tokenless trusted-proxy bootstrap responses", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => ({
         ok: true,
-        json: async () => ({ token: "ws-token", ws_path: "/", expires_in: 300 }),
+        json: async () => ({ ws_path: "/", ws_url: "wss://proxy.example/" }),
       })),
     );
 
-    const promise = fetchBootstrap();
-    await expect(promise).rejects.toMatchObject({
-      name: "BootstrapAuthRequiredError",
-      message: "bootstrap authentication required: missing api_token",
+    await expect(fetchBootstrap()).resolves.toMatchObject({
+      ws_path: "/",
+      ws_url: "wss://proxy.example/",
     });
-    await expect(promise).rejects.toBeInstanceOf(BootstrapAuthRequiredError);
   });
 
   it("consumes bootstrap secrets from the URL fragment", () => {


### PR DESCRIPTION
## Summary

Adds an opt-in trusted upstream-proxy authentication path for `/webui/bootstrap`, for deployments such as Cloudflare Tunnel + Cloudflare Access.

Trusted-proxy mode is intentionally tokenless:

- Requires both the direct TCP peer to match explicitly configured IPv4/IPv6 CIDRs and a non-empty configured assertion header.
- Uses only `connection.remote_address`; forwarded client headers never establish trust.
- Requires `assertionHeader` to identify a proxy-generated authentication assertion. Routing/client metadata headers such as `Host`, `Forwarded`, `X-Forwarded-*`, `X-Real-IP`, and `CF-Connecting-IP` are rejected by configuration.
- The proxy assertion authenticates `/webui/bootstrap`, the WebSocket handshake, and REST API routes.
- Trusted-proxy bootstrap returns connection metadata only: no WebSocket bootstrap token, no REST `api_token`, and no token query parameter.
- Preserves token-based behavior for localhost, static-token, and `tokenIssueSecret` deployments.
- Disabled by default; universal CIDRs and mapped-address universal ranges are rejected.
- Adds focused regression coverage and deployment/WebSocket configuration documentation.

This intentionally does not implement the CIDR-only bypass discussed in #3876 and #3891: source address alone is not sufficient authentication. It also does not cryptographically validate the upstream assertion; the identity-aware proxy remains responsible for that validation. The trusted proxy must prevent untrusted clients from reaching nanobot directly and must strip or overwrite the configured assertion header before forwarding.

## Verification

- `uv run --no-sync pytest nanobot/channels/websocket/tests/test_websocket_http_routes.py -q` — 92 passed.
- `uv run --no-sync pytest nanobot/channels/websocket/tests -q` — 327 passed.
- `uv run --no-sync ruff check nanobot/` — passed.
- Targeted `basedpyright` on changed Python files — passed.
- `bun run build` — passed.
- `git diff --check` — passed.

Known baseline/environment check:

- The WebUI Vitest setup cannot initialize in this environment because `localStorage` is unavailable in `src/tests/setup.ts`; the targeted bootstrap suite therefore cannot collect tests. The production WebUI build passes.
