### PR TITLE
feat(mattermost): separate group policy for threads and expose in WebUI

### DIFF
--- a/docs/guides/mattermost-ai-agent.md
+++ b/docs/guides/mattermost-ai-agent.md
@@ -41,6 +41,7 @@ Merge this snippet into `~/.nanobot/config.json`:
       "token": "YOUR_MATTERMOST_TOKEN",
       "teamId": "YOUR_TEAM_ID",
       "groupPolicy": "mention",
+      "groupPolicyInThread": "open",
       "replyInThread": true,
       "dm": {
         "policy": "allowlist"
@@ -51,7 +52,15 @@ Merge this snippet into `~/.nanobot/config.json`:
 ```
 
 `teamId` scopes the channel to a Mattermost team. Keep `groupPolicy` as
-`mention` for the first test.
+`mention` for the first test. `groupPolicyInThread` can be `"mention"`,
+`"open"`, or `"allowlist"` and controls messages that reply inside a
+thread. If it is omitted, it inherits `groupPolicy`, preserving the behavior
+of existing configurations. Set it to `"open"` explicitly when follow-up
+messages in threads should not require another @mention.
+
+When `groupPolicy` is `"allowlist"`, `groupAllowFrom` remains the outer
+channel boundary for root posts and thread replies. A thread policy cannot open
+a channel that is not on that allowlist.
 
 Mattermost DMs are open by default. Setting `dm.policy` to `"allowlist"` with no
 `dm.allowFrom` entries makes new DM senders receive a pairing code. Approve the
@@ -93,8 +102,8 @@ Then DM the bot again, or mention it in a channel where the bot has access:
 - If DMs are ignored, review the `dm` policy and pairing approval state.
 - If channel messages are ignored, confirm the bot is mentioned and belongs to
   the team/channel.
-- If thread replies are surprising, review `replyInThread` and
-  `includeThreadContext`.
+- If thread replies are surprising, review `groupPolicyInThread`,
+  `replyInThread`, and `includeThreadContext`.
 
 ## Next: memory, automations, MCP tools
 

--- a/nanobot/channels/mattermost/manifest.py
+++ b/nanobot/channels/mattermost/manifest.py
@@ -10,6 +10,7 @@ SETUP_SPEC = ChannelSetupSpec(
         "token": field("secret"),
         "teamId": field(),
         "groupPolicy": field("enum", choices=GROUP_POLICIES, default="mention"),
+        "groupPolicyInThread": field("enum", choices=GROUP_POLICIES, default="mention"),
         "allowFrom": field("list"),
     },
     required=required_fields("serverUrl", "token"),

--- a/nanobot/channels/mattermost/runtime.py
+++ b/nanobot/channels/mattermost/runtime.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import httpx
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
@@ -59,6 +59,22 @@ class MattermostConfig(Base):
     send_progress: bool = True
     send_tool_hints: bool = True
     dm: MattermostDMConfig = Field(default_factory=MattermostDMConfig)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _inherit_thread_policy(cls, data: Any) -> Any:
+        """Preserve the existing group policy unless a thread override is set."""
+        if not isinstance(data, dict):
+            return data
+        raw = cast(dict[str, Any], data)
+        if "groupPolicyInThread" in raw or "group_policy_in_thread" in raw:
+            return raw
+        values = dict(raw)
+        values["group_policy_in_thread"] = values.get(
+            "groupPolicy",
+            values.get("group_policy", "mention"),
+        )
+        return values
 
 
 def _server_url_to_ws_url(server_url: str) -> str:

--- a/nanobot/channels/mattermost/runtime.py
+++ b/nanobot/channels/mattermost/runtime.py
@@ -47,6 +47,7 @@ class MattermostConfig(Base):
     allow_from_match_mode: str = "id"
     allow_from: list[str] = Field(default_factory=list)
     group_policy: str = "mention"
+    group_policy_in_thread: str = "open"
     group_allow_from: list[str] = Field(default_factory=list)
     reply_in_thread: bool = True
     include_thread_context: bool = True
@@ -244,8 +245,10 @@ class MattermostChannel(BaseChannel):
                 )
             return
 
-        if not is_dm and not self._should_respond_in_channel(message_text, channel_id):
-            return
+        if not is_dm:
+            in_thread = bool(root_id)
+            if not self._should_respond_in_channel(message_text, channel_id, in_thread=in_thread):
+                return
 
         message_text = self._strip_bot_mention(message_text)
 
@@ -360,12 +363,18 @@ class MattermostChannel(BaseChannel):
             return chat_id in self.config.group_allow_from
         return True
 
-    def _should_respond_in_channel(self, text: str, chat_id: str) -> bool:
-        if self.config.group_policy == "open":
+    def _should_respond_in_channel(
+        self, text: str, chat_id: str, *, in_thread: bool = False,
+    ) -> bool:
+        policy = (
+            self.config.group_policy_in_thread if in_thread
+            else self.config.group_policy
+        )
+        if policy == "open":
             return True
-        if self.config.group_policy == "mention":
+        if policy == "mention":
             return self._is_mentioned(text)
-        if self.config.group_policy == "allowlist":
+        if policy == "allowlist":
             return chat_id in self.config.group_allow_from
         return False
 

--- a/nanobot/channels/mattermost/tests/test_mattermost_channel.py
+++ b/nanobot/channels/mattermost/tests/test_mattermost_channel.py
@@ -375,6 +375,53 @@ async def test_group_policy_allowlist():
     assert channel._should_respond_in_channel("msg", "c2") is False
 
 
+@pytest.mark.asyncio
+async def test_group_policy_in_thread_default_open():
+    """Thread uses open policy by default, so no mention needed in threads."""
+    channel, fake = _make_channel({"groupPolicy": "mention"})
+    channel._self_username = "nanobot"
+    # In a main channel (not thread), mention is required
+    assert channel._should_respond_in_channel("hello", "c1", in_thread=False) is False
+    assert channel._should_respond_in_channel("@nanobot hello", "c1", in_thread=False) is True
+    # In a thread, no mention needed (default open policy)
+    assert channel._should_respond_in_channel("hello", "c1", in_thread=True) is True
+
+
+@pytest.mark.asyncio
+async def test_group_policy_in_thread_mention():
+    """Thread can also use mention policy when configured."""
+    channel, fake = _make_channel({
+        "groupPolicy": "mention",
+        "groupPolicyInThread": "mention",
+    })
+    channel._self_username = "nanobot"
+    # In a thread with mention policy, mention is required
+    assert channel._should_respond_in_channel("hello", "c1", in_thread=True) is False
+    assert channel._should_respond_in_channel("@nanobot hello", "c1", in_thread=True) is True
+
+
+@pytest.mark.asyncio
+async def test_group_policy_in_thread_open():
+    """Thread uses open policy when explicitly configured."""
+    channel, fake = _make_channel({
+        "groupPolicy": "mention",
+        "groupPolicyInThread": "open",
+    })
+    assert channel._should_respond_in_channel("hello", "c1", in_thread=True) is True
+
+
+@pytest.mark.asyncio
+async def test_group_policy_in_thread_allowlist():
+    """Thread uses allowlist policy when configured."""
+    channel, fake = _make_channel({
+        "groupPolicy": "mention",
+        "groupPolicyInThread": "allowlist",
+        "groupAllowFrom": ["c1"],
+    })
+    assert channel._should_respond_in_channel("msg", "c1", in_thread=True) is True
+    assert channel._should_respond_in_channel("msg", "c2", in_thread=True) is False
+
+
 # ---------------------------------------------------------------------------
 # Match mode: id / username / email
 # ---------------------------------------------------------------------------

--- a/nanobot/channels/mattermost/tests/test_mattermost_channel.py
+++ b/nanobot/channels/mattermost/tests/test_mattermost_channel.py
@@ -12,6 +12,7 @@ import pytest
 
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
+from nanobot.channels.mattermost.manifest import SETUP_SPEC
 from nanobot.channels.mattermost.runtime import (
     MATTERMOST_MAX_MESSAGE_LEN,
     MattermostChannel,
@@ -123,6 +124,25 @@ def test_config_defaults():
     assert config.dm.enabled is True
     assert config.dm.policy == "open"
     assert config.reply_in_thread is True
+    assert config.group_policy_in_thread == "mention"
+
+
+def test_thread_policy_inherits_group_policy_when_omitted():
+    config = MattermostConfig.model_validate({"groupPolicy": "open"})
+    assert config.group_policy_in_thread == "open"
+
+    explicit = MattermostConfig.model_validate({
+        "groupPolicy": "open",
+        "groupPolicyInThread": "mention",
+    })
+    assert explicit.group_policy_in_thread == "mention"
+
+
+def test_setup_contract_exposes_thread_policy():
+    field = SETUP_SPEC.fields["groupPolicyInThread"]
+    assert field.kind == "enum"
+    assert field.choices == {"open", "mention", "allowlist"}
+    assert field.default == "mention"
 
 
 def test_config_camelcase_aliases():
@@ -376,15 +396,16 @@ async def test_group_policy_allowlist():
 
 
 @pytest.mark.asyncio
-async def test_group_policy_in_thread_default_open():
-    """Thread uses open policy by default, so no mention needed in threads."""
+async def test_group_policy_in_thread_defaults_to_group_policy():
+    """Existing configs keep their main-channel behavior in threads."""
     channel, fake = _make_channel({"groupPolicy": "mention"})
     channel._self_username = "nanobot"
     # In a main channel (not thread), mention is required
     assert channel._should_respond_in_channel("hello", "c1", in_thread=False) is False
     assert channel._should_respond_in_channel("@nanobot hello", "c1", in_thread=False) is True
-    # In a thread, no mention needed (default open policy)
-    assert channel._should_respond_in_channel("hello", "c1", in_thread=True) is True
+    # In a thread, the omitted override inherits mention policy.
+    assert channel._should_respond_in_channel("hello", "c1", in_thread=True) is False
+    assert channel._should_respond_in_channel("@nanobot hello", "c1", in_thread=True) is True
 
 
 @pytest.mark.asyncio
@@ -408,6 +429,38 @@ async def test_group_policy_in_thread_open():
         "groupPolicyInThread": "open",
     })
     assert channel._should_respond_in_channel("hello", "c1", in_thread=True) is True
+
+
+@pytest.mark.asyncio
+async def test_posted_thread_event_uses_thread_policy():
+    """A real posted event derives thread policy from its root_id."""
+    channel, fake = _make_channel({
+        "groupPolicy": "mention",
+        "groupPolicyInThread": "open",
+        "includeThreadContext": False,
+    })
+    channel._self_id = "bot_id"
+    channel._self_username = "nanobot"
+    with patch.object(channel, "_handle_message", AsyncMock()) as mock_handle:
+        ws_msg = {
+            "event": "posted",
+            "data": {
+                "channel_type": "O",
+                "post": json.dumps({
+                    "id": "reply_1",
+                    "user_id": "user_1",
+                    "channel_id": "channel_1",
+                    "message": "follow up without a mention",
+                    "root_id": "root_1",
+                }),
+            },
+            "broadcast": {},
+        }
+
+        await channel._handle_ws_message(ws_msg)
+
+    mock_handle.assert_awaited_once()
+    assert mock_handle.call_args.kwargs["session_key"] == "mattermost:channel_1:root_1"
 
 
 @pytest.mark.asyncio

--- a/nanobot/channels/mattermost/webui/index.ts
+++ b/nanobot/channels/mattermost/webui/index.ts
@@ -15,6 +15,7 @@ export default {
         { key: "channels.mattermost.token" },
         { key: "channels.mattermost.teamId" },
         { key: "channels.mattermost.groupPolicy" },
+        { key: "channels.mattermost.groupPolicyInThread" },
       ],
     },
   },

--- a/nanobot/channels/mattermost/webui/locales/en.json
+++ b/nanobot/channels/mattermost/webui/locales/en.json
@@ -27,10 +27,18 @@
         "placeholder": "Optional team ID"
       },
       "groupPolicy": {
-        "label": "Group behavior",
+        "label": "Channel behavior",
         "choices": {
           "mention": "Mention only",
           "open": "All messages",
+          "allowlist": "Allowlist"
+        }
+      },
+      "groupPolicyInThread": {
+        "label": "Thread behavior",
+        "choices": {
+          "mention": "Mention only",
+          "open": "All messages (no mention needed)",
           "allowlist": "Allowlist"
         }
       },

--- a/nanobot/channels/mattermost/webui/locales/es.json
+++ b/nanobot/channels/mattermost/webui/locales/es.json
@@ -27,10 +27,18 @@
         "placeholder": "ID de equipo opcional"
       },
       "groupPolicy": {
-        "label": "Comportamiento en grupos",
+        "label": "Comportamiento en canales",
         "choices": {
           "mention": "Solo menciones",
           "open": "Todos los mensajes",
+          "allowlist": "Lista permitida"
+        }
+      },
+      "groupPolicyInThread": {
+        "label": "Comportamiento en hilos",
+        "choices": {
+          "mention": "Solo menciones",
+          "open": "Todos los mensajes (sin mención)",
           "allowlist": "Lista permitida"
         }
       },

--- a/nanobot/channels/mattermost/webui/locales/fr.json
+++ b/nanobot/channels/mattermost/webui/locales/fr.json
@@ -27,11 +27,19 @@
         "placeholder": "ID d’équipe facultatif"
       },
       "groupPolicy": {
-        "label": "Comportement en groupe",
+        "label": "Comportement en canal",
         "choices": {
           "mention": "Mentions uniquement",
           "open": "Tous les messages",
-          "allowlist": "Liste d’autorisation"
+          "allowlist": "Liste d'autorisation"
+        }
+      },
+      "groupPolicyInThread": {
+        "label": "Comportement en fil",
+        "choices": {
+          "mention": "Mentions uniquement",
+          "open": "Tous les messages (sans mention)",
+          "allowlist": "Liste d'autorisation"
         }
       },
       "allowFrom": {

--- a/nanobot/channels/mattermost/webui/locales/id.json
+++ b/nanobot/channels/mattermost/webui/locales/id.json
@@ -27,10 +27,18 @@
         "placeholder": "ID tim opsional"
       },
       "groupPolicy": {
-        "label": "Perilaku grup",
+        "label": "Perilaku kanal",
         "choices": {
           "mention": "Hanya sebutan",
           "open": "Semua pesan",
+          "allowlist": "Daftar izin"
+        }
+      },
+      "groupPolicyInThread": {
+        "label": "Perilaku thread",
+        "choices": {
+          "mention": "Hanya sebutan",
+          "open": "Semua pesan (tanpa sebutan)",
           "allowlist": "Daftar izin"
         }
       },

--- a/nanobot/channels/mattermost/webui/locales/ja.json
+++ b/nanobot/channels/mattermost/webui/locales/ja.json
@@ -27,10 +27,18 @@
         "placeholder": "任意のチーム ID"
       },
       "groupPolicy": {
-        "label": "グループでの動作",
+        "label": "チャンネルでの動作",
         "choices": {
           "mention": "メンションのみ",
           "open": "すべてのメッセージ",
+          "allowlist": "許可リスト"
+        }
+      },
+      "groupPolicyInThread": {
+        "label": "スレッドでの動作",
+        "choices": {
+          "mention": "メンションのみ",
+          "open": "すべてのメッセージ (メンション不要)",
           "allowlist": "許可リスト"
         }
       },

--- a/nanobot/channels/mattermost/webui/locales/ko.json
+++ b/nanobot/channels/mattermost/webui/locales/ko.json
@@ -27,10 +27,18 @@
         "placeholder": "선택적 팀 ID"
       },
       "groupPolicy": {
-        "label": "그룹 동작",
+        "label": "채널 동작",
         "choices": {
           "mention": "멘션만",
           "open": "모든 메시지",
+          "allowlist": "허용 목록"
+        }
+      },
+      "groupPolicyInThread": {
+        "label": "스레드 동작",
+        "choices": {
+          "mention": "멘션만",
+          "open": "모든 메시지 (언급 불필요)",
           "allowlist": "허용 목록"
         }
       },

--- a/nanobot/channels/mattermost/webui/locales/pt-BR.json
+++ b/nanobot/channels/mattermost/webui/locales/pt-BR.json
@@ -27,10 +27,18 @@
         "placeholder": "ID de equipe opcional"
       },
       "groupPolicy": {
-        "label": "Comportamento em grupos",
+        "label": "Comportamento em canais",
         "choices": {
           "mention": "Somente menções",
           "open": "Todas as mensagens",
+          "allowlist": "Lista de permissão"
+        }
+      },
+      "groupPolicyInThread": {
+        "label": "Comportamento em threads",
+        "choices": {
+          "mention": "Somente menções",
+          "open": "Todas as mensagens (sem menção)",
           "allowlist": "Lista de permissão"
         }
       },

--- a/nanobot/channels/mattermost/webui/locales/vi.json
+++ b/nanobot/channels/mattermost/webui/locales/vi.json
@@ -27,10 +27,18 @@
         "placeholder": "ID nhóm tùy chọn"
       },
       "groupPolicy": {
-        "label": "Hành vi trong nhóm",
+        "label": "Hành vi trong kênh",
         "choices": {
           "mention": "Chỉ khi được nhắc",
           "open": "Mọi tin nhắn",
+          "allowlist": "Danh sách cho phép"
+        }
+      },
+      "groupPolicyInThread": {
+        "label": "Hành vi trong thread",
+        "choices": {
+          "mention": "Chỉ khi được nhắc",
+          "open": "Mọi tin nhắn (không cần nhắc)",
           "allowlist": "Danh sách cho phép"
         }
       },

--- a/nanobot/channels/mattermost/webui/locales/zh-CN.json
+++ b/nanobot/channels/mattermost/webui/locales/zh-CN.json
@@ -27,10 +27,18 @@
         "placeholder": "可选的团队 ID"
       },
       "groupPolicy": {
-        "label": "群组行为",
+        "label": "频道行为",
         "choices": {
           "mention": "仅提及时",
           "open": "所有消息",
+          "allowlist": "白名单"
+        }
+      },
+      "groupPolicyInThread": {
+        "label": "线程行为",
+        "choices": {
+          "mention": "仅提及时",
+          "open": "所有消息（无需提及）",
           "allowlist": "白名单"
         }
       },

--- a/nanobot/channels/mattermost/webui/locales/zh-TW.json
+++ b/nanobot/channels/mattermost/webui/locales/zh-TW.json
@@ -27,10 +27,18 @@
         "placeholder": "可選的團隊 ID"
       },
       "groupPolicy": {
-        "label": "群組行為",
+        "label": "頻道行為",
         "choices": {
           "mention": "僅提及時",
           "open": "所有訊息",
+          "allowlist": "允許清單"
+        }
+      },
+      "groupPolicyInThread": {
+        "label": "線程行為",
+        "choices": {
+          "mention": "僅提及時",
+          "open": "所有訊息（無需提及）",
           "allowlist": "允許清單"
         }
       },


### PR DESCRIPTION
This PR is a follow-up to [#4459](https://github.com/HKUDS/nanobot/pull/4459), which added Mattermost channel support. It adds the `groupPolicyInThread` config field so users can set different mention requirements for threads and main channels, and exposes it in the WebUI.

### Changes

- **`nanobot/channels/mattermost/runtime.py`** — adds `groupPolicyInThread` and selects the thread policy from a posted event's `root_id`
- **Backward-compatible default** — when `groupPolicyInThread` is omitted, it inherits `groupPolicy`; users can explicitly choose `open`, `mention`, or `allowlist`
- **`nanobot/channels/mattermost/manifest.py`** — exposes the field through the backend setup contract so the WebUI can render and save it
- **`nanobot/channels/mattermost/tests/test_mattermost_channel.py`** — covers inheritance, all three policies, the setup contract, and real posted-event routing
- **`nanobot/channels/mattermost/webui/*`** — adds the visible setup field and localized copy for all supported locales
- **`docs/guides/mattermost-ai-agent.md`** — documents the new setting, compatibility behavior, and the outer channel allowlist boundary

### Why this matters

Thread replies are contextually anchored, so requiring another @mention can be unnecessary friction. Users can keep strict main-channel behavior while explicitly allowing relaxed thread follow-ups.

Existing configurations retain their previous behavior: an omitted thread policy inherits the configured main-channel policy. When `groupPolicy` is `allowlist`, `groupAllowFrom` remains the outer channel boundary for root posts and thread replies.

### Verification

- 201 focused Python channel/setup/plugin tests passed
- 8 focused WebUI channel contract and locale tests passed
- Ruff passed
- strict BasedPyright passed
- WebUI lint and production build passed
- GitHub Actions passed 6/6 on the current head
