### PR TITLE
fix(providers): keep DeepSeek reasoning items wire-valid

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -1082,16 +1082,6 @@ class OpenAICompatProvider(LLMProvider):
             "not supported",
             "unknown parameter",
             "unrecognized request argument",
-            # Serde-style body rejection: the endpoint could not parse the
-            # Responses wire format (e.g. DeepSeek's Responses gateway
-            # rejecting an input item shape with "Failed to deserialize the
-            # JSON body ... expected a sequence"). These are compatibility
-            # failures: fall back to Chat Completions for the same model.
-            "failed to deserialize",
-            "invalid type",
-            "expected a sequence",
-            "expected a struct",
-            "unknown field",
         )
         return any(marker in body_text for marker in compatibility_markers)
 

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -1082,6 +1082,16 @@ class OpenAICompatProvider(LLMProvider):
             "not supported",
             "unknown parameter",
             "unrecognized request argument",
+            # Serde-style body rejection: the endpoint could not parse the
+            # Responses wire format (e.g. DeepSeek's Responses gateway
+            # rejecting an input item shape with "Failed to deserialize the
+            # JSON body ... expected a sequence"). These are compatibility
+            # failures: fall back to Chat Completions for the same model.
+            "failed to deserialize",
+            "invalid type",
+            "expected a sequence",
+            "expected a struct",
+            "unknown field",
         )
         return any(marker in body_text for marker in compatibility_markers)
 

--- a/nanobot/providers/openai_responses/converters.py
+++ b/nanobot/providers/openai_responses/converters.py
@@ -45,7 +45,7 @@ def convert_messages(
                 if isinstance(reasoning, str) and reasoning:
                     input_items.append({
                         "type": "reasoning",
-                        "content": reasoning,
+                        "content": [{"type": "output_text", "text": reasoning}],
                     })
             if isinstance(content, str) and content:
                 message_id = _unique_item_id(f"msg_{idx}", used_item_ids)

--- a/tests/providers/test_openai_responses.py
+++ b/tests/providers/test_openai_responses.py
@@ -156,7 +156,10 @@ class TestConvertMessages:
         ], preserve_reasoning=True)
 
         assert items == [
-            {"type": "reasoning", "content": "think first"},
+            {
+                "type": "reasoning",
+                "content": [{"type": "output_text", "text": "think first"}],
+            },
             {
                 "type": "message",
                 "role": "assistant",
@@ -165,6 +168,32 @@ class TestConvertMessages:
                 "id": "msg_0",
             },
         ]
+
+    def test_reasoning_content_serialized_as_array_for_deepseek(self):
+        # Regression for PR #5214: DeepSeek's Responses gateway rejects
+        # reasoning items whose ``content`` is a plain string with
+        # "input: invalid type: string ..., expected a sequence" (observed
+        # after context consolidation cleared provider state and forced
+        # full-history conversion). ``content`` must be a list of parts,
+        # matching both the OpenAI Responses schema and DeepSeek's accepted
+        # wire shape.
+        _, items = convert_messages([
+            {
+                "role": "assistant",
+                "reasoning_content": "Michael topped up DeepSeek with $10.",
+                "content": "",
+                "tool_calls": [{
+                    "id": "call_1|fc_1",
+                    "function": {"name": "list_dir", "arguments": "{}"},
+                }],
+            },
+        ], preserve_reasoning=True)
+
+        assert items[0]["type"] == "reasoning"
+        assert items[0]["content"] == [
+            {"type": "output_text", "text": "Michael topped up DeepSeek with $10."},
+        ]
+        assert items[1]["type"] == "function_call"
 
     def test_assistant_empty_content_skipped(self):
         _, items = convert_messages([{"role": "assistant", "content": ""}])
@@ -823,6 +852,59 @@ class TestResponsesConversationState:
             "content": [{"type": "input_text", "text": "continue"}],
         }
         assert "lossy public transcript" not in str(items)
+
+    def test_replayed_and_delta_reasoning_items_keep_array_content(self):
+        # Regression for PR #5214: token consolidation clears
+        # ``provider_state``, so the next turn converts the full history
+        # (including assistant reasoning) instead of replaying server items.
+        # Both paths must keep reasoning ``content`` as a list - DeepSeek's
+        # Responses gateway rejects the string form with a serde error.
+        prior_items = [
+            {
+                "type": "reasoning",
+                "id": "rs_1",
+                "content": [{"type": "output_text", "text": "prior reasoning"}],
+            },
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "prior answer"}],
+                "status": "completed",
+                "id": "msg_0",
+            },
+        ]
+        state = build_responses_state(
+            provider="openai:test",
+            model="deepseek-v4-flash",
+            input_items=prior_items,
+            output_items=[],
+        ).with_pending_messages([
+            {
+                "role": "assistant",
+                "reasoning_content": "think before acting",
+                "content": "answer",
+            },
+            {"role": "user", "content": "audit the tools"},
+        ])
+
+        instructions, items, replayed = prepare_responses_input(
+            [
+                {"role": "system", "content": "You are KITT."},
+                {"role": "user", "content": "audit the tools"},
+            ],
+            state=state,
+            provider="openai:test",
+            model="deepseek-v4-flash",
+            preserve_reasoning=True,
+        )
+
+        assert instructions == "You are KITT."
+        assert replayed is True
+        reasoning_items = [item for item in items if item.get("type") == "reasoning"]
+        assert len(reasoning_items) == 2  # one replayed, one converted delta
+        for item in reasoning_items:
+            assert isinstance(item["content"], list)
+            assert item["content"][0]["type"] == "output_text"
 
 
 # ======================================================================

--- a/tests/providers/test_responses_circuit_breaker.py
+++ b/tests/providers/test_responses_circuit_breaker.py
@@ -166,8 +166,9 @@ class _FakeAPIError(Exception):
         self.response = None
 
 
-def test_serde_deserialize_error_triggers_fallback():
-    # DeepSeek Responses gateway rejecting the wire body (observed Aug 2026).
+def test_serde_deserialize_error_does_not_trigger_fallback():
+    # Serde errors can also identify malformed user-provided request fields.
+    # The known DeepSeek wire-shape bug is fixed at serialization time instead.
     err = _FakeAPIError(400, {
         "message": (
             "Failed to deserialize the JSON body into the target type: "
@@ -177,32 +178,12 @@ def test_serde_deserialize_error_triggers_fallback():
         "type": "invalid_request_error",
         "param": None,
     })
-    assert OpenAICompatProvider._should_fallback_from_responses_error(err) is True
-
-
-def test_invalid_type_error_triggers_fallback():
-    err = _FakeAPIError(422, "input[0]: invalid type: map, expected a string")
-    assert OpenAICompatProvider._should_fallback_from_responses_error(err) is True
-
-
-def test_unknown_field_error_triggers_fallback():
-    err = _FakeAPIError(400, "unknown field `foo`, expected one of `input`, `instructions`")
-    assert OpenAICompatProvider._should_fallback_from_responses_error(err) is True
+    assert OpenAICompatProvider._should_fallback_from_responses_error(err) is False
 
 
 def test_legacy_compatibility_markers_still_trigger_fallback():
     err = _FakeAPIError(400, "parameter `instructions` is unsupported")
     assert OpenAICompatProvider._should_fallback_from_responses_error(err) is True
-
-
-def test_unrelated_400_does_not_trigger_fallback():
-    err = _FakeAPIError(400, {"message": "rate limit exceeded", "type": "rate_limit_error"})
-    assert OpenAICompatProvider._should_fallback_from_responses_error(err) is False
-
-
-def test_server_error_does_not_trigger_fallback():
-    err = _FakeAPIError(500, {"message": "internal server error"})
-    assert OpenAICompatProvider._should_fallback_from_responses_error(err) is False
 
 
 # ======================================================================

--- a/tests/providers/test_responses_circuit_breaker.py
+++ b/tests/providers/test_responses_circuit_breaker.py
@@ -10,6 +10,7 @@ from nanobot.providers.openai_compat_provider import (
     _RESPONSES_PROBE_INTERVAL_S,
     OpenAICompatProvider,
 )
+from nanobot.providers.openai_responses.state import build_responses_state
 
 
 @pytest.fixture()
@@ -202,3 +203,107 @@ def test_unrelated_400_does_not_trigger_fallback():
 def test_server_error_does_not_trigger_fallback():
     err = _FakeAPIError(500, {"message": "internal server error"})
     assert OpenAICompatProvider._should_fallback_from_responses_error(err) is False
+
+
+# ======================================================================
+# DeepSeek Responses wire shape (PR #5214 root cause)
+# ======================================================================
+
+
+def _deepseek_provider(provider):
+    provider._spec = type("Spec", (), {
+        "name": "deepseek",
+        "responses_models": ("deepseek-v4-flash",),
+        "strip_model_prefix": False,
+        "strip_model_prefixes": (),
+    })()
+    provider._effective_base = "https://api.deepseek.com"
+    provider.default_model = "deepseek-v4-flash"
+    provider._extra_body = {}
+    return provider
+
+
+def test_deepseek_full_history_body_keeps_reasoning_content_as_array(provider):
+    # Full-history fixture: DeepSeek's Responses gateway rejects reasoning
+    # items whose ``content`` is a plain string ("input: invalid type: string
+    # ..., expected a sequence"); the wire body must keep it as a part list.
+    _deepseek_provider(provider)
+
+    body = provider._build_responses_body(
+        messages=[
+            {
+                "role": "assistant",
+                "reasoning_content": "Michael topped up DeepSeek with $10.",
+                "content": "All systems aligned now.",
+            },
+            {"role": "user", "content": "audit the custom tools"},
+        ],
+        tools=None,
+        model="deepseek-v4-flash",
+        max_tokens=1000,
+        temperature=0.1,
+        reasoning_effort=None,
+        tool_choice=None,
+    )
+
+    reasoning_items = [item for item in body["input"] if item.get("type") == "reasoning"]
+    assert len(reasoning_items) == 1
+    assert reasoning_items[0]["content"] == [
+        {"type": "output_text", "text": "Michael topped up DeepSeek with $10."},
+    ]
+
+
+def test_deepseek_replay_body_keeps_reasoning_content_as_array(provider):
+    # Replay/consolidation fixture: after token consolidation clears
+    # provider_state the next turn converts full history on top of the
+    # replayed prior items. Both replayed and converted reasoning items must
+    # keep list content on the wire.
+    _deepseek_provider(provider)
+
+    prior_items = [
+        {
+            "type": "reasoning",
+            "id": "rs_1",
+            "content": [{"type": "output_text", "text": "prior reasoning"}],
+        },
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "prior answer"}],
+            "status": "completed",
+            "id": "msg_0",
+        },
+    ]
+    state = build_responses_state(
+        provider=provider._responses_state_provider(),
+        model="deepseek-v4-flash",
+        input_items=prior_items,
+        output_items=[],
+    ).with_pending_messages([
+        {
+            "role": "assistant",
+            "reasoning_content": "think first",
+            "content": "answer",
+        },
+        {"role": "user", "content": "audit the custom tools"},
+    ])
+
+    body = provider._build_responses_body(
+        messages=[
+            {"role": "system", "content": "You are KITT."},
+            {"role": "user", "content": "audit the custom tools"},
+        ],
+        tools=None,
+        model="deepseek-v4-flash",
+        max_tokens=1000,
+        temperature=0.1,
+        reasoning_effort=None,
+        tool_choice=None,
+        provider_context=ProviderCallContext(conversation_state=state),
+    )
+
+    reasoning_items = [item for item in body["input"] if item.get("type") == "reasoning"]
+    assert len(reasoning_items) == 2  # one replayed from state, one converted
+    for item in reasoning_items:
+        assert isinstance(item["content"], list)
+        assert item["content"][0]["type"] == "output_text"

--- a/tests/providers/test_responses_circuit_breaker.py
+++ b/tests/providers/test_responses_circuit_breaker.py
@@ -150,3 +150,55 @@ def test_reasoning_effort_key_is_case_insensitive(provider):
     for _ in range(_RESPONSES_FAILURE_THRESHOLD):
         provider._record_responses_failure("o3", "High")
     assert provider._should_use_responses_api("o3", "high") is False
+
+
+# ======================================================================
+# _should_fallback_from_responses_error
+# ======================================================================
+
+
+class _FakeAPIError(Exception):
+    def __init__(self, status_code, body):
+        super().__init__(str(body))
+        self.status_code = status_code
+        self.body = body
+        self.response = None
+
+
+def test_serde_deserialize_error_triggers_fallback():
+    # DeepSeek Responses gateway rejecting the wire body (observed Aug 2026).
+    err = _FakeAPIError(400, {
+        "message": (
+            "Failed to deserialize the JSON body into the target type: "
+            "input: invalid type: string \"Michael topped up DeepSeek ...\", "
+            "expected a sequence at line 1 column 268612"
+        ),
+        "type": "invalid_request_error",
+        "param": None,
+    })
+    assert OpenAICompatProvider._should_fallback_from_responses_error(err) is True
+
+
+def test_invalid_type_error_triggers_fallback():
+    err = _FakeAPIError(422, "input[0]: invalid type: map, expected a string")
+    assert OpenAICompatProvider._should_fallback_from_responses_error(err) is True
+
+
+def test_unknown_field_error_triggers_fallback():
+    err = _FakeAPIError(400, "unknown field `foo`, expected one of `input`, `instructions`")
+    assert OpenAICompatProvider._should_fallback_from_responses_error(err) is True
+
+
+def test_legacy_compatibility_markers_still_trigger_fallback():
+    err = _FakeAPIError(400, "parameter `instructions` is unsupported")
+    assert OpenAICompatProvider._should_fallback_from_responses_error(err) is True
+
+
+def test_unrelated_400_does_not_trigger_fallback():
+    err = _FakeAPIError(400, {"message": "rate limit exceeded", "type": "rate_limit_error"})
+    assert OpenAICompatProvider._should_fallback_from_responses_error(err) is False
+
+
+def test_server_error_does_not_trigger_fallback():
+    err = _FakeAPIError(500, {"message": "internal server error"})
+    assert OpenAICompatProvider._should_fallback_from_responses_error(err) is False


### PR DESCRIPTION
## Problem

Conversations routed through the OpenAI Responses API can fail when the endpoint rejects the request body with a serde-style deserialization error, for example:

```
Failed to deserialize the JSON body into the target type: input: invalid type: string "Michael topped up DeepSeek with $10...", expected a sequence at line 1 column 268612
```

This was observed with DeepSeek's Responses endpoint for `deepseek-v4-flash`: the request failed only on the first turn *after* token consolidation cleared the provider state.

## Root cause

`convert_messages()` emitted a `reasoning` input item with `content` as a plain string whenever `preserve_reasoning` was enabled (the DeepSeek spec). DeepSeek's Responses gateway rejects that shape because its schema requires `content` to be a list of content parts.

Normal multi-turn requests did not hit this because the replay path sends back the server's own output items, which already carry list content. Token consolidation clears `provider_state`, forcing the full-history conversion path, so the first request after consolidation included an assistant reasoning step converted by nanobot.

This was reproduced live against `api.deepseek.com/responses`:

- `{"type": "reasoning", "content": "..."}` → `400 input: invalid type: string "...", expected a sequence`
- `{"type": "reasoning", "content": [{"type": "output_text", "text": "..."}]}` → `200 OK`

The array form matches the OpenAI Responses schema and DeepSeek's own output items.

## Change

Serialize reasoning item content as a list of `output_text` parts in `convert_messages()`. This keeps the wire format valid for DeepSeek Responses and is inert for providers without `preserve_reasoning`.

Serde parsing phrases remain explicit errors rather than generic fallback markers: messages such as `invalid type` and `unknown field` can also identify malformed user-provided request fields. The existing fallback behavior for explicit Responses compatibility errors is unchanged.

## Tests

- `tests/providers/test_openai_responses.py`: array-shape coverage for direct conversion and replayed plus newly converted reasoning items.
- `tests/providers/test_responses_circuit_breaker.py`: provider-level full-history and replay/consolidation request fixtures, plus coverage that the observed serde error stays explicit while legacy compatibility markers still fall back.
- Focused provider tests: 133 passed.
- `ruff check` passed on all changed files.
- Live `deepseek-v4-flash` verification completed through the public Nanobot SDK with ingested assistant reasoning history and returned `DS_REAL_OK` without an error or tool call.
