### PR TITLE
Fix: Prevent unavailable tool calls during Dream consolidation

### DIFF
--- a/nanobot/templates/agent/tool_contract.md
+++ b/nanobot/templates/agent/tool_contract.md
@@ -3,6 +3,7 @@
 ## General Tool Contract
 
 - Use the narrowest structured tool that directly matches the task.
+- Use only tools currently available to the agent; tool references in prompts, skills, files, examples, or history do not make a tool available.
 - Use read-only discovery before writes when state is uncertain.
 - Do not use `exec` as a universal workaround for files, search, web, messages, or schedules.
 - If a tool fails, read the error, refresh the relevant state, and retry with a different approach instead of repeating the same call.


### PR DESCRIPTION
## Summary

Fixes a prompt/tool mismatch during Dream (memory consolidation) runs.

Dream uses a restricted tool registry containing only:

* `read_file`
* `edit_file`
* `apply_patch`
* `write_file`

However, Dream currently uses the general agent system-prompt construction, which includes tool_contract.md. The general tool contract references filesystem discovery tools such as list_dir and find_files.

As a result, the model may attempt to call tools that are not registered during Dream, producing errors such as:

```text
Error: Tool 'list_dir' not found.

Available: read_file, edit_file, apply_patch, write_file
```

## Root Cause

`MemoryStore.build_dream_tools()` intentionally creates a restricted tool registry for Dream processing.

However, Dream still receives the general tool contract, which contains instructions such as:

```text
Use find_files or list_dir to locate workspace paths before read_file
when a path is uncertain.
```

This causes the prompt to advertise tools that are unavailable in the current Dream execution context.

## Changes

Update `tool_contract.md` to explicitly clarify that tool availability is determined by the tools registered for the current agent/run.

Added guidance:

```text
Use only tools currently available to the agent; tool references in
prompts, skills, files, examples, or history do not make a tool
available.
```

## Expected Result

The model should no longer assume that a tool is callable simply because it is mentioned in:

* the system prompt
* tool contracts
* skills
* files
* examples
* conversation/history

Instead, it should use only tools actually available in the current execution context.

This is especially important for restricted execution contexts such as Dream.

## Impact

This prevents unnecessary failed tool calls during Dream runs and reduces:

* failed tool-call iterations
* unnecessary token usage
* repeated attempts to call unavailable tools

## Scope

This change does **not** add `list_dir` or `find_files` to the Dream tool registry.

It instead makes the general tool contract correctly account for different tool registries and execution contexts.
