### PR TITLE
fix(channels): preserve indentation across message splits

### DIFF
--- a/nanobot/channels/signal/runtime.py
+++ b/nanobot/channels/signal/runtime.py
@@ -269,19 +269,18 @@ def _partition_styles(
     if not text_styles:
         return [[] for _ in chunks]
 
-    # Locate each chunk's UTF-16 start in plain_text. split_message lstrips at
-    # boundaries (but not before the first chunk), so we skip whitespace
-    # between chunks to mirror that.
+    # Locate each chunk in the original text. This accounts for delimiters
+    # removed at split points while retaining indentation inside a chunk.
     chunk_ranges: list[tuple[int, int]] = []
     cursor = 0  # Python codepoint cursor in plain_text
-    for i, chunk in enumerate(chunks):
-        if i > 0:
-            while cursor < len(plain_text) and plain_text[cursor].isspace():
-                cursor += 1
-        utf16_start = _utf16_len(plain_text[:cursor])
+    for chunk in chunks:
+        chunk_start = plain_text.find(chunk, cursor)
+        if chunk_start < 0:
+            chunk_start = cursor
+        utf16_start = _utf16_len(plain_text[:chunk_start])
         utf16_end = utf16_start + _utf16_len(chunk)
         chunk_ranges.append((utf16_start, utf16_end))
-        cursor += len(chunk)
+        cursor = chunk_start + len(chunk)
 
     result: list[list[str]] = [[] for _ in chunks]
     for entry in text_styles:

--- a/nanobot/channels/signal/tests/test_signal_markdown.py
+++ b/nanobot/channels/signal/tests/test_signal_markdown.py
@@ -384,6 +384,15 @@ def test_partition_styles_drops_styles_outside_chunks():
     assert parts == [[], []]
 
 
+def test_partition_styles_keeps_offset_in_indented_chunk():
+    """Styles after preserved indentation remain relative to the chunk."""
+    plain = "header\n    code"
+    chunks = split_message(plain, 10)
+
+    assert chunks == ["header", "    code"]
+    assert _partition_styles(plain, chunks, ["11:4:BOLD"]) == [[], ["4:4:BOLD"]]
+
+
 def test_partition_styles_long_message_preserves_chunk_one_styles():
     """A bold span deep in the message must follow the message into chunk 1."""
     # Two ~30-char paragraphs separated by a blank line, then **tail**.

--- a/nanobot/channels/signal/tests/test_signal_markdown.py
+++ b/nanobot/channels/signal/tests/test_signal_markdown.py
@@ -393,6 +393,14 @@ def test_partition_styles_keeps_offset_in_indented_chunk():
     assert _partition_styles(plain, chunks, ["11:4:BOLD"]) == [[], ["4:4:BOLD"]]
 
 
+def test_partition_styles_keeps_offset_after_crlf_boundary():
+    plain = "header\r\n    code"
+    chunks = split_message(plain, 10)
+
+    assert chunks == ["header", "    code"]
+    assert _partition_styles(plain, chunks, ["12:4:BOLD"]) == [[], ["4:4:BOLD"]]
+
+
 def test_partition_styles_long_message_preserves_chunk_one_styles():
     """A bold span deep in the message must follow the message into chunk 1."""
     # Two ~30-char paragraphs separated by a blank line, then **tail**.

--- a/nanobot/channels/signal/tests/test_signal_markdown.py
+++ b/nanobot/channels/signal/tests/test_signal_markdown.py
@@ -391,6 +391,15 @@ def test_partition_styles_drops_styles_outside_chunks():
     assert parts == [[], []]
 
 
+def test_partition_styles_keeps_offset_in_indented_chunk():
+    """Styles after preserved indentation remain relative to the chunk."""
+    plain = "header\n    code"
+    chunks = split_message(plain, 10)
+
+    assert chunks == ["header", "    code"]
+    assert _partition_styles(plain, chunks, ["11:4:BOLD"]) == [[], ["4:4:BOLD"]]
+
+
 def test_partition_styles_long_message_preserves_chunk_one_styles():
     """A bold span deep in the message must follow the message into chunk 1."""
     # Two ~30-char paragraphs separated by a blank line, then **tail**.

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -639,14 +639,23 @@ def split_message(content: str, max_len: int = 2000) -> list[str]:
             chunks.append(content)
             break
         cut = content[:max_len]
-        # Try to break at newline first, then space, then hard break
-        pos = cut.rfind("\n")
-        if pos <= 0:
-            pos = cut.rfind(" ")
-        if pos <= 0:
-            pos = max_len
-        chunks.append(content[:pos])
-        content = content[pos:].lstrip()
+        # Consume only the newline itself so indentation starts the next chunk.
+        newline_pos = cut.rfind("\n")
+        if newline_pos > 0:
+            chunks.append(content[:newline_pos])
+            content = content[newline_pos + 1 :]
+            continue
+
+        # Keep the existing word-boundary behavior, but avoid emitting a
+        # whitespace-only chunk when an indented line exceeds max_len.
+        space_pos = cut.rfind(" ")
+        if space_pos > 0 and cut[:space_pos].strip():
+            chunks.append(content[:space_pos])
+            content = content[space_pos:].lstrip()
+            continue
+
+        chunks.append(content[:max_len])
+        content = content[max_len:]
     return chunks
 
 

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -633,6 +633,7 @@ def split_message(content: str, max_len: int = 2000) -> list[str]:
         return [content]
     if len(content) <= max_len:
         return [content]
+    original_content = content
     chunks: list[str] = []
     while content:
         if len(content) <= max_len:
@@ -642,8 +643,14 @@ def split_message(content: str, max_len: int = 2000) -> list[str]:
         cut = content[:max_len]
         # Consume only the newline itself so indentation starts the next chunk.
         newline_pos = cut.rfind("\n")
-        if newline_pos > 0:
-            chunks.append(content[:newline_pos])
+        if newline_pos >= 0:
+            # Exclude both bytes of a CRLF boundary from the emitted chunk.
+            line_end = newline_pos
+            if line_end > 0 and content[line_end - 1] == "\r":
+                line_end -= 1
+            chunk = content[:line_end]
+            if chunk.strip():
+                chunks.append(chunk)
             content = content[newline_pos + 1 :]
             continue
 
@@ -652,11 +659,31 @@ def split_message(content: str, max_len: int = 2000) -> list[str]:
         space_pos = cut.rfind(" ")
         if space_pos > 0 and cut[:space_pos].strip():
             chunks.append(content[:space_pos])
-            content = content[space_pos:].lstrip()
+            content = content[space_pos:].lstrip(" \t")
+            # A space boundary may sit immediately before a line break. Drop
+            # that delimiter too, without stripping the next line's indent.
+            if content.startswith("\r\n"):
+                content = content[2:]
+            elif content.startswith("\n"):
+                content = content[1:]
             continue
 
-        chunks.append(content[:max_len])
+        # Do not split between the two code points of a CRLF delimiter.
+        if cut.endswith("\r") and content[max_len : max_len + 1] == "\n":
+            chunk = cut[:-1]
+            if chunk.strip():
+                chunks.append(chunk)
+            content = content[max_len + 1 :]
+            continue
+
+        chunk = content[:max_len]
+        if chunk.strip():
+            chunks.append(chunk)
         content = content[max_len:]
+        if not chunk.strip():
+            # Keep any remaining indentation so the final non-blank chunk can
+            # retain as much of it as the channel limit permits.
+            continue
         # A delimiter can sit immediately after the hard-break boundary. Keep
         # ordinary space trimming, but consume only the newline so indentation
         # on the following line is preserved.
@@ -665,7 +692,10 @@ def split_message(content: str, max_len: int = 2000) -> list[str]:
             content = content[2:]
         elif content.startswith("\n"):
             content = content[1:]
-    return chunks
+    # Preserve the historical non-empty-input contract for callers that take
+    # the first chunk directly. This fallback is only reachable for content
+    # made entirely of whitespace.
+    return chunks or [original_content[:max_len]]
 
 
 def build_assistant_message(

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -636,7 +636,8 @@ def split_message(content: str, max_len: int = 2000) -> list[str]:
     chunks: list[str] = []
     while content:
         if len(content) <= max_len:
-            chunks.append(content)
+            if content.strip():
+                chunks.append(content)
             break
         cut = content[:max_len]
         # Consume only the newline itself so indentation starts the next chunk.
@@ -656,6 +657,14 @@ def split_message(content: str, max_len: int = 2000) -> list[str]:
 
         chunks.append(content[:max_len])
         content = content[max_len:]
+        # A delimiter can sit immediately after the hard-break boundary. Keep
+        # ordinary space trimming, but consume only the newline so indentation
+        # on the following line is preserved.
+        content = content.lstrip(" \t")
+        if content.startswith("\r\n"):
+            content = content[2:]
+        elif content.startswith("\n"):
+            content = content[1:]
     return chunks
 
 

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -634,14 +634,23 @@ def split_message(content: str, max_len: int = 2000) -> list[str]:
             chunks.append(content)
             break
         cut = content[:max_len]
-        # Try to break at newline first, then space, then hard break
-        pos = cut.rfind("\n")
-        if pos <= 0:
-            pos = cut.rfind(" ")
-        if pos <= 0:
-            pos = max_len
-        chunks.append(content[:pos])
-        content = content[pos:].lstrip()
+        # Consume only the newline itself so indentation starts the next chunk.
+        newline_pos = cut.rfind("\n")
+        if newline_pos > 0:
+            chunks.append(content[:newline_pos])
+            content = content[newline_pos + 1 :]
+            continue
+
+        # Keep the existing word-boundary behavior, but avoid emitting a
+        # whitespace-only chunk when an indented line exceeds max_len.
+        space_pos = cut.rfind(" ")
+        if space_pos > 0 and cut[:space_pos].strip():
+            chunks.append(content[:space_pos])
+            content = content[space_pos:].lstrip()
+            continue
+
+        chunks.append(content[:max_len])
+        content = content[max_len:]
     return chunks
 
 

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -631,7 +631,8 @@ def split_message(content: str, max_len: int = 2000) -> list[str]:
     chunks: list[str] = []
     while content:
         if len(content) <= max_len:
-            chunks.append(content)
+            if content.strip():
+                chunks.append(content)
             break
         cut = content[:max_len]
         # Consume only the newline itself so indentation starts the next chunk.
@@ -651,6 +652,14 @@ def split_message(content: str, max_len: int = 2000) -> list[str]:
 
         chunks.append(content[:max_len])
         content = content[max_len:]
+        # A delimiter can sit immediately after the hard-break boundary. Keep
+        # ordinary space trimming, but consume only the newline so indentation
+        # on the following line is preserved.
+        content = content.lstrip(" \t")
+        if content.startswith("\r\n"):
+            content = content[2:]
+        elif content.startswith("\n"):
+            content = content[1:]
     return chunks
 
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -29,6 +29,23 @@ def test_split_message_preserves_indentation_across_hard_break():
     assert split_message(content, max_len=8) == ["head", "    abcd", "efghij"]
 
 
+def test_split_message_preserves_indentation_when_newline_is_at_hard_break():
+    content = "abcdefgh\n    code"
+
+    assert split_message(content, max_len=8) == ["abcdefgh", "    code"]
+    assert split_message(content.replace("\n", "\r\n"), max_len=8) == [
+        "abcdefgh",
+        "    code",
+    ]
+
+
+def test_split_message_drops_whitespace_only_tail_after_hard_break():
+    prefix = "abcdefgh"
+
+    assert split_message(prefix + "\n", max_len=8) == [prefix]
+    assert split_message(prefix + " ", max_len=8) == [prefix]
+
+
 def test_split_message_nonpositive_maxlen_returns_unsplit():
     content = "alpha beta gamma delta"
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -17,6 +17,18 @@ def test_split_message_no_code_blocks_unchanged():
     assert split_message(content, max_len=12) == ["alpha beta", "gamma delta"]
 
 
+def test_split_message_preserves_indentation_after_newline():
+    content = "header\n    indented code"
+
+    assert split_message(content, max_len=18) == ["header", "    indented code"]
+
+
+def test_split_message_preserves_indentation_across_hard_break():
+    content = "head\n    abcdefghij"
+
+    assert split_message(content, max_len=8) == ["head", "    abcd", "efghij"]
+
+
 def test_split_message_nonpositive_maxlen_returns_unsplit():
     content = "alpha beta gamma delta"
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -39,11 +39,53 @@ def test_split_message_preserves_indentation_when_newline_is_at_hard_break():
     ]
 
 
+def test_split_message_handles_crlf_before_hard_break():
+    content = "header\r\n    indented code"
+
+    assert split_message(content, max_len=18) == ["header", "    indented code"]
+    assert split_message("abcdefg\r\n    code", max_len=8) == [
+        "abcdefg",
+        "    code",
+    ]
+
+
+def test_split_message_preserves_indent_after_space_then_newline_boundary():
+    content = "abcdef \n    code"
+
+    assert split_message(content, max_len=7) == ["abcdef", "    cod", "e"]
+    assert split_message(content.replace("\n", "\r\n"), max_len=7) == [
+        "abcdef",
+        "    cod",
+        "e",
+    ]
+
+
+def test_split_message_drops_blank_chunks_from_long_indentation():
+    content = "head\n" + " " * 20 + "x"
+
+    chunks = split_message(content, max_len=8)
+
+    assert chunks == ["head", "    x"]
+    assert all(chunk.strip() for chunk in chunks)
+
+
+def test_split_message_drops_whitespace_only_line_at_boundary():
+    content = "    \nhello world"
+
+    assert split_message(content, max_len=8) == ["hello", "world"]
+
+
 def test_split_message_drops_whitespace_only_tail_after_hard_break():
     prefix = "abcdefgh"
 
     assert split_message(prefix + "\n", max_len=8) == [prefix]
     assert split_message(prefix + " ", max_len=8) == [prefix]
+
+
+def test_split_message_keeps_one_chunk_for_all_whitespace_input():
+    content = " " * 10
+
+    assert split_message(content, max_len=4) == [" " * 4]
 
 
 def test_split_message_nonpositive_maxlen_returns_unsplit():


### PR DESCRIPTION
## Summary

- preserve indentation after newline-based message splits
- avoid whitespace-only chunks when an indented line requires a hard split
- keep Signal UTF-16 style offsets aligned with the actual emitted chunks

## Root cause

`split_message` used `lstrip()` after every boundary. When a long response was split at a newline, that removed both the delimiter and all indentation from the next line. Signal's style partitioner also assumed every boundary stripped all whitespace, so preserving indentation without updating the mapper would shift rich-text offsets.

The fix consumes only the selected newline, keeps the existing ordinary space-boundary behavior, and locates Signal chunks sequentially in the original text.

## Validation

- `python -m pytest tests/utils/test_helpers.py nanobot/channels/signal/tests/test_signal_markdown.py nanobot/channels/signal/tests/test_signal_channel.py::TestSend::test_send_split_message_redistributes_text_styles nanobot/channels/mattermost/tests/test_mattermost_channel.py::test_message_splitting -q` - 64 passed
- `python -m ruff check` on all four changed files - passed
- randomized check across 2,000 inputs and five chunk limits - chunk bounds and progress passed
- `python -m pytest -q` - collection blocked in the local environment because `watchfiles` is not installed; no full-suite result claimed
