### PR TITLE
fix(skills): allow marketplace skills to shadow builtins

### DIFF
--- a/docs/webui.md
+++ b/docs/webui.md
@@ -252,8 +252,9 @@ Open **Skills → Discover** to browse or search skills from skills.sh and
 SkillHub. A marketplace skill is copied into the active agent workspace after
 you confirm the installation. skills.sh installation requires Node.js with
 `npx`; SkillHub installation does not. Installing a marketplace skill with the
-same name as a built-in skill creates a workspace override; removing that
-workspace skill reveals the built-in version again.
+same name as a built-in or plugin-provided skill creates a workspace override;
+removing that workspace skill reveals the original version again without
+silently changing its enabled or disabled state.
 
 Marketplace skills are third-party instructions and may include executable
 scripts. Review the source and instructions before installing one, and enable

--- a/docs/webui.md
+++ b/docs/webui.md
@@ -251,7 +251,9 @@ want.
 Open **Skills → Discover** to browse or search skills from skills.sh and
 SkillHub. A marketplace skill is copied into the active agent workspace after
 you confirm the installation. skills.sh installation requires Node.js with
-`npx`; SkillHub installation does not.
+`npx`; SkillHub installation does not. Installing a marketplace skill with the
+same name as a built-in skill creates a workspace override; removing that
+workspace skill reveals the built-in version again.
 
 Marketplace skills are third-party instructions and may include executable
 scripts. Review the source and instructions before installing one, and enable

--- a/nanobot/webui/skills_api.py
+++ b/nanobot/webui/skills_api.py
@@ -119,12 +119,18 @@ def delete_webui_skill(
     config = load_config()
     original_disabled = list(config.agents.defaults.disabled_skills)
     next_disabled = set(original_disabled)
-    if name in next_disabled:
-        next_disabled.remove(name)
     with tempfile.TemporaryDirectory(prefix=".nanobot-delete-", dir=skills_root) as staging:
         staged_target = Path(staging) / name
         target.replace(staged_target)
         try:
+            fallback_exists = any(
+                item["name"] == name
+                for item in SkillsLoader(workspace_path).list_skills(
+                    filter_unavailable=False,
+                )
+            )
+            if not fallback_exists:
+                next_disabled.discard(name)
             if next_disabled != set(original_disabled):
                 config.agents.defaults.disabled_skills = sorted(next_disabled)
                 save_config(config)

--- a/nanobot/webui/skills_marketplace.py
+++ b/nanobot/webui/skills_marketplace.py
@@ -358,7 +358,7 @@ async def _install_skills_sh_skill(
 
     loader = SkillsLoader(workspace_path)
     existing = {entry["name"]: entry for entry in loader.list_skills(filter_unavailable=False)}
-    if skill_id in existing:
+    if existing.get(skill_id, {}).get("source") == "workspace":
         return {"installed": True, "already_installed": True, "name": skill_id}
 
     workspace = workspace_path.expanduser().resolve()
@@ -447,7 +447,7 @@ async def _install_skillhub_skill(
 
     loader = SkillsLoader(workspace_path)
     existing = {entry["name"]: entry for entry in loader.list_skills(filter_unavailable=False)}
-    if skill_id in existing:
+    if existing.get(skill_id, {}).get("source") == "workspace":
         return {
             "installed": True,
             "already_installed": True,
@@ -744,6 +744,7 @@ def _installed_skill_names(workspace_path: Path) -> set[str]:
     return {
         entry["name"]
         for entry in SkillsLoader(workspace_path).list_skills(filter_unavailable=False)
+        if entry.get("source") == "workspace"
     }
 
 

--- a/tests/webui/test_skills_api.py
+++ b/tests/webui/test_skills_api.py
@@ -128,6 +128,33 @@ def test_delete_webui_skill_only_deletes_workspace_skills(
     assert exc_info.value.status == 403
 
 
+def test_delete_workspace_override_preserves_disabled_builtin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_skill(tmp_path, "github")
+    config = _config("github")
+    saved: list[object] = []
+    monkeypatch.setattr("nanobot.webui.skills_api.load_config", lambda: config)
+    monkeypatch.setattr("nanobot.webui.skills_api.save_config", saved.append)
+    disabled = {"github"}
+
+    action = delete_webui_skill(
+        tmp_path,
+        "github",
+        disabled_skills=disabled,
+    )
+
+    skills = webui_skills_payload(tmp_path, disabled_skills=disabled)["skills"]
+    github = next(skill for skill in skills if skill["name"] == "github")
+    assert action["deleted"] is True
+    assert github["source"] == "builtin"
+    assert github["enabled"] is False
+    assert disabled == {"github"}
+    assert config.agents.defaults.disabled_skills == ["github"]
+    assert saved == []
+
+
 def test_delete_webui_skill_rejects_symlinked_skills_root(
     tmp_path: Path,
 ) -> None:

--- a/tests/webui/test_skills_marketplace.py
+++ b/tests/webui/test_skills_marketplace.py
@@ -7,6 +7,7 @@ from typing import Any
 import httpx
 import pytest
 
+from nanobot.agent.skills import SkillsLoader
 from nanobot.webui.skills_marketplace import (
     SkillsMarketplaceError,
     _valid_skillhub_download_url,
@@ -18,11 +19,19 @@ from nanobot.webui.skills_marketplace import (
 )
 
 
+def _assert_builtin_skill(workspace_path: Path, name: str) -> None:
+    assert any(
+        entry["name"] == name and entry["source"] == "builtin"
+        for entry in SkillsLoader(workspace_path).list_skills(filter_unavailable=False)
+    )
+
+
 @pytest.mark.asyncio
 async def test_search_marketplace_skills_filters_and_marks_installed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _assert_builtin_skill(tmp_path, "github")
     skill_dir = tmp_path / "skills" / "react-testing"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text("---\nname: react-testing\n---\n", encoding="utf-8")
@@ -40,6 +49,12 @@ async def test_search_marketplace_skills_filters_and_marks_installed(
                         "skillId": "react-testing",
                         "source": "acme/agent-skills",
                         "installs": 42,
+                    },
+                    {
+                        "name": "GitHub",
+                        "skillId": "github",
+                        "source": "acme/agent-skills",
+                        "installs": 40,
                     },
                     {"skillId": "../escape", "source": "acme/agent-skills"},
                     {"skillId": "valid-name", "source": "not-a-repository"},
@@ -91,7 +106,19 @@ async def test_search_marketplace_skills_filters_and_marks_installed(
                 "installed": True,
                 "install_supported": True,
                 "metric": "installs_total",
-            }
+            },
+            {
+                "id": "acme/agent-skills/github",
+                "skill_id": "github",
+                "name": "GitHub",
+                "source": "acme/agent-skills",
+                "provider": "skills_sh",
+                "installs": 40,
+                "url": "https://skills.sh/acme/agent-skills/github",
+                "installed": False,
+                "install_supported": True,
+                "metric": "installs_total",
+            },
         ],
     }
 
@@ -368,12 +395,67 @@ async def test_install_marketplace_skill_uses_official_cli_and_workspace(
 
 
 @pytest.mark.asyncio
-async def test_install_skillhub_skill_checks_fingerprint_and_extracts_safely(
+async def test_install_marketplace_skill_can_shadow_builtin(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _assert_builtin_skill(tmp_path, "github")
+    launched = False
+
+    class FakeProcess:
+        returncode = 0
+
+        async def communicate(self) -> tuple[bytes, None]:
+            skill_dir = tmp_path / "skills" / "github"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: github\n---\n",
+                encoding="utf-8",
+            )
+            return b"installed", None
+
+        def kill(self) -> None:
+            raise AssertionError("successful install must not be killed")
+
+    async def create_subprocess_exec(*_command: str, **_kwargs: object) -> FakeProcess:
+        nonlocal launched
+        launched = True
+        return FakeProcess()
+
+    monkeypatch.setattr(
+        "nanobot.webui.skills_marketplace.shutil.which",
+        lambda executable: "/usr/local/bin/npx" if executable == "npx" else None,
+    )
+    monkeypatch.setattr(
+        "nanobot.webui.skills_marketplace.asyncio.create_subprocess_exec",
+        create_subprocess_exec,
+    )
+
+    result = await install_marketplace_skill(
+        "acme/agent-skills",
+        "github",
+        tmp_path,
+    )
+
+    assert launched is True
+    assert result == {
+        "installed": True,
+        "already_installed": False,
+        "name": "github",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("skill_id", ["ima-skills", "github"])
+async def test_install_skillhub_skill_checks_fingerprint_and_extracts_safely(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    skill_id: str,
+) -> None:
+    if skill_id == "github":
+        _assert_builtin_skill(tmp_path, skill_id)
     archive_buffer = io.BytesIO()
-    skill_content = b"---\nname: ima-skills\ndescription: Tencent knowledge skill.\n---\n"
+    skill_content = f"---\nname: {skill_id}\ndescription: Marketplace skill.\n---\n".encode()
     with zipfile.ZipFile(archive_buffer, "w", zipfile.ZIP_DEFLATED) as archive:
         archive.writestr("SKILL.md", skill_content)
         archive.writestr("_meta.json", b'{"version":"1.1.8"}')
@@ -432,13 +514,13 @@ async def test_install_skillhub_skill_checks_fingerprint_and_extracts_safely(
             if url.endswith("/signature"):
                 return FakeResponse(payload={"signed": True, "content_hash": content_hash})
             assert url == "https://api.skillhub.cn/api/v1/download"
-            assert params == {"slug": "ima-skills", "version": "1.1.8"}
+            assert params == {"slug": skill_id, "version": "1.1.8"}
             return FakeResponse(
                 status_code=302,
                 headers={
                     "location": (
                         "https://skillhub-1388575217.cos.accelerate.myqcloud.com/"
-                        "skills/ima-skills.zip"
+                        f"skills/{skill_id}.zip"
                     )
                 },
             )
@@ -451,7 +533,7 @@ async def test_install_skillhub_skill_checks_fingerprint_and_extracts_safely(
             headers: dict[str, str],
         ) -> FakeResponse:
             assert method == "GET"
-            assert url.endswith("/skills/ima-skills.zip")
+            assert url.endswith(f"/skills/{skill_id}.zip")
             assert "application/zip" in headers["Accept"]
             return FakeResponse(
                 headers={"content-length": str(len(archive_bytes))},
@@ -465,7 +547,7 @@ async def test_install_skillhub_skill_checks_fingerprint_and_extracts_safely(
 
     result = await install_marketplace_skill(
         "",
-        "ima-skills",
+        skill_id,
         tmp_path,
         provider="skillhub",
         version="1.1.8",
@@ -474,11 +556,11 @@ async def test_install_skillhub_skill_checks_fingerprint_and_extracts_safely(
     assert result == {
         "installed": True,
         "already_installed": False,
-        "name": "ima-skills",
+        "name": skill_id,
         "provider": "skillhub",
         "version": "1.1.8",
     }
-    assert (tmp_path / "skills" / "ima-skills" / "SKILL.md").read_bytes() == skill_content
+    assert (tmp_path / "skills" / skill_id / "SKILL.md").read_bytes() == skill_content
 
 
 @pytest.mark.parametrize(
@@ -532,6 +614,35 @@ async def test_install_marketplace_skill_is_idempotent(
         "installed": True,
         "already_installed": True,
         "name": "already-here",
+    }
+
+
+@pytest.mark.asyncio
+async def test_install_skillhub_skill_is_idempotent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skill_dir = tmp_path / "skills" / "already-here"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: already-here\n---\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "nanobot.webui.skills_marketplace._skillhub_client",
+        pytest.fail,
+    )
+
+    result = await install_marketplace_skill(
+        "",
+        "already-here",
+        tmp_path,
+        provider="skillhub",
+        version="1.1.8",
+    )
+
+    assert result == {
+        "installed": True,
+        "already_installed": True,
+        "name": "already-here",
+        "provider": "skillhub",
     }
 
 

--- a/webui/src/components/settings/SkillsMarketplace.tsx
+++ b/webui/src/components/settings/SkillsMarketplace.tsx
@@ -66,6 +66,11 @@ export function SkillsMarketplace({
       ),
     [installedSkills],
   );
+  const selectedShadowsInstalled =
+    selected !== null &&
+    installedSkills.some(
+      (skill) => skill.name === selected.skill_id && skill.source !== "workspace",
+    );
   const visibleTrending = useMemo(
     () =>
       provider === "all"
@@ -321,6 +326,14 @@ export function SkillsMarketplace({
                     "This third-party skill comes from {{provider}} ({{source}}) and may include instructions or executable scripts.",
                 })}
               </span>
+              {selectedShadowsInstalled ? (
+                <span className="block rounded-control bg-amber-500/10 px-2.5 py-2 text-amber-800 dark:text-amber-200">
+                  {t("settings.skills.marketplaceOverrideNotice", {
+                    defaultValue:
+                      "This workspace copy will override the existing built-in or plugin skill until you delete it.",
+                  })}
+                </span>
+              ) : null}
               <span className="flex flex-wrap items-center gap-2 rounded-control bg-muted px-2 py-1.5 text-[12px] text-foreground">
                 {selected ? <ProviderMark provider={selected.provider} /> : null}
                 <code>{selected?.source}</code>

--- a/webui/src/components/settings/SkillsMarketplace.tsx
+++ b/webui/src/components/settings/SkillsMarketplace.tsx
@@ -58,7 +58,12 @@ export function SkillsMarketplace({
   const [provider, setProvider] = useState<MarketplaceProvider>("all");
   const [selected, setSelected] = useState<MarketplaceSkillSummary | null>(null);
   const installedNames = useMemo(
-    () => new Set(installedSkills.map((skill) => skill.name)),
+    () =>
+      new Set(
+        installedSkills
+          .filter((skill) => skill.source === "workspace")
+          .map((skill) => skill.name),
+      ),
     [installedSkills],
   );
   const visibleTrending = useMemo(

--- a/webui/src/i18n/locales/en/common.json
+++ b/webui/src/i18n/locales/en/common.json
@@ -958,6 +958,7 @@
       "marketplaceEmpty": "No skills found for “{{query}}”.",
       "marketplaceConfirmTitle": "Install {{name}}?",
       "marketplaceConfirmDescription": "This third-party skill comes from {{provider}} ({{source}}) and may include instructions or executable scripts.",
+      "marketplaceOverrideNotice": "This workspace copy will override the existing built-in or plugin skill until you delete it.",
       "marketplaceConfirmInstall": "Install skill",
       "marketplaceOpen": "Open {{name}} on {{provider}}",
       "marketplaceOpenProvider": "Open {{provider}}",

--- a/webui/src/i18n/locales/es/common.json
+++ b/webui/src/i18n/locales/es/common.json
@@ -945,6 +945,7 @@
       "marketplaceEmpty": "No se encontraron habilidades para “{{query}}”.",
       "marketplaceConfirmTitle": "¿Instalar {{name}}?",
       "marketplaceConfirmDescription": "Esta habilidad de terceros procede de {{provider}} ({{source}}) y puede incluir instrucciones o scripts ejecutables.",
+      "marketplaceOverrideNotice": "Esta copia del espacio de trabajo sustituirá la habilidad integrada o de complemento existente hasta que la elimines.",
       "marketplaceConfirmInstall": "Instalar habilidad",
       "marketplaceOpen": "Abrir {{name}} en {{provider}}",
       "marketplaceOpenProvider": "Abrir {{provider}}",

--- a/webui/src/i18n/locales/fr/common.json
+++ b/webui/src/i18n/locales/fr/common.json
@@ -944,6 +944,7 @@
       "marketplaceEmpty": "Aucune compétence trouvée pour « {{query}} ».",
       "marketplaceConfirmTitle": "Installer {{name}} ?",
       "marketplaceConfirmDescription": "Cette compétence tierce provient de {{provider}} ({{source}}) et peut contenir des instructions ou des scripts exécutables.",
+      "marketplaceOverrideNotice": "Cette copie de l’espace de travail remplacera la compétence intégrée ou fournie par un plugin jusqu’à sa suppression.",
       "marketplaceConfirmInstall": "Installer la compétence",
       "marketplaceOpen": "Ouvrir {{name}} sur {{provider}}",
       "marketplaceOpenProvider": "Ouvrir {{provider}}",

--- a/webui/src/i18n/locales/id/common.json
+++ b/webui/src/i18n/locales/id/common.json
@@ -944,6 +944,7 @@
       "marketplaceEmpty": "Tidak ada keterampilan yang ditemukan untuk “{{query}}”.",
       "marketplaceConfirmTitle": "Pasang {{name}}?",
       "marketplaceConfirmDescription": "Keterampilan pihak ketiga ini berasal dari {{provider}} ({{source}}) dan mungkin berisi instruksi atau skrip yang dapat dijalankan.",
+      "marketplaceOverrideNotice": "Salinan ruang kerja ini akan menimpa keterampilan bawaan atau plugin yang ada hingga Anda menghapusnya.",
       "marketplaceConfirmInstall": "Pasang keterampilan",
       "marketplaceOpen": "Buka {{name}} di {{provider}}",
       "marketplaceOpenProvider": "Buka {{provider}}",

--- a/webui/src/i18n/locales/ja/common.json
+++ b/webui/src/i18n/locales/ja/common.json
@@ -944,6 +944,7 @@
       "marketplaceEmpty": "「{{query}}」に一致するスキルはありません。",
       "marketplaceConfirmTitle": "{{name}} をインストールしますか？",
       "marketplaceConfirmDescription": "このサードパーティ製スキルは {{provider}}（{{source}}）から提供され、指示や実行可能なスクリプトを含む場合があります。",
+      "marketplaceOverrideNotice": "このワークスペースのコピーは、削除するまで既存の組み込みまたはプラグインスキルを上書きします。",
       "marketplaceConfirmInstall": "スキルをインストール",
       "marketplaceOpen": "{{provider}} で {{name}} を開く",
       "marketplaceOpenProvider": "{{provider}} を開く",

--- a/webui/src/i18n/locales/ko/common.json
+++ b/webui/src/i18n/locales/ko/common.json
@@ -944,6 +944,7 @@
       "marketplaceEmpty": "“{{query}}”에 해당하는 스킬이 없습니다.",
       "marketplaceConfirmTitle": "{{name}}을(를) 설치할까요?",
       "marketplaceConfirmDescription": "이 타사 스킬은 {{provider}}({{source}})에서 제공되며 지침이나 실행 가능한 스크립트를 포함할 수 있습니다.",
+      "marketplaceOverrideNotice": "이 워크스페이스 사본은 삭제할 때까지 기존 기본 제공 또는 플러그인 스킬을 재정의합니다.",
       "marketplaceConfirmInstall": "스킬 설치",
       "marketplaceOpen": "{{provider}}에서 {{name}} 열기",
       "marketplaceOpenProvider": "{{provider}} 열기",

--- a/webui/src/i18n/locales/pt-BR/common.json
+++ b/webui/src/i18n/locales/pt-BR/common.json
@@ -958,6 +958,7 @@
       "marketplaceEmpty": "Nenhuma habilidade encontrada para “{{query}}”.",
       "marketplaceConfirmTitle": "Instalar {{name}}?",
       "marketplaceConfirmDescription": "Esta habilidade de terceiros vem de {{provider}} ({{source}}) e pode incluir instruções ou scripts executáveis.",
+      "marketplaceOverrideNotice": "Esta cópia do espaço de trabalho substituirá a habilidade integrada ou de plugin existente até ser excluída.",
       "marketplaceConfirmInstall": "Instalar habilidade",
       "marketplaceOpen": "Abrir {{name}} no {{provider}}",
       "marketplaceOpenProvider": "Abrir {{provider}}",

--- a/webui/src/i18n/locales/vi/common.json
+++ b/webui/src/i18n/locales/vi/common.json
@@ -944,6 +944,7 @@
       "marketplaceEmpty": "Không tìm thấy kỹ năng cho “{{query}}”.",
       "marketplaceConfirmTitle": "Cài đặt {{name}}?",
       "marketplaceConfirmDescription": "Kỹ năng của bên thứ ba này đến từ {{provider}} ({{source}}) và có thể chứa hướng dẫn hoặc tập lệnh thực thi.",
+      "marketplaceOverrideNotice": "Bản sao trong không gian làm việc này sẽ ghi đè kỹ năng tích hợp hoặc kỹ năng từ plugin cho đến khi bạn xóa nó.",
       "marketplaceConfirmInstall": "Cài đặt kỹ năng",
       "marketplaceOpen": "Mở {{name}} trên {{provider}}",
       "marketplaceOpenProvider": "Mở {{provider}}",

--- a/webui/src/i18n/locales/zh-CN/common.json
+++ b/webui/src/i18n/locales/zh-CN/common.json
@@ -958,6 +958,7 @@
       "marketplaceEmpty": "没有找到与“{{query}}”相关的技能。",
       "marketplaceConfirmTitle": "安装 {{name}}？",
       "marketplaceConfirmDescription": "此第三方技能来自 {{provider}}（{{source}}），其中可能包含操作指令或可执行脚本。",
+      "marketplaceOverrideNotice": "此工作区副本会覆盖现有的内置或插件技能，删除该副本后才会恢复原版本。",
       "marketplaceConfirmInstall": "安装技能",
       "marketplaceOpen": "在 {{provider}} 中打开 {{name}}",
       "marketplaceOpenProvider": "打开 {{provider}}",

--- a/webui/src/i18n/locales/zh-TW/common.json
+++ b/webui/src/i18n/locales/zh-TW/common.json
@@ -944,6 +944,7 @@
       "marketplaceEmpty": "找不到與「{{query}}」相關的技能。",
       "marketplaceConfirmTitle": "安裝 {{name}}？",
       "marketplaceConfirmDescription": "此第三方技能來自 {{provider}}（{{source}}），其中可能包含操作指示或可執行腳本。",
+      "marketplaceOverrideNotice": "此工作區副本會覆蓋現有的內建或外掛技能，刪除該副本後才會恢復原版本。",
       "marketplaceConfirmInstall": "安裝技能",
       "marketplaceOpen": "在 {{provider}} 開啟 {{name}}",
       "marketplaceOpenProvider": "開啟 {{provider}}",

--- a/webui/src/tests/i18n.test.tsx
+++ b/webui/src/tests/i18n.test.tsx
@@ -134,6 +134,7 @@ const LOCALIZED_SETTINGS_COPY_KEYS = [
   "settings.skills.marketplaceEmpty",
   "settings.skills.marketplaceConfirmTitle",
   "settings.skills.marketplaceConfirmDescription",
+  "settings.skills.marketplaceOverrideNotice",
   "settings.skills.marketplaceConfirmInstall",
   "settings.skills.marketplaceOpen",
   "settings.skills.marketplaceOpenProvider",

--- a/webui/src/tests/skills-marketplace.test.tsx
+++ b/webui/src/tests/skills-marketplace.test.tsx
@@ -167,7 +167,14 @@ describe("SkillsMarketplace", () => {
 
     await act(async () => {});
 
-    expect(screen.getByRole("button", { name: "Install GitHub" })).toBeEnabled();
+    const install = screen.getByRole("button", { name: "Install GitHub" });
+    expect(install).toBeEnabled();
+    fireEvent.click(install);
+    expect(
+      screen.getByText(
+        "This workspace copy will override the existing built-in or plugin skill until you delete it.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("keeps a marketplace skill disabled when it is installed in the workspace", async () => {

--- a/webui/src/tests/skills-marketplace.test.tsx
+++ b/webui/src/tests/skills-marketplace.test.tsx
@@ -1,8 +1,10 @@
 import { act, fireEvent, render, renderHook, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SkillsMarketplace } from "@/components/settings/SkillsMarketplace";
 import {
+  fetchMarketplaceSkillTrends,
   fetchSkills,
   fetchTrendingMarketplaceSkills,
   searchMarketplaceSkills,
@@ -16,6 +18,7 @@ vi.mock("@/lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/api")>();
   return {
     ...actual,
+    fetchMarketplaceSkillTrends: vi.fn(),
     fetchSkills: vi.fn(),
     fetchTrendingMarketplaceSkills: vi.fn(),
     searchMarketplaceSkills: vi.fn(),
@@ -24,11 +27,14 @@ vi.mock("@/lib/api", async (importOriginal) => {
 
 const client = {} as NanobotClient;
 
-function marketplace(token: string) {
+function marketplace(
+  token: string,
+  installedSkills: ComponentProps<typeof SkillsMarketplace>["installedSkills"] = [],
+) {
   return (
     <ClientProvider client={client} token={token}>
       <SkillsMarketplace
-        installedSkills={[]}
+        installedSkills={installedSkills}
         installing=""
         onInstallingChange={() => {}}
       />
@@ -78,6 +84,9 @@ describe("SkillsMarketplace", () => {
       install_supported: true,
       skills: [],
     });
+    vi.mocked(fetchMarketplaceSkillTrends).mockReset().mockResolvedValue({
+      trends: { "acme/agent-skills/github": [] },
+    });
     vi.mocked(searchMarketplaceSkills).mockReset().mockImplementation(
       async (_token, query) => ({
         query,
@@ -124,5 +133,75 @@ describe("SkillsMarketplace", () => {
     });
     expect(searchMarketplaceSkills).toHaveBeenCalledTimes(2);
     expect(searchMarketplaceSkills).toHaveBeenLastCalledWith("tok-new", "Vue");
+  });
+
+  it("allows a marketplace skill to shadow a built-in skill with the same name", async () => {
+    vi.mocked(fetchTrendingMarketplaceSkills).mockResolvedValueOnce({
+      period: "mixed",
+      provider: "all",
+      install_supported: true,
+      skills: [
+        {
+          id: "acme/agent-skills/github",
+          skill_id: "github",
+          name: "GitHub",
+          source: "acme/agent-skills",
+          provider: "skills_sh",
+          installs: 42,
+          url: "https://skills.sh/acme/agent-skills/github",
+          installed: false,
+          install_supported: true,
+          metric: "installs_total",
+        },
+      ],
+    });
+
+    render(marketplace("tok", [
+      {
+        name: "github",
+        description: "Bundled GitHub skill.",
+        source: "builtin",
+        available: true,
+      },
+    ]));
+
+    await act(async () => {});
+
+    expect(screen.getByRole("button", { name: "Install GitHub" })).toBeEnabled();
+  });
+
+  it("keeps a marketplace skill disabled when it is installed in the workspace", async () => {
+    vi.mocked(fetchTrendingMarketplaceSkills).mockResolvedValueOnce({
+      period: "mixed",
+      provider: "all",
+      install_supported: true,
+      skills: [
+        {
+          id: "acme/agent-skills/github",
+          skill_id: "github",
+          name: "GitHub",
+          source: "acme/agent-skills",
+          provider: "skills_sh",
+          installs: 42,
+          url: "https://skills.sh/acme/agent-skills/github",
+          installed: false,
+          install_supported: true,
+          metric: "installs_total",
+        },
+      ],
+    });
+
+    render(marketplace("tok", [
+      {
+        name: "github",
+        description: "Workspace GitHub skill.",
+        source: "workspace",
+        available: true,
+      },
+    ]));
+
+    await act(async () => {});
+
+    expect(screen.getByRole("button", { name: "Installed GitHub" })).toBeDisabled();
   });
 });


### PR DESCRIPTION
SkillsLoader lets workspace skills override bundled skills with the same name. The Marketplace marked every skill returned by the loader as installed. As a result, a bundled skill such as github disabled the install button, and both install backends returned without installing the workspace copy.

The fix counts a skill as installed by the Marketplace only when its source is workspace. The server applies this rule when it reports and installs Marketplace skills, and the WebUI uses the same check. Existing workspace installs remain idempotent, while skills.sh and SkillHub can install a workspace skill that shadows a bundled skill.

## Tests

- uv run pytest tests/webui/test_skills_marketplace.py: 19 passed, 1 skipped
- uv run ruff check nanobot/webui/skills_marketplace.py tests/webui/test_skills_marketplace.py
- uv run basedpyright: 0 errors, 0 warnings
- cd webui && bun run test src/tests/skills-marketplace.test.tsx: 4 passed
- cd webui && bun run test:coverage
- cd webui && bun run lint
- cd webui && bun run build