### PR TITLE
fix(cron): reject invalid cron expressions when adding schedules

### DIFF
--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -75,13 +75,27 @@ def _validate_schedule_for_add(schedule: CronSchedule) -> None:
     if schedule.tz and schedule.kind != "cron":
         raise ValueError("tz can only be used with cron schedules")
 
-    if schedule.kind == "cron" and schedule.tz:
-        try:
-            from zoneinfo import ZoneInfo
+    if schedule.kind == "cron":
+        if not schedule.expr:
+            raise ValueError("cron schedule requires an expression (expr)")
+        from croniter import croniter
 
-            ZoneInfo(schedule.tz)
-        except Exception:
-            raise ValueError(f"unknown timezone '{schedule.tz}'") from None
+        if not croniter.is_valid(schedule.expr):
+            raise ValueError(f"invalid cron expression '{schedule.expr}'")
+
+        if schedule.tz:
+            try:
+                from zoneinfo import ZoneInfo
+
+                ZoneInfo(schedule.tz)
+            except Exception:
+                raise ValueError(f"unknown timezone '{schedule.tz}'") from None
+    elif schedule.kind == "every":
+        if not schedule.every_ms or schedule.every_ms <= 0:
+            raise ValueError("every schedule requires a positive every_ms interval")
+    elif schedule.kind == "at":
+        if not schedule.at_ms or schedule.at_ms <= 0:
+            raise ValueError("at schedule requires a positive at_ms timestamp")
 
 
 def _has_legacy_delivery_context(payload: CronPayload) -> bool:

--- a/tests/cron/test_cron_service.py
+++ b/tests/cron/test_cron_service.py
@@ -127,6 +127,16 @@ def test_add_job_rejects_unknown_timezone(tmp_path) -> None:
     assert service.list_jobs(include_disabled=True) == []
 
 
+def test_validate_schedule_rejects_invalid_cron_expression(tmp_path) -> None:
+    service = CronService(tmp_path / "cron" / "jobs.json")
+    with pytest.raises(ValueError, match="invalid cron expression"):
+        service.add_job(
+            name="invalid cron test",
+            schedule=CronSchedule(kind="cron", expr="invalid cron expr"),
+            message="hello",
+        )
+    assert service.list_jobs(include_disabled=True) == []
+
 def test_add_job_accepts_valid_timezone(tmp_path) -> None:
     service = CronService(tmp_path / "cron" / "jobs.json")
 


### PR DESCRIPTION
`_validate_schedule_for_add` only checked that `tz` is a known zone for cron jobs. An invalid `expr` was accepted, persisted, and computed to `next_run_at_ms=None`, so the job sits enabled-or-present but never runs. Users get a silent dead schedule instead of an immediate error.

For `kind=="cron"`, require a non-empty expression and validate it with `croniter.is_valid` before insert. Also reject non-positive `every_ms` / `at_ms` for those kinds so other schedule shapes cannot be stored non-runnable the same way.

## Test plan
- [x] `pytest tests/cron/test_cron_service.py`
- [x] RED: invalid expr stored with `next_run_at_ms is None`
- [x] GREEN: `ValueError: invalid cron expression` and no job retained
