### PR TITLE
feat(memory): archive idle sessions for Dream

### DIFF
--- a/nanobot/agent/autocompact.py
+++ b/nanobot/agent/autocompact.py
@@ -8,10 +8,10 @@ from typing import TYPE_CHECKING, Any, Callable, Coroutine, cast
 
 from loguru import logger
 
+from nanobot.agent.memory import DREAM_TAIL_SESSION_KEY_PREFIX, Consolidator
 from nanobot.session.manager import Session, SessionManager
 
 if TYPE_CHECKING:
-    from nanobot.agent.memory import Consolidator
     from nanobot.utils.llm_runtime import LLMRuntime
 
 
@@ -47,7 +47,10 @@ class AutoCompact:
 
     def _has_compactable_idle_tail(self, key: str) -> bool:
         session = self.sessions.get_or_create(key)
-        tail = list(session.messages[session.last_consolidated:])
+        # Must use Consolidator.archive_start, or a session whose only unarchived
+        # content is already dream-tail-archived would silently skip both paths.
+        start = Consolidator.archive_start(session)
+        tail = list(session.messages[start:])
         if not tail:
             return False
         probe = Session(
@@ -64,6 +67,80 @@ class AutoCompact:
         )
         messages_to_remove = result.dropped[result.already_consolidated_count:]
         return bool(messages_to_remove)
+
+    # -- Dream-only tail archive for short idle sessions (#3973) --------------------
+    # Sessions that never exceed the retained recent-suffix window never reach the
+    # real archive path below, so history.jsonl stays empty and Dream has nothing
+    # to process. This path writes a raw copy for Dream without touching the live
+    # prompt. Every real archive boundary (Consolidator.archive_start, used across
+    # this file and memory.py, plus Session.enforce_file_cap's trim path) starts
+    # from `max(last_consolidated, dream_tail_marker)`, so none of them ever
+    # re-cover a range this path already archived.
+
+    def _needs_dream_tail_archive(self, key: str) -> bool:
+        session = self.sessions.get_or_create(key)
+        if not session.messages:
+            return False
+        # Gate on last_consolidated == 0: without it, any session that already
+        # compacted once would have its whole protected recent suffix raw-dumped
+        # into Dream on the next idle tick, even with no new messages — far
+        # wider than this fix's actual scope.
+        if session.last_consolidated != 0:
+            return False
+        # Must match _dream_tail_archive's own boundary below.
+        start = Consolidator.archive_start(session)
+        return start < len(session.messages)
+
+    async def _dream_tail_archive(self, key: str) -> None:
+        if self._is_internal_session(key):
+            self._archiving.discard(key)
+            return
+        try:
+            lock = self.consolidator.get_lock(key)
+            async with lock:
+                session = self.sessions.get_or_create(key)
+                if session.last_consolidated != 0:
+                    # Re-check under the lock: the scan and this task aren't
+                    # atomic, so a real archive could have advanced
+                    # last_consolidated in between. No mutation happened, so
+                    # don't save().
+                    return
+                start = Consolidator.archive_start(session)
+                new_messages = session.messages[start:]
+                if (
+                    len(new_messages) > self._RECENT_SUFFIX_MESSAGES
+                    and self._has_compactable_idle_tail(key)
+                ):
+                    # Defer to the real archive path only if it's actually viable
+                    # now — a raw message count alone isn't reliable proof (see
+                    # TestDreamTailArchiveUnanswerableTailDoesNotStarve).
+                    return
+                if not new_messages:
+                    # Nothing changed — avoid an unnecessary sessions.save().
+                    return
+                # raw_archive() already strips runtime-context suffixes and caps at
+                # 16k, same as every other raw-dump path; a batch exceeding that
+                # cap still advances the marker, permanently losing the excess
+                # (see TestDreamTailArchiveTruncationStillAdvancesMarker).
+                #
+                # session_key uses a distinct prefix so this entry doesn't also
+                # surface via "# Recent History" on a resumed turn. Dream itself
+                # reads history.jsonl by cursor, not session_key, so it's unaffected.
+                self.consolidator.store.raw_archive(
+                    new_messages,
+                    session_key=f"{DREAM_TAIL_SESSION_KEY_PREFIX}{key}",
+                    degraded=False,
+                )
+                # Records the range just archived, not len(session.messages) at
+                # write time — session.messages isn't lock-protected against
+                # concurrent turn processing, so a message appended mid-write
+                # would otherwise be silently treated as already archived.
+                session.metadata[Consolidator.DREAM_TAIL_MARKER_KEY] = start + len(new_messages)
+                self.sessions.save(session)
+        except Exception:
+            logger.exception("Dream tail archive: failed for {}", key)
+        finally:
+            self._archiving.discard(key)
 
     @staticmethod
     def _format_summary(text: str, last_active: datetime) -> str:
@@ -88,15 +165,26 @@ class AutoCompact:
             if key in active_session_keys:
                 continue
             updated_at = info.get("updated_at")
-            if self._is_expired(updated_at, now) and self._has_compactable_idle_tail(key):
+            if not self._is_expired(updated_at, now):
+                continue
+            if self._has_compactable_idle_tail(key):
                 session = self.sessions.get_or_create(key)
                 try:
                     runtime = resolve_runtime(session)
                 except (KeyError, ValueError):
                     # Invalid session selections remain recoverable through /model.
+                    # Deliberately does NOT fall back to the dream-tail path here:
+                    # this session already qualified for real (LLM-summarized)
+                    # archiving, and letting the raw-dump tail path claim it first
+                    # would advance its marker past all its messages, permanently
+                    # downgrading it to a raw dump — even after the model config
+                    # is fixed and it would otherwise get a proper summary.
                     continue
                 self._archiving.add(key)
                 schedule_background(self._archive(key, runtime=runtime))
+            elif self._needs_dream_tail_archive(key):
+                self._archiving.add(key)
+                schedule_background(self._dream_tail_archive(key))
 
     async def _archive(self, key: str, *, runtime: LLMRuntime) -> None:
         if self._is_internal_session(key):

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -21,7 +21,11 @@ from typing import TYPE_CHECKING, Any, Callable, Iterator, cast
 from loguru import logger
 
 from nanobot.runtime_context import public_history_messages
-from nanobot.session.manager import Session, SessionManager
+from nanobot.session.manager import (
+    Session,
+    SessionManager,
+    register_position_dependent_metadata_key,
+)
 from nanobot.utils.gitstore import GitStore
 from nanobot.utils.helpers import (
     content_with_media_breadcrumbs,
@@ -49,6 +53,14 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # MemoryStore — pure file I/O layer
 # ---------------------------------------------------------------------------
+
+# Session-key prefix for AutoCompact's dream-tail archive entries (#3973):
+# written under f"{DREAM_TAIL_SESSION_KEY_PREFIX}{real_key}" instead of the
+# real session's own key, and excluded via _INTERNAL_HISTORY_SESSION_PREFIXES
+# below so it doesn't duplicate into a resumed session's live prompt. Single
+# source of truth for both the write side (AutoCompact) and the filter side
+# (MemoryStore).
+DREAM_TAIL_SESSION_KEY_PREFIX = "tail:"
 
 
 class DreamRunProgress:
@@ -82,7 +94,7 @@ class MemoryStore:
     # durable files are tiny in practice (~5 KB total), but a runaway file must
     # not unbounded the prompt.
     _DREAM_FILE_EMBED_CAP = 8000
-    _INTERNAL_HISTORY_SESSION_PREFIXES = ("cron:", "dream:")
+    _INTERNAL_HISTORY_SESSION_PREFIXES = ("cron:", "dream:", DREAM_TAIL_SESSION_KEY_PREFIX)
     _INTERNAL_HISTORY_SESSION_KEYS = {"heartbeat"}
     _LEGACY_ENTRY_START_RE = re.compile(r"^\[(\d{4}-\d{2}-\d{2}[^\]]*)\]\s*")
     _LEGACY_TIMESTAMP_RE = re.compile(r"^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2})\]\s*")
@@ -725,8 +737,17 @@ class MemoryStore:
         *,
         max_chars: int | None = None,
         session_key: str | None = None,
+        degraded: bool = True,
     ) -> None:
-        """Fallback: dump raw messages to history.jsonl without LLM summarization."""
+        """Dump raw messages to history.jsonl without LLM summarization.
+
+        ``degraded`` controls whether this call represents a fallback from a
+        failed/skipped LLM summarization pass (the historical, and default,
+        meaning of this method — logged as a warning) versus an intentionally
+        lightweight raw dump on an expected path, such as AutoCompact's
+        Dream-tail archive for short sessions (#3973), which never attempts an
+        LLM summary in the first place and should not be logged as degraded.
+        """
         limit = max_chars if max_chars is not None else _RAW_ARCHIVE_MAX_CHARS
         formatted = truncate_text(
             self._format_messages(public_history_messages(messages)),
@@ -737,9 +758,12 @@ class MemoryStore:
             f"{formatted}",
             session_key=session_key,
         )
-        logger.warning(
-            "Memory consolidation degraded: raw-archived {} messages", len(messages)
-        )
+        if degraded:
+            logger.warning(
+                "Memory consolidation degraded: raw-archived {} messages", len(messages)
+            )
+        else:
+            logger.info("Raw-archived {} messages", len(messages))
 
     # ------------------------------------------------------------------
     # Dream helpers
@@ -812,6 +836,12 @@ class Consolidator:
 
     _SAFETY_BUFFER = 1024  # extra headroom for tokenizer estimation drift
 
+    # Single source of truth for the session.metadata key AutoCompact's Dream-tail
+    # archive (#3973) uses to record how far it has archived. Public (no leading
+    # underscore) because AutoCompact reads it too — a mismatched copy of this
+    # string in two files would silently corrupt archive boundaries.
+    DREAM_TAIL_MARKER_KEY = "_dream_tail_through"
+
     def __init__(
         self,
         store: MemoryStore,
@@ -835,13 +865,35 @@ class Consolidator:
         """Return the shared consolidation lock for one session."""
         return self._locks.setdefault(session_key, asyncio.Lock())
 
+    # Skip content already covered by AutoCompact's Dream-tail archive (#3973).
+    # Deliberately does NOT touch session.last_consolidated / live-prompt
+    # retention — only shifts where formal archiving *starts*, so resume fidelity
+    # is unaffected and an already-tail-archived range is never re-summarized
+    # into a duplicate history.jsonl entry.
+    @classmethod
+    def dream_tail_marker(cls, session: Session) -> int:
+        marker = session.metadata.get(cls.DREAM_TAIL_MARKER_KEY, 0)
+        if isinstance(marker, bool) or not isinstance(marker, int) or marker < 0:
+            return 0
+        # Clamp: an unclamped stale marker would point past len(session.messages),
+        # making every archive path see nothing to do — permanently, not once.
+        return min(marker, len(session.messages))
+
+    @classmethod
+    def archive_start(cls, session: Session) -> int:
+        """The boundary every real archive path (and the tail-archive path)
+        must start from: whichever of last_consolidated / dream_tail_marker is
+        further along, so neither path ever re-covers what the other already
+        archived."""
+        return max(session.last_consolidated, cls.dream_tail_marker(session))
+
     def pick_consolidation_boundary(
         self,
         session: Session,
         tokens_to_remove: int,
     ) -> tuple[int, int] | None:
         """Pick a user-turn boundary that removes enough old prompt tokens."""
-        start = session.last_consolidated
+        start = self.archive_start(session)
         if start >= len(session.messages) or tokens_to_remove <= 0:
             return None
 
@@ -861,7 +913,17 @@ class Consolidator:
     def _full_unconsolidated_history(
         session: Session,
     ) -> list[dict[str, Any]]:
-        """Return the whole unconsolidated tail for consolidation decisions."""
+        """Return the whole unconsolidated tail for consolidation decisions.
+
+        Deliberately counts from ``last_consolidated`` only, not
+        ``max(last_consolidated, dream_tail_marker)`` like the real archive
+        boundaries do — and this is exactly correct, not a trade-off. This
+        feeds token-budget *estimation* for the live prompt, and tail-archived
+        messages are still sent raw in that prompt (dream_tail_marker never
+        advances ``last_consolidated`` — see TestLastConsolidatedMustNotCoverTheLiveSuffix).
+        Subtracting the tail-marker range here would *undercount* real prompt
+        size, since those messages have not actually left the live context.
+        """
         unconsolidated_count = len(session.messages) - session.last_consolidated
         if unconsolidated_count <= 0:
             return []
@@ -874,7 +936,8 @@ class Consolidator:
     ) -> int | None:
         if not replay_max_messages or replay_max_messages <= 0:
             return None
-        tail = list(enumerate(session.messages[session.last_consolidated:], session.last_consolidated))
+        start = Consolidator.archive_start(session)
+        tail = list(enumerate(session.messages[start:], start))
         if len(tail) <= replay_max_messages:
             return None
 
@@ -887,10 +950,10 @@ class Consolidator:
         sliced = tail[start_idx:]
         for i, (_idx, message) in enumerate(sliced):
             if message.get("role") == "user":
-                start = i
+                retain_from = i
                 if i > 0 and sliced[i - 1][1].get("_channel_delivery"):
-                    start = i - 1
-                sliced = sliced[start:]
+                    retain_from = i - 1
+                sliced = sliced[retain_from:]
                 break
 
         legal_start = find_legal_message_start([message for _idx, message in sliced])
@@ -900,7 +963,7 @@ class Consolidator:
             return len(session.messages)
 
         first_visible_idx = sliced[0][0]
-        if first_visible_idx <= session.last_consolidated:
+        if first_visible_idx <= start:
             return None
         return first_visible_idx
 
@@ -915,7 +978,8 @@ class Consolidator:
         end_idx = self._replay_overflow_boundary(session, replay_max_messages)
         if end_idx is None:
             return None
-        chunk = session.messages[session.last_consolidated:end_idx]
+        chunk_start = self.archive_start(session)
+        chunk = session.messages[chunk_start:end_idx]
         if not chunk:
             return None
         logger.info(
@@ -924,10 +988,14 @@ class Consolidator:
             len(chunk),
             replay_max_messages,
         )
+        # Summary context starts at last_consolidated, while the end remains
+        # end_idx; see compact_idle_session for why only the start is widened.
+        summary_messages = list(session.messages[session.last_consolidated:end_idx])
         summary = await self.archive(
             chunk,
             runtime=runtime,
             session_key=session.key,
+            summary_messages=summary_messages,
         )
         session.last_consolidated = end_idx
         session.provider_state = None
@@ -1111,7 +1179,8 @@ class Consolidator:
 
                 end_idx = boundary[0]
 
-                chunk = session.messages[session.last_consolidated:end_idx]
+                chunk_start = self.archive_start(session)
+                chunk = session.messages[chunk_start:end_idx]
                 if not chunk:
                     break
 
@@ -1124,10 +1193,15 @@ class Consolidator:
                     source,
                     len(chunk),
                 )
+                # Summary context starts at last_consolidated, while the end
+                # remains end_idx; see compact_idle_session for why only the
+                # start is widened.
+                summary_messages = list(session.messages[session.last_consolidated:end_idx])
                 summary = await self.archive(
                     chunk,
                     runtime=runtime,
                     session_key=session.key,
+                    summary_messages=summary_messages,
                 )
                 # Advance the cursor either way: on success the chunk was
                 # summarized; on failure archive() already raw-archived it as
@@ -1168,14 +1242,15 @@ class Consolidator:
             self.sessions.invalidate(session_key)
             session = self.sessions.get_or_create(session_key)
 
-            messages_to_summarize = list(session.messages[session.last_consolidated:])
-            if not messages_to_summarize:
+            idle_start = self.archive_start(session)
+            tail = list(session.messages[idle_start:])
+            if not tail:
                 self.sessions.save(session)
                 return ""
 
             probe = Session(
                 key=session.key,
-                messages=messages_to_summarize.copy(),
+                messages=tail.copy(),
                 created_at=session.created_at,
                 updated_at=session.updated_at,
                 metadata={},
@@ -1190,12 +1265,22 @@ class Consolidator:
                 return ""
 
             last_active = session.updated_at
-            # The visible suffix informs the summary but stays out of raw fallback.
+            new_last_consolidated = len(session.messages) - len(visible_suffix)
+            # summary_messages spans from last_consolidated through the end
+            # of the session — widening only the start (not archive_start/
+            # idle_start), not the end. The end must stay at the full session
+            # tail: the retained visible suffix is deliberately included too
+            # (#4264 — a late correction landing in that suffix must still
+            # reach the persisted summary). summary_messages is pure LLM
+            # context, never written anywhere, so widening the start can't
+            # cause a duplicate history.jsonl entry — only messages_to_remove
+            # (bounded by archive_start) decides what leaves the live view.
+            summary_messages = list(session.messages[session.last_consolidated:])
             summary = await self.archive(
                 messages_to_remove,
                 runtime=runtime,
                 session_key=session_key,
-                summary_messages=messages_to_summarize,
+                summary_messages=summary_messages,
             )
 
             if summary and summary != "(nothing)":
@@ -1205,7 +1290,7 @@ class Consolidator:
                 }
 
             # Preserve history and advance only the replay boundary.
-            session.last_consolidated = len(session.messages) - len(visible_suffix)
+            session.last_consolidated = new_last_consolidated
             session.provider_state = None
             self.sessions.save(session)
 
@@ -1219,3 +1304,11 @@ class Consolidator:
             )
 
             return summary
+
+
+# Session.clear() and fork_session_before_user_index() both need to treat this
+# key as an absolute index into session.messages (same category as the
+# built-in last_consolidated field) — see register_position_dependent_metadata_
+# key's docstring for why this is a registry call rather than Session directly
+# importing Consolidator (would cycle).
+register_position_dependent_metadata_key(Consolidator.DREAM_TAIL_MARKER_KEY)

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -300,10 +300,19 @@ async def cmd_status(ctx: CommandContext) -> OutboundMessage:
 
 async def cmd_new(ctx: CommandContext) -> OutboundMessage:
     """Stop active task and start a fresh session."""
+    # Imported locally: nanobot.agent.memory pulls in nanobot.agent.loop, which
+    # imports from nanobot.command — a module-level import here cycles back
+    # (breaks `import nanobot.command` and `import nanobot.webui.ws_http`).
+    from nanobot.agent.memory import Consolidator
+
     loop = ctx.loop
     await loop._cancel_active_tasks(ctx.key)  # pyright: ignore[reportPrivateUsage]
     session = ctx.session or loop.sessions.get_or_create(ctx.key)
-    snapshot = session.messages[session.last_consolidated:]
+    # Consolidator.archive_start, not last_consolidated alone: a session that
+    # was only ever dream-tail-archived (last_consolidated still 0) would
+    # otherwise have its already-archived prefix re-summarized into this
+    # snapshot too.
+    snapshot = session.messages[Consolidator.archive_start(session):]
     runtime = None
     if snapshot:
         runtime = ctx.runtime or loop.runtime_for_session(session)

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 from collections import OrderedDict
+from collections.abc import Collection
 from contextlib import suppress
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -56,6 +57,28 @@ _FORK_VOLATILE_METADATA_KEYS = {
     "title",
     "title_user_edited",
 }
+
+# Metadata keys that hold an absolute index into session.messages (the same
+# category as the built-in last_consolidated field), registered by higher-level
+# modules that mint such keys (e.g. Consolidator.DREAM_TAIL_MARKER_KEY in
+# memory.py — see the registration call there). Session/SessionManager can't
+# import those modules directly (memory.py already imports Session from here,
+# so the reverse would cycle), so this is a passive registry callers push into
+# instead of a hardcoded reference. Any key registered here is automatically
+# reset by Session.clear() and remapped by fork_session_before_user_index() —
+# callers don't need to remember to opt in per call site.
+_POSITION_DEPENDENT_METADATA_KEYS: set[str] = set()
+
+
+def register_position_dependent_metadata_key(key: str) -> None:
+    """Register a metadata key that holds an absolute index into session.messages.
+
+    Such keys need the same treatment last_consolidated already gets: cleared on
+    Session.clear(), remapped (or dropped) on fork. See the module-level comment
+    above _POSITION_DEPENDENT_METADATA_KEYS for why this is a registry rather
+    than a direct import.
+    """
+    _POSITION_DEPENDENT_METADATA_KEYS.add(key)
 
 
 def _json_object(value: object) -> dict[str, Any]:
@@ -320,6 +343,13 @@ class Session:
         self.provider_state = None
         self.updated_at = datetime.now()
         self.metadata.pop("_last_summary", None)
+        # Any registered position-dependent key (see
+        # register_position_dependent_metadata_key) is an absolute index into
+        # messages, same as last_consolidated above — with messages now empty,
+        # a stale value would silently make future content look "already
+        # archived" from turn one.
+        for key in _POSITION_DEPENDENT_METADATA_KEYS:
+            self.metadata.pop(key, None)
 
     def retain_recent_legal_suffix(
         self,
@@ -349,6 +379,13 @@ class Session:
 
         original = list(self.messages)
         before_lc = self.last_consolidated
+        before_marker_values = {
+            key: value
+            for key in _POSITION_DEPENDENT_METADATA_KEYS
+            if isinstance(value := self.metadata.get(key), int)
+            and not isinstance(value, bool)
+            and value > 0
+        }
 
         start_idx = max(0, len(self.messages) - max_messages)
         if extend_to_user:
@@ -392,13 +429,14 @@ class Session:
         retained_ids = set(id(m) for m in retained)
         dropped = [m for m in original if id(m) not in retained_ids]
 
-        # Count how many dropped messages were in the already-consolidated
-        # prefix of the original list.  This cannot be a simple min() because
-        # dropped may include messages from *after* the consolidated prefix
-        # (e.g. in the else branch).
+        # Must include any registered marker too, or enforce_file_cap would
+        # re-archive a range another mechanism already covered. Not a plain
+        # min() because dropped can include messages from *after* the
+        # consolidated prefix (e.g. in the else branch above).
+        already_covered_before = max(before_lc, *before_marker_values.values()) if before_marker_values else before_lc
         already_consolidated = sum(
             1 for i, m in enumerate(original)
-            if i < before_lc and id(m) not in retained_ids
+            if i < already_covered_before and id(m) not in retained_ids
         )
 
         # New last_consolidated = count of retained messages that were inside
@@ -407,6 +445,19 @@ class Session:
             1 for i, m in enumerate(original)
             if i < before_lc and id(m) in retained_ids
         )
+
+        # Same identity-based remapping as new_lc, for any registered
+        # position-dependent key: left at its old absolute index, a marker
+        # would land on the wrong message after a trim.
+        for key, before_value in before_marker_values.items():
+            new_value = sum(
+                1 for i, m in enumerate(original)
+                if i < before_value and id(m) in retained_ids
+            )
+            if new_value > 0:
+                self.metadata[key] = new_value
+            else:
+                self.metadata.pop(key, None)
 
         self.messages = retained
         self.last_consolidated = new_lc
@@ -1111,6 +1162,8 @@ class SessionManager:
         source_key: str,
         target_key: str,
         before_user_index: int,
+        *,
+        extra_index_metadata_keys: Collection[str] = (),
     ) -> Session | None:
         """Create *target_key* from *source_key* before a global user-message index.
 
@@ -1119,6 +1172,11 @@ class SessionManager:
         second user message", and so on. A value equal to the total user-message
         count copies the full session prefix. WebUI assistant-reply forks pass
         the next user index so the selected completed assistant turn is included.
+
+        ``extra_index_metadata_keys`` names any other ``session.metadata`` keys
+        that hold an absolute message index (like ``last_consolidated``) and so
+        need the same fork-time remapping — see Consolidator.DREAM_TAIL_MARKER_KEY
+        for the motivating example.
         """
         if before_user_index < 0:
             return None
@@ -1149,6 +1207,23 @@ class SessionManager:
         if source.last_consolidated > len(copied):
             metadata.pop("_last_summary", None)
             last_consolidated = 0
+
+        # Any other metadata key holding an absolute message index (e.g. Dream's
+        # tail-archive marker) needs handling too — but clamped, not dropped
+        # like last_consolidated above: last_consolidated covers a range an LLM
+        # *summary* absorbed (doesn't describe the fork's own subset), so
+        # resetting is correct there. The tail marker covers verbatim raw-dumped
+        # text; dropping it would make the fork raw-dump that same text again
+        # under its own session_key. Clamping means "already covered, verbatim,
+        # by the source's entry" — exactly true.
+        # Registered keys are covered automatically; extra_index_metadata_keys
+        # is an escape hatch for keys that were never registered.
+        for meta_key in _POSITION_DEPENDENT_METADATA_KEYS | set(extra_index_metadata_keys):
+            value = metadata.get(meta_key)
+            if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+                continue
+            if value > len(copied):
+                metadata[meta_key] = len(copied)
 
         now = datetime.now()
         target = Session(

--- a/nanobot/webui/forking.py
+++ b/nanobot/webui/forking.py
@@ -7,6 +7,7 @@ import uuid
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, TypeGuard
 
+from nanobot.agent.memory import Consolidator
 from nanobot.session.manager import SessionManager
 from nanobot.session.webui_turns import WEBUI_TITLE_METADATA_KEY, clean_generated_title
 from nanobot.webui.transcript import (
@@ -40,10 +41,15 @@ def create_webui_chat_fork(
     source_key = f"websocket:{source_chat_id}"
     target_key = f"websocket:{new_id}"
     try:
+        # Explicit rather than relying on the module-level registry (populated
+        # when nanobot.agent.memory happens to be imported): a fork that misses
+        # the marker would raw-dump already-archived content again under its
+        # own session_key.
         forked = session_manager.fork_session_before_user_index(
             source_key,
             target_key,
             before_user_index,
+            extra_index_metadata_keys=(Consolidator.DREAM_TAIL_MARKER_KEY,),
         )
         if forked is None:
             return None

--- a/tests/agent/test_autocompact_unit.py
+++ b/tests/agent/test_autocompact_unit.py
@@ -405,8 +405,17 @@ class TestCheckExpired:
         scheduler.assert_not_called()
         assert "dream:20260602-155256" not in ac._archiving
 
-    def test_already_trimmed_session_skips(self):
-        """Expired session with no removable tail should not be re-scheduled."""
+    def test_already_trimmed_session_skips_real_archive_but_takes_dream_tail_path(self):
+        """Expired session with no removable tail should not go through the real
+        compact_idle_session archive path.
+
+        Intentional behavior change for #3973 (Dream hunger problem): this test used
+        to assert the scheduler was never called at all for such a session. That is
+        precisely the bug #3973 describes — a short session (<= _RECENT_SUFFIX_MESSAGES)
+        idling forever without ever producing a history.jsonl entry, starving Dream of
+        input. It is now expected to be scheduled onto the separate, lightweight
+        _dream_tail_archive path instead of the real archive path (see AutoCompact.
+        check_expired's if/elif branching)."""
         ac = _make_autocompact(ttl=15)
         mock_sm = MagicMock(spec=SessionManager)
         last_active = datetime(2026, 1, 1, 10, 0, 0)
@@ -417,11 +426,17 @@ class TestCheckExpired:
         ]
         mock_sm.get_or_create.return_value = session
         ac.sessions = mock_sm
+        ac._dream_tail_archive = AsyncMock()
 
         scheduler = MagicMock()
         ac.check_expired(scheduler, _runtime)
 
-        scheduler.assert_not_called()
+        # The real archive path (which would call consolidator.compact_idle_session)
+        # must still not fire — this session has nothing a full LLM-summarized
+        # archive pass could remove.
+        ac.consolidator.compact_idle_session.assert_not_called()
+        scheduler.assert_called_once()
+        ac._dream_tail_archive.assert_called_once_with("cli:done")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -686,6 +686,44 @@ class TestCompactIdleSession:
         assert "CORRECTED_FINAL_RESULT_alpha" in summarized
 
     @pytest.mark.asyncio
+    async def test_summary_context_includes_a_previously_tail_archived_prefix(
+        self, real_consolidator, mock_provider, runtime
+    ):
+        """A session already dream-tail-archived (marker > 0, last_consolidated
+        == 0) must still have that prefix included in the LLM's summarization
+        context on its first real consolidation — excluding it from
+        history.jsonl duplication (archive_start) is correct, but excluding it
+        from the summary too would make that content invisible everywhere
+        except Dream's raw input: not in the live prompt (trimmed here), not
+        in the persisted summary. summary_messages is pure LLM context and
+        never written anywhere, so widening it can't cause duplication."""
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="Summary.", finish_reason="stop"
+        )
+        sessions = real_consolidator.sessions
+        session = sessions.get_or_create("cli:tailprefix")
+        for i in range(4):
+            session.add_message("user", f"TAILARCHIVED_u{i}")
+            session.add_message("assistant", f"TAILARCHIVED_a{i}")
+        for i in range(15):
+            session.add_message("user", f"user msg {i}")
+            session.add_message("assistant", f"assistant msg {i}")
+        session.metadata[Consolidator.DREAM_TAIL_MARKER_KEY] = 8
+        sessions.save(session)
+        assert session.last_consolidated == 0
+
+        await real_consolidator.compact_idle_session(
+            "cli:tailprefix", runtime=runtime, max_suffix=8
+        )
+
+        summarized = mock_provider.chat_with_retry.call_args.kwargs["messages"][1]["content"]
+        assert "TAILARCHIVED_u0" in summarized, (
+            "The tail-archived prefix should still reach the LLM's summary "
+            "context even though it's excluded from what actually gets "
+            "removed/raw-fallback-dumped. Summary input: " + summarized
+        )
+
+    @pytest.mark.asyncio
     async def test_raw_dumps_only_dropped_messages_on_llm_failure(
         self, real_consolidator, mock_provider, store, runtime
     ):

--- a/tests/agent/test_dream_tail_archive.py
+++ b/tests/agent/test_dream_tail_archive.py
@@ -1,0 +1,1053 @@
+"""Tests for the Dream-tail archive path (#3973).
+
+Short sessions (<= AutoCompact._RECENT_SUFFIX_MESSAGES total messages) can never
+produce a compactable tail under the existing idle-archive path, because
+retain_recent_legal_suffix always keeps everything when the session is that
+short. That means history.jsonl stays empty for them forever, starving Dream of
+input for what is the most common conversation shape. These tests cover the
+lightweight, independent tail-archive path added to close that gap, and the
+corresponding boundary adjustments in Consolidator so it never re-archives a
+range that tail-archive already covered.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.agent.memory import DREAM_TAIL_SESSION_KEY_PREFIX, Consolidator
+from nanobot.bus.queue import MessageBus
+from nanobot.providers.base import LLMResponse
+from nanobot.runtime_context import RUNTIME_CONTEXT_HISTORY_META
+
+
+def _make_loop(tmp_path: Path, session_ttl_minutes: int = 15) -> AgentLoop:
+    """Minimal AgentLoop with a deterministic fake LLM provider (mirrors test_auto_compact.py)."""
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.estimate_prompt_tokens.return_value = (10_000, "test")
+    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(content="ok", tool_calls=[]))
+    provider.generation.max_tokens = 4096
+    loop = AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+        context_window_tokens=128_000,
+        session_ttl_minutes=session_ttl_minutes,
+    )
+    loop.tools.get_definitions = MagicMock(return_value=[])
+    return loop
+
+
+def _add_turns(session, turns: int, *, prefix: str = "msg") -> None:
+    for i in range(turns):
+        session.add_message("user", f"{prefix} user {i}")
+        session.add_message("assistant", f"{prefix} assistant {i}")
+
+
+async def _drain_background_tasks(loop: AgentLoop) -> None:
+    tasks = list(loop._background_tasks)
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+    await asyncio.sleep(0)
+
+
+async def _run_check_expired(loop: AgentLoop, active_session_keys=()) -> None:
+    loop.auto_compact.check_expired(
+        loop.schedule_background,
+        loop.runtime_for_session,
+        active_session_keys=active_session_keys,
+    )
+    await _drain_background_tasks(loop)
+
+
+def _history_entries_for(loop: AgentLoop, session_key: str) -> list[dict]:
+    """Entries produced by/for this session, whether written under its own
+    real key (real consolidation) or dream-tail-archive prefixed."""
+    entries = loop.context.memory.read_unprocessed_history(since_cursor=0)
+    tail_key = f"{DREAM_TAIL_SESSION_KEY_PREFIX}{session_key}"
+    return [e for e in entries if e.get("session_key") in (session_key, tail_key)]
+
+
+class TestDreamTailArchiveBasics:
+    """A short idle session should get a history.jsonl entry, exactly once."""
+
+    @pytest.mark.asyncio
+    async def test_short_idle_session_produces_a_history_entry(self, tmp_path):
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)  # shipped default
+        session = loop.sessions.get_or_create("cli:short")
+        _add_turns(session, 2, prefix="short")  # 4 messages, well under the 8-floor
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+
+        await _run_check_expired(loop)
+
+        entries = _history_entries_for(loop, "cli:short")
+        assert len(entries) > 0, (
+            "Short idle sessions must produce a history.jsonl entry even under the "
+            "default TTL — otherwise Dream never has input for short conversations."
+        )
+        await loop.close_mcp()
+
+    @pytest.mark.asyncio
+    async def test_second_scan_does_not_duplicate(self, tmp_path):
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)
+        session = loop.sessions.get_or_create("cli:short")
+        _add_turns(session, 2, prefix="short")
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+
+        await _run_check_expired(loop)
+        first_count = len(_history_entries_for(loop, "cli:short"))
+        assert first_count > 0
+
+        # Second scan: nothing changed, session still "idle" (updated_at untouched).
+        await _run_check_expired(loop)
+        second_count = len(_history_entries_for(loop, "cli:short"))
+        assert second_count == first_count, (
+            f"Idempotency violated: first scan wrote {first_count} entries, "
+            f"second scan produced {second_count}."
+        )
+        await loop.close_mcp()
+
+    @pytest.mark.asyncio
+    async def test_long_session_does_not_take_the_tail_branch(self, tmp_path):
+        """Sessions with > 8 messages must still take the existing
+        compact_idle_session path unchanged — the new branch must not fire."""
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)
+        session = loop.sessions.get_or_create("cli:long")
+        _add_turns(session, 6, prefix="old")  # 12 messages, > 8-message floor
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+
+        tail_archive_called = False
+        original = loop.auto_compact._dream_tail_archive
+
+        async def _spy(key):
+            nonlocal tail_archive_called
+            tail_archive_called = True
+            await original(key)
+
+        loop.auto_compact._dream_tail_archive = _spy
+
+        await _run_check_expired(loop)
+
+        assert not tail_archive_called, (
+            "Regression: the new Dream-tail branch fired for a >8-message session "
+            "that should have taken the existing compact_idle_session path instead."
+        )
+        session_after = loop.sessions.get_or_create("cli:long")
+        # Existing retain-8 behavior must be completely unaffected.
+        assert len(session_after.get_history(max_messages=20)) == (
+            loop.auto_compact._RECENT_SUFFIX_MESSAGES
+        )
+        await loop.close_mcp()
+
+
+class TestDreamTailArchiveIncrementalMessages:
+    """New messages added after a session was already tail-archived must
+    eventually surface, and must be routed to the correct branch."""
+
+    @pytest.mark.asyncio
+    async def test_new_messages_after_tail_archive_are_not_permanently_skipped(self, tmp_path):
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)
+        session = loop.sessions.get_or_create("cli:short")
+        _add_turns(session, 2, prefix="short")  # 4 messages
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+
+        await _run_check_expired(loop)
+        assert len(_history_entries_for(loop, "cli:short")) == 1
+
+        # Session "resumes": 2 more messages, then idle again.
+        session = loop.sessions.get_or_create("cli:short")
+        _add_turns(session, 1, prefix="resumed")  # +2 messages = 6 total
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+
+        await _run_check_expired(loop)
+        entries = _history_entries_for(loop, "cli:short")
+        all_content = "\n".join(e.get("content", "") for e in entries)
+        assert "resumed" in all_content, (
+            "The 2 new messages added after the first tail-archive were never "
+            "written to history.jsonl by a second idle scan — permanently invisible "
+            "to Dream. Entries seen: " + repr(entries)
+        )
+        await loop.close_mcp()
+
+    @pytest.mark.asyncio
+    async def test_resume_past_the_retain_floor_is_not_dropped_by_the_wrong_branch(self, tmp_path):
+        """A session that resumes and grows past the 8-message retain floor, but
+        whose only genuinely new content still fits under that floor, must not
+        fall through the crack between _has_compactable_idle_tail (which only
+        sees the real archive path) and _needs_dream_tail_archive (the fallback)."""
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)
+        session = loop.sessions.get_or_create("cli:edge")
+        _add_turns(session, 2, prefix="original")  # 4 messages
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+
+        await _run_check_expired(loop)
+        first_entries = _history_entries_for(loop, "cli:edge")
+        assert len(first_entries) == 1
+        assert "original" in first_entries[0]["content"]
+
+        # 4 original + 6 new = 10 total messages: _has_compactable_idle_tail
+        # (unpatched) would see 10 messages from index 0 and find something to
+        # drop, routing into compact_idle_session — which then correctly starts
+        # from the tail marker, finds only 6 new messages (<= 8), and no-ops,
+        # silently losing this scan's worth of new content unless the boundary
+        # check is itself marker-aware.
+        session = loop.sessions.get_or_create("cli:edge")
+        _add_turns(session, 3, prefix="resumed")  # 4 + 6 = 10 messages total
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+
+        await _run_check_expired(loop)
+
+        all_entries = _history_entries_for(loop, "cli:edge")
+        all_content = "\n".join(e.get("content", "") for e in all_entries)
+        assert "resumed" in all_content, (
+            "The new messages fell through the if/elif crack: neither the real "
+            "archive path nor the dream-tail path picked them up. Entries: "
+            + repr(all_entries)
+        )
+        original_reappears_in_new_entry = any(
+            e["cursor"] != first_entries[0]["cursor"] and "original" in e.get("content", "")
+            for e in all_entries
+        )
+        assert not original_reappears_in_new_entry, (
+            "The already tail-archived 'original ...' messages were re-archived "
+            "into a second entry — duplicate Dream input."
+        )
+
+        # Recent-8 legality: session.get_history should still return a coherent,
+        # role-legal suffix regardless of which branch fired.
+        session_after = loop.sessions.get_or_create("cli:edge")
+        recent = session_after.get_history(max_messages=20)
+        assert recent, "Expected some recent history to remain visible for the live prompt"
+        await loop.close_mcp()
+
+
+class TestDreamTailArchiveNoDuplicateOnRealConsolidation:
+    """Neither direction of the two archive paths may re-cover content the other
+    one already archived: real consolidation must not re-summarize tail-archived
+    content, and tail-archive must not re-dump already-consolidated content."""
+
+    @pytest.mark.asyncio
+    async def test_tail_archive_never_fires_once_real_consolidation_has_touched_a_session(self, tmp_path):
+        """A session that already went through real consolidation must never be
+        routed to the tail-archive path again, even once its unconsolidated
+        remainder shrinks to <= 8 messages (the normal post-compaction state).
+        Without the last_consolidated == 0 gate, a session's entire protected
+        recent suffix would get raw-dumped into Dream on the very next idle
+        tick after any real compaction — a much bigger behavior change than
+        this fix's scope (sessions that can never produce ANY entry at all)."""
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)
+        session = loop.sessions.get_or_create("cli:consolidated-first")
+        _add_turns(session, 6, prefix="old")  # 12 messages: > 8-message floor
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+
+        # First scan: real archive path fires (has_compactable_idle_tail=True for
+        # 12 messages), archives a prefix via compact_idle_session, advances
+        # last_consolidated. The tail marker is untouched (still 0).
+        await _run_check_expired(loop)
+        session = loop.sessions.get_or_create("cli:consolidated-first")
+        assert session.last_consolidated > 0, "Expected real consolidation to have archived a prefix"
+        assert Consolidator.dream_tail_marker(session) == 0, "Tail marker should be untouched by the real path"
+        first_entries = _history_entries_for(loop, "cli:consolidated-first")
+        assert len(first_entries) == 1
+
+        # Second scan: session is idle again with zero new messages. The gate
+        # must keep it out of the tail-archive branch entirely — no new entry.
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+        await _run_check_expired(loop)
+
+        all_entries = _history_entries_for(loop, "cli:consolidated-first")
+        assert len(all_entries) == 1, (
+            "A session real consolidation has already touched must not get its "
+            "protected recent-suffix raw-dumped by the tail path on a later "
+            f"idle tick. Entries: {all_entries!r}"
+        )
+        await loop.close_mcp()
+
+    @pytest.mark.asyncio
+    async def test_formal_consolidation_does_not_recover_tail_archived_messages(self, tmp_path):
+        # Small context window so real token-based consolidation actually triggers
+        # once the session grows, using the real tokenizer (no fake override).
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+        provider.chat_with_retry = AsyncMock(
+            return_value=LLMResponse(content="[SUMMARY of formal consolidation]", tool_calls=[])
+        )
+        provider.generation.max_tokens = 100
+        loop = AgentLoop(
+            bus=bus, provider=provider, workspace=tmp_path, model="test-model",
+            context_window_tokens=1000, session_ttl_minutes=15,
+        )
+        loop.tools.get_definitions = MagicMock(return_value=[])
+
+        session = loop.sessions.get_or_create("cli:grows")
+        _add_turns(session, 2, prefix="original")  # 4 messages, the ones tail will cover
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+
+        # Step 1: idle tail-archive fires for the short session.
+        await _run_check_expired(loop)
+        tail_entries = _history_entries_for(loop, "cli:grows")
+        assert len(tail_entries) == 1
+        assert "original" in tail_entries[0]["content"]
+
+        # Step 2: session "resumes" and grows enough to blow the (small) token budget.
+        session = loop.sessions.get_or_create("cli:grows")
+        _add_turns(session, 40, prefix="growth")
+        loop.sessions.save(session)
+
+        # Spy on the real archive() input: what was actually fed into consolidation,
+        # not the LLM's (mocked, input-independent) output text.
+        captured_chunks: list[list[dict]] = []
+        real_archive = loop.consolidator.archive
+
+        async def _spy_archive(messages, **kwargs):
+            captured_chunks.append(messages)
+            return await real_archive(messages, **kwargs)
+
+        loop.consolidator.archive = _spy_archive
+
+        runtime = loop.runtime_for_session(session)
+        await loop.consolidator.maybe_consolidate_by_tokens(session, runtime=runtime)
+
+        assert captured_chunks, "Expected maybe_consolidate_by_tokens to call archive() at least once"
+        for chunk in captured_chunks:
+            chunk_text = " ".join(str(m.get("content", "")) for m in chunk)
+            assert "original" not in chunk_text, (
+                "Formal consolidation's input chunk contains messages already "
+                "delivered to Dream via the tail entry. Captured chunk: " + repr(chunk)
+            )
+        all_chunk_text = " ".join(
+            str(m.get("content", "")) for chunk in captured_chunks for m in chunk
+        )
+        assert "growth" in all_chunk_text, (
+            "Sanity check failed: formal consolidation's input chunk should still "
+            "contain the newer 'growth ...' messages — if it doesn't, the boundary "
+            "fix over-skipped and messages are being silently dropped, not just "
+            "de-duplicated."
+        )
+        await loop.close_mcp()
+
+    @pytest.mark.asyncio
+    async def test_formal_consolidation_still_shows_the_llm_the_tail_archived_prefix_as_context(self, tmp_path):
+        """Excluding tail-archived content from archive()'s removal/raw-fallback
+        chunk (verified above) is correct — but that content must not also
+        disappear from the LLM's summarization *context* (summary_messages),
+        or a session's earliest content becomes invisible everywhere except
+        Dream's raw history: not in the live prompt (trimmed by real
+        consolidation), not in the persisted summary (excluded here), only in
+        history.jsonl. summary_messages is never written anywhere itself, so
+        including the tail-archived prefix there can't cause duplication."""
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+        provider.chat_with_retry = AsyncMock(
+            return_value=LLMResponse(content="[SUMMARY]", tool_calls=[])
+        )
+        provider.generation.max_tokens = 100
+        loop = AgentLoop(
+            bus=bus, provider=provider, workspace=tmp_path, model="test-model",
+            context_window_tokens=1000, session_ttl_minutes=15,
+        )
+        loop.tools.get_definitions = MagicMock(return_value=[])
+
+        session = loop.sessions.get_or_create("cli:grows2")
+        _add_turns(session, 2, prefix="original")  # 4 messages, tail will cover these
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+
+        await _run_check_expired(loop)
+        assert len(_history_entries_for(loop, "cli:grows2")) == 1
+
+        session = loop.sessions.get_or_create("cli:grows2")
+        _add_turns(session, 40, prefix="growth")
+        loop.sessions.save(session)
+
+        captured_summary_messages: list[list[dict] | None] = []
+        real_archive = loop.consolidator.archive
+
+        async def _spy_archive(messages, **kwargs):
+            captured_summary_messages.append(kwargs.get("summary_messages"))
+            return await real_archive(messages, **kwargs)
+
+        loop.consolidator.archive = _spy_archive
+
+        runtime = loop.runtime_for_session(session)
+        await loop.consolidator.maybe_consolidate_by_tokens(session, runtime=runtime)
+
+        assert captured_summary_messages, "Expected archive() to be called at least once"
+        all_summary_text = " ".join(
+            str(m.get("content", ""))
+            for msgs in captured_summary_messages if msgs
+            for m in msgs
+        )
+        assert "original" in all_summary_text, (
+            "The LLM's summarization context should still include the "
+            "tail-archived prefix, even though it's excluded from the "
+            "removal/raw-fallback chunk. Captured summary_messages: "
+            + repr(captured_summary_messages)
+        )
+        await loop.close_mcp()
+
+
+class TestDreamTailArchiveTruncationStillAdvancesMarker:
+    """raw_archive() truncates at _RAW_ARCHIVE_MAX_CHARS (16k); the marker must
+    still advance past all of new_messages regardless, matching every other
+    raw-dump path in this codebase. The truncated remainder is permanently
+    lost, not retried — a documented, accepted limitation (see the PR
+    description), locked here so a future change can't silently alter it."""
+
+    @pytest.mark.asyncio
+    async def test_marker_advances_past_a_message_too_large_to_fit_in_the_dump(self, tmp_path):
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)
+        session = loop.sessions.get_or_create("cli:huge")
+        session.add_message("user", "x" * 20_000)  # exceeds the 16k raw-dump cap
+        session.add_message("assistant", "ok")
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+
+        await _run_check_expired(loop)
+
+        session_after = loop.sessions.get_or_create("cli:huge")
+        marker = Consolidator.dream_tail_marker(session_after)
+        assert marker == 2, (
+            "The marker must advance past both messages even though the raw "
+            f"dump truncated the oversized one — got marker={marker}. A "
+            "marker that stalls here would make the idle scan retry the same "
+            "oversized message forever."
+        )
+        entries = _history_entries_for(loop, "cli:huge")
+        assert entries, "Expected a (truncated) entry to still be written"
+        assert len(entries[0]["content"]) < 20_000, (
+            "Sanity check: the entry should actually be truncated, not the "
+            "full 20k message verbatim"
+        )
+        await loop.close_mcp()
+
+
+class TestDreamTailArchiveConcurrentTurn:
+    """session.messages is not protected by the consolidator lock against normal
+    turn processing (only other archive-path callers respect it) — a message
+    appended concurrently, between the tail-archive slice and the marker write,
+    must not get silently marked as archived without ever being written."""
+
+    @pytest.mark.asyncio
+    async def test_marker_reflects_the_archived_range_not_live_length_at_write_time(self, tmp_path):
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)
+        session = loop.sessions.get_or_create("cli:race")
+        _add_turns(session, 2, prefix="short")  # 4 messages
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+
+        # Inject a concurrent append between the slice (inside raw_archive, called
+        # after start/new_messages are already computed) and the marker write —
+        # simulating a live turn racing the background tail-archive task.
+        real_raw_archive = loop.consolidator.store.raw_archive
+
+        def _raw_archive_then_concurrent_append(*args, **kwargs):
+            real_raw_archive(*args, **kwargs)
+            live_session = loop.sessions.get_or_create("cli:race")
+            live_session.add_message("user", "concurrent turn message")
+
+        loop.consolidator.store.raw_archive = _raw_archive_then_concurrent_append
+
+        await _run_check_expired(loop)
+
+        session_after = loop.sessions.get_or_create("cli:race")
+        marker = Consolidator.dream_tail_marker(session_after)
+        assert marker == 4, (
+            "The marker must reflect exactly what was archived (4 messages), not "
+            f"the live message count at write time (5, after the concurrent "
+            f"append) — got marker={marker}. A marker of 5 here would mean the "
+            "concurrently-appended message gets silently treated as already "
+            "archived despite never having been written to history.jsonl."
+        )
+        entries = _history_entries_for(loop, "cli:race")
+        assert "concurrent turn message" not in "\n".join(e["content"] for e in entries), (
+            "Sanity check: the concurrent message should not appear in the "
+            "archive from this scan (it arrived after the slice) — it should "
+            "surface on the *next* idle scan instead, now that the marker "
+            "correctly still considers it unarchived."
+        )
+        await loop.close_mcp()
+
+
+class TestDreamTailArchiveYieldsToRealArchiveGateRace:
+    """_needs_dream_tail_archive (the scan) and _dream_tail_archive (the task
+    that actually runs under the consolidator lock) aren't atomic: real
+    consolidation could advance last_consolidated in between. The task
+    re-checks the gate under the lock and must bail out rather than raw-
+    dumping content real consolidation already covered."""
+
+    @pytest.mark.asyncio
+    async def test_real_consolidation_winning_the_race_makes_the_task_bail_out(self, tmp_path):
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)
+        session = loop.sessions.get_or_create("cli:gaterace")
+        _add_turns(session, 2, prefix="short")  # 4 messages
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+
+        # Scan decides the tail path applies (last_consolidated == 0 here).
+        assert loop.auto_compact._needs_dream_tail_archive("cli:gaterace")
+
+        # Simulate real consolidation winning the race and completing first —
+        # by the time the scheduled task actually acquires the lock and reads
+        # the session, last_consolidated is no longer 0.
+        session = loop.sessions.get_or_create("cli:gaterace")
+        session.last_consolidated = 2
+        loop.sessions.save(session)
+
+        await loop.auto_compact._dream_tail_archive("cli:gaterace")
+
+        entries = _history_entries_for(loop, "cli:gaterace")
+        assert entries == [], (
+            "The task should have bailed out under the re-checked gate instead "
+            f"of raw-dumping content real consolidation already covered. Entries: {entries!r}"
+        )
+        session_after = loop.sessions.get_or_create("cli:gaterace")
+        assert Consolidator.dream_tail_marker(session_after) == 0, (
+            "Marker must not advance when the task bails out on the re-checked gate"
+        )
+        await loop.close_mcp()
+
+
+class TestDreamTailArchiveYieldsToRealArchiveOnConcurrentGrowth:
+    """The scan (_needs_dream_tail_archive) and the actual task
+    (_dream_tail_archive) aren't atomic — a burst of activity between them
+    could grow the session well past a "lightweight raw dump" amount. The task
+    must bail out in that case rather than raw-dumping a large burst
+    permanently (no LLM summary, ever, for that content)."""
+
+    @pytest.mark.asyncio
+    async def test_large_growth_between_scan_and_run_is_left_for_the_next_real_scan(self, tmp_path):
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)
+        session = loop.sessions.get_or_create("cli:burst")
+        _add_turns(session, 1, prefix="short")  # 2 messages, qualifies for tail-archive
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+        assert loop.auto_compact._needs_dream_tail_archive("cli:burst")
+
+        # Simulate a burst of activity landing between the scan's decision and
+        # the task actually running under the lock.
+        session = loop.sessions.get_or_create("cli:burst")
+        _add_turns(session, 20, prefix="burst")  # +40 messages, cleanly droppable
+        loop.sessions.save(session)
+        assert loop.auto_compact._has_compactable_idle_tail("cli:burst"), (
+            "Precondition: this burst shape should be cleanly droppable by the "
+            "real path, unlike the unanswered-tail shape in "
+            "TestDreamTailArchiveUnanswerableTailDoesNotStarve"
+        )
+
+        await loop.auto_compact._dream_tail_archive("cli:burst")
+
+        entries = _history_entries_for(loop, "cli:burst")
+        assert entries == [], (
+            "Expected the tail-archive task to bail out and leave this large "
+            "burst for the next scan's real archive path instead of "
+            f"permanently raw-dumping it. Entries: {entries!r}"
+        )
+        session_after = loop.sessions.get_or_create("cli:burst")
+        assert Consolidator.dream_tail_marker(session_after) == 0, (
+            "Marker must not advance when the task bails out — otherwise the "
+            "burst content would look 'already archived' without ever having "
+            "been written anywhere."
+        )
+        await loop.close_mcp()
+
+
+class TestDreamTailArchiveUnanswerableTailDoesNotStarve:
+    """A raw message count above _RECENT_SUFFIX_MESSAGES is not, by itself, proof
+    that the real archive path is viable: retain_recent_legal_suffix(8,
+    extend_to_user=True) walks backward to the nearest user turn, and for a
+    session shaped like 4 complete Q&A pairs plus one trailing unanswered
+    question (9 messages total), that walk lands on index 0 — nothing is
+    droppable, so the real path permanently no-ops. The old bail condition
+    (bare "> 8 messages") would make the tail task defer to that real path
+    forever too, starving the session of any Dream input at all — exactly the
+    bug this PR exists to fix, just in a shape the last_consolidated == 0 gate
+    doesn't by itself prevent."""
+
+    @pytest.mark.asyncio
+    async def test_nine_message_session_with_unanswered_tail_still_gets_archived(self, tmp_path):
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)
+        session = loop.sessions.get_or_create("cli:nine")
+        _add_turns(session, 4, prefix="qa")  # 8 messages: 4 complete Q&A pairs
+        session.add_message("user", "unanswered question")  # 9th, no reply
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+
+        assert not loop.auto_compact._has_compactable_idle_tail("cli:nine"), (
+            "Precondition: retain_recent_legal_suffix's extend_to_user walk "
+            "should find nothing droppable for this exact shape"
+        )
+
+        await _run_check_expired(loop)
+
+        entries = _history_entries_for(loop, "cli:nine")
+        assert len(entries) == 1, (
+            "A session real consolidation can never make progress on must "
+            "still get a tail-archive entry, even with > 8 messages. Entries: "
+            + repr(entries)
+        )
+
+        # Idempotency: a second scan with nothing new must not duplicate.
+        session = loop.sessions.get_or_create("cli:nine")
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+        await _run_check_expired(loop)
+        entries_after_second_scan = _history_entries_for(loop, "cli:nine")
+        assert len(entries_after_second_scan) == 1, (
+            "Second scan should not duplicate: " + repr(entries_after_second_scan)
+        )
+        await loop.close_mcp()
+
+
+class TestDreamTailArchiveCrashSafety:
+    """If the process dies between writing the history entry and persisting the
+    tail marker, a restarted process may re-archive that range once more — but
+    only once the marker save actually succeeds does duplication stop."""
+
+    @pytest.mark.asyncio
+    async def test_crash_between_entry_write_and_marker_save_then_process_restart(self, tmp_path):
+        loop1 = _make_loop(tmp_path, session_ttl_minutes=15)
+        session = loop1.sessions.get_or_create("cli:short")
+        _add_turns(session, 2, prefix="short")
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop1.sessions.save(session)
+
+        # Really write the entry (a normal, completed append_history() call — it
+        # is not fsync'd, but it does fully return, unlike a mid-write crash),
+        # then raise before the metadata marker is ever set or saved.
+        real_raw_archive = loop1.consolidator.store.raw_archive
+
+        def _write_then_crash(*args, **kwargs):
+            real_raw_archive(*args, **kwargs)
+            raise RuntimeError("simulated process crash after entry write")
+
+        loop1.consolidator.store.raw_archive = _write_then_crash
+        await _run_check_expired(loop1)  # exception is caught+logged inside _dream_tail_archive
+
+        entries_after_crash = _history_entries_for(loop1, "cli:short")
+        assert len(entries_after_crash) == 1, "The entry write itself should have survived the crash"
+        await loop1.close_mcp()
+
+        # Process restart: brand new loop / SessionManager / MemoryStore, same workspace.
+        loop2 = _make_loop(tmp_path, session_ttl_minutes=15)
+        session_reloaded = loop2.sessions.get_or_create("cli:short")
+        assert len(session_reloaded.messages) == 4, "Session content must survive the restart"
+        assert Consolidator.DREAM_TAIL_MARKER_KEY not in session_reloaded.metadata, (
+            "Precondition check: the marker genuinely was never persisted"
+        )
+        session_reloaded.updated_at = datetime.now() - timedelta(minutes=20)
+        loop2.sessions.save(session_reloaded)
+
+        # First post-restart scan: marker is still missing, so exactly one more
+        # duplicate entry is expected (new process has no memory of the crash).
+        await _run_check_expired(loop2)
+        entries_after_restart_scan_1 = _history_entries_for(loop2, "cli:short")
+        assert len(entries_after_restart_scan_1) == 2, (
+            f"Expected exactly one duplicate from the first post-restart scan, got "
+            f"{len(entries_after_restart_scan_1)} entries total"
+        )
+
+        # This scan's marker save should have succeeded (no crash injected this time) —
+        # a second post-restart scan must not add a third entry.
+        session_reloaded = loop2.sessions.get_or_create("cli:short")
+        session_reloaded.updated_at = datetime.now() - timedelta(minutes=20)
+        loop2.sessions.save(session_reloaded)
+        await _run_check_expired(loop2)
+        entries_after_restart_scan_2 = _history_entries_for(loop2, "cli:short")
+        assert len(entries_after_restart_scan_2) == 2, (
+            "Once a marker save succeeds, duplication must stop — got "
+            f"{len(entries_after_restart_scan_2)} entries after a third scan"
+        )
+        await loop2.close_mcp()
+
+
+class TestDreamTailMarkerRemappedOnFileCapTrim:
+    """Session.enforce_file_cap (triggered past FILE_MAX_MESSAGES, tested here
+    with a small custom limit) must remap the tail-archive marker the same way
+    it already remaps last_consolidated when trimming session.messages —
+    otherwise the marker either duplicates already-covered content or, worse,
+    silently excludes a range that was never actually archived."""
+
+    def test_marker_remapped_not_just_clamped_on_trim(self, tmp_path):
+        from nanobot.session.manager import Session
+
+        session = Session(key="cli:cap", messages=[], metadata={"_dream_tail_through": 6})
+        for i in range(6):
+            session.add_message("user", f"msg{i}")
+            session.add_message("assistant", f"reply{i}")
+        # 12 messages total; marker=6 covers the first 3 user/assistant pairs.
+
+        archived: list[dict] = []
+        session.enforce_file_cap(on_archive=archived.extend, limit=8)
+
+        assert len(session.messages) == 8
+        new_marker = Consolidator.dream_tail_marker(session)
+        # Of the original marker=6 range (indices 0-5), only indices 4-5
+        # (msg2/reply2) survive into the retained last-8 window — so the
+        # correctly remapped marker is 2, not 6 (unclamped/stale) and not
+        # dropped-to-0 (which would falsely treat msg2/reply2 as brand new).
+        assert new_marker == 2, (
+            f"Expected the marker to be remapped to 2 (how many of the "
+            f"originally-covered messages survived the trim), got {new_marker}. "
+            "An unremapped/merely-clamped marker would either point at the "
+            "wrong message or silently exclude content that was never "
+            "actually archived."
+        )
+        # Everything file-cap dropped (msg0/reply0/msg1/reply1) was already
+        # covered by the tail marker (before_marker=6 > all 4 dropped
+        # indices), so on_archive must not be called with any of it — doing
+        # so would raw-dump content that's already in Dream's input verbatim.
+        assert archived == [], (
+            "file-cap re-archived content already covered by the tail marker: "
+            + repr(archived)
+        )
+
+    def test_archive_chunk_still_covers_genuinely_new_content_past_the_marker(self, tmp_path):
+        """The marker-awareness fix must not over-exclude: dropped content
+        that was never covered by the marker (or last_consolidated) still
+        needs to reach on_archive, or it's lost entirely."""
+        from nanobot.session.manager import Session
+
+        session = Session(key="cli:cap2", messages=[], metadata={"_dream_tail_through": 2})
+        for i in range(6):
+            session.add_message("user", f"msg{i}")
+            session.add_message("assistant", f"reply{i}")
+        # 12 messages; marker=2 covers indices 0-1 (msg0, reply0). Trim to last
+        # 8 drops indices 0-3 (msg0/reply0/msg1/reply1) — msg0/reply0 are
+        # marker-covered; msg1/reply1 are genuinely new and must still reach
+        # on_archive.
+
+        archived: list[dict] = []
+        session.enforce_file_cap(on_archive=archived.extend, limit=8)
+
+        archived_text = " ".join(str(m.get("content", "")) for m in archived)
+        assert "msg0" not in archived_text and "reply0" not in archived_text, (
+            "msg0/reply0 were already marker-covered, should not be re-archived: " + repr(archived)
+        )
+        assert "msg1" in archived_text and "reply1" in archived_text, (
+            "Genuinely unarchived dropped content must still reach on_archive: " + repr(archived)
+        )
+
+
+class TestDreamTailArchiveForkDoesNotDuplicateContent:
+    """End-to-end: forking a tail-archived session and letting the fork go idle
+    must not produce a second history.jsonl entry with the same verbatim
+    content the source session's entry already covers."""
+
+    @pytest.mark.asyncio
+    async def test_fork_of_tail_archived_session_does_not_redump_copied_prefix(self, tmp_path):
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)
+        session = loop.sessions.get_or_create("websocket:source")
+        _add_turns(session, 2, prefix="orig")  # 4 messages
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+
+        await _run_check_expired(loop)
+        source_entries = _history_entries_for(loop, "websocket:source")
+        assert len(source_entries) == 1
+        assert "orig user 0" in source_entries[0]["content"]
+
+        forked = loop.sessions.fork_session_before_user_index(
+            "websocket:source", "websocket:fork", 1,
+            extra_index_metadata_keys=(Consolidator.DREAM_TAIL_MARKER_KEY,),
+        )
+        assert forked is not None
+        forked.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(forked)
+        await _run_check_expired(loop)
+
+        fork_entries = _history_entries_for(loop, "websocket:fork")
+        assert fork_entries == [], (
+            "The fork's copy of an already tail-archived prefix must not be "
+            "raw-dumped again under the fork's own session_key — that content "
+            "is already in Dream's input via the source session's entry. Got: "
+            + repr(fork_entries)
+        )
+        await loop.close_mcp()
+
+
+class TestDreamTailArchiveLivePromptImpact:
+    """A tail-archived entry must not surface in a resumed session's own
+    "# Recent History" section: that content is already visible via normal
+    conversation history (session.messages is untouched), so re-injecting it
+    from history.jsonl would duplicate it in the prompt. Entries are written
+    under a "tail:{session_key}" key (see AutoCompact._dream_tail_archive)
+    specifically so read_recent_history_for_prompt's exact-match filtering
+    (the default, unified_session=False) never picks them up for the real
+    session_key, and its unified-session prefix-exclusion also excludes them
+    via MemoryStore._INTERNAL_HISTORY_SESSION_PREFIXES. Dream itself is
+    unaffected either way: build_dream_prompt consumes history.jsonl by
+    cursor only, never by session_key."""
+
+    @pytest.mark.asyncio
+    async def test_recent_history_section_excludes_the_tail_dump(self, tmp_path):
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)
+        session = loop.sessions.get_or_create("cli:resumed")
+        _add_turns(session, 2, prefix="short")  # 4 messages
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+
+        await _run_check_expired(loop)
+        entries = _history_entries_for(loop, "cli:resumed")
+        assert len(entries) == 1
+
+        prompt = loop.context.build_system_prompt(session_key="cli:resumed")
+        assert "# Recent History" not in prompt, (
+            "The tail-archived entry leaked into Recent History for a resumed "
+            "turn on the same session — this duplicates content already "
+            "present in normal conversation history, and is permanent (never "
+            "self-heals) whenever dream.enabled=False."
+        )
+        assert "short user 0" not in prompt, (
+            "The tail-dump content should not appear anywhere in the system "
+            "prompt via Recent History"
+        )
+        await loop.close_mcp()
+
+    @pytest.mark.asyncio
+    async def test_dream_still_consumes_the_tail_entry_by_cursor(self, tmp_path):
+        """The "tail:" key rename must not hide the entry from Dream itself —
+        build_dream_prompt reads by cursor only, never by session_key."""
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)
+        session = loop.sessions.get_or_create("cli:resumed2")
+        _add_turns(session, 2, prefix="short")  # 4 messages
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+
+        await _run_check_expired(loop)
+        result = loop.context.memory.build_dream_prompt()
+        assert result is not None, "Expected Dream to have unprocessed input from the tail entry"
+        prompt, _last_cursor = result
+        assert "short user 0" in prompt, (
+            "The tail-archived content should still reach Dream's own prompt "
+            "despite being stored under a 'tail:' prefixed session_key"
+        )
+        await loop.close_mcp()
+
+    @pytest.mark.asyncio
+    async def test_write_side_and_filter_side_use_the_same_prefix_constant(self, tmp_path):
+        """The write side (AutoCompact._dream_tail_archive) and the filter
+        side (MemoryStore._INTERNAL_HISTORY_SESSION_PREFIXES) must derive from
+        the same DREAM_TAIL_SESSION_KEY_PREFIX constant, not two independently
+        maintained "tail:" literals that could drift apart."""
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)
+        session = loop.sessions.get_or_create("cli:constcheck")
+        _add_turns(session, 2, prefix="short")
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+
+        await _run_check_expired(loop)
+
+        entries = loop.context.memory.read_unprocessed_history(since_cursor=0)
+        written_key = next(e["session_key"] for e in entries if "short user 0" in e.get("content", ""))
+        assert written_key == f"{DREAM_TAIL_SESSION_KEY_PREFIX}cli:constcheck"
+        assert written_key.startswith(DREAM_TAIL_SESSION_KEY_PREFIX)
+        await loop.close_mcp()
+
+
+class TestDreamTailArchiveSafety:
+    """The tail-archive path must reuse the same content-safety treatment as
+    every other raw-dump path in this codebase."""
+
+    @pytest.mark.asyncio
+    async def test_runtime_context_suffix_does_not_leak_into_history(self, tmp_path):
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)
+        session = loop.sessions.get_or_create("cli:ctx")
+        session.add_message(
+            "user",
+            "visible user text\n\nSECRET_RUNTIME_BLOCK_MARKER",
+            **{
+                RUNTIME_CONTEXT_HISTORY_META: {
+                    "version": 1,
+                    "sources": ["webui-quote"],
+                    "suffix": "SECRET_RUNTIME_BLOCK_MARKER",
+                }
+            },
+        )
+        session.add_message("assistant", "ok")
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+
+        await _run_check_expired(loop)
+
+        entries = _history_entries_for(loop, "cli:ctx")
+        assert entries, "Expected the short session to produce a tail entry"
+        all_content = "\n".join(e.get("content", "") for e in entries)
+        assert "visible user text" in all_content
+        assert "SECRET_RUNTIME_BLOCK_MARKER" not in all_content, (
+            "Trusted runtime-context content leaked into history.jsonl (and therefore "
+            "into Dream's input) — the tail-archive path must apply the same "
+            "public_history_messages() stripping that Consolidator.archive() applies "
+            "(it does, via MemoryStore.raw_archive())."
+        )
+        await loop.close_mcp()
+
+
+class TestDreamTailMarkerDefensiveReads:
+    """dream_tail_marker() must reject bool (isinstance(True, int) is True in
+    Python — must not silently treat it as 1) and clamp to the current message
+    count (a stale marker left over from a trim must not point past the end of
+    session.messages, which would make every archive path conclude there's
+    permanently nothing to do rather than just re-covering a small range once)."""
+
+    def test_bool_marker_value_is_rejected(self, tmp_path):
+        from nanobot.session.manager import Session
+
+        session = Session(key="cli:bool", messages=[], metadata={"_dream_tail_through": True})
+        assert Consolidator.dream_tail_marker(session) == 0
+
+    def test_marker_beyond_message_count_is_clamped_not_left_dangling(self, tmp_path):
+        from nanobot.session.manager import Session
+
+        session = Session(
+            key="cli:stale",
+            messages=[{"role": "user", "content": "only one message"}],
+            metadata={"_dream_tail_through": 999},
+        )
+        assert Consolidator.dream_tail_marker(session) == 1, (
+            "An unclamped marker (999) would make session.messages[999:] "
+            "always empty, permanently hiding this session from every "
+            "archive path — not just risking a one-time duplicate."
+        )
+
+
+class TestCmdNewSnapshotSkipsTailArchivedContent:
+    """cmd_new (/new) archives an outgoing session's unarchived tail via
+    Consolidator.archive() before clearing it. That snapshot must start from
+    Consolidator.archive_start(session), not session.last_consolidated alone —
+    otherwise a session that was only ever dream-tail-archived would have its
+    already-archived prefix fed into a second, real LLM summarization pass."""
+
+    @pytest.mark.asyncio
+    async def test_new_snapshot_excludes_already_tail_archived_prefix(self, tmp_path):
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock
+
+        from nanobot.bus.events import InboundMessage
+        from nanobot.command.builtin import cmd_new
+        from nanobot.command.router import CommandContext
+        from nanobot.session.manager import SessionManager
+
+        sessions = SessionManager(tmp_path)
+        session = sessions.get_or_create("cli:new-after-tail")
+        _add_turns(session, 2, prefix="old")  # 4 messages
+        session.metadata[Consolidator.DREAM_TAIL_MARKER_KEY] = 4  # already tail-archived
+        _add_turns(session, 1, prefix="unarchived")  # +2 messages, never archived
+        sessions.save(session)
+
+        admitted_runtime = MagicMock(name="admitted_runtime")
+        loop = SimpleNamespace(
+            sessions=sessions,
+            consolidator=SimpleNamespace(archive=AsyncMock(return_value="summary")),
+            _cancel_active_tasks=AsyncMock(return_value=0),
+            llm_runtime=MagicMock(return_value=MagicMock()),
+            schedule_background=lambda coro: asyncio.ensure_future(coro),
+        )
+        msg = InboundMessage(
+            channel="cli", sender_id="user1", chat_id="1", content="/new",
+        )
+        ctx = CommandContext(
+            msg=msg, session=None, key="cli:new-after-tail", raw="/new",
+            loop=loop, runtime=admitted_runtime,
+        )
+
+        await cmd_new(ctx)
+
+        loop.consolidator.archive.assert_called_once()
+        snapshot = loop.consolidator.archive.call_args.args[0]
+        snapshot_text = " ".join(str(m.get("content", "")) for m in snapshot)
+        assert "old" not in snapshot_text, (
+            "The /new snapshot re-fed already tail-archived messages into a "
+            "real LLM summarization pass: " + repr(snapshot)
+        )
+        assert "unarchived" in snapshot_text, (
+            "Sanity check: the genuinely unarchived messages should still be "
+            "in the snapshot"
+        )
+        await asyncio.sleep(0)  # let the scheduled archive() coroutine settle
+
+
+class TestDreamTailMarkerClearedOnSessionReset:
+    """/new (Session.clear()) must reset the tail-archive marker along with
+    last_consolidated — otherwise a brand new conversation under the same
+    session key inherits a stale marker and its early messages are silently
+    treated as already archived, forever."""
+
+    @pytest.mark.asyncio
+    async def test_new_conversation_after_clear_is_not_silently_skipped(self, tmp_path):
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)
+        session = loop.sessions.get_or_create("cli:reset")
+        _add_turns(session, 2, prefix="old")  # 4 messages
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+
+        await _run_check_expired(loop)
+        first_entries = _history_entries_for(loop, "cli:reset")
+        assert len(first_entries) == 1
+
+        session = loop.sessions.get_or_create("cli:reset")
+        assert Consolidator.dream_tail_marker(session) == 4
+        session.clear()
+        assert Consolidator.DREAM_TAIL_MARKER_KEY not in session.metadata, (
+            "Session.clear() must drop any registered position-dependent "
+            "metadata key, the same way it already drops last_consolidated "
+            "and _last_summary."
+        )
+        loop.sessions.save(session)
+
+        session = loop.sessions.get_or_create("cli:reset")
+        _add_turns(session, 1, prefix="new")  # 2 messages in the fresh conversation
+        session.updated_at = datetime.now() - timedelta(minutes=20)
+        loop.sessions.save(session)
+        await _run_check_expired(loop)
+
+        all_entries = _history_entries_for(loop, "cli:reset")
+        assert len(all_entries) == 2, (
+            f"Expected the post-clear() conversation to produce its own new "
+            f"entry, got {len(all_entries)} total entries: {all_entries!r}"
+        )
+        assert "new user 0" in all_entries[-1]["content"]
+        await loop.close_mcp()
+
+
+class TestLastConsolidatedMustNotCoverTheLiveSuffix:
+    """last_consolidated must never advance to cover the entire session:
+    doing so would make a resumed short session lose all raw context on the
+    next turn, contradicting the documented intent behind retaining a recent
+    live suffix (commit 1cb28b3: 'preserve freshest live context' on resume)."""
+
+    def test_advancing_last_consolidated_to_end_loses_raw_resume_context(self, tmp_path):
+        loop = _make_loop(tmp_path)
+        session = loop.sessions.get_or_create("cli:tiny")
+        _add_turns(session, 2, prefix="tiny")  # 4 messages
+
+        # last_consolidated == len(messages) is the scenario this test locks against.
+        session.last_consolidated = len(session.messages)
+
+        unconsolidated = Consolidator._full_unconsolidated_history(session)
+        assert unconsolidated == [], (
+            "Once last_consolidated == len(messages), a resumed short session has "
+            "zero raw messages available for the live prompt — it would see only "
+            "the (thinner) tail summary, contradicting the documented intent of "
+            "commit 1cb28b3 ('preserve freshest live context')."
+        )

--- a/tests/agent/test_loop_consolidation_tokens.py
+++ b/tests/agent/test_loop_consolidation_tokens.py
@@ -241,7 +241,7 @@ async def test_preflight_consolidation_before_llm_call(tmp_path, monkeypatch) ->
 
     archived_session_keys: list[str | None] = []
 
-    async def track_consolidate(messages, *, runtime, session_key=None):
+    async def track_consolidate(messages, *, runtime, session_key=None, summary_messages=None):
         order.append("consolidate")
         archived_session_keys.append(session_key)
         return True

--- a/tests/agent/test_session_manager_history.py
+++ b/tests/agent/test_session_manager_history.py
@@ -595,6 +595,84 @@ def test_fork_session_drops_summary_when_fork_point_is_inside_consolidated_prefi
     assert "_last_summary" not in forked.metadata
 
 
+def test_fork_session_clamps_extra_index_metadata_key_beyond_copied_prefix(tmp_path):
+    """Clamp-not-drop rationale: see fork_session_before_user_index's own
+    comment. Here the marker (4) exceeds the copied prefix (2 messages), so
+    it must clamp to 2, not reset to 0 like last_consolidated would."""
+    manager = SessionManager(tmp_path)
+    source = manager.get_or_create("websocket:source")
+    source.messages = [
+        {"role": "user", "content": "round1"},
+        {"role": "assistant", "content": "answer1"},
+        {"role": "user", "content": "round2 fork me"},
+        {"role": "assistant", "content": "answer2"},
+    ]
+    source.metadata["_dream_tail_through"] = 4
+    manager.save(source)
+
+    forked = manager.fork_session_before_user_index(
+        "websocket:source",
+        "websocket:fork",
+        1,
+        extra_index_metadata_keys=("_dream_tail_through",),
+    )
+
+    assert forked is not None
+    assert [m["content"] for m in forked.messages] == ["round1", "answer1"]
+    assert forked.metadata.get("_dream_tail_through") == 2, (
+        "Marker should be clamped to len(copied)=2, not dropped — the fork's "
+        "2 copied messages are already covered verbatim by the source "
+        "session's tail-archive entry."
+    )
+
+
+def test_fork_session_keeps_extra_index_metadata_key_within_copied_prefix(tmp_path):
+    """The counterpart to the test above: a marker that still points within the
+    copied prefix is valid and must be preserved, not unconditionally dropped."""
+    manager = SessionManager(tmp_path)
+    source = manager.get_or_create("websocket:source")
+    source.messages = [
+        {"role": "user", "content": "round1"},
+        {"role": "assistant", "content": "answer1"},
+        {"role": "user", "content": "round2 fork me"},
+        {"role": "assistant", "content": "answer2"},
+    ]
+    source.metadata["_dream_tail_through"] = 2
+    manager.save(source)
+
+    forked = manager.fork_session_before_user_index(
+        "websocket:source",
+        "websocket:fork",
+        1,
+        extra_index_metadata_keys=("_dream_tail_through",),
+    )
+
+    assert forked is not None
+    assert forked.metadata.get("_dream_tail_through") == 2
+
+
+def test_fork_session_ignores_extra_index_metadata_key_when_not_requested(tmp_path):
+    """Without extra_index_metadata_keys, an unrelated metadata key must ride
+    through deepcopy unchanged — this call site opts in explicitly."""
+    manager = SessionManager(tmp_path)
+    source = manager.get_or_create("websocket:source")
+    source.messages = [
+        {"role": "user", "content": "round1"},
+        {"role": "assistant", "content": "answer1"},
+    ]
+    source.metadata["unrelated_counter"] = 999
+    manager.save(source)
+
+    forked = manager.fork_session_before_user_index(
+        "websocket:source",
+        "websocket:fork",
+        1,
+    )
+
+    assert forked is not None
+    assert forked.metadata.get("unrelated_counter") == 999
+
+
 def test_get_history_ignores_media_kwarg_on_non_user_rows():
     """``media`` only ever appears on user entries in practice, but the
     synthesizer must be defensive: assistants / tools with list content

--- a/tests/webui/test_forking.py
+++ b/tests/webui/test_forking.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from nanobot.agent.memory import Consolidator
+from nanobot.session.manager import SessionManager
+from nanobot.webui.forking import create_webui_chat_fork
+
+
+def test_fork_preserves_dream_tail_marker_via_production_entry_point(tmp_path: Path) -> None:
+    """create_webui_chat_fork (the real WebUI fork_chat handler's entry point,
+    not the lower-level SessionManager.fork_session_before_user_index tested
+    elsewhere) must carry the dream-tail marker into the fork. Without the
+    explicit extra_index_metadata_keys passed here, correctness would depend
+    on nanobot.agent.memory having already been imported somewhere in the
+    process for the marker key to be in the registry — this test can't prove
+    that dependency doesn't exist (pytest's own collection already imports
+    memory.py), only that the explicit path works regardless of it."""
+    manager = SessionManager(tmp_path)
+    source = manager.get_or_create("websocket:src")
+    for i in range(4):
+        source.add_message("user", f"msg{i}")
+        source.add_message("assistant", f"reply{i}")
+    # marker=6 covers indices 0-5 (msg0/reply0/msg1/reply1/msg2/reply2) —
+    # beyond the 4-message prefix before_user_index=2 will copy, so a correct
+    # fork must clamp it to 4, not carry the stale out-of-range value forward.
+    source.metadata[Consolidator.DREAM_TAIL_MARKER_KEY] = 6
+    manager.save(source)
+
+    result = create_webui_chat_fork(
+        manager,
+        source_chat_id="src",
+        before_user_index=2,
+    )
+    assert result is not None
+    _chat_id, fork_key = result
+
+    forked = manager.get_or_create(fork_key)
+    assert forked.metadata.get(Consolidator.DREAM_TAIL_MARKER_KEY) == 4, (
+        "Expected the marker to be clamped to the copied prefix length (4), "
+        f"got metadata={forked.metadata!r}"
+    )


### PR DESCRIPTION
## Problem

`history.jsonl` is Dream's only input source. A short idle session that never exceeds `retain_recent_legal_suffix`'s protected recent-suffix window never produces a `history.jsonl` entry, no matter how long it idles — so Dream has no input to process for that session.

## Solution

Add a lightweight archive path for sessions the real archive path structurally can't reach yet: sessions with `last_consolidated == 0` and unarchived messages. It reuses `MemoryStore.raw_archive()` and tracks progress via a new `dream_tail_marker`. Every real archive boundary now starts from `max(last_consolidated, dream_tail_marker)`, so the two paths never re-cover each other's range; `last_consolidated`'s own semantics are unchanged. The LLM's summarization context and the removal/raw-fallback boundary are kept separate, so a session already tail-archived doesn't lose that content from future summaries. Tail entries are written under a `tail:` session-key prefix so Dream still consumes them by cursor while a resumed session's live prompt doesn't see them twice.

This is narrower than the eager-consolidation design attempted in #4402/#4626 for the related #2604, which was closed over double-archiving between the eager and token-driven paths — the boundary formula above is specifically designed to avoid that failure mode. Thanks to @hamb1y for the original root-cause analysis on #3973.

## Changes

- `nanobot/agent/autocompact.py`: new `_dream_tail_archive` scan/execute path, gated on `last_consolidated == 0`. Entries write under the `tail:` session-key prefix.
- `nanobot/agent/memory.py`: `dream_tail_marker()` / `archive_start()`, used by all real archive boundary calculations; `compact_idle_session`, `maybe_consolidate_by_tokens`, and `_consolidate_replay_overflow` updated accordingly. `tail:` is excluded from `# Recent History`.
- `nanobot/session/manager.py`: a registry so `Session.clear()`, `fork_session_before_user_index()`, and file-cap trimming all handle the marker automatically — clamped on fork, remapped on trim.
- `nanobot/webui/forking.py`, `nanobot/command/builtin.py`: the WebUI fork entry point and `/new`'s pre-clear snapshot handle the marker explicitly.

## Testing

Tests are grouped into four areas:

- **Archive-boundary invariants** — tail archive and real consolidation never re-cover each other's range in either direction; the LLM's summarization context stays complete even for an already-tail-archived prefix.
- **Lifecycle** — `/new` clearing, fork, file-cap trimming, and incremental messages after a tail archive.
- **Reliability** — deterministic concurrency (scan-vs-run races, concurrent append), a real process-restart crash-recovery scenario, and at-least-once write semantics.
- **Integration** — Recent History exclusion, Dream's cursor-based consumption, and the real WebUI fork entry point.

No-duplication tests inspect the actual messages passed to `Consolidator.archive()`, rather than inferring them from mocked LLM output.

One existing test's expectation was intentionally changed: it previously asserted a session with no removable tail should never be scheduled for archiving — precisely the bug this PR fixes.

Full suite: `6063 passed, 11 skipped` (`pytest -q`, matching this repo's own `testpaths`), `ruff check` and `basedpyright` clean.

## Trade-offs / Known limitations

- **16k truncation**: `raw_archive()` truncates the whole batch at `_RAW_ARCHIVE_MAX_CHARS`, and the marker advances past the full batch regardless of what was actually written. Content past the truncation point is lost to Dream permanently, though it remains visible in the live conversation.
- **Crash safety is at-least-once, not exactly-once**: a crash between the entry write and the marker save can produce one extra duplicate entry per crash event; duplication stops once a marker save succeeds.
- **SDK attribution**: `nanobot.sdk.clients.MemoryClient.read_history` filtered by a session's real key no longer sees its tail-archived entries (they're under the `tail:` key instead) — accepted, since the alternative (permanent Recent History duplication when `dream.enabled=False`) is worse.
- `session_ttl_minutes=0` (AutoCompact disabled) isn't covered, and a session already through one real consolidation stays out of scope for this path even if its tail later shrinks back to ≤8 messages.

## Scope decision

`_needs_dream_tail_archive` has no explicit upper bound on batch size — short of the 2000-message file cap, it can fire for any `last_consolidated == 0` session, regardless of size. Locally, this path activates for a 61-message single-user tool-chain session, with no explicit bound before the file cap. The real idle path intentionally preserves the complete user/tool sequence (`3ce0cd97`), so this shape remains non-compactable by design.

This raises two independent questions:

1. **Scope gate** — should this path fire only for bounded, short-session tails, or for every session the real path can't reach, regardless of size?
2. **Payload-fit** — independent of scope, should the marker only advance when the full batch fits inside `raw_archive()`'s 16k cap, or is "marker advances regardless of truncation" (the existing `raw_archive()` contract everywhere else) acceptable here too?

| Option | Scope | Marker semantics | Cost |
|---|---|---|---|
| Current behavior | Unbounded | Advances even past truncated/lost content | Long tool-chain sessions lose newest content repeatedly as they keep growing |
| Count gate only | Bounded short sessions | Same as today's `raw_archive()` elsewhere | Simplest; an oversized *short* session can still truncate (rare, already-accepted edge case) |
| Payload-fit only | Unbounded | Only advances on a full, untruncated write | Oversized sessions retry every idle scan, indefinitely, with no progress |
| Count gate + payload-fit | Bounded short sessions | Strictest — only advances on a full write | Same retry-without-progress cost, now confined to the rare in-scope case of a short session whose total payload exceeds 16k |

Note: this PR's existing unanswered-tail regression test uses a 9-message session; a count-based boundary below 9 would change that test's expectation.

My preference is **count gate only**: it matches #3973's own concrete scope (`hamb1y`'s "last N" / "5 short exchanges"), keeps the fallback bounded, and doesn't introduce a retry-without-progress loop. Batched raw archiving would turn this focused fallback into a second consolidation pipeline, so I don't think this PR should implement it. Long single-user tool-chain sessions should be tracked explicitly as a separate case rather than becoming part of this PR's scope only because the fallback currently reaches them.

## Why this is a draft

Two decisions I'd like maintainer input on before polishing further:

1. Whether `dream_tail_marker` — a second, lightweight archive boundary living alongside `last_consolidated` — is a semantic you want in this codebase.
2. Which scope/payload-fit option above (or a different bound) this path should implement.
