### PR TITLE
fix(memory): ignore runtime files inside tracked workspace dirs

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -22,7 +22,7 @@ from loguru import logger
 
 from nanobot.runtime_context import public_history_messages
 from nanobot.session.manager import Session, SessionManager
-from nanobot.utils.gitstore import GitStore
+from nanobot.utils.gitstore import GitStore, GitStoreError
 from nanobot.utils.helpers import (
     content_with_media_breadcrumbs,
     ensure_dir,
@@ -109,6 +109,10 @@ class MemoryStore:
         self._git = GitStore(workspace, tracked_files=[
             "SOUL.md", "USER.md", "memory/MEMORY.md", "memory/.dream_cursor",
         ])
+        try:
+            self._git.ensure_gitignore()
+        except GitStoreError:
+            logger.warning("Failed to backfill workspace .gitignore at {}", workspace)
         self._maybe_migrate_legacy_history()
 
     @property

--- a/nanobot/utils/gitstore.py
+++ b/nanobot/utils/gitstore.py
@@ -241,9 +241,60 @@ class GitStore:
         for d in sorted(dirs):
             lines.append(f"!{d}/")
         for f in self._tracked_files:
-            lines.append(f"!{f}")
+            if str(Path(f).parent) == ".":
+                lines.append(f"!{f}")
         lines.append("!.gitignore")
+        lines.extend(self._missing_dir_blocks(set()))
         return "\n".join(lines) + "\n"
+
+    def _missing_dir_blocks(self, existing_lines: set[str]) -> list[str]:
+        """Ignore rules for tracked directories not covered by *existing_lines*.
+
+        Everything inside a tracked directory is ignored unless explicitly
+        tracked, so runtime artifacts created after init (``memory/history.jsonl``,
+        ``memory/.cursor``, ...) never surface as untracked files (#5246).
+        """
+        dirs: set[str] = set()
+        for f in self._tracked_files:
+            parent = str(Path(f).parent)
+            if parent != ".":
+                dirs.add(parent)
+        additions: list[str] = []
+        for d in sorted(dirs):
+            if f"{d}/*" in existing_lines:
+                continue
+            additions.append(f"{d}/*")
+            additions.extend(
+                f"!{f}" for f in self._tracked_files if str(Path(f).parent) == d
+            )
+        return additions
+
+    def ensure_gitignore(self) -> bool:
+        """Backfill ignore rules into an already-initialized workspace.
+
+        Workspaces created before the per-directory rules existed may show
+        runtime files such as ``memory/history.jsonl`` as untracked (#5246).
+        Returns True when .gitignore was updated, False when it was already
+        up to date or the repo is not initialized.
+        """
+        if not self.is_initialized():
+            return False
+
+        gitignore = self._workspace / ".gitignore"
+        try:
+            existing = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
+            additions = self._missing_dir_blocks(set(existing.splitlines()))
+            if not additions:
+                return False
+            merged = existing.rstrip("\n")
+            body = (merged + "\n" if merged else "") + "\n".join(additions) + "\n"
+            gitignore.write_text(body, encoding="utf-8")
+            logger.debug("Git store ignore rules backfilled at {}", self._workspace)
+            return True
+        except OSError as exc:
+            raise GitStoreError(
+                f"Git ignore backfill failed for {self._workspace}"
+            ) from exc
 
     # -- query -----------------------------------------------------------------
 

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -901,6 +901,7 @@ def sync_workspace_templates(workspace: Path, silent: bool = False) -> list[str]
                 "SOUL.md",
                 "USER.md",
                 "memory/MEMORY.md",
+                "memory/.dream_cursor",
             ],
         )
         gs.init()

--- a/tests/agent/test_memory_store.py
+++ b/tests/agent/test_memory_store.py
@@ -597,3 +597,18 @@ def test_raw_archive_handles_none_timestamp_and_missing_role(tmp_path: Path) -> 
     assert "[?] USER: message with none timestamp" in raw_history
     assert "[1720000000] ASSISTANT: message with int timestamp" in raw_history
     assert "[2026-07-28T12:00] UNKNOWN: message with missing role" in raw_history
+
+
+def test_legacy_workspace_gitignore_backfilled_on_construction(tmp_path):
+    """#5246: MemoryStore repairs pre-fix workspace .gitignore on startup."""
+    from dulwich import porcelain
+
+    porcelain.init(str(tmp_path))
+    legacy = "/*\n!memory/\n!SOUL.md\n!USER.md\n!memory/MEMORY.md\n!.gitignore\n"
+    (tmp_path / ".gitignore").write_text(legacy, encoding="utf-8")
+
+    MemoryStore(tmp_path)
+
+    lines = (tmp_path / ".gitignore").read_text(encoding="utf-8").splitlines()
+    assert "memory/*" in lines
+    assert "!memory/.dream_cursor" in lines

--- a/tests/utils/test_gitstore.py
+++ b/tests/utils/test_gitstore.py
@@ -332,3 +332,72 @@ class TestCommitIdEncoding:
             capture_output=True, text=True, check=True,
         ).stdout.strip()
         assert git._resolve_sha(real) is not None
+
+
+class TestRuntimeFileIgnoring:
+    """Regression tests for GitHub issue #5246.
+
+    Runtime files created inside tracked directories (memory/history.jsonl,
+    memory/.cursor) must not show up as untracked in the workspace repo.
+    """
+
+    TRACKED = ["SOUL.md", "USER.md", "memory/MEMORY.md", "memory/.dream_cursor"]
+
+    def test_new_workspace_ignores_runtime_files(self, tmp_path):
+        g = GitStore(tmp_path, tracked_files=self.TRACKED)
+        g.init()
+        (tmp_path / "memory" / "history.jsonl").write_text("{}\n", encoding="utf-8")
+        (tmp_path / "memory" / ".cursor").write_text("0", encoding="utf-8")
+        status = subprocess.run(
+            ["git", "-C", str(tmp_path), "status", "--porcelain"],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        assert "history.jsonl" not in status
+        assert ".cursor" not in status
+
+    def test_tracked_files_remain_unignored(self, tmp_path):
+        g = GitStore(tmp_path, tracked_files=self.TRACKED)
+        g.init()
+        result = subprocess.run(
+            ["git", "-C", str(tmp_path), "check-ignore", "memory/MEMORY.md", "SOUL.md"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 1  # exit 1: no path ignored
+
+    def test_ensure_gitignore_backfills_legacy_workspace(self, tmp_path):
+        from dulwich import porcelain
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        porcelain.init(str(workspace))
+        legacy = "/*\n!memory/\n!SOUL.md\n!USER.md\n!memory/MEMORY.md\n!.gitignore\n"
+        (workspace / ".gitignore").write_text(legacy, encoding="utf-8")
+
+        g = GitStore(workspace, tracked_files=self.TRACKED)
+        assert g.ensure_gitignore() is True
+
+        lines = (workspace / ".gitignore").read_text(encoding="utf-8").splitlines()
+        assert "memory/*" in lines
+        ignore_idx = lines.index("memory/*")
+        # Negations must follow the ignore rule to keep tracked files visible.
+        last_negations = {
+            line: idx for idx, line in enumerate(lines) if line.startswith("!memory/")
+        }
+        assert last_negations["!memory/MEMORY.md"] > ignore_idx
+        assert last_negations["!memory/.dream_cursor"] > ignore_idx
+        assert legacy.strip() in "\n".join(lines)  # legacy content preserved
+        assert g.ensure_gitignore() is False  # idempotent
+
+        memory_dir = workspace / "memory"
+        memory_dir.mkdir(exist_ok=True)
+        (memory_dir / "history.jsonl").write_text("{}\n", encoding="utf-8")
+        result = subprocess.run(
+            ["git", "-C", str(workspace), "check-ignore", "memory/history.jsonl"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+
+    def test_ensure_gitignore_noop_when_not_initialized(self, tmp_path):
+        g = GitStore(tmp_path, tracked_files=self.TRACKED)
+        assert g.ensure_gitignore() is False
+        assert not (tmp_path / ".gitignore").exists()


### PR DESCRIPTION
## Summary

- Ignore runtime artifacts created inside tracked workspace directories.
- Preserve explicitly tracked memory files with per-directory negation rules.
- Backfill ignore rules for existing workspaces when MemoryStore starts.
- Include memory/.dream_cursor in workspace scaffolding.
- Add regression coverage for new and legacy workspaces.

## Why

The workspace-level ignore file unignored the memory directory but did not ignore everything else within it. As a result, runtime files such as memory/history.jsonl and memory/.cursor appeared as untracked files after initialization.

Fixes #5246.

## Impact

New workspaces start with the correct ignore rules, while existing workspaces are repaired idempotently without replacing their current .gitignore contents.

## Validation

- Added focused regression tests in tests/utils/test_gitstore.py and tests/agent/test_memory_store.py.
- Tests and lint could not be executed in this checkout because pytest, ruff, and uv are not installed in the current environment.