### PR TITLE
fix(providers): preserve list content when merging same-role messages

### DIFF
--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -665,7 +665,21 @@ class LLMProvider(ABC):
                 if isinstance(prev_content, str) and isinstance(curr_content, str):
                     prev["content"] = (prev_content + "\n\n" + curr_content).strip()
                 else:
-                    merged[-1] = dict(msg)
+                    p_blocks = (
+                        list(prev_content)
+                        if isinstance(prev_content, list)
+                        else [{"type": "text", "text": str(prev_content)}]
+                        if prev_content
+                        else []
+                    )
+                    c_blocks = (
+                        list(curr_content)
+                        if isinstance(curr_content, list)
+                        else [{"type": "text", "text": str(curr_content)}]
+                        if curr_content
+                        else []
+                    )
+                    prev["content"] = p_blocks + c_blocks
             else:
                 merged.append(dict(msg))
 

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -665,15 +665,15 @@ class LLMProvider(ABC):
                 if isinstance(prev_content, str) and isinstance(curr_content, str):
                     prev["content"] = (prev_content + "\n\n" + curr_content).strip()
                 else:
-                    p_blocks = (
-                        list(prev_content)
+                    p_blocks: list[Any] = (
+                        list(cast(list[Any], prev_content))
                         if isinstance(prev_content, list)
                         else [{"type": "text", "text": str(prev_content)}]
                         if prev_content
                         else []
                     )
-                    c_blocks = (
-                        list(curr_content)
+                    c_blocks: list[Any] = (
+                        list(cast(list[Any], curr_content))
                         if isinstance(curr_content, list)
                         else [{"type": "text", "text": str(curr_content)}]
                         if curr_content

--- a/tests/providers/test_enforce_role_alternation.py
+++ b/tests/providers/test_enforce_role_alternation.py
@@ -48,6 +48,17 @@ class TestEnforceRoleAlternation:
         assert len(result) == 1
         assert "Hello" in result[0]["content"]
         assert "How are you?" in result[0]["content"]
+    def test_consecutive_user_list_content_merged(self):
+        msgs = [
+            {"role": "user", "content": [{"type": "text", "text": "part1"}]},
+            {"role": "user", "content": [{"type": "text", "text": "part2"}]},
+        ]
+        result = LLMProvider._enforce_role_alternation(msgs)
+        assert len(result) == 1
+        assert result[0]["content"] == [
+            {"type": "text", "text": "part1"},
+            {"type": "text", "text": "part2"},
+        ]
 
     def test_consecutive_assistant_messages_merged(self):
         msgs = [
@@ -112,14 +123,17 @@ class TestEnforceRoleAlternation:
         assert result[1]["content"] is None
         assert result[2]["role"] == "tool"
 
-    def test_non_string_content_uses_latest(self):
+    def test_mixed_content_merged(self):
         msgs = [
             {"role": "user", "content": [{"type": "text", "text": "A"}]},
             {"role": "user", "content": "B"},
         ]
         result = LLMProvider._enforce_role_alternation(msgs)
         assert len(result) == 1
-        assert result[0]["content"] == "B"
+        assert result[0]["content"] == [
+            {"type": "text", "text": "A"},
+            {"type": "text", "text": "B"},
+        ]
 
     def test_original_messages_not_mutated(self):
         msgs = [


### PR DESCRIPTION
`_enforce_role_alternation` merges consecutive same-role messages so providers that require strict alternation stay valid. String+string content is concatenated, but any non-string pair replaced the previous message entirely. That drops earlier multimodal/list parts (images, segmented text blocks) before the provider call.

When either side is non-string, normalize both sides to block lists and concatenate blocks instead of discarding the earlier message.

## Test plan
- [x] `pytest tests/providers/test_enforce_role_alternation.py`
- [x] RED: consecutive user list contents keep only the latest list
- [x] GREEN: lists merge; mixed list+string becomes two text blocks
