### PR TITLE
feat(usage): log per-iteration token diagnostics

### DIFF
--- a/nanobot/webui/token_usage.py
+++ b/nanobot/webui/token_usage.py
@@ -361,9 +361,30 @@ class TokenUsageHook(AgentHook):
 
     async def after_iteration(self, context: AgentHookContext) -> None:
         try:
+            normalized = _normalize_usage(context.usage)
+            if not normalized:
+                return
+
+            source = _source_from_session_key(context.session_key)
+            session = context.session_key if context.session_key is not None else "default"
+
+            logger.info(
+                "Token usage: source={} session={} iteration={} prompt={} "
+                "completion={} cached={} total={} provider={} estimated={}",
+                source,
+                session,
+                context.iteration,
+                normalized.get("prompt_tokens", 0),
+                normalized.get("completion_tokens", 0),
+                normalized.get("cached_tokens", 0),
+                normalized.get("total_tokens", 0),
+                normalized.get("provider_tokens", 0),
+                normalized.get("estimated_tokens", 0),
+            )
+
             record_token_usage(
-                context.usage,
-                source=_source_from_session_key(context.session_key),
+                normalized,
+                source=source,
                 timezone_name=self._timezone_name,
             )
         except Exception:

--- a/tests/webui/test_token_usage.py
+++ b/tests/webui/test_token_usage.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
+from loguru import logger
 
 from nanobot.agent.hook import AgentHookContext
 from nanobot.webui.token_usage import (
@@ -201,3 +202,137 @@ async def test_token_usage_hook_classifies_source_from_session_key(tmp_path, mon
     payload = token_usage_payload(now=datetime(2026, 6, 3, tzinfo=timezone.utc))
 
     assert payload["days"][0]["sources"]["cron"]["total_tokens"] == 15
+
+
+@pytest.mark.asyncio
+async def test_token_usage_hook_logs_diagnostic(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("nanobot.webui.token_usage.get_webui_dir", lambda: tmp_path / "webui")
+    monkeypatch.setattr("nanobot.webui.token_usage._local_day", lambda *_, **__: "2026-06-03")
+
+    logs = []
+    handler_id = logger.add(
+        lambda msg: logs.append(msg.record["message"]),
+        filter=lambda record: record["message"].startswith("Token usage:"),
+    )
+
+    try:
+        hook = TokenUsageHook()
+        await hook.after_iteration(
+            AgentHookContext(
+                iteration=2,
+                messages=[],
+                session_key="cron:drink-water",
+                usage={
+                    "prompt_tokens": 100,
+                    "completion_tokens": 20,
+                    "cached_tokens": 10,
+                },
+            )
+        )
+
+        assert len(logs) == 1
+        log_msg = logs[0]
+        assert "source=cron" in log_msg
+        assert "session=cron:drink-water" in log_msg
+        assert "iteration=2" in log_msg
+        assert "prompt=100" in log_msg
+        assert "completion=20" in log_msg
+        assert "total=120" in log_msg
+
+        # Verify aggregate is still working
+        payload = token_usage_payload(now=datetime(2026, 6, 3, tzinfo=timezone.utc))
+        assert payload["days"][0]["sources"]["cron"]["total_tokens"] == 120
+    finally:
+        logger.remove(handler_id)
+
+
+@pytest.mark.asyncio
+async def test_token_usage_hook_logs_heartbeat(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("nanobot.webui.token_usage.get_webui_dir", lambda: tmp_path / "webui")
+
+    logs = []
+    handler_id = logger.add(
+        lambda msg: logs.append(msg.record["message"]),
+        filter=lambda record: record["message"].startswith("Token usage:"),
+    )
+
+    try:
+        hook = TokenUsageHook()
+        await hook.after_iteration(
+            AgentHookContext(
+                iteration=0,
+                messages=[],
+                session_key="heartbeat",
+                usage={"prompt_tokens": 5, "completion_tokens": 1},
+            )
+        )
+
+        assert len(logs) == 1
+        log_msg = logs[0]
+        assert "source=cron" in log_msg
+        assert "session=heartbeat" in log_msg
+    finally:
+        logger.remove(handler_id)
+
+
+@pytest.mark.asyncio
+async def test_token_usage_hook_ignores_empty_usage(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("nanobot.webui.token_usage.get_webui_dir", lambda: tmp_path / "webui")
+
+    logs = []
+    handler_id = logger.add(
+        lambda msg: logs.append(msg.record["message"]),
+        filter=lambda record: record["message"].startswith("Token usage:"),
+    )
+
+    try:
+        hook = TokenUsageHook()
+        await hook.after_iteration(
+            AgentHookContext(
+                iteration=1,
+                messages=[],
+                session_key="user",
+                usage={"prompt_tokens": 0, "completion_tokens": 0},
+            )
+        )
+
+        assert len(logs) == 0
+
+        payload = token_usage_payload(now=datetime(2026, 6, 3, tzinfo=timezone.utc))
+        assert payload["days"] == []
+    finally:
+        logger.remove(handler_id)
+
+
+@pytest.mark.asyncio
+async def test_token_usage_hook_logs_estimated_usage(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("nanobot.webui.token_usage.get_webui_dir", lambda: tmp_path / "webui")
+
+    logs = []
+    handler_id = logger.add(
+        lambda msg: logs.append(msg.record["message"]),
+        filter=lambda record: record["message"].startswith("Token usage:"),
+    )
+
+    try:
+        hook = TokenUsageHook()
+        await hook.after_iteration(
+            AgentHookContext(
+                iteration=3,
+                messages=[],
+                session_key="user:123",
+                usage={
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "provider_tokens": 0,
+                    "estimated_tokens": 15,
+                },
+            )
+        )
+
+        assert len(logs) == 1
+        log_msg = logs[0]
+        assert "provider=0" in log_msg
+        assert "estimated=15" in log_msg
+    finally:
+        logger.remove(handler_id)


### PR DESCRIPTION
Related to #5266

## Problem

Token usage is currently persisted as aggregated WebUI statistics by day and source. That is useful for understanding overall consumption, but it makes it difficult to identify which agent execution produced unexpectedly high token usage.

For debugging normal conversations, cron/heartbeat runs, or dream executions, users currently lack a lightweight built-in diagnostic that identifies the session and agent iteration responsible for the usage.

## Solution

Reuse the existing `TokenUsageHook` and `AgentHookContext` rather than introducing a separate telemetry subsystem.

For each iteration with non-empty token usage, the hook now emits an INFO-level diagnostic containing the execution source, session key, iteration number, and token breakdown. The existing aggregation and persistence behavior remains unchanged.

## Changes

- Log per-iteration token usage from the existing `TokenUsageHook`
- Include source, session, iteration, prompt, completion, cached, total, provider-reported, and estimated token counts
- Reuse the existing usage normalization and source classification logic
- Keep the existing `token-usage.json` schema and aggregation behavior unchanged
- Add tests covering normal diagnostics, heartbeat attribution, empty usage, and estimated usage

## Testing

- `python -m pytest tests/webui/test_token_usage.py -q` — 12 passed
- `python -m ruff check nanobot/webui/token_usage.py tests/webui/test_token_usage.py` — passed
- `git diff --check` — passed

## Notes for Reviewer

This intentionally keeps the scope small: it adds iteration-level runtime diagnostics for #5266 without introducing a WebUI diagnostics surface or a new per-provider-call tracing abstraction.

An agent iteration is not guaranteed to map 1:1 to a provider request because internal retries can be aggregated within the same iteration. Strict per-provider-call tracing is intentionally outside the scope of this change.

I also noticed the discussion about a possible WebUI dev mode and stricter per-call accounting. If that is the preferred direction, I’m happy to adjust the scope before marking this ready for review.