### PR TITLE
fix(webui): reject discarded temporary chat messages

### DIFF
--- a/nanobot/channels/websocket/runtime.py
+++ b/nanobot/channels/websocket/runtime.py
@@ -1045,6 +1045,17 @@ class WebSocketChannel(BaseChannel):
                 )
                 if session_mentions:
                     metadata["session_mentions"] = session_mentions
+            if temporary_policy is not None:
+                try:
+                    self._temporary_chats.validate_active(connection, cid)
+                except TemporaryChatError as exc:
+                    await self._send_event(
+                        connection,
+                        "error",
+                        detail=exc.detail,
+                        **rejection_fields,
+                    )
+                    return
             metadata[WORKSPACE_SCOPE_METADATA_KEY] = scope.metadata()
             self._workspaces.persist_scope(cid, scope)
             is_webui = metadata.get("webui") is True

--- a/nanobot/channels/websocket/tests/test_websocket_channel.py
+++ b/nanobot/channels/websocket/tests/test_websocket_channel.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -338,6 +339,75 @@ async def test_temporary_chat_is_transient_and_discarded(bus, tmp_path) -> None:
     assert chat_id not in channel._conn_chats.get(connection, set())
     assert not upload.exists()
     assert read_transcript_lines(inbound.session_key) == []
+
+
+@pytest.mark.asyncio
+async def test_discarded_temporary_chat_in_flight_message_is_not_resurrected(
+    bus,
+    tmp_path,
+    monkeypatch,
+) -> None:
+    sessions = SessionManager(tmp_path)
+    channel = WebSocketChannel(
+        {"enabled": True, "allowFrom": ["*"]},
+        bus,
+        gateway=_basic_handler(bus, session_manager=sessions, workspace_path=tmp_path),
+    )
+    connection = AsyncMock()
+    connection.remote_address = ("127.0.0.1", 5000)
+    chat_id = await _new_temporary_chat(channel, connection)
+
+    policy_captured = threading.Event()
+    release = threading.Event()
+    original = channel._session_access.normalize_mentions
+
+    def blocked_normalize_mentions(raw: object, *, exclude_session_key: str | None = None):
+        policy_captured.set()
+        if not release.wait(timeout=10):
+            raise TimeoutError("test release was never signalled")
+        return original(raw, exclude_session_key=exclude_session_key)
+
+    monkeypatch.setattr(
+        channel._session_access,
+        "normalize_mentions",
+        blocked_normalize_mentions,
+    )
+
+    message_task = asyncio.create_task(
+        channel._dispatch_envelope(
+            connection,
+            "webui-client",
+            {
+                "type": "message",
+                "chat_id": chat_id,
+                "content": "hello",
+                "webui": True,
+                "turn_id": "turn-race",
+            },
+        )
+    )
+    assert await asyncio.to_thread(policy_captured.wait, 10)
+
+    await channel._dispatch_envelope(
+        connection,
+        "webui-client",
+        {"type": "discard_temporary_chat", "chat_id": chat_id},
+    )
+    release.set()
+    await message_task
+
+    session_key = f"websocket:{chat_id}"
+    assert sessions.get_cached(session_key) is None
+    assert sessions.list_sessions() == []
+    assert bus.publish_inbound.await_count == 1
+    control = bus.publish_inbound.await_args.args[0]
+    assert control.metadata[INBOUND_META_RUNTIME_CONTROL] == RUNTIME_CONTROL_SESSION_DISCARD
+    sent = _sent_ws_payloads(connection)
+    assert [payload["event"] for payload in sent] == ["error"]
+    payload = sent[0]
+    assert payload["detail"] == "temporary_chat_unavailable"
+    assert payload["chat_id"] == chat_id
+    assert payload["turn_id"] == "turn-race"
 
 
 @pytest.mark.asyncio

--- a/nanobot/channels/websocket/tests/test_websocket_channel.py
+++ b/nanobot/channels/websocket/tests/test_websocket_channel.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -372,6 +373,75 @@ async def test_temporary_chat_is_transient_and_discarded(bus, tmp_path) -> None:
     assert chat_id not in channel._conn_chats.get(connection, set())
     assert not upload.exists()
     assert read_transcript_lines(inbound.session_key) == []
+
+
+@pytest.mark.asyncio
+async def test_discarded_temporary_chat_in_flight_message_is_not_resurrected(
+    bus,
+    tmp_path,
+    monkeypatch,
+) -> None:
+    sessions = SessionManager(tmp_path)
+    channel = WebSocketChannel(
+        {"enabled": True, "allowFrom": ["*"]},
+        bus,
+        gateway=_basic_handler(bus, session_manager=sessions, workspace_path=tmp_path),
+    )
+    connection = AsyncMock()
+    connection.remote_address = ("127.0.0.1", 5000)
+    chat_id = await _new_temporary_chat(channel, connection)
+
+    policy_captured = threading.Event()
+    release = threading.Event()
+    original = channel._commands._session_access.normalize_mentions
+
+    def blocked_normalize_mentions(raw: object, *, exclude_session_key: str | None = None):
+        policy_captured.set()
+        if not release.wait(timeout=10):
+            raise TimeoutError("test release was never signalled")
+        return original(raw, exclude_session_key=exclude_session_key)
+
+    monkeypatch.setattr(
+        channel._commands._session_access,
+        "normalize_mentions",
+        blocked_normalize_mentions,
+    )
+
+    message_task = asyncio.create_task(
+        channel._dispatch_envelope(
+            connection,
+            "webui-client",
+            {
+                "type": "message",
+                "chat_id": chat_id,
+                "content": "hello",
+                "webui": True,
+                "turn_id": "turn-race",
+            },
+        )
+    )
+    assert await asyncio.to_thread(policy_captured.wait, 10)
+
+    await channel._dispatch_envelope(
+        connection,
+        "webui-client",
+        {"type": "discard_temporary_chat", "chat_id": chat_id},
+    )
+    release.set()
+    await message_task
+
+    session_key = f"websocket:{chat_id}"
+    assert sessions.get_cached(session_key) is None
+    assert sessions.list_sessions() == []
+    assert bus.publish_inbound.await_count == 1
+    control = bus.publish_inbound.await_args.args[0]
+    assert control.metadata[INBOUND_META_RUNTIME_CONTROL] == RUNTIME_CONTROL_SESSION_DISCARD
+    sent = _sent_ws_payloads(connection)
+    assert [payload["event"] for payload in sent] == ["error"]
+    payload = sent[0]
+    assert payload["detail"] == "temporary_chat_unavailable"
+    assert payload["chat_id"] == chat_id
+    assert payload["turn_id"] == "turn-race"
 
 
 @pytest.mark.asyncio

--- a/nanobot/webui/inbound_commands.py
+++ b/nanobot/webui/inbound_commands.py
@@ -666,6 +666,17 @@ class WebUICommandRouter:
                     context_blocks.append(session_context)
                 if context_blocks:
                     metadata[RUNTIME_CONTEXT_INPUT_META] = context_blocks
+            if temporary_policy is not None:
+                try:
+                    self._temporary_chats.validate_active(connection, chat_id)
+                except TemporaryChatError as exc:
+                    await self._transport.webui_send_event(
+                        connection,
+                        "error",
+                        detail=exc.detail,
+                        **rejection_fields,
+                    )
+                    return
             await self._transport.webui_dispatch_message(
                 sender_id=client_id,
                 chat_id=chat_id,

--- a/nanobot/webui/temporary_chats.py
+++ b/nanobot/webui/temporary_chats.py
@@ -156,6 +156,14 @@ class WebUITemporaryChats:
     def owns(self, owner: object, chat_id: str) -> bool:
         return self._owners.get(chat_id) is owner
 
+    def validate_active(self, owner: object, chat_id: str) -> None:
+        """Reject in-flight work for a Temporary Chat that was discarded."""
+        if (
+            self._owners.get(chat_id) is not owner
+            or not self._cached_session_is_transient(chat_id)
+        ):
+            raise TemporaryChatError("temporary_chat_unavailable")
+
     def should_persist_transcript(self, chat_id: str) -> bool:
         """Apply the session policy and retain it for late events after disposal."""
         return (


### PR DESCRIPTION
# PR draft

## Title

fix(webui): reject discarded temporary chat messages

## Body

The WebSocket message path reads the Temporary Chat policy and then waits for
later work. If the user discards the chat during that wait, the request could
resume and persist the scope as a normal chat before publishing the message.

The handler now checks the chat owner and transient session again immediately
before persistence and message-bus changes. A message that loses its Temporary
Chat state returns `temporary_chat_unavailable` instead of recreating the session
or entering the bus.

## Tests

- `uv run --no-sync pytest nanobot/channels/websocket/tests/test_websocket_channel.py tests/utils/test_webui_workspaces.py tests/agent/test_loop_session_policy.py tests/session/test_session_cache.py -q` (200 passed)
- `uv run --no-sync basedpyright` (0 errors, 0 warnings)
- `uv run --no-sync ruff check nanobot/channels/websocket/runtime.py nanobot/channels/websocket/tests/test_websocket_channel.py nanobot/webui/temporary_chats.py`
