### PR TITLE
fix(webui): preserve newly created topic route

### DIFF
--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -1004,6 +1004,7 @@ function Shell({
     useState<Record<string, WorkspaceScopePayload>>({});
   const runningChatIdsRef = useRef<Set<string>>(new Set());
   const activeChatIdRef = useRef<string | null>(null);
+  const pendingCreatedSessionKeyRef = useRef<string | null>(null);
   const hostSidebarPreviewCloseTimerRef = useRef<number | null>(null);
   const effectiveRuntimeSurface =
     settingsSnapshot?.surface ?? settingsSnapshot?.runtime_surface ?? runtimeSurface;
@@ -1181,8 +1182,15 @@ function Shell({
   }, [loading, sessions]);
 
   useEffect(() => {
-    if (loading || !activeKey) return;
-    if (sessions.some((session) => session.key === activeKey)) return;
+    if (loading) return;
+    const pendingCreatedKey = pendingCreatedSessionKeyRef.current;
+    if (pendingCreatedKey && sessions.some((session) => session.key === pendingCreatedKey)) {
+      pendingCreatedSessionKeyRef.current = null;
+    }
+    if (!activeKey || sessions.some((session) => session.key === activeKey)) return;
+    // WebKit can commit the route before useSessions' optimistic insert.
+    // Keep that just-created destination valid until the session list catches up.
+    if (pendingCreatedKey === activeKey) return;
     const currentRoute = readShellRoute();
     navigate(
       currentRoute.view === "chat"
@@ -1366,9 +1374,11 @@ function Shell({
     try {
       const scope = workspaceScope ?? activeWorkspaceScope;
       const chatId = await createChat(scope);
+      const key = `websocket:${chatId}`;
+      pendingCreatedSessionKeyRef.current = key;
       navigate({
         view: "chat",
-        activeKey: `websocket:${chatId}`,
+        activeKey: key,
         settingsSection: "overview",
       });
       setMobileSidebarOpen(false);

--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -367,6 +367,23 @@ describe("App layout", () => {
     );
   });
 
+  it("keeps a just-created topic route while the session list catches up", async () => {
+    render(<App />);
+
+    await waitFor(() => expect(connectSpy).toHaveBeenCalled());
+    fireEvent.change(screen.getByRole("textbox", { name: "Message input" }), {
+      target: { value: "/model" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() => expect(createChatSpy).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(window.location.hash).toBe(
+        `#/chat/${encodeURIComponent("websocket:chat-1")}`,
+      ),
+    );
+  });
+
   it("restores the Settings route after a restart fallback hash", async () => {
     localStorage.setItem("nanobot-webui.restartStartedAt", String(Date.now()));
     localStorage.setItem("nanobot-webui.restartRoute", "#/settings?section=channels");


### PR DESCRIPTION
## Summary

- preserve the route for the topic returned by `createChat` until the optimistic session list acknowledges it
- clear that pending route as soon as the session appears so normal missing-session fallback remains intact
- add an App-level regression test for the route/list commit gap exposed by WebKit/Safari

## Root cause

WebKit can commit the new hash route before React commits `useSessions`' optimistic session row. The missing-session cleanup effect then mistakes the newly created key for an invalid URL and replaces it with `#/new`, leaving the Hero composer stuck even though the topic exists in the sidebar.

## Verification

- `bun run test -- src/tests/app-layout.test.tsx` (44 passed)
- `bun run test -- src/tests/useSessions.test.tsx src/tests/thread-shell.test.tsx` (87 passed)
- `bun run build`
- `bun run lint`
- isolated real gateway + Playwright WebKit: Hero `/model` send navigates to the created topic, REST replay contains the command and response, refresh preserves the route/selection, and an arbitrary missing session still falls back to `#/new`
- isolated real gateway + Chromium control: Hero send still navigates to and selects the created topic

## Limitations

Playwright WebKit on Windows exercises the Safari engine behavior but is not a physical macOS/iOS Safari run.