### PR TITLE
feat(providers): add OrcaRouter as a named gateway provider

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -123,6 +123,40 @@ appended to nanobot's generated functions. This keeps unrelated local tools such
 available in the same request. Responses-only server tools require an API surface that the
 OpenRouter provider does not currently enable.
 
+### OrcaRouter Gateway
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway. Configure
+the built-in `orcarouter` provider and use a model ID from OrcaRouter's catalog:
+
+```json
+{
+  "providers": {
+    "orcarouter": {
+      "apiKey": "${ORCAROUTER_API_KEY}"
+    }
+  },
+  "modelPresets": {
+    "primary": {
+      "provider": "orcarouter",
+      "model": "orcarouter/auto",
+      "maxTokens": 8192,
+      "contextWindowTokens": 65536
+    }
+  },
+  "agents": {
+    "defaults": {
+      "modelPreset": "primary"
+    }
+  }
+}
+```
+
+Use the model ID exactly as OrcaRouter lists it. `orcarouter/auto` routes to a
+suitable upstream automatically; explicit IDs such as
+`anthropic/claude-sonnet-4.6` or `openai/gpt-5` are also accepted. OrcaRouter API keys start with
+`sk-orca-`. The WebUI can load the account's model catalog after the API key is saved under
+**Settings → Models**.
+
 ### Eden AI Gateway
 
 Eden AI exposes an OpenAI-compatible chat-completions endpoint at

--- a/nanobot/channels/websocket/tests/test_websocket_channel.py
+++ b/nanobot/channels/websocket/tests/test_websocket_channel.py
@@ -3132,6 +3132,10 @@ async def test_settings_api_returns_safe_subset_and_updates_whitelist(
         assert providers["azure_openai"]["api_key_required"] is False  # AAD auth supported; no static key required
         assert providers["openrouter"]["configured"] is False
         assert providers["openrouter"]["api_key_required"] is True
+        assert providers["orcarouter"]["label"] == "OrcaRouter"
+        assert providers["orcarouter"]["configured"] is False
+        assert providers["orcarouter"]["api_key_required"] is True
+        assert providers["orcarouter"]["default_api_base"] == "https://api.orcarouter.ai/v1"
         assert providers["skywork"]["label"] == "Skywork"
         assert providers["skywork"]["default_api_base"] == "https://api.apifree.ai/agent/v1"
         assert providers["ant_ling"]["label"] == "Ant Ling"

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -262,6 +262,7 @@ class ProvidersConfig(Base):
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
     openai: ProviderConfig = Field(default_factory=ProviderConfig)
     openrouter: ProviderConfig = Field(default_factory=ProviderConfig)
+    orcarouter: ProviderConfig = Field(default_factory=ProviderConfig)  # OrcaRouter API gateway
     assemblyai: ProviderConfig = Field(default_factory=ProviderConfig)  # AssemblyAI voice transcription
     huggingface: ProviderConfig = Field(default_factory=ProviderConfig)
     skywork: ProviderConfig = Field(default_factory=ProviderConfig)  # Skywork / APIFree API gateway

--- a/nanobot/providers/factory.py
+++ b/nanobot/providers/factory.py
@@ -49,6 +49,30 @@ def _provider_extra_headers(
     return headers or None
 
 
+def _provider_spec_for_config(
+    provider_name: str,
+    provider_config: ProviderConfig | None,
+) -> ProviderSpec | None:
+    spec = find_by_name(provider_name)
+    if (
+        spec is not None
+        and spec.name == "orcarouter"
+        and provider_config is not None
+        and provider_config.api_base
+        and provider_config.api_base.rstrip("/").lower()
+        != spec.default_api_base.rstrip("/").lower()
+    ):
+        # Before OrcaRouter became a built-in provider, this name was valid for a
+        # dynamic custom provider. Preserve that provider's model-prefix behavior
+        # when an existing config points the name at a different endpoint.
+        return create_dynamic_spec(
+            provider_name,
+            display_name=provider_config.display_name or "",
+            thinking_style=provider_config.thinking_style or "",
+        )
+    return spec
+
+
 def _resolve_provider_setup(
     config: Config,
     *,
@@ -61,7 +85,7 @@ def _resolve_provider_setup(
     p = config.get_provider(model, preset=preset)
     if not provider_name:
         raise ValueError(f"No provider is configured for model '{model}'.")
-    spec = find_by_name(provider_name)
+    spec = _provider_spec_for_config(provider_name, p)
     if not spec and p:
         if not p.api_base:
             raise ValueError(f"Provider '{provider_name}' requires api_base in config.")

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -199,6 +199,18 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         supports_prompt_caching=True,
         gateway_reasoning_style="reasoning_effort",
     ),
+    # OrcaRouter: global gateway, keys start with "sk-orca-"
+    ProviderSpec(
+        name="orcarouter",
+        keywords=("orcarouter",),
+        env_key="ORCAROUTER_API_KEY",
+        display_name="OrcaRouter",
+        backend="openai_compat",
+        is_gateway=True,
+        detect_by_key_prefix="sk-orca-",
+        detect_by_base_keyword="orcarouter",
+        default_api_base="https://api.orcarouter.ai/v1",
+    ),
     # Eden AI: OpenAI-compatible gateway. Models use the "provider/model"
     # naming scheme (e.g. "anthropic/claude-sonnet-4-5"); the full id is sent upstream.
     ProviderSpec(

--- a/tests/providers/test_orcarouter_provider.py
+++ b/tests/providers/test_orcarouter_provider.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 from nanobot.config.schema import Config, ProvidersConfig
+from nanobot.providers.factory import make_provider
 from nanobot.providers.openai_compat_provider import OpenAICompatProvider
 from nanobot.providers.registry import PROVIDERS, find_by_name
 
@@ -55,7 +56,7 @@ def test_orcarouter_forced_provider_uses_default_api_base() -> None:
     assert config.get_api_base("deepseek/deepseek-chat") == "https://api.orcarouter.ai/v1"
 
 
-def test_orcarouter_gateway_routes_unprefixed_models_when_configured() -> None:
+def test_orcarouter_gateway_routes_auto_model_when_configured() -> None:
     config = Config.model_validate({
         "providers": {
             "orcarouter": {
@@ -72,6 +73,39 @@ def test_orcarouter_gateway_routes_unprefixed_models_when_configured() -> None:
     assert config.get_provider_name("orcarouter/auto") == "orcarouter"
     assert config.get_api_key("orcarouter/auto") == "sk-orca-test-key"
     assert config.get_api_base("orcarouter/auto") == "https://api.orcarouter.ai/v1"
+
+
+def test_legacy_custom_provider_named_orcarouter_keeps_prefix_stripping() -> None:
+    config = Config.model_validate({
+        "providers": {
+            "orcarouter": {
+                "apiKey": "legacy-test-key",
+                "apiBase": "https://legacy-gateway.example/v1",
+            },
+        },
+        "agents": {
+            "defaults": {
+                "model": "orcarouter/custom-model",
+                "provider": "orcarouter",
+            },
+        },
+    })
+
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        provider = make_provider(config)
+
+    assert isinstance(provider, OpenAICompatProvider)
+    assert provider.api_base == "https://legacy-gateway.example/v1"
+    kwargs = provider._build_kwargs(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        model="orcarouter/custom-model",
+        max_tokens=1024,
+        temperature=0.7,
+        reasoning_effort=None,
+        tool_choice=None,
+    )
+    assert kwargs["model"] == "custom-model"
 
 
 def test_orcarouter_preserves_model_api_id() -> None:

--- a/tests/providers/test_orcarouter_provider.py
+++ b/tests/providers/test_orcarouter_provider.py
@@ -1,0 +1,98 @@
+"""Tests for the OrcaRouter provider registration."""
+
+from unittest.mock import patch
+
+from nanobot.config.schema import Config, ProvidersConfig
+from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+from nanobot.providers.registry import PROVIDERS, find_by_name
+
+
+def test_orcarouter_config_field_exists() -> None:
+    config = ProvidersConfig()
+
+    assert hasattr(config, "orcarouter")
+
+
+def test_orcarouter_provider_in_registry() -> None:
+    specs = {spec.name: spec for spec in PROVIDERS}
+
+    assert "orcarouter" in specs
+    orcarouter = specs["orcarouter"]
+    assert orcarouter.backend == "openai_compat"
+    assert orcarouter.env_key == "ORCAROUTER_API_KEY"
+    assert orcarouter.display_name == "OrcaRouter"
+    assert orcarouter.is_gateway is True
+    assert orcarouter.detect_by_key_prefix == "sk-orca-"
+    assert orcarouter.detect_by_base_keyword == "orcarouter"
+    assert orcarouter.default_api_base == "https://api.orcarouter.ai/v1"
+    assert orcarouter.strip_model_prefix is False
+
+
+def test_find_by_name_orcarouter() -> None:
+    spec = find_by_name("orcarouter")
+
+    assert spec is not None
+    assert spec.name == "orcarouter"
+
+
+def test_orcarouter_forced_provider_uses_default_api_base() -> None:
+    config = Config.model_validate({
+        "providers": {
+            "orcarouter": {
+                "apiKey": "sk-orca-test-key",
+            },
+        },
+        "agents": {
+            "defaults": {
+                "model": "deepseek/deepseek-chat",
+                "provider": "orcarouter",
+            },
+        },
+    })
+
+    assert config.get_provider_name("deepseek/deepseek-chat") == "orcarouter"
+    assert config.get_api_key("deepseek/deepseek-chat") == "sk-orca-test-key"
+    assert config.get_api_base("deepseek/deepseek-chat") == "https://api.orcarouter.ai/v1"
+
+
+def test_orcarouter_gateway_routes_unprefixed_models_when_configured() -> None:
+    config = Config.model_validate({
+        "providers": {
+            "orcarouter": {
+                "apiKey": "sk-orca-test-key",
+            },
+        },
+        "agents": {
+            "defaults": {
+                "model": "orcarouter/auto",
+            },
+        },
+    })
+
+    assert config.get_provider_name("orcarouter/auto") == "orcarouter"
+    assert config.get_api_key("orcarouter/auto") == "sk-orca-test-key"
+    assert config.get_api_base("orcarouter/auto") == "https://api.orcarouter.ai/v1"
+
+
+def test_orcarouter_preserves_model_api_id() -> None:
+    spec = find_by_name("orcarouter")
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        provider = OpenAICompatProvider(
+            api_key="sk-orca-test-key",
+            default_model="anthropic/claude-sonnet-4.6",
+            spec=spec,
+        )
+
+    kwargs = provider._build_kwargs(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        model="anthropic/claude-sonnet-4.6",
+        max_tokens=1024,
+        temperature=0.7,
+        reasoning_effort=None,
+        tool_choice=None,
+    )
+
+    assert kwargs["model"] == "anthropic/claude-sonnet-4.6"
+    assert kwargs["max_tokens"] == 1024
+    assert "max_completion_tokens" not in kwargs

--- a/tests/webui/test_settings_api.py
+++ b/tests/webui/test_settings_api.py
@@ -111,6 +111,26 @@ def test_settings_payload_exposes_edenai_provider(
     assert edenai["model_selectable"] is True
 
 
+def test_settings_payload_exposes_orcarouter_provider(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config()
+    config.providers.orcarouter.api_key = "sk-orca-test"
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    payload = settings_payload()
+    orcarouter = next(row for row in payload["providers"] if row["name"] == "orcarouter")
+
+    assert orcarouter["label"] == "OrcaRouter"
+    assert orcarouter["configured"] is True
+    assert orcarouter["default_api_base"] == "https://api.orcarouter.ai/v1"
+    assert orcarouter["model_catalog"] == "catalog"
+    assert orcarouter["model_selectable"] is True
+
+
 def test_settings_payload_includes_relocated_capabilities(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1958,10 +1978,47 @@ def test_provider_models_payload_requires_gateway_key(
     assert payload["models"] == []
 
 
+def test_provider_models_payload_fetches_orcarouter_catalog(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config()
+    config.providers.orcarouter.api_key = "sk-orca-test"
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    def fake_get(url: str, **kwargs):
+        assert url == "https://api.orcarouter.ai/v1/models"
+        assert kwargs["headers"]["Authorization"] == "Bearer sk-orca-test"
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {"id": "orcarouter/auto", "owned_by": "orcarouter"},
+                    {"id": "anthropic/claude-sonnet-4.6", "owned_by": "anthropic"},
+                ]
+            },
+            request=httpx.Request("GET", url),
+        )
+
+    monkeypatch.setattr("nanobot.webui.settings_api.httpx.get", fake_get)
+
+    payload = provider_models_payload({"provider": ["orcarouter"]})
+
+    assert payload["status"] == "available"
+    assert payload["catalog_kind"] == "catalog"
+    assert [model["id"] for model in payload["models"]] == [
+        "orcarouter/auto",
+        "anthropic/claude-sonnet-4.6",
+    ]
+
+
 def test_model_catalog_kind_uses_provider_spec_metadata() -> None:
     assert _model_catalog_kind(find_by_name("skywork")) == "official"
     assert _model_catalog_kind(find_by_name("anthropic")) == "unsupported"
     assert _model_catalog_kind(find_by_name("openrouter")) == "catalog"
+    assert _model_catalog_kind(find_by_name("orcarouter")) == "catalog"
     assert _model_catalog_kind(find_by_name("openai_codex")) == "builtin"
 
 

--- a/webui/src/components/settings/shared/ModelControls.tsx
+++ b/webui/src/components/settings/shared/ModelControls.tsx
@@ -52,6 +52,7 @@ const DEFERRED_MODEL_LIST_PROVIDERS = new Set([
   "novita",
   "ollama",
   "openrouter",
+  "orcarouter",
   "ovms",
   "siliconflow",
   "vllm",
@@ -577,6 +578,7 @@ export function optionRowsWithCurrent(
 export const PROVIDER_ICONS: Record<string, LucideIcon> = {
   custom: Hexagon,
   openrouter: Sparkles,
+  orcarouter: Sparkles,
   skywork: Sparkles,
   aihubmix: Triangle,
   anthropic: Brain,

--- a/webui/src/lib/provider-brand.ts
+++ b/webui/src/lib/provider-brand.ts
@@ -184,6 +184,7 @@ const PROVIDER_BRANDS: Record<string, ProviderBrand> = {
   ollama: brand("ollama.com", "#111827", "O"),
   openai: brand("openai.com", "#111827", "AI"),
   openrouter: brand("openrouter.ai", "#111827", "OR"),
+  orcarouter: brand("orcarouter.ai", "#111827", "OR"),
   ovms: brand("openvino.ai", "#0071C5", "OV"),
   qianfan: brand("cloud.baidu.com", "#2932E1", "QF"),
   searxng: brand("searxng.org", "#3050FF", "SX"),

--- a/webui/src/tests/settings-models.test.tsx
+++ b/webui/src/tests/settings-models.test.tsx
@@ -1003,6 +1003,90 @@ describe("Settings models", () => {
     ).toBe(false);
   });
 
+  it("defers the OrcaRouter catalog until the user searches", async () => {
+    const base = settingsPayload();
+    const payload: SettingsPayload = {
+      ...base,
+      agent: {
+        ...base.agent,
+        model: "orcarouter/auto",
+        provider: "orcarouter",
+        resolved_provider: "orcarouter",
+      },
+      model_presets: [
+        {
+          ...base.model_presets[0],
+          model: "orcarouter/auto",
+          provider: "orcarouter",
+          resolved_provider: "orcarouter",
+        },
+      ],
+      providers: [
+        {
+          name: "orcarouter",
+          label: "OrcaRouter",
+          configured: true,
+          auth_type: "api_key",
+          api_key_required: true,
+          api_key_hint: "sk-o••••test",
+          api_base: null,
+          default_api_base: "https://api.orcarouter.ai/v1",
+          model_catalog: "catalog",
+        },
+      ],
+    };
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/settings") return jsonResponse(payload);
+      if (url === "/api/settings/cli-apps") {
+        return jsonResponse({ apps: [], installed_count: 0 });
+      }
+      if (url === "/api/settings/mcp-presets") {
+        return jsonResponse({ presets: [], installed_count: 0 });
+      }
+      if (url === "/api/settings/provider-models?provider=orcarouter") {
+        return jsonResponse({
+          provider: "orcarouter",
+          label: "OrcaRouter",
+          status: "available",
+          catalog_kind: "catalog",
+          models: [
+            { id: "orcarouter/auto", owned_by: "orcarouter" },
+            { id: "anthropic/claude-sonnet-4.6", owned_by: "anthropic" },
+          ],
+          model_count: 2,
+          fetched_at: 1,
+        });
+      }
+      return { ok: false, status: 404, json: async () => ({}) } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderSettingsView({ initialSection: "models" });
+
+    await togglePresetEditor();
+    const modelButtons = await screen.findAllByRole("button", { name: /orcarouter\/auto/i });
+    await openPopover(modelButtons[modelButtons.length - 1]);
+    expect(await screen.findByText("Search provider catalog to choose a model.")).toBeInTheDocument();
+    expect(
+      fetchMock.mock.calls.some(([input]) =>
+        String(input).startsWith("/api/settings/provider-models"),
+      ),
+    ).toBe(false);
+
+    fireEvent.change(screen.getByPlaceholderText("Search or type model ID"), {
+      target: { value: "cl" },
+    });
+
+    await screen.findByText("anthropic/claude-sonnet-4.6");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/settings/provider-models?provider=orcarouter",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer tok" },
+      }),
+    );
+  });
+
   it("loads curated models for configured OAuth providers", async () => {
     const base = settingsPayload();
     const payload: SettingsPayload = {


### PR DESCRIPTION
## What

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway that brings 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint and API key. Beyond routing, it runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. This PR registers it as a named provider so users can opt in directly.

I'm an engineer on the OrcaRouter team.

## Changes

- **`nanobot/providers/registry.py`** — adds an `orcarouter` `ProviderSpec` right after the `openrouter` gateway entry, mirroring it: `backend="openai_compat"`, `is_gateway=True`, `env_key="ORCAROUTER_API_KEY"`, `detect_by_key_prefix="sk-orca-"`, `detect_by_base_keyword="orcarouter"`, `default_api_base="https://api.orcarouter.ai/v1"`. Because `PROVIDERS` is the single source of truth, the provider automatically appears in `nanobot status`, Quick Start, Settings, and the WebUI model picker.
- **`nanobot/config/schema.py`** — adds the matching `orcarouter` field to `ProvidersConfig`, so `providers.orcarouter.apiKey` / `apiBase` config is recognized (no custom-provider fallback needed).
- **`webui/src/components/settings/SettingsView.tsx`** — adds `orcarouter` to `DEFERRED_MODEL_LIST_PROVIDERS` (gateway catalog loads on demand) and to `PROVIDER_ICONS`.
- **`webui/src/lib/provider-brand.ts`** — adds the `orcarouter` brand row.
- **`docs/providers.md`** — adds an **OrcaRouter Gateway** section (config JSON + `orcarouter/auto` / explicit `provider/model` IDs), mirroring the OpenRouter section.
- **Tests** — new `tests/providers/test_orcarouter_provider.py` (6 tests: registry spec, `find_by_name`, config field, forced provider uses default base URL, gateway routes unprefixed models, model API id preserved). Also asserts OrcaRouter in the websocket Settings payload test.

## Verification

- `pytest tests/providers/ tests/config/` → 1048 passed, 1 skipped.
- `pytest tests/cli/test_commands.py tests/agent/test_onboard_logic.py tests/agent/test_runtime_refresh.py tests/providers/test_litellm_kwargs.py` → 398 passed, 1 skipped.
- `pytest "nanobot/channels/websocket/tests/test_websocket_channel.py::test_settings_api_returns_safe_subset_and_updates_whitelist"` → passed (Settings payload includes OrcaRouter).
- `ruff check` on all changed files → clean.
- Live L3 through the real provider path with a real key: `OpenAICompatProvider` + `orcarouter` spec → `orcarouter/auto` returns `PONG` (HTTP 200); `anthropic/claude-sonnet-4.6` returns `PONG` (HTTP 200); wrong key → `401 Invalid token` (fails loud).
