### PR TITLE
fix(wecom): fall back when filename sanitization strips everything

### DIFF
--- a/nanobot/channels/wecom/runtime.py
+++ b/nanobot/channels/wecom/runtime.py
@@ -30,12 +30,12 @@ WECOM_UPLOAD_MAX_BYTES = 1024 * 1024 * 200  # 200MB
 _SAFE_NAME_RE = re.compile(r"[^\w.\-()\[\]（）【】\u4e00-\u9fff]+", re.UNICODE)
 
 
-def _sanitize_filename(name: str) -> str:
+def _sanitize_filename(name: str, fallback: str = "unnamed") -> str:
     """Sanitize filename to avoid traversal and problematic chars."""
     name = (name or "").strip()
     name = Path(name).name
     name = _SAFE_NAME_RE.sub("_", name).strip("._ ")
-    return name
+    return name or fallback
 
 
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}
@@ -399,9 +399,8 @@ class WecomChannel(BaseChannel):
                 return None
 
             media_dir = get_media_dir("wecom")
-            if not filename:
-                filename = fname or f"{media_type}_{hash(file_url) % 100000}"
-            filename = _sanitize_filename(cast(str, filename))
+            fallback_name = fname or f"{media_type}_{hash(file_url) % 100000}"
+            filename = _sanitize_filename(cast(str, filename or fallback_name), fallback=fallback_name)
 
             file_path = media_dir / filename
             await asyncio.to_thread(file_path.write_bytes, data)

--- a/nanobot/channels/wecom/runtime.py
+++ b/nanobot/channels/wecom/runtime.py
@@ -32,10 +32,12 @@ _SAFE_NAME_RE = re.compile(r"[^\w.\-()\[\]（）【】\u4e00-\u9fff]+", re.UNICO
 
 def _sanitize_filename(name: str, fallback: str = "unnamed") -> str:
     """Sanitize filename to avoid traversal and problematic chars."""
-    name = (name or "").strip()
-    name = Path(name).name
-    name = _SAFE_NAME_RE.sub("_", name).strip("._ ")
-    return name or fallback
+    def _clean(value: str) -> str:
+        value = (value or "").strip()
+        value = Path(value).name
+        return _SAFE_NAME_RE.sub("_", value).strip("._ ")
+
+    return _clean(name) or _clean(fallback) or "unnamed"
 
 
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}

--- a/nanobot/channels/wecom/tests/test_wecom_channel.py
+++ b/nanobot/channels/wecom/tests/test_wecom_channel.py
@@ -93,8 +93,13 @@ def test_sanitize_filename_keeps_chinese_chars() -> None:
 
 
 def test_sanitize_filename_empty_input() -> None:
-    assert _sanitize_filename("") == ""
+    assert _sanitize_filename("") == "unnamed"
 
+
+def test_sanitize_filename_empty_or_dots_fallback() -> None:
+    assert _sanitize_filename("...") == "unnamed"
+    assert _sanitize_filename("..", fallback="fallback.txt") == "fallback.txt"
+    assert _sanitize_filename("") == "unnamed"
 
 def test_guess_wecom_media_type_image() -> None:
     for ext in (".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"):

--- a/nanobot/channels/wecom/tests/test_wecom_channel.py
+++ b/nanobot/channels/wecom/tests/test_wecom_channel.py
@@ -99,7 +99,9 @@ def test_sanitize_filename_empty_input() -> None:
 def test_sanitize_filename_empty_or_dots_fallback() -> None:
     assert _sanitize_filename("...") == "unnamed"
     assert _sanitize_filename("..", fallback="fallback.txt") == "fallback.txt"
+    assert _sanitize_filename("...", fallback="../../outside.txt") == "outside.txt"
     assert _sanitize_filename("") == "unnamed"
+
 
 def test_guess_wecom_media_type_image() -> None:
     for ext in (".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"):
@@ -147,6 +149,27 @@ async def test_download_and_save_success() -> None:
     assert os.path.basename(path) == "photo.png"
     # Cleanup
     os.unlink(path)
+
+
+@pytest.mark.asyncio
+async def test_download_and_save_sanitizes_sdk_fallback(tmp_path: Path) -> None:
+    """An unsafe SDK filename cannot escape the channel media directory."""
+    channel = WecomChannel(WecomConfig(bot_id="b", secret="s", allow_from=["*"]), MessageBus())
+    client = _FakeWeComClient()
+    client.download_file.return_value = (b"payload", "../../outside.txt")
+    channel._client = client
+
+    with patch("nanobot.channels.wecom.runtime.get_media_dir", return_value=tmp_path):
+        path = await channel._download_and_save_media(
+            "https://example.com/file",
+            "aes_key",
+            "file",
+            "...",
+        )
+
+    assert path is not None
+    assert Path(path) == tmp_path / "outside.txt"
+    assert Path(path).read_bytes() == b"payload"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
WeCom media download sanitizes inbound filenames before writing under the media dir. Names that are only dots/spaces/unsafe characters strip to an empty string. Joining that with the media directory yields the directory path itself, so the write step targets the directory rather than a file.

- `_sanitize_filename` returns a fallback (default `unnamed`) when sanitization is empty.
- Download path always supplies a concrete fallback name derived from the remote fname/media type.

## Test plan
- [x] `pytest nanobot/channels/wecom/tests/test_wecom_channel.py -k sanitize_filename` (requires wecom_aibot_sdk)
- [x] RED: `...` / `` -> `''`
- [x] GREEN: `...` -> `unnamed`; custom fallback honored
