### PR TITLE
fix(providers): handle string items when applying prompt cache markers

### DIFF
--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -515,11 +515,13 @@ class AnthropicProvider(LLMProvider):
         if isinstance(system, str) and system:
             system = [{"type": "text", "text": system, "cache_control": marker}]
         elif isinstance(system, list) and system:
-            system = list(system)
-            if isinstance(system[-1], dict):
-                system[-1] = {**system[-1], "cache_control": marker}
-            elif isinstance(system[-1], str):
-                system[-1] = {"type": "text", "text": system[-1], "cache_control": marker}
+            sys_blocks: list[Any] = list(cast(list[Any], system))
+            last = sys_blocks[-1]
+            if isinstance(last, dict):
+                sys_blocks[-1] = {**last, "cache_control": marker}
+            elif isinstance(last, str):
+                sys_blocks[-1] = {"type": "text", "text": last, "cache_control": marker}
+            system = sys_blocks
 
         new_msgs = list(messages)
         if len(new_msgs) >= 3:
@@ -529,10 +531,11 @@ class AnthropicProvider(LLMProvider):
                 new_msgs[-2] = {**m, "content": [{"type": "text", "text": c, "cache_control": marker}]}
             elif isinstance(c, list) and c:
                 nc = list(cast(list[Any], c))
-                if isinstance(nc[-1], dict):
-                    nc[-1] = {**nc[-1], "cache_control": marker}
-                elif isinstance(nc[-1], str):
-                    nc[-1] = {"type": "text", "text": nc[-1], "cache_control": marker}
+                last = nc[-1]
+                if isinstance(last, dict):
+                    nc[-1] = {**last, "cache_control": marker}
+                elif isinstance(last, str):
+                    nc[-1] = {"type": "text", "text": last, "cache_control": marker}
                 new_msgs[-2] = {**m, "content": nc}
 
         new_tools = tools

--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -199,7 +199,7 @@ class AnthropicProvider(LLMProvider):
 
             if role == "system":
                 system = (
-                    cast(list[dict[str, Any]], content)
+                    cast(list[Any], content)
                     if isinstance(content, list)
                     else content
                     if isinstance(content, str)
@@ -528,7 +528,7 @@ class AnthropicProvider(LLMProvider):
             if isinstance(c, str):
                 new_msgs[-2] = {**m, "content": [{"type": "text", "text": c, "cache_control": marker}]}
             elif isinstance(c, list) and c:
-                nc = list(cast(list[dict[str, Any]], c))
+                nc = list(cast(list[Any], c))
                 if isinstance(nc[-1], dict):
                     nc[-1] = {**nc[-1], "cache_control": marker}
                 elif isinstance(nc[-1], str):

--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -516,7 +516,10 @@ class AnthropicProvider(LLMProvider):
             system = [{"type": "text", "text": system, "cache_control": marker}]
         elif isinstance(system, list) and system:
             system = list(system)
-            system[-1] = {**system[-1], "cache_control": marker}
+            if isinstance(system[-1], dict):
+                system[-1] = {**system[-1], "cache_control": marker}
+            elif isinstance(system[-1], str):
+                system[-1] = {"type": "text", "text": system[-1], "cache_control": marker}
 
         new_msgs = list(messages)
         if len(new_msgs) >= 3:
@@ -526,7 +529,10 @@ class AnthropicProvider(LLMProvider):
                 new_msgs[-2] = {**m, "content": [{"type": "text", "text": c, "cache_control": marker}]}
             elif isinstance(c, list) and c:
                 nc = list(cast(list[dict[str, Any]], c))
-                nc[-1] = {**nc[-1], "cache_control": marker}
+                if isinstance(nc[-1], dict):
+                    nc[-1] = {**nc[-1], "cache_control": marker}
+                elif isinstance(nc[-1], str):
+                    nc[-1] = {"type": "text", "text": nc[-1], "cache_control": marker}
                 new_msgs[-2] = {**m, "content": nc}
 
         new_tools = tools

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -601,11 +601,12 @@ class OpenAICompatProvider(LLMProvider):
                     {"type": "text", "text": content, "cache_control": cache_marker},
                 ]}
             if isinstance(content, list) and content:
-                nc = list(cast(list[Any], content))
-                if isinstance(nc[-1], dict):
-                    nc[-1] = {**nc[-1], "cache_control": cache_marker}
-                elif isinstance(nc[-1], str):
-                    nc[-1] = {"type": "text", "text": nc[-1], "cache_control": cache_marker}
+                nc: list[Any] = list(cast(list[Any], content))
+                last = nc[-1]
+                if isinstance(last, dict):
+                    nc[-1] = {**last, "cache_control": cache_marker}
+                elif isinstance(last, str):
+                    nc[-1] = {"type": "text", "text": last, "cache_control": cache_marker}
                 return {**msg, "content": nc}
             return msg
 

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -602,7 +602,10 @@ class OpenAICompatProvider(LLMProvider):
                 ]}
             if isinstance(content, list) and content:
                 nc = list(cast(list[dict[str, Any]], content))
-                nc[-1] = {**nc[-1], "cache_control": cache_marker}
+                if isinstance(nc[-1], dict):
+                    nc[-1] = {**nc[-1], "cache_control": cache_marker}
+                elif isinstance(nc[-1], str):
+                    nc[-1] = {"type": "text", "text": nc[-1], "cache_control": cache_marker}
                 return {**msg, "content": nc}
             return msg
 

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -601,7 +601,7 @@ class OpenAICompatProvider(LLMProvider):
                     {"type": "text", "text": content, "cache_control": cache_marker},
                 ]}
             if isinstance(content, list) and content:
-                nc = list(cast(list[dict[str, Any]], content))
+                nc = list(cast(list[Any], content))
                 if isinstance(nc[-1], dict):
                     nc[-1] = {**nc[-1], "cache_control": cache_marker}
                 elif isinstance(nc[-1], str):

--- a/tests/providers/test_prompt_cache_markers.py
+++ b/tests/providers/test_prompt_cache_markers.py
@@ -85,3 +85,39 @@ def test_openai_compat_marks_only_tail_without_mcp() -> None:
         _openai_tools("read_file", "write_file"),
     )
     assert _marked_openai_tool_names(marked_tools) == ["write_file"]
+
+def test_openai_compat_cache_control_with_list_content_strings() -> None:
+    messages = [
+        {"role": "system", "content": ["system prompt line 1", "system prompt line 2"]},
+        {"role": "assistant", "content": "assistant"},
+        {"role": "user", "content": ["user line 1", "user line 2"]},
+    ]
+    new_messages, _ = OpenAICompatProvider._apply_cache_control(messages, None)
+    assert new_messages[0]["content"][-1] == {
+        "type": "text",
+        "text": "system prompt line 2",
+        "cache_control": {"type": "ephemeral"},
+    }
+
+
+def test_anthropic_cache_control_with_list_content_strings() -> None:
+    messages = [
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": ["assistant line 1", "assistant line 2"]},
+        {"role": "user", "content": "u2"},
+    ]
+    system, new_messages, _ = AnthropicProvider._apply_cache_control(
+        ["system line 1", "system line 2"],
+        messages,
+        None,
+    )
+    assert system[-1] == {
+        "type": "text",
+        "text": "system line 2",
+        "cache_control": {"type": "ephemeral"},
+    }
+    assert new_messages[-2]["content"][-1] == {
+        "type": "text",
+        "text": "assistant line 2",
+        "cache_control": {"type": "ephemeral"},
+    }


### PR DESCRIPTION
Prompt-cache marker injection assumes every list content item is a dict and does `{**item, "cache_control": ...}`. Real messages can carry list content with bare strings (system lines, assistant/user segments). That path raises `TypeError: 'str' object is not a mapping` and aborts the request before the provider call.

In OpenAI-compat and Anthropic `_apply_cache_control`:
- If the last list item is a dict, attach `cache_control` as before.
- If it is a string, wrap it as a text block and attach the marker.

## Test plan
- [x] `pytest tests/providers/test_prompt_cache_markers.py`
- [x] RED: string list content TypeError on main
- [x] GREEN: markers applied on wrapped string tails
