### PR TITLE
fix(channels): preserve global progress defaults

### DIFF
--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -101,6 +101,14 @@ class BaseChannel(ABC):
         """
         pass
 
+    def progress_transport_defaults(self) -> tuple[bool, bool] | None:
+        """Return channel-owned defaults for progress and tool-hint messages.
+
+        ``None`` keeps the global channel policy. Channels should override this
+        only when their transport requires different defaults.
+        """
+        return None
+
     def should_retry_send_error(self, error: Exception) -> bool:
         """Return whether the channel manager may retry a failed delivery.
 

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -187,15 +187,9 @@ class ChannelManager:
         channel = cls(section, self.bus, **kwargs)
         if runtime_name and runtime_name != channel.name:
             channel.name = runtime_name
-        # Channel-owned config models may deliberately choose safer transport
-        # defaults than the global channel policy (for example, a quota-limited
-        # platform can disable progress messages).  Preserve those defaults
-        # while still letting an explicit per-channel value win below.
-        progress_default = getattr(
-            channel.config, "send_progress", self.config.channels.send_progress,
-        )
-        tool_hints_default = getattr(
-            channel.config, "send_tool_hints", self.config.channels.send_tool_hints,
+        progress_default, tool_hints_default = channel.progress_transport_defaults() or (
+            self.config.channels.send_progress,
+            self.config.channels.send_tool_hints,
         )
         channel.send_progress = self._resolve_bool_override(
             section, "send_progress", progress_default,

--- a/nanobot/channels/weixin/runtime.py
+++ b/nanobot/channels/weixin/runtime.py
@@ -339,6 +339,9 @@ class WeixinChannel(BaseChannel):
         self._reply_run_ids: dict[str, str] = {}
         self._reply_progress_counts: dict[str, int] = {}
 
+    def progress_transport_defaults(self) -> tuple[bool, bool]:
+        return self.config.send_progress, self.config.send_tool_hints
+
     def should_retry_send_error(self, error: Exception) -> bool:
         if isinstance(error, WeixinAPIError):
             return error.retryable

--- a/tests/channels/test_channel_manager_delta_coalescing.py
+++ b/tests/channels/test_channel_manager_delta_coalescing.py
@@ -17,6 +17,7 @@ from nanobot.bus.outbound_events import (
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
 from nanobot.channels.manager import ChannelManager
+from nanobot.channels.mattermost.runtime import MattermostChannel
 from nanobot.config.schema import Config
 
 
@@ -310,6 +311,38 @@ class TestProgressFiltering:
 
         assert manager._should_send_progress("mock", tool_hint=False) is False
         assert manager._should_send_progress("mock", tool_hint=True) is False
+
+    def test_channel_config_defaults_do_not_override_global_policy(self, bus):
+        manager = ChannelManager.__new__(ChannelManager)
+        manager.config = Config.model_validate({
+            "channels": {
+                "sendProgress": False,
+                "sendToolHints": False,
+            },
+        })
+        manager.bus = bus
+
+        channel = manager._build_channel(
+            "mattermost",
+            MattermostChannel,
+            {"enabled": True},
+        )
+
+        assert channel.send_progress is False
+        assert channel.send_tool_hints is False
+
+        opted_in = manager._build_channel(
+            "mattermost",
+            MattermostChannel,
+            {
+                "enabled": True,
+                "sendProgress": True,
+                "sendToolHints": True,
+            },
+        )
+
+        assert opted_in.send_progress is True
+        assert opted_in.send_tool_hints is True
 
     def test_progress_visibility_returns_false_for_missing_channel(self, manager):
         assert manager._should_send_progress("nonexistent", tool_hint=False) is False


### PR DESCRIPTION
## Summary

- preserve global `sendProgress` and `sendToolHints` defaults for channels that do not explicitly opt into transport-specific defaults
- keep WeChat's quota-safe defaults channel-owned through a small `BaseChannel` extension point
- add a concrete Mattermost regression test while preserving explicit per-channel overrides

## Why

The WeChat hardening in #5263 read defaults from every channel's parsed config model. For Mattermost, that changed an omitted local setting from inheriting a global `false` to its model default `true`, which could unexpectedly re-enable progress and tool-hint messages.

## Verification

- public Config → ChannelManager smoke: baseline Mattermost `true/true`, candidate `false/false`
- WeChat default `false/false`; explicit opt-in `true/true`
- `389 passed` across channel, WeChat, and Mattermost tests
- Ruff passed on changed files
- BasedPyright: 0 errors, 0 warnings