### PR TITLE
fix(webui): clarify model preset display names

### DIFF
--- a/webui/src/components/settings/models/ModelsSettings.tsx
+++ b/webui/src/components/settings/models/ModelsSettings.tsx
@@ -350,7 +350,22 @@ export function ModelsSettings({
           </span>
         </div>
       ) : null}
-      <SettingsRow title={tx("settings.models.presetName", "Preset name")}>
+      <SettingsRow
+        title={
+          creating
+            ? tx("settings.models.presetName", "Preset name")
+            : tx("settings.models.presetDisplayName", "Display name")
+        }
+        description={
+          creating
+            ? undefined
+            : tx(
+                "settings.models.presetDisplayNameHelp",
+                "Shown in the interface. The command name stays /model {{name}}.",
+                { name: form.modelPreset },
+              )
+        }
+      >
         <Input
           autoFocus={creating}
           value={form.presetLabel}

--- a/webui/src/i18n/locales/en/common.json
+++ b/webui/src/i18n/locales/en/common.json
@@ -144,6 +144,8 @@
       "editPreset": "Edit preset",
       "presetName": "Preset name",
       "presetNameHelp": "A short name used throughout model settings.",
+      "presetDisplayName": "Display name",
+      "presetDisplayNameHelp": "Shown in the interface. The command name stays /model {{name}}.",
       "presetNamePlaceholder": "Fast writing",
       "advancedOptions": "Advanced options",
       "advancedSummary": "Context {{context}} · Max {{max}} tokens",

--- a/webui/src/i18n/locales/es/common.json
+++ b/webui/src/i18n/locales/es/common.json
@@ -420,6 +420,8 @@
       "editPreset": "Editar preajuste",
       "presetName": "Nombre del preajuste",
       "presetNameHelp": "Un nombre corto para usar en los ajustes de modelos.",
+      "presetDisplayName": "Nombre para mostrar",
+      "presetDisplayNameHelp": "Se muestra en la interfaz. El nombre del comando sigue siendo /model {{name}}.",
       "presetNamePlaceholder": "Escritura rápida",
       "advancedOptions": "Opciones avanzadas",
       "advancedSummary": "Contexto {{context}} · Máx. {{max}} tokens",

--- a/webui/src/i18n/locales/fr/common.json
+++ b/webui/src/i18n/locales/fr/common.json
@@ -420,6 +420,8 @@
       "editPreset": "Modifier le préréglage",
       "presetName": "Nom du préréglage",
       "presetNameHelp": "Un nom court utilisé dans les paramètres des modèles.",
+      "presetDisplayName": "Nom d’affichage",
+      "presetDisplayNameHelp": "Affiché dans l’interface. Le nom de commande reste /model {{name}}.",
       "presetNamePlaceholder": "Rédaction rapide",
       "advancedOptions": "Options avancées",
       "advancedSummary": "Contexte {{context}} · Max. {{max}} tokens",

--- a/webui/src/i18n/locales/id/common.json
+++ b/webui/src/i18n/locales/id/common.json
@@ -420,6 +420,8 @@
       "editPreset": "Ubah prasetel",
       "presetName": "Nama prasetel",
       "presetNameHelp": "Nama singkat yang digunakan di pengaturan model.",
+      "presetDisplayName": "Nama tampilan",
+      "presetDisplayNameHelp": "Ditampilkan di antarmuka. Nama perintah tetap /model {{name}}.",
       "presetNamePlaceholder": "Menulis cepat",
       "advancedOptions": "Opsi lanjutan",
       "advancedSummary": "Konteks {{context}} · Maks. {{max}} token",

--- a/webui/src/i18n/locales/ja/common.json
+++ b/webui/src/i18n/locales/ja/common.json
@@ -420,6 +420,8 @@
       "editPreset": "プリセットを編集",
       "presetName": "プリセット名",
       "presetNameHelp": "モデル設定で使用する短い名前です。",
+      "presetDisplayName": "表示名",
+      "presetDisplayNameHelp": "画面に表示される名前です。コマンド名は /model {{name}} のままです。",
       "presetNamePlaceholder": "高速執筆",
       "advancedOptions": "詳細オプション",
       "advancedSummary": "コンテキスト {{context}} · 最大 {{max}} トークン",

--- a/webui/src/i18n/locales/ko/common.json
+++ b/webui/src/i18n/locales/ko/common.json
@@ -420,6 +420,8 @@
       "editPreset": "프리셋 편집",
       "presetName": "프리셋 이름",
       "presetNameHelp": "모델 설정에서 사용할 짧은 이름입니다.",
+      "presetDisplayName": "표시 이름",
+      "presetDisplayNameHelp": "화면에 표시되는 이름입니다. 명령 이름은 /model {{name}} 그대로 유지됩니다.",
       "presetNamePlaceholder": "빠른 작성",
       "advancedOptions": "고급 옵션",
       "advancedSummary": "컨텍스트 {{context}} · 최대 {{max}} 토큰",

--- a/webui/src/i18n/locales/pt-BR/common.json
+++ b/webui/src/i18n/locales/pt-BR/common.json
@@ -144,6 +144,8 @@
       "editPreset": "Editar predefinição",
       "presetName": "Nome da predefinição",
       "presetNameHelp": "Um nome curto usado nas configurações de modelo.",
+      "presetDisplayName": "Nome de exibição",
+      "presetDisplayNameHelp": "Exibido na interface. O nome do comando continua sendo /model {{name}}.",
       "presetNamePlaceholder": "Escrita rápida",
       "advancedOptions": "Opções avançadas",
       "advancedSummary": "Contexto {{context}} · Máx. {{max}} tokens",

--- a/webui/src/i18n/locales/vi/common.json
+++ b/webui/src/i18n/locales/vi/common.json
@@ -420,6 +420,8 @@
       "editPreset": "Sửa cấu hình đặt trước",
       "presetName": "Tên cấu hình đặt trước",
       "presetNameHelp": "Tên ngắn dùng trong phần thiết lập mô hình.",
+      "presetDisplayName": "Tên hiển thị",
+      "presetDisplayNameHelp": "Tên được hiển thị trong giao diện. Tên lệnh vẫn là /model {{name}}.",
       "presetNamePlaceholder": "Viết nhanh",
       "advancedOptions": "Tùy chọn nâng cao",
       "advancedSummary": "Ngữ cảnh {{context}} · Tối đa {{max}} token",

--- a/webui/src/i18n/locales/zh-CN/common.json
+++ b/webui/src/i18n/locales/zh-CN/common.json
@@ -144,6 +144,8 @@
       "editPreset": "编辑预设",
       "presetName": "预设名称",
       "presetNameHelp": "在模型设置中使用的简短名称。",
+      "presetDisplayName": "显示名称",
+      "presetDisplayNameHelp": "显示在界面中；命令名称仍为 /model {{name}}。",
       "presetNamePlaceholder": "快速写作",
       "advancedOptions": "高级选项",
       "advancedSummary": "上下文 {{context}} · 最大输出 {{max}} tokens",

--- a/webui/src/i18n/locales/zh-TW/common.json
+++ b/webui/src/i18n/locales/zh-TW/common.json
@@ -420,6 +420,8 @@
       "editPreset": "編輯預設",
       "presetName": "預設名稱",
       "presetNameHelp": "模型設定中使用的簡短名稱。",
+      "presetDisplayName": "顯示名稱",
+      "presetDisplayNameHelp": "顯示在介面中；命令名稱仍為 /model {{name}}。",
       "presetNamePlaceholder": "快速寫作",
       "advancedOptions": "進階選項",
       "advancedSummary": "上下文 {{context}} · 最大輸出 {{max}} tokens",

--- a/webui/src/tests/settings-models.test.tsx
+++ b/webui/src/tests/settings-models.test.tsx
@@ -89,6 +89,27 @@ async function togglePresetEditor(name = "primary") {
 describe("Settings models", () => {
   installSettingsViewTestHooks();
 
+  it("distinguishes the editable display name from the stable command name", async () => {
+    const payload = settingsPayload();
+    payload.model_presets[0] = {
+      ...payload.model_presets[0],
+      name: "openai",
+      label: "minimax",
+    };
+    payload.model_call_order = ["openai"];
+    payload.agent.model_preset = "openai";
+    vi.stubGlobal("fetch", vi.fn(() => new Promise<Response>(() => {})));
+
+    renderSettingsView({ initialSection: "models", initialSettings: payload });
+
+    await togglePresetEditor("openai");
+
+    expect(screen.getByText("Display name")).toBeInTheDocument();
+    expect(
+      screen.getByText("Shown in the interface. The command name stays /model openai."),
+    ).toBeInTheDocument();
+    expect(screen.getByDisplayValue("minimax")).toBeInTheDocument();
+  });
 
   it("keeps generation parameters collapsed until advanced options are opened", async () => {
     vi.stubGlobal(


### PR DESCRIPTION
## Summary
- distinguish a preset display label from its stable `/model` command name
- show the stable command name while editing an existing preset
- localize the clarification across supported WebUI languages

## Why
Editing a preset named `openai` to display as `minimax` previously looked like a true rename in WebUI, while `/model` correctly retained the stable `openai` identifier. This preserves session compatibility and makes that distinction explicit.

## Test plan
- `bun run test -- src/tests/settings-models.test.tsx`
- `bun run lint`
- `bun run build`