### PR TITLE
fix(webui): stabilize thread during IME input

### DIFF
--- a/webui/src/components/thread/ThreadComposer.tsx
+++ b/webui/src/components/thread/ThreadComposer.tsx
@@ -1799,6 +1799,7 @@ export function ThreadComposer({
   };
 
   const onInput: React.FormEventHandler<HTMLTextAreaElement> = (e) => {
+    if ((e.nativeEvent as InputEvent).isComposing) return;
     const el = e.currentTarget;
     el.style.height = "auto";
     el.style.height = `${Math.min(el.scrollHeight, 260)}px`;

--- a/webui/src/components/thread/ThreadViewport.tsx
+++ b/webui/src/components/thread/ThreadViewport.tsx
@@ -186,6 +186,7 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
   const pendingPromptJumpRef = useRef<string | null>(null);
   const restoreScrollAfterPrependRef =
     useRef<{ height: number; top: number } | null>(null);
+  const composerInputScrollTopRef = useRef<number | null>(null);
   const composerDockHeightRef = useRef(0);
   const [atBottom, setAtBottom] = useState(true);
   const [composerDockHeight, setComposerDockHeight] = useState(0);
@@ -688,7 +689,21 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
             data-testid="thread-composer-dock"
             onInputCapture={(event) => {
               if (event.target instanceof HTMLTextAreaElement) {
+                composerInputScrollTopRef.current = scrollRef.current?.scrollTop ?? null;
                 threadMotionRef.current?.handleComposerInput();
+              }
+            }}
+            onInput={(event) => {
+              if (!(event.target instanceof HTMLTextAreaElement)) return;
+              const previousScrollTop = composerInputScrollTopRef.current;
+              composerInputScrollTopRef.current = null;
+              const scrollEl = scrollRef.current;
+              if (scrollEl && previousScrollTop !== null) {
+                // Textarea autosizing briefly collapses to `height: auto` while
+                // measuring. Chrome can clamp the sibling thread scrollport in
+                // that intermediate layout; restore it before paint, then let
+                // ResizeObserver handle any real final composer height change.
+                scrollEl.scrollTop = previousScrollTop;
               }
             }}
             className={cn(

--- a/webui/src/tests/thread-composer.test.tsx
+++ b/webui/src/tests/thread-composer.test.tsx
@@ -441,6 +441,33 @@ describe("ThreadComposer", () => {
     expect(input.parentElement?.parentElement?.className).toContain("max-w-[58rem]");
   });
 
+  it("defers textarea autosizing until IME composition commits", () => {
+    render(
+      <ThreadComposer
+        onSend={vi.fn()}
+        placeholder="Type your message..."
+      />,
+    );
+    const input = screen.getByLabelText("Message input") as HTMLTextAreaElement;
+    Object.defineProperty(input, "scrollHeight", {
+      configurable: true,
+      value: 120,
+    });
+    input.style.height = "50px";
+
+    fireEvent.input(input, {
+      target: { value: "zhongwen" },
+      isComposing: true,
+    });
+    expect(input.style.height).toBe("50px");
+
+    fireEvent.input(input, {
+      target: { value: "中文" },
+      isComposing: false,
+    });
+    expect(input.style.height).toBe("120px");
+  });
+
   it("lets long model preset labels use their intrinsic width", () => {
     render(
       <ThreadComposer

--- a/webui/src/tests/thread-viewport.test.tsx
+++ b/webui/src/tests/thread-viewport.test.tsx
@@ -1116,6 +1116,36 @@ describe("ThreadViewport", () => {
     }
   });
 
+  it("restores thread scroll after the textarea autosize measurement collapses it", () => {
+    let scroller: HTMLElement | null = null;
+    const { container } = render(
+      <ThreadViewport
+        messages={messages}
+        isStreaming={false}
+        composer={(
+          <textarea
+            aria-label="Message input"
+            onInput={() => {
+              if (scroller) scroller.scrollTop = 692;
+            }}
+          />
+        )}
+      />,
+    );
+    scroller = getScroller(container);
+    Object.defineProperty(scroller, "scrollTop", {
+      configurable: true,
+      writable: true,
+      value: 700,
+    });
+
+    fireEvent.input(screen.getByLabelText("Message input"), {
+      target: { value: "中文" },
+    });
+
+    expect(scroller.scrollTop).toBe(700);
+  });
+
   it("keeps the thread scrollport above a mobile soft keyboard", async () => {
     const visualViewport = stubVisualViewport({ innerHeight: 800, height: 480 });
     try {


### PR DESCRIPTION
## Summary

- defer textarea autosizing while an IME composition is active, then resize on commit
- preserve the thread scroll position across the transient height measurement used by composer autosizing
- add regression coverage for both IME composition and Chrome scroll clamping

## Problem

On desktop Chrome, Chinese IME input emits several provisional input events. The composer measured every event by temporarily setting the textarea height to auto. That intermediate layout enlarged the sibling thread scrollport, causing Chrome to clamp scrollTop. When the textarea height was restored, the thread remained at the clamped position, so repeated composition updates made the view jump vertically.

## Verification

- bun run test -- src/tests/thread-viewport.test.tsx src/tests/thread-composer.test.tsx src/tests/thread-motion.test.ts (130 passed)
- bun run build
- real gateway bootstrap and public webui-thread route through the built WebUI
- headless Chrome CDP composition sequence z to zhongwen to 中文: PASS, bottom gap remained 0
- normal typing across a textarea wrap from 50px to 58px: PASS, bottom gap remained 0