### PR TITLE
fix(image): send Gemini Flash hints via generationConfig.imageConfig

### DIFF
--- a/nanobot/providers/image_generation.py
+++ b/nanobot/providers/image_generation.py
@@ -808,7 +808,12 @@ class GeminiImageGenerationClient(ImageGenerationProvider):
         generation_config: dict[str, Any] = {"responseModalities": ["TEXT", "IMAGE"]}
         image_config = _gemini_flash_image_config(model, aspect_ratio, image_size)
         if image_config:
-            generation_config["responseFormat"] = {"image": image_config}
+            # Gemini Flash image models accept plain-string values under
+            # ``generationConfig.imageConfig``. The legacy
+            # ``responseFormat.image`` block is rejected with INVALID_ARGUMENT
+            # by gemini-3.1-flash-lite-image (enum-based fields), so it is not
+            # used here.
+            generation_config["imageConfig"] = image_config
 
         body: dict[str, Any] = {
             "contents": [{"role": "user", "parts": parts}],
@@ -864,11 +869,13 @@ def _gemini_flash_image_config(
     aspect_ratio: str | None,
     image_size: str | None,
 ) -> dict[str, str]:
-    """Build the ``responseFormat.image`` config for Gemini Flash image models.
+    """Build the ``generationConfig.imageConfig`` config for Gemini Flash image models.
 
-    Capabilities are model-specific: Gemini 3.1 Flash variants support four
-    additional extreme ratios, while configurable image sizes are limited to
-    the documented Gemini 3 image model families.
+    Values are the documented plain strings (e.g. ``16:9``, ``1K``) that the
+    live v1beta API accepts under ``imageConfig``. Capabilities are
+    model-specific: Gemini 3.1 Flash variants support four additional extreme
+    ratios, while configurable image sizes are limited to the documented
+    Gemini 3 image model families.
     """
     config: dict[str, str] = {}
     if aspect_ratio and aspect_ratio in _gemini_flash_supported_aspect_ratios(model):

--- a/tests/providers/test_image_generation.py
+++ b/tests/providers/test_image_generation.py
@@ -464,7 +464,7 @@ async def test_gemini_flash_forwards_aspect_ratio_and_image_size() -> None:
         image_size="2K",
     )
 
-    image_config = fake.calls[0]["json"]["generationConfig"]["responseFormat"]["image"]
+    image_config = fake.calls[0]["json"]["generationConfig"]["imageConfig"]
     assert image_config == {"aspectRatio": "16:9", "imageSize": "2K"}
 
 
@@ -480,7 +480,7 @@ async def test_gemini_flash_2_5_drops_image_size() -> None:
         image_size="1K",
     )
 
-    image_config = fake.calls[0]["json"]["generationConfig"]["responseFormat"]["image"]
+    image_config = fake.calls[0]["json"]["generationConfig"]["imageConfig"]
     assert image_config == {"aspectRatio": "4:3"}
 
 
@@ -496,7 +496,7 @@ async def test_gemini_flash_2_0_drops_image_size() -> None:
         image_size="1K",
     )
 
-    image_config = fake.calls[0]["json"]["generationConfig"]["responseFormat"]["image"]
+    image_config = fake.calls[0]["json"]["generationConfig"]["imageConfig"]
     assert image_config == {"aspectRatio": "16:9"}
 
 
@@ -524,8 +524,8 @@ async def test_gemini_flash_scopes_extreme_aspect_ratios_by_model(
         aspect_ratio=aspect_ratio,
     )
 
-    response_format = fake.calls[0]["json"]["generationConfig"].get("responseFormat")
-    assert response_format == ({"image": expected} if expected else None)
+    image_config = fake.calls[0]["json"]["generationConfig"].get("imageConfig")
+    assert image_config == expected
 
 
 @pytest.mark.parametrize(
@@ -553,8 +553,8 @@ async def test_gemini_flash_scopes_image_size_by_model(
         image_size=image_size,
     )
 
-    response_format = fake.calls[0]["json"]["generationConfig"].get("responseFormat")
-    assert response_format == ({"image": expected} if expected else None)
+    image_config = fake.calls[0]["json"]["generationConfig"].get("imageConfig")
+    assert image_config == expected
 
 
 @pytest.mark.asyncio
@@ -571,7 +571,7 @@ async def test_gemini_flash_ignores_unsupported_hints() -> None:
         image_size="1024x1024",
     )
 
-    assert "responseFormat" not in fake.calls[0]["json"]["generationConfig"]
+    assert "imageConfig" not in fake.calls[0]["json"]["generationConfig"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# fix(image): send Gemini Flash hints via `generationConfig.imageConfig`

## Summary

Gemini Flash image models (`gemini-3.1-flash-lite-image`, `gemini-2.5-flash-image`, and other `generateContent`-based image models) fail with `HTTP 400 INVALID_ARGUMENT` whenever an aspect ratio or image size hint is supplied. The provider sends these hints under `generationConfig.responseFormat.image`, a legacy block whose `aspectRatio` / `imageSize` fields are enum-based on the live v1beta API and reject plain-string values such as `"16:9"` or `"1K"` — even though those are the documented values.

## Root cause

`_generate_gemini_flash` currently builds the request as:

```json
"generationConfig": {
  "responseModalities": ["TEXT", "IMAGE"],
  "responseFormat": { "image": { "aspectRatio": "16:9", "imageSize": "1K" } }
}
```

The live API rejects this payload with:

```
Invalid value at 'generation_config.response_format.image.aspect_ratio' ... "16:9"
```

The enum in question (`google.ai.generativelanguage.v1beta.ImageResponseFormat.AspectRatio`) only accepts values such as `ASPECT_RATIO_SIXTEEN_BY_NINE` (and `ImageSize` accepts `IMAGE_SIZE_ONE_K`), so the plain-string values the code sends are always rejected. A request without the `responseFormat` block succeeds, which is why the failure only appears when a hint is requested.

## Fix

Gemini Flash image models accept the same plain-string hints under `generationConfig.imageConfig`, which is the documented non-enum path (the `ImageConfig` message). This PR switches the Flash branch to:

```json
"generationConfig": {
  "responseModalities": ["TEXT", "IMAGE"],
  "imageConfig": { "aspectRatio": "16:9", "imageSize": "1K" }
}
```

The change is confined to `nanobot/providers/image_generation.py` (request construction plus docstring/comments clarifying the wire contract) and the matching tests in `tests/providers/test_image_generation.py`. AIHubMix, Ollama and Imagen paths are untouched.

## Verification

- Direct `curl` calls against `https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite-image:generateContent`:
  - with `generationConfig.imageConfig` (`aspectRatio: "16:9"`, `imageSize: "1K"`) → **image returned**;
  - with the old `responseFormat.image` block and the same values → **HTTP 400 INVALID_ARGUMENT**;
  - same `imageConfig` request against `gemini-2.5-flash-image` → **image returned**.
- `tests/providers/test_image_generation.py`: **93 passed**.
- `tests/tools/test_image_generation_tool.py`: **8 passed** (run standalone).
- `ruff check` on the touched files: clean.

Note: running `tests/providers/...` and `tests/tools/test_image_generation_tool.py` in a single `pytest` invocation hits a pre-existing collection-order `ImportError` in the tool test file (it imports `ImageGenerationToolConfig` from `nanobot.config.schema`, where the symbol is attached lazily). This reproduces identically on `origin/main` without this change and is unrelated to this PR.

## Scope / no-regression

Only the Gemini Flash `generateContent` path is modified. Model-specific capability scoping (extreme aspect ratios for 3.1 Flash variants, `1K`-only for Flash Lite, no configurable size for 2.x models) is preserved; the existing parametrized tests cover those cases unchanged.
