### PR TITLE
fix(security): harden WebUI caches and CLI app subprocesses

### DIFF
--- a/nanobot/apps/cli/service.py
+++ b/nanobot/apps/cli/service.py
@@ -1029,6 +1029,7 @@ class CliAppManager:
             encoding="utf-8",
             errors="replace",
             timeout=timeout,
+            env=self._subprocess_env(),
         )
         logger.info("CLI Apps: command exited with code {}: {}", result.returncode, command)
         output = (result.stderr or result.stdout or "").strip()

--- a/nanobot/channels/websocket/tests/test_websocket_channel.py
+++ b/nanobot/channels/websocket/tests/test_websocket_channel.py
@@ -717,7 +717,7 @@ async def test_token_issue_route_requires_secret_when_static_token_configured(bu
         bus,
         port=port,
         token="static-token",
-        tokenIssuePath="/auth/token",
+        tokenIssuePath="/custom-token",
         websocketRequiresToken=True,
     )
 
@@ -725,15 +725,16 @@ async def test_token_issue_route_requires_secret_when_static_token_configured(bu
     await asyncio.sleep(0.3)
 
     try:
-        denied = await _http_get(f"http://127.0.0.1:{port}/auth/token")
+        denied = await _http_get(f"http://127.0.0.1:{port}/custom-token")
         assert denied.status_code == 401
 
         allowed = await _http_get(
-            f"http://127.0.0.1:{port}/auth/token",
+            f"http://127.0.0.1:{port}/custom-token",
             headers={"Authorization": "Bearer static-token"},
         )
         assert allowed.status_code == 200
         assert allowed.json()["token"].startswith("nbwt_")
+        assert allowed.headers["Cache-Control"] == "no-store"
     finally:
         await channel.stop()
         await server_task
@@ -3803,6 +3804,7 @@ async def test_token_issue_rejects_when_at_capacity(bus: MagicMock) -> None:
             headers={"Authorization": "Bearer s"},
         )
         assert resp.status_code == 429
+        assert resp.headers["Cache-Control"] == "no-store"
         data = resp.json()
         assert "error" in data
     finally:

--- a/nanobot/channels/websocket/tests/test_websocket_http_routes.py
+++ b/nanobot/channels/websocket/tests/test_websocket_http_routes.py
@@ -227,6 +227,7 @@ async def test_bootstrap_returns_token_for_localhost(
     try:
         resp = await _http_get("http://127.0.0.1:29901/webui/bootstrap")
         assert resp.status_code == 200
+        assert resp.headers["Cache-Control"] == "no-store"
         body = resp.json()
         assert body["token"].startswith("nbwt_")
         assert channel.gateway.tokens.issued_token_audiences[body["token"]] == "webui"

--- a/nanobot/webui/http_utils.py
+++ b/nanobot/webui/http_utils.py
@@ -100,6 +100,7 @@ def http_json_response(
     *,
     status: int = 200,
     accept_encoding: str | None = None,
+    extra_headers: list[tuple[str, str]] | None = None,
 ) -> Response:
     body = json.dumps(data, ensure_ascii=False).encode("utf-8")
     headers = [
@@ -112,6 +113,8 @@ def http_json_response(
         if len(body) >= _JSON_GZIP_MIN_BYTES and accepts_gzip(accept_encoding):
             body = gzip.compress(body, compresslevel=_JSON_GZIP_LEVEL, mtime=0)
             headers.append(("Content-Encoding", "gzip"))
+    if extra_headers:
+        headers.extend(extra_headers)
     headers.append(("Content-Length", str(len(body))))
     reason = http.HTTPStatus(status).phrase
     return Response(status, reason, Headers(headers), body)

--- a/nanobot/webui/ws_http.py
+++ b/nanobot/webui/ws_http.py
@@ -121,6 +121,7 @@ from nanobot.webui.workspaces import WebUIWorkspaceController
 _SLOW_WEBUI_HTTP_LOG_MS = 1_000
 _WEBUI_MUTATION_PAYLOAD_ATTR = "_nanobot_webui_mutation_payload"
 _WEBUI_MUTATION_REQUEST_ATTR = "_nanobot_webui_mutation_request"
+_NO_STORE_HEADERS = [("Cache-Control", "no-store")]
 
 _WEBUI_MUTATION_PATHS = {
     "automation.enable": "/api/webui/automations/enable",
@@ -547,9 +548,16 @@ class GatewayHTTPHandler:
                 "too many outstanding issued tokens ({}), rejecting issuance",
                 len(self.tokens.issued_tokens),
             )
-            return _http_json_response({"error": "too many outstanding tokens"}, status=429)
+            return _http_json_response(
+                {"error": "too many outstanding tokens"},
+                status=429,
+                extra_headers=_NO_STORE_HEADERS,
+            )
         token_value = self.tokens.issue_token(self.config.token_ttl_s)
-        return _http_json_response(token_response_payload(token_value, self.config.token_ttl_s))
+        return _http_json_response(
+            token_response_payload(token_value, self.config.token_ttl_s),
+            extra_headers=_NO_STORE_HEADERS,
+        )
 
     # -- Bootstrap ----------------------------------------------------------
 
@@ -579,7 +587,7 @@ class GatewayHTTPHandler:
                 "runtime_surface": self._runtime_surface,
                 "runtime_capabilities": self._capabilities,
             }
-            return _http_json_response(payload)
+            return _http_json_response(payload, extra_headers=_NO_STORE_HEADERS)
 
         api_token_allowed = bool(secret) or is_local_browser
         if not self.tokens.can_issue(include_api_token=api_token_allowed):
@@ -587,6 +595,7 @@ class GatewayHTTPHandler:
                 json.dumps({"error": "too many outstanding tokens"}).encode("utf-8"),
                 status=429,
                 content_type="application/json; charset=utf-8",
+                extra_headers=_NO_STORE_HEADERS,
             )
         token = self.tokens.issue_token(self.config.token_ttl_s, audience="webui")
         api_token = (
@@ -611,7 +620,7 @@ class GatewayHTTPHandler:
         }
         if api_token is not None:
             payload["api_token"] = api_token
-        return _http_json_response(payload)
+        return _http_json_response(payload, extra_headers=_NO_STORE_HEADERS)
 
     def _bootstrap_ws_url(self, request: Any) -> str:
         headers = getattr(request, "headers", {}) or {}

--- a/tests/apps/test_cli_subprocess_env.py
+++ b/tests/apps/test_cli_subprocess_env.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import subprocess
+
 from nanobot.apps.cli.service import CliAppManager
 
 
@@ -67,3 +69,22 @@ def test_run_passes_filtered_env(monkeypatch, tmp_path) -> None:
     env = captured.get("env")
     assert isinstance(env, dict)
     assert "OPENAI_API_KEY" not in env
+
+
+def test_management_subprocesses_use_filtered_env(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-should-not-leak")
+    captured: dict[str, object] = {}
+
+    def fake_run(*args, **kwargs):
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(args[0], 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("nanobot.apps.cli.service.subprocess.run", fake_run)
+    manager = CliAppManager(workspace=tmp_path, data_dir=tmp_path / "cli-apps")
+
+    manager._run_argv(["example-cli", "--help"], timeout=5)
+
+    env = captured.get("env")
+    assert isinstance(env, dict)
+    assert "OPENAI_API_KEY" not in env
+    assert env["PYTHONUNBUFFERED"] == "1"

--- a/tests/cli_apps/test_service.py
+++ b/tests/cli_apps/test_service.py
@@ -442,12 +442,15 @@ def test_run_argv_logs_command_exit_and_output(
         encoding: str,
         errors: str,
         timeout: int,
+        env: dict[str, str],
     ) -> subprocess.CompletedProcess[str]:
         assert capture_output is True
         assert text is True
         assert encoding == "utf-8"
         assert errors == "replace"
         assert timeout == 5
+        assert "OPENAI_API_KEY" not in env
+        assert env["PYTHONUNBUFFERED"] == "1"
         return subprocess.CompletedProcess(argv, 0, stdout="installed ok", stderr="")
 
     monkeypatch.setattr(cli_service, "logger", _Logger())

--- a/webui/public/sw.js
+++ b/webui/public/sw.js
@@ -1,6 +1,23 @@
-const CACHE_NAME = "nanobot-static-v1";
+const CACHE_PREFIX = "nanobot-static-";
+const CACHE_NAME = `${CACHE_PREFIX}v2`;
 const ASSET_MANIFEST_PATH = "/asset-manifest.json";
 const PRECACHE = ["/", "/manifest.json", ASSET_MANIFEST_PATH];
+const NETWORK_FIRST_STATIC_PATHS = new Set([
+  "/",
+  "/manifest.json",
+  ASSET_MANIFEST_PATH,
+  "/brand/nanobot_apple_touch.png",
+  "/brand/nanobot_favicon_32.png",
+  "/brand/nanobot_icon_192.png",
+  "/brand/nanobot_icon_512.png",
+  "/brand/nanobot_icon_maskable.png",
+  "/brand/nanobot_mark.svg",
+]);
+
+function responseMayBeCached(response) {
+  const cacheControl = response.headers?.get("Cache-Control") ?? "";
+  return response.ok && !/(?:^|,)\s*(?:private|no-cache|no-store)\b/i.test(cacheControl);
+}
 
 self.addEventListener("install", (event) => {
   event.waitUntil(
@@ -91,7 +108,7 @@ self.addEventListener("activate", (event) => {
       .then((keys) =>
         Promise.all(
           keys
-            .filter((k) => k !== CACHE_NAME)
+            .filter((k) => k.startsWith(CACHE_PREFIX) && k !== CACHE_NAME)
             .map((k) => caches.delete(k))
         )
       )
@@ -107,27 +124,12 @@ self.addEventListener("fetch", (event) => {
   // (never reconstructed), so their credentials mode is preserved and gateway
   // auth cookies flow through on every path we touch. WebSocket upgrades are
   // never dispatched to a service worker's fetch handler, so the WS endpoint
-  // cannot be cached; the /__nanobot exclusion below still protects its HTTP
-  // polling/socket bootstrap endpoints.
+  // cannot be cached. Unknown HTTP endpoints are passed through below.
   if (request.method !== "GET") return;
   if (new URL(request.url).origin !== self.location.origin) return;
 
   const url = new URL(request.url);
   const path = url.pathname;
-
-  // Never cache API, auth, WebSocket, HMR, or WebUI endpoint paths. In
-  // particular /webui/bootstrap issues fresh gateway credentials on every page
-  // load and must never be cached or replayed offline. The /auth prefix covers
-  // the default token endpoint; custom token_issue_path values should be kept
-  // under one of these prefixes.
-  if (
-    path.startsWith("/api") ||
-    path.startsWith("/auth") ||
-    path.startsWith("/__nanobot") ||
-    path.startsWith("/webui")
-  ) {
-    return;
-  }
 
   // Static assets: cache-first. Only files under /assets/ carry content hashes
   // (the gateway serves them immutable); brand icons, the favicon and other
@@ -138,7 +140,7 @@ self.addEventListener("fetch", (event) => {
       caches.match(request).then((cached) => {
         if (cached) return cached;
         return fetch(request).then((response) => {
-          if (response.ok) {
+          if (responseMayBeCached(response)) {
             const clone = response.clone();
             caches.open(CACHE_NAME).then((c) => c.put(request, clone));
           }
@@ -149,22 +151,28 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
-  // Everything else: network-first (index.html, manifest, brand assets, etc.)
+  // Cache only explicit public files and browser navigations. Dynamic routes
+  // are deliberately passed through because token_issue_path and extension
+  // endpoints are configurable and cannot be safely identified by prefixes.
+  const isNavigation = request.mode === "navigate";
+  if (!isNavigation && !NETWORK_FIRST_STATIC_PATHS.has(path)) return;
+
+  // App shell and public files: network-first with an offline fallback.
   const networkResponse = fetch(request);
   event.waitUntil(
     networkResponse
       .then(async (response) => {
-        if (!response.ok) return;
+        if (!responseMayBeCached(response)) return;
         // Clone before the first await. The original response is also handed
         // to respondWith(), which may lock its body as soon as this callback
         // yields to the event loop.
         const cachedResponse = response.clone();
         const cache = await caches.open(CACHE_NAME);
-        await cache.put(request, cachedResponse);
+        await cache.put(isNavigation ? "/" : request, cachedResponse);
         // Refresh the complete build graph before pruning. A deployment can
         // change index.html without changing sw.js, so this cannot rely only
         // on the manifest cached when the worker was installed.
-        if (path === "/") {
+        if (isNavigation || path === "/") {
           if (await refreshAssetManifest(cache)) await pruneStaleEntries();
         }
       })

--- a/webui/src/tests/sw.test.ts
+++ b/webui/src/tests/sw.test.ts
@@ -7,7 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const SW_SCRIPT = readFileSync(resolve(process.cwd(), "public/sw.js"), "utf8");
 
 const ORIGIN = "https://nanobot.test";
-const CACHE_NAME = "nanobot-static-v1";
+const CACHE_NAME = "nanobot-static-v2";
 
 /** Minimal Cache-compatible in-memory store with SW-style URL normalization. */
 class FakeCacheStore {
@@ -66,7 +66,7 @@ function loadSw(): LoadedSw {
   const caches = {
     open: vi.fn(async () => store),
     match: vi.fn((input: Request | string) => store.match(input)),
-    keys: vi.fn(async () => [CACHE_NAME, "nanobot-static-v0"]),
+    keys: vi.fn(async () => [CACHE_NAME, "nanobot-static-v1", "other-app-cache"]),
     delete: vi.fn(async (name: string) => {
       deletedCacheNames.push(name);
       return true;
@@ -149,7 +149,7 @@ describe("service worker", () => {
 
     await sw.fire("activate");
 
-    expect(sw.deletedCacheNames).toEqual(["nanobot-static-v0"]);
+    expect(sw.deletedCacheNames).toEqual(["nanobot-static-v1"]);
     expect(sw.claimMock).toHaveBeenCalledTimes(1);
     expect(sw.store.entries.has(`${ORIGIN}/`)).toBe(true);
     expect(sw.store.entries.has(`${ORIGIN}/manifest.json`)).toBe(true);
@@ -161,7 +161,7 @@ describe("service worker", () => {
     expect(sw.store.entries.has(`${ORIGIN}/assets/index-v1.css`)).toBe(false);
   });
 
-  it("does not intercept API, auth, WebSocket, or WebUI endpoint requests", async () => {
+  it("does not intercept dynamic or unknown endpoint requests", async () => {
     const sw = loadSw();
     const paths = [
       "/api/v1/models",
@@ -171,6 +171,8 @@ describe("service worker", () => {
       "/api/chat/completions",
       "/webui/bootstrap",
       "/webui/session/list",
+      "/custom-token",
+      "/mcp-oauth/callback",
     ];
 
     for (const path of paths) {
@@ -228,6 +230,30 @@ describe("service worker", () => {
     expect(sw.fetchMock).toHaveBeenCalledWith(originalRequest);
     expect(sw.store.entries.has(assetUrl)).toBe(true);
   });
+
+  it.each(["private", "no-cache", "no-store"])(
+    "does not cache a %s response even under the static asset prefix",
+    async (cacheControl) => {
+      const sw = loadSw();
+      const tokenUrl = `${ORIGIN}/assets/custom-token`;
+      const originalRequest = new Request(tokenUrl);
+      sw.fetchMock.mockResolvedValue(
+        new Response('{"token":"short-lived"}', {
+          headers: {
+            "Cache-Control": cacheControl,
+            "Content-Type": "application/json",
+          },
+        }),
+      );
+
+      const event = { request: originalRequest, respondWith: vi.fn() };
+      await sw.fire("fetch", event);
+
+      const response = (await event.respondWith.mock.calls[0][0]) as Response;
+      expect(await response.json()).toEqual({ token: "short-lived" });
+      expect(sw.store.entries.has(tokenUrl)).toBe(false);
+    },
+  );
 
   it("keeps un-hashed brand assets on the network-first path", async () => {
     const sw = loadSw();


### PR DESCRIPTION
## Summary

- mark token-issuing gateway responses `Cache-Control: no-store`
- restrict the service worker to the WebUI shell and explicit public assets, while honoring cache-control directives
- migrate the nanobot cache from v1 to v2 and preserve caches owned by other same-origin apps
- apply the filtered subprocess environment to CLI App install, update, uninstall, discovery, and test commands as well as normal runs

## Why

This closes two credential-boundary gaps:

1. The service worker treated unknown same-origin GET routes as cacheable, so a custom token endpoint could leave a short-lived bearer token in CacheStorage.
2. CLI App management commands used a shared subprocess helper that still inherited the complete host environment, bypassing the filtering applied to normal app runs in #5270.

## Compatibility

| Contract | Result |
| --- | --- |
| Token/bootstrap HTTP API | Status codes and JSON bodies are unchanged; `Cache-Control: no-store` is additive. |
| Custom token paths | Remain supported and are covered by regression tests. |
| Installed PWA cache | The worker migrates `nanobot-static-v1` to v2, removing stale entries without touching other apps' caches. |
| Offline WebUI | Static assets and app-shell navigation remain available. |
| CLI App execution | Arguments, timeouts, working directories, output, and install state are unchanged; every subprocess entry point now uses the same minimal environment. |

## Validation

- WebUI test suite: 1045 passed before the CLI-only follow-up; focused service-worker suite: 13 passed
- WebUI lint and production build passed
- WebSocket HTTP routes: 97 passed; token/bootstrap subset: 6 passed
- CLI Apps environment tests: 4 passed
- CLI Apps service/tool tests: 41 passed
- Ruff passed on all changed Python files

Follow-up to #5270 and #5336.
