### PR TITLE
fix(providers): preserve nanobot tools with OpenRouter server tools

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -330,7 +330,11 @@ By default, OpenAI uses `apiType: "auto"`: nanobot calls Chat Completions normal
 
 Valid `apiType` values are exactly `auto`, `chat_completions`, and `responses`.
 
-`extraBody` follows the selected OpenAI API surface. With Chat Completions, nanobot passes it through as the SDK `extra_body` value. With Responses, configure it in Responses API body shape; nanobot merges ordinary top-level fields into the Responses request body, appends `extraBody.tools` after generated function tools, and merges `extraBody.include` without duplicates:
+`extraBody` follows the selected OpenAI API surface. With Chat Completions, nanobot passes
+ordinary fields through as the SDK `extra_body` value; list-valued `extraBody.tools` is handled
+specially and appended after generated function tools. With Responses, configure it in Responses
+API body shape; nanobot merges ordinary top-level fields into the Responses request body, appends
+`extraBody.tools` after generated function tools, and merges `extraBody.include` without duplicates:
 
 ```json
 {

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -117,9 +117,11 @@ To opt into OpenRouter server-managed search and fetch, add:
 }
 ```
 
-OpenRouter [server tools](https://openrouter.ai/docs/guides/features/server-tools) configured
-through `extraBody.tools` are appended to nanobot's generated Chat Completions functions. This
-keeps unrelated local tools such as `write_file` available in the same request.
+Chat Completions-compatible OpenRouter
+[server tools](https://openrouter.ai/docs/guides/features/server-tools), such as those above, are
+appended to nanobot's generated functions. This keeps unrelated local tools such as `write_file`
+available in the same request. Responses-only server tools require an API surface that the
+OpenRouter provider does not currently enable.
 
 ### Eden AI Gateway
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -100,6 +100,27 @@ Gateway-style setup for model IDs served through OpenRouter.
 
 Use the model ID exactly as OpenRouter lists it.
 
+To opt into OpenRouter server-managed search and fetch, add:
+
+```json
+{
+  "providers": {
+    "openrouter": {
+      "extraBody": {
+        "tools": [
+          { "type": "openrouter:web_search" },
+          { "type": "openrouter:web_fetch" }
+        ]
+      }
+    }
+  }
+}
+```
+
+OpenRouter [server tools](https://openrouter.ai/docs/guides/features/server-tools) configured
+through `extraBody.tools` are appended to nanobot's generated Chat Completions functions. This
+keeps unrelated local tools such as `write_file` available in the same request.
+
 ### Eden AI Gateway
 
 Eden AI exposes an OpenAI-compatible chat-completions endpoint at

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -447,6 +447,28 @@ def _merge_unique_list(base: object, override: object) -> object:
     return result
 
 
+def _merge_chat_extra_body(
+    kwargs: dict[str, Any],
+    extra_body: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge configured Chat Completions fields without clobbering tools."""
+    regular_extra = {key: value for key, value in extra_body.items() if key != "tools"}
+    merged = dict(kwargs)
+    if regular_extra:
+        existing = kwargs.get("extra_body", {})
+        merged["extra_body"] = _deep_merge(existing, regular_extra)
+
+    if "tools" in extra_body:
+        current_tools = kwargs.get("tools")
+        configured_tools = extra_body["tools"]
+        if isinstance(current_tools, list) and isinstance(configured_tools, list):
+            merged["tools"] = [*current_tools, *configured_tools]
+        else:
+            merged["tools"] = configured_tools
+
+    return merged
+
+
 def _merge_responses_extra_body(
     body: dict[str, Any],
     extra_body: dict[str, Any],
@@ -968,14 +990,11 @@ class OpenAICompatProvider(LLMProvider):
                 if msg.get("role") == "assistant" and "reasoning_content" not in msg:
                     msg["reasoning_content"] = ""
 
-        # Merge user-configured extra_body last so it can override or
-        # extend provider-specific defaults (e.g. chat_template_kwargs,
-        # guided_json, repetition_penalty).  Uses recursive merge so
-        # nested dicts like {"chat_template_kwargs": {"enable_thinking": false}}
-        # do not clobber sibling keys already set by thinking-style logic.
+        # Merge user-configured extra_body last so ordinary fields can override
+        # provider defaults. Keep configured tools at the top level: the SDK
+        # otherwise lets extra_body.tools replace nanobot's generated functions.
         if self._extra_body:
-            existing = kwargs.get("extra_body", {})
-            kwargs["extra_body"] = _deep_merge(existing, self._extra_body)
+            kwargs = _merge_chat_extra_body(kwargs, self._extra_body)
 
         return kwargs
 

--- a/tests/providers/test_extra_body_config.py
+++ b/tests/providers/test_extra_body_config.py
@@ -117,6 +117,30 @@ class TestBuildKwargsExtraBody:
             "chat_template_kwargs": {"enable_thinking": False},
         }
 
+    def test_extra_body_appends_tools_without_clobbering_functions(self) -> None:
+        function_tool = {
+            "type": "function",
+            "function": {
+                "name": "write_file",
+                "description": "Write a local file",
+                "parameters": {"type": "object"},
+            },
+        }
+        server_tool = {"type": "openrouter:web_search"}
+        provider = _make_provider({
+            "tools": [server_tool],
+            "custom_param": "value",
+        })
+
+        kwargs = provider._build_kwargs(
+            messages=_simple_messages(),
+            tools=[function_tool], model=None, max_tokens=100,
+            temperature=0.1, reasoning_effort=None, tool_choice=None,
+        )
+
+        assert kwargs["tools"] == [function_tool, server_tool]
+        assert kwargs["extra_body"] == {"custom_param": "value"}
+
     def test_extra_body_merges_with_thinking(self) -> None:
         """Config extra_body should merge with (and override) thinking params."""
         from nanobot.providers.registry import ProviderSpec


### PR DESCRIPTION
## Summary

- merge Chat Completions `extraBody.tools` into nanobot's generated top-level tool list
- keep ordinary `extraBody` fields on the existing recursive last-write-wins path
- document optional OpenRouter web search and fetch server tools

## Problem

The OpenAI SDK merges `extra_body` into the final request after normal arguments. Configuring
OpenRouter server tools through `extraBody.tools` therefore replaced every generated nanobot
function, including unrelated capabilities such as `write_file`.

The provider now treats `tools` as a reserved Chat Completions field and appends configured tool
lists, matching the existing Responses API behavior.

Closes #5333.

## Verification

- wire-level MockTransport probe: `write_file`, `openrouter:web_search`, and
  `openrouter:web_fetch` coexist in the serialized SDK request
- `uv run --no-sync pytest tests/providers/test_extra_body_config.py tests/providers/test_litellm_kwargs.py -q` — 135 passed
- `uv run --no-sync ruff check nanobot/providers/openai_compat_provider.py tests/providers/test_extra_body_config.py`
- `uv run --no-sync python -m scripts.install_channel_dependencies --all-channels`
- `uv run --no-sync basedpyright` — 0 errors, 0 warnings, 0 notes

## Scope

This does not enable OpenRouter's Responses API or Responses-only server tools. Live OpenRouter
beta-service execution was not exercised locally; the verification covers nanobot's outbound wire
contract without external requests or charges.
