### PR TITLE
feat(providers): add DashScope (Bailian) native protocol support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -292,6 +292,7 @@ Tracing covers the providers that go through nanobot's OpenAI-compatible client 
 | `siliconflow` | LLM (SiliconFlow/硅基流动) | [siliconflow.cn](https://siliconflow.cn) |
 | `novita` | LLM (Novita AI OpenAI-compatible gateway) | [novita.ai](https://novita.ai) |
 | `dashscope` | LLM (Qwen) | [dashscope.console.aliyun.com](https://dashscope.console.aliyun.com) |
+| `dashscope_native` | LLM + Image generation + Speech-to-text (Bailian native protocol) | [dashscope.console.aliyun.com](https://dashscope.console.aliyun.com) |
 | `modelscope` | LLM (ModelScope/魔搭社区) + Image generation | [modelscope.cn](https://modelscope.cn) |
 | `moonshot` | LLM (Moonshot/Kimi) | [platform.kimi.com](https://platform.kimi.com?aff=nanobot) |
 | `kimi_coding` | LLM (Kimi Coding Plan, Anthropic Messages API) | [platform.kimi.com](https://platform.kimi.com?aff=nanobot) |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -407,6 +407,56 @@ ModelScope image generation reuses the same provider key but is configured under
 
 Use the image model's exact ModelScope ID without a leading `modelscope/`; the image client sends this value unchanged and handles ModelScope's async submit/poll flow. The example uses [`Qwen/Qwen-Image-2512`](https://modelscope.cn/models/Qwen/Qwen-Image-2512). See [Image Generation](./image-generation.md#modelscope) for supported sizes, aspect ratios, and the complete provider configuration.
 
+### DashScope (Alibaba Cloud Bailian)
+
+DashScope offers two built-in providers sharing the same `DASHSCOPE_API_KEY`:
+
+- `dashscope` — the OpenAI-compatible endpoint (`compatible-mode/v1`). Simplest option; covers most text models plus vision input.
+- `dashscope_native` — the [DashScope native protocol](https://help.aliyun.com/zh/model-studio/qwen-api-via-dashscope). Use it for the full parameter surface (native thinking controls such as `reasoning_effort`) and models or features that compatible-mode does not expose.
+
+```json
+{
+  "providers": {
+    "dashscope_native": {
+      "apiKey": "${DASHSCOPE_API_KEY}"
+    }
+  },
+  "modelPresets": {
+    "primary": {
+      "provider": "dashscope_native",
+      "model": "qwen3.8-max"
+    }
+  },
+  "agents": {
+    "defaults": {
+      "modelPreset": "primary"
+    }
+  }
+}
+```
+
+The default base URL is `https://dashscope.aliyuncs.com`; override `providers.dashscope_native.apiBase` only for workspace-specific endpoints. Messages containing images are routed to the multimodal-generation endpoint automatically.
+
+`dashscope_native` also backs Bailian image generation and speech-to-text, configured separately:
+
+```json
+{
+  "tools": {
+    "imageGeneration": {
+      "enabled": true,
+      "provider": "dashscope_native",
+      "model": "qwen-image-3.0-pro"
+    }
+  },
+  "transcription": {
+    "provider": "dashscope",
+    "model": "qwen3-asr-flash"
+  }
+}
+```
+
+See [Image Generation](./image-generation.md) for the complete image tool configuration.
+
 ### Ollama
 
 Start Ollama separately, then point nanobot at the OpenAI-compatible endpoint.

--- a/nanobot/audio/transcription_registry.py
+++ b/nanobot/audio/transcription_registry.py
@@ -80,6 +80,12 @@ TRANSCRIPTION_PROVIDERS: tuple[TranscriptionProviderSpec, ...] = (
         adapter="nanobot.providers.transcription:OpenAITranscriptionProvider",
         aliases=("silicon",),
     ),
+    TranscriptionProviderSpec(
+        name="dashscope",
+        default_model="qwen3-asr-flash",
+        adapter="nanobot.providers.transcription:DashScopeTranscriptionProvider",
+        aliases=("dashscope_native", "bailian"),
+    ),
 )
 
 _BY_NAME = {spec.name: spec for spec in TRANSCRIPTION_PROVIDERS}

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -269,6 +269,7 @@ class ProvidersConfig(Base):
     groq: ProviderConfig = Field(default_factory=ProviderConfig)
     zhipu: ProviderConfig = Field(default_factory=ProviderConfig)
     dashscope: ProviderConfig = Field(default_factory=ProviderConfig)
+    dashscope_native: ProviderConfig = Field(default_factory=ProviderConfig)  # DashScope native protocol (百炼)
     modelscope: ProviderConfig = Field(default_factory=ProviderConfig)
     vllm: ProviderConfig = Field(default_factory=ProviderConfig)
     ollama: ProviderConfig = Field(default_factory=ProviderConfig)  # Ollama local models

--- a/nanobot/providers/__init__.py
+++ b/nanobot/providers/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "GitHubCopilotProvider",
     "AzureOpenAIProvider",
     "BedrockProvider",
+    "DashScopeProvider",
 ]
 
 _LAZY_IMPORTS = {
@@ -27,12 +28,14 @@ _LAZY_IMPORTS = {
     "GitHubCopilotProvider": ".github_copilot_provider",
     "AzureOpenAIProvider": ".azure_openai_provider",
     "BedrockProvider": ".bedrock_provider",
+    "DashScopeProvider": ".dashscope_provider",
 }
 
 if TYPE_CHECKING:
     from nanobot.providers.anthropic_provider import AnthropicProvider
     from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
     from nanobot.providers.bedrock_provider import BedrockProvider
+    from nanobot.providers.dashscope_provider import DashScopeProvider
     from nanobot.providers.github_copilot_provider import GitHubCopilotProvider
     from nanobot.providers.openai_codex_provider import OpenAICodexProvider
     from nanobot.providers.openai_compat_provider import OpenAICompatProvider

--- a/nanobot/providers/dashscope_provider.py
+++ b/nanobot/providers/dashscope_provider.py
@@ -8,12 +8,16 @@ https://help.aliyun.com/zh/model-studio/qwen-api-via-dashscope
 
 Wire shape (result_format="message"):
 
-    POST {base}/api/v1/services/aigc/text-generation/generation
     POST {base}/api/v1/services/aigc/multimodal-generation/generation
 
     {"model": "...",
      "input": {"messages": [{"role": "user", "content": "..."}]},
      "parameters": {"result_format": "message", "tools": [...], ...}}
+
+All traffic — text-only included — goes through the multimodal-generation
+endpoint: the classic ``text-generation/generation`` path has been retired on
+the public ``dashscope.aliyuncs.com`` host and answers ``url error``, while
+multimodal-generation serves text, images, tools, and SSE streaming.
 
 Streaming adds ``X-DashScope-SSE: enable`` and ``incremental_output: true``;
 each SSE ``data:`` line carries one output.choices[0].message delta.
@@ -37,10 +41,7 @@ from nanobot.providers.base import (
 )
 
 _DEFAULT_API_BASE = "https://dashscope.aliyuncs.com"
-_TEXT_GENERATION_PATH = "/api/v1/services/aigc/text-generation/generation"
-_MULTIMODAL_GENERATION_PATH = (
-    "/api/v1/services/aigc/multimodal-generation/generation"
-)
+_GENERATION_PATH = "/api/v1/services/aigc/multimodal-generation/generation"
 _SSE_HEADERS = {
     "Accept": "text/event-stream",
     "X-DashScope-SSE": "enable",
@@ -64,7 +65,7 @@ class DashScopeProvider(LLMProvider):
         self,
         api_key: str | None = None,
         api_base: str | None = None,
-        default_model: str = "qwen-plus",
+        default_model: str = "qwen3.8-max",
         *,
         extra_headers: dict[str, str] | None = None,
         extra_body: dict[str, Any] | None = None,
@@ -179,7 +180,7 @@ class DashScopeProvider(LLMProvider):
         *,
         stream: bool,
     ) -> tuple[dict[str, Any], str]:
-        ds_messages, has_multimodal = self._convert_messages(messages)
+        ds_messages, _has_multimodal = self._convert_messages(messages)
         parameters: dict[str, Any] = {
             "result_format": "message",
             "max_tokens": max_tokens,
@@ -203,8 +204,7 @@ class DashScopeProvider(LLMProvider):
             "input": {"messages": ds_messages},
             "parameters": parameters,
         }
-        path = _MULTIMODAL_GENERATION_PATH if has_multimodal else _TEXT_GENERATION_PATH
-        return payload, path
+        return payload, _GENERATION_PATH
 
     # ------------------------------------------------------------------
     # Response parsing
@@ -395,6 +395,29 @@ class DashScopeProvider(LLMProvider):
         if isinstance(content, str) and content:
             content_parts.append(content)
             content_delta = content
+        elif isinstance(content, list):
+            # Multimodal models stream content as an array of {"text": ...}
+            # parts; each part arrives complete, so track per-slot text and
+            # emit only the growth (works for once-complete and incremental).
+            slots: list[str] = state.setdefault("content_slots", [])
+            part_texts: list[str] = []
+            for raw_part in cast(list[object], content):
+                if isinstance(raw_part, dict):
+                    text = cast(dict[str, Any], raw_part).get("text")
+                    part_texts.append(text if isinstance(text, str) else "")
+            while len(slots) < len(part_texts):
+                slots.append("")
+            for i, text in enumerate(part_texts):
+                seen = slots[i]
+                if text.startswith(seen) and len(text) > len(seen):
+                    delta = text[len(seen):]
+                    slots[i] = text
+                    content_parts.append(delta)
+                    content_delta += delta
+                elif text and text != seen:
+                    slots[i] = text
+                    content_parts.append(text)
+                    content_delta += text
         reasoning = message.get("reasoning_content")
         reasoning_delta = ""
         if isinstance(reasoning, str) and reasoning:

--- a/nanobot/providers/dashscope_provider.py
+++ b/nanobot/providers/dashscope_provider.py
@@ -1,0 +1,598 @@
+"""Alibaba Cloud DashScope (Bailian) native-protocol provider.
+
+Talks to the DashScope native HTTP API rather than the OpenAI-compatible
+endpoint, which unlocks models and parameters that compatible-mode does not
+expose (full multimodal parameter surface, thinking controls such as
+``reasoning_effort``, native-only models). See provider docs:
+https://help.aliyun.com/zh/model-studio/qwen-api-via-dashscope
+
+Wire shape (result_format="message"):
+
+    POST {base}/api/v1/services/aigc/text-generation/generation
+    POST {base}/api/v1/services/aigc/multimodal-generation/generation
+
+    {"model": "...",
+     "input": {"messages": [{"role": "user", "content": "..."}]},
+     "parameters": {"result_format": "message", "tools": [...], ...}}
+
+Streaming adds ``X-DashScope-SSE: enable`` and ``incremental_output: true``;
+each SSE ``data:`` line carries one output.choices[0].message delta.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any, cast
+
+import httpx
+
+from nanobot.providers.base import (
+    LLMProvider,
+    LLMResponse,
+    ToolCallRequest,
+    parse_tool_arguments,
+    resolve_stream_idle_timeout_s,
+)
+
+_DEFAULT_API_BASE = "https://dashscope.aliyuncs.com"
+_TEXT_GENERATION_PATH = "/api/v1/services/aigc/text-generation/generation"
+_MULTIMODAL_GENERATION_PATH = (
+    "/api/v1/services/aigc/multimodal-generation/generation"
+)
+_SSE_HEADERS = {
+    "Accept": "text/event-stream",
+    "X-DashScope-SSE": "enable",
+}
+# Non-streaming requests must still allow long thinking turns.
+_REQUEST_TIMEOUT_S = httpx.Timeout(300.0, connect=15.0)
+
+_FINISH_REASONS = {
+    "stop": "stop",
+    "length": "length",
+    "tool_calls": "tool_calls",
+    "function_call": "tool_calls",
+    "content_filter": "content_filter",
+}
+
+
+class DashScopeProvider(LLMProvider):
+    """LLM provider for the DashScope native protocol (Bailian)."""
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        api_base: str | None = None,
+        default_model: str = "qwen-plus",
+        *,
+        extra_headers: dict[str, str] | None = None,
+        extra_body: dict[str, Any] | None = None,
+        proxy: str | None = None,
+        client: Any | None = None,
+    ):
+        super().__init__(api_key, api_base)
+        self.default_model = default_model
+        self._extra_headers = dict(extra_headers or {})
+        self._extra_body = dict(extra_body or {})
+        self._proxy = proxy
+        self._client = client
+
+    def _http_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        headers = {"Authorization": f"Bearer {self.api_key or ''}"}
+        headers.update(self._extra_headers)
+        self._client = httpx.AsyncClient(
+            base_url=self.api_base or _DEFAULT_API_BASE,
+            headers=headers,
+            timeout=_REQUEST_TIMEOUT_S,
+            proxy=self._proxy,
+        )
+        return self._client
+
+    # ------------------------------------------------------------------
+    # Request building
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _convert_user_content(
+        cls, content: Any
+    ) -> tuple[Any, bool]:
+        """Convert OpenAI-style user content to the DashScope shape.
+
+        Returns ``(converted, is_multimodal)``. Multimodal content becomes a
+        list of ``{"text": ...}`` / ``{"image": url}`` objects.
+        """
+        if not isinstance(content, list):
+            return content, False
+        blocks: list[dict[str, Any]] = []
+        has_image = False
+        for raw_block in cast(list[object], content):
+            if not isinstance(raw_block, dict):
+                continue
+            block = cast(dict[str, Any], raw_block)
+            block_type = block.get("type")
+            if block_type == "text":
+                text = block.get("text")
+                if isinstance(text, str):
+                    blocks.append({"text": text})
+            elif block_type == "image_url":
+                image_url = cast(dict[str, Any], block.get("image_url") or {})
+                url = image_url.get("url")
+                if isinstance(url, str) and url:
+                    blocks.append({"image": url})
+                    has_image = True
+        if has_image:
+            return blocks, True
+        return "".join(str(b.get("text") or "") for b in blocks), False
+
+    @classmethod
+    def _convert_messages(
+        cls, messages: list[dict[str, Any]]
+    ) -> tuple[list[dict[str, Any]], bool]:
+        converted: list[dict[str, Any]] = []
+        has_multimodal = False
+        for msg in messages:
+            role = msg.get("role")
+            if role == "user":
+                content, multimodal = cls._convert_user_content(msg.get("content"))
+                has_multimodal = has_multimodal or multimodal
+                converted.append({"role": "user", "content": content})
+            elif role == "assistant":
+                out: dict[str, Any] = {"role": "assistant", "content": msg.get("content")}
+                tool_calls = msg.get("tool_calls")
+                if isinstance(tool_calls, list) and tool_calls:
+                    out["tool_calls"] = tool_calls
+                converted.append(out)
+            elif role == "tool":
+                converted.append({
+                    "role": "tool",
+                    "content": msg.get("content") or "",
+                    "tool_call_id": msg.get("tool_call_id") or "",
+                })
+            elif role == "system":
+                converted.append({"role": "system", "content": msg.get("content") or ""})
+        return converted, has_multimodal
+
+    @staticmethod
+    def _convert_tool_choice(tool_choice: str | dict[str, Any] | None) -> Any:
+        if tool_choice is None or tool_choice == "auto":
+            return None
+        if isinstance(tool_choice, dict):
+            return tool_choice
+        if tool_choice == "none":
+            return "none"
+        if tool_choice == "required":
+            return "required"
+        return None
+
+    def _build_payload(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        model: str | None,
+        max_tokens: int,
+        temperature: float,
+        reasoning_effort: str | None,
+        tool_choice: str | dict[str, Any] | None,
+        *,
+        stream: bool,
+    ) -> tuple[dict[str, Any], str]:
+        ds_messages, has_multimodal = self._convert_messages(messages)
+        parameters: dict[str, Any] = {
+            "result_format": "message",
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        }
+        if stream:
+            parameters["incremental_output"] = True
+        if reasoning_effort is not None:
+            parameters["enable_thinking"] = True
+            parameters["reasoning_effort"] = reasoning_effort
+        if tools:
+            # DashScope keeps tools and tool_choice inside `parameters`, and
+            # requires result_format="message" (already set) for tool calls.
+            parameters["tools"] = tools
+            converted_choice = self._convert_tool_choice(tool_choice)
+            if converted_choice is not None:
+                parameters["tool_choice"] = converted_choice
+        parameters.update(self._extra_body)
+        payload = {
+            "model": model or self.default_model,
+            "input": {"messages": ds_messages},
+            "parameters": parameters,
+        }
+        path = _MULTIMODAL_GENERATION_PATH if has_multimodal else _TEXT_GENERATION_PATH
+        return payload, path
+
+    # ------------------------------------------------------------------
+    # Response parsing
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _usage(usage: object) -> dict[str, int]:
+        if not isinstance(usage, dict):
+            return {}
+        data = cast(dict[str, Any], usage)
+        result: dict[str, int] = {}
+        for source, target in (
+            ("input_tokens", "prompt_tokens"),
+            ("output_tokens", "completion_tokens"),
+            ("total_tokens", "total_tokens"),
+        ):
+            value = data.get(source)
+            if isinstance(value, int):
+                result[target] = value
+        details = data.get("prompt_tokens_details")
+        if isinstance(details, dict):
+            cached = cast(dict[str, Any], details).get("cached_tokens")
+            if isinstance(cached, int):
+                result["cached_tokens"] = cached
+        return result
+
+    @staticmethod
+    def _finish_reason(value: Any) -> str:
+        token = str(value or "").strip().lower()
+        return _FINISH_REASONS.get(token, "stop")
+
+    @classmethod
+    def _parse_tool_calls(cls, raw: object) -> list[ToolCallRequest]:
+        calls: list[ToolCallRequest] = []
+        if not isinstance(raw, list):
+            return calls
+        for raw_item in cast(list[object], raw):
+            if not isinstance(raw_item, dict):
+                continue
+            item = cast(dict[str, Any], raw_item)
+            function = cast(dict[str, Any], item.get("function") or {})
+            arguments = parse_tool_arguments(function.get("arguments"))
+            calls.append(ToolCallRequest(
+                id=str(item.get("id") or ""),
+                name=str(function.get("name") or ""),
+                arguments=arguments,
+            ))
+        return calls
+
+    @classmethod
+    def _message_content(cls, content: object) -> str | None:
+        if isinstance(content, str):
+            return content or None
+        if isinstance(content, list):
+            text = "".join(
+                str(cast(dict[str, Any], part).get("text") or "")
+                for part in cast(list[object], content)
+                if isinstance(part, dict)
+            )
+            return text or None
+        return None
+
+    @classmethod
+    def _error_response(
+        cls,
+        *,
+        message: str,
+        status_code: int | None = None,
+        code: str | None = None,
+        kind: str | None = None,
+    ) -> LLMResponse:
+        should_retry: bool | None = None
+        if kind in ("timeout", "connection"):
+            should_retry = True
+        elif status_code is not None:
+            should_retry = status_code == 429 or status_code >= 500
+        code_token = (code or "").lower()
+        if any(token in code_token for token in ("throttl", "timeout", "unavailable")):
+            should_retry = True
+        elif should_retry is None:
+            should_retry = False
+        return LLMResponse(
+            content=f"Error: {message[:500]}",
+            finish_reason="error",
+            error_status_code=status_code,
+            error_kind=kind,
+            error_type=code_token or None,
+            error_code=code_token or None,
+            error_should_retry=should_retry,
+        )
+
+    @classmethod
+    def _handle_http_error(cls, status_code: int, body: str) -> LLMResponse:
+        code: str | None = None
+        message = body.strip()[:500]
+        try:
+            parsed = json.loads(body) if body.strip() else None
+        except (json.JSONDecodeError, ValueError):
+            parsed = None
+        if isinstance(parsed, dict):
+            data = cast(dict[str, Any], parsed)
+            code = str(data.get("code") or "") or None
+            message = str(data.get("message") or "") or message
+        return cls._error_response(
+            message=message,
+            status_code=status_code,
+            code=code,
+        )
+
+    @classmethod
+    def _parse_response(cls, data: dict[str, Any]) -> LLMResponse:
+        output = cast(dict[str, Any], data.get("output") or {})
+        usage = cls._usage(output.get("usage"))
+        if data.get("code") or data.get("message"):
+            # DashScope reports some logical errors with HTTP 200.
+            return cls._error_response(
+                message=str(data.get("message") or data.get("code")),
+                code=str(data.get("code") or "") or None,
+            )
+        choices = output.get("choices")
+        if not isinstance(choices, list) or not choices:
+            return LLMResponse(content=None, finish_reason="stop", usage=usage)
+        items = cast(list[object], choices)
+        choice = cast(dict[str, Any], items[0]) if isinstance(items[0], dict) else {}
+        message = cast(dict[str, Any], choice.get("message") or {})
+        reasoning = message.get("reasoning_content")
+        return LLMResponse(
+            content=cls._message_content(message.get("content")),
+            tool_calls=cls._parse_tool_calls(message.get("tool_calls")),
+            finish_reason=cls._finish_reason(choice.get("finish_reason")),
+            usage=usage,
+            reasoning_content=str(reasoning) if reasoning else None,
+        )
+
+    @classmethod
+    def _handle_exception(cls, e: Exception) -> LLMResponse:
+        if isinstance(e, httpx.HTTPStatusError):
+            return cls._handle_http_error(
+                e.response.status_code,
+                e.response.text,
+            )
+        name = e.__class__.__name__.lower()
+        kind = None
+        if "timeout" in name:
+            kind = "timeout"
+        elif "connect" in name or "request" in name:
+            kind = "connection"
+        return cls._error_response(
+            message=str(e),
+            kind=kind,
+            code="timeout" if kind == "timeout" else None,
+        )
+
+    # ------------------------------------------------------------------
+    # Streaming
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _apply_stream_chunk(
+        cls,
+        chunk: dict[str, Any],
+        *,
+        content_parts: list[str],
+        reasoning_parts: list[str],
+        tool_buffers: dict[int, dict[str, Any]],
+        state: dict[str, Any],
+    ) -> tuple[str, str, dict[str, Any] | None]:
+        """Fold one SSE chunk into accumulator state; return delta callbacks.
+
+        Returns ``(content_delta, reasoning_delta, tool_call_delta)`` where
+        empty strings / None mean "nothing to emit".
+        """
+        output = cast(dict[str, Any], chunk.get("output") or {})
+        usage = cls._usage(output.get("usage"))
+        if usage:
+            state["usage"] = usage
+        choices = output.get("choices")
+        if not isinstance(choices, list) or not choices:
+            return "", "", None
+        items = cast(list[object], choices)
+        choice = cast(dict[str, Any], items[0]) if isinstance(items[0], dict) else {}
+        finish = choice.get("finish_reason")
+        if finish not in (None, "", "null"):
+            state["finish_reason"] = cls._finish_reason(finish)
+        message = cast(dict[str, Any], choice.get("message") or {})
+        content = message.get("content")
+        content_delta = ""
+        if isinstance(content, str) and content:
+            content_parts.append(content)
+            content_delta = content
+        reasoning = message.get("reasoning_content")
+        reasoning_delta = ""
+        if isinstance(reasoning, str) and reasoning:
+            reasoning_parts.append(reasoning)
+            reasoning_delta = reasoning
+        tool_delta: dict[str, Any] | None = None
+        tool_calls = message.get("tool_calls")
+        if isinstance(tool_calls, list) and tool_calls:
+            for raw_item in cast(list[object], tool_calls):
+                if not isinstance(raw_item, dict):
+                    continue
+                item = cast(dict[str, Any], raw_item)
+                index = item.get("index")
+                idx = index if isinstance(index, int) else 0
+                buffer = tool_buffers.setdefault(
+                    idx, {"id": "", "name": "", "arguments": ""}
+                )
+                call_id = item.get("id")
+                if isinstance(call_id, str) and call_id:
+                    buffer["id"] = call_id
+                function = cast(dict[str, Any], item.get("function") or {})
+                name = function.get("name")
+                if isinstance(name, str) and name and not buffer["name"]:
+                    buffer["name"] = name
+                args = function.get("arguments")
+                args_delta = ""
+                if isinstance(args, str) and args:
+                    buffer["arguments"] += args
+                    args_delta = args
+                tool_delta = {
+                    "index": idx,
+                    "call_id": buffer["id"],
+                    "name": buffer["name"],
+                    "arguments_delta": args_delta,
+                }
+        return content_delta, reasoning_delta, tool_delta
+
+    @classmethod
+    def _stream_result(
+        cls,
+        *,
+        content_parts: list[str],
+        reasoning_parts: list[str],
+        tool_buffers: dict[int, dict[str, Any]],
+        state: dict[str, Any],
+    ) -> LLMResponse:
+        tool_calls: list[ToolCallRequest] = []
+        for idx in sorted(tool_buffers):
+            buffer = tool_buffers[idx]
+            arguments: Any = {}
+            if buffer["arguments"]:
+                arguments = parse_tool_arguments(buffer["arguments"])
+            tool_calls.append(ToolCallRequest(
+                id=buffer["id"],
+                name=buffer["name"],
+                arguments=arguments,
+            ))
+        return LLMResponse(
+            content="".join(content_parts) or None,
+            tool_calls=tool_calls,
+            finish_reason=str(state.get("finish_reason") or "stop"),
+            usage=cast(dict[str, int], state.get("usage") or {}),
+            reasoning_content="".join(reasoning_parts) or None,
+        )
+
+    # ------------------------------------------------------------------
+    # LLMProvider API
+    # ------------------------------------------------------------------
+
+    async def chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        model: str | None = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+        reasoning_effort: str | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+    ) -> LLMResponse:
+        if not self.api_key:
+            return self._error_response(
+                message="DashScope provider requires an API key "
+                "(providers.dashscope_native.api_key or DASHSCOPE_API_KEY).",
+                code="missing_api_key",
+            )
+        try:
+            payload, path = self._build_payload(
+                messages,
+                tools,
+                model,
+                max_tokens,
+                temperature,
+                reasoning_effort,
+                tool_choice,
+                stream=False,
+            )
+            client = self._http_client()
+            response = await client.post(path, json=payload)
+            if response.status_code != 200:
+                return self._handle_http_error(response.status_code, response.text)
+            return self._parse_response(response.json())
+        except Exception as e:
+            return self._handle_exception(e)
+
+    async def chat_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        model: str | None = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+        reasoning_effort: str | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+        on_content_delta: Callable[[str], Awaitable[None]] | None = None,
+        on_thinking_delta: Callable[[str], Awaitable[None]] | None = None,
+        on_tool_call_delta: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+    ) -> LLMResponse:
+        if not self.api_key:
+            return self._error_response(
+                message="DashScope provider requires an API key "
+                "(providers.dashscope_native.api_key or DASHSCOPE_API_KEY).",
+                code="missing_api_key",
+            )
+        idle_timeout_s = resolve_stream_idle_timeout_s()
+        content_parts: list[str] = []
+        reasoning_parts: list[str] = []
+        tool_buffers: dict[int, dict[str, Any]] = {}
+        state: dict[str, Any] = {}
+        try:
+            payload, path = self._build_payload(
+                messages,
+                tools,
+                model,
+                max_tokens,
+                temperature,
+                reasoning_effort,
+                tool_choice,
+                stream=True,
+            )
+            client = self._http_client()
+            async with client.stream(
+                "POST", path, json=payload, headers=_SSE_HEADERS
+            ) as response:
+                if response.status_code != 200:
+                    body = (await response.aread()).decode("utf-8", errors="replace")
+                    return self._handle_http_error(response.status_code, body)
+                lines = response.aiter_lines().__aiter__()
+                while True:
+                    try:
+                        line = await asyncio.wait_for(
+                            lines.__anext__(), timeout=idle_timeout_s
+                        )
+                    except StopAsyncIteration:
+                        break
+                    line = line.strip()
+                    if not line.startswith("data:"):
+                        continue
+                    data_str = line[len("data:"):].strip()
+                    if not data_str or data_str == "[DONE]":
+                        continue
+                    try:
+                        chunk = json.loads(data_str)
+                    except (json.JSONDecodeError, ValueError):
+                        continue
+                    if not isinstance(chunk, dict):
+                        continue
+                    content_delta, reasoning_delta, tool_delta = (
+                        self._apply_stream_chunk(
+                            cast(dict[str, Any], chunk),
+                            content_parts=content_parts,
+                            reasoning_parts=reasoning_parts,
+                            tool_buffers=tool_buffers,
+                            state=state,
+                        )
+                    )
+                    if content_delta and on_content_delta:
+                        await on_content_delta(content_delta)
+                    if reasoning_delta and on_thinking_delta:
+                        await on_thinking_delta(reasoning_delta)
+                    if tool_delta is not None and on_tool_call_delta:
+                        await on_tool_call_delta(tool_delta)
+            return self._stream_result(
+                content_parts=content_parts,
+                reasoning_parts=reasoning_parts,
+                tool_buffers=tool_buffers,
+                state=state,
+            )
+        except asyncio.TimeoutError:
+            return LLMResponse(
+                content=(
+                    f"Error calling LLM: stream stalled for more than "
+                    f"{idle_timeout_s:g} seconds"
+                ),
+                finish_reason="error",
+                error_kind="timeout",
+            )
+        except Exception as e:
+            return self._handle_exception(e)
+
+    def get_default_model(self) -> str:
+        return self.default_model

--- a/nanobot/providers/factory.py
+++ b/nanobot/providers/factory.py
@@ -201,7 +201,7 @@ def _make_provider_core(
             api_key=(p.api_key if p and p.api_key else None)
             or os.environ.get(spec.env_key if spec else "", ""),
             api_base=config.get_api_base(model, preset=preset),
-            default_model=model or "qwen-plus",
+            default_model=model or "qwen3.8-max",
             extra_headers=_provider_extra_headers(spec, p),
             extra_body=p.extra_body if p else None,
             proxy=p.proxy if p else None,

--- a/nanobot/providers/factory.py
+++ b/nanobot/providers/factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -73,7 +74,9 @@ def _resolve_provider_setup(
     if spec and spec.is_transcription_only:
         raise ValueError(f"Provider '{provider_name}' only supports transcription.")
     backend = spec.backend if spec else "openai_compat"
-    if p and p.proxy and backend not in {"openai_compat", "openai_codex", "xai_grok"}:
+    if p and p.proxy and backend not in {
+        "openai_compat", "openai_codex", "xai_grok", "dashscope_native",
+    }:
         raise ValueError(
             f"providers.{provider_name}.proxy is only supported for "
             "OpenAI-compatible providers, OpenAI Codex, and xAI Grok."
@@ -190,6 +193,18 @@ def _make_provider_core(
             region=getattr(p, "region", None) if p else None,
             profile=getattr(p, "profile", None) if p else None,
             extra_body=p.extra_body if p else None,
+        )
+    elif backend == "dashscope_native":
+        from nanobot.providers.dashscope_provider import DashScopeProvider
+
+        provider = DashScopeProvider(
+            api_key=(p.api_key if p and p.api_key else None)
+            or os.environ.get(spec.env_key if spec else "", ""),
+            api_base=config.get_api_base(model, preset=preset),
+            default_model=model or "qwen-plus",
+            extra_headers=_provider_extra_headers(spec, p),
+            extra_body=p.extra_body if p else None,
+            proxy=p.proxy if p else None,
         )
     else:
         from nanobot.providers.openai_compat_provider import OpenAICompatProvider

--- a/nanobot/providers/image_generation.py
+++ b/nanobot/providers/image_generation.py
@@ -2112,9 +2112,6 @@ class ModelScopeImageGenerationClient(ImageGenerationProvider):
         return images
 
 
-_DASHSCOPE_POLL_INTERVAL_S = 3.0
-_DASHSCOPE_POLL_MAX_ATTEMPTS = 100  # 5 min at 3s intervals
-
 _DASHSCOPE_ASPECT_SIZES = {
     "1:1": "1024*1024",
     "9:16": "720*1280",
@@ -2136,12 +2133,13 @@ def _dashscope_size(aspect_ratio: str | None, image_size: str | None) -> str:
 
 
 class DashScopeImageGenerationClient(ImageGenerationProvider):
-    """Async client for DashScope (Bailian) native image synthesis.
+    """Synchronous client for DashScope (Bailian) image generation.
 
-    DashScope uses the async task pattern shared across its AIGC services:
-    POST with ``X-DashScope-Async: enable`` returns ``output.task_id``, then
-    GET /api/v1/tasks/{task_id} is polled until ``output.task_status`` is
-    SUCCEEDED or FAILED.
+    qwen-image / wan models serve through the same multimodal-generation
+    endpoint as chat: one POST returns signed image URLs inside
+    ``output.choices[0].message.content[*].image``. (The classic async
+    ``text2image/image-synthesis`` task flow has been retired on the public
+    host and answers ``url error``.)
     """
 
     provider_name = "dashscope_native"
@@ -2150,6 +2148,7 @@ class DashScopeImageGenerationClient(ImageGenerationProvider):
         "DashScope API key is not configured. "
         "Set providers.dashscope_native.apiKey."
     )
+    default_timeout = 180.0
 
     def _default_base_url(self) -> str:
         return "https://dashscope.aliyuncs.com"
@@ -2169,28 +2168,30 @@ class DashScopeImageGenerationClient(ImageGenerationProvider):
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
-            "X-DashScope-Async": "enable",
             **self.extra_headers,
         }
 
+        content: list[dict[str, Any]] = [
+            {"image": image_path_to_data_url(path)}
+            for path in list(reference_images or [])
+        ]
+        content.append({"text": prompt})
+        parameters: dict[str, Any] = {
+            "prompt_extend": True,
+            "size": _dashscope_size(aspect_ratio, image_size),
+        }
+        parameters.update(self.extra_body)
         body: dict[str, Any] = {
             "model": model,
-            "input": {"prompt": prompt},
-            "parameters": {
-                "size": _dashscope_size(aspect_ratio, image_size),
-                "n": 1,
-            },
+            "input": {"messages": [{"role": "user", "content": content}]},
+            "parameters": parameters,
         }
-        refs = list(reference_images or [])
-        if refs:
-            body["input"]["ref_img"] = image_path_to_data_url(refs[0])
-        body["parameters"].update(self.extra_body)
 
-        submit_url = f"{self.api_base}/api/v1/services/aigc/text2image/image-synthesis"
+        url = f"{self.api_base}/api/v1/services/aigc/multimodal-generation/generation"
         client = self._client or httpx.AsyncClient(**self._http_client_kwargs())
         try:
             try:
-                response = await client.post(submit_url, headers=headers, json=body)
+                response = await client.post(url, headers=headers, json=body)
             except httpx.TimeoutException as exc:
                 raise ImageGenerationError(
                     "DashScope image generation request timed out"
@@ -2208,69 +2209,36 @@ class DashScopeImageGenerationClient(ImageGenerationProvider):
                     f"DashScope image generation failed: {detail}"
                 ) from exc
 
-            task_data = cast(dict[str, Any], response.json())
-            output = cast(dict[str, Any], task_data.get("output") or {})
-            task_id = output.get("task_id")
-            if not task_id:
+            data = cast(dict[str, Any], response.json())
+            if data.get("code") or data.get("message"):
                 raise ImageGenerationError(
-                    f"DashScope did not return a task_id: {response.text[:500]}"
+                    f"DashScope image generation failed: "
+                    f"{data.get('code')}: {data.get('message')}"
                 )
-
-            images = await self._poll_task(
-                client, cast(str, task_id), headers
-            )
-            self._require_images(images, task_data)
-            return GeneratedImageResponse(images=images, content="", raw=task_data)
+            images = await self._collect_images(data)
+            self._require_images(images, data)
+            return GeneratedImageResponse(images=images, content="", raw=data)
         finally:
             if self._client is None:
                 await client.aclose()
 
-    async def _poll_task(
-        self,
-        client: httpx.AsyncClient,
-        task_id: str,
-        submit_headers: dict[str, str],
-    ) -> list[str]:
-        poll_url = f"{self.api_base}/api/v1/tasks/{task_id}"
-        for _ in range(_DASHSCOPE_POLL_MAX_ATTEMPTS):
-            try:
-                response = await client.get(poll_url, headers=submit_headers)
-            except httpx.RequestError:
-                await asyncio.sleep(_DASHSCOPE_POLL_INTERVAL_S)
-                continue
-
-            try:
-                response.raise_for_status()
-            except httpx.HTTPStatusError as exc:
-                detail = _http_error_detail(response)
-                raise ImageGenerationError(
-                    f"DashScope task polling failed: {detail}"
-                ) from exc
-
-            data = cast(dict[str, Any], response.json())
-            output = cast(dict[str, Any], data.get("output") or {})
-            status = output.get("task_status")
-
-            if status == "SUCCEEDED":
-                return await self._collect_images(output)
-            if status in ("FAILED", "CANCELED", "UNKNOWN"):
-                raise ImageGenerationError(
-                    f"DashScope image generation task {status}: {data}"
-                )
-
-            await asyncio.sleep(_DASHSCOPE_POLL_INTERVAL_S)
-
-        raise ImageGenerationError(
-            f"DashScope image generation timed out after "
-            f"{_DASHSCOPE_POLL_MAX_ATTEMPTS} polls"
+    async def _collect_images(self, data: dict[str, Any]) -> list[str]:
+        output = cast(dict[str, Any], data.get("output") or {})
+        choices = output.get("choices")
+        if not isinstance(choices, list) or not choices:
+            return []
+        choice = (
+            cast(dict[str, Any], choices[0]) if isinstance(choices[0], dict) else {}
         )
-
-    async def _collect_images(self, output: dict[str, Any]) -> list[str]:
+        message = cast(dict[str, Any], choice.get("message") or {})
+        content = message.get("content")
+        if not isinstance(content, list):
+            return []
         images: list[str] = []
-        for raw_result in cast(list[object], output.get("results") or []):
-            if not isinstance(raw_result, dict):
+        for raw_part in cast(list[object], content):
+            if not isinstance(raw_part, dict):
                 continue
-            url = cast(dict[str, Any], raw_result).get("url")
+            url = cast(dict[str, Any], raw_part).get("image")
             if isinstance(url, str) and url:
                 images.append(
                     await _download_image_data_url(url, proxy=self.proxy)

--- a/nanobot/providers/image_generation.py
+++ b/nanobot/providers/image_generation.py
@@ -2112,6 +2112,172 @@ class ModelScopeImageGenerationClient(ImageGenerationProvider):
         return images
 
 
+_DASHSCOPE_POLL_INTERVAL_S = 3.0
+_DASHSCOPE_POLL_MAX_ATTEMPTS = 100  # 5 min at 3s intervals
+
+_DASHSCOPE_ASPECT_SIZES = {
+    "1:1": "1024*1024",
+    "9:16": "720*1280",
+    "3:4": "768*1152",
+    "16:9": "1280*720",
+    "4:3": "1152*768",
+}
+
+
+def _dashscope_size(aspect_ratio: str | None, image_size: str | None) -> str:
+    """Resolve aspect ratio / image_size to a DashScope ``W*H`` size string."""
+    if image_size:
+        normalized = image_size.strip().lower().replace("x", "*")
+        if "*" in normalized:
+            return normalized
+    if aspect_ratio and aspect_ratio in _DASHSCOPE_ASPECT_SIZES:
+        return _DASHSCOPE_ASPECT_SIZES[aspect_ratio]
+    return "1024*1024"
+
+
+class DashScopeImageGenerationClient(ImageGenerationProvider):
+    """Async client for DashScope (Bailian) native image synthesis.
+
+    DashScope uses the async task pattern shared across its AIGC services:
+    POST with ``X-DashScope-Async: enable`` returns ``output.task_id``, then
+    GET /api/v1/tasks/{task_id} is polled until ``output.task_status`` is
+    SUCCEEDED or FAILED.
+    """
+
+    provider_name = "dashscope_native"
+    model_options = ("qwen-image-3.0-pro", "wan2.7-image-pro")
+    missing_key_message = (
+        "DashScope API key is not configured. "
+        "Set providers.dashscope_native.apiKey."
+    )
+
+    def _default_base_url(self) -> str:
+        return "https://dashscope.aliyuncs.com"
+
+    async def generate(
+        self,
+        *,
+        prompt: str,
+        model: str,
+        reference_images: list[str] | None = None,
+        aspect_ratio: str | None = None,
+        image_size: str | None = None,
+    ) -> GeneratedImageResponse:
+        if not self.api_key:
+            raise ImageGenerationError(self.missing_key_message)
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "X-DashScope-Async": "enable",
+            **self.extra_headers,
+        }
+
+        body: dict[str, Any] = {
+            "model": model,
+            "input": {"prompt": prompt},
+            "parameters": {
+                "size": _dashscope_size(aspect_ratio, image_size),
+                "n": 1,
+            },
+        }
+        refs = list(reference_images or [])
+        if refs:
+            body["input"]["ref_img"] = image_path_to_data_url(refs[0])
+        body["parameters"].update(self.extra_body)
+
+        submit_url = f"{self.api_base}/api/v1/services/aigc/text2image/image-synthesis"
+        client = self._client or httpx.AsyncClient(**self._http_client_kwargs())
+        try:
+            try:
+                response = await client.post(submit_url, headers=headers, json=body)
+            except httpx.TimeoutException as exc:
+                raise ImageGenerationError(
+                    "DashScope image generation request timed out"
+                ) from exc
+            except httpx.RequestError as exc:
+                raise ImageGenerationError(
+                    f"DashScope image generation request failed: {exc}"
+                ) from exc
+
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                detail = _http_error_detail(response)
+                raise ImageGenerationError(
+                    f"DashScope image generation failed: {detail}"
+                ) from exc
+
+            task_data = cast(dict[str, Any], response.json())
+            output = cast(dict[str, Any], task_data.get("output") or {})
+            task_id = output.get("task_id")
+            if not task_id:
+                raise ImageGenerationError(
+                    f"DashScope did not return a task_id: {response.text[:500]}"
+                )
+
+            images = await self._poll_task(
+                client, cast(str, task_id), headers
+            )
+            self._require_images(images, task_data)
+            return GeneratedImageResponse(images=images, content="", raw=task_data)
+        finally:
+            if self._client is None:
+                await client.aclose()
+
+    async def _poll_task(
+        self,
+        client: httpx.AsyncClient,
+        task_id: str,
+        submit_headers: dict[str, str],
+    ) -> list[str]:
+        poll_url = f"{self.api_base}/api/v1/tasks/{task_id}"
+        for _ in range(_DASHSCOPE_POLL_MAX_ATTEMPTS):
+            try:
+                response = await client.get(poll_url, headers=submit_headers)
+            except httpx.RequestError:
+                await asyncio.sleep(_DASHSCOPE_POLL_INTERVAL_S)
+                continue
+
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                detail = _http_error_detail(response)
+                raise ImageGenerationError(
+                    f"DashScope task polling failed: {detail}"
+                ) from exc
+
+            data = cast(dict[str, Any], response.json())
+            output = cast(dict[str, Any], data.get("output") or {})
+            status = output.get("task_status")
+
+            if status == "SUCCEEDED":
+                return await self._collect_images(output)
+            if status in ("FAILED", "CANCELED", "UNKNOWN"):
+                raise ImageGenerationError(
+                    f"DashScope image generation task {status}: {data}"
+                )
+
+            await asyncio.sleep(_DASHSCOPE_POLL_INTERVAL_S)
+
+        raise ImageGenerationError(
+            f"DashScope image generation timed out after "
+            f"{_DASHSCOPE_POLL_MAX_ATTEMPTS} polls"
+        )
+
+    async def _collect_images(self, output: dict[str, Any]) -> list[str]:
+        images: list[str] = []
+        for raw_result in cast(list[object], output.get("results") or []):
+            if not isinstance(raw_result, dict):
+                continue
+            url = cast(dict[str, Any], raw_result).get("url")
+            if isinstance(url, str) and url:
+                images.append(
+                    await _download_image_data_url(url, proxy=self.proxy)
+                )
+        return images
+
+
 # ---------------------------------------------------------------------------
 # Provider registration
 # ---------------------------------------------------------------------------
@@ -2127,3 +2293,4 @@ register_image_gen_provider(OpenRouterImageGenerationClient)
 register_image_gen_provider(StepFunImageGenerationClient)
 register_image_gen_provider(ZhipuImageGenerationClient)
 register_image_gen_provider(ModelScopeImageGenerationClient)
+register_image_gen_provider(DashScopeImageGenerationClient)

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -530,29 +530,14 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
                 context_window=1000000,
             ),
             ProviderModelSpec(
-                id="qwen-max",
-                label="Qwen-Max",
-                description="Stable alias of the latest Qwen flagship model.",
-            ),
-            ProviderModelSpec(
                 id="qwen3.7-plus",
                 label="Qwen3.7-Plus",
                 description="Balanced model for everyday multimodal work.",
             ),
             ProviderModelSpec(
-                id="qwen-plus",
-                label="Qwen-Plus",
-                description="Stable alias of the latest Qwen plus-tier model.",
-            ),
-            ProviderModelSpec(
                 id="qwen3.7-flash",
                 label="Qwen3.7-Flash",
                 description="Fast and cost-efficient model.",
-            ),
-            ProviderModelSpec(
-                id="qwen-turbo",
-                label="Qwen-Turbo",
-                description="Stable alias of the fastest Qwen model.",
             ),
             ProviderModelSpec(
                 id="qwen3.5-omni-plus",

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -513,6 +513,65 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="https://dashscope.aliyuncs.com/compatible-mode/v1",
         thinking_style="enable_thinking",
     ),
+    # DashScope native protocol (百炼原生接口): full parameter surface and
+    # native-only models that compatible-mode does not expose.
+    ProviderSpec(
+        name="dashscope_native",
+        keywords=("dashscope_native", "dashscope-native"),
+        env_key="DASHSCOPE_API_KEY",
+        display_name="DashScope (Native)",
+        backend="dashscope_native",
+        model_catalog="builtin",
+        builtin_models=(
+            ProviderModelSpec(
+                id="qwen3.8-max",
+                label="Qwen3.8-Max",
+                description="Flagship multimodal model (text and image input).",
+                context_window=1000000,
+            ),
+            ProviderModelSpec(
+                id="qwen-max",
+                label="Qwen-Max",
+                description="Stable alias of the latest Qwen flagship model.",
+            ),
+            ProviderModelSpec(
+                id="qwen3.7-plus",
+                label="Qwen3.7-Plus",
+                description="Balanced model for everyday multimodal work.",
+            ),
+            ProviderModelSpec(
+                id="qwen-plus",
+                label="Qwen-Plus",
+                description="Stable alias of the latest Qwen plus-tier model.",
+            ),
+            ProviderModelSpec(
+                id="qwen3.7-flash",
+                label="Qwen3.7-Flash",
+                description="Fast and cost-efficient model.",
+            ),
+            ProviderModelSpec(
+                id="qwen-turbo",
+                label="Qwen-Turbo",
+                description="Stable alias of the fastest Qwen model.",
+            ),
+            ProviderModelSpec(
+                id="qwen3.5-omni-plus",
+                label="Qwen3.5-Omni-Plus",
+                description="Omni model accepting text, image, audio, and video.",
+            ),
+            ProviderModelSpec(
+                id="deepseek-v4-pro",
+                label="DeepSeek-V4-Pro",
+                description="DeepSeek reasoning model hosted on Bailian.",
+            ),
+            ProviderModelSpec(
+                id="deepseek-v4-flash",
+                label="DeepSeek-V4-Flash",
+                description="Fast DeepSeek model hosted on Bailian.",
+            ),
+        ),
+        default_api_base="https://dashscope.aliyuncs.com",
+    ),
     # ModelScope (魔搭社区): OpenAI-compatible API
     ProviderSpec(
         name="modelscope",

--- a/nanobot/providers/transcription.py
+++ b/nanobot/providers/transcription.py
@@ -11,6 +11,7 @@ import base64
 import json
 import mimetypes
 import os
+import urllib.parse
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, cast
@@ -24,6 +25,20 @@ _STEPFUN_ASR_PATH = "audio/asr/sse"
 _ASSEMBLYAI_DEFAULT_API_BASE = "https://api.assemblyai.com/v2"
 _ASSEMBLYAI_POLL_ATTEMPTS = 60
 _ASSEMBLYAI_POLL_INTERVAL_S = 2.0
+_DASHSCOPE_ASR_MAX_BYTES = 10 * 1024 * 1024
+_DASHSCOPE_AUDIO_MIME_BY_SUFFIX = {
+    "m4a": "audio/mp4",
+    "mp3": "audio/mpeg",
+    "oga": "audio/ogg",
+    "ogg": "audio/ogg",
+    "opus": "audio/ogg",
+    "wav": "audio/wav",
+    "weba": "audio/webm",
+    "webm": "audio/webm",
+    "aac": "audio/aac",
+    "flac": "audio/flac",
+    "mpga": "audio/mpeg",
+}
 _AUDIO_MIME_OVERRIDES = {
     ".m4a": "audio/mp4",
     ".mpga": "audio/mpeg",
@@ -746,6 +761,181 @@ class OpenRouterTranscriptionProvider:
             path=path,
             model=self.model,
             provider_label="OpenRouter",
+            language=self.language,
+        )
+
+
+async def _post_dashscope_asr_with_retry(
+    url: str,
+    *,
+    api_key: str | None,
+    path: Path,
+    model: str,
+    provider_label: str,
+    language: str | None = None,
+) -> str:
+    """POST audio (base64 data URL) to DashScope native ASR and return text."""
+    try:
+        data = path.read_bytes()
+    except OSError as e:
+        logger.exception("{} transcription error: cannot read audio file: {}", provider_label, e)
+        return ""
+    if len(data) > _DASHSCOPE_ASR_MAX_BYTES:
+        logger.error(
+            "{} transcription error: audio file exceeds {} bytes",
+            provider_label,
+            _DASHSCOPE_ASR_MAX_BYTES,
+        )
+        return ""
+
+    mime = (
+        mimetypes.guess_type(path)[0]
+        or _DASHSCOPE_AUDIO_MIME_BY_SUFFIX.get(path.suffix.lstrip(".").lower())
+        or "audio/wav"
+    )
+    audio_url = f"data:{mime};base64,{base64.b64encode(data).decode('ascii')}"
+
+    content: list[dict[str, Any]] = [{"audio": audio_url}]
+    parameters: dict[str, Any] = {"asr_options": {"enable_itn": True}}
+    if language:
+        parameters["asr_options"]["language"] = language
+
+    body: dict[str, Any] = {
+        "model": model,
+        "input": {
+            "messages": [
+                {"role": "user", "content": content},
+            ]
+        },
+        "parameters": parameters,
+    }
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    async with httpx.AsyncClient() as client:
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                response = await client.post(url, headers=headers, json=body, timeout=60.0)
+                if response.status_code in _RETRYABLE_STATUS and attempt < _MAX_RETRIES:
+                    logger.warning(
+                        "{} transcription transient HTTP {} (attempt {}/{})",
+                        provider_label,
+                        response.status_code,
+                        attempt + 1,
+                        _MAX_RETRIES + 1,
+                    )
+                    await asyncio.sleep(_BACKOFF_S[attempt])
+                    continue
+                response.raise_for_status()
+                payload_raw: object = response.json()
+                if isinstance(payload_raw, dict):
+                    payload = cast(dict[str, Any], payload_raw)
+                    if payload.get("code"):
+                        logger.error(
+                            "{} ASR error {}: {}",
+                            provider_label,
+                            payload.get("code"),
+                            payload.get("message"),
+                        )
+                        return ""
+                    return _dashscope_asr_text(payload)
+                return _dashscope_asr_text(payload_raw)
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code in _RETRYABLE_STATUS and attempt < _MAX_RETRIES:
+                    await asyncio.sleep(_BACKOFF_S[attempt])
+                    continue
+                logger.error(
+                    "{} transcription HTTP {}{}",
+                    provider_label,
+                    e.response.status_code,
+                    f" {e.response.reason_phrase}" if e.response.reason_phrase else "",
+                )
+                return ""
+            except (httpx.RequestError, Exception):
+                if attempt < _MAX_RETRIES:
+                    await asyncio.sleep(_BACKOFF_S[attempt])
+                    continue
+                logger.exception("{} transcription request error", provider_label)
+                return ""
+    return ""
+
+
+def _dashscope_asr_text(payload: object) -> str:
+    """Extract text from a DashScope multimodal-generation ASR response."""
+    if not isinstance(payload, dict):
+        return ""
+    data = cast(dict[str, Any], payload)
+    output = data.get("output")
+    if not isinstance(output, dict):
+        return ""
+    output_data = cast(dict[str, Any], output)
+    choices = output_data.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return ""
+    items = cast(list[object], choices)
+    choice = cast(dict[str, Any], items[0]) if isinstance(items[0], dict) else {}
+    message = choice.get("message")
+    if not isinstance(message, dict):
+        return ""
+    content = cast(dict[str, Any], message).get("content")
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        return "".join(
+            str(cast(dict[str, Any], part).get("text") or "")
+            for part in cast(list[object], content)
+            if isinstance(part, dict)
+        ).strip()
+    return ""
+
+
+class DashScopeTranscriptionProvider:
+    """Voice transcription provider using DashScope (Bailian) native ASR.
+
+    Uses the synchronous multimodal-generation endpoint with a base64 audio
+    content block (``qwen3-asr-flash``); no file upload or task polling.
+    """
+
+    _DEFAULT_BASE = "https://dashscope.aliyuncs.com"
+    _GENERATION_PATH = "/api/v1/services/aigc/multimodal-generation/generation"
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        api_base: str | None = None,
+        language: str | None = None,
+        model: str | None = None,
+    ):
+        self.api_key = api_key or os.environ.get("DASHSCOPE_API_KEY")
+        # Accept any DashScope-shaped base (including compatible-mode URLs)
+        # and normalize to the host root for native-protocol endpoints.
+        base = api_base or os.environ.get("DASHSCOPE_API_BASE") or self._DEFAULT_BASE
+        parts = urllib.parse.urlsplit(base.strip())
+        root = f"{parts.scheme}://{parts.netloc}" if parts.scheme and parts.netloc else self._DEFAULT_BASE
+        self.api_url = f"{root}{self._GENERATION_PATH}"
+        self.language = language or None
+        self.model = model or "qwen3-asr-flash"
+        logger.debug("DashScope transcription endpoint: {}", self.api_url)
+
+    async def transcribe(self, file_path: str | Path) -> str:
+        if not self.api_key:
+            logger.warning("DashScope API key not configured for transcription")
+            return ""
+
+        path = Path(file_path)
+        if not path.exists():
+            logger.error("Audio file not found: {}", file_path)
+            return ""
+
+        return await _post_dashscope_asr_with_retry(
+            self.api_url,
+            api_key=self.api_key,
+            path=path,
+            model=self.model,
+            provider_label="DashScope",
             language=self.language,
         )
 

--- a/nanobot/providers/transcription.py
+++ b/nanobot/providers/transcription.py
@@ -794,9 +794,16 @@ async def _post_dashscope_asr_with_retry(
         or "audio/wav"
     )
     audio_url = f"data:{mime};base64,{base64.b64encode(data).decode('ascii')}"
+    # The ASR models require the container format in `parameters` (the
+    # qwen-audio-3.0 series rejects requests without it as
+    # UNSUPPORTED_FORMAT / "format is empty").
+    audio_format = path.suffix.lstrip(".").lower() or "wav"
 
     content: list[dict[str, Any]] = [{"audio": audio_url}]
-    parameters: dict[str, Any] = {"asr_options": {"enable_itn": True}}
+    parameters: dict[str, Any] = {
+        "format": audio_format,
+        "asr_options": {"enable_itn": True},
+    }
     if language:
         parameters["asr_options"]["language"] = language
 

--- a/tests/providers/test_dashscope_asr.py
+++ b/tests/providers/test_dashscope_asr.py
@@ -1,0 +1,275 @@
+"""Tests for the DashScope (Bailian) native ASR transcription provider."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from nanobot.audio.transcription_registry import (
+    get_transcription_provider,
+    resolve_transcription_provider,
+    transcription_provider_names,
+)
+from nanobot.providers.transcription import DashScopeTranscriptionProvider
+
+
+@pytest.fixture
+def audio_file(tmp_path: Path) -> Path:
+    p = tmp_path / "voice.mp3"
+    p.write_bytes(b"ID3\x03fake-audio-bytes")
+    return p
+
+
+_NATIVE_URL = (
+    "https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation"
+)
+
+
+# ---------------------------------------------------------------------------
+# Defaults and base normalization
+# ---------------------------------------------------------------------------
+
+
+def test_dashscope_defaults() -> None:
+    provider = DashScopeTranscriptionProvider(api_key="sk-test")
+    assert provider.api_url == _NATIVE_URL
+    assert provider.model == "qwen3-asr-flash"
+
+
+def test_dashscope_base_normalized_from_compatible_mode() -> None:
+    """A compatible-mode apiBase must be normalized to the host root."""
+    provider = DashScopeTranscriptionProvider(
+        api_key="sk-test",
+        api_base="https://dashscope.aliyuncs.com/compatible-mode/v1",
+    )
+    assert provider.api_url == _NATIVE_URL
+
+
+def test_dashscope_custom_model_and_language() -> None:
+    provider = DashScopeTranscriptionProvider(
+        api_key="sk-test",
+        model="qwen3-asr-flash-filetrans",
+        language="zh",
+    )
+    assert provider.model == "qwen3-asr-flash-filetrans"
+    assert provider.language == "zh"
+
+
+# ---------------------------------------------------------------------------
+# Short-circuit: missing key / missing file
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_api_key_short_circuits(audio_file: Path) -> None:
+    with patch.dict("os.environ", {}, clear=True):
+        provider = DashScopeTranscriptionProvider(api_key=None)
+        post_mock = AsyncMock()
+        with patch("httpx.AsyncClient.post", post_mock):
+            assert await provider.transcribe(audio_file) == ""
+        post_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_missing_file_short_circuits() -> None:
+    provider = DashScopeTranscriptionProvider(api_key="sk-test")
+    post_mock = AsyncMock()
+    with patch("httpx.AsyncClient.post", post_mock):
+        assert await provider.transcribe("/nonexistent/voice.mp3") == ""
+    post_mock.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Request shape and response parsing
+# ---------------------------------------------------------------------------
+
+
+def _post_mock(payload: dict[str, Any], status: int = 200) -> tuple[MagicMock, list[dict[str, Any]]]:
+    calls: list[dict[str, Any]] = []
+
+    class FakeResponse:
+        status_code = status
+        reason_phrase = "OK" if status < 400 else "Error"
+
+        def json(self) -> dict[str, Any]:
+            return payload
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise httpx.HTTPStatusError(
+                    f"HTTP {self.status_code}",
+                    request=httpx.Request("POST", _NATIVE_URL),
+                    response=httpx.Response(self.status_code),
+                )
+
+    async def fake_post(url: str, **kwargs: Any) -> FakeResponse:
+        calls.append({"url": url, **kwargs})
+        return FakeResponse()
+
+    return MagicMock(side_effect=fake_post), calls
+
+
+@pytest.mark.asyncio
+async def test_transcribe_happy_path(audio_file: Path) -> None:
+    payload = {
+        "output": {
+            "choices": [{
+                "message": {"role": "assistant", "content": [{"text": "你好世界"}]},
+            }],
+        },
+        "request_id": "r1",
+    }
+    mock, calls = _post_mock(payload)
+
+    provider = DashScopeTranscriptionProvider(api_key="sk-test", language="zh")
+    with patch("httpx.AsyncClient.post", mock):
+        result = await provider.transcribe(audio_file)
+
+    assert result == "你好世界"
+    call = calls[0]
+    assert call["url"] == _NATIVE_URL
+    assert call["headers"]["Authorization"] == "Bearer sk-test"
+
+    body = call["json"]
+    assert body["model"] == "qwen3-asr-flash"
+    assert body["parameters"]["asr_options"]["enable_itn"] is True
+    assert body["parameters"]["asr_options"]["language"] == "zh"
+
+    audio_block = body["input"]["messages"][0]["content"][0]
+    expected_prefix = "data:audio/mpeg;base64,"
+    assert audio_block["audio"].startswith(expected_prefix)
+    encoded = audio_block["audio"][len(expected_prefix):]
+    assert base64.b64decode(encoded) == audio_file.read_bytes()
+
+
+@pytest.mark.asyncio
+async def test_transcribe_string_content(audio_file: Path) -> None:
+    payload = {
+        "output": {"choices": [{"message": {"content": "hello world"}}]},
+    }
+    mock, _ = _post_mock(payload)
+
+    provider = DashScopeTranscriptionProvider(api_key="sk-test")
+    with patch("httpx.AsyncClient.post", mock):
+        assert await provider.transcribe(audio_file) == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_transcribe_logical_error_returns_empty(audio_file: Path) -> None:
+    payload = {"code": "InvalidApiKey", "message": "Invalid API-key provided."}
+    mock, _ = _post_mock(payload)
+
+    provider = DashScopeTranscriptionProvider(api_key="sk-test")
+    with patch("httpx.AsyncClient.post", mock):
+        assert await provider.transcribe(audio_file) == ""
+
+
+@pytest.mark.asyncio
+async def test_transcribe_http_401_no_retry(audio_file: Path) -> None:
+    mock, calls = _post_mock({}, status=401)
+
+    provider = DashScopeTranscriptionProvider(api_key="sk-test")
+    sleep = AsyncMock()
+    with patch("httpx.AsyncClient.post", mock), patch("asyncio.sleep", sleep):
+        assert await provider.transcribe(audio_file) == ""
+
+    assert len(calls) == 1
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_transcribe_retries_503_then_succeeds(audio_file: Path) -> None:
+    success = {
+        "output": {"choices": [{"message": {"content": "ok"}}]},
+    }
+    attempt = [0]
+    calls: list[int] = []
+
+    class FakeResponse:
+        def __init__(self, status: int) -> None:
+            self.status_code = status
+            self.reason_phrase = "OK" if status < 400 else "Error"
+
+        def json(self) -> dict[str, Any]:
+            return success
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise httpx.HTTPStatusError(
+                    f"HTTP {self.status_code}",
+                    request=httpx.Request("POST", _NATIVE_URL),
+                    response=httpx.Response(self.status_code),
+                )
+
+    async def fake_post(url: str, **kwargs: Any) -> FakeResponse:
+        attempt[0] += 1
+        calls.append(attempt[0])
+        return FakeResponse(503 if attempt[0] == 1 else 200)
+
+    provider = DashScopeTranscriptionProvider(api_key="sk-test")
+    with patch("httpx.AsyncClient.post", MagicMock(side_effect=fake_post)), patch(
+        "asyncio.sleep", AsyncMock()
+    ):
+        assert await provider.transcribe(audio_file) == "ok"
+    assert calls == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_transcribe_oversized_file_returns_empty(tmp_path: Path) -> None:
+    big = tmp_path / "big.mp3"
+    big.write_bytes(b"\x00" * (10 * 1024 * 1024 + 1))
+    post_mock = AsyncMock()
+
+    provider = DashScopeTranscriptionProvider(api_key="sk-test")
+    with patch("httpx.AsyncClient.post", post_mock):
+        assert await provider.transcribe(big) == ""
+    post_mock.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Registry integration
+# ---------------------------------------------------------------------------
+
+
+def test_dashscope_in_registry() -> None:
+    assert "dashscope" in transcription_provider_names()
+    spec = get_transcription_provider("dashscope")
+    assert spec is not None
+    assert spec.default_model == "qwen3-asr-flash"
+    assert spec.adapter == "nanobot.providers.transcription:DashScopeTranscriptionProvider"
+    # aliases
+    assert resolve_transcription_provider("bailian") is spec
+    assert resolve_transcription_provider("dashscope_native") is spec
+
+
+def test_config_resolves_dashscope_key() -> None:
+    from nanobot.audio.transcription import resolve_transcription_config
+    from nanobot.config.schema import Config
+
+    config = Config()
+    config.transcription.provider = "dashscope"
+    config.transcription.model = "qwen3-asr-flash"
+    config.providers.dashscope.api_key = "ds-key"
+
+    resolved = resolve_transcription_config(config)
+    assert resolved.provider == "dashscope"
+    assert resolved.api_key == "ds-key"
+    assert resolved.configured is True
+
+
+def test_asr_text_extraction_shapes() -> None:
+    from nanobot.providers.transcription import _dashscope_asr_text
+
+    assert _dashscope_asr_text({"output": {"choices": [{"message": {"content": "x"}}]}}) == "x"
+    assert _dashscope_asr_text(
+        {"output": {"choices": [{"message": {"content": [{"text": "a"}, {"text": "b"}]}}]}}
+    ) == "ab"
+    assert _dashscope_asr_text({}) == ""
+    assert _dashscope_asr_text(None) == ""
+    assert _dashscope_asr_text(json.loads('{"output": {"choices": []}}')) == ""

--- a/tests/providers/test_dashscope_asr.py
+++ b/tests/providers/test_dashscope_asr.py
@@ -138,6 +138,7 @@ async def test_transcribe_happy_path(audio_file: Path) -> None:
 
     body = call["json"]
     assert body["model"] == "qwen3-asr-flash"
+    assert body["parameters"]["format"] == "mp3"
     assert body["parameters"]["asr_options"]["enable_itn"] is True
     assert body["parameters"]["asr_options"]["language"] == "zh"
 

--- a/tests/providers/test_dashscope_provider.py
+++ b/tests/providers/test_dashscope_provider.py
@@ -26,7 +26,9 @@ def test_dashscope_native_registry_spec() -> None:
     assert spec.model_catalog == "builtin"
     model_ids = [m.id for m in spec.builtin_models]
     assert "qwen3.8-max" in model_ids
-    assert "qwen-plus" in model_ids
+    # Stable aliases (qwen-plus etc.) are invalid on the native
+    # multimodal-generation endpoint and must not be catalogued.
+    assert "qwen-plus" not in model_ids
 
 
 def test_dashscope_native_config_field_and_provider_resolution() -> None:
@@ -117,7 +119,7 @@ def test_convert_user_content_text_only_list_stays_string() -> None:
 
 
 def _provider() -> DashScopeProvider:
-    return DashScopeProvider(api_key="sk-test", default_model="qwen-plus")
+    return DashScopeProvider(api_key="sk-test")
 
 
 def test_build_payload_places_tools_in_parameters() -> None:
@@ -135,7 +137,7 @@ def test_build_payload_places_tools_in_parameters() -> None:
         "auto",
         stream=False,
     )
-    assert path == "/api/v1/services/aigc/text-generation/generation"
+    assert path == "/api/v1/services/aigc/multimodal-generation/generation"
     assert payload["model"] == "qwen3.8-max"
     assert payload["parameters"]["result_format"] == "message"
     assert payload["parameters"]["max_tokens"] == 1024
@@ -156,12 +158,12 @@ def test_build_payload_stream_and_tool_choice() -> None:
         "required",
         stream=True,
     )
-    assert payload["model"] == "qwen-plus"  # default model fallback
+    assert payload["model"] == "qwen3.8-max"  # default model fallback
     assert payload["parameters"]["incremental_output"] is True
     assert payload["parameters"]["tool_choice"] == "required"
 
 
-def test_build_payload_multimodal_routing_and_thinking() -> None:
+def test_build_payload_image_content_and_thinking() -> None:
     payload, path = _provider()._build_payload(
         [{
             "role": "user",
@@ -429,7 +431,7 @@ async def test_chat_stream_content_and_reasoning_deltas() -> None:
     assert response.usage["prompt_tokens"] == 7
 
     stream_call = fake.stream_calls[0]
-    assert stream_call["path"] == "/api/v1/services/aigc/text-generation/generation"
+    assert stream_call["path"] == "/api/v1/services/aigc/multimodal-generation/generation"
     assert stream_call["headers"]["X-DashScope-SSE"] == "enable"
     assert stream_call["json"]["parameters"]["incremental_output"] is True
 
@@ -492,3 +494,44 @@ async def test_chat_stream_http_error() -> None:
     assert response.finish_reason == "error"
     assert response.error_status_code == 401
     assert response.error_should_retry is False
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_array_content_parts() -> None:
+    """Multimodal-generation streams content as [{"text": ...}] arrays that
+    arrive complete in one chunk; deltas must be emitted exactly once."""
+    lines = [
+        _sse({"output": {"choices": [{
+            "finish_reason": "null",
+            "message": {"content": []},
+        }]}}),
+        _sse({"output": {"choices": [{
+            "finish_reason": "null",
+            "message": {"content": [{"text": "你好呀"}]},
+        }]}}),
+        _sse({"output": {"choices": [{
+            "finish_reason": "null",
+            "message": {"content": []},
+        }]}}),
+        _sse({"output": {
+            "choices": [{"finish_reason": "stop", "message": {"content": []}}],
+            "usage": {"input_tokens": 5, "output_tokens": 3, "total_tokens": 8},
+        }}),
+    ]
+    fake = FakeClient(stream_response=FakeStreamResponse(200, lines))
+    provider = DashScopeProvider(api_key="sk-test", client=fake)
+
+    content_deltas: list[str] = []
+
+    async def on_content(text: str) -> None:
+        content_deltas.append(text)
+
+    response = await provider.chat_stream(
+        [{"role": "user", "content": "hi"}],
+        on_content_delta=on_content,
+    )
+
+    assert content_deltas == ["你好呀"]
+    assert response.content == "你好呀"
+    assert response.finish_reason == "stop"
+    assert response.usage["prompt_tokens"] == 5

--- a/tests/providers/test_dashscope_provider.py
+++ b/tests/providers/test_dashscope_provider.py
@@ -1,0 +1,494 @@
+"""Tests for the DashScope native-protocol provider."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from nanobot.config.schema import Config
+from nanobot.providers.dashscope_provider import DashScopeProvider
+from nanobot.providers.factory import make_provider
+from nanobot.providers.registry import find_by_name
+
+# ---------------------------------------------------------------------------
+# Registry / config wiring
+# ---------------------------------------------------------------------------
+
+
+def test_dashscope_native_registry_spec() -> None:
+    spec = find_by_name("dashscope_native")
+    assert spec is not None
+    assert spec.backend == "dashscope_native"
+    assert spec.env_key == "DASHSCOPE_API_KEY"
+    assert spec.default_api_base == "https://dashscope.aliyuncs.com"
+    assert spec.model_catalog == "builtin"
+    model_ids = [m.id for m in spec.builtin_models]
+    assert "qwen3.8-max" in model_ids
+    assert "qwen-plus" in model_ids
+
+
+def test_dashscope_native_config_field_and_provider_resolution() -> None:
+    cfg = Config.model_validate({
+        "providers": {"dashscope_native": {"apiKey": "sk-test"}},
+        "modelPresets": {
+            "main": {"model": "qwen3.8-max", "provider": "dashscope_native"},
+        },
+    })
+    assert cfg.get_provider_name("qwen3.8-max") == "dashscope_native"
+    provider = make_provider(cfg, preset=cfg.model_presets["main"])
+    assert isinstance(provider, DashScopeProvider)
+    assert provider.get_default_model() == "qwen3.8-max"
+
+
+def test_qwen_models_still_match_compatible_spec() -> None:
+    """Keyword matching for qwen* model names must keep resolving to the
+    OpenAI-compatible dashscope provider, not the native one."""
+    cfg = Config.model_validate({
+        "providers": {"dashscope": {"apiKey": "sk-test"}},
+    })
+    assert cfg.get_provider_name("qwen3.7-plus") == "dashscope"
+
+
+# ---------------------------------------------------------------------------
+# Message conversion
+# ---------------------------------------------------------------------------
+
+
+def test_convert_messages_text_only() -> None:
+    messages = [
+        {"role": "system", "content": "be brief"},
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "f", "arguments": "{}"},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "42"},
+    ]
+    converted, multimodal = DashScopeProvider._convert_messages(messages)
+    assert multimodal is False
+    assert converted == [
+        {"role": "system", "content": "be brief"},
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "f", "arguments": "{}"},
+            }],
+        },
+        {"role": "tool", "content": "42", "tool_call_id": "call_1"},
+    ]
+
+
+def test_convert_user_content_image_blocks() -> None:
+    content = [
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,xyz"}},
+        {"type": "text", "text": "what is this?"},
+        {"_meta": {"path": "/tmp/a.png"}},
+    ]
+    converted, multimodal = DashScopeProvider._convert_user_content(content)
+    assert multimodal is True
+    assert converted == [
+        {"image": "data:image/png;base64,xyz"},
+        {"text": "what is this?"},
+    ]
+
+
+def test_convert_user_content_text_only_list_stays_string() -> None:
+    converted, multimodal = DashScopeProvider._convert_user_content(
+        [{"type": "text", "text": "plain"}]
+    )
+    assert multimodal is False
+    assert converted == "plain"
+
+
+# ---------------------------------------------------------------------------
+# Payload building
+# ---------------------------------------------------------------------------
+
+
+def _provider() -> DashScopeProvider:
+    return DashScopeProvider(api_key="sk-test", default_model="qwen-plus")
+
+
+def test_build_payload_places_tools_in_parameters() -> None:
+    tools = [{
+        "type": "function",
+        "function": {"name": "f", "description": "d", "parameters": {}},
+    }]
+    payload, path = _provider()._build_payload(
+        [{"role": "user", "content": "hi"}],
+        tools,
+        "qwen3.8-max",
+        1024,
+        0.5,
+        None,
+        "auto",
+        stream=False,
+    )
+    assert path == "/api/v1/services/aigc/text-generation/generation"
+    assert payload["model"] == "qwen3.8-max"
+    assert payload["parameters"]["result_format"] == "message"
+    assert payload["parameters"]["max_tokens"] == 1024
+    assert payload["parameters"]["temperature"] == 0.5
+    assert payload["parameters"]["tools"] == tools
+    assert "tool_choice" not in payload["parameters"]
+    assert "incremental_output" not in payload["parameters"]
+
+
+def test_build_payload_stream_and_tool_choice() -> None:
+    payload, _ = _provider()._build_payload(
+        [{"role": "user", "content": "hi"}],
+        [{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        None,
+        64,
+        0.1,
+        None,
+        "required",
+        stream=True,
+    )
+    assert payload["model"] == "qwen-plus"  # default model fallback
+    assert payload["parameters"]["incremental_output"] is True
+    assert payload["parameters"]["tool_choice"] == "required"
+
+
+def test_build_payload_multimodal_routing_and_thinking() -> None:
+    payload, path = _provider()._build_payload(
+        [{
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "https://x/y.png"}},
+                {"type": "text", "text": "describe"},
+            ],
+        }],
+        None,
+        "qwen3.8-max",
+        512,
+        0.7,
+        "medium",
+        None,
+        stream=False,
+    )
+    assert path == "/api/v1/services/aigc/multimodal-generation/generation"
+    assert payload["parameters"]["enable_thinking"] is True
+    assert payload["parameters"]["reasoning_effort"] == "medium"
+    assert payload["input"]["messages"][0]["content"][0] == {"image": "https://x/y.png"}
+
+
+def test_build_payload_merges_extra_body() -> None:
+    provider = DashScopeProvider(
+        api_key="sk-test",
+        extra_body={"top_k": 20},
+    )
+    payload, _ = provider._build_payload(
+        [{"role": "user", "content": "hi"}],
+        None,
+        None,
+        64,
+        0.1,
+        None,
+        None,
+        stream=False,
+    )
+    assert payload["parameters"]["top_k"] == 20
+
+
+# ---------------------------------------------------------------------------
+# Fake HTTP client
+# ---------------------------------------------------------------------------
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, data: dict[str, Any] | None = None, text: str = ""):
+        self.status_code = status_code
+        self._data = data or {}
+        self.text = text or (json.dumps(self._data) if data else "")
+
+    def json(self) -> dict[str, Any]:
+        return self._data
+
+
+class FakeStreamResponse:
+    def __init__(self, status_code: int, lines: list[str], error_text: str = ""):
+        self.status_code = status_code
+        self._lines = lines
+        self._error_text = error_text
+
+    async def aread(self) -> bytes:
+        return self._error_text.encode()
+
+    def aiter_lines(self):
+        async def _gen():
+            for line in self._lines:
+                yield line
+        return _gen()
+
+
+class FakeStreamContext:
+    def __init__(self, response: FakeStreamResponse):
+        self.response = response
+
+    async def __aenter__(self) -> FakeStreamResponse:
+        return self.response
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+
+class FakeClient:
+    def __init__(
+        self,
+        post_response: FakeResponse | None = None,
+        stream_response: FakeStreamResponse | None = None,
+    ):
+        self.post_response = post_response
+        self.stream_response = stream_response
+        self.post_calls: list[dict[str, Any]] = []
+        self.stream_calls: list[dict[str, Any]] = []
+
+    async def post(self, path: str, **kwargs: Any) -> FakeResponse:
+        self.post_calls.append({"path": path, **kwargs})
+        assert self.post_response is not None
+        return self.post_response
+
+    def stream(self, method: str, path: str, **kwargs: Any) -> FakeStreamContext:
+        self.stream_calls.append({"method": method, "path": path, **kwargs})
+        assert self.stream_response is not None
+        return FakeStreamContext(self.stream_response)
+
+
+# ---------------------------------------------------------------------------
+# chat() non-streaming
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chat_parses_content_usage_and_tool_calls() -> None:
+    fake = FakeClient(post_response=FakeResponse(200, {
+        "request_id": "r1",
+        "output": {
+            "choices": [{
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "index": 0,
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": "{\"city\": \"Beijing\"}",
+                        },
+                    }],
+                },
+            }],
+            "usage": {"input_tokens": 12, "output_tokens": 8, "total_tokens": 20},
+        },
+    }))
+    provider = DashScopeProvider(api_key="sk-test", client=fake)
+
+    response = await provider.chat(
+        [{"role": "user", "content": "weather?"}],
+        tools=[{"type": "function", "function": {"name": "get_weather", "parameters": {}}}],
+    )
+
+    assert response.finish_reason == "tool_calls"
+    assert response.has_tool_calls
+    assert response.tool_calls[0].name == "get_weather"
+    assert response.tool_calls[0].arguments == {"city": "Beijing"}
+    assert response.usage == {
+        "prompt_tokens": 12,
+        "completion_tokens": 8,
+        "total_tokens": 20,
+    }
+    # tools must ride in `parameters`, not `input`
+    body = fake.post_calls[0]["json"]
+    assert body["parameters"]["tools"][0]["function"]["name"] == "get_weather"
+    assert "tools" not in body["input"]
+
+
+@pytest.mark.asyncio
+async def test_chat_reasoning_and_array_content() -> None:
+    fake = FakeClient(post_response=FakeResponse(200, {
+        "output": {
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"text": "你好"}, {"text": "世界"}],
+                    "reasoning_content": "let me think",
+                },
+            }],
+            "usage": {},
+        },
+    }))
+    provider = DashScopeProvider(api_key="sk-test", client=fake)
+
+    response = await provider.chat([{"role": "user", "content": "hi"}])
+    assert response.content == "你好世界"
+    assert response.reasoning_content == "let me think"
+
+
+@pytest.mark.asyncio
+async def test_chat_http_error_sets_retry_metadata() -> None:
+    fake = FakeClient(post_response=FakeResponse(
+        429,
+        text=json.dumps({"code": "Throttling.RateQuota", "message": "Requests rate exceeded"}),
+    ))
+    provider = DashScopeProvider(api_key="sk-test", client=fake)
+
+    response = await provider.chat([{"role": "user", "content": "hi"}])
+    assert response.finish_reason == "error"
+    assert response.error_status_code == 429
+    assert response.error_code == "throttling.ratequota"
+    assert response.error_should_retry is True
+
+
+@pytest.mark.asyncio
+async def test_chat_logical_error_with_http_200() -> None:
+    fake = FakeClient(post_response=FakeResponse(200, {
+        "code": "InvalidApiKey",
+        "message": "Invalid API-key provided.",
+        "request_id": "r9",
+    }))
+    provider = DashScopeProvider(api_key="sk-test", client=fake)
+
+    response = await provider.chat([{"role": "user", "content": "hi"}])
+    assert response.finish_reason == "error"
+    assert response.error_code == "invalidapikey"
+    assert response.error_should_retry is False
+
+
+@pytest.mark.asyncio
+async def test_chat_requires_api_key() -> None:
+    provider = DashScopeProvider(api_key=None)
+    response = await provider.chat([{"role": "user", "content": "hi"}])
+    assert response.finish_reason == "error"
+    assert "API key" in (response.content or "")
+
+
+# ---------------------------------------------------------------------------
+# chat_stream() streaming
+# ---------------------------------------------------------------------------
+
+
+def _sse(obj: dict[str, Any]) -> str:
+    return f"data: {json.dumps(obj, ensure_ascii=False)}"
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_content_and_reasoning_deltas() -> None:
+    lines = [
+        _sse({"output": {"choices": [{
+            "finish_reason": "null",
+            "message": {"content": "Hel", "reasoning_content": "th"},
+        }]}}),
+        ": keep-alive comment",
+        _sse({"output": {"choices": [{
+            "finish_reason": "null",
+            "message": {"content": "lo"},
+        }]}}),
+        _sse({"output": {
+            "choices": [{"finish_reason": "stop", "message": {}}],
+            "usage": {"input_tokens": 7, "output_tokens": 2, "total_tokens": 9},
+        }}),
+    ]
+    fake = FakeClient(stream_response=FakeStreamResponse(200, lines))
+    provider = DashScopeProvider(api_key="sk-test", client=fake)
+
+    content_deltas: list[str] = []
+    thinking_deltas: list[str] = []
+
+    async def on_content(text: str) -> None:
+        content_deltas.append(text)
+
+    async def on_thinking(text: str) -> None:
+        thinking_deltas.append(text)
+
+    response = await provider.chat_stream(
+        [{"role": "user", "content": "hi"}],
+        on_content_delta=on_content,
+        on_thinking_delta=on_thinking,
+    )
+
+    assert content_deltas == ["Hel", "lo"]
+    assert thinking_deltas == ["th"]
+    assert response.content == "Hello"
+    assert response.reasoning_content == "th"
+    assert response.finish_reason == "stop"
+    assert response.usage["prompt_tokens"] == 7
+
+    stream_call = fake.stream_calls[0]
+    assert stream_call["path"] == "/api/v1/services/aigc/text-generation/generation"
+    assert stream_call["headers"]["X-DashScope-SSE"] == "enable"
+    assert stream_call["json"]["parameters"]["incremental_output"] is True
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_tool_call_accumulation() -> None:
+    lines = [
+        _sse({"output": {"choices": [{
+            "finish_reason": "null",
+            "message": {"tool_calls": [{
+                "index": 0,
+                "id": "call_1",
+                "function": {"name": "get_weather", "arguments": "{\"city\":"},
+            }]},
+        }]}}),
+        _sse({"output": {"choices": [{
+            "finish_reason": "null",
+            "message": {"tool_calls": [{
+                "index": 0,
+                "function": {"arguments": " \"Beijing\"}"},
+            }]},
+        }]}}),
+        _sse({"output": {
+            "choices": [{"finish_reason": "tool_calls", "message": {}}],
+            "usage": {"input_tokens": 5, "output_tokens": 5, "total_tokens": 10},
+        }}),
+    ]
+    fake = FakeClient(stream_response=FakeStreamResponse(200, lines))
+    provider = DashScopeProvider(api_key="sk-test", client=fake)
+
+    tool_deltas: list[dict[str, Any]] = []
+
+    async def on_tool_delta(delta: dict[str, Any]) -> None:
+        tool_deltas.append(delta)
+
+    response = await provider.chat_stream(
+        [{"role": "user", "content": "weather?"}],
+        on_tool_call_delta=on_tool_delta,
+    )
+
+    assert response.finish_reason == "tool_calls"
+    assert len(response.tool_calls) == 1
+    assert response.tool_calls[0].id == "call_1"
+    assert response.tool_calls[0].name == "get_weather"
+    assert response.tool_calls[0].arguments == {"city": "Beijing"}
+    assert tool_deltas[0]["name"] == "get_weather"
+    assert tool_deltas[1]["arguments_delta"] == ' "Beijing"}'
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_http_error() -> None:
+    fake = FakeClient(stream_response=FakeStreamResponse(
+        401,
+        [],
+        error_text=json.dumps({"code": "InvalidApiKey", "message": "bad key"}),
+    ))
+    provider = DashScopeProvider(api_key="sk-test", client=fake)
+
+    response = await provider.chat_stream([{"role": "user", "content": "hi"}])
+    assert response.finish_reason == "error"
+    assert response.error_status_code == 401
+    assert response.error_should_retry is False

--- a/tests/providers/test_image_generation.py
+++ b/tests/providers/test_image_generation.py
@@ -1949,3 +1949,111 @@ def test_image_provider_http_client_kwargs_include_explicit_proxy() -> None:
         "proxy": proxy,
         "trust_env": False,
     }
+
+
+# ---------------------------------------------------------------------------
+# DashScope (Bailian) native image synthesis
+# ---------------------------------------------------------------------------
+
+
+from nanobot.providers.image_generation import DashScopeImageGenerationClient  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _dashscope_fast_poll(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Skip the real asyncio.sleep between DashScope poll attempts."""
+    monkeypatch.setattr(
+        "nanobot.providers.image_generation._DASHSCOPE_POLL_INTERVAL_S", 0.0
+    )
+
+
+@pytest.mark.asyncio
+async def test_dashscope_image_generation_submit_and_poll(
+    generated_image_downloads: list[tuple[str, str | None]],
+) -> None:
+    submit = FakeResponse({"output": {"task_id": "abc123", "task_status": "PENDING"}})
+    poll_responses = [
+        FakeResponse({"output": {"task_status": "RUNNING"}}),
+        FakeResponse({"output": {
+            "task_status": "SUCCEEDED",
+            "results": [{"url": "https://cdn.example/image.png"}],
+        }}),
+    ]
+    fake = ModelScopeFakeClient(submit, poll_responses)
+    client = DashScopeImageGenerationClient(
+        api_key="ds-token",
+        client=fake,  # type: ignore[arg-type]
+    )
+
+    response = await client.generate(prompt="A golden cat", model="qwen-image-3.0-pro")
+
+    assert response.images[0].startswith("data:image/png;base64,")
+    assert generated_image_downloads == [("https://cdn.example/image.png", None)]
+
+    post_call = fake.calls[0]
+    assert post_call["url"] == (
+        "https://dashscope.aliyuncs.com/api/v1/services/aigc/text2image/image-synthesis"
+    )
+    assert post_call["headers"]["Authorization"] == "Bearer ds-token"
+    assert post_call["headers"]["X-DashScope-Async"] == "enable"
+    body = post_call["json"]
+    assert body["model"] == "qwen-image-3.0-pro"
+    assert body["input"]["prompt"] == "A golden cat"
+    assert body["parameters"]["n"] == 1
+
+    assert "/api/v1/tasks/abc123" in fake.get_calls[0]["url"]
+
+
+@pytest.mark.asyncio
+async def test_dashscope_image_generation_size_mapping() -> None:
+    submit = FakeResponse({"output": {"task_id": "t1"}})
+    poll = [FakeResponse({"output": {"task_status": "SUCCEEDED", "results": [{"url": "https://cdn/img.png"}]}})]
+    fake = ModelScopeFakeClient(submit, poll)
+    client = DashScopeImageGenerationClient(
+        api_key="ds-token",
+        client=fake,  # type: ignore[arg-type]
+    )
+
+    await client.generate(prompt="test", model="wan2.7-image-pro", aspect_ratio="16:9")
+    assert fake.calls[-1]["json"]["parameters"]["size"] == "1280*720"
+
+    await client.generate(prompt="test", model="wan2.7-image-pro", image_size="1664x928")
+    assert fake.calls[-1]["json"]["parameters"]["size"] == "1664*928"
+
+    await client.generate(prompt="test", model="wan2.7-image-pro")
+    assert fake.calls[-1]["json"]["parameters"]["size"] == "1024*1024"
+
+
+@pytest.mark.asyncio
+async def test_dashscope_image_generation_task_failed() -> None:
+    submit = FakeResponse({"output": {"task_id": "bad-task"}})
+    poll = [FakeResponse({"output": {"task_status": "FAILED", "code": "InternalError"}})]
+    fake = ModelScopeFakeClient(submit, poll)
+    client = DashScopeImageGenerationClient(
+        api_key="ds-token",
+        client=fake,  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(ImageGenerationError, match="FAILED"):
+        await client.generate(prompt="test", model="m")
+
+
+@pytest.mark.asyncio
+async def test_dashscope_image_generation_requires_api_key() -> None:
+    client = DashScopeImageGenerationClient(api_key=None)
+
+    with pytest.raises(ImageGenerationError, match="API key"):
+        await client.generate(prompt="draw", model="m")
+
+
+@pytest.mark.asyncio
+async def test_dashscope_image_generation_missing_task_id() -> None:
+    submit = FakeResponse({"unexpected": "response"})
+    fake = ModelScopeFakeClient(submit, [])
+    client = DashScopeImageGenerationClient(
+        api_key="ds-token",
+        client=fake,  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(ImageGenerationError, match="task_id"):
+        await client.generate(prompt="draw", model="m")

--- a/tests/providers/test_image_generation.py
+++ b/tests/providers/test_image_generation.py
@@ -1959,27 +1959,40 @@ def test_image_provider_http_client_kwargs_include_explicit_proxy() -> None:
 from nanobot.providers.image_generation import DashScopeImageGenerationClient  # noqa: E402
 
 
-@pytest.fixture(autouse=True)
-def _dashscope_fast_poll(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Skip the real asyncio.sleep between DashScope poll attempts."""
-    monkeypatch.setattr(
-        "nanobot.providers.image_generation._DASHSCOPE_POLL_INTERVAL_S", 0.0
-    )
+class DashScopeFakeClient:
+    """Fake httpx client returning one canned JSON response for POST."""
+
+    def __init__(self, response: FakeResponse) -> None:
+        self.response = response
+        self.calls: list[dict[str, Any]] = []
+
+    async def post(self, url: str, **kwargs: Any) -> FakeResponse:
+        self.calls.append({"url": url, **kwargs})
+        return self.response
+
+
+def _dashscope_success_payload(image_url: str = "https://oss.example/img.png") -> dict[str, Any]:
+    return {
+        "output": {
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"image": image_url}],
+                },
+            }],
+            "rewrite_status": "success",
+        },
+        "usage": {"output_image_count": 1},
+        "request_id": "r1",
+    }
 
 
 @pytest.mark.asyncio
-async def test_dashscope_image_generation_submit_and_poll(
+async def test_dashscope_image_generation_sync_call(
     generated_image_downloads: list[tuple[str, str | None]],
 ) -> None:
-    submit = FakeResponse({"output": {"task_id": "abc123", "task_status": "PENDING"}})
-    poll_responses = [
-        FakeResponse({"output": {"task_status": "RUNNING"}}),
-        FakeResponse({"output": {
-            "task_status": "SUCCEEDED",
-            "results": [{"url": "https://cdn.example/image.png"}],
-        }}),
-    ]
-    fake = ModelScopeFakeClient(submit, poll_responses)
+    fake = DashScopeFakeClient(FakeResponse(_dashscope_success_payload()))
     client = DashScopeImageGenerationClient(
         api_key="ds-token",
         client=fake,  # type: ignore[arg-type]
@@ -1988,27 +2001,23 @@ async def test_dashscope_image_generation_submit_and_poll(
     response = await client.generate(prompt="A golden cat", model="qwen-image-3.0-pro")
 
     assert response.images[0].startswith("data:image/png;base64,")
-    assert generated_image_downloads == [("https://cdn.example/image.png", None)]
+    assert generated_image_downloads == [("https://oss.example/img.png", None)]
 
-    post_call = fake.calls[0]
-    assert post_call["url"] == (
-        "https://dashscope.aliyuncs.com/api/v1/services/aigc/text2image/image-synthesis"
+    call = fake.calls[0]
+    assert call["url"] == (
+        "https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation"
     )
-    assert post_call["headers"]["Authorization"] == "Bearer ds-token"
-    assert post_call["headers"]["X-DashScope-Async"] == "enable"
-    body = post_call["json"]
+    assert call["headers"]["Authorization"] == "Bearer ds-token"
+    body = call["json"]
     assert body["model"] == "qwen-image-3.0-pro"
-    assert body["input"]["prompt"] == "A golden cat"
-    assert body["parameters"]["n"] == 1
-
-    assert "/api/v1/tasks/abc123" in fake.get_calls[0]["url"]
+    assert body["input"]["messages"][0]["content"] == [{"text": "A golden cat"}]
+    assert body["parameters"]["prompt_extend"] is True
+    assert body["parameters"]["size"] == "1024*1024"
 
 
 @pytest.mark.asyncio
 async def test_dashscope_image_generation_size_mapping() -> None:
-    submit = FakeResponse({"output": {"task_id": "t1"}})
-    poll = [FakeResponse({"output": {"task_status": "SUCCEEDED", "results": [{"url": "https://cdn/img.png"}]}})]
-    fake = ModelScopeFakeClient(submit, poll)
+    fake = DashScopeFakeClient(FakeResponse(_dashscope_success_payload()))
     client = DashScopeImageGenerationClient(
         api_key="ds-token",
         client=fake,  # type: ignore[arg-type]
@@ -2025,17 +2034,19 @@ async def test_dashscope_image_generation_size_mapping() -> None:
 
 
 @pytest.mark.asyncio
-async def test_dashscope_image_generation_task_failed() -> None:
-    submit = FakeResponse({"output": {"task_id": "bad-task"}})
-    poll = [FakeResponse({"output": {"task_status": "FAILED", "code": "InternalError"}})]
-    fake = ModelScopeFakeClient(submit, poll)
+async def test_dashscope_image_generation_logical_error() -> None:
+    fake = DashScopeFakeClient(FakeResponse({
+        "code": "InvalidParameter",
+        "message": "url error",
+        "request_id": "r9",
+    }))
     client = DashScopeImageGenerationClient(
         api_key="ds-token",
         client=fake,  # type: ignore[arg-type]
     )
 
-    with pytest.raises(ImageGenerationError, match="FAILED"):
-        await client.generate(prompt="test", model="m")
+    with pytest.raises(ImageGenerationError, match="InvalidParameter"):
+        await client.generate(prompt="test", model="qwen-image-3.0-pro")
 
 
 @pytest.mark.asyncio
@@ -2043,17 +2054,45 @@ async def test_dashscope_image_generation_requires_api_key() -> None:
     client = DashScopeImageGenerationClient(api_key=None)
 
     with pytest.raises(ImageGenerationError, match="API key"):
-        await client.generate(prompt="draw", model="m")
+        await client.generate(prompt="draw", model="qwen-image-3.0-pro")
 
 
 @pytest.mark.asyncio
-async def test_dashscope_image_generation_missing_task_id() -> None:
-    submit = FakeResponse({"unexpected": "response"})
-    fake = ModelScopeFakeClient(submit, [])
+async def test_dashscope_image_generation_no_image_in_response() -> None:
+    fake = DashScopeFakeClient(FakeResponse({
+        "output": {"choices": [{"message": {"content": []}}]},
+    }))
     client = DashScopeImageGenerationClient(
         api_key="ds-token",
         client=fake,  # type: ignore[arg-type]
     )
 
-    with pytest.raises(ImageGenerationError, match="task_id"):
-        await client.generate(prompt="draw", model="m")
+    with pytest.raises(ImageGenerationError, match="no images"):
+        await client.generate(prompt="draw", model="qwen-image-3.0-pro")
+
+
+@pytest.mark.asyncio
+async def test_dashscope_image_generation_reference_image_content() -> None:
+    """Reference images ride along as image content parts before the text."""
+    fake = DashScopeFakeClient(FakeResponse(_dashscope_success_payload()))
+    client = DashScopeImageGenerationClient(
+        api_key="ds-token",
+        client=fake,  # type: ignore[arg-type]
+    )
+
+    import tempfile
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+        f.write(PNG_BYTES)
+        ref_path = f.name
+
+    try:
+        await client.generate(
+            prompt="edit this",
+            model="qwen-image-3.0-pro",
+            reference_images=[ref_path],
+        )
+        content = fake.calls[0]["json"]["input"]["messages"][0]["content"]
+        assert content[0]["image"].startswith("data:image/png;base64,")
+        assert content[1] == {"text": "edit this"}
+    finally:
+        Path(ref_path).unlink(missing_ok=True)

--- a/tests/providers/test_providers_init.py
+++ b/tests/providers/test_providers_init.py
@@ -17,6 +17,7 @@ def test_importing_providers_package_is_lazy(monkeypatch) -> None:
     monkeypatch.delitem(sys.modules, "nanobot.providers.github_copilot_provider", raising=False)
     monkeypatch.delitem(sys.modules, "nanobot.providers.azure_openai_provider", raising=False)
     monkeypatch.delitem(sys.modules, "nanobot.providers.bedrock_provider", raising=False)
+    monkeypatch.delitem(sys.modules, "nanobot.providers.dashscope_provider", raising=False)
 
     try:
         providers = importlib.import_module("nanobot.providers")
@@ -29,6 +30,7 @@ def test_importing_providers_package_is_lazy(monkeypatch) -> None:
         assert "nanobot.providers.github_copilot_provider" not in sys.modules
         assert "nanobot.providers.azure_openai_provider" not in sys.modules
         assert "nanobot.providers.bedrock_provider" not in sys.modules
+        assert "nanobot.providers.dashscope_provider" not in sys.modules
         assert providers.__all__ == [
             "LLMProvider",
             "LLMResponse",
@@ -39,6 +41,7 @@ def test_importing_providers_package_is_lazy(monkeypatch) -> None:
             "GitHubCopilotProvider",
             "AzureOpenAIProvider",
             "BedrockProvider",
+            "DashScopeProvider",
         ]
     finally:
         # Importing a replacement subpackage also replaces nanobot.providers on the

--- a/webui/src/components/settings/shared/ModelControls.tsx
+++ b/webui/src/components/settings/shared/ModelControls.tsx
@@ -584,6 +584,7 @@ export const PROVIDER_ICONS: Record<string, LucideIcon> = {
   deepseek: Waves,
   zhipu: Grid3X3,
   dashscope: Cloud,
+  dashscope_native: Cloud,
   modelscope: Layers,
   moonshot: Moon,
   minimax: Zap,

--- a/webui/src/lib/provider-brand.ts
+++ b/webui/src/lib/provider-brand.ts
@@ -160,6 +160,7 @@ const PROVIDER_BRANDS: Record<string, ProviderBrand> = {
   brave: brand("brave.com", "#FB542B", "B"),
   byteplus: brand("byteplus.com", "#325CFF", "BP"),
   dashscope: brand("dashscope.aliyun.com", "#FF6A00", "DS"),
+  dashscope_native: brand("dashscope.aliyun.com", "#FF6A00", "DS"),
   deepseek: brand("deepseek.com", "#4D6BFE", "DS"),
   duckduckgo: brand("duckduckgo.com", "#DE5833", "DDG"),
   exa: brand("exa.ai", "#5B5BF6", "E"),


### PR DESCRIPTION
## Summary

Adds a `dashscope_native` LLM provider speaking the DashScope native protocol, alongside the existing OpenAI-compatible `dashscope` provider. Both share `DASHSCOPE_API_KEY`.

The native protocol unlocks what compatible-mode does not expose:

- the full parameter surface (native thinking controls such as `enable_thinking` / `reasoning_effort`)
- Bailian image generation (`qwen-image-3.0-pro`, `wan2.7-image-pro`) under `tools.imageGeneration`
- speech-to-text via `qwen3-asr-flash` under `transcription.provider: "dashscope"`

## Implementation notes (live-verified against dashscope.aliyuncs.com)

- The classic `text-generation/generation` path has been retired on the public host (answers `url error`); all traffic — text-only included — goes through `multimodal-generation/generation`, which serves text, images, tools, and SSE streaming.
- Stable model aliases (`qwen-plus` etc.) are invalid on the native endpoint; the builtin catalog lists concrete model IDs only.
- Streaming replies arrive as `[{"text": ...}]` content parts (each part complete) rather than string deltas; the stream parser folds them with per-slot tracking so deltas fire exactly once.
- ASR requires `parameters.format` (container suffix); `qwen3-asr-flash` accepts base64 data URLs synchronously — no file upload or task polling.
- Image generation is a synchronous multimodal-generation call returning signed image URLs in `content[*].image` (the async `text2image/image-synthesis` task flow is also retired on the public host). Reference images ride along as image content parts.

## Config

```json
{
  "providers": { "dashscope_native": { "apiKey": "${DASHSCOPE_API_KEY}" } },
  "modelPresets": { "primary": { "provider": "dashscope_native", "model": "qwen3.8-max" } },
  "tools": { "imageGeneration": { "enabled": true, "provider": "dashscope_native", "model": "qwen-image-3.0-pro" } },
  "transcription": { "provider": "dashscope", "model": "qwen3-asr-flash" }
}
```

## Testing

- ~40 new tests: provider (payload/streaming/errors/wiring), ASR adapter, image-gen client, lazy-import registry
- Full suite 5093 passed; ruff + basedpyright clean
- All four capabilities verified live: streaming chat with thinking deltas, image input, image generation, and speech transcription

Docs updated in `docs/providers.md` and `docs/configuration.md`.