### PR TITLE
fix(skills): make weather workflow Windows-safe

### DIFF
--- a/nanobot/skills/weather/SKILL.md
+++ b/nanobot/skills/weather/SKILL.md
@@ -11,22 +11,35 @@ Two free services, no API keys needed.
 
 ## wttr.in (primary)
 
-Quick one-liner:
+Platform notes:
+- On Windows PowerShell, use `curl.exe`; bare `curl` may resolve to
+  `Invoke-WebRequest`.
+- On macOS and Linux, use `curl`.
+
+Current conditions only:
 ```bash
-curl -s "wttr.in/London?format=3"
+curl -s "https://wttr.in/London?format=3"
 # Output: London: ⛅️ +8°C
 ```
 
-Compact format:
+Custom current conditions format:
 ```bash
-curl -s "wttr.in/London?format=%l:+%c+%t+%h+%w"
+curl -s "https://wttr.in/London?format=%l:+%c+%t+%h+%w"
 # Output: London: ⛅️ +8°C 71% ↙5km/h
+```
+
+Today's weather, including current conditions (use this single request for
+questions about today's weather):
+```bash
+curl -s "https://wttr.in/London?1&m"
 ```
 
 Full forecast:
 ```bash
-curl -s "wttr.in/London?T"
+curl -s "https://wttr.in/London?T&m"
 ```
+
+On Windows PowerShell, replace `curl` with `curl.exe` in the commands above.
 
 Format codes: `%c` condition · `%t` temp · `%h` humidity · `%w` wind · `%l` location · `%m` moon
 
@@ -35,7 +48,8 @@ Tips:
 - Airport codes: `wttr.in/JFK`
 - Units: `?m` (metric) `?u` (USCS)
 - Today only: `?1` · Current only: `?0`
-- PNG: `curl -s "wttr.in/Berlin.png" -o /tmp/weather.png`
+- PNG (macOS/Linux): `curl -s "https://wttr.in/Berlin.png" -o weather.png`
+- PNG (Windows PowerShell): `curl.exe -s "https://wttr.in/Berlin.png" -o weather.png`
 
 ## Open-Meteo (fallback, JSON)
 

--- a/tests/agent/test_builtin_weather_skill.py
+++ b/tests/agent/test_builtin_weather_skill.py
@@ -1,0 +1,16 @@
+from nanobot.agent.skills import BUILTIN_SKILLS_DIR
+
+
+def test_weather_skill_uses_windows_safe_single_today_request() -> None:
+    content = (BUILTIN_SKILLS_DIR / "weather" / "SKILL.md").read_text(encoding="utf-8")
+    normalized = " ".join(content.split())
+
+    assert "On Windows PowerShell, use `curl.exe`" in normalized
+    assert "bare `curl` may resolve to `Invoke-WebRequest`" in normalized
+    assert "https://wttr.in/London?1&m" in content
+    assert 'curl.exe -s "https://wttr.in/Berlin.png" -o weather.png' in content
+    assert "/tmp/weather.png" not in content
+    assert (
+        "use this single request for"
+        " questions about today's weather"
+    ) in normalized


### PR DESCRIPTION
## Problem

On Windows PowerShell, bare `curl` may resolve to the `Invoke-WebRequest` alias instead of the native cURL executable.

The weather skill previously used bare `curl` in its examples. This could cause the first weather command to fail, requiring the agent to analyze the error and retry with `curl.exe`.

Closes #5303

## Changes

- Add platform notes documenting Windows PowerShell vs macOS/Linux difference
- Use explicit HTTPS URLs for wttr.in requests
- Add single `?1&m` request for today's weather to avoid redundant calls
- Use cross-platform output path (`weather.png` instead of `/tmp/weather.png`)
- Add regression test for the weather skill guidance

## Testing

- `pytest tests/agent/test_builtin_weather_skill.py -v` — 1 passed
- Manually verified the weather workflow on Windows PowerShell