### PR TITLE
fix(webui): align timestamp tooltip styles

### DIFF
--- a/webui/src/components/MessageBubble.tsx
+++ b/webui/src/components/MessageBubble.tsx
@@ -4,6 +4,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type ComponentPropsWithoutRef,
   type ReactNode,
 } from "react";
 import {
@@ -77,6 +78,42 @@ function ForkArrowIcon({ className }: { className?: string }) {
       <path d="m21 3-7.536 7.536A5 5 0 0 0 12 14.07V21" />
       <path d="m3 3 7.536 7.536A5 5 0 0 1 12 14.07V15" />
     </svg>
+  );
+}
+
+type MessageTimestampProps = Omit<
+  ComponentPropsWithoutRef<"time">,
+  "dateTime" | "title"
+> & {
+  timestamp: number;
+  tooltipLabel: string;
+};
+
+function MessageTimestamp({
+  timestamp,
+  tooltipLabel,
+  className,
+  children,
+  ...props
+}: MessageTimestampProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <time
+          {...props}
+          dateTime={new Date(timestamp).toISOString()}
+          tabIndex={0}
+          className={cn(
+            "cursor-help text-[11px] leading-none text-muted-foreground/70 tabular-nums",
+            "focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            className,
+          )}
+        >
+          {children}
+        </time>
+      </TooltipTrigger>
+      <TooltipContent side="top" align="center">{tooltipLabel}</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -307,14 +344,13 @@ export function MessageBubble({
           <TooltipProvider delayDuration={220} skipDelayDuration={80}>
             <div className="flex min-h-8 items-center justify-end gap-1.5 text-muted-foreground">
               {showCreatedAt ? (
-                <time
+                <MessageTimestamp
                   data-message-created-at
-                  dateTime={new Date(message.createdAt).toISOString()}
-                  className="text-[11px] leading-none text-muted-foreground/70 tabular-nums"
-                  title={createdAtTitle}
+                  timestamp={message.createdAt}
+                  tooltipLabel={createdAtTitle}
                 >
                   {createdAtLabel}
-                </time>
+                </MessageTimestamp>
               ) : null}
               <UserDeliveryStatus
                 status={message.deliveryStatus}
@@ -436,15 +472,14 @@ export function MessageBubble({
               </Tooltip>
             ) : null}
             {showAssistantTimestamp ? (
-              <time
+              <MessageTimestamp
                 {...(showCompletedAt ? { "data-assistant-completed-at": true } : {})}
                 data-message-timestamp
-                dateTime={new Date(assistantTimestamp).toISOString()}
-                className="text-[11px] leading-none text-muted-foreground/70 tabular-nums"
-                title={assistantTimestampTitle}
+                timestamp={assistantTimestamp}
+                tooltipLabel={assistantTimestampTitle}
               >
                 {assistantTimestampLabel}
-              </time>
+              </MessageTimestamp>
             ) : null}
             {showAutomationTrigger ? (
               <AutomationTriggerMeta

--- a/webui/src/tests/message-bubble.test.tsx
+++ b/webui/src/tests/message-bubble.test.tsx
@@ -347,7 +347,7 @@ describe("MessageBubble", () => {
     expect(onForkFromHere).toHaveBeenCalledTimes(1);
   });
 
-  it("shows the assistant completion time in the former latency slot", () => {
+  it("shows the assistant completion time in the former latency slot", async () => {
     const completedAt = Date.UTC(2026, 6, 25, 12, 34, 56);
     const { container } = render(
       <MessageBubble
@@ -366,13 +366,18 @@ describe("MessageBubble", () => {
     const time = container.querySelector("[data-assistant-completed-at]");
     expect(time).toHaveTextContent(formatMessageEndTime(completedAt));
     expect(time).toHaveAttribute("dateTime", new Date(completedAt).toISOString());
-    expect(time).toHaveAttribute("title", fmtDateTime(completedAt));
+    expect(time).not.toHaveAttribute("title");
+    expect(time).toHaveAttribute("tabIndex", "0");
     expect(time).toHaveClass(
+      "cursor-help",
       "text-[11px]",
       "leading-none",
       "text-muted-foreground/70",
       "tabular-nums",
     );
+
+    fireEvent.pointerMove(time!);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(fmtDateTime(completedAt));
   });
 
   it("falls back to the assistant creation time when replay has no completion time", () => {
@@ -391,11 +396,11 @@ describe("MessageBubble", () => {
     const time = container.querySelector("[data-message-timestamp]");
     expect(time).toHaveTextContent(formatMessageEndTime(createdAt));
     expect(time).toHaveAttribute("dateTime", new Date(createdAt).toISOString());
-    expect(time).toHaveAttribute("title", fmtDateTime(createdAt));
+    expect(time).not.toHaveAttribute("title");
     expect(time).not.toHaveAttribute("data-assistant-completed-at");
   });
 
-  it("renders the creation time for user messages", () => {
+  it("renders the creation time for user messages", async () => {
     const createdAt = Date.UTC(2026, 6, 25, 12, 34, 56);
     const { container } = render(
       <MessageBubble
@@ -411,7 +416,11 @@ describe("MessageBubble", () => {
     const time = container.querySelector("[data-message-created-at]");
     expect(time).toHaveTextContent(formatMessageEndTime(createdAt));
     expect(time).toHaveAttribute("dateTime", new Date(createdAt).toISOString());
-    expect(time).toHaveAttribute("title", fmtDateTime(createdAt));
+    expect(time).not.toHaveAttribute("title");
+    expect(time).toHaveAttribute("tabIndex", "0");
+
+    fireEvent.pointerMove(time!);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(fmtDateTime(createdAt));
   });
 
   it("does not infer completion time from the assistant creation timestamp", () => {


### PR DESCRIPTION
## Summary
- replace native browser timestamp titles with the WebUI's shared tooltip styling
- reuse one file-local timestamp component for user and assistant message footers
- keep semantic date-time values while making the full timestamp keyboard-accessible

## Testing
- `bun run test -- src/tests/message-bubble.test.tsx` (34 passed)
- `bun run lint`
- `bun run build`
- isolated gateway + Playwright replay verification for hover, focus, adjacent tooltip style parity, and console health