### PR TITLE
fix(telegram): keep fenced code intact when language has special chars

### DIFF
--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -166,7 +166,7 @@ def _strip_md_block(text: str) -> str:
     markdown syntax while the response is still being generated.
     """
     # Code blocks -> just the code
-    text = re.sub(r'```[\w]*\n?([\s\S]*?)```', r'\1', text)
+    text = re.sub(r'```[^\n]*\n?([\s\S]*?)```', r'\1', text)
     # Headers -> plain text
     text = re.sub(r'^#{1,6}\s+(.+)$', r'\1', text, flags=re.MULTILINE)
     # Blockquotes
@@ -232,7 +232,7 @@ def _markdown_to_telegram_html(text: str) -> str:
         code_blocks.append(m.group(1))
         return f"\x00CB{len(code_blocks) - 1}\x00"
 
-    text = re.sub(r'```[\w]*\n?([\s\S]*?)```', save_code_block, text)
+    text = re.sub(r'```[^\n]*\n?([\s\S]*?)```', save_code_block, text)
 
     # 1.5. Convert markdown tables to box-drawing (reuse code_block placeholders)
     lines = text.split('\n')

--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -166,7 +166,7 @@ def _strip_md_block(text: str) -> str:
     markdown syntax while the response is still being generated.
     """
     # Code blocks -> just the code
-    text = re.sub(r'```[^\n]*\n?([\s\S]*?)```', r'\1', text)
+    text = re.sub(r'```(?:[^\n]*\n)?([\s\S]*?)```', r'\1', text)
     # Headers -> plain text
     text = re.sub(r'^#{1,6}\s+(.+)$', r'\1', text, flags=re.MULTILINE)
     # Blockquotes
@@ -232,7 +232,7 @@ def _markdown_to_telegram_html(text: str) -> str:
         code_blocks.append(m.group(1))
         return f"\x00CB{len(code_blocks) - 1}\x00"
 
-    text = re.sub(r'```[^\n]*\n?([\s\S]*?)```', save_code_block, text)
+    text = re.sub(r'```(?:[^\n]*\n)?([\s\S]*?)```', save_code_block, text)
 
     # 1.5. Convert markdown tables to box-drawing (reuse code_block placeholders)
     lines = text.split('\n')

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -2395,3 +2395,13 @@ async def test_callback_query_handles_inaccessible_message() -> None:
     query.answer.assert_awaited_once()
     channel._handle_message.assert_awaited_once()
     assert channel._handle_message.await_args.kwargs["chat_id"] == "123"
+
+def test_markdown_to_html_code_block_special_chars_language() -> None:
+    from nanobot.channels.telegram.runtime import _markdown_to_telegram_html, _strip_md_block
+
+    text = "```c++\nint main() { return 0; }\n```"
+    html = _markdown_to_telegram_html(text)
+    assert html == "<pre><code>int main() { return 0; }\n</code></pre>"
+
+    stripped = _strip_md_block(text)
+    assert stripped == "int main() { return 0; }\n"

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -2405,3 +2405,16 @@ def test_markdown_to_html_code_block_special_chars_language() -> None:
 
     stripped = _strip_md_block(text)
     assert stripped == "int main() { return 0; }\n"
+def test_markdown_to_html_code_block_same_line_no_newline() -> None:
+    """
+    Locks out the regression where triple-backtick content without a newline
+    (e.g., Use ```<tag>``` here) was mistaken for a language info string and discarded.
+    """
+    from nanobot.channels.telegram.runtime import _markdown_to_telegram_html, _strip_md_block
+
+    text = "Use ```<tag>``` here"
+    html = _markdown_to_telegram_html(text)
+    assert html == "Use <pre><code>&lt;tag&gt;</code></pre> here"
+
+    stripped = _strip_md_block(text)
+    assert stripped == "Use <tag> here"


### PR DESCRIPTION
Telegram HTML conversion and plain strip both matched fenced code with ` ```[\w]* `. Language tags like `c++`, `objective-c`, or `html+django` stop at the first non-word character, so the remainder of the language token is treated as code. Users see corrupted code blocks (e.g. leading `++`) in Telegram messages.

Accept any non-newline language tail: ` ```[^\n]* ` in both `_markdown_to_telegram_html` and `_strip_md_block`.

## Test plan
- [x] `pytest nanobot/channels/telegram/tests/test_telegram_channel.py -k markdown_to_html_code_block_special`
- [x] RED: ` ```c++\nint main...` renders with `++` inside `<code>`
- [x] GREEN: code body is exactly `int main() { return 0; }\n`
