### PR TITLE
fix(telegram): bridge stdlib logging and detect stalled polling

### DIFF
--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -38,6 +38,7 @@ from nanobot.config.paths import get_media_dir
 from nanobot.config.schema import Base
 from nanobot.security.network import validate_url_target
 from nanobot.utils.helpers import split_message
+from nanobot.utils.logging_bridge import redirect_lib_logging
 
 TELEGRAM_MAX_MESSAGE_LEN = 4000  # Telegram message character limit
 # Telegram's actual API limit is 4096; we split raw markdown at 4000 as a
@@ -52,6 +53,29 @@ TELEGRAM_REPLY_CONTEXT_MAX_LEN = TELEGRAM_MAX_MESSAGE_LEN  # Max length for repl
 # explicit rather than allowing unspecialized generics to spread Unknown.
 TelegramApplication: TypeAlias = Application[Any, Any, Any, Any, Any, Any]
 _T = TypeVar("_T")
+
+# A healthy long poll completes a round trip roughly every ~10s even with zero
+# traffic, so an idle gap this long is a reliable stall signal (see #5156).
+POLLING_STALL_THRESHOLD_SECONDS = 120.0
+POLLING_STALL_CHECK_INTERVAL_SECONDS = 30.0
+
+
+class _LivenessTrackedRequest(HTTPXRequest):
+    """HTTPXRequest that timestamps each completed HTTP round trip.
+
+    Used only for the getUpdates pool so a watchdog can detect a wedged
+    long-poll loop that PTB's own retry logic treats as a normal timeout
+    and only logs at DEBUG (never surfaced via ``error_callback``).
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.last_success_monotonic: float = time.monotonic()
+
+    async def do_request(self, *args: Any, **kwargs: Any) -> tuple[int, bytes]:
+        result = await super().do_request(*args, **kwargs)
+        self.last_success_monotonic = time.monotonic()
+        return result
 
 
 def _split_telegram_markdown(content: str, max_len: int) -> list[str]:
@@ -477,6 +501,8 @@ class TelegramChannel(BaseChannel):
         self._inbound_buffers: dict[str, list[_QueuedTelegramUpdate]] = {}
         self._inbound_workers: dict[str, asyncio.Task[None]] = {}
         self._rich_send_disabled: bool = False  # Latch off if Bot API < 10.1
+        self._poll_request: _LivenessTrackedRequest | None = None
+        self._liveness_task: asyncio.Task[None] | None = None
 
     def _require_app(self) -> TelegramApplication:
         if self._app is None:
@@ -521,6 +547,9 @@ class TelegramChannel(BaseChannel):
             self.logger.error("bot token not configured")
             return
 
+        redirect_lib_logging("telegram")
+        redirect_lib_logging("httpx", level="WARNING")
+
         self._running = True
 
         proxy = self.config.proxy or None
@@ -533,13 +562,14 @@ class TelegramChannel(BaseChannel):
             read_timeout=30.0,
             proxy=proxy,
         )
-        poll_request = HTTPXRequest(
+        poll_request = _LivenessTrackedRequest(
             connection_pool_size=4,
             pool_timeout=self.config.pool_timeout,
             connect_timeout=30.0,
             read_timeout=30.0,
             proxy=proxy,
         )
+        self._poll_request = poll_request
         builder = (
             Application.builder()
             .token(self.config.token)
@@ -627,14 +657,45 @@ class TelegramChannel(BaseChannel):
                 drop_pending_updates=False,  # Process pending messages on startup
                 error_callback=self._on_polling_error,
             )
+            self._liveness_task = asyncio.create_task(self._watch_polling_liveness())
 
         # Keep running until stopped
         while self._running:
             await asyncio.sleep(1)
 
+    async def _watch_polling_liveness(self) -> None:
+        """Detect a wedged getUpdates pool that PTB's own retry loop stays silent about.
+
+        PTB treats a stuck long-poll (PoolTimeout -> TimedOut, infinite retries)
+        as a normal timeout: it never calls ``error_callback`` and only logs at
+        DEBUG (see #5156), so this is the only reliable signal that polling has
+        stalled.
+        """
+        stalled = False
+        while self._running:
+            await asyncio.sleep(POLLING_STALL_CHECK_INTERVAL_SECONDS)
+            poll_request = self._poll_request
+            if poll_request is None:
+                continue
+            idle = time.monotonic() - poll_request.last_success_monotonic
+            if idle > POLLING_STALL_THRESHOLD_SECONDS:
+                if not stalled:
+                    stalled = True
+                    self.logger.error(
+                        "polling appears stalled: no successful getUpdates round-trip in {:.0f}s",
+                        idle,
+                    )
+            elif stalled:
+                stalled = False
+                self.logger.info("polling recovered after {:.0f}s stall", idle)
+
     async def stop(self) -> None:
         """Stop the Telegram bot."""
         self._running = False
+
+        if self._liveness_task:
+            self._liveness_task.cancel()
+            self._liveness_task = None
 
         # Cancel all typing indicators
         for chat_id in list(self._typing_tasks):

--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import re
 import time
+import traceback
 import unicodedata
 from contextlib import suppress
 from dataclasses import dataclass
@@ -61,21 +62,77 @@ POLLING_STALL_CHECK_INTERVAL_SECONDS = 30.0
 
 
 class _LivenessTrackedRequest(HTTPXRequest):
-    """HTTPXRequest that timestamps each completed HTTP round trip.
+    """HTTPXRequest that timestamps each completed HTTP round trip and tracks
+    per-request lifecycle state for the getUpdates pool.
 
-    Used only for the getUpdates pool so a watchdog can detect a wedged
-    long-poll loop that PTB's own retry logic treats as a normal timeout
-    and only logs at DEBUG (never surfaced via ``error_callback``).
+    Temporary diagnostic instrumentation for #5156: used only for the
+    getUpdates pool so a watchdog can detect a wedged long-poll loop that
+    PTB's own retry logic treats as a normal timeout and only logs at DEBUG
+    (never surfaced via ``error_callback``), and so a stall report can carry
+    enough state (in-flight count, cancellations vs. errors, raw httpcore
+    connection state) to tell a PTB lifecycle bug apart from a proxy-layer
+    connection leak. Not meant to survive once the root cause is found.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.last_success_monotonic: float = time.monotonic()
+        self.active_requests: int = 0
+        self.total_started: int = 0
+        self.total_completed: int = 0
+        self.total_cancelled: int = 0
+        self.total_errors: int = 0
 
     async def do_request(self, *args: Any, **kwargs: Any) -> tuple[int, bytes]:
-        result = await super().do_request(*args, **kwargs)
-        self.last_success_monotonic = time.monotonic()
-        return result
+        self.active_requests += 1
+        self.total_started += 1
+        try:
+            result = await super().do_request(*args, **kwargs)
+        except asyncio.CancelledError:
+            self.total_cancelled += 1
+            raise
+        except Exception:
+            self.total_errors += 1
+            raise
+        else:
+            self.last_success_monotonic = time.monotonic()
+            self.total_completed += 1
+            return result
+        finally:
+            self.active_requests -= 1
+
+    def pool_snapshot(self) -> list[str]:
+        """Best-effort dump of the underlying httpcore connections' raw state.
+
+        Reaches through private httpx/httpcore attributes (``_transport``,
+        ``_pool``) that aren't part of any public API; acceptable only
+        because this is diagnostic-only instrumentation, never merged as-is.
+        """
+        try:
+            pool: Any = self._client._transport._pool  # type: ignore[attr-defined]
+            return _describe_pool_connections(pool)
+        except Exception as exc:  # pragma: no cover - best-effort introspection
+            return [f"<pool introspection failed: {exc!r}>"]
+
+
+def _describe_pool_connections(pool: Any) -> list[str]:
+    """``pool.connections`` returns httpcore's untyped connection objects; funnel
+    the ``Any`` here so callers stay fully typed."""
+    return [str(conn.info()) for conn in pool.connections]
+
+
+def _dump_task_stacks(limit: int = 20) -> list[str]:
+    """Format the stack of every live asyncio task, for stall diagnostics."""
+    dumps: list[str] = []
+    for task in asyncio.all_tasks():
+        stack = task.get_stack(limit=limit)
+        if not stack:
+            continue
+        # ``stack[-1]`` is the innermost frame; format_stack walks its
+        # f_back chain, so this yields the full call chain in order.
+        formatted = "".join(traceback.format_stack(stack[-1], limit=limit))
+        dumps.append(f"{task.get_name()}:\n{formatted}")
+    return dumps
 
 
 def _split_telegram_markdown(content: str, max_len: int) -> list[str]:
@@ -547,7 +604,10 @@ class TelegramChannel(BaseChannel):
             self.logger.error("bot token not configured")
             return
 
-        redirect_lib_logging("telegram")
+        # WARNING, not DEBUG: PTB logs the full Bot API base URL (which embeds the
+        # bot token), request parameters, and update contents at DEBUG. The liveness
+        # watchdog below already covers the PoolTimeout path PTB only logs at DEBUG.
+        redirect_lib_logging("telegram", level="WARNING")
         redirect_lib_logging("httpx", level="WARNING")
 
         self._running = True
@@ -672,6 +732,7 @@ class TelegramChannel(BaseChannel):
         stalled.
         """
         stalled = False
+        stall_started: float = 0.0
         while self._running:
             await asyncio.sleep(POLLING_STALL_CHECK_INTERVAL_SECONDS)
             poll_request = self._poll_request
@@ -681,12 +742,24 @@ class TelegramChannel(BaseChannel):
             if idle > POLLING_STALL_THRESHOLD_SECONDS:
                 if not stalled:
                     stalled = True
+                    stall_started = poll_request.last_success_monotonic
                     self.logger.error(
-                        "polling appears stalled: no successful getUpdates round-trip in {:.0f}s",
+                        "polling appears stalled: no successful getUpdates round-trip in {:.0f}s "
+                        "(active={} started={} completed={} cancelled={} errors={})",
                         idle,
+                        poll_request.active_requests,
+                        poll_request.total_started,
+                        poll_request.total_completed,
+                        poll_request.total_cancelled,
+                        poll_request.total_errors,
                     )
+                    for line in poll_request.pool_snapshot():
+                        self.logger.error("polling stall: pool connection {}", line)
+                    for stack in _dump_task_stacks():
+                        self.logger.error("polling stall: task stack {}", stack)
             elif stalled:
                 stalled = False
+                idle = time.monotonic() - stall_started
                 self.logger.info("polling recovered after {:.0f}s stall", idle)
 
     async def stop(self) -> None:

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -376,7 +376,7 @@ async def test_start_bridges_stdlib_logging(monkeypatch) -> None:
 
     await channel.start()
 
-    assert ("telegram", None) in calls
+    assert ("telegram", "WARNING") in calls
     assert ("httpx", "WARNING") in calls
 
 
@@ -426,18 +426,32 @@ async def test_watch_polling_liveness_logs_stall_and_recovery(monkeypatch) -> No
     )
     recorded: list[tuple[str, str]] = []
     monkeypatch.setattr(
-        channel.logger, "error", lambda message, idle: recorded.append(("error", message))
+        channel.logger,
+        "error",
+        lambda message, *args: recorded.append(("error", message)),
     )
     monkeypatch.setattr(
-        channel.logger, "info", lambda message, idle: recorded.append(("info", message))
+        channel.logger, "info", lambda message, *args: recorded.append(("info", message))
     )
 
     channel._running = True
-    channel._poll_request = SimpleNamespace(last_success_monotonic=time.monotonic() - 1.0)
+    channel._poll_request = SimpleNamespace(
+        last_success_monotonic=time.monotonic() - 1.0,
+        active_requests=1,
+        total_started=1,
+        total_completed=0,
+        total_cancelled=0,
+        total_errors=0,
+        pool_snapshot=lambda: [],
+    )
     task = asyncio.create_task(channel._watch_polling_liveness())
 
     await asyncio.sleep(0.3)
-    assert recorded == [("error", "polling appears stalled: no successful getUpdates round-trip in {:.0f}s")]
+    assert (
+        "error",
+        "polling appears stalled: no successful getUpdates round-trip in {:.0f}s "
+        "(active={} started={} completed={} cancelled={} errors={})",
+    ) in recorded
 
     channel._poll_request.last_success_monotonic = time.monotonic()
     await asyncio.sleep(0.08)  # < threshold, so it must not have re-stalled yet

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -1,4 +1,6 @@
 import asyncio
+import time
+from contextlib import suppress
 from datetime import timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -323,6 +325,7 @@ async def test_start_creates_separate_pools_with_proxy(monkeypatch) -> None:
     builder = _FakeBuilder(app)
 
     monkeypatch.setattr("nanobot.channels.telegram.runtime.HTTPXRequest", _FakeHTTPXRequest)
+    monkeypatch.setattr("nanobot.channels.telegram.runtime._LivenessTrackedRequest", _FakeHTTPXRequest)
     monkeypatch.setattr(
         "nanobot.channels.telegram.runtime.Application",
         SimpleNamespace(builder=lambda: builder),
@@ -349,6 +352,35 @@ async def test_start_creates_separate_pools_with_proxy(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_start_bridges_stdlib_logging(monkeypatch) -> None:
+    """python-telegram-bot and httpx logs must be bridged into loguru so
+    polling failures are no longer silent (see PR #5156)."""
+    _FakeHTTPXRequest.clear()
+    config = TelegramConfig(enabled=True, token="123:abc", allow_from=["*"])
+    bus = MessageBus()
+    channel = TelegramChannel(config, bus)
+    app = _FakeApp(lambda: setattr(channel, "_running", False))
+    builder = _FakeBuilder(app)
+
+    monkeypatch.setattr("nanobot.channels.telegram.runtime.HTTPXRequest", _FakeHTTPXRequest)
+    monkeypatch.setattr("nanobot.channels.telegram.runtime._LivenessTrackedRequest", _FakeHTTPXRequest)
+    monkeypatch.setattr(
+        "nanobot.channels.telegram.runtime.Application",
+        SimpleNamespace(builder=lambda: builder),
+    )
+    calls: list[tuple[str, str | None]] = []
+    monkeypatch.setattr(
+        "nanobot.channels.telegram.runtime.redirect_lib_logging",
+        lambda name, level=None: calls.append((name, level)),
+    )
+
+    await channel.start()
+
+    assert ("telegram", None) in calls
+    assert ("httpx", "WARNING") in calls
+
+
+@pytest.mark.asyncio
 async def test_start_respects_custom_pool_config(monkeypatch) -> None:
     _FakeHTTPXRequest.clear()
     config = TelegramConfig(
@@ -364,6 +396,7 @@ async def test_start_respects_custom_pool_config(monkeypatch) -> None:
     builder = _FakeBuilder(app)
 
     monkeypatch.setattr("nanobot.channels.telegram.runtime.HTTPXRequest", _FakeHTTPXRequest)
+    monkeypatch.setattr("nanobot.channels.telegram.runtime._LivenessTrackedRequest", _FakeHTTPXRequest)
     monkeypatch.setattr(
         "nanobot.channels.telegram.runtime.Application",
         SimpleNamespace(builder=lambda: builder),
@@ -376,6 +409,45 @@ async def test_start_respects_custom_pool_config(monkeypatch) -> None:
     assert api_req.kwargs["connection_pool_size"] == 32
     assert api_req.kwargs["pool_timeout"] == 10.0
     assert poll_req.kwargs["pool_timeout"] == 10.0
+
+
+@pytest.mark.asyncio
+async def test_watch_polling_liveness_logs_stall_and_recovery(monkeypatch) -> None:
+    """PTB's own retry loop stays silent on a wedged getUpdates pool (#5156),
+    so nanobot's watchdog must be the one to surface it."""
+    import nanobot.channels.telegram.runtime as runtime_module
+
+    monkeypatch.setattr(runtime_module, "POLLING_STALL_CHECK_INTERVAL_SECONDS", 0.05)
+    monkeypatch.setattr(runtime_module, "POLLING_STALL_THRESHOLD_SECONDS", 0.15)
+
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
+        MessageBus(),
+    )
+    recorded: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        channel.logger, "error", lambda message, idle: recorded.append(("error", message))
+    )
+    monkeypatch.setattr(
+        channel.logger, "info", lambda message, idle: recorded.append(("info", message))
+    )
+
+    channel._running = True
+    channel._poll_request = SimpleNamespace(last_success_monotonic=time.monotonic() - 1.0)
+    task = asyncio.create_task(channel._watch_polling_liveness())
+
+    await asyncio.sleep(0.3)
+    assert recorded == [("error", "polling appears stalled: no successful getUpdates round-trip in {:.0f}s")]
+
+    channel._poll_request.last_success_monotonic = time.monotonic()
+    await asyncio.sleep(0.08)  # < threshold, so it must not have re-stalled yet
+
+    channel._running = False
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
+
+    assert recorded[-1] == ("info", "polling recovered after {:.0f}s stall")
 
 
 def test_webhook_config_requires_https_url_and_secret() -> None:
@@ -421,6 +493,7 @@ async def test_start_webhook_mode(monkeypatch) -> None:
     builder = _FakeBuilder(app)
 
     monkeypatch.setattr("nanobot.channels.telegram.runtime.HTTPXRequest", _FakeHTTPXRequest)
+    monkeypatch.setattr("nanobot.channels.telegram.runtime._LivenessTrackedRequest", _FakeHTTPXRequest)
     monkeypatch.setattr(
         "nanobot.channels.telegram.runtime.Application",
         SimpleNamespace(builder=lambda: builder),

--- a/nanobot/utils/logging_bridge.py
+++ b/nanobot/utils/logging_bridge.py
@@ -39,9 +39,11 @@ def redirect_lib_logging(name: str, level: str | None = None) -> None:
     handler does not filter — loguru's own level controls visibility.
     """
     lib_logger = logging.getLogger(name)
+    resolved = getattr(logging, level.upper(), logging.WARNING) if level else logging.DEBUG
+    lib_logger.setLevel(resolved)
     if not any(isinstance(h, _LoguruBridge) for h in lib_logger.handlers):
         handler = _LoguruBridge(name)
         if level is not None:
-            handler.setLevel(getattr(logging, level.upper(), logging.WARNING))
+            handler.setLevel(resolved)
         lib_logger.handlers = [handler]
         lib_logger.propagate = False

--- a/tests/utils/test_logging_bridge.py
+++ b/tests/utils/test_logging_bridge.py
@@ -1,0 +1,52 @@
+import logging
+
+from nanobot.utils.logging_bridge import redirect_lib_logging
+
+
+def _reset_logger(name: str) -> None:
+    lib_logger = logging.getLogger(name)
+    lib_logger.handlers = []
+    lib_logger.setLevel(logging.NOTSET)
+    lib_logger.propagate = True
+
+
+def test_redirect_lib_logging_sets_logger_level_so_records_reach_the_handler() -> None:
+    """Without an explicit logger level, records below root's default WARNING
+    never reach the bridge handler regardless of what the handler filters."""
+    name = "test_lib_no_level"
+    _reset_logger(name)
+    try:
+        redirect_lib_logging(name)
+
+        lib_logger = logging.getLogger(name)
+        assert lib_logger.isEnabledFor(logging.DEBUG)
+        assert lib_logger.propagate is False
+    finally:
+        _reset_logger(name)
+
+
+def test_redirect_lib_logging_with_level_filters_at_logger_and_handler() -> None:
+    name = "test_lib_warning_level"
+    _reset_logger(name)
+    try:
+        redirect_lib_logging(name, level="WARNING")
+
+        lib_logger = logging.getLogger(name)
+        assert not lib_logger.isEnabledFor(logging.INFO)
+        assert lib_logger.isEnabledFor(logging.WARNING)
+        assert lib_logger.handlers[0].level == logging.WARNING
+    finally:
+        _reset_logger(name)
+
+
+def test_redirect_lib_logging_is_idempotent() -> None:
+    name = "test_lib_idempotent"
+    _reset_logger(name)
+    try:
+        redirect_lib_logging(name)
+        redirect_lib_logging(name)
+
+        lib_logger = logging.getLogger(name)
+        assert len(lib_logger.handlers) == 1
+    finally:
+        _reset_logger(name)


### PR DESCRIPTION
## Context

Related to #5156, which adds a full watchdog that rebuilds stalled Telegram polling connection pools. This PR splits out the low-risk observability piece: bridging stdlib logging into loguru, plus a lightweight liveness check that only logs (no teardown/rebuild).

## Why

PTB's retry loop treats `TimedOut`/`PoolTimeout` as expected during long-polling: it retries immediately, never calls `error_callback`, and only logs at DEBUG. That means a stalled `getUpdates` pool currently looks like silence in nanobot's logs after the initial WARNING lines, and bridging the library logs alone doesn't fix it either — those retries stay at DEBUG forever (max_retries is -1 for polling), so under nanobot's default INFO log level they're still invisible.

## Changes

- Bridge `telegram` and `httpx` (WARNING+) stdlib logging into loguru in `TelegramChannel.start()`, matching the pattern already used by feishu, matrix, qq, and websocket.
- Fix `redirect_lib_logging` to also set the logger's own level, not just the handler's — the logger-level check runs before the handler, so records were being dropped regardless of handler/loguru level.
- Add a liveness watchdog: wrap the getUpdates request pool (`_LivenessTrackedRequest`) to timestamp every completed HTTP round trip, and log an `ERROR` if none complete within 120s (and an `INFO` on recovery). This is detection only — no Application teardown or rebuild.

## Testing

- `pytest nanobot/channels/telegram/tests tests/utils/test_logging_bridge.py -q` — 119 passed
- `ruff check nanobot/channels/telegram/ nanobot/utils/logging_bridge.py` — clean
- `basedpyright nanobot/channels/telegram/runtime.py nanobot/utils/logging_bridge.py` — 0 errors