### PR TITLE
test(webui): await lazy settings import deterministically

### DIFF
--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -441,8 +441,12 @@ describe("App layout", () => {
     const sidebar = screen.getByRole("navigation", { name: "Sidebar navigation" });
     fireEvent.click(within(sidebar).getByRole("button", { name: "Settings" }));
 
+    await act(async () => {
+      await import("@/components/settings/SettingsView");
+    });
+
     expect(
-      await screen.findByRole("navigation", { name: "Settings sections" }),
+      screen.getByRole("navigation", { name: "Settings sections" }),
     ).toBeInTheDocument();
     expect(container.querySelectorAll("main")).toHaveLength(1);
     expect(screen.getByRole("heading", { level: 1, name: "Settings" })).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- await the actual `SettingsView` dynamic import inside `act()` after clicking Settings
- switch the post-import navigation assertion to a synchronous query
- keep production lazy loading, global test configuration, and timeout values unchanged

## Context

This fixes the single WebUI coverage failure from the post-merge `main` run: https://github.com/HKUDS/nanobot/actions/runs/31461689179/job/93687181810

The previous assertion relied on Testing Library's default one-second polling deadline. The same test took about 1.50 seconds in a focused run and 2.77 seconds under coverage, so increasing the deadline would only make the timing dependency less visible. Waiting for the exact dynamic import makes the synchronization deterministic without adding a fixed delay.

## Verification

- focused `app-layout` regression test: PASS
- `bun run test:coverage`: PASS (59 files, 986 tests)
- `bun run lint`: PASS
- `bun run build`: PASS
- real gateway/browser smoke: Settings route, navigation, unique `main`, and `Settings` heading PASS before and after refresh; 0 console errors/warnings; clean teardown
- candidate gates: `simplify`, `verify`, `candidate-review` PASS

## Risk

Low. The change is isolated to one existing test and does not alter production behavior.
