### PR TITLE
feat(webui): add interactive particle hero background

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -5,6 +5,46 @@ nanobot Python distribution (`pip install nanobot-ai`).
 
 ---
 
+## Canvas UI Particle Object — WebUI particle background (MIT + Commons Clause)
+
+- **Source**: https://github.com/DavidHDev/canvas-ui
+- **Bundled**: `webui/src/components/canvasui/ParticleObject.tsx` and the compiled
+  `nanobot/web/dist/assets/index-*.js`
+- **Modifications**: adapted for nanobot's React WebUI, pointer interaction, reduced-motion
+  behavior, and mobile scrolling
+
+```
+MIT + Commons Clause License Condition v1.0
+
+Copyright (c) 2026 David Haz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, and distribute the Software as part of
+an application, website, or product, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+Commons Clause Restriction
+
+You may use this Software, including for any commercial purpose, so long as
+you do not sell, sublicense, or redistribute the components themselves -
+whether alone, in a bundle, or as a ported version.
+
+No Warranty
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+---
+
 ## Tabler Icons — interface icons (MIT)
 
 - **Source**: https://github.com/tabler/tabler-icons

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -9,7 +9,7 @@ nanobot Python distribution (`pip install nanobot-ai`).
 
 - **Source**: https://github.com/DavidHDev/canvas-ui
 - **Bundled**: `webui/src/components/canvasui/ParticleObject.tsx` and the compiled
-  `nanobot/web/dist/assets/index-*.js`
+  `nanobot/web/dist/assets/ParticleObject-*.js`
 - **Modifications**: adapted for nanobot's React WebUI, pointer interaction, reduced-motion
   behavior, and mobile scrolling
 

--- a/webui/bun.lock
+++ b/webui/bun.lock
@@ -27,6 +27,7 @@
         "remark-math": "^6.0.0",
         "streamdown": "2.5.0",
         "tailwind-merge": "^2.6.0",
+        "three": "^0.185.1",
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -39,6 +40,7 @@
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@types/react-syntax-highlighter": "^15.5.13",
+        "@types/three": "^0.185.1",
         "@vitejs/plugin-react": "^4.3.4",
         "@vitest/coverage-v8": "2.1.9",
         "autoprefixer": "^10.4.20",
@@ -111,6 +113,8 @@
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
 
     "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
+
+    "@dimforge/rapier3d-compat": ["@dimforge/rapier3d-compat@0.12.0", "", {}, "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
 
@@ -344,6 +348,8 @@
 
     "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
+    "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
+
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
@@ -448,9 +454,15 @@
 
     "@types/react-syntax-highlighter": ["@types/react-syntax-highlighter@15.5.13", "", { "dependencies": { "@types/react": "*" } }, "sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA=="],
 
+    "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
+
+    "@types/three": ["@types/three@0.185.1", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "fflate": "~0.8.2", "meshoptimizer": "~1.1.1" } }, "sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A=="],
+
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.62.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.62.1", "@typescript-eslint/type-utils": "8.62.1", "@typescript-eslint/utils": "8.62.1", "@typescript-eslint/visitor-keys": "8.62.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.62.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA=="],
 
@@ -746,6 +758,8 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
+
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
@@ -971,6 +985,8 @@
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "mermaid": ["mermaid@11.16.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA=="],
+
+    "meshoptimizer": ["meshoptimizer@1.1.1", "", {}, "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g=="],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
@@ -1253,6 +1269,8 @@
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
+
+    "three": ["three@0.185.1", "", {}, "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -30,7 +30,8 @@
         "remark-gfm": "^4.0.0",
         "remark-math": "^6.0.0",
         "streamdown": "2.5.0",
-        "tailwind-merge": "^2.6.0"
+        "tailwind-merge": "^2.6.0",
+        "three": "^0.185.1"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -43,6 +44,7 @@
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@types/react-syntax-highlighter": "^15.5.13",
+        "@types/three": "^0.185.1",
         "@vitejs/plugin-react": "^4.3.4",
         "@vitest/coverage-v8": "2.1.9",
         "autoprefixer": "^10.4.20",
@@ -380,6 +382,13 @@
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
       "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2456,6 +2465,13 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
@@ -2862,6 +2878,28 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -2871,6 +2909,13 @@
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4827,6 +4872,13 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -6384,6 +6436,13 @@
       "engines": {
         "node": ">= 20"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -8379,6 +8438,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -34,7 +34,8 @@
     "remark-gfm": "^4.0.0",
     "remark-math": "^6.0.0",
     "streamdown": "2.5.0",
-    "tailwind-merge": "^2.6.0"
+    "tailwind-merge": "^2.6.0",
+    "three": "^0.185.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -47,6 +48,7 @@
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "@types/three": "^0.185.1",
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/coverage-v8": "2.1.9",
     "autoprefixer": "^10.4.20",

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -11,6 +11,7 @@ import {
 import { Eye, EyeOff, Moon, PanelLeft, ShieldCheck, Sun, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { channelUiPresentation } from "@/channel-plugins/registry";
+import { NanobotParticleMark } from "@/components/NanobotParticleMark";
 import { Sidebar } from "@/components/Sidebar";
 import type { SidebarDeleteItem } from "@/components/ChatList";
 import type { SettingsSectionKey } from "@/components/settings/SettingsView";
@@ -336,6 +337,7 @@ function AuthForm({
   onSecret: (secret: string) => void;
 }) {
   const { t } = useTranslation();
+  const { theme } = useTheme();
   const inputRef = useRef<HTMLInputElement>(null);
   const [value, setValue] = useState("");
   const [passwordVisible, setPasswordVisible] = useState(false);
@@ -358,67 +360,86 @@ function AuthForm({
   };
 
   return (
-    <div className="flex h-full w-full items-center justify-center px-6">
-      <form
-        onSubmit={handleSubmit}
-        className="flex w-full max-w-sm flex-col gap-4"
+    <main className="relative isolate grid h-full w-full place-items-center overflow-hidden px-6 py-8">
+      <section
+        aria-labelledby="webui-auth-title"
+        className="relative z-10 flex w-full max-w-[22rem] -translate-y-[1vh] flex-col items-center"
       >
-        <div className="space-y-2">
-          <h1 className="text-sm font-medium text-foreground">
-            <label htmlFor="webui-access-password">{t("app.auth.label")}</label>
-          </h1>
-          <div className="relative">
-            <Input
-              ref={inputRef}
-              id="webui-access-password"
-              name="webui-access-password"
-              type={passwordVisible ? "text" : "password"}
-              autoComplete="current-password"
-              value={value}
-              onChange={(e) => {
-                setValue(e.target.value);
-                setValidationError(null);
-              }}
-              disabled={submitting}
-              aria-invalid={validationError ? true : undefined}
-              aria-describedby={validationError ? "webui-auth-error" : undefined}
-              className="pr-10"
-              autoFocus
-            />
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              disabled={submitting}
-              aria-label={t(
-                passwordVisible ? "app.auth.hidePassword" : "app.auth.showPassword",
-              )}
-              aria-controls="webui-access-password"
-              onClick={() => setPasswordVisible((visible) => !visible)}
-              className="absolute right-1 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-            >
-              {passwordVisible ? (
-                <EyeOff className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-              ) : (
-                <Eye className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-              )}
-            </Button>
+        <header className="flex flex-col items-center">
+          <div
+            className="h-[clamp(13rem,36vh,18rem)] w-[min(30rem,94vw)] opacity-90"
+            aria-hidden="true"
+          >
+            <NanobotParticleMark theme={theme} />
           </div>
-          {errorMessage ? (
-            <p id="webui-auth-error" role="alert" className="text-sm text-destructive">
-              {errorMessage}
-            </p>
-          ) : null}
-        </div>
-        <Button
-          type="submit"
-          className="w-full"
-          disabled={submitting}
-        >
-          {t("app.auth.submit")}
-        </Button>
-      </form>
-    </div>
+          <h1
+            id="webui-auth-title"
+            className="-mt-16 text-lg font-semibold tracking-[-0.03em] text-foreground"
+          >
+            nanobot
+          </h1>
+        </header>
+        <form onSubmit={handleSubmit} className="mt-7 flex w-full flex-col gap-4">
+          <div className="space-y-2">
+            <label
+              htmlFor="webui-access-password"
+              className="text-sm font-medium text-foreground"
+            >
+              {t("app.auth.label")}
+            </label>
+            <div className="relative">
+              <Input
+                ref={inputRef}
+                id="webui-access-password"
+                name="webui-access-password"
+                type={passwordVisible ? "text" : "password"}
+                autoComplete="current-password"
+                value={value}
+                onChange={(e) => {
+                  setValue(e.target.value);
+                  setValidationError(null);
+                }}
+                disabled={submitting}
+                aria-invalid={validationError ? true : undefined}
+                aria-describedby={validationError ? "webui-auth-error" : undefined}
+                className="auth-password-input h-11 rounded-lg bg-background pr-11 text-base shadow-none"
+                autoFocus
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                disabled={submitting}
+                aria-label={t(
+                  passwordVisible ? "app.auth.hidePassword" : "app.auth.showPassword",
+                )}
+                aria-controls="webui-access-password"
+                onClick={() => setPasswordVisible((visible) => !visible)}
+                className="absolute right-1.5 top-1/2 h-8 w-8 -translate-y-1/2 rounded-md text-muted-foreground hover:text-foreground"
+              >
+                {passwordVisible ? (
+                  <EyeOff className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+                ) : (
+                  <Eye className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+                )}
+              </Button>
+            </div>
+            {errorMessage ? (
+              <p id="webui-auth-error" role="alert" className="text-sm text-destructive">
+                {errorMessage}
+              </p>
+            ) : null}
+          </div>
+          <Button
+            type="submit"
+            className="h-11 w-full rounded-lg transition-transform active:scale-[0.98]"
+            disabled={submitting}
+          >
+            {t("app.auth.submit")}
+          </Button>
+        </form>
+      </section>
+    </main>
   );
 }
 

--- a/webui/src/components/NanobotParticleMark.tsx
+++ b/webui/src/components/NanobotParticleMark.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState } from "react";
+import { lazy, Suspense } from "react";
 
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 
@@ -15,32 +15,18 @@ const ParticleObject = lazy(async () => {
 });
 
 export function NanobotParticleMark({ theme }: NanobotParticleMarkProps) {
-  const [ready, setReady] = useState(false);
   const compact = useMediaQuery("(max-width: 639px)");
 
   return (
     <div
       aria-hidden="true"
       data-particle-profile={compact ? "compact" : "desktop"}
-      data-particle-state={ready ? "ready" : "loading"}
       data-testid="nanobot-particle-mark"
       className="relative h-full w-full"
     >
       <div
         className={`pointer-events-none absolute inset-[18%] rounded-full blur-3xl ${
           theme === "dark" ? "bg-orange-500/[0.05]" : "bg-orange-400/[0.035]"
-        }`}
-      />
-
-      <img
-        src={LOGO_SRC}
-        alt=""
-        className={`pointer-events-none absolute left-1/2 top-[44%] w-52 -translate-x-1/2 -translate-y-1/2 transition-opacity duration-500 sm:w-72 ${
-          ready
-            ? "opacity-0"
-            : theme === "dark"
-              ? "opacity-[0.12]"
-              : "opacity-[0.08]"
         }`}
       />
 
@@ -51,25 +37,24 @@ export function NanobotParticleMark({ theme }: NanobotParticleMarkProps) {
             count={compact ? 1_400 : 2_600}
             size={compact ? 4.75 : 4.25}
             sizeVariance={0.4}
-            radius={compact ? 112 : 180}
-            strength={compact ? 3.8 : 4.2}
-            swirl={compact ? 1.05 : 1.35}
-            spring={compact ? 0.48 : 0.38}
-            damping={compact ? 0.24 : 0.18}
-            drift={compact ? 0.65 : 0.9}
+            radius={compact ? 84 : 120}
+            strength={compact ? 0.8 : 1.1}
+            swirl={compact ? 0.2 : 0.25}
+            spring={compact ? 0.9 : 0.85}
+            damping={compact ? 0.55 : 0.5}
+            drift={compact ? 0.18 : 0.25}
             scale={compact ? 2.4 : 3.4}
             yOffset={compact ? 0.2 : 0.38}
-            floatIntensity={compact ? 1.1 : 1.6}
-            rotationIntensity={compact ? 0.85 : 1.25}
-            floatSpeed={compact ? 1.4 : 1.7}
+            floatIntensity={compact ? 0.25 : 0.35}
+            rotationIntensity={compact ? 0.18 : 0.25}
+            floatSpeed={compact ? 0.6 : 0.75}
             orbit={false}
             zoom={false}
             autoRotate={false}
             fov={58}
             cameraDistance={4.2}
             canvasTouchAction="pan-y"
-            onLoad={() => setReady(true)}
-            className={`h-full w-full transition-opacity duration-700 ${
+            className={`h-full w-full ${
               theme === "dark" ? "opacity-[0.28]" : "opacity-[0.22]"
             }`}
           />

--- a/webui/src/components/canvasui/ParticleObject.tsx
+++ b/webui/src/components/canvasui/ParticleObject.tsx
@@ -1,0 +1,1071 @@
+/**
+ * Canvas UI Particle Object
+ * Source: https://github.com/DavidHDev/canvas-ui
+ * License: MIT + Commons Clause
+ */
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import * as THREE from "three";
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+import { DRACOLoader } from "three/addons/loaders/DRACOLoader.js";
+import { GLTFLoader } from "three/addons/loaders/GLTFLoader.js";
+
+export interface ParticleObjectOptions {
+  /** URL of the asset to display: GLB/glTF, SVG, PNG, JPEG, WebP, or GIF. Object URLs from a file input work too. The format is sniffed from the bytes, not the extension. */
+  src?: string;
+  /** Number of particles the asset is rebuilt from. */
+  count?: number;
+  /** Particle size in CSS pixels at the model's distance. */
+  size?: number;
+  /** Random per-particle size variation (0 to 1). */
+  sizeVariance?: number;
+  /** Override color as any CSS color. Empty string keeps the asset's own colors. */
+  color?: string;
+  /** Radius of the cursor's push field in CSS pixels. */
+  radius?: number;
+  /** How hard the cursor pushes particles away. */
+  strength?: number;
+  /** Tangential curl of the push (0 to 2). Particles spiral around the cursor instead of only fleeing it. */
+  swirl?: number;
+  /** How quickly displaced particles spring back home. */
+  spring?: number;
+  /** Velocity damping (0 to 1). Lower values keep particles wobbling longer. */
+  damping?: number;
+  /** Idle shimmer of the resting particles (0 disables). */
+  drift?: number;
+  /** Background color behind the particles. Empty string keeps the canvas transparent. */
+  background?: string;
+  /** Size of the longest side of the asset in scene units. The camera sits about 4 units away. */
+  scale?: number;
+  /** Horizontal offset of the asset in scene units. */
+  xOffset?: number;
+  /** Vertical offset of the asset in scene units. */
+  yOffset?: number;
+  /** Strength of the floating bob animation (0 disables). */
+  floatIntensity?: number;
+  /** Strength of the idle rocking rotation (0 disables). */
+  rotationIntensity?: number;
+  /** Speed of the float and rocking animation. */
+  floatSpeed?: number;
+  /** Let the user orbit the camera by dragging. */
+  orbit?: boolean;
+  /** Let the user zoom with the scroll wheel or pinch. */
+  zoom?: boolean;
+  /** Spin the camera around the asset turntable-style. */
+  autoRotate?: boolean;
+  /** Turntable speed when autoRotate is on. */
+  autoRotateSpeed?: number;
+  /** Camera field of view in degrees. */
+  fov?: number;
+  /** Camera distance from the center of the asset. */
+  cameraDistance?: number;
+  /** Base URL of the Draco decoder, fetched only when a model needs it. */
+  dracoDecoderPath?: string;
+  /** Called after an asset finishes loading. */
+  onLoad?: (() => void) | null;
+  /** Called when an asset fails to load. */
+  onError?: ((error: unknown) => void) | null;
+}
+
+export interface ParticleObjectElements {
+  /** Canvas the scene renders to. */
+  canvas: HTMLCanvasElement;
+}
+
+export interface ParticleObjectInstance {
+  /** Update options live. Changing src loads the new asset. */
+  setOptions: (options: ParticleObjectOptions) => void;
+  /** Re-read canvas size. Call when the element is resized. */
+  resize: () => void;
+  /** Stop the loop and release all GPU resources. */
+  destroy: () => void;
+}
+
+const DEFAULTS: Required<ParticleObjectOptions> = {
+  src: "",
+  count: 14000,
+  size: 2.4,
+  sizeVariance: 0.6,
+  color: "",
+  radius: 110,
+  strength: 1,
+  swirl: 0.6,
+  spring: 1,
+  damping: 0.35,
+  drift: 0.6,
+  background: "",
+  scale: 3,
+  xOffset: 0,
+  yOffset: 0,
+  floatIntensity: 2,
+  rotationIntensity: 1,
+  floatSpeed: 2,
+  orbit: true,
+  zoom: false,
+  autoRotate: false,
+  autoRotateSpeed: 2,
+  fov: 65,
+  cameraDistance: 4.2,
+  dracoDecoderPath: "https://www.gstatic.com/draco/versioned/decoders/1.5.7/",
+  onLoad: null,
+  onError: null,
+};
+
+const CAMERA_DIR = new THREE.Vector3(0, -1, 4).normalize();
+const MODEL_LIFT = 0.3;
+const RASTER_SIZE = 420;
+const ALBEDO_SIZE = 128;
+
+const VERT = `
+in vec3 aColor;
+in float aShade;
+in float aSeed;
+out vec3 vColor;
+uniform float uTime;
+uniform float uDrift;
+uniform float uSize;
+uniform float uVariance;
+uniform float uDpr;
+uniform float uRefDist;
+uniform vec3 uTint;
+uniform float uUseTint;
+
+void main() {
+  vec3 p = position;
+
+  float t = uTime + aSeed * 39.0;
+  p += uDrift * 0.005 * vec3(
+    sin(t * 1.7 + aSeed * 61.0),
+    cos(t * 1.3 + aSeed * 23.0),
+    sin(t * 2.3 + aSeed * 47.0));
+  vec4 mv = modelViewMatrix * vec4(p, 1.0);
+  float jitter = 1.0 + uVariance * (fract(aSeed * 7.13) - 0.5) * 1.4;
+  gl_PointSize = clamp(
+    uSize * uDpr * jitter * (uRefDist / max(-mv.z, 0.1)), 0.0, 64.0);
+  vColor = mix(aColor, uTint * aShade, uUseTint);
+  gl_Position = projectionMatrix * mv;
+}`;
+
+const FRAG = `
+precision highp float;
+in vec3 vColor;
+out vec4 outColor;
+
+void main() {
+  vec2 c = gl_PointCoord - 0.5;
+  float r2 = dot(c, c);
+  float alpha = 1.0 - smoothstep(0.16, 0.25, r2);
+  if (alpha < 0.08) discard;
+  outColor = vec4(vColor, alpha);
+}`;
+
+interface CloudSample {
+  positions: Float32Array;
+  colors: Float32Array;
+  shades: Float32Array;
+}
+
+interface MeshSource {
+  kind: "mesh";
+  scene: THREE.Group;
+}
+
+interface ImageSource {
+  kind: "image";
+  data: ImageData;
+}
+
+type AssetSource = MeshSource | ImageSource;
+
+interface TriangleBucket {
+  positions: THREE.BufferAttribute | THREE.InterleavedBufferAttribute;
+  normals: THREE.BufferAttribute | THREE.InterleavedBufferAttribute | null;
+  uvs: THREE.BufferAttribute | THREE.InterleavedBufferAttribute | null;
+  vertexColors: THREE.BufferAttribute | THREE.InterleavedBufferAttribute | null;
+  index: THREE.BufferAttribute | null;
+  matrix: THREE.Matrix4;
+  normalMatrix: THREE.Matrix3;
+  baseColor: THREE.Color;
+  albedo: ImageData | null;
+  albedoFlipY: boolean;
+  triangleCount: number;
+}
+
+function disposeObject(root: THREE.Object3D) {
+  root.traverse((node) => {
+    const mesh = node as THREE.Mesh;
+    if (mesh.geometry) mesh.geometry.dispose();
+    const materials = Array.isArray(mesh.material)
+      ? mesh.material
+      : [mesh.material];
+    for (const material of materials) {
+      if (!material) continue;
+      for (const value of Object.values(material)) {
+        if (value instanceof THREE.Texture) value.dispose();
+      }
+      material.dispose();
+    }
+  });
+}
+
+function readAlbedo(map: THREE.Texture | null): ImageData | null {
+  const image = map?.image as
+    HTMLImageElement | HTMLCanvasElement | ImageBitmap | undefined;
+  if (!image || !image.width || !image.height) return null;
+  try {
+    const ratio = Math.min(
+      1,
+      ALBEDO_SIZE / Math.max(image.width, image.height),
+    );
+    const width = Math.max(1, Math.round(image.width * ratio));
+    const height = Math.max(1, Math.round(image.height * ratio));
+    const scratch = document.createElement("canvas");
+    scratch.width = width;
+    scratch.height = height;
+    const ctx = scratch.getContext("2d");
+    if (!ctx) return null;
+    ctx.drawImage(image, 0, 0, width, height);
+    return ctx.getImageData(0, 0, width, height);
+  } catch {
+    return null;
+  }
+}
+
+function sampleAlbedo(
+  data: ImageData,
+  u: number,
+  v: number,
+  flipY: boolean,
+  out: THREE.Color,
+) {
+  const x = Math.min(
+    data.width - 1,
+    Math.max(0, Math.floor((u - Math.floor(u)) * data.width)),
+  );
+  const vWrapped = v - Math.floor(v);
+  const y = Math.min(
+    data.height - 1,
+    Math.max(0, Math.floor((flipY ? 1 - vWrapped : vWrapped) * data.height)),
+  );
+  const i = (y * data.width + x) * 4;
+  out.setRGB(
+    data.data[i] / 255,
+    data.data[i + 1] / 255,
+    data.data[i + 2] / 255,
+    THREE.SRGBColorSpace,
+  );
+}
+
+function sampleMesh(scene: THREE.Group, count: number): CloudSample {
+  scene.updateMatrixWorld(true);
+  const buckets: TriangleBucket[] = [];
+
+  scene.traverse((node) => {
+    const mesh = node as THREE.Mesh;
+    if (!mesh.isMesh) return;
+    const geometry = mesh.geometry as THREE.BufferGeometry;
+    const positions = geometry.getAttribute("position");
+    if (!positions) return;
+    const index = geometry.getIndex();
+    const triangleCount = Math.floor(
+      (index ? index.count : positions.count) / 3,
+    );
+    if (triangleCount === 0) return;
+    const material = (
+      Array.isArray(mesh.material) ? mesh.material[0] : mesh.material
+    ) as THREE.MeshStandardMaterial;
+    buckets.push({
+      positions,
+      normals: geometry.getAttribute("normal") ?? null,
+      uvs: geometry.getAttribute("uv") ?? null,
+      vertexColors: geometry.getAttribute("color") ?? null,
+      index,
+      matrix: mesh.matrixWorld.clone(),
+      normalMatrix: new THREE.Matrix3().getNormalMatrix(mesh.matrixWorld),
+      baseColor: material?.color?.clone() ?? new THREE.Color(1, 1, 1),
+      albedo: readAlbedo(material?.map ?? null),
+      albedoFlipY: material?.map?.flipY ?? false,
+      triangleCount,
+    });
+  });
+
+  const positions = new Float32Array(count * 3);
+  const colors = new Float32Array(count * 3);
+  const shades = new Float32Array(count);
+  if (buckets.length === 0) return { positions, colors, shades };
+
+  const areas: number[] = [];
+  const owners: { bucket: TriangleBucket; tri: number }[] = [];
+  const a = new THREE.Vector3();
+  const b = new THREE.Vector3();
+  const c = new THREE.Vector3();
+  const ab = new THREE.Vector3();
+  const ac = new THREE.Vector3();
+  let totalArea = 0;
+
+  const vertexIndex = (bucket: TriangleBucket, tri: number, corner: number) =>
+    bucket.index ? bucket.index.getX(tri * 3 + corner) : tri * 3 + corner;
+
+  for (const bucket of buckets) {
+    for (let tri = 0; tri < bucket.triangleCount; tri++) {
+      const i0 = vertexIndex(bucket, tri, 0);
+      const i1 = vertexIndex(bucket, tri, 1);
+      const i2 = vertexIndex(bucket, tri, 2);
+      a.fromBufferAttribute(bucket.positions, i0).applyMatrix4(bucket.matrix);
+      b.fromBufferAttribute(bucket.positions, i1).applyMatrix4(bucket.matrix);
+      c.fromBufferAttribute(bucket.positions, i2).applyMatrix4(bucket.matrix);
+      ab.subVectors(b, a);
+      ac.subVectors(c, a);
+      totalArea += ab.cross(ac).length() * 0.5;
+      areas.push(totalArea);
+      owners.push({ bucket, tri });
+    }
+  }
+  if (totalArea <= 0) return { positions, colors, shades };
+
+  const normal = new THREE.Vector3();
+  const albedo = new THREE.Color();
+  const texel = new THREE.Color();
+  const final = new THREE.Color();
+  const light = new THREE.Vector3(0.5, 0.8, 0.6).normalize();
+
+  for (let i = 0; i < count; i++) {
+    const pick = Math.random() * totalArea;
+    let lo = 0;
+    let hi = areas.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (areas[mid] < pick) lo = mid + 1;
+      else hi = mid;
+    }
+    const { bucket, tri } = owners[lo];
+    const i0 = vertexIndex(bucket, tri, 0);
+    const i1 = vertexIndex(bucket, tri, 1);
+    const i2 = vertexIndex(bucket, tri, 2);
+
+    let u = Math.random();
+    let v = Math.random();
+    if (u + v > 1) {
+      u = 1 - u;
+      v = 1 - v;
+    }
+    const w = 1 - u - v;
+
+    a.fromBufferAttribute(bucket.positions, i0);
+    b.fromBufferAttribute(bucket.positions, i1);
+    c.fromBufferAttribute(bucket.positions, i2);
+    a.multiplyScalar(w).addScaledVector(b, u).addScaledVector(c, v);
+    a.applyMatrix4(bucket.matrix);
+    positions[i * 3] = a.x;
+    positions[i * 3 + 1] = a.y;
+    positions[i * 3 + 2] = a.z;
+
+    albedo.copy(bucket.baseColor);
+    if (bucket.albedo && bucket.uvs) {
+      const tu =
+        bucket.uvs.getX(i0) * w +
+        bucket.uvs.getX(i1) * u +
+        bucket.uvs.getX(i2) * v;
+      const tv =
+        bucket.uvs.getY(i0) * w +
+        bucket.uvs.getY(i1) * u +
+        bucket.uvs.getY(i2) * v;
+      sampleAlbedo(bucket.albedo, tu, tv, bucket.albedoFlipY, texel);
+      albedo.multiply(texel);
+    }
+    if (bucket.vertexColors) {
+      albedo.multiplyScalar(
+        (bucket.vertexColors.getX(i0) * w +
+          bucket.vertexColors.getX(i1) * u +
+          bucket.vertexColors.getX(i2) * v +
+          bucket.vertexColors.getY(i0) * w +
+          bucket.vertexColors.getY(i1) * u +
+          bucket.vertexColors.getY(i2) * v +
+          bucket.vertexColors.getZ(i0) * w +
+          bucket.vertexColors.getZ(i1) * u +
+          bucket.vertexColors.getZ(i2) * v) /
+          3,
+      );
+    }
+
+    let shade = 0.85;
+    if (bucket.normals) {
+      normal.set(
+        bucket.normals.getX(i0) * w +
+          bucket.normals.getX(i1) * u +
+          bucket.normals.getX(i2) * v,
+        bucket.normals.getY(i0) * w +
+          bucket.normals.getY(i1) * u +
+          bucket.normals.getY(i2) * v,
+        bucket.normals.getZ(i0) * w +
+          bucket.normals.getZ(i1) * u +
+          bucket.normals.getZ(i2) * v,
+      );
+      normal.applyMatrix3(bucket.normalMatrix).normalize();
+      shade = 0.45 + 0.65 * Math.max(normal.dot(light) * 0.5 + 0.5, 0);
+    }
+
+    final.copy(albedo).multiplyScalar(shade);
+    final.convertLinearToSRGB();
+    colors[i * 3] = Math.min(final.r, 1);
+    colors[i * 3 + 1] = Math.min(final.g, 1);
+    colors[i * 3 + 2] = Math.min(final.b, 1);
+    shades[i] = Math.min(Math.pow(shade, 1 / 2.2), 1);
+  }
+
+  return { positions, colors, shades };
+}
+
+function sampleImage(data: ImageData, count: number): CloudSample {
+  const positions = new Float32Array(count * 3);
+  const colors = new Float32Array(count * 3);
+  const shades = new Float32Array(count);
+
+  const pixels: number[] = [];
+  const weights: number[] = [];
+  let totalWeight = 0;
+  for (let i = 0; i < data.width * data.height; i++) {
+    const alpha = data.data[i * 4 + 3];
+    if (alpha < 10) continue;
+    totalWeight += alpha;
+    pixels.push(i);
+    weights.push(totalWeight);
+  }
+  if (pixels.length === 0) return { positions, colors, shades };
+
+  const longest = Math.max(data.width, data.height);
+  for (let i = 0; i < count; i++) {
+    const pick = Math.random() * totalWeight;
+    let lo = 0;
+    let hi = weights.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (weights[mid] < pick) lo = mid + 1;
+      else hi = mid;
+    }
+    const p = pixels[lo];
+    const px = p % data.width;
+    const py = Math.floor(p / data.width);
+    positions[i * 3] = (px + Math.random() - data.width / 2) / longest;
+    positions[i * 3 + 1] = -(py + Math.random() - data.height / 2) / longest;
+    positions[i * 3 + 2] = (Math.random() - 0.5) * 0.02;
+    colors[i * 3] = data.data[p * 4] / 255;
+    colors[i * 3 + 1] = data.data[p * 4 + 1] / 255;
+    colors[i * 3 + 2] = data.data[p * 4 + 2] / 255;
+    shades[i] = 1;
+  }
+
+  return { positions, colors, shades };
+}
+
+function normalizeCloud(sample: CloudSample) {
+  const p = sample.positions;
+  if (p.length === 0) return;
+  let minX = Infinity,
+    minY = Infinity,
+    minZ = Infinity;
+  let maxX = -Infinity,
+    maxY = -Infinity,
+    maxZ = -Infinity;
+  for (let i = 0; i < p.length; i += 3) {
+    minX = Math.min(minX, p[i]);
+    maxX = Math.max(maxX, p[i]);
+    minY = Math.min(minY, p[i + 1]);
+    maxY = Math.max(maxY, p[i + 1]);
+    minZ = Math.min(minZ, p[i + 2]);
+    maxZ = Math.max(maxZ, p[i + 2]);
+  }
+  const cx = (minX + maxX) / 2;
+  const cy = (minY + maxY) / 2;
+  const cz = (minZ + maxZ) / 2;
+  const inv = 1 / Math.max(maxX - minX, maxY - minY, maxZ - minZ, 1e-4);
+  for (let i = 0; i < p.length; i += 3) {
+    p[i] = (p[i] - cx) * inv;
+    p[i + 1] = (p[i + 1] - cy) * inv;
+    p[i + 2] = (p[i + 2] - cz) * inv;
+  }
+}
+
+function sniffKind(
+  bytes: Uint8Array,
+): "glb" | "gltf" | "svg" | "bitmap" | null {
+  if (bytes.length < 4) return null;
+  const ascii = (start: number, text: string) => {
+    for (let i = 0; i < text.length; i++) {
+      if (bytes[start + i] !== text.charCodeAt(i)) return false;
+    }
+    return true;
+  };
+  if (ascii(0, "glTF")) return "glb";
+  if (bytes[0] === 0x89 && ascii(1, "PNG")) return "bitmap";
+  if (bytes[0] === 0xff && bytes[1] === 0xd8) return "bitmap";
+  if (ascii(0, "RIFF") && ascii(8, "WEBP")) return "bitmap";
+  if (ascii(0, "GIF8")) return "bitmap";
+  let head: string;
+  try {
+    head = new TextDecoder()
+      .decode(bytes.subarray(0, 2048))
+      .replace(/^\uFEFF/, "")
+      .trimStart();
+  } catch {
+    return null;
+  }
+  if (head.startsWith("{")) return "gltf";
+  if (head.startsWith("<")) {
+    return head.includes("<svg") ? "svg" : null;
+  }
+  return null;
+}
+
+function rasterizeImage(blob: Blob): Promise<ImageData> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(blob);
+    const image = new Image();
+    image.onload = () => {
+      URL.revokeObjectURL(url);
+      const width = image.naturalWidth || 1024;
+      const height = image.naturalHeight || 1024;
+      const ratio = Math.min(1, RASTER_SIZE / Math.max(width, height));
+      const canvas = document.createElement("canvas");
+      canvas.width = Math.max(1, Math.round(width * ratio));
+      canvas.height = Math.max(1, Math.round(height * ratio));
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        reject(new Error("2d context unavailable"));
+        return;
+      }
+      ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
+      resolve(ctx.getImageData(0, 0, canvas.width, canvas.height));
+    };
+    image.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error("Could not decode the image"));
+    };
+    image.src = url;
+  });
+}
+
+export function createParticleObject(
+  elements: ParticleObjectElements,
+  options: ParticleObjectOptions = {},
+): ParticleObjectInstance | null {
+  const { canvas } = elements;
+  const config: Required<ParticleObjectOptions> = { ...DEFAULTS, ...options };
+
+  let renderer: THREE.WebGLRenderer;
+  try {
+    renderer = new THREE.WebGLRenderer({
+      canvas,
+      antialias: false,
+      alpha: true,
+      powerPreference: "high-performance",
+    });
+  } catch {
+    return null;
+  }
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(config.fov, 1, 0.1, 200);
+  camera.position.copy(CAMERA_DIR).multiplyScalar(config.cameraDistance);
+
+  const floatGroup = new THREE.Group();
+  floatGroup.position.y = MODEL_LIFT;
+  const fitGroup = new THREE.Group();
+  floatGroup.add(fitGroup);
+  scene.add(floatGroup);
+
+  const controls = new OrbitControls(camera, canvas);
+  controls.enableDamping = true;
+  controls.enablePan = false;
+
+  const material = new THREE.ShaderMaterial({
+    glslVersion: THREE.GLSL3,
+    vertexShader: VERT,
+    fragmentShader: FRAG,
+    transparent: true,
+    depthWrite: true,
+    uniforms: {
+      uTime: { value: Math.random() * 100 },
+      uDrift: { value: config.drift },
+      uSize: { value: config.size },
+      uVariance: { value: config.sizeVariance },
+      uDpr: { value: 1 },
+      uRefDist: { value: config.cameraDistance },
+      uTint: { value: new THREE.Color(1, 1, 1) },
+      uUseTint: { value: 0 },
+    },
+  });
+
+  let points: THREE.Points | null = null;
+  let homes: Float32Array | null = null;
+  let velocities: Float32Array | null = null;
+  let particleCount = 0;
+  let assetSource: AssetSource | null = null;
+  let builtCount = -1;
+  let loadedSrc: string | null = null;
+  let loadToken = 0;
+  let disposed = false;
+
+  const loader = new GLTFLoader();
+  const draco = new DRACOLoader();
+  draco.setDecoderPath(config.dracoDecoderPath);
+  loader.setDRACOLoader(draco);
+
+  function clearPoints() {
+    if (!points) return;
+    fitGroup.remove(points);
+    points.geometry.dispose();
+    points = null;
+    homes = null;
+    velocities = null;
+    particleCount = 0;
+  }
+
+  function clearAsset() {
+    if (assetSource?.kind === "mesh") disposeObject(assetSource.scene);
+    assetSource = null;
+    builtCount = -1;
+    clearPoints();
+  }
+
+  function buildCloud() {
+    if (!assetSource) return;
+    const count = Math.max(Math.round(config.count), 16);
+    if (count === builtCount && points) return;
+    builtCount = count;
+    clearPoints();
+
+    const sample =
+      assetSource.kind === "mesh"
+        ? sampleMesh(assetSource.scene, count)
+        : sampleImage(assetSource.data, count);
+    normalizeCloud(sample);
+
+    const seeds = new Float32Array(count);
+    for (let i = 0; i < count; i++) seeds[i] = Math.random();
+
+    const geometry = new THREE.BufferGeometry();
+    const positionAttr = new THREE.BufferAttribute(sample.positions.slice(), 3);
+    positionAttr.setUsage(THREE.DynamicDrawUsage);
+    geometry.setAttribute("position", positionAttr);
+    geometry.setAttribute(
+      "aColor",
+      new THREE.BufferAttribute(sample.colors, 3),
+    );
+    geometry.setAttribute(
+      "aShade",
+      new THREE.BufferAttribute(sample.shades, 1),
+    );
+    geometry.setAttribute("aSeed", new THREE.BufferAttribute(seeds, 1));
+
+    homes = sample.positions;
+    velocities = new Float32Array(count * 3);
+    particleCount = count;
+    points = new THREE.Points(geometry, material);
+    points.frustumCulled = false;
+    fitGroup.add(points);
+  }
+
+  async function loadAsset() {
+    const src = config.src;
+    if (src === loadedSrc) return;
+    loadedSrc = src;
+    const token = ++loadToken;
+    if (!src) {
+      clearAsset();
+      return;
+    }
+    try {
+      const response = await fetch(src);
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const buffer = await response.arrayBuffer();
+      if (disposed || token !== loadToken) return;
+      const bytes = new Uint8Array(buffer);
+      const kind = sniffKind(bytes);
+      if (!kind) throw new Error("Unrecognized asset format");
+
+      if (kind === "glb" || kind === "gltf") {
+        draco.setDecoderPath(config.dracoDecoderPath);
+        const resourcePath = src.slice(0, src.lastIndexOf("/") + 1);
+        const data = kind === "glb" ? buffer : new TextDecoder().decode(bytes);
+        const gltf = await loader.parseAsync(data, resourcePath);
+        if (disposed || token !== loadToken) {
+          disposeObject(gltf.scene);
+          return;
+        }
+        clearAsset();
+        assetSource = { kind: "mesh", scene: gltf.scene };
+      } else {
+        const blob = new Blob([buffer], {
+          type: kind === "svg" ? "image/svg+xml" : "",
+        });
+        const data = await rasterizeImage(blob);
+        if (disposed || token !== loadToken) return;
+        clearAsset();
+        assetSource = { kind: "image", data };
+      }
+      buildCloud();
+      config.onLoad?.();
+    } catch (error) {
+      if (disposed || token !== loadToken) return;
+      config.onError?.(error);
+    }
+  }
+
+  const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+  let reducedMotion = motionQuery.matches;
+  const onMotionChange = () => {
+    reducedMotion = motionQuery.matches;
+    if (reducedMotion) floatGroup.rotation.set(0, 0, 0);
+    applyOptions();
+  };
+  motionQuery.addEventListener("change", onMotionChange);
+
+  const tint = new THREE.Color();
+
+  function applyOptions() {
+    renderer.setClearColor(
+      new THREE.Color(config.background || "#000000"),
+      config.background ? 1 : 0,
+    );
+    controls.enableRotate = config.orbit;
+    controls.enableZoom = config.zoom;
+    controls.autoRotate = config.autoRotate && !reducedMotion;
+    controls.autoRotateSpeed = config.autoRotateSpeed;
+    camera.fov = config.fov;
+    camera.updateProjectionMatrix();
+    floatGroup.position.x = config.xOffset;
+    floatGroup.position.y = MODEL_LIFT + config.yOffset;
+    fitGroup.scale.setScalar(config.scale);
+    material.uniforms.uDrift.value = reducedMotion
+      ? 0
+      : Math.max(config.drift, 0);
+    material.uniforms.uSize.value = Math.max(config.size, 0.1);
+    material.uniforms.uVariance.value = Math.min(
+      Math.max(config.sizeVariance, 0),
+      1,
+    );
+    material.uniforms.uRefDist.value = config.cameraDistance;
+    if (config.color) {
+      tint.set(config.color);
+      (material.uniforms.uTint.value as THREE.Color).copy(tint);
+      material.uniforms.uUseTint.value = 1;
+    } else {
+      material.uniforms.uUseTint.value = 0;
+    }
+  }
+
+  function resize() {
+    const width = Math.max(canvas.clientWidth, 1);
+    const height = Math.max(canvas.clientHeight, 1);
+    const pr = Math.min(window.devicePixelRatio || 1, 2);
+    renderer.setPixelRatio(pr);
+    renderer.setSize(width, height, false);
+    material.uniforms.uDpr.value = pr;
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+  }
+
+  const observer = new ResizeObserver(resize);
+  observer.observe(canvas);
+  resize();
+  applyOptions();
+  loadAsset();
+
+  let pointerX = 0;
+  let pointerY = 0;
+  let pointerActive = false;
+  let pointerSpeed = 0;
+  let lastPointerX = 0;
+  let lastPointerY = 0;
+  let lastPointerTime = 0;
+  let shoveX = 0;
+  let shoveY = 0;
+
+  function onPointerMove(event: PointerEvent) {
+    const rect = canvas.getBoundingClientRect();
+    pointerX = event.clientX - rect.left;
+    pointerY = event.clientY - rect.top;
+    const now = performance.now();
+    if (pointerActive && lastPointerTime) {
+      const dt = Math.max((now - lastPointerTime) / 1000, 1e-3);
+      const dx = pointerX - lastPointerX;
+      const dy = pointerY - lastPointerY;
+      const speed = Math.hypot(dx, dy) / dt;
+      pointerSpeed += (speed - pointerSpeed) * 0.35;
+      if (speed > 1) {
+        const inv = 1 / Math.max(Math.hypot(dx, dy), 1e-3);
+        shoveX += (dx * inv - shoveX) * 0.4;
+        shoveY += (dy * inv - shoveY) * 0.4;
+      }
+    }
+    lastPointerX = pointerX;
+    lastPointerY = pointerY;
+    lastPointerTime = now;
+    pointerActive = true;
+  }
+
+  function onPointerLeave() {
+    pointerActive = false;
+    pointerSpeed = 0;
+    lastPointerTime = 0;
+  }
+
+  canvas.addEventListener("pointerdown", onPointerMove, { passive: true });
+  canvas.addEventListener("pointermove", onPointerMove, { passive: true });
+  canvas.addEventListener("pointerup", onPointerLeave, { passive: true });
+  canvas.addEventListener("pointerleave", onPointerLeave, { passive: true });
+  canvas.addEventListener("pointercancel", onPointerLeave, { passive: true });
+
+  const raycaster = new THREE.Raycaster();
+  const ndc = new THREE.Vector2();
+  const inverseMatrix = new THREE.Matrix4();
+  const localOrigin = new THREE.Vector3();
+  const localDir = new THREE.Vector3();
+  const camRight = new THREE.Vector3();
+  const camUp = new THREE.Vector3();
+  const camBack = new THREE.Vector3();
+  const localShove = new THREE.Vector3();
+
+  function simulate(delta: number) {
+    if (!points || !homes || !velocities || particleCount === 0) return;
+    const positionAttr = points.geometry.getAttribute(
+      "position",
+    ) as THREE.BufferAttribute;
+    const p = positionAttr.array as Float32Array;
+    const h = homes;
+    const v = velocities;
+
+    const stiffness = 60 * Math.max(config.spring, 0.05);
+    const dampingRate = 3 + 12 * Math.min(Math.max(config.damping, 0), 1);
+    const decay = Math.exp(-dampingRate * delta);
+
+    let pushing = false;
+    let ox = 0,
+      oy = 0,
+      oz = 0,
+      dx = 0,
+      dy = 0,
+      dz = 1;
+    let localRadius = 0;
+    let pushAccel = 0;
+    let shove = 0;
+
+    // Reduced motion disables ambient movement, but direct pointer input remains responsive.
+    if (pointerActive && config.strength > 0) {
+      const width = Math.max(canvas.clientWidth, 1);
+      const height = Math.max(canvas.clientHeight, 1);
+      ndc.set((pointerX / width) * 2 - 1, -(pointerY / height) * 2 + 1);
+      raycaster.setFromCamera(ndc, camera);
+
+      points.updateWorldMatrix(true, false);
+      inverseMatrix.copy(points.matrixWorld).invert();
+      localOrigin.copy(raycaster.ray.origin).applyMatrix4(inverseMatrix);
+      localDir.copy(raycaster.ray.direction).transformDirection(inverseMatrix);
+
+      const worldScale = Math.max(fitGroup.scale.x, 1e-4);
+      const worldPerPx =
+        (2 *
+          camera.position.distanceTo(floatGroup.position) *
+          Math.tan(THREE.MathUtils.degToRad(camera.fov) / 2)) /
+        height;
+      localRadius = (Math.max(config.radius, 1) * worldPerPx) / worldScale;
+      pushAccel = 26 * config.strength;
+      shove = Math.min(pointerSpeed / 900, 2) * 14 * config.strength;
+      camera.matrixWorld.extractBasis(camRight, camUp, camBack);
+      localShove
+        .set(0, 0, 0)
+        .addScaledVector(camRight, shoveX)
+        .addScaledVector(camUp, -shoveY)
+        .transformDirection(inverseMatrix);
+
+      ox = localOrigin.x;
+      oy = localOrigin.y;
+      oz = localOrigin.z;
+      dx = localDir.x;
+      dy = localDir.y;
+      dz = localDir.z;
+      pushing = true;
+    }
+
+    const swirl = Math.min(Math.max(config.swirl, 0), 2);
+    const r2max = localRadius * localRadius;
+
+    for (let i = 0; i < particleCount; i++) {
+      const ix = i * 3;
+      const iy = ix + 1;
+      const iz = ix + 2;
+      let vx = v[ix];
+      let vy = v[iy];
+      let vz = v[iz];
+
+      if (pushing) {
+        const wx = p[ix] - ox;
+        const wy = p[iy] - oy;
+        const wz = p[iz] - oz;
+        const t = Math.max(wx * dx + wy * dy + wz * dz, 0);
+        let rx = wx - dx * t;
+        let ry = wy - dy * t;
+        let rz = wz - dz * t;
+        const dist2 = rx * rx + ry * ry + rz * rz;
+        if (dist2 < r2max) {
+          const dist = Math.sqrt(dist2);
+          const inv = 1 / Math.max(dist, 1e-5);
+          rx *= inv;
+          ry *= inv;
+          rz *= inv;
+          const fall = 1 - dist / localRadius;
+          const f = fall * fall * delta;
+          const tx = dy * rz - dz * ry;
+          const ty = dz * rx - dx * rz;
+          const tz = dx * ry - dy * rx;
+          vx += (rx + tx * swirl) * pushAccel * f + localShove.x * shove * f;
+          vy += (ry + ty * swirl) * pushAccel * f + localShove.y * shove * f;
+          vz += (rz + tz * swirl) * pushAccel * f + localShove.z * shove * f;
+        }
+      }
+
+      vx += (h[ix] - p[ix]) * stiffness * delta;
+      vy += (h[iy] - p[iy]) * stiffness * delta;
+      vz += (h[iz] - p[iz]) * stiffness * delta;
+      vx *= decay;
+      vy *= decay;
+      vz *= decay;
+      p[ix] += vx * delta;
+      p[iy] += vy * delta;
+      p[iz] += vz * delta;
+      v[ix] = vx;
+      v[iy] = vy;
+      v[iz] = vz;
+    }
+
+    positionAttr.needsUpdate = true;
+  }
+
+  let inView = true;
+  const viewObserver =
+    typeof IntersectionObserver !== "undefined"
+      ? new IntersectionObserver((entries) => {
+          inView = entries[entries.length - 1]?.isIntersecting ?? true;
+        })
+      : null;
+  viewObserver?.observe(canvas);
+
+  let lastTime = 0;
+  let elapsed = Math.random() * 100;
+
+  renderer.setAnimationLoop((time: number) => {
+    if (!inView) {
+      lastTime = 0;
+      return;
+    }
+    const delta = lastTime ? Math.min((time - lastTime) / 1000, 1 / 30) : 0;
+    lastTime = time;
+    controls.update();
+
+    if (!reducedMotion) {
+      elapsed += delta * config.floatSpeed;
+      floatGroup.rotation.x =
+        (Math.cos(elapsed / 4) / 8) * config.rotationIntensity;
+      floatGroup.rotation.y =
+        (Math.sin(elapsed / 4) / 8) * config.rotationIntensity;
+      floatGroup.rotation.z =
+        (Math.sin(elapsed / 4) / 20) * config.rotationIntensity;
+      floatGroup.position.y =
+        MODEL_LIFT +
+        config.yOffset +
+        (Math.sin(elapsed / 1.5) / 10) * config.floatIntensity;
+      material.uniforms.uTime.value += delta;
+    }
+
+    pointerSpeed *= Math.exp(-3 * delta);
+
+    if (delta > 0) simulate(delta);
+    renderer.render(scene, camera);
+  });
+
+  return {
+    setOptions(next: ParticleObjectOptions) {
+      const previousDistance = config.cameraDistance;
+      const previousCount = config.count;
+      Object.assign(config, next);
+      if (config.cameraDistance !== previousDistance) {
+        camera.position.copy(CAMERA_DIR).multiplyScalar(config.cameraDistance);
+      }
+      applyOptions();
+      if (config.count !== previousCount) buildCloud();
+      loadAsset();
+    },
+    resize,
+    destroy() {
+      disposed = true;
+      loadToken += 1;
+      renderer.setAnimationLoop(null);
+      observer.disconnect();
+      viewObserver?.disconnect();
+      motionQuery.removeEventListener("change", onMotionChange);
+      canvas.removeEventListener("pointerdown", onPointerMove);
+      canvas.removeEventListener("pointermove", onPointerMove);
+      canvas.removeEventListener("pointerup", onPointerLeave);
+      canvas.removeEventListener("pointerleave", onPointerLeave);
+      canvas.removeEventListener("pointercancel", onPointerLeave);
+      controls.dispose();
+      clearAsset();
+      material.dispose();
+      draco.dispose();
+      renderer.dispose();
+    },
+  };
+}
+
+export interface ParticleObjectProps extends ParticleObjectOptions {
+  className?: string;
+  style?: React.CSSProperties;
+  canvasTouchAction?: React.CSSProperties["touchAction"];
+}
+
+export function ParticleObject({
+  className,
+  style,
+  canvasTouchAction = "none",
+  ...options
+}: ParticleObjectProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const instanceRef = useRef<ParticleObjectInstance | null>(null);
+  const [initialOptions] = useState(options);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    instanceRef.current = createParticleObject({ canvas }, initialOptions);
+    return () => {
+      instanceRef.current?.destroy();
+      instanceRef.current = null;
+    };
+  }, [initialOptions]);
+
+  useEffect(() => {
+    instanceRef.current?.setOptions(options);
+  });
+
+  return (
+    <div className={className} style={{ position: "relative", ...style }}>
+      <canvas
+        ref={canvasRef}
+        style={{
+          position: "absolute",
+          inset: 0,
+          width: "100%",
+          height: "100%",
+          display: "block",
+          touchAction: canvasTouchAction,
+        }}
+      />
+    </div>
+  );
+}
+
+
+export default ParticleObject;

--- a/webui/src/components/canvasui/ParticleObject.tsx
+++ b/webui/src/components/canvasui/ParticleObject.tsx
@@ -1047,6 +1047,14 @@ export function ParticleObject({
   }, [initialOptions]);
 
   useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    // OrbitControls sets touch-action to none while it attaches its listeners.
+    // Restore the embedding surface's policy after the controller is created.
+    canvas.style.touchAction = canvasTouchAction;
+  }, [canvasTouchAction]);
+
+  useEffect(() => {
     instanceRef.current?.setOptions(options);
   });
 

--- a/webui/src/components/thread/NanobotParticleMark.tsx
+++ b/webui/src/components/thread/NanobotParticleMark.tsx
@@ -1,0 +1,80 @@
+import { lazy, Suspense, useState } from "react";
+
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+
+interface NanobotParticleMarkProps {
+  theme: "light" | "dark";
+}
+
+const LOGO_SRC = "/brand/nanobot_icon.png";
+const PARTICLES_ENABLED = import.meta.env.MODE !== "test";
+
+const ParticleObject = lazy(async () => {
+  const module = await import("@/components/canvasui/ParticleObject");
+  return { default: module.ParticleObject };
+});
+
+export function NanobotParticleMark({ theme }: NanobotParticleMarkProps) {
+  const [ready, setReady] = useState(false);
+  const compact = useMediaQuery("(max-width: 639px)");
+
+  return (
+    <div
+      aria-hidden="true"
+      data-particle-profile={compact ? "compact" : "desktop"}
+      data-particle-state={ready ? "ready" : "loading"}
+      data-testid="nanobot-particle-mark"
+      className="relative h-full w-full"
+    >
+      <div
+        className={`pointer-events-none absolute inset-[18%] rounded-full blur-3xl ${
+          theme === "dark" ? "bg-orange-500/[0.05]" : "bg-orange-400/[0.035]"
+        }`}
+      />
+
+      <img
+        src={LOGO_SRC}
+        alt=""
+        className={`pointer-events-none absolute left-1/2 top-[44%] w-52 -translate-x-1/2 -translate-y-1/2 transition-opacity duration-500 sm:w-72 ${
+          ready
+            ? "opacity-0"
+            : theme === "dark"
+              ? "opacity-[0.12]"
+              : "opacity-[0.08]"
+        }`}
+      />
+
+      {PARTICLES_ENABLED ? (
+        <Suspense fallback={null}>
+          <ParticleObject
+            src={LOGO_SRC}
+            count={compact ? 1_400 : 2_600}
+            size={compact ? 4.75 : 4.25}
+            sizeVariance={0.4}
+            radius={compact ? 112 : 180}
+            strength={compact ? 3.8 : 4.2}
+            swirl={compact ? 1.05 : 1.35}
+            spring={compact ? 0.48 : 0.38}
+            damping={compact ? 0.24 : 0.18}
+            drift={compact ? 0.65 : 0.9}
+            scale={compact ? 2.4 : 3.4}
+            yOffset={compact ? 0.2 : 0.38}
+            floatIntensity={compact ? 1.1 : 1.6}
+            rotationIntensity={compact ? 0.85 : 1.25}
+            floatSpeed={compact ? 1.4 : 1.7}
+            orbit={false}
+            zoom={false}
+            autoRotate={false}
+            fov={58}
+            cameraDistance={4.2}
+            canvasTouchAction="pan-y"
+            onLoad={() => setReady(true)}
+            className={`h-full w-full transition-opacity duration-700 ${
+              theme === "dark" ? "opacity-[0.28]" : "opacity-[0.22]"
+            }`}
+          />
+        </Suspense>
+      ) : null}
+    </div>
+  );
+}

--- a/webui/src/components/thread/NanobotParticleMark.tsx
+++ b/webui/src/components/thread/NanobotParticleMark.tsx
@@ -6,7 +6,7 @@ interface NanobotParticleMarkProps {
   theme: "light" | "dark";
 }
 
-const LOGO_SRC = "/brand/nanobot_icon.png";
+const LOGO_SRC = "/brand/nanobot_mark.svg";
 const PARTICLES_ENABLED = import.meta.env.MODE !== "test";
 
 const ParticleObject = lazy(async () => {

--- a/webui/src/components/thread/ThreadComposer.tsx
+++ b/webui/src/components/thread/ThreadComposer.tsx
@@ -2284,7 +2284,7 @@ export function ThreadComposer({
         className={cn(
           "thread-composer-surface group/composer relative mx-auto flex w-full flex-col overflow-visible transition-all duration-200",
           isHero
-            ? "max-w-[58rem] rounded-[28px] bg-muted/30 focus-within:bg-muted/50 dark:bg-card dark:focus-within:bg-white/[0.06]"
+            ? "max-w-[58rem] rounded-[28px] bg-card"
             : "max-w-[49.5rem] rounded-[22px] bg-muted/30 focus-within:bg-muted/50 dark:bg-card dark:focus-within:bg-white/[0.06]",
           interactionDisabled && "opacity-60",
           sessionDragPreview && "ring-1 ring-primary/25",

--- a/webui/src/components/thread/ThreadShell.tsx
+++ b/webui/src/components/thread/ThreadShell.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 
 import { FilePreviewAvailabilityProvider } from "@/components/FilePreviewAvailabilityContext";
 import { FilePreviewPanel } from "@/components/FilePreviewPanel";
+import { NanobotParticleMark } from "@/components/thread/NanobotParticleMark";
 import { PromptNavigator } from "@/components/thread/PromptNavigator";
 import { SessionInfoPopover } from "@/components/thread/SessionInfoPopover";
 import { ThreadComposer } from "@/components/thread/ThreadComposer";
@@ -1520,6 +1521,9 @@ export function ThreadShell({
       <HeroGreeting text={t(heroGreetingKey)} />
     </div>
   );
+  const emptyStateBackground = loading ? null : (
+    <NanobotParticleMark theme={theme} />
+  );
   const sessionInfoAction = historyKey ? (
     <SessionInfoPopover sessionKey={historyKey} token={token} title={title} />
   ) : undefined;
@@ -1566,6 +1570,7 @@ export function ThreadShell({
             temporary={temporary}
             isStreaming={turnActive}
             emptyState={emptyState}
+            emptyStateBackground={emptyStateBackground}
             composer={composerPortalTarget === undefined ? composer : null}
             activeTurnId={viewportTurnId}
             activeTurnStartedHere={activeTurnStartedHere}

--- a/webui/src/components/thread/ThreadShell.tsx
+++ b/webui/src/components/thread/ThreadShell.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 
 import { FilePreviewAvailabilityProvider } from "@/components/FilePreviewAvailabilityContext";
 import { FilePreviewPanel } from "@/components/FilePreviewPanel";
-import { NanobotParticleMark } from "@/components/thread/NanobotParticleMark";
+import { NanobotParticleMark } from "@/components/NanobotParticleMark";
 import { PromptNavigator } from "@/components/thread/PromptNavigator";
 import { SessionInfoPopover } from "@/components/thread/SessionInfoPopover";
 import { ThreadComposer } from "@/components/thread/ThreadComposer";

--- a/webui/src/components/thread/ThreadViewport.tsx
+++ b/webui/src/components/thread/ThreadViewport.tsx
@@ -39,6 +39,7 @@ interface ThreadViewportProps {
   isStreaming: boolean;
   composer?: ReactNode;
   emptyState?: ReactNode;
+  emptyStateBackground?: ReactNode;
   scrollToBottomSignal?: number;
   activeTurnId?: string | null;
   activeTurnStartedHere?: boolean;
@@ -163,6 +164,7 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
   isStreaming,
   composer,
   emptyState,
+  emptyStateBackground,
   scrollToBottomSignal = 0,
   activeTurnId = null,
   activeTurnStartedHere = false,
@@ -667,12 +669,17 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
           data-testid={!hasMessages ? "thread-welcome-layout" : undefined}
           data-layout={hasComposer ? (hasMessages ? "thread" : "hero") : "external"}
           className={cn(
-            "thread-layout mx-auto grid min-h-full w-full",
+            "thread-layout relative mx-auto grid min-h-full w-full",
             hasMessages
               ? "h-full max-w-[64rem]"
               : "max-w-[72rem] px-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] pt-6 sm:px-4 sm:py-12",
           )}
         >
+          {!hasMessages && emptyStateBackground ? (
+            <div className="absolute inset-0 z-20 overflow-hidden">
+              {emptyStateBackground}
+            </div>
+          ) : null}
           {hasMessages ? (
             <div
               ref={messageRegionRef}
@@ -705,7 +712,7 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
           ) : (
             <div
               className={cn(
-                "row-start-1 flex min-h-0 min-w-0 w-full items-center justify-center",
+                "pointer-events-none relative z-30 row-start-1 flex min-h-0 min-w-0 w-full items-center justify-center",
                 hasComposer && "sm:items-end sm:pb-8",
               )}
             >
@@ -737,8 +744,10 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
                 }
               }}
               className={cn(
-                "row-start-2 z-10 w-full",
-                hasMessages ? "relative bg-background" : "relative self-center",
+                "row-start-2 w-full",
+                hasMessages
+                  ? "relative z-10 bg-background"
+                  : "relative z-30 self-center",
               )}
             >
               <div
@@ -761,7 +770,7 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
           {hasComposer ? (
             <div
               aria-hidden
-              className="thread-layout-spacer row-start-3 min-h-0 overflow-hidden"
+              className="thread-layout-spacer pointer-events-none row-start-3 min-h-0 overflow-hidden"
             />
           ) : null}
         </div>

--- a/webui/src/globals.css
+++ b/webui/src/globals.css
@@ -724,6 +724,19 @@
   container-type: inline-size;
 }
 
+.auth-password-input:-webkit-autofill,
+.auth-password-input:-webkit-autofill:hover,
+.auth-password-input:-webkit-autofill:focus {
+  -webkit-text-fill-color: hsl(var(--foreground));
+  caret-color: hsl(var(--foreground));
+  box-shadow: inset 0 0 0 1000px hsl(var(--background));
+}
+
+.auth-password-input:-webkit-autofill:focus-visible {
+  outline: 2px solid hsl(var(--ring) / 0.5);
+  outline-offset: -2px;
+}
+
 .thread-composer-footer-actions {
   flex: 0 1 auto;
   max-width: 58%;

--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -346,7 +346,7 @@ describe("App layout", () => {
 
     render(<App />);
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Password" }))
+    expect(await screen.findByRole("heading", { level: 1, name: "nanobot" }))
       .toBeInTheDocument();
     const password = screen.getByLabelText("Password");
     expect(password).toHaveAttribute(
@@ -354,6 +354,11 @@ describe("App layout", () => {
       "current-password",
     );
     expect(password).not.toHaveAttribute("placeholder");
+    expect(password).toHaveClass("bg-background");
+    expect(screen.getByTestId("nanobot-particle-mark")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
     expect(screen.queryByText("Authentication required")).not.toBeInTheDocument();
     expect(
       screen.queryByText("Incorrect password. Try again."),
@@ -417,7 +422,7 @@ describe("App layout", () => {
 
     render(<App />);
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Password" }))
+    expect(await screen.findByRole("heading", { level: 1, name: "nanobot" }))
       .toBeInTheDocument();
     expect(
       screen.queryByText("Incorrect password. Try again."),

--- a/webui/src/tests/nanobot-particle-mark.test.tsx
+++ b/webui/src/tests/nanobot-particle-mark.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { NanobotParticleMark } from "@/components/thread/NanobotParticleMark";
+
+function stubViewport(compact: boolean) {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn((query: string) => ({
+      matches: compact && query === "(max-width: 639px)",
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("NanobotParticleMark", () => {
+  it("uses the desktop particle profile on wider viewports", () => {
+    stubViewport(false);
+
+    render(<NanobotParticleMark theme="dark" />);
+
+    expect(screen.getByTestId("nanobot-particle-mark")).toHaveAttribute(
+      "data-particle-profile",
+      "desktop",
+    );
+  });
+
+  it("uses the compact particle profile on mobile viewports", () => {
+    stubViewport(true);
+
+    render(<NanobotParticleMark theme="light" />);
+
+    expect(screen.getByTestId("nanobot-particle-mark")).toHaveAttribute(
+      "data-particle-profile",
+      "compact",
+    );
+  });
+});

--- a/webui/src/tests/nanobot-particle-mark.test.tsx
+++ b/webui/src/tests/nanobot-particle-mark.test.tsx
@@ -1,3 +1,6 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -29,10 +32,14 @@ describe("NanobotParticleMark", () => {
 
     render(<NanobotParticleMark theme="dark" />);
 
-    expect(screen.getByTestId("nanobot-particle-mark")).toHaveAttribute(
+    const mark = screen.getByTestId("nanobot-particle-mark");
+    expect(mark).toHaveAttribute(
       "data-particle-profile",
       "desktop",
     );
+    const source = mark.querySelector("img")?.getAttribute("src");
+    expect(source).toBe("/brand/nanobot_mark.svg");
+    expect(existsSync(resolve(process.cwd(), "public", source!.slice(1)))).toBe(true);
   });
 
   it("uses the compact particle profile on mobile viewports", () => {

--- a/webui/src/tests/nanobot-particle-mark.test.tsx
+++ b/webui/src/tests/nanobot-particle-mark.test.tsx
@@ -4,7 +4,7 @@ import { resolve } from "node:path";
 import { render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { NanobotParticleMark } from "@/components/thread/NanobotParticleMark";
+import { NanobotParticleMark } from "@/components/NanobotParticleMark";
 
 function stubViewport(compact: boolean) {
   vi.stubGlobal(
@@ -37,9 +37,10 @@ describe("NanobotParticleMark", () => {
       "data-particle-profile",
       "desktop",
     );
-    const source = mark.querySelector("img")?.getAttribute("src");
-    expect(source).toBe("/brand/nanobot_mark.svg");
-    expect(existsSync(resolve(process.cwd(), "public", source!.slice(1)))).toBe(true);
+    expect(mark.querySelector("img")).toBeNull();
+    expect(
+      existsSync(resolve(process.cwd(), "public", "brand", "nanobot_mark.svg")),
+    ).toBe(true);
   });
 
   it("uses the compact particle profile on mobile viewports", () => {

--- a/webui/src/tests/thread-composer.test.tsx
+++ b/webui/src/tests/thread-composer.test.tsx
@@ -476,7 +476,11 @@ describe("ThreadComposer", () => {
     expect(input.className).toContain("pt-[27px]");
     fireEvent.change(input, { target: { value: "1" } });
     expect(input.className).toContain("pt-[27px]");
-    expect(input.parentElement?.parentElement?.className).toContain("max-w-[58rem]");
+    const surface = input.parentElement?.parentElement;
+    expect(surface?.className).toContain("max-w-[58rem]");
+    expect(surface?.className).toContain("bg-card");
+    expect(surface?.className).not.toContain("bg-muted/30");
+    expect(surface?.className).not.toContain("shadow-");
   });
 
   it("defers textarea autosizing until IME composition commits", () => {

--- a/webui/src/tests/thread-shell.test.tsx
+++ b/webui/src/tests/thread-shell.test.tsx
@@ -1272,6 +1272,7 @@ describe("ThreadShell", () => {
     const greeting = screen.getByRole("heading", { level: 1, name: HERO_GREETING_PATTERN });
     expect(greeting).toHaveAttribute("data-testid", "hero-greeting");
     expect(greeting).toHaveClass("select-none", "whitespace-nowrap");
+    expect(screen.getByTestId("nanobot-particle-mark")).toHaveAttribute("aria-hidden", "true");
     expect(screen.getByPlaceholderText("Ask anything...")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Write code" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Create a project plan" })).not.toBeInTheDocument();

--- a/webui/src/tests/thread-viewport.test.tsx
+++ b/webui/src/tests/thread-viewport.test.tsx
@@ -1290,18 +1290,25 @@ describe("ThreadViewport", () => {
         isStreaming={false}
         composer={<div>composer</div>}
         emptyState={<div>welcome</div>}
+        emptyStateBackground={<div data-testid="welcome-background" />}
       />,
     );
 
     const layout = screen.getByTestId("thread-welcome-layout");
     expect(layout).toHaveClass("thread-layout", "grid");
     expect(layout).toHaveAttribute("data-layout", "hero");
+    expect(screen.getByTestId("welcome-background").parentElement).toHaveClass(
+      "z-20",
+    );
     expect(screen.getByText("welcome").parentElement).toHaveClass(
       "min-h-0",
       "items-center",
+      "pointer-events-none",
       "sm:items-end",
       "sm:pb-8",
+      "z-30",
     );
+    expect(screen.getByTestId("thread-composer-dock")).toHaveClass("z-30");
     expect(screen.getByTestId("thread-composer-motion")).toContainElement(
       screen.getByText("composer"),
     );


### PR DESCRIPTION
## Summary

- add a lazy-loaded Canvas UI particle background to the empty-thread hero
- tune particle scale, opacity, pointer response, spring motion, and compact mobile behavior
- keep the greeting and composer layered above the interactive canvas while preserving the current message-thread layout
- use the current bundled nanobot SVG and preserve vertical touch scrolling after OrbitControls initializes
- document the bundled Canvas UI code under its MIT + Commons Clause terms

## Validation

- `npm ci --ignore-scripts --dry-run`
- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run test` (64 files, 1,006 tests)
- `bun run build`
- isolated gateway + headless browser at 1280×720 and 390×844: particle state reached `ready`, desktop/compact profiles selected correctly, canvas retained `touch-action: pan-y`, foreground controls stayed visible, and no console errors were reported

## Review notes

- Draft port of [chengyongru/nanobot#315](https://github.com/chengyongru/nanobot/pull/315), rebased onto the current `HKUDS/nanobot:main`.
- The bundled component is covered by MIT + Commons Clause terms recorded in `THIRD_PARTY_NOTICES.md`. Please confirm that the additional restriction is acceptable before marking this ready or merging.
- The lazy `ParticleObject` production chunk is about 649.5 kB (168.0 kB gzip), above Vite's warning threshold. It is excluded from the initial bundle, but the empty-thread download/runtime cost should be reviewed.