### PR TITLE
feat(telegram): support reusable sticker replies

### DIFF
--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -10,7 +10,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Literal, TypeAlias, TypeVar, cast
+from typing import Any, Awaitable, Callable, Literal, TypeAlias, TypedDict, TypeVar, cast
 from urllib.parse import urlparse
 
 from pydantic import Field, field_validator, model_validator
@@ -47,6 +47,11 @@ TELEGRAM_MAX_MESSAGE_LEN = 4000  # Telegram message character limit
 # boundary so the final rendered message never overflows.
 TELEGRAM_HTML_MAX_LEN = 4096
 TELEGRAM_REPLY_CONTEXT_MAX_LEN = TELEGRAM_MAX_MESSAGE_LEN  # Max length for reply context in user message
+TELEGRAM_STICKER_MARKER_RE = re.compile(
+    r"^\[sticker:\s*file_id=(?P<file_id>[A-Za-z0-9_-]+)"
+    r"(?:,\s*emoji=[^,\]]*)?(?:,\s*set_name=[^\]]*)?\]$",
+    re.IGNORECASE,
+)
 
 # python-telegram-bot exposes a six-parameter Application generic. Nanobot
 # doesn't customize its context/data/job-queue types, so keep that SDK boundary
@@ -89,6 +94,14 @@ class _LivenessTrackedRequest(BaseRequest):
         result = await self.inner.do_request(*args, **kwargs)
         self._on_round_trip()
         return result
+
+
+class TelegramStickerMetadata(TypedDict):
+    """Agent-visible subset of Telegram's inbound sticker payload."""
+
+    file_id: str
+    emoji: str | None
+    set_name: str | None
 
 
 def _split_telegram_markdown(content: str, max_len: int) -> list[str]:
@@ -657,12 +670,12 @@ class TelegramChannel(BaseChannel):
         )
         self._app.add_handler(MessageHandler(filters.Regex(r"^/help(?:@\w+)?$"), self._on_help))
 
-        # Add message handler for text, photos, video, voice, documents, and locations
+        # Add message handler for text, media, stickers, and locations
         self._app.add_handler(
             MessageHandler(
                 (filters.TEXT | filters.PHOTO | filters.VIDEO | filters.VIDEO_NOTE
                  | filters.ANIMATION | filters.VOICE | filters.AUDIO
-                 | filters.Document.ALL | filters.LOCATION)
+                 | filters.Document.ALL | filters.Sticker.ALL | filters.LOCATION)
                 & ~filters.COMMAND,
                 self._on_message
             )
@@ -933,6 +946,26 @@ class TelegramChannel(BaseChannel):
                     message_id=reply_to_message_id,
                     allow_sending_without_reply=True
                 )
+
+        sticker_file_id = self._extract_sticker_file_id(msg.content)
+        if sticker_file_id is not None:
+            try:
+                await self._call_with_retry(
+                    app.bot.send_sticker,
+                    chat_id=chat_id,
+                    sticker=sticker_file_id,
+                    reply_parameters=reply_params,
+                    **thread_kwargs,
+                )
+            except Exception:
+                self.logger.exception("Failed to send Telegram sticker")
+                await app.bot.send_message(
+                    chat_id=chat_id,
+                    text="[Failed to send sticker]",
+                    reply_parameters=reply_params,
+                    **thread_kwargs,
+                )
+            return
 
         # Send media files
         for media_path in (msg.media or []):
@@ -1377,7 +1410,7 @@ class TelegramChannel(BaseChannel):
     def _build_message_metadata(message: Message, user: User) -> dict[str, Any]:
         """Build common Telegram inbound metadata payload."""
         reply_to = getattr(message, "reply_to_message", None)
-        return {
+        metadata: dict[str, Any] = {
             "message_id": message.message_id,
             "user_id": user.id,
             "username": user.username,
@@ -1387,6 +1420,40 @@ class TelegramChannel(BaseChannel):
             "is_forum": bool(getattr(message.chat, "is_forum", False)),
             "reply_to_message_id": getattr(reply_to, "message_id", None) if reply_to else None,
         }
+        if sticker := TelegramChannel._get_sticker_metadata(message):
+            metadata["sticker"] = sticker
+        return metadata
+
+    @staticmethod
+    def _get_sticker_metadata(message: Message) -> TelegramStickerMetadata | None:
+        """Normalize the reusable part of an inbound Telegram sticker."""
+        sticker = getattr(message, "sticker", None)
+        file_id = getattr(sticker, "file_id", None)
+        if not isinstance(file_id, str) or not file_id:
+            return None
+        emoji = getattr(sticker, "emoji", None)
+        set_name = getattr(sticker, "set_name", None)
+        return {
+            "file_id": file_id,
+            "emoji": emoji if isinstance(emoji, str) else None,
+            "set_name": set_name if isinstance(set_name, str) else None,
+        }
+
+    @staticmethod
+    def _format_sticker_content(sticker: TelegramStickerMetadata) -> str:
+        """Expose sticker data in a marker that can be reused as an outbound reply."""
+        emoji = sticker["emoji"] or "unknown"
+        set_name = sticker["set_name"] or "unknown"
+        return (
+            f"[sticker: file_id={sticker['file_id']}, "
+            f"emoji={emoji}, set_name={set_name}]"
+        )
+
+    @staticmethod
+    def _extract_sticker_file_id(content: str) -> str | None:
+        """Return a Telegram file_id only when the whole response is a sticker marker."""
+        match = TELEGRAM_STICKER_MARKER_RE.fullmatch(content.strip())
+        return match.group("file_id") if match else None
 
     async def _extract_reply_context(self, message: Message) -> str | None:
         """Extract text from the message being replied to, if any."""
@@ -1649,7 +1716,7 @@ class TelegramChannel(BaseChannel):
         )
 
     async def _on_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-        """Handle incoming messages (text, photos, voice, documents)."""
+        """Handle incoming messages (text, media, stickers, and locations)."""
         if not update.message or not update.effective_user:
             return
         if not self._running:
@@ -1692,6 +1759,9 @@ class TelegramChannel(BaseChannel):
             lat = message.location.latitude
             lon = message.location.longitude
             content_parts.append(f"[location: {lat}, {lon}]")
+
+        if sticker := self._get_sticker_metadata(message):
+            content_parts.append(self._format_sticker_content(sticker))
 
         # Download current message media
         current_media_paths, current_media_parts = await self._download_message_media(

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -92,6 +92,9 @@ class _FakeBot:
     async def send_document(self, **kwargs) -> None:
         self.sent_media.append({"kind": "document", **kwargs})
 
+    async def send_sticker(self, **kwargs) -> None:
+        self.sent_media.append({"kind": "sticker", **kwargs})
+
     async def send_chat_action(self, **kwargs) -> None:
         pass
 
@@ -174,6 +177,8 @@ def _make_telegram_update(
     caption_entities=None,
     reply_to_message=None,
     location=None,
+    sticker=None,
+    message_thread_id=None,
 ):
     user = SimpleNamespace(id=12345, username="alice", first_name="Alice")
     message = SimpleNamespace(
@@ -188,9 +193,10 @@ def _make_telegram_update(
         voice=None,
         audio=None,
         document=None,
+        sticker=sticker,
         location=location,
         media_group_id=None,
-        message_thread_id=None,
+        message_thread_id=message_thread_id,
         message_id=1,
     )
     return SimpleNamespace(message=message, effective_user=user)
@@ -1482,6 +1488,54 @@ async def test_send_reply_infers_topic_from_message_id_cache() -> None:
 
 
 @pytest.mark.asyncio
+async def test_send_sticker_file_id_preserves_topic_and_reply() -> None:
+    config = TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], reply_to_message=True)
+    channel = TelegramChannel(config, MessageBus())
+    _install_ready_app(channel)
+
+    await channel.send(
+        OutboundMessage(
+            channel="telegram",
+            chat_id="-100123",
+            content=(
+                "[sticker: file_id=CAACAgQAAxkBAA_test, "
+                "emoji=🐝, set_name=NanobotBees]"
+            ),
+            metadata={"message_id": 10, "message_thread_id": 42},
+        )
+    )
+
+    assert len(channel._app.bot.sent_media) == 1
+    sent = channel._app.bot.sent_media[0]
+    assert sent["kind"] == "sticker"
+    assert sent["chat_id"] == -100123
+    assert sent["sticker"] == "CAACAgQAAxkBAA_test"
+    assert sent["message_thread_id"] == 42
+    assert sent["reply_parameters"].message_id == 10
+    assert channel._app.bot.sent_messages == []
+
+
+@pytest.mark.asyncio
+async def test_send_does_not_interpret_sticker_marker_embedded_in_text() -> None:
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
+        MessageBus(),
+    )
+    _install_ready_app(channel)
+
+    await channel.send(
+        OutboundMessage(
+            channel="telegram",
+            chat_id="123",
+            content="Use [sticker: file_id=CAACAgQAAxkBAA_test] to reply.",
+        )
+    )
+
+    assert channel._app.bot.sent_media == []
+    assert channel._app.bot.sent_messages[0]["text"].startswith("Use [sticker:")
+
+
+@pytest.mark.asyncio
 async def test_send_remote_media_url_after_security_validation(monkeypatch) -> None:
     channel = TelegramChannel(
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
@@ -2200,6 +2254,45 @@ async def test_on_message_location_content() -> None:
 
     assert len(handled) == 1
     assert handled[0]["content"] == "[location: 48.8566, 2.3522]"
+
+
+@pytest.mark.asyncio
+async def test_on_message_exposes_reusable_sticker_content_and_metadata() -> None:
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], group_policy="open"),
+        MessageBus(),
+    )
+    channel._app = _FakeApp(lambda: None)
+    handled = []
+
+    async def capture_handle(**kwargs) -> None:
+        handled.append(kwargs)
+
+    channel._handle_message = capture_handle
+    channel._start_typing = lambda _chat_id: None
+    update = _make_telegram_update(
+        sticker=SimpleNamespace(
+            file_id="CAACAgQAAxkBAA_test",
+            file_unique_id="AgAD_test",
+            emoji="🐝",
+            set_name="NanobotBees",
+        ),
+        message_thread_id=42,
+    )
+
+    await channel._on_message(update, None)
+
+    assert handled[0]["content"] == (
+        "[sticker: file_id=CAACAgQAAxkBAA_test, emoji=🐝, set_name=NanobotBees]"
+    )
+    assert handled[0]["metadata"]["sticker"] == {
+        "file_id": "CAACAgQAAxkBAA_test",
+        "emoji": "🐝",
+        "set_name": "NanobotBees",
+    }
+    assert handled[0]["metadata"]["message_thread_id"] == 42
+    assert handled[0]["session_key"] == "telegram:-100123:topic:42"
+    assert handled[0]["media"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- expose inbound Telegram sticker `file_id`, emoji, and set name in content and metadata
- dispatch a reusable sticker when the complete outbound reply is a sticker marker
- preserve chat, topic, and reply routing while leaving the existing acknowledgement reaction lifecycle unchanged
- avoid interpreting sticker markers embedded in ordinary text

## Scope and assumptions

This is the smallest channel-local, backward-compatible sticker increment supported by the issue and the existing Telegram message route. It deliberately does not add agent-initiated reactions, reaction allowlists, configuration fields, or a new public tool contract; those choices are independent public-capability decisions. Existing text/media behavior and defaults are unchanged.

Relates to #5289.

## Validation

- Telegram channel test suite: 113 passed
- Ruff: passed
- BasedPyright: 0 errors, 0 warnings, 0 notes
- `git diff --check`: passed
