### PR TITLE
Restore Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,3 +334,15 @@ Nanobot was started by [Xubin Ren](https://github.com/re-bin) as a personal open
   <em> Thanks for visiting ✨ nanobot!</em><br><br>
   <img src="https://visitor-badge.laobi.icu/badge?page_id=HKUDS.nanobot&style=for-the-badge&color=00d4ff" alt="Views">
 </p>
+
+## ⭐ Star History
+
+<div align="center">
+  <a href="https://star-history.dera.page/#HKUDS/nanobot&Date">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=HKUDS/nanobot&type=Date&theme=dark" />
+      <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=HKUDS/nanobot&type=Date" />
+      <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=HKUDS/nanobot&type=Date" style="border-radius: 15px; box-shadow: 0 0 30px rgba(0, 217, 255, 0.3);" />
+    </picture>
+  </a>
+</div>


### PR DESCRIPTION
It was removed in https://github.com/HKUDS/nanobot/commit/276cbd947f6edc00ca4ec25a0513efaeefe60d53 because Github killed the original project

This new provider revives it and is not subject to recent Github restrictions