### PR TITLE
refactor: narrow file-level Pyright suppressions

### DIFF
--- a/nanobot/agent/tools/cli_apps.py
+++ b/nanobot/agent/tools/cli_apps.py
@@ -1,7 +1,5 @@
 """Controlled runner for installed CLI Apps."""
 
-# pyright: reportIncompatibleMethodOverride=false
-
 from __future__ import annotations
 
 from pathlib import Path
@@ -133,7 +131,8 @@ class CliAppsTool(Tool):
             return None
         return RuntimeContextBlock(source="cli_apps", content=content)
 
-    async def execute(
+    # Typed kwargs are narrower than Tool.execute(**kwargs).
+    async def execute(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         name: str,
         args: list[str] | None = None,

--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -1,7 +1,5 @@
 """Cron tool for scheduling reminders and tasks."""
 
-# pyright: reportIncompatibleMethodOverride=false
-
 from __future__ import annotations
 
 from contextvars import ContextVar, Token
@@ -133,7 +131,8 @@ class CronTool(Tool):
             errors.append("job_id is required when action='remove'")
         return errors
 
-    async def execute(
+    # Typed kwargs are narrower than Tool.execute(**kwargs).
+    async def execute(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         action: str,
         name: str | None = None,

--- a/nanobot/agent/tools/long_task.py
+++ b/nanobot/agent/tools/long_task.py
@@ -1,7 +1,5 @@
 """Sustained-goal tools with explicit user opt-in at the execution boundary."""
 
-# pyright: reportIncompatibleMethodOverride=false
-
 from __future__ import annotations
 
 from copy import deepcopy
@@ -191,7 +189,8 @@ class CreateGoalTool(Tool, _GoalToolsMixin):
         content = "\n\n".join(part for part in (guidance, state) if part)
         return RuntimeContextBlock(source="goal", content=content)
 
-    async def execute(
+    # Typed kwargs are narrower than Tool.execute(**kwargs).
+    async def execute(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         objective: str,
         ui_summary: str | None = None,
@@ -297,7 +296,8 @@ class UpdateGoalTool(Tool, _GoalToolsMixin):
             "the requested objective changes."
         )
 
-    async def execute(
+    # Typed kwargs are narrower than Tool.execute(**kwargs).
+    async def execute(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         action: str,
         recap: str | None = None,

--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -1,7 +1,5 @@
 """Message tool for sending messages to users."""
 
-# pyright: reportIncompatibleMethodOverride=false
-
 from contextvars import ContextVar, Token
 from pathlib import Path
 from typing import Any, Awaitable, Callable, cast
@@ -143,7 +141,8 @@ class MessageTool(Tool):
                 resolved.append(str(resolve_workspace_path(p, workspace, access.allowed_root)))
         return resolved
 
-    async def execute(
+    # Typed kwargs are narrower than Tool.execute(**kwargs).
+    async def execute(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         content: str,
         channel: str | None = None,
@@ -152,7 +151,7 @@ class MessageTool(Tool):
         media: list[str] | None = None,
         buttons: Any = None,
         **kwargs: Any,
-    ) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
+    ) -> str:
         from nanobot.utils.helpers import strip_think
 
         content = strip_think(content)

--- a/nanobot/agent/tools/self.py
+++ b/nanobot/agent/tools/self.py
@@ -1,8 +1,5 @@
 """MyTool: runtime state inspection and configuration for the agent loop."""
 
-# Tool.execute accepts heterogeneous schemas.
-# pyright: reportIncompatibleMethodOverride=false
-
 from __future__ import annotations
 
 import time
@@ -358,7 +355,8 @@ class MyTool(Tool):
     # Action dispatch
     # ------------------------------------------------------------------
 
-    async def execute(
+    # Typed kwargs are narrower than Tool.execute(**kwargs).
+    async def execute(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         action: str,
         key: str | None = None,

--- a/nanobot/agent/tools/sessions.py
+++ b/nanobot/agent/tools/sessions.py
@@ -1,7 +1,5 @@
 """Tools for finding and reading persisted conversations."""
 
-# pyright: reportIncompatibleMethodOverride=false
-
 from __future__ import annotations
 
 import asyncio
@@ -92,7 +90,8 @@ class SearchSessionsTool(_SessionTool):
             "session_ref using Markdown. The current session is excluded."
         )
 
-    async def execute(
+    # Typed kwargs are narrower than Tool.execute(**kwargs).
+    async def execute(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         query: str,
         **kwargs: Any,
@@ -166,7 +165,8 @@ class ReadSessionTool(_SessionTool):
             "changes a session."
         )
 
-    async def execute(
+    # Typed kwargs are narrower than Tool.execute(**kwargs).
+    async def execute(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         session_key: str,
         query: str | None = None,

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -1,7 +1,5 @@
 """Spawn tool for creating background subagents."""
 
-# pyright: reportIncompatibleMethodOverride=false
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
@@ -73,7 +71,8 @@ class SpawnTool(Tool):
             "and use a dedicated subdirectory when helpful."
         )
 
-    async def execute(
+    # Typed kwargs are narrower than Tool.execute(**kwargs).
+    async def execute(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         task: str,
         label: str | None = None,

--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -1,7 +1,5 @@
 """Web tools: web_search and web_fetch."""
 
-# pyright: reportIncompatibleMethodOverride=false
-
 from __future__ import annotations
 
 import asyncio
@@ -468,7 +466,8 @@ class WebSearchTool(Tool):
         """DuckDuckGo searches are serialized because ddgs is not concurrency-safe."""
         return self._effective_provider() == "duckduckgo"
 
-    async def execute(
+    # Typed kwargs are narrower than Tool.execute(**kwargs).
+    async def execute(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         query: str,
         count: int | None = None,
@@ -476,7 +475,7 @@ class WebSearchTool(Tool):
         auth_level: int | None = None,
         query_rewrite: bool | None = None,
         **kwargs: Any,
-    ) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
+    ) -> str:
         self._refresh_config()
         provider = self.config.provider.strip().lower() or "brave"
         n = min(max(count or self.config.max_results, 1), 10)
@@ -1096,13 +1095,14 @@ class WebFetchTool(Tool):
     def read_only(self) -> bool:
         return True
 
-    async def execute(
+    # Typed kwargs are narrower than Tool.execute(**kwargs).
+    async def execute(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         url: str,
         extract_mode: str = "markdown",
         max_chars: int | None = None,
         **kwargs: Any,
-    ) -> Any:  # pyright: ignore[reportIncompatibleMethodOverride]
+    ) -> Any:
         url = url.strip(" \t\r\n`\"'")
         extract_mode = kwargs.pop("extractMode", extract_mode)
         max_chars = cast(int, kwargs.pop("maxChars", max_chars) or self.max_chars)


### PR DESCRIPTION
Fixes #5161.

## What changed
- `nanobot/agent/tools/cli_apps.py`
- `nanobot/agent/tools/cron.py`
- `nanobot/agent/tools/long_task.py`
- `nanobot/agent/tools/message.py`
- `nanobot/agent/tools/self.py`
- `nanobot/agent/tools/sessions.py`
- `nanobot/agent/tools/spawn.py`
- `nanobot/agent/tools/web.py`

## Verification
The project's own test suite was run before and after this change; it introduces no new test failures or lint violations.