### PR TITLE
fix(webui): stage out-of-media-root attachments on history reads

### DIFF
--- a/nanobot/channels/websocket/tests/test_websocket_media_route.py
+++ b/nanobot/channels/websocket/tests/test_websocket_media_route.py
@@ -551,6 +551,54 @@ async def test_session_messages_exposes_signed_media_urls(
 
 
 @pytest.mark.asyncio
+async def test_session_messages_stages_media_outside_media_root(
+    bus: MagicMock, tmp_path: Path
+) -> None:
+    """History must stage project/workspace attachments like the live WS path.
+
+    Files under e.g. ``projects/`` are outside the media root, so
+    ``sign_media_path`` alone returns None and drops ``media_urls``. The
+    history endpoint has to use ``sign_or_stage_media_path`` instead.
+    """
+    media = tmp_path / "media"
+    media.mkdir()
+    project_file = tmp_path / "projects" / "report.png"
+    project_file.parent.mkdir()
+    project_file.write_bytes(_PNG_BYTES)
+
+    sm = SessionManager(tmp_path / "ws_state")
+    sess = Session(key="websocket:stage-outside")
+    sess.add_message("assistant", "here is the report", media=[str(project_file)])
+    sm.save(sess)
+
+    channel = _ch(bus, session_manager=sm, port=29931)
+    with patch("nanobot.webui.media_gateway.get_media_dir", side_effect=_fake_media_dir(media)):
+        server_task = asyncio.create_task(channel.start())
+        try:
+            token = channel.gateway.tokens.issue_api_token(300)
+            resp = await _http_get(
+                "http://127.0.0.1:29931/api/sessions/websocket:stage-outside/messages",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assistant_msg = next(m for m in resp.json()["messages"] if m["role"] == "assistant")
+            urls = assistant_msg["media_urls"]
+            assert len(urls) == 1
+            assert urls[0]["name"] == "report.png"
+            assert urls[0]["url"].startswith("/api/media/")
+            assert "media" not in assistant_msg
+
+            fetched = await _http_get(f"http://127.0.0.1:29931{urls[0]['url']}")
+            assert fetched.status_code == 200
+            assert fetched.content == _PNG_BYTES
+            staged = list((media / "websocket").iterdir())
+            assert len(staged) == 1
+            assert staged[0].read_bytes() == _PNG_BYTES
+        finally:
+            await channel.stop()
+            await server_task
+
+
+@pytest.mark.asyncio
 async def test_session_messages_skips_vanished_media(
     bus: MagicMock, tmp_path: Path
 ) -> None:

--- a/nanobot/webui/media_api.py
+++ b/nanobot/webui/media_api.py
@@ -32,7 +32,10 @@ from nanobot.webui.http_utils import (
 
 MediaDirProvider = Callable[[str | None], Path]
 SignedMediaPath = Callable[[Path], dict[str, str] | None]
-SignedMediaUrl = Callable[[Path], str | None]
+# History and streaming both need staging for paths outside the media root.
+# Accept a bare URL string (legacy sign_media_path) or a {url, name} dict
+# (sign_or_stage_media_path).
+SignedMediaUrl = Callable[[Path], str | dict[str, str] | None]
 
 
 def b64url_encode(data: bytes) -> str:
@@ -215,7 +218,13 @@ def attach_signed_media_urls(
             signed = sign_path(Path(entry))
             if signed is None:
                 continue
-            urls.append({"url": signed, "name": Path(entry).name})
+            if isinstance(signed, str):
+                urls.append({"url": signed, "name": Path(entry).name})
+                continue
+            url = signed.get("url")
+            if not url:
+                continue
+            urls.append({"url": url, "name": signed.get("name") or Path(entry).name})
         if urls:
             message["media_urls"] = urls
         message.pop("media", None)

--- a/nanobot/webui/media_gateway.py
+++ b/nanobot/webui/media_gateway.py
@@ -100,7 +100,9 @@ class WebUIMediaGateway:
         )
 
     def augment_media_urls(self, payload: dict[str, Any]) -> None:
-        attach_signed_media_urls(payload, sign_path=self.sign_media_path)
+        # Match the streaming path: stage files outside the media root so
+        # history can emit the same media_urls clients see on live events.
+        attach_signed_media_urls(payload, sign_path=self.sign_or_stage_media_path)
 
     def augment_transcript_media(self, paths: list[str]) -> list[dict[str, Any]]:
         return signed_media_attachments(


### PR DESCRIPTION
## Summary
`GET /api/sessions/{key}/messages` signed attachments with `sign_media_path` only, so files outside the media root (e.g. under `projects/`) silently lost `media_urls` after a refresh. The live WebSocket path already stages via `sign_or_stage_media_path`.

## Changes
- Route history augmentation through `sign_or_stage_media_path`
- Widen `attach_signed_media_urls` to accept `str | dict | None` signer returns
- Add regression test for out-of-media-root history hydration

Fixes #5264

## Test plan
- [x] `pytest nanobot/channels/websocket/tests/test_websocket_media_route.py::test_session_messages_stages_media_outside_media_root nanobot/channels/websocket/tests/test_websocket_media_route.py::test_session_messages_exposes_signed_media_urls`