### PR TITLE
Draft: truthful API service status for externally-managed servers + `nanobot api status`

### DIFF
--- a/nanobot/api/runtime.py
+++ b/nanobot/api/runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import sys
+from urllib.request import urlopen
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -11,6 +12,7 @@ from nanobot.process_runtime import (
     ManagedProcessRuntime,
     ProcessRuntimePaths,
     ProcessStartOptions,
+    ProcessStatus,
 )
 
 
@@ -35,10 +37,53 @@ def api_runtime_paths(config_path: Path) -> ProcessRuntimePaths:
     )
 
 
+def probe_api_health(host: str, port: int, *, timeout: float = 0.5) -> bool:
+    """Return True when an OpenAI-compatible API answers on ``host:port``.
+
+    The API server exposes an unauthenticated ``/health`` endpoint; a 200 here
+    means a ``nanobot serve`` instance is already listening, even when this
+    gateway did not start it (for example, a systemd-managed service).
+    """
+    url = f"http://{host}:{port}/health"
+    try:
+        with urlopen(url, timeout=timeout) as response:
+            return response.status == 200
+    except (OSError, ValueError):
+        return False
+
+
 class ApiRuntime(ManagedProcessRuntime[ApiStartOptions]):
     """Manage a WebUI-controlled OpenAI-compatible API process."""
 
     service_name = "api"
+
+    def effective_status(
+        self,
+        *,
+        host: str,
+        port: int,
+        probe_timeout: float = 0.5,
+    ) -> ProcessStatus:
+        """Return live status, including externally-managed API servers.
+
+        When no process is recorded in this runtime's state file, probe the
+        configured endpoint: an API answering on ``/health`` was started
+        outside this gateway (e.g. systemd) and is reported as running with
+        ``managed=False`` so callers never treat it as their own.
+        """
+        status = self.status()
+        if status.running:
+            return status
+        if probe_api_health(host, port, timeout=probe_timeout):
+            return ProcessStatus(
+                running=True,
+                pid=None,
+                state_path=self.paths.state_path,
+                log_path=self.paths.log_path,
+                port=port,
+                reason="external",
+            )
+        return status
 
     def _build_child_command(self, options: ApiStartOptions) -> list[str]:
         command = [

--- a/nanobot/api/runtime.py
+++ b/nanobot/api/runtime.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import hashlib
 import json
 import sys
-from urllib.request import urlopen
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.request import urlopen
 
 from nanobot.process_runtime import (
     ManagedProcessRuntime,
@@ -75,6 +75,10 @@ class ApiRuntime(ManagedProcessRuntime[ApiStartOptions]):
         configured endpoint: an API answering on ``/health`` was started
         outside this gateway (e.g. systemd) and is reported as running with
         ``managed=False`` so callers never treat it as their own.
+
+        Detection is scoped to the endpoint given here. An API instance
+        started from a different config file is inspected separately, e.g.
+        via ``nanobot api status --config <path>``.
         """
         status = self.status()
         if status.running:

--- a/nanobot/api/runtime.py
+++ b/nanobot/api/runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import sys
 from urllib.request import urlopen
 from dataclasses import dataclass
@@ -38,16 +39,20 @@ def api_runtime_paths(config_path: Path) -> ProcessRuntimePaths:
 
 
 def probe_api_health(host: str, port: int, *, timeout: float = 0.5) -> bool:
-    """Return True when an OpenAI-compatible API answers on ``host:port``.
+    """Return True when a nanobot API answers on ``host:port``.
 
-    The API server exposes an unauthenticated ``/health`` endpoint; a 200 here
-    means a ``nanobot serve`` instance is already listening, even when this
-    gateway did not start it (for example, a systemd-managed service).
+    The API server exposes an unauthenticated ``/health`` endpoint that
+    identifies itself with a ``service`` field; a matching response means a
+    ``nanobot serve`` instance is already listening, even when this gateway
+    did not start it (for example, a systemd-managed service).
     """
     url = f"http://{host}:{port}/health"
     try:
         with urlopen(url, timeout=timeout) as response:
-            return response.status == 200
+            if response.status != 200:
+                return False
+            payload = json.loads(response.read().decode("utf-8"))
+            return payload.get("service") == "nanobot"
     except (OSError, ValueError):
         return False
 

--- a/nanobot/api/server.py
+++ b/nanobot/api/server.py
@@ -439,7 +439,7 @@ async def handle_models(request: web.Request) -> web.Response:
 
 async def handle_health(request: web.Request) -> web.Response:
     """GET /health"""
-    return web.json_response({"status": "ok"})
+    return web.json_response({"status": "ok", "service": "nanobot"})
 
 
 # ---------------------------------------------------------------------------

--- a/nanobot/cli/api.py
+++ b/nanobot/cli/api.py
@@ -54,7 +54,7 @@ def create_api_app(
         console.print(f"Logs: {status.log_path}")
 
     @api_app.command("status")
-    def api_status(
+    def api_status(  # pyright: ignore[reportUnusedFunction]
         config: str | None = typer.Option(None, "--config", "-c", help="Path to config file"),
     ) -> None:
         """Show the OpenAI-compatible API server status."""

--- a/nanobot/cli/api.py
+++ b/nanobot/cli/api.py
@@ -38,11 +38,12 @@ def create_api_app(
             config_path = Path(config).expanduser().resolve(strict=False)
         return ApiRuntime(paths=api_runtime_paths(config_path))
 
-    def print_status(status: ProcessStatus, *, endpoint: str) -> None:
+    def print_status(status: ProcessStatus, *, endpoint: str, config_path: Path) -> None:
         console.print(f"Running: {'yes' if status.running else 'no'}")
         console.print(f"Managed: {'yes' if status.managed else 'no'}")
         console.print(f"Reason: {status.reason}")
         console.print(f"Endpoint: {endpoint}")
+        console.print(f"Config: {config_path}")
         if status.pid is not None:
             console.print(f"PID: {status.pid}")
         if status.port is not None:
@@ -61,10 +62,11 @@ def create_api_app(
         api_cfg = loaded.api
         connect_host = "127.0.0.1" if api_cfg.host in {"0.0.0.0", "::"} else api_cfg.host
         endpoint = f"http://{connect_host}:{api_cfg.port}/v1"
+        display_config = Path(config).expanduser().resolve(strict=False) if config else get_config_path()
         status = runtime_for_instance(config=config).effective_status(
             host=connect_host,
             port=api_cfg.port,
         )
-        print_status(status, endpoint=endpoint)
+        print_status(status, endpoint=endpoint, config_path=display_config)
 
     return api_app

--- a/nanobot/cli/api.py
+++ b/nanobot/cli/api.py
@@ -1,0 +1,70 @@
+"""Typer commands for reporting the OpenAI-compatible API server status."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import typer
+from rich.console import Console
+
+from nanobot.api.runtime import ApiRuntime, api_runtime_paths
+from nanobot.config.loader import get_config_path
+from nanobot.config.schema import Config
+from nanobot.process_runtime import ProcessStatus
+
+RuntimeConfigLoader = Callable[[str | None, str | None], Config]
+ApiRuntimeFactory = Callable[..., Any]
+
+
+def create_api_app(
+    *,
+    console: Console,
+    load_runtime_config: RuntimeConfigLoader,
+    runtime_factory: ApiRuntimeFactory | None = None,
+) -> typer.Typer:
+    api_app = typer.Typer(
+        help="Report the OpenAI-compatible API server status.",
+        invoke_without_command=True,
+        no_args_is_help=False,
+    )
+
+    def runtime_for_instance(*, config: str | None = None) -> ApiRuntime:
+        if runtime_factory is not None:
+            return runtime_factory(config=config)
+        config_path = get_config_path()
+        if config:
+            config_path = Path(config).expanduser().resolve(strict=False)
+        return ApiRuntime(paths=api_runtime_paths(config_path))
+
+    def print_status(status: ProcessStatus, *, endpoint: str) -> None:
+        console.print(f"Running: {'yes' if status.running else 'no'}")
+        console.print(f"Managed: {'yes' if status.managed else 'no'}")
+        console.print(f"Reason: {status.reason}")
+        console.print(f"Endpoint: {endpoint}")
+        if status.pid is not None:
+            console.print(f"PID: {status.pid}")
+        if status.port is not None:
+            console.print(f"Port: {status.port}")
+        if status.started_at is not None:
+            console.print(f"Started At: {status.started_at}")
+        console.print(f"State: {status.state_path}")
+        console.print(f"Logs: {status.log_path}")
+
+    @api_app.command("status")
+    def api_status(
+        config: str | None = typer.Option(None, "--config", "-c", help="Path to config file"),
+    ) -> None:
+        """Show the OpenAI-compatible API server status."""
+        loaded = load_runtime_config(config, None)
+        api_cfg = loaded.api
+        connect_host = "127.0.0.1" if api_cfg.host in {"0.0.0.0", "::"} else api_cfg.host
+        endpoint = f"http://{connect_host}:{api_cfg.port}/v1"
+        status = runtime_for_instance(config=config).effective_status(
+            host=connect_host,
+            port=api_cfg.port,
+        )
+        print_status(status, endpoint=endpoint)
+
+    return api_app

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -51,6 +51,7 @@ from nanobot.agent.hooks import create_file_edit_activity_hook  # noqa: E402
 from nanobot.agent.loop import AgentLoop  # noqa: E402
 from nanobot.cli import terminal as cli_terminal  # noqa: E402
 from nanobot.cli.agent import agent  # noqa: E402
+from nanobot.cli.api import create_api_app  # noqa: E402
 from nanobot.cli.gateway import create_gateway_app  # noqa: E402
 from nanobot.cli.gateway_runtime import _run_gateway  # noqa: E402
 from nanobot.cli.log_control import _set_nanobot_logs  # noqa: E402
@@ -406,6 +407,14 @@ app.command(name="webui")(webui)
 # Gateway / Server
 # ============================================================================
 
+
+app.add_typer(
+    create_api_app(
+        console=console,
+        load_runtime_config=_load_runtime_config,
+    ),
+    name="api",
+)
 
 app.add_typer(
     create_gateway_app(

--- a/nanobot/process_runtime.py
+++ b/nanobot/process_runtime.py
@@ -42,6 +42,10 @@ class ProcessStatus:
     port: int | None = None
     command: tuple[str, ...] = ()
     reason: str = "not_started"
+    #: True when this runtime owns the running process. A server answering on
+    #: the configured port but started elsewhere (e.g. systemd) is running but
+    #: not managed by this runtime.
+    managed: bool = False
 
 
 @dataclass(frozen=True)
@@ -220,6 +224,7 @@ class ManagedProcessRuntime(Generic[_StartOptionsT]):
             port=_as_int(state.get("port")),
             command=tuple(cast(list[str], command)) if isinstance(command, list) else (),
             reason=reason or "running",
+            managed=True,
         )
 
     def read_log_tail(self, *, tail: int = 200) -> list[str]:

--- a/nanobot/webui/settings_routes.py
+++ b/nanobot/webui/settings_routes.py
@@ -634,6 +634,7 @@ class WebUISettingsRouter:
             "api_key_hint": self._masked_secret(config.api.api_key),
             "endpoint": f"http://{connect_host}:{config.api.port}/v1",
             "command": "nanobot serve",
+            "config_path": str(get_config_path().expanduser().resolve(strict=False)),
             "log_path": str(status.log_path),
         }
         if last_action:

--- a/nanobot/webui/settings_routes.py
+++ b/nanobot/webui/settings_routes.py
@@ -39,6 +39,7 @@ from nanobot.optional_features import (
     with_channel_runtime_status,
 )
 from nanobot.pairing import approve_code, deny_code, list_pending
+from nanobot.process_runtime import ProcessStatus
 from nanobot.webui.cli_apps_api import cli_apps_action, cli_apps_payload
 from nanobot.webui.http_utils import case_insensitive_header
 from nanobot.webui.http_utils import is_local_browser_request as _is_local_browser_request
@@ -175,7 +176,7 @@ class WebUISettingsRouter:
         if path == "/api/settings/web-search/update":
             return self._handle_settings_web_search_update(request)
         if path == "/api/settings/api-service":
-            return self._handle_settings_api_service(request)
+            return await self._handle_settings_api_service(request)
         if path == "/api/settings/api-service/start":
             return await self._handle_settings_api_service_start(connection, request)
         if path == "/api/settings/api-service/stop":
@@ -506,10 +507,12 @@ class WebUISettingsRouter:
             return self._error_response(e.status, e.message)
         return self._json_response(self._with_restart_state(payload, section="browser"))
 
-    def _handle_settings_api_service(self, request: WsRequest) -> Response:
+    async def _handle_settings_api_service(self, request: WsRequest) -> Response:
         if not self._authorized(request):
             return self._unauthorized()
-        return self._json_response(self._api_service_payload())
+        config = load_config()
+        status = await asyncio.to_thread(self._api_service_status, config)
+        return self._json_response(self._api_service_payload(status=status))
 
     async def _handle_settings_api_service_start(
         self,
@@ -519,6 +522,10 @@ class WebUISettingsRouter:
         if not self._authorized(request):
             return self._unauthorized()
         try:
+            config = load_config()
+            status = await asyncio.to_thread(self._api_service_status, config)
+            if status.running and not status.managed:
+                return self._error_response(409, self._api_runtime_message("api_running_external"))
             await asyncio.to_thread(
                 nanobot_features_action,
                 "enable",
@@ -581,6 +588,10 @@ class WebUISettingsRouter:
         if not self._authorized(request):
             return self._unauthorized()
         try:
+            config = load_config()
+            status = await asyncio.to_thread(self._api_service_status, config)
+            if status.running and not status.managed:
+                return self._error_response(409, self._api_runtime_message("api_running_external"))
             result = await asyncio.to_thread(self._api_runtime().stop)
         except Exception as e:
             self.logger.exception("failed to stop managed API service")
@@ -594,15 +605,29 @@ class WebUISettingsRouter:
         config_path = get_config_path().expanduser().resolve(strict=False)
         return ApiRuntime(paths=api_runtime_paths(config_path))
 
-    def _api_service_payload(self, *, last_action: str | None = None) -> dict[str, Any]:
+    @staticmethod
+    def _api_service_status(config: Any) -> ProcessStatus:
+        """Live API status, including servers managed outside this gateway."""
+        runtime = ApiRuntime(
+            paths=api_runtime_paths(get_config_path().expanduser().resolve(strict=False))
+        )
+        connect_host = "127.0.0.1" if config.api.host in {"0.0.0.0", "::"} else config.api.host
+        return runtime.effective_status(host=connect_host, port=config.api.port)
+
+    def _api_service_payload(
+        self,
+        *,
+        status: ProcessStatus | None = None,
+        last_action: str | None = None,
+    ) -> dict[str, Any]:
         config = load_config()
-        status = self._api_runtime().status()
+        status = status if status is not None else self._api_service_status(config)
         extras = optional_dependency_groups()
         connect_host = "127.0.0.1" if config.api.host in {"0.0.0.0", "::"} else config.api.host
         payload = {
             "installed": extra_installed("api", extras.get("api")),
             "running": status.running,
-            "managed": status.running,
+            "managed": status.managed,
             "host": config.api.host,
             "port": config.api.port,
             "timeout": config.api.timeout,
@@ -628,6 +653,10 @@ class WebUISettingsRouter:
             "api_exited_during_startup": "API server exited during startup. Check its log for details.",
             "api_stop_timeout": "API server did not stop in time.",
             "api_state_stale": "API server state was stale; try starting it again.",
+            "api_running_external": (
+                "API server is already running outside this app (e.g. systemd). "
+                "Stop it there first, then manage it here."
+            ),
         }
         if message in known:
             return known[message]

--- a/tests/cli/test_api_commands.py
+++ b/tests/cli/test_api_commands.py
@@ -50,14 +50,16 @@ def _status(tmp_path: Path, *, running: bool, managed: bool, reason: str) -> Pro
 
 def test_api_status_reports_externally_managed(tmp_path) -> None:
     app = _test_app(tmp_path, _status(tmp_path, running=True, managed=False, reason="external"))
+    config_path = str((tmp_path / "config.json").resolve())
 
-    result = runner.invoke(app, ["api", "status"])
+    result = runner.invoke(app, ["api", "status", "--config", config_path])
 
     assert result.exit_code == 0
     assert "Running: yes" in result.output
     assert "Managed: no" in result.output
     assert "Reason: external" in result.output
     assert "Endpoint: http://127.0.0.1:8900/v1" in result.output
+    assert f"Config: {config_path}" in result.output
     assert "Port: 8900" in result.output
 
 

--- a/tests/cli/test_api_commands.py
+++ b/tests/cli/test_api_commands.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from typer.testing import CliRunner
+
+from nanobot.cli.api import create_api_app
+from nanobot.config.schema import Config
+from nanobot.process_runtime import ProcessStatus
+
+runner = CliRunner()
+
+
+class FakeRuntime:
+    def __init__(self, status: ProcessStatus) -> None:
+        self.status_value = status
+
+    def effective_status(self, *, host: str, port: int, **_kwargs) -> ProcessStatus:
+        return self.status_value
+
+
+def _test_app(tmp_path: Path, status: ProcessStatus) -> typer.Typer:
+    app = typer.Typer()
+
+    def load_runtime_config(_config_path, _workspace) -> Config:
+        return Config()
+
+    app.add_typer(
+        create_api_app(
+            console=Console(),
+            load_runtime_config=load_runtime_config,
+            runtime_factory=lambda **_kwargs: FakeRuntime(status),
+        ),
+        name="api",
+    )
+    return app
+
+
+def _status(tmp_path: Path, *, running: bool, managed: bool, reason: str) -> ProcessStatus:
+    return ProcessStatus(
+        running=running,
+        pid=1234 if running and managed else None,
+        state_path=tmp_path / "api.json",
+        log_path=tmp_path / "api.log",
+        port=8900 if running else None,
+        reason=reason,
+        managed=managed,
+    )
+
+
+def test_api_status_reports_externally_managed(tmp_path) -> None:
+    app = _test_app(tmp_path, _status(tmp_path, running=True, managed=False, reason="external"))
+
+    result = runner.invoke(app, ["api", "status"])
+
+    assert result.exit_code == 0
+    assert "Running: yes" in result.output
+    assert "Managed: no" in result.output
+    assert "Reason: external" in result.output
+    assert "Endpoint: http://127.0.0.1:8900/v1" in result.output
+    assert "Port: 8900" in result.output
+
+
+def test_api_status_reports_managed_running(tmp_path) -> None:
+    app = _test_app(tmp_path, _status(tmp_path, running=True, managed=True, reason="running"))
+
+    result = runner.invoke(app, ["api", "status"])
+
+    assert result.exit_code == 0
+    assert "Running: yes" in result.output
+    assert "Managed: yes" in result.output
+    assert "PID: 1234" in result.output
+
+
+def test_api_status_reports_off(tmp_path) -> None:
+    app = _test_app(tmp_path, _status(tmp_path, running=False, managed=False, reason="not_started"))
+
+    result = runner.invoke(app, ["api", "status"])
+
+    assert result.exit_code == 0
+    assert "Running: no" in result.output
+    assert "Managed: no" in result.output
+    assert "Reason: not_started" in result.output

--- a/tests/cli/test_api_commands.py
+++ b/tests/cli/test_api_commands.py
@@ -27,7 +27,7 @@ def _test_app(tmp_path: Path, status: ProcessStatus) -> typer.Typer:
 
     app.add_typer(
         create_api_app(
-            console=Console(),
+            console=Console(width=200),
             load_runtime_config=load_runtime_config,
             runtime_factory=lambda **_kwargs: FakeRuntime(status),
         ),

--- a/tests/gateway/test_api_runtime.py
+++ b/tests/gateway/test_api_runtime.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from nanobot.api.runtime import ApiRuntime, ApiStartOptions, api_runtime_paths
+from nanobot.api.runtime import ApiRuntime, ApiStartOptions, api_runtime_paths, probe_api_health
 
 
 class FakeProcess:
@@ -55,3 +55,106 @@ def test_api_runtime_builds_detached_serve_command(tmp_path: Path, monkeypatch) 
         "--config",
         "/tmp/config.json",
     ]]
+    assert result.ok is True
+    assert result.message == "api_started_background"
+    assert calls == [[
+        "/python",
+        "-m",
+        "nanobot",
+        "serve",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "9900",
+        "--workspace",
+        "/tmp/workspace",
+        "--config",
+        "/tmp/config.json",
+    ]]
+
+
+class FakeHealthResponse:
+    def __init__(self, status: int) -> None:
+        self.status = status
+
+    def __enter__(self) -> "FakeHealthResponse":
+        return self
+
+    def __exit__(self, *_args) -> None:
+        return None
+
+
+def test_probe_api_health_success(monkeypatch) -> None:
+    def fake_urlopen(url, **kwargs):
+        assert url == "http://127.0.0.1:9900/health"
+        assert kwargs["timeout"] == 0.25
+        return FakeHealthResponse(200)
+
+    monkeypatch.setattr("nanobot.api.runtime.urlopen", fake_urlopen)
+    assert probe_api_health("127.0.0.1", 9900, timeout=0.25) is True
+
+
+def test_probe_api_health_rejects_other_responses(monkeypatch) -> None:
+    def fake_urlopen(_url, **_kwargs):
+        return FakeHealthResponse(404)
+
+    monkeypatch.setattr("nanobot.api.runtime.urlopen", fake_urlopen)
+    assert probe_api_health("127.0.0.1", 9900) is False
+
+
+def test_probe_api_health_swallows_errors(monkeypatch) -> None:
+    def fake_urlopen(_url, **_kwargs):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("nanobot.api.runtime.urlopen", fake_urlopen)
+    assert probe_api_health("127.0.0.1", 9900) is False
+
+
+def test_effective_status_detects_external_server(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("nanobot.api.runtime.probe_api_health", lambda _host, _port, **kwargs: True)
+    runtime = ApiRuntime(paths=api_runtime_paths(tmp_path / "config.json"))
+
+    status = runtime.effective_status(host="127.0.0.1", port=9900)
+
+    assert status.running is True
+    assert status.managed is False
+    assert status.pid is None
+    assert status.port == 9900
+    assert status.reason == "external"
+
+
+def test_effective_status_reports_off_without_server(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("nanobot.api.runtime.probe_api_health", lambda _host, _port, **kwargs: False)
+    runtime = ApiRuntime(paths=api_runtime_paths(tmp_path / "config.json"))
+
+    status = runtime.effective_status(host="127.0.0.1", port=9900)
+
+    assert status.running is False
+    assert status.managed is False
+    assert status.reason == "not_started"
+
+
+def test_effective_status_keeps_managed_running(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "nanobot.api.runtime.probe_api_health",
+        lambda _host, _port, **kwargs: (_ for _ in ()).throw(AssertionError("probe must not run")),
+    )
+    runtime = ApiRuntime(
+        paths=api_runtime_paths(tmp_path / "config.json"),
+        platform_name="Linux",
+        python_executable="/python",
+        popen=lambda *_args, **_kwargs: FakeProcess(),
+        sleep=lambda _seconds: None,
+    )
+    monkeypatch.setattr(runtime, "_is_pid_running", lambda _pid: True)
+    monkeypatch.setattr(runtime, "_process_identity", lambda _pid: 23456)
+
+    started = runtime.start_background(ApiStartOptions(host="127.0.0.1", port=9900))
+    assert started.ok is True
+
+    status = runtime.effective_status(host="127.0.0.1", port=9900)
+
+    assert status.running is True
+    assert status.managed is True
+    assert status.pid == 23456
+    assert status.reason == "running"

--- a/tests/gateway/test_api_runtime.py
+++ b/tests/gateway/test_api_runtime.py
@@ -74,8 +74,12 @@ def test_api_runtime_builds_detached_serve_command(tmp_path: Path, monkeypatch) 
 
 
 class FakeHealthResponse:
-    def __init__(self, status: int) -> None:
+    def __init__(self, status: int, body: bytes) -> None:
         self.status = status
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
 
     def __enter__(self) -> "FakeHealthResponse":
         return self
@@ -84,19 +88,38 @@ class FakeHealthResponse:
         return None
 
 
+NANOBOT_HEALTH = b'{"status": "ok", "service": "nanobot"}'
+
+
 def test_probe_api_health_success(monkeypatch) -> None:
     def fake_urlopen(url, **kwargs):
         assert url == "http://127.0.0.1:9900/health"
         assert kwargs["timeout"] == 0.25
-        return FakeHealthResponse(200)
+        return FakeHealthResponse(200, NANOBOT_HEALTH)
 
     monkeypatch.setattr("nanobot.api.runtime.urlopen", fake_urlopen)
     assert probe_api_health("127.0.0.1", 9900, timeout=0.25) is True
 
 
+def test_probe_api_health_rejects_foreign_service(monkeypatch) -> None:
+    def fake_urlopen(_url, **_kwargs):
+        return FakeHealthResponse(200, b'{"status": "ok", "service": "something-else"}')
+
+    monkeypatch.setattr("nanobot.api.runtime.urlopen", fake_urlopen)
+    assert probe_api_health("127.0.0.1", 9900) is False
+
+
 def test_probe_api_health_rejects_other_responses(monkeypatch) -> None:
     def fake_urlopen(_url, **_kwargs):
-        return FakeHealthResponse(404)
+        return FakeHealthResponse(404, b"not found")
+
+    monkeypatch.setattr("nanobot.api.runtime.urlopen", fake_urlopen)
+    assert probe_api_health("127.0.0.1", 9900) is False
+
+
+def test_probe_api_health_rejects_malformed_body(monkeypatch) -> None:
+    def fake_urlopen(_url, **_kwargs):
+        return FakeHealthResponse(200, b"<html>not json</html>")
 
     monkeypatch.setattr("nanobot.api.runtime.urlopen", fake_urlopen)
     assert probe_api_health("127.0.0.1", 9900) is False

--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -361,6 +361,7 @@ async def test_health_endpoint(aiohttp_client, app) -> None:
     assert resp.status == 200
     body = await resp.json()
     assert body["status"] == "ok"
+    assert body["service"] == "nanobot"
 
 
 @pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")

--- a/tests/webui/test_settings_routes.py
+++ b/tests/webui/test_settings_routes.py
@@ -175,6 +175,9 @@ def _patch_api_service_deps(monkeypatch, status: ProcessStatus) -> None:
         lambda: SimpleNamespace(api=_api_config(), workspace_path=Path("/tmp/workspace")),
     )
     monkeypatch.setattr(
+        "nanobot.webui.settings_routes.get_config_path", lambda: Path("/tmp/config.json")
+    )
+    monkeypatch.setattr(
         "nanobot.webui.settings_routes.ApiRuntime.effective_status",
         lambda _self, **_kwargs: status,
     )
@@ -199,6 +202,7 @@ async def test_api_service_payload_reports_externally_managed(monkeypatch) -> No
     assert body["running"] is True
     assert body["managed"] is False
     assert body["endpoint"] == "http://127.0.0.1:8900/v1"
+    assert body["config_path"] == "/tmp/config.json"
 
 
 @pytest.mark.asyncio

--- a/tests/webui/test_settings_routes.py
+++ b/tests/webui/test_settings_routes.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
 from urllib.parse import parse_qs, urlsplit
 
 import pytest
 from websockets.datastructures import Headers
 
+from nanobot.process_runtime import ProcessStatus
 from nanobot.webui.http_utils import http_json_response
 from nanobot.webui.settings_routes import WebUISettingsRouter
 
@@ -138,3 +140,112 @@ async def test_model_preset_mutation_routes(
     assert response.status_code == 200
     assert json.loads(response.body)["routed"] == function_name
     assert captured["query"] == expected_query
+    monkeypatch.setattr(f"nanobot.webui.settings_routes.{function_name}", mutate)
+    request = SimpleNamespace(path=request_path, headers=Headers())
+
+    response = await _router().dispatch(None, request, route_path)
+
+    assert response is not None
+    assert response.status_code == 200
+    assert json.loads(response.body)["routed"] == function_name
+    assert captured["query"] == expected_query
+
+
+def _api_config(**overrides) -> SimpleNamespace:
+    values = {"host": "0.0.0.0", "port": 8900, "timeout": 120.0, "api_key": ""}
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _status(*, running: bool, managed: bool, reason: str) -> ProcessStatus:
+    return ProcessStatus(
+        running=running,
+        pid=1234 if running and managed else None,
+        state_path=Path("/tmp/api-state.json"),
+        log_path=Path("/tmp/api.log"),
+        port=8900 if running else None,
+        reason=reason,
+        managed=managed,
+    )
+
+
+def _patch_api_service_deps(monkeypatch, status: ProcessStatus) -> None:
+    monkeypatch.setattr(
+        "nanobot.webui.settings_routes.load_config",
+        lambda: SimpleNamespace(api=_api_config(), workspace_path=Path("/tmp/workspace")),
+    )
+    monkeypatch.setattr(
+        "nanobot.webui.settings_routes.ApiRuntime.effective_status",
+        lambda _self, **_kwargs: status,
+    )
+    monkeypatch.setattr(
+        "nanobot.webui.settings_routes.optional_dependency_groups", lambda: {"api": ["aiohttp"]}
+    )
+    monkeypatch.setattr(
+        "nanobot.webui.settings_routes.extra_installed", lambda *_args, **_kwargs: True
+    )
+
+
+@pytest.mark.asyncio
+async def test_api_service_payload_reports_externally_managed(monkeypatch) -> None:
+    _patch_api_service_deps(monkeypatch, _status(running=True, managed=False, reason="external"))
+    request = SimpleNamespace(path="/api/settings/api-service", headers=Headers())
+
+    response = await _router().dispatch(None, request, "/api/settings/api-service")
+
+    assert response is not None
+    assert response.status_code == 200
+    body = json.loads(response.body)
+    assert body["running"] is True
+    assert body["managed"] is False
+    assert body["endpoint"] == "http://127.0.0.1:8900/v1"
+
+
+@pytest.mark.asyncio
+async def test_api_service_payload_reports_managed_running(monkeypatch) -> None:
+    _patch_api_service_deps(monkeypatch, _status(running=True, managed=True, reason="running"))
+    request = SimpleNamespace(path="/api/settings/api-service", headers=Headers())
+
+    response = await _router().dispatch(None, request, "/api/settings/api-service")
+
+    assert response is not None
+    body = json.loads(response.body)
+    assert body["running"] is True
+    assert body["managed"] is True
+
+
+@pytest.mark.asyncio
+async def test_api_service_payload_reports_off(monkeypatch) -> None:
+    _patch_api_service_deps(monkeypatch, _status(running=False, managed=False, reason="not_started"))
+    request = SimpleNamespace(path="/api/settings/api-service", headers=Headers())
+
+    response = await _router().dispatch(None, request, "/api/settings/api-service")
+
+    assert response is not None
+    body = json.loads(response.body)
+    assert body["running"] is False
+    assert body["managed"] is False
+
+
+@pytest.mark.asyncio
+async def test_api_service_start_refuses_external(monkeypatch) -> None:
+    _patch_api_service_deps(monkeypatch, _status(running=True, managed=False, reason="external"))
+    request = SimpleNamespace(path="/api/settings/api-service/start", headers=Headers())
+
+    response = await _router().dispatch(None, request, "/api/settings/api-service/start")
+
+    assert response is not None
+    assert response.status_code == 409
+    assert "outside this app" in json.loads(response.body)["error"]
+
+
+@pytest.mark.asyncio
+async def test_api_service_stop_refuses_external(monkeypatch) -> None:
+    _patch_api_service_deps(monkeypatch, _status(running=True, managed=False, reason="external"))
+    request = SimpleNamespace(path="/api/settings/api-service/stop", headers=Headers())
+
+    response = await _router().dispatch(None, request, "/api/settings/api-service/stop")
+
+    assert response is not None
+    assert response.status_code == 409
+    assert "outside this app" in json.loads(response.body)["error"]

--- a/tests/webui/test_settings_routes.py
+++ b/tests/webui/test_settings_routes.py
@@ -169,13 +169,13 @@ def _status(*, running: bool, managed: bool, reason: str) -> ProcessStatus:
     )
 
 
-def _patch_api_service_deps(monkeypatch, status: ProcessStatus) -> None:
+def _patch_api_service_deps(monkeypatch, status: ProcessStatus, *, config_path: Path) -> None:
     monkeypatch.setattr(
         "nanobot.webui.settings_routes.load_config",
         lambda: SimpleNamespace(api=_api_config(), workspace_path=Path("/tmp/workspace")),
     )
     monkeypatch.setattr(
-        "nanobot.webui.settings_routes.get_config_path", lambda: Path("/tmp/config.json")
+        "nanobot.webui.settings_routes.get_config_path", lambda: config_path
     )
     monkeypatch.setattr(
         "nanobot.webui.settings_routes.ApiRuntime.effective_status",
@@ -190,8 +190,11 @@ def _patch_api_service_deps(monkeypatch, status: ProcessStatus) -> None:
 
 
 @pytest.mark.asyncio
-async def test_api_service_payload_reports_externally_managed(monkeypatch) -> None:
-    _patch_api_service_deps(monkeypatch, _status(running=True, managed=False, reason="external"))
+async def test_api_service_payload_reports_externally_managed(monkeypatch, tmp_path) -> None:
+    config_path = tmp_path / "config.json"
+    _patch_api_service_deps(
+        monkeypatch, _status(running=True, managed=False, reason="external"), config_path=config_path
+    )
     request = SimpleNamespace(path="/api/settings/api-service", headers=Headers())
 
     response = await _router().dispatch(None, request, "/api/settings/api-service")
@@ -202,12 +205,16 @@ async def test_api_service_payload_reports_externally_managed(monkeypatch) -> No
     assert body["running"] is True
     assert body["managed"] is False
     assert body["endpoint"] == "http://127.0.0.1:8900/v1"
-    assert body["config_path"] == "/tmp/config.json"
+    assert body["config_path"] == str(config_path)
 
 
 @pytest.mark.asyncio
-async def test_api_service_payload_reports_managed_running(monkeypatch) -> None:
-    _patch_api_service_deps(monkeypatch, _status(running=True, managed=True, reason="running"))
+async def test_api_service_payload_reports_managed_running(monkeypatch, tmp_path) -> None:
+    _patch_api_service_deps(
+        monkeypatch,
+        _status(running=True, managed=True, reason="running"),
+        config_path=tmp_path / "config.json",
+    )
     request = SimpleNamespace(path="/api/settings/api-service", headers=Headers())
 
     response = await _router().dispatch(None, request, "/api/settings/api-service")
@@ -219,8 +226,12 @@ async def test_api_service_payload_reports_managed_running(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_api_service_payload_reports_off(monkeypatch) -> None:
-    _patch_api_service_deps(monkeypatch, _status(running=False, managed=False, reason="not_started"))
+async def test_api_service_payload_reports_off(monkeypatch, tmp_path) -> None:
+    _patch_api_service_deps(
+        monkeypatch,
+        _status(running=False, managed=False, reason="not_started"),
+        config_path=tmp_path / "config.json",
+    )
     request = SimpleNamespace(path="/api/settings/api-service", headers=Headers())
 
     response = await _router().dispatch(None, request, "/api/settings/api-service")
@@ -232,8 +243,12 @@ async def test_api_service_payload_reports_off(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_api_service_start_refuses_external(monkeypatch) -> None:
-    _patch_api_service_deps(monkeypatch, _status(running=True, managed=False, reason="external"))
+async def test_api_service_start_refuses_external(monkeypatch, tmp_path) -> None:
+    _patch_api_service_deps(
+        monkeypatch,
+        _status(running=True, managed=False, reason="external"),
+        config_path=tmp_path / "config.json",
+    )
     request = SimpleNamespace(path="/api/settings/api-service/start", headers=Headers())
 
     response = await _router().dispatch(None, request, "/api/settings/api-service/start")
@@ -244,8 +259,12 @@ async def test_api_service_start_refuses_external(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_api_service_stop_refuses_external(monkeypatch) -> None:
-    _patch_api_service_deps(monkeypatch, _status(running=True, managed=False, reason="external"))
+async def test_api_service_stop_refuses_external(monkeypatch, tmp_path) -> None:
+    _patch_api_service_deps(
+        monkeypatch,
+        _status(running=True, managed=False, reason="external"),
+        config_path=tmp_path / "config.json",
+    )
     request = SimpleNamespace(path="/api/settings/api-service/stop", headers=Headers())
 
     response = await _router().dispatch(None, request, "/api/settings/api-service/stop")

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -8416,6 +8416,12 @@ function RuntimeSettings({
               )}
             </div>
           </SettingsRow>
+          {apiDefaults.config_path ? (
+            <ReadOnlyRow
+              title={tx("settings.api.configFile", "Config file")}
+              value={apiDefaults.config_path}
+            />
+          ) : null}
           {!apiDefaults.running ? (
             <>
               <SettingsRow

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -8365,40 +8365,55 @@ function RuntimeSettings({
                     ? tx("settings.values.running", "Running")
                     : tx("settings.values.off", "Off")}
               </StatusPill>
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={apiServiceLoading || apiServiceAction !== null || apiMissingNetworkKey}
-                onClick={() =>
-                  onApiServiceAction(
-                    apiDefaults.running ? "stop" : "start",
-                    apiDefaults.running
-                      ? undefined
-                      : {
-                          host: apiHost,
-                          port: apiPort,
-                          timeout: apiDefaults.timeout,
-                          apiKey: apiKey.trim() || undefined,
-                        },
-                  )
-                }
-                className="rounded-full"
-              >
-                {apiServiceAction ? (
-                  <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" aria-hidden />
-                ) : apiDefaults.running ? (
-                  <PauseCircle className="mr-1.5 h-3.5 w-3.5" aria-hidden />
-                ) : (
-                  <PlayCircle className="mr-1.5 h-3.5 w-3.5" aria-hidden />
-                )}
-                {apiServiceAction === "start"
-                  ? tx("settings.api.starting", "Starting...")
-                  : apiServiceAction === "stop"
-                    ? tx("settings.api.stopping", "Stopping...")
-                    : apiDefaults.running
-                      ? tx("settings.api.stop", "Stop")
-                      : tx("settings.api.start", "Start API server")}
-              </Button>
+              {apiDefaults.running && !apiDefaults.managed ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled
+                  className="rounded-full"
+                  title={tx(
+                    "settings.api.externalManagedHelp",
+                    "The API server is managed outside this app (e.g. systemd).",
+                  )}
+                >
+                  {tx("settings.api.externallyManaged", "Managed externally")}
+                </Button>
+              ) : (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={apiServiceLoading || apiServiceAction !== null || apiMissingNetworkKey}
+                  onClick={() =>
+                    onApiServiceAction(
+                      apiDefaults.running ? "stop" : "start",
+                      apiDefaults.running
+                        ? undefined
+                        : {
+                            host: apiHost,
+                            port: apiPort,
+                            timeout: apiDefaults.timeout,
+                            apiKey: apiKey.trim() || undefined,
+                          },
+                    )
+                  }
+                  className="rounded-full"
+                >
+                  {apiServiceAction ? (
+                    <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" aria-hidden />
+                  ) : apiDefaults.running ? (
+                    <PauseCircle className="mr-1.5 h-3.5 w-3.5" aria-hidden />
+                  ) : (
+                    <PlayCircle className="mr-1.5 h-3.5 w-3.5" aria-hidden />
+                  )}
+                  {apiServiceAction === "start"
+                    ? tx("settings.api.starting", "Starting...")
+                    : apiServiceAction === "stop"
+                      ? tx("settings.api.stopping", "Stopping...")
+                      : apiDefaults.running
+                        ? tx("settings.api.stop", "Stop")
+                        : tx("settings.api.start", "Start API server")}
+                </Button>
+              )}
             </div>
           </SettingsRow>
           {!apiDefaults.running ? (

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -724,6 +724,7 @@ export interface ApiServicePayload {
   api_key_hint?: string | null;
   endpoint: string;
   command: string;
+  config_path?: string | null;
   log_path?: string | null;
   last_action?: "started" | "stopped" | string;
 }


### PR DESCRIPTION
## Summary

This draft proposes two related changes so the WebUI's API server section tells the truth about `nanobot serve` instances that the gateway did not start:

1. The panel currently reports the API as **Off** whenever it was not started by the gateway itself — even when a `nanobot serve` process is actively answering on the configured port (e.g. launched by systemd, docker, tmux, or any external supervisor). It also offers a Start button that would spawn a second server into the occupied port (`EADDRINUSE`).
2. There is no CLI surface that reports the API server's status: `nanobot status` covers config/provider readiness only, and `nanobot gateway status` covers the gateway process. The WebUI panel is the *only* nanobot-native status surface for the API — and it is wrong for externally-managed instances.

The proposal: report the API as running when a nanobot API provably answers on the configured port, mark it as *externally managed* when the gateway did not start it, refuse start/stop for servers the gateway does not own, and add `nanobot api status` as a first-class CLI status command.

## Use cases

- **systemd / docker / supervisor deployments** (our own motivation: a `nanobot-api.service` unit). The API must be always-on and self-healing, independent of the gateway; the panel should reflect reality, not ownership.
- **Mixed management**: anyone who runs `nanobot serve` standalone but also opens the WebUI hits a false "Off" state and a Start button that breaks.
- **Operators who live in a terminal**: `nanobot api status` gives a truthful, scriptable answer to "is the API up?" without opening a browser.

## Why external management exists

We found no first-party autostart mechanism: `ApiConfig` has only host/port/timeout/api_key, the gateway never spawns the API at boot, and nothing restarts it after a reboot. For an always-on API, external supervision is currently the only option — which makes truthful status reporting for that case a correctness fix, not a niche feature.

## Approach

- **Identity-checked health probe** (`nanobot/api/runtime.py`): `/health` now returns `{"status": "ok", "service": "nanobot"}` (a backwards-compatible extra field). `probe_api_health()` only accepts a response that is 200 *and* carries the `service: nanobot` marker, so a foreign service merely answering 200 on the port is not mistaken for the nanobot API.
- **`ProcessStatus.managed`** (`nanobot/process_runtime.py`): a new field distinguishing "this runtime owns the running process" from "a server answers here, started elsewhere". Default `False`; the managed-running path sets it explicitly.
- **`ApiRuntime.effective_status()`**: returns the managed status when the gateway owns the process, otherwise probes the configured endpoint and reports `running=True, managed=False, reason="external"` on a match.
- **Safe start/stop** (`nanobot/webui/settings_routes.py`): the panel's start/stop handlers return 409 when the API is externally managed — the gateway must never spawn into an occupied port or kill a process it does not own.
- **WebUI**: when externally managed, the panel shows Running with a disabled "Managed externally" control instead of Start/Stop, and displays the resolved config file path so a diverging unit (e.g. a custom `--config`) is immediately visible.
- **CLI** (`nanobot/cli/api.py`): `nanobot api status` mirrors `nanobot gateway status` (Running/Managed/Reason/Endpoint/Config/PID/Port/State/Logs) and reuses `effective_status`.

## Scope and limitations

- Detection is scoped to the endpoint described by the config the gateway owns. An API instance started from a *different* config file (e.g. a custom `--config` in a unit) is a separate deployment and is inspected with `nanobot api status --config <path>`; the panel cannot enumerate instances it does not know about.
- The probe is a heuristic by design (HTTP 200 + service marker), but it is safe in every failure mode: worst case the panel reports "running externally" for something that answers `/health` like nanobot, in which case refusing start/stop is still correct because the port is occupied.
- No config schema changes, no new dependencies, no changes to the `nanobot serve` CLI surface.

## Testing

- Probe: success, foreign service, non-200, malformed body, network error.
- Runtime: external detection, off case, managed-running preserved.
- Routes: payload shape (`running` / `managed` / `config_path`), start/stop refusing external instances with 409.
- CLI: `nanobot api status` output for external / managed / off (CliRunner).
- Health endpoint identity field.
- Full touched suites pass (523 tests across gateway, cli, webui, api); `ruff`, `tsc`, and `eslint` are clean.

## Files changed

12 files, +561/-42: probe hardening + runtime, `ProcessStatus` field, settings routes, new CLI module + registration, WebUI type/component, and tests.

## Why draft

The change is deliberately small and non-invasive. Opening as a draft to discuss the shape before it grows: whether a stronger identity in the health payload is preferred over the `service` marker, whether `managed` belongs on the shared `ProcessStatus`, and whether `nanobot api status` is the right CLI surface.
