### PR TITLE
fix(webui): prevent image hover clipping

### DIFF
--- a/webui/src/components/MessageBubble.tsx
+++ b/webui/src/components/MessageBubble.tsx
@@ -725,7 +725,7 @@ function UserImageCell({
         className={cn(
           tileClasses,
           "block cursor-zoom-in p-0 transition-transform duration-150 motion-reduce:transition-none",
-          "hover:scale-[1.01] hover:ring-2 hover:ring-primary/25",
+          "hover:scale-[1.01]",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50",
         )}
       >

--- a/webui/src/components/MessageBubble.tsx
+++ b/webui/src/components/MessageBubble.tsx
@@ -724,8 +724,7 @@ function UserImageCell({
         aria-label={image.name ? `${openLabel}: ${image.name}` : openLabel}
         className={cn(
           tileClasses,
-          "block cursor-zoom-in p-0 transition-transform duration-150 motion-reduce:transition-none",
-          "hover:scale-[1.01]",
+          "block cursor-zoom-in p-0",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50",
         )}
       >

--- a/webui/src/tests/message-bubble.test.tsx
+++ b/webui/src/tests/message-bubble.test.tsx
@@ -916,6 +916,14 @@ describe("MessageBubble", () => {
 
     const imageButton = screen.getByRole("button", { name: /view image/i });
     expect(imageButton).toHaveClass("w-[min(100%,34rem)]", "rounded-[20px]");
+    expect(imageButton).toHaveClass(
+      "border",
+      "border-border/60",
+      "hover:scale-[1.01]",
+      "focus-visible:ring-2",
+    );
+    expect(imageButton).not.toHaveClass("hover:ring-2");
+    expect(imageButton).not.toHaveClass("hover:ring-primary/25");
     expect(imageButton).not.toHaveAttribute("title");
     expect(container.querySelector("img")).toHaveClass("h-auto", "w-full", "object-contain");
   });

--- a/webui/src/tests/message-bubble.test.tsx
+++ b/webui/src/tests/message-bubble.test.tsx
@@ -919,9 +919,9 @@ describe("MessageBubble", () => {
     expect(imageButton).toHaveClass(
       "border",
       "border-border/60",
-      "hover:scale-[1.01]",
       "focus-visible:ring-2",
     );
+    expect(imageButton).not.toHaveClass("hover:scale-[1.01]");
     expect(imageButton).not.toHaveClass("hover:ring-2");
     expect(imageButton).not.toHaveClass("hover:ring-primary/25");
     expect(imageButton).not.toHaveAttribute("title");


### PR DESCRIPTION
## Summary

- remove hover scaling and the hover ring from assistant image previews so container clipping cannot hide image edges
- retain the zoom cursor, static border, native button behavior, and keyboard focus-visible ring
- add regression coverage for the removed and retained interaction classes

## Verification

- `cd webui && bun run test -- src/tests/message-bubble.test.tsx` — 35 tests passed
- targeted ESLint for the changed component and test — passed with zero warnings
- `cd webui && bun run build` — passed
- isolated gateway + Playwright verification — hover transform remained `none` and image geometry stayed unchanged at desktop, 720px, and 390px widths; static border, zoom cursor, keyboard focus ring, refresh replay, and console health all passed

## Gate

`nanobot-gate`: simplify PASS, verify PASS, candidate-review PASS