### PR TITLE
fix(mcp): preserve credentials when OAuth store read fails

### DIFF
--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -1051,6 +1051,7 @@ async def connect_mcp_servers(
                     return False
                 from nanobot.agent.tools.mcp_oauth import (
                     MCPAuthorizationRequiredError,
+                    MCPAuthorizationStoreError,
                     create_mcp_oauth_auth,
                 )
 
@@ -1062,6 +1063,9 @@ async def connect_mcp_servers(
                     )
                 except MCPAuthorizationRequiredError:
                     logger.info("MCP server '{}': waiting for browser authorization", name)
+                    return False
+                except MCPAuthorizationStoreError as exc:
+                    logger.warning("MCP server '{}': {}", name, exc)
                     return False
 
             if transport_type == "stdio":

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -1038,6 +1038,7 @@ async def connect_mcp_servers(
                     return False
                 from nanobot.agent.tools.mcp_oauth import (
                     MCPAuthorizationRequiredError,
+                    MCPAuthorizationStoreError,
                     create_mcp_oauth_auth,
                 )
 
@@ -1049,6 +1050,9 @@ async def connect_mcp_servers(
                     )
                 except MCPAuthorizationRequiredError:
                     logger.info("MCP server '{}': waiting for browser authorization", name)
+                    return False
+                except MCPAuthorizationStoreError as exc:
+                    logger.warning("MCP server '{}': {}", name, exc)
                     return False
 
             if transport_type == "stdio":

--- a/nanobot/agent/tools/mcp_oauth.py
+++ b/nanobot/agent/tools/mcp_oauth.py
@@ -56,6 +56,10 @@ class MCPAuthorizationRequiredError(RuntimeError):
     """Raised when a background MCP connection needs interactive authorization."""
 
 
+class MCPAuthorizationStoreError(RuntimeError):
+    """Raised when the MCP OAuth credential store cannot be read safely."""
+
+
 @dataclass(frozen=True)
 class MCPOAuthHandlers:
     """Browser callbacks supplied only for a user-initiated OAuth attempt."""
@@ -83,25 +87,37 @@ def _stored_server(value: object) -> _StoredServer | None:
         return None
     raw = cast(dict[object, object], value)
     entry: _StoredServer = {}
-    fingerprint = raw.get("server_fingerprint")
-    if isinstance(fingerprint, str):
+    if "server_fingerprint" in raw:
+        fingerprint = raw["server_fingerprint"]
+        if not isinstance(fingerprint, str):
+            return None
         entry["server_fingerprint"] = fingerprint
-    write_lease = raw.get("write_lease")
-    if isinstance(write_lease, str) and write_lease:
+    if "write_lease" in raw:
+        write_lease = raw["write_lease"]
+        if not isinstance(write_lease, str) or not write_lease:
+            return None
         entry["write_lease"] = write_lease
-    redirect_uri = raw.get("redirect_uri")
-    if isinstance(redirect_uri, str):
+    if "redirect_uri" in raw:
+        redirect_uri = raw["redirect_uri"]
+        if not isinstance(redirect_uri, str):
+            return None
         entry["redirect_uri"] = redirect_uri
-    tokens = raw.get("tokens")
-    if isinstance(tokens, dict):
+    if "tokens" in raw:
+        tokens = raw["tokens"]
+        if not isinstance(tokens, dict):
+            return None
         token_values = cast(dict[object, object], tokens)
-        if all(isinstance(key, str) for key in token_values):
-            entry["tokens"] = cast(dict[str, Any], token_values)
-    client_info = raw.get("client_info")
-    if isinstance(client_info, dict):
+        if not all(isinstance(key, str) for key in token_values):
+            return None
+        entry["tokens"] = cast(dict[str, Any], token_values)
+    if "client_info" in raw:
+        client_info = raw["client_info"]
+        if not isinstance(client_info, dict):
+            return None
         client_values = cast(dict[object, object], client_info)
-        if all(isinstance(key, str) for key in client_values):
-            entry["client_info"] = cast(dict[str, Any], client_values)
+        if not all(isinstance(key, str) for key in client_values):
+            return None
+        entry["client_info"] = cast(dict[str, Any], client_values)
     return entry
 
 
@@ -112,24 +128,50 @@ def _read_store_unlocked(path: Path) -> _CredentialStore:
         return _empty_store()
     except (OSError, ValueError, TypeError) as exc:
         logger.warning("Could not read MCP OAuth credentials: {}", type(exc).__name__)
-        return _empty_store()
+        raise MCPAuthorizationStoreError(
+            "MCP OAuth credential store is unreadable; refusing to overwrite it"
+        ) from exc
     if not isinstance(raw, dict):
-        return _empty_store()
+        raise MCPAuthorizationStoreError(
+            "MCP OAuth credential store has an invalid top-level value; "
+            "refusing to overwrite it"
+        )
     payload = cast(dict[object, object], raw)
     raw_servers = payload.get("servers")
     if not isinstance(raw_servers, dict):
-        return _empty_store()
+        raise MCPAuthorizationStoreError(
+            "MCP OAuth credential store has an invalid servers section; "
+            "refusing to overwrite it"
+        )
     servers: dict[str, _StoredServer] = {}
     for name, value in cast(dict[object, object], raw_servers).items():
+        if not isinstance(name, str):
+            raise MCPAuthorizationStoreError(
+                "MCP OAuth credential store has an invalid server name; "
+                "refusing to overwrite it"
+            )
         entry = _stored_server(value)
-        if isinstance(name, str) and entry is not None:
-            servers[name] = entry
+        if entry is None:
+            raise MCPAuthorizationStoreError(
+                f"MCP OAuth credential store has an invalid entry for '{name}'; "
+                "refusing to overwrite it"
+            )
+        servers[name] = entry
     generations: dict[str, str] = {}
     raw_generations = payload.get("generations")
+    if raw_generations is not None and not isinstance(raw_generations, dict):
+        raise MCPAuthorizationStoreError(
+            "MCP OAuth credential store has an invalid generations section; "
+            "refusing to overwrite it"
+        )
     if isinstance(raw_generations, dict):
         for name, value in cast(dict[object, object], raw_generations).items():
-            if isinstance(name, str) and isinstance(value, str) and value:
-                generations[name] = value
+            if not isinstance(name, str) or not isinstance(value, str) or not value:
+                raise MCPAuthorizationStoreError(
+                    "MCP OAuth credential store has an invalid generation entry; "
+                    "refusing to overwrite it"
+                )
+            generations[name] = value
     return {
         "version": _STORE_VERSION,
         "servers": servers,
@@ -166,7 +208,14 @@ class MCPOAuthStorage:
             return None
         # Writes replace the whole file atomically, so this observes either side
         # of a concurrent deletion without blocking the async connection path.
-        return _read_store_unlocked(path)["generations"].get(self.server_name)
+        try:
+            return _read_store_unlocked(path)["generations"].get(self.server_name)
+        except MCPAuthorizationStoreError:
+            logger.warning(
+                "Could not read MCP OAuth generation for '{}'",
+                self.server_name,
+            )
+            return None
 
     def _generation_is_current(self, payload: _CredentialStore) -> bool:
         return payload["generations"].get(self.server_name) == self._observed_generation
@@ -211,12 +260,28 @@ class MCPOAuthStorage:
 
     def _read_entry_sync(self) -> _StoredServer | None:
         path = _store_path()
-        with _with_store_lock(path):
-            payload = _read_store_unlocked(path)
-            entry, changed = self._bind_entry_unlocked(payload, create=False)
-            if changed:
-                _write_store_unlocked(path, payload)
-            return entry
+        try:
+            with _with_store_lock(path):
+                try:
+                    payload = _read_store_unlocked(path)
+                except MCPAuthorizationStoreError:
+                    logger.warning(
+                        "Could not read MCP OAuth credentials for '{}'",
+                        self.server_name,
+                    )
+                    return None
+                entry, changed = self._bind_entry_unlocked(payload, create=False)
+                if changed:
+                    with suppress(OSError):
+                        _write_store_unlocked(path, payload)
+                return entry
+        except OSError as exc:
+            logger.warning(
+                "Could not read MCP OAuth credentials for '{}': {}",
+                self.server_name,
+                type(exc).__name__,
+            )
+            return None
 
     def _update_entry_sync(
         self,

--- a/nanobot/webui/mcp_presets_api.py
+++ b/nanobot/webui/mcp_presets_api.py
@@ -75,22 +75,21 @@ class McpPresetError(Exception):
         self.status = status
 
 
-def _safe_delete_oauth_credentials(name: str) -> str:
-    """Best-effort OAuth credential cleanup after a config change is already committed.
+def _delete_oauth_credentials_before_config(name: str) -> None:
+    """Clear credentials before committing a config replacement or removal.
 
-    Returns an empty string on success or a human-readable warning message if the
-    credential store could not be read. The config change must not be rolled back
-    for a store error — the server entry is already removed from config, so stale
-    credentials are inert until the store is repaired.
+    The config and credential store are separate files, so they cannot share one
+    filesystem transaction. Clearing credentials first gives the safe failure mode:
+    if cleanup fails, the config remains unchanged; if the later config write fails,
+    the old config only loses its credentials and cannot reuse stale tokens.
     """
     try:
         delete_mcp_oauth_credentials(name)
-    except MCPAuthorizationStoreError as exc:
-        return (
-            f"Could not clean up OAuth credentials for '{name}': {exc}. "
-            "The config change was saved, but stale credentials may remain."
-        )
-    return ""
+    except (MCPAuthorizationStoreError, OSError) as exc:
+        raise McpPresetError(
+            f"Could not clear OAuth credentials for '{name}'; MCP config was not changed",
+            status=503,
+        ) from exc
 
 
 @dataclass(frozen=True)
@@ -1483,18 +1482,15 @@ def custom_mcp_action(
     if action == "custom":
         name, cfg = _custom_server_from_query(query)
         delete_credentials = _oauth_credentials_replaced(config.tools.mcp_servers.get(name), cfg)
+        if delete_credentials:
+            _delete_oauth_credentials_before_config(name)
         config.tools.mcp_servers[name] = cfg
         save_config(config, config_path)
-        credential_warning = ""
-        if delete_credentials:
-            credential_warning = _safe_delete_oauth_credentials(name)
         payload = mcp_presets_payload(
             last_action=_server_action_message(action, name),
             config_path=config_path,
         )
         payload["requires_restart"] = True
-        if credential_warning:
-            payload["credential_warning"] = credential_warning
         return payload
 
     if action in {"import", "import-cursor"}:
@@ -1504,12 +1500,10 @@ def custom_mcp_action(
             for name, cfg in servers.items()
             if _oauth_credentials_replaced(config.tools.mcp_servers.get(name), cfg)
         ]
+        for name in delete_credentials:
+            _delete_oauth_credentials_before_config(name)
         config.tools.mcp_servers.update(servers)
         save_config(config, config_path)
-        credential_warnings = [
-            _safe_delete_oauth_credentials(name)
-            for name in delete_credentials
-        ]
         payload = mcp_presets_payload(
             last_action={
                 "ok": True,
@@ -1518,9 +1512,6 @@ def custom_mcp_action(
             config_path=config_path,
         )
         payload["requires_restart"] = True
-        warnings = [w for w in credential_warnings if w]
-        if warnings:
-            payload["credential_warning"] = " ".join(warnings)
         return payload
 
     if action == "tools":
@@ -1593,16 +1584,15 @@ def mcp_presets_action(
             raise McpPresetError("unknown MCP server", status=404)
         removed_runtime_files = False
         cleanup_error = ""
-        credential_warning = ""
         if name in config.tools.mcp_servers:
             existing_cfg = config.tools.mcp_servers[name]
+            _delete_oauth_credentials_before_config(name)
             try:
                 removed_runtime_files = _remove_managed_stdio_cwd(name, existing_cfg)
             except OSError as exc:
                 cleanup_error = str(exc)
             del config.tools.mcp_servers[name]
             save_config(config, config_path)
-            credential_warning = _safe_delete_oauth_credentials(name)
         last_action = (
             _action_message(action, preset)
             if preset is not None
@@ -1618,13 +1608,6 @@ def mcp_presets_action(
                 f"{last_action['message']} Could not remove managed runtime files: {cleanup_error}"
             )
             last_action["verification_failed"] = ["managed_paths_absent"]
-        if credential_warning:
-            last_action["ok"] = False
-            last_action["message"] = f"{last_action['message']} {credential_warning}"
-            last_action["verification_failed"] = [
-                *(last_action.get("verification_failed") or []),
-                "oauth_credentials_absent",
-            ]
         payload = mcp_presets_payload(
             last_action=last_action,
             config_path=config_path,

--- a/nanobot/webui/mcp_presets_api.py
+++ b/nanobot/webui/mcp_presets_api.py
@@ -22,6 +22,7 @@ from nanobot.agent.plugins import (
     set_agent_plugin_enabled,
 )
 from nanobot.agent.tools.mcp_oauth import (
+    MCPAuthorizationStoreError,
     delete_mcp_oauth_credentials,
     mcp_oauth_has_credentials,
 )
@@ -73,6 +74,24 @@ class McpPresetError(Exception):
         super().__init__(message)
         self.message = message
         self.status = status
+
+
+def _safe_delete_oauth_credentials(name: str) -> str:
+    """Best-effort OAuth credential cleanup after a config change is already committed.
+
+    Returns an empty string on success or a human-readable warning message if the
+    credential store could not be read. The config change must not be rolled back
+    for a store error — the server entry is already removed from config, so stale
+    credentials are inert until the store is repaired.
+    """
+    try:
+        delete_mcp_oauth_credentials(name)
+    except MCPAuthorizationStoreError as exc:
+        return (
+            f"Could not clean up OAuth credentials for '{name}': {exc}. "
+            "The config change was saved, but stale credentials may remain."
+        )
+    return ""
 
 
 @dataclass(frozen=True)
@@ -1462,13 +1481,16 @@ def custom_mcp_action(
         delete_credentials = _oauth_credentials_replaced(config.tools.mcp_servers.get(name), cfg)
         config.tools.mcp_servers[name] = cfg
         save_config(config, config_path)
+        credential_warning = ""
         if delete_credentials:
-            delete_mcp_oauth_credentials(name)
+            credential_warning = _safe_delete_oauth_credentials(name)
         payload = mcp_presets_payload(
             last_action=_server_action_message(action, name),
             config_path=config_path,
         )
         payload["requires_restart"] = True
+        if credential_warning:
+            payload["credential_warning"] = credential_warning
         return payload
 
     if action in {"import", "import-cursor"}:
@@ -1480,8 +1502,10 @@ def custom_mcp_action(
         ]
         config.tools.mcp_servers.update(servers)
         save_config(config, config_path)
-        for name in delete_credentials:
-            delete_mcp_oauth_credentials(name)
+        credential_warnings = [
+            _safe_delete_oauth_credentials(name)
+            for name in delete_credentials
+        ]
         payload = mcp_presets_payload(
             last_action={
                 "ok": True,
@@ -1490,6 +1514,9 @@ def custom_mcp_action(
             config_path=config_path,
         )
         payload["requires_restart"] = True
+        warnings = [w for w in credential_warnings if w]
+        if warnings:
+            payload["credential_warning"] = " ".join(warnings)
         return payload
 
     if action == "tools":
@@ -1562,6 +1589,7 @@ def mcp_presets_action(
             raise McpPresetError("unknown MCP server", status=404)
         removed_runtime_files = False
         cleanup_error = ""
+        credential_warning = ""
         if name in config.tools.mcp_servers:
             existing_cfg = config.tools.mcp_servers[name]
             try:
@@ -1570,7 +1598,7 @@ def mcp_presets_action(
                 cleanup_error = str(exc)
             del config.tools.mcp_servers[name]
             save_config(config, config_path)
-            delete_mcp_oauth_credentials(name)
+            credential_warning = _safe_delete_oauth_credentials(name)
         last_action = (
             _action_message(action, preset)
             if preset is not None
@@ -1586,6 +1614,13 @@ def mcp_presets_action(
                 f"{last_action['message']} Could not remove managed runtime files: {cleanup_error}"
             )
             last_action["verification_failed"] = ["managed_paths_absent"]
+        if credential_warning:
+            last_action["ok"] = False
+            last_action["message"] = f"{last_action['message']} {credential_warning}"
+            last_action["verification_failed"] = [
+                *(last_action.get("verification_failed") or []),
+                "oauth_credentials_absent",
+            ]
         payload = mcp_presets_payload(
             last_action=last_action,
             config_path=config_path,

--- a/nanobot/webui/mcp_presets_api.py
+++ b/nanobot/webui/mcp_presets_api.py
@@ -76,22 +76,21 @@ class McpPresetError(Exception):
         self.status = status
 
 
-def _safe_delete_oauth_credentials(name: str) -> str:
-    """Best-effort OAuth credential cleanup after a config change is already committed.
+def _delete_oauth_credentials_before_config(name: str) -> None:
+    """Clear credentials before committing a config replacement or removal.
 
-    Returns an empty string on success or a human-readable warning message if the
-    credential store could not be read. The config change must not be rolled back
-    for a store error — the server entry is already removed from config, so stale
-    credentials are inert until the store is repaired.
+    The config and credential store are separate files, so they cannot share one
+    filesystem transaction. Clearing credentials first gives the safe failure mode:
+    if cleanup fails, the config remains unchanged; if the later config write fails,
+    the old config only loses its credentials and cannot reuse stale tokens.
     """
     try:
         delete_mcp_oauth_credentials(name)
-    except MCPAuthorizationStoreError as exc:
-        return (
-            f"Could not clean up OAuth credentials for '{name}': {exc}. "
-            "The config change was saved, but stale credentials may remain."
-        )
-    return ""
+    except (MCPAuthorizationStoreError, OSError) as exc:
+        raise McpPresetError(
+            f"Could not clear OAuth credentials for '{name}'; MCP config was not changed",
+            status=503,
+        ) from exc
 
 
 @dataclass(frozen=True)
@@ -1479,18 +1478,15 @@ def custom_mcp_action(
     if action == "custom":
         name, cfg = _custom_server_from_query(query)
         delete_credentials = _oauth_credentials_replaced(config.tools.mcp_servers.get(name), cfg)
+        if delete_credentials:
+            _delete_oauth_credentials_before_config(name)
         config.tools.mcp_servers[name] = cfg
         save_config(config, config_path)
-        credential_warning = ""
-        if delete_credentials:
-            credential_warning = _safe_delete_oauth_credentials(name)
         payload = mcp_presets_payload(
             last_action=_server_action_message(action, name),
             config_path=config_path,
         )
         payload["requires_restart"] = True
-        if credential_warning:
-            payload["credential_warning"] = credential_warning
         return payload
 
     if action in {"import", "import-cursor"}:
@@ -1500,12 +1496,10 @@ def custom_mcp_action(
             for name, cfg in servers.items()
             if _oauth_credentials_replaced(config.tools.mcp_servers.get(name), cfg)
         ]
+        for name in delete_credentials:
+            _delete_oauth_credentials_before_config(name)
         config.tools.mcp_servers.update(servers)
         save_config(config, config_path)
-        credential_warnings = [
-            _safe_delete_oauth_credentials(name)
-            for name in delete_credentials
-        ]
         payload = mcp_presets_payload(
             last_action={
                 "ok": True,
@@ -1514,9 +1508,6 @@ def custom_mcp_action(
             config_path=config_path,
         )
         payload["requires_restart"] = True
-        warnings = [w for w in credential_warnings if w]
-        if warnings:
-            payload["credential_warning"] = " ".join(warnings)
         return payload
 
     if action == "tools":
@@ -1589,16 +1580,15 @@ def mcp_presets_action(
             raise McpPresetError("unknown MCP server", status=404)
         removed_runtime_files = False
         cleanup_error = ""
-        credential_warning = ""
         if name in config.tools.mcp_servers:
             existing_cfg = config.tools.mcp_servers[name]
+            _delete_oauth_credentials_before_config(name)
             try:
                 removed_runtime_files = _remove_managed_stdio_cwd(name, existing_cfg)
             except OSError as exc:
                 cleanup_error = str(exc)
             del config.tools.mcp_servers[name]
             save_config(config, config_path)
-            credential_warning = _safe_delete_oauth_credentials(name)
         last_action = (
             _action_message(action, preset)
             if preset is not None
@@ -1614,13 +1604,6 @@ def mcp_presets_action(
                 f"{last_action['message']} Could not remove managed runtime files: {cleanup_error}"
             )
             last_action["verification_failed"] = ["managed_paths_absent"]
-        if credential_warning:
-            last_action["ok"] = False
-            last_action["message"] = f"{last_action['message']} {credential_warning}"
-            last_action["verification_failed"] = [
-                *(last_action.get("verification_failed") or []),
-                "oauth_credentials_absent",
-            ]
         payload = mcp_presets_payload(
             last_action=last_action,
             config_path=config_path,

--- a/nanobot/webui/mcp_presets_api.py
+++ b/nanobot/webui/mcp_presets_api.py
@@ -22,6 +22,7 @@ from nanobot.agent.plugins import (
     set_agent_plugin_enabled,
 )
 from nanobot.agent.tools.mcp_oauth import (
+    MCPAuthorizationStoreError,
     delete_mcp_oauth_credentials,
     mcp_oauth_has_credentials,
 )
@@ -72,6 +73,24 @@ class McpPresetError(Exception):
         super().__init__(message)
         self.message = message
         self.status = status
+
+
+def _safe_delete_oauth_credentials(name: str) -> str:
+    """Best-effort OAuth credential cleanup after a config change is already committed.
+
+    Returns an empty string on success or a human-readable warning message if the
+    credential store could not be read. The config change must not be rolled back
+    for a store error — the server entry is already removed from config, so stale
+    credentials are inert until the store is repaired.
+    """
+    try:
+        delete_mcp_oauth_credentials(name)
+    except MCPAuthorizationStoreError as exc:
+        return (
+            f"Could not clean up OAuth credentials for '{name}': {exc}. "
+            "The config change was saved, but stale credentials may remain."
+        )
+    return ""
 
 
 @dataclass(frozen=True)
@@ -1466,13 +1485,16 @@ def custom_mcp_action(
         delete_credentials = _oauth_credentials_replaced(config.tools.mcp_servers.get(name), cfg)
         config.tools.mcp_servers[name] = cfg
         save_config(config, config_path)
+        credential_warning = ""
         if delete_credentials:
-            delete_mcp_oauth_credentials(name)
+            credential_warning = _safe_delete_oauth_credentials(name)
         payload = mcp_presets_payload(
             last_action=_server_action_message(action, name),
             config_path=config_path,
         )
         payload["requires_restart"] = True
+        if credential_warning:
+            payload["credential_warning"] = credential_warning
         return payload
 
     if action in {"import", "import-cursor"}:
@@ -1484,8 +1506,10 @@ def custom_mcp_action(
         ]
         config.tools.mcp_servers.update(servers)
         save_config(config, config_path)
-        for name in delete_credentials:
-            delete_mcp_oauth_credentials(name)
+        credential_warnings = [
+            _safe_delete_oauth_credentials(name)
+            for name in delete_credentials
+        ]
         payload = mcp_presets_payload(
             last_action={
                 "ok": True,
@@ -1494,6 +1518,9 @@ def custom_mcp_action(
             config_path=config_path,
         )
         payload["requires_restart"] = True
+        warnings = [w for w in credential_warnings if w]
+        if warnings:
+            payload["credential_warning"] = " ".join(warnings)
         return payload
 
     if action == "tools":
@@ -1566,6 +1593,7 @@ def mcp_presets_action(
             raise McpPresetError("unknown MCP server", status=404)
         removed_runtime_files = False
         cleanup_error = ""
+        credential_warning = ""
         if name in config.tools.mcp_servers:
             existing_cfg = config.tools.mcp_servers[name]
             try:
@@ -1574,7 +1602,7 @@ def mcp_presets_action(
                 cleanup_error = str(exc)
             del config.tools.mcp_servers[name]
             save_config(config, config_path)
-            delete_mcp_oauth_credentials(name)
+            credential_warning = _safe_delete_oauth_credentials(name)
         last_action = (
             _action_message(action, preset)
             if preset is not None
@@ -1590,6 +1618,13 @@ def mcp_presets_action(
                 f"{last_action['message']} Could not remove managed runtime files: {cleanup_error}"
             )
             last_action["verification_failed"] = ["managed_paths_absent"]
+        if credential_warning:
+            last_action["ok"] = False
+            last_action["message"] = f"{last_action['message']} {credential_warning}"
+            last_action["verification_failed"] = [
+                *(last_action.get("verification_failed") or []),
+                "oauth_credentials_absent",
+            ]
         payload = mcp_presets_payload(
             last_action=last_action,
             config_path=config_path,

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from urllib.parse import parse_qs, urlsplit
 
 import httpx
@@ -9,6 +10,7 @@ from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 
 from nanobot.agent.tools.mcp_oauth import (
     MCPAuthorizationRequiredError,
+    MCPAuthorizationStoreError,
     MCPOAuthHandlers,
     MCPOAuthStorage,
     create_mcp_oauth_auth,
@@ -61,6 +63,180 @@ async def test_mcp_oauth_storage_isolates_name_and_server_url(
     payload = json.loads((tmp_path / "auth" / "mcp.json").read_text(encoding="utf-8"))
     assert "https://mcp.example.com/mcp" not in str(payload)
     assert "access-secret" in str(payload)
+
+
+@pytest.mark.asyncio
+async def test_transient_store_read_failure_does_not_wipe_credentials_on_update(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _use_data_dir(tmp_path, monkeypatch)
+    first = MCPOAuthStorage("first", "https://mcp.example.com/mcp")
+    second = MCPOAuthStorage("second", "https://mcp.example.com/mcp")
+    await first.set_tokens(OAuthToken(access_token="first-token"))
+    await second.set_tokens(OAuthToken(access_token="second-token"))
+
+    store_path = tmp_path / "auth" / "mcp.json"
+    original = store_path.read_bytes()
+    real_read_text = Path.read_text
+
+    def fail_store_read(self: Path, *args: object, **kwargs: object) -> str:
+        if self == store_path:
+            raise PermissionError("temporarily locked")
+        return real_read_text(self, *args, **kwargs)
+
+    with monkeypatch.context() as context:
+        context.setattr(Path, "read_text", fail_store_read)
+        with pytest.raises(MCPAuthorizationStoreError):
+            await first.set_tokens(OAuthToken(access_token="replacement-token"))
+
+    assert store_path.read_bytes() == original
+    assert await MCPOAuthStorage("second", "https://mcp.example.com/mcp").get_tokens() == (
+        OAuthToken(access_token="second-token")
+    )
+
+
+@pytest.mark.asyncio
+async def test_transient_store_read_failure_does_not_wipe_credentials_on_delete(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _use_data_dir(tmp_path, monkeypatch)
+    first = MCPOAuthStorage("first", "https://mcp.example.com/mcp")
+    second = MCPOAuthStorage("second", "https://mcp.example.com/mcp")
+    await first.set_tokens(OAuthToken(access_token="first-token"))
+    await second.set_tokens(OAuthToken(access_token="second-token"))
+
+    store_path = tmp_path / "auth" / "mcp.json"
+    original = store_path.read_bytes()
+    real_read_text = Path.read_text
+
+    def fail_store_read(self: Path, *args: object, **kwargs: object) -> str:
+        if self == store_path:
+            raise PermissionError("temporarily locked")
+        return real_read_text(self, *args, **kwargs)
+
+    with monkeypatch.context() as context:
+        context.setattr(Path, "read_text", fail_store_read)
+        with pytest.raises(MCPAuthorizationStoreError):
+            delete_mcp_oauth_credentials("first")
+
+    assert store_path.read_bytes() == original
+    assert await MCPOAuthStorage("first", "https://mcp.example.com/mcp").get_tokens() == (
+        OAuthToken(access_token="first-token")
+    )
+    assert await MCPOAuthStorage("second", "https://mcp.example.com/mcp").get_tokens() == (
+        OAuthToken(access_token="second-token")
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"unexpected": True},
+        {"servers": {"first": None}},
+        {"servers": {}, "generations": []},
+    ],
+)
+def test_invalid_store_structure_is_not_replaced(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    payload: dict[str, object],
+) -> None:
+    _use_data_dir(tmp_path, monkeypatch)
+    store_path = tmp_path / "auth" / "mcp.json"
+    store_path.parent.mkdir(parents=True)
+    store_path.write_text(json.dumps(payload), encoding="utf-8")
+    original = store_path.read_bytes()
+
+    with pytest.raises(MCPAuthorizationStoreError):
+        delete_mcp_oauth_credentials("first")
+
+    assert store_path.read_bytes() == original
+
+
+def test_malformed_store_is_not_replaced(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _use_data_dir(tmp_path, monkeypatch)
+    store_path = tmp_path / "auth" / "mcp.json"
+    store_path.parent.mkdir(parents=True)
+    store_path.write_text("{not-json", encoding="utf-8")
+    original = store_path.read_bytes()
+
+    with pytest.raises(MCPAuthorizationStoreError):
+        delete_mcp_oauth_credentials("first")
+
+    assert store_path.read_bytes() == original
+
+
+@pytest.mark.asyncio
+async def test_unreadable_store_does_not_crash_read_paths(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Read-only operations return safe defaults when the store is unreadable."""
+    _use_data_dir(tmp_path, monkeypatch)
+    storage = MCPOAuthStorage("notion", "https://mcp.example.com/mcp")
+    await storage.set_tokens(OAuthToken(access_token="access-secret"))
+
+    store_path = tmp_path / "auth" / "mcp.json"
+    original = store_path.read_bytes()
+    real_read_text = Path.read_text
+
+    def fail_store_read(self: Path, *args: object, **kwargs: object) -> str:
+        if self == store_path:
+            raise PermissionError("temporarily locked")
+        return real_read_text(self, *args, **kwargs)
+
+    with monkeypatch.context() as context:
+        context.setattr(Path, "read_text", fail_store_read)
+
+        # __init__ must not raise – generation falls back to None.
+        fresh = MCPOAuthStorage("notion", "https://mcp.example.com/mcp")
+        assert fresh._observed_generation is None
+
+        # Read paths return safe defaults.
+        assert not mcp_oauth_has_credentials("notion", "https://mcp.example.com/mcp")
+        assert await fresh.get_tokens() is None
+        assert await fresh.get_client_info() is None
+        assert await fresh.redirect_uri() is None
+
+    # Store is untouched.
+    assert store_path.read_bytes() == original
+
+
+@pytest.mark.asyncio
+async def test_lock_timeout_does_not_crash_read_paths(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lock acquisition failure returns safe defaults instead of raising."""
+    _use_data_dir(tmp_path, monkeypatch)
+    storage = MCPOAuthStorage("notion", "https://mcp.example.com/mcp")
+    await storage.set_tokens(OAuthToken(access_token="access-secret"))
+
+    import filelock
+
+    real_filelock_init = filelock.FileLock.__init__
+
+    def slow_lock_init(self: filelock.FileLock, *args: object, **kwargs: object) -> None:
+        real_filelock_init(self, *args, **kwargs)
+        self.timeout = 0.01  # type: ignore[assignment]
+
+    def fail_acquire(self: filelock.FileLock, *args: object, **kwargs: object) -> None:
+        raise filelock.Timeout(str(self.lock_file))
+
+    with monkeypatch.context() as context:
+        context.setattr(filelock.FileLock, "__init__", slow_lock_init)
+        context.setattr(filelock.FileLock, "acquire", fail_acquire)
+
+        # Read paths must not raise — they return safe defaults.
+        assert not mcp_oauth_has_credentials("notion", "https://mcp.example.com/mcp")
+        assert await storage.get_tokens() is None
+        assert await storage.get_client_info() is None
+        assert await storage.redirect_uri() is None
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1380,6 +1380,7 @@ async def test_connect_mcp_servers_attaches_oauth_to_remote_http_client(
 
     oauth_mod = ModuleType("nanobot.agent.tools.mcp_oauth")
     oauth_mod.MCPAuthorizationRequiredError = RuntimeError  # type: ignore[attr-defined]
+    oauth_mod.MCPAuthorizationStoreError = RuntimeError  # type: ignore[attr-defined]
     oauth_mod.create_mcp_oauth_auth = _create_auth  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "nanobot.agent.tools.mcp_oauth", oauth_mod)
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1334,6 +1334,7 @@ async def test_connect_mcp_servers_attaches_oauth_to_remote_http_client(
 
     oauth_mod = ModuleType("nanobot.agent.tools.mcp_oauth")
     oauth_mod.MCPAuthorizationRequiredError = RuntimeError  # type: ignore[attr-defined]
+    oauth_mod.MCPAuthorizationStoreError = RuntimeError  # type: ignore[attr-defined]
     oauth_mod.create_mcp_oauth_auth = _create_auth  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "nanobot.agent.tools.mcp_oauth", oauth_mod)
 

--- a/tests/webui/test_mcp_presets_api.py
+++ b/tests/webui/test_mcp_presets_api.py
@@ -9,7 +9,11 @@ import pytest
 from mcp.shared.auth import OAuthToken
 
 from nanobot.agent.plugins import AGENT_PLUGIN_MCP_SCHEMA, AGENT_PLUGIN_SCHEMA
-from nanobot.agent.tools.mcp_oauth import MCPOAuthStorage, mcp_oauth_has_credentials
+from nanobot.agent.tools.mcp_oauth import (
+    MCPAuthorizationStoreError,
+    MCPOAuthStorage,
+    mcp_oauth_has_credentials,
+)
 from nanobot.config.loader import load_config
 from nanobot.webui.mcp_presets_api import (
     McpPresetError,
@@ -661,6 +665,78 @@ async def test_replacing_oauth_config_removes_its_stored_credentials(
     )
 
     assert not mcp_oauth_has_credentials("company-mcp", server_url)
+
+
+@pytest.mark.parametrize(
+    "cleanup_error",
+    [MCPAuthorizationStoreError("store is unreadable"), OSError("store is busy")],
+)
+def test_replacing_oauth_config_is_not_committed_when_cleanup_fails(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    cleanup_error: Exception,
+) -> None:
+    _use_config(tmp_path, monkeypatch)
+    server_url = "https://mcp.example.com/mcp"
+    custom_mcp_action(
+        "custom",
+        {
+            "name": ["company-mcp"],
+            "transport": ["streamableHttp"],
+            "url": [server_url],
+            "auth": ["oauth"],
+        },
+    )
+
+    def fail_cleanup(_name: str) -> None:
+        raise cleanup_error
+
+    monkeypatch.setattr(
+        "nanobot.webui.mcp_presets_api.delete_mcp_oauth_credentials",
+        fail_cleanup,
+    )
+
+    with pytest.raises(McpPresetError) as exc:
+        custom_mcp_action(
+            "custom",
+            {
+                "name": ["company-mcp"],
+                "transport": ["streamableHttp"],
+                "url": [server_url],
+            },
+        )
+
+    assert exc.value.status == 503
+    config = load_config()
+    assert config.tools.mcp_servers["company-mcp"].auth == "oauth"
+    assert config.tools.mcp_servers["company-mcp"].url == server_url
+
+
+def test_removing_oauth_config_is_not_committed_when_cleanup_fails(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _use_config(tmp_path, monkeypatch)
+    server_url = "https://mcp.example.com/mcp"
+    custom_mcp_action(
+        "custom",
+        {
+            "name": ["company-mcp"],
+            "transport": ["streamableHttp"],
+            "url": [server_url],
+            "auth": ["oauth"],
+        },
+    )
+    monkeypatch.setattr(
+        "nanobot.webui.mcp_presets_api.delete_mcp_oauth_credentials",
+        lambda _name: (_ for _ in ()).throw(OSError("store is busy")),
+    )
+
+    with pytest.raises(McpPresetError) as exc:
+        mcp_presets_action("remove", {"name": ["company-mcp"]})
+
+    assert exc.value.status == 503
+    assert "company-mcp" in load_config().tools.mcp_servers
 
 
 def test_normalize_mcp_preset_mentions_accepts_configured_custom_server(

--- a/tests/webui/test_mcp_presets_api.py
+++ b/tests/webui/test_mcp_presets_api.py
@@ -9,7 +9,11 @@ import pytest
 from mcp.shared.auth import OAuthToken
 
 from nanobot.agent.plugins import AGENT_PLUGIN_MCP_SCHEMA, AGENT_PLUGIN_SCHEMA
-from nanobot.agent.tools.mcp_oauth import MCPOAuthStorage, mcp_oauth_has_credentials
+from nanobot.agent.tools.mcp_oauth import (
+    MCPAuthorizationStoreError,
+    MCPOAuthStorage,
+    mcp_oauth_has_credentials,
+)
 from nanobot.config.loader import load_config, save_config
 from nanobot.config.schema import Config
 from nanobot.webui.mcp_presets_api import (
@@ -702,6 +706,78 @@ async def test_replacing_oauth_config_removes_its_stored_credentials(
     )
 
     assert not mcp_oauth_has_credentials("company-mcp", server_url)
+
+
+@pytest.mark.parametrize(
+    "cleanup_error",
+    [MCPAuthorizationStoreError("store is unreadable"), OSError("store is busy")],
+)
+def test_replacing_oauth_config_is_not_committed_when_cleanup_fails(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    cleanup_error: Exception,
+) -> None:
+    _use_config(tmp_path, monkeypatch)
+    server_url = "https://mcp.example.com/mcp"
+    custom_mcp_action(
+        "custom",
+        {
+            "name": ["company-mcp"],
+            "transport": ["streamableHttp"],
+            "url": [server_url],
+            "auth": ["oauth"],
+        },
+    )
+
+    def fail_cleanup(_name: str) -> None:
+        raise cleanup_error
+
+    monkeypatch.setattr(
+        "nanobot.webui.mcp_presets_api.delete_mcp_oauth_credentials",
+        fail_cleanup,
+    )
+
+    with pytest.raises(McpPresetError) as exc:
+        custom_mcp_action(
+            "custom",
+            {
+                "name": ["company-mcp"],
+                "transport": ["streamableHttp"],
+                "url": [server_url],
+            },
+        )
+
+    assert exc.value.status == 503
+    config = load_config()
+    assert config.tools.mcp_servers["company-mcp"].auth == "oauth"
+    assert config.tools.mcp_servers["company-mcp"].url == server_url
+
+
+def test_removing_oauth_config_is_not_committed_when_cleanup_fails(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _use_config(tmp_path, monkeypatch)
+    server_url = "https://mcp.example.com/mcp"
+    custom_mcp_action(
+        "custom",
+        {
+            "name": ["company-mcp"],
+            "transport": ["streamableHttp"],
+            "url": [server_url],
+            "auth": ["oauth"],
+        },
+    )
+    monkeypatch.setattr(
+        "nanobot.webui.mcp_presets_api.delete_mcp_oauth_credentials",
+        lambda _name: (_ for _ in ()).throw(OSError("store is busy")),
+    )
+
+    with pytest.raises(McpPresetError) as exc:
+        mcp_presets_action("remove", {"name": ["company-mcp"]})
+
+    assert exc.value.status == 503
+    assert "company-mcp" in load_config().tools.mcp_servers
 
 
 def test_normalize_mcp_preset_mentions_accepts_configured_custom_server(


### PR DESCRIPTION
# PR draft

## Title

fix(mcp): preserve credentials when OAuth store read fails

## Body

MCP OAuth storage previously treated a read failure as an empty store. A later
token update or credential removal could then overwrite credentials belonging to
another server.

The storage layer now treats only a missing file as an empty store. Invalid or
unreadable content raises `MCPAuthorizationStoreError`, so mutation paths stop
before writing. Read paths handle store and lock failures by returning safe
defaults, and MCP connection setup reports store errors without crashing the
connection task.

MCP config replacement and removal now clear OAuth credentials before saving the
new config. If cleanup fails, the API returns 503 and leaves the config unchanged.
This avoids committing a config change while an old token is still available for
the same server name.

## Tests

- `uv run --no-sync pytest tests/tools/test_mcp_oauth.py tests/webui/test_mcp_presets_api.py tests/webui/test_mcp_oauth_api.py tests/webui/test_settings_routes.py tests/agent/test_mcp_connection.py tests/agent/test_mcp_reconnect_crash.py -q` (83 passed)
- `uv run --no-sync ruff check nanobot/agent/tools/mcp.py nanobot/agent/tools/mcp_oauth.py nanobot/webui/mcp_presets_api.py tests/tools/test_mcp_oauth.py tests/webui/test_mcp_presets_api.py`
- `uv run --no-sync basedpyright nanobot/agent/tools/mcp.py nanobot/agent/tools/mcp_oauth.py nanobot/webui/mcp_presets_api.py` (0 errors, 0 warnings)
