### PR TITLE
fix(agent): bound per-session file state lifecycle

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -377,11 +377,15 @@ class AgentLoop:
 
         self.context = ContextBuilder(workspace, timezone=timezone, disabled_skills=disabled_skills)
         self.sessions = session_manager or SessionManager(workspace)
-        self.sessions.set_file_cap_archiver(self.context.memory.raw_archive)
-        self.tools = tool_registry if tool_registry is not None else ToolRegistry()
         # One file-read/write tracker per logical session. The tool registry is
         # shared by this loop, so tools resolve the active state via contextvars.
         self._file_state_store = FileStateStore(max_sessions=SESSION_CACHE_MAX_SIZE)
+        # SessionManager owns every durable deletion entrypoint, including the
+        # WebUI and fork rollback paths.  Observe that boundary once instead of
+        # duplicating cleanup in each consumer.
+        self.sessions.set_delete_observer(self._file_state_store.discard)
+        self.sessions.set_file_cap_archiver(self.context.memory.raw_archive)
+        self.tools = tool_registry if tool_registry is not None else ToolRegistry()
         self._exec_session_manager = ExecSessionManager()
         self.runner = AgentRunner()
         self.subagents = SubagentManager(

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -76,6 +76,7 @@ from nanobot.session.goal_state import (
 from nanobot.session.history_visibility import HIDDEN_HISTORY_META
 from nanobot.session.keys import UNIFIED_SESSION_KEY, remember_last_channel
 from nanobot.session.manager import (
+    SESSION_CACHE_MAX_SIZE,
     Session,
     SessionManager,
     replay_max_messages_for_context,
@@ -380,7 +381,7 @@ class AgentLoop:
         self.tools = tool_registry if tool_registry is not None else ToolRegistry()
         # One file-read/write tracker per logical session. The tool registry is
         # shared by this loop, so tools resolve the active state via contextvars.
-        self._file_state_store = FileStateStore()
+        self._file_state_store = FileStateStore(max_sessions=SESSION_CACHE_MAX_SIZE)
         self._exec_session_manager = ExecSessionManager()
         self.runner = AgentRunner()
         self.subagents = SubagentManager(
@@ -818,7 +819,12 @@ class AgentLoop:
             self.sessions.invalidate(key)
             await self._cancel_active_tasks(key)
         finally:
+            self.discard_session_file_state(key)
             self._discarding_sessions.discard(key)
+
+    def discard_session_file_state(self, key: str) -> None:
+        """Forget ephemeral file-read state for a reset or removed session."""
+        self._file_state_store.discard(key)
 
     def _effective_session_key(self, msg: InboundMessage) -> str:
         """Return the session key used for task routing and mid-turn injections."""

--- a/nanobot/agent/tools/file_state.py
+++ b/nanobot/agent/tools/file_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+from collections import OrderedDict
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
 from pathlib import Path
@@ -135,20 +136,29 @@ class FileStates:
 
 
 class FileStateStore:
-    """Lookup table for per-session file read/write state."""
+    """Bounded lookup table for per-session file read/write state."""
 
-    __slots__ = ("_states_by_key",)
+    __slots__ = ("_max_sessions", "_states_by_key")
 
-    def __init__(self) -> None:
-        self._states_by_key: dict[str, FileStates] = {}
+    def __init__(self, *, max_sessions: int = 128) -> None:
+        if max_sessions <= 0:
+            raise ValueError("max_sessions must be positive")
+        self._max_sessions = max_sessions
+        self._states_by_key: OrderedDict[str, FileStates] = OrderedDict()
 
     def for_session(self, session_key: str | None) -> FileStates:
         key = session_key or "__default__"
-        states = self._states_by_key.get(key)
+        states = self._states_by_key.pop(key, None)
         if states is None:
             states = FileStates()
-            self._states_by_key[key] = states
+        self._states_by_key[key] = states
+        while len(self._states_by_key) > self._max_sessions:
+            self._states_by_key.popitem(last=False)
         return states
+
+    def discard(self, session_key: str | None) -> None:
+        """Forget file state when a session is reset or removed."""
+        self._states_by_key.pop(session_key or "__default__", None)
 
     def clear(self) -> None:
         self._states_by_key.clear()

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -302,6 +302,7 @@ async def cmd_new(ctx: CommandContext) -> OutboundMessage:
     """Stop active task and start a fresh session."""
     loop = ctx.loop
     await loop._cancel_active_tasks(ctx.key)  # pyright: ignore[reportPrivateUsage]
+    loop.discard_session_file_state(ctx.key)
     session = ctx.session or loop.sessions.get_or_create(ctx.key)
     snapshot = session.messages[session.last_consolidated:]
     runtime = None

--- a/nanobot/sdk/clients.py
+++ b/nanobot/sdk/clients.py
@@ -146,7 +146,6 @@ class SessionClient:
 
     def delete(self, session_key: str) -> bool:
         """Delete one session from disk and cache."""
-        self._loop.discard_session_file_state(session_key)
         return self._loop.sessions.delete_session(session_key)
 
     def flush(self) -> int:

--- a/nanobot/sdk/clients.py
+++ b/nanobot/sdk/clients.py
@@ -138,6 +138,7 @@ class SessionClient:
 
     def clear(self, session_key: str) -> SessionSnapshot:
         """Clear one session and persist the empty session."""
+        self._loop.discard_session_file_state(session_key)
         session = self._loop.sessions.get_or_create(session_key)
         session.clear()
         self._loop.sessions.save(session)
@@ -145,6 +146,7 @@ class SessionClient:
 
     def delete(self, session_key: str) -> bool:
         """Delete one session from disk and cache."""
+        self._loop.discard_session_file_state(session_key)
         return self._loop.sessions.delete_session(session_key)
 
     def flush(self) -> int:

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -1523,6 +1523,7 @@ class SessionManager:
         self._overflow_cache: WeakValueDictionary[str, Session] = WeakValueDictionary()
         self._max_cached_sessions = SESSION_CACHE_MAX_SIZE
         self._file_cap_archiver: Callable[..., None] | None = None
+        self._delete_observer: Callable[[str], None] | None = None
 
     def _remember(self, session: Session) -> None:
         """Keep recent sessions strongly cached without duplicating live objects."""
@@ -1551,6 +1552,10 @@ class SessionManager:
     def set_file_cap_archiver(self, archiver: Callable[..., None]) -> None:
         """Archive unconsolidated overflow whenever a session is persisted."""
         self._file_cap_archiver = archiver
+
+    def set_delete_observer(self, observer: Callable[[str], None]) -> None:
+        """Observe explicit session deletion for process-local state cleanup."""
+        self._delete_observer = observer
 
     @staticmethod
     def safe_key(key: str) -> str:
@@ -1684,7 +1689,10 @@ class SessionManager:
     def delete_session(self, key: str) -> bool:
         """Delete a persisted session and invalidate its cache entry."""
         self.invalidate(key)
-        return self._store.delete(key)
+        deleted = self._store.delete(key)
+        if self._delete_observer is not None:
+            self._delete_observer(key)
+        return deleted
 
     def restore_sessions_to_workspace(self) -> SessionRestoreResult:
         """Restore session files to the pre-relocation path for an explicit rollback."""

--- a/tests/agent/test_loop_session_policy.py
+++ b/tests/agent/test_loop_session_policy.py
@@ -131,6 +131,7 @@ async def test_session_discard_control_cancels_active_turn(tmp_path, monkeypatch
         terminate_exec_sessions,
     )
     key = "websocket:transient-cancelled"
+    previous_file_state = loop._file_state_store.for_session(key)
     loop.sessions.get_or_create_transient(
         key,
         disabled_tools={"create_goal", "update_goal", "spawn", "cron"},
@@ -157,6 +158,7 @@ async def test_session_discard_control_cancels_active_turn(tmp_path, monkeypatch
         await asyncio.wait_for(active_task, timeout=2)
     await asyncio.wait_for(wait_for_discard(key), timeout=2)
     assert loop.sessions.get_cached(key) is None
+    assert loop._file_state_store.for_session(key) is not previous_file_state
     terminate_exec_sessions.assert_awaited_once_with(key)
 
     loop.stop()

--- a/tests/agent/test_session_delete.py
+++ b/tests/agent/test_session_delete.py
@@ -34,6 +34,17 @@ def test_delete_session_returns_false_when_missing(tmp_path: Path) -> None:
     assert sm.delete_session("nope:none") is False
 
 
+def test_delete_session_notifies_process_local_state_observer(tmp_path: Path) -> None:
+    sm = _seed(tmp_path, "websocket:abc")
+    deleted_keys: list[str] = []
+    sm.set_delete_observer(deleted_keys.append)
+
+    assert sm.delete_session("websocket:abc") is True
+    assert sm.delete_session("websocket:missing") is False
+
+    assert deleted_keys == ["websocket:abc", "websocket:missing"]
+
+
 def test_read_session_file_returns_metadata_and_messages(tmp_path: Path) -> None:
     sm = _seed(tmp_path, "telegram:abc")
     data = sm.read_session_file("telegram:abc")

--- a/tests/agent/test_unified_session.py
+++ b/tests/agent/test_unified_session.py
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from nanobot.agent.loop import AgentLoop
+from nanobot.agent.tools.file_state import FileStateStore
 from nanobot.bus.events import InboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.command.builtin import cmd_new, register_builtin_commands
@@ -250,10 +251,16 @@ class TestCmdNewUnifiedSession:
         # asyncio.create_task().  Mirror that exactly so the coroutine is consumed
         # and no RuntimeWarning is emitted.
         admitted_runtime = MagicMock(name="admitted_runtime")
+        file_state_store = FileStateStore()
+        previous_file_state = file_state_store.for_session("unified:default")
+        tracked_file = tmp_path / "tracked.txt"
+        tracked_file.write_text("tracked", encoding="utf-8")
+        previous_file_state.record_read(tracked_file)
         loop = SimpleNamespace(
             sessions=sessions,
             consolidator=SimpleNamespace(archive=AsyncMock(return_value=True)),
             _cancel_active_tasks=AsyncMock(return_value=0),
+            discard_session_file_state=file_state_store.discard,
             llm_runtime=MagicMock(return_value=MagicMock()),
             schedule_background=lambda coro: asyncio.ensure_future(coro),
         )
@@ -278,6 +285,9 @@ class TestCmdNewUnifiedSession:
         sessions.invalidate("unified:default")
         reloaded = sessions.get_or_create("unified:default")
         assert reloaded.messages == []
+        reset_file_state = file_state_store.for_session("unified:default")
+        assert reset_file_state is not previous_file_state
+        assert reset_file_state.is_unchanged(tracked_file) is False
         loop.consolidator.archive.assert_called_once_with(
             expected_snapshot,
             runtime=admitted_runtime,
@@ -302,6 +312,7 @@ class TestCmdNewUnifiedSession:
             sessions=sessions,
             consolidator=SimpleNamespace(archive=AsyncMock(return_value=True)),
             _cancel_active_tasks=AsyncMock(return_value=0),
+            discard_session_file_state=MagicMock(),
             runtime_for_session=MagicMock(return_value=MagicMock()),
             schedule_background=lambda coro: asyncio.ensure_future(coro),
         )

--- a/tests/test_nanobot_facade.py
+++ b/tests/test_nanobot_facade.py
@@ -1500,10 +1500,15 @@ async def test_session_helpers_get_list_export_clear_delete_flush(tmp_path):
     exported.messages[0]["content"] = "mutated copy"
     assert bot.sessions.get("sdk:first").messages[0]["content"] == "hello"
 
+    state_before_clear = bot._loop._file_state_store.for_session("sdk:first")
     cleared = bot.sessions.clear("sdk:first")
     assert cleared.messages == []
+    state_after_clear = bot._loop._file_state_store.for_session("sdk:first")
+    assert state_after_clear is not state_before_clear
     assert bot.sessions.flush() >= 1
+    state_before_delete = state_after_clear
     assert bot.sessions.delete("sdk:first") is True
+    assert bot._loop._file_state_store.for_session("sdk:first") is not state_before_delete
     assert bot.sessions.get("sdk:first") is None
 
 

--- a/tests/tools/test_file_state_store.py
+++ b/tests/tools/test_file_state_store.py
@@ -1,0 +1,29 @@
+import pytest
+
+from nanobot.agent.tools.file_state import FileStateStore
+
+
+def test_file_state_store_evicts_least_recently_used_session() -> None:
+    store = FileStateStore(max_sessions=2)
+    first = store.for_session("first")
+    second = store.for_session("second")
+
+    assert store.for_session("first") is first
+    store.for_session("third")
+
+    assert store.for_session("first") is first
+    assert store.for_session("second") is not second
+
+
+def test_file_state_store_discards_reset_session() -> None:
+    store = FileStateStore()
+    previous = store.for_session("websocket:chat")
+
+    store.discard("websocket:chat")
+
+    assert store.for_session("websocket:chat") is not previous
+
+
+def test_file_state_store_requires_positive_capacity() -> None:
+    with pytest.raises(ValueError, match="max_sessions must be positive"):
+        FileStateStore(max_sessions=0)


### PR DESCRIPTION
## Why

`FileStateStore` retains one `FileStates` object for every session key for the lifetime of the agent loop. High-cardinality API or temporary sessions therefore grow the table without a bound.

The same state also survived session lifecycle boundaries. After `/new`, runtime discard, or SDK clear/delete, a fresh conversation could inherit the previous conversation's read-dedup and read-before-edit state even though that read was no longer present in its context.

## What changed

- make `FileStateStore` a least-recently-used table bounded to the same 128-session budget as `SessionManager`
- add explicit per-session discard semantics
- discard file state on `/new`, runtime session disposal, and SDK `clear()` / `delete()`
- keep active turns safe: their context variable retains the selected `FileStates` object even if its idle cache entry is evicted
- cover LRU ordering, explicit discard, unified `/new`, transient session disposal, and SDK lifecycle paths

LRU eviction only removes an optimization and safety hint from a future turn; it does not interrupt an active turn or alter persisted conversation history.

## Verification

- `uv run --extra dev pytest tests/tools/test_read_enhancements.py tests/tools/test_edit_enhancements.py tests/tools/test_edit_advanced.py tests/agent/test_loop_session_policy.py tests/agent/test_unified_session.py tests/agent/test_loop_save_turn.py -q` (151 passed)
- `uv run --extra dev pytest tests/test_nanobot_facade.py::test_session_helpers_get_list_export_clear_delete_flush tests/agent/test_unified_session.py tests/agent/test_loop_session_policy.py tests/tools/test_file_state_store.py -q` (30 passed)
- `uv run --extra dev ruff check ...`
- `uv run --extra dev basedpyright nanobot/sdk/clients.py nanobot/agent/tools/file_state.py nanobot/agent/loop.py nanobot/command/builtin.py`
