### PR TITLE
feat(skills): support manual-only invocation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2347,6 +2347,23 @@ Disabled skills are excluded from the main agent's skill summary, from always-on
 |--------|---------|-------------|
 | `agents.defaults.disabledSkills` | `[]` | List of skill directory names to exclude from loading. Applies to both built-in skills and workspace skills. |
 
+To keep a skill available for explicit user invocation while preventing the model
+from selecting it automatically, add `disable-model-invocation: true` to its
+`SKILL.md` frontmatter:
+
+```yaml
+---
+name: deploy
+description: Deploy the current project.
+disable-model-invocation: true
+---
+```
+
+The skill remains visible to users through `/skill` and can be loaded for the
+current turn with `$deploy`. Its name and description are omitted from main-agent
+and subagent skill summaries, and `disable-model-invocation` takes precedence over
+`always: true`.
+
 ### Agent Plugins v1
 
 nanobot discovers [Agent Plugins](https://agent-plugins.org/) under `<workspace>/plugins/`; a v1 package has `plugin.json` and may add `mcp.json`, `skills/<name>/SKILL.md`, or both. Agent Plugins are the common package and activation boundary for installable capabilities; they do not replace native providers, channels, tools, standalone workspace skills, or directly configured MCP servers.

--- a/nanobot/agent/skills.py
+++ b/nanobot/agent/skills.py
@@ -179,6 +179,11 @@ class SkillsLoader:
                 invoked.append(name)
         return invoked
 
+    def is_model_invocable(self, name: str) -> bool:
+        """Return whether the model may discover or automatically load a skill."""
+        metadata = self.get_skill_metadata(name) or {}
+        return metadata.get("disable-model-invocation") is not True
+
     def build_explicit_skill_runtime_context(
         self,
         text: str,
@@ -238,6 +243,7 @@ class SkillsLoader:
                 entry
                 for entry in all_skills
                 if entry["source"] == source and (not exclude or entry["name"] not in exclude)
+                and self.is_model_invocable(entry["name"])
             ]
             if not entries:
                 continue
@@ -353,6 +359,7 @@ class SkillsLoader:
             entry["name"]
             for entry in self.list_skills(filter_unavailable=True)
             if (meta := self.get_skill_metadata(entry["name"]) or {})
+            and meta.get("disable-model-invocation") is not True
             and (
                 self._parse_nanobot_metadata(meta.get("metadata")).get("always")
                 or meta.get("always")

--- a/nanobot/skills/README.md
+++ b/nanobot/skills/README.md
@@ -5,8 +5,12 @@ This directory contains built-in skills that extend nanobot's capabilities.
 ## Skill Format
 
 Each skill is a directory containing a `SKILL.md` file with:
-- YAML frontmatter (name, description, metadata)
+- YAML frontmatter (`name`, `description`, and optional behavior fields)
 - Markdown instructions for the agent
+
+Set `disable-model-invocation: true` for manual-only workflows. The skill stays
+available to users through `$skill-name`, but its description is omitted from
+model and subagent skill summaries and it is never injected by `always: true`.
 
 When skills reference large local documentation or logs, prefer nanobot's built-in
 `grep` tool to narrow the search space before loading full files.

--- a/nanobot/skills/skill-creator/SKILL.md
+++ b/nanobot/skills/skill-creator/SKILL.md
@@ -328,7 +328,7 @@ Write the YAML frontmatter with `name` and `description`:
   - Include all "when to use" information here - Not in the body. The body is only loaded after triggering, so "When to Use This Skill" sections in the body are not helpful to the agent.
   - Example description for a `docx` skill: "Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. Use when the agent needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks"
 
-Keep frontmatter minimal. In `nanobot`, `metadata` and `always` are also supported when needed, but avoid adding extra fields unless they are actually required.
+Keep frontmatter minimal. In `nanobot`, `metadata` and `always` are also supported when needed. Set `disable-model-invocation: true` for workflows that only the user should trigger explicitly with `$skill-name`; their descriptions stay out of model and subagent skill summaries until invoked. Avoid adding extra fields unless they are actually required.
 
 ##### Body
 

--- a/nanobot/skills/skill-creator/scripts/quick_validate.py
+++ b/nanobot/skills/skill-creator/scripts/quick_validate.py
@@ -21,6 +21,7 @@ ALLOWED_FRONTMATTER_KEYS = {
     "always",
     "license",
     "allowed-tools",
+    "disable-model-invocation",
 }
 ALLOWED_RESOURCE_DIRS = {"scripts", "references", "assets"}
 PLACEHOLDER_MARKERS = ("[todo", "todo:")
@@ -186,6 +187,14 @@ def validate_skill(skill_path: str | Path) -> tuple[bool, str]:
     always = frontmatter.get("always")
     if always is not None and not isinstance(always, bool):
         return False, f"'always' must be a boolean, got {type(always).__name__}"
+
+    disable_model_invocation = frontmatter.get("disable-model-invocation")
+    if disable_model_invocation is not None and not isinstance(disable_model_invocation, bool):
+        return (
+            False,
+            "'disable-model-invocation' must be a boolean, "
+            f"got {type(disable_model_invocation).__name__}",
+        )
 
     for child in skill_path.iterdir():
         if child.name == "SKILL.md":

--- a/tests/agent/test_context_builder.py
+++ b/tests/agent/test_context_builder.py
@@ -7,10 +7,10 @@ import pytest
 from nanobot.agent.context import ContextBuilder
 from nanobot.runtime_context import RuntimeContextBlock
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 def _builder(tmp_path: Path, **kw) -> ContextBuilder:
     return ContextBuilder(workspace=tmp_path, **kw)
 

--- a/tests/agent/test_context_builder.py
+++ b/tests/agent/test_context_builder.py
@@ -7,10 +7,10 @@ import pytest
 from nanobot.agent.context import ContextBuilder
 from nanobot.runtime_context import RuntimeContextBlock
 
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
 def _builder(tmp_path: Path, **kw) -> ContextBuilder:
     return ContextBuilder(workspace=tmp_path, **kw)
 
@@ -431,6 +431,33 @@ class TestBuildMessages:
         assert messages[-1]["_meta"]["runtime_context"]["sources"] == [
             "explicit_skills"
         ]
+
+    def test_manual_only_skill_is_hidden_until_explicitly_invoked(self, tmp_path):
+        skill_dir = tmp_path / "skills" / "deploy"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: deploy\n"
+            "description: Deploy the current project.\n"
+            "disable-model-invocation: true\n"
+            "---\n\n"
+            "# Deploy workflow\n\nFollow the private deployment checklist.",
+            encoding="utf-8",
+        )
+        builder = _builder(tmp_path)
+
+        ordinary_messages = builder.build_messages([], "Is the project ready?")
+        invoked_messages = builder.build_messages([], "Please $deploy now.")
+        ordinary_system_prompt = ordinary_messages[0]["content"]
+        invoked_system_prompt = invoked_messages[0]["content"]
+        invoked_user_prompt = invoked_messages[-1]["content"]
+
+        assert "Deploy the current project." not in ordinary_system_prompt
+        assert "private deployment checklist" not in ordinary_system_prompt
+        assert "Deploy the current project." not in invoked_system_prompt
+        assert "private deployment checklist" not in invoked_system_prompt
+        assert "### Skill: deploy" in invoked_user_prompt
+        assert "private deployment checklist" in invoked_user_prompt
 
     def test_unknown_skill_reference_does_not_change_active_skills(self, tmp_path):
         messages = _builder(tmp_path).build_messages([], "Keep the shell literal $HOME.")

--- a/tests/agent/test_skill_creator_scripts.py
+++ b/tests/agent/test_skill_creator_scripts.py
@@ -72,6 +72,45 @@ def test_validate_skill_rejects_root_files_outside_allowed_dirs(tmp_path: Path) 
     assert "Unexpected file or directory in skill root" in message
 
 
+def test_validate_skill_accepts_manual_only_frontmatter(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "manual-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: manual-skill\n"
+        "description: Run a user-controlled workflow.\n"
+        "disable-model-invocation: true\n"
+        "---\n"
+        "# Manual workflow\n",
+        encoding="utf-8",
+    )
+
+    valid, message = quick_validate.validate_skill(skill_dir)
+
+    assert valid, message
+
+
+def test_validate_skill_rejects_non_boolean_manual_only_frontmatter(
+    tmp_path: Path,
+) -> None:
+    skill_dir = tmp_path / "manual-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: manual-skill\n"
+        "description: Run a user-controlled workflow.\n"
+        'disable-model-invocation: "true"\n'
+        "---\n"
+        "# Manual workflow\n",
+        encoding="utf-8",
+    )
+
+    valid, message = quick_validate.validate_skill(skill_dir)
+
+    assert not valid
+    assert "'disable-model-invocation' must be a boolean" in message
+
+
 def test_package_skill_creates_archive(tmp_path: Path) -> None:
     skill_dir = tmp_path / "package-me"
     skill_dir.mkdir()

--- a/tests/agent/test_skills_loader.py
+++ b/tests/agent/test_skills_loader.py
@@ -433,6 +433,48 @@ def test_multiple_explicit_skills_share_one_ordered_runtime_context(tmp_path: Pa
     assert "### Skill: always" not in context.content
 
 
+def test_manual_only_skill_is_hidden_from_model_but_explicitly_invocable(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "ws"
+    skills_root = workspace / "skills"
+    manual = skills_root / "deploy"
+    manual.mkdir(parents=True)
+    (manual / "SKILL.md").write_text(
+        "---\n"
+        "name: deploy\n"
+        "description: Deploy the current project.\n"
+        "always: true\n"
+        "disable-model-invocation: true\n"
+        "---\n\n"
+        "# Deploy\n\nRun the deployment workflow.\n",
+        encoding="utf-8",
+    )
+    automatic = skills_root / "review"
+    automatic.mkdir()
+    (automatic / "SKILL.md").write_text(
+        "---\n"
+        "name: review\n"
+        "description: Review the current changes.\n"
+        "always: true\n"
+        "disable-model-invocation: false\n"
+        "---\n\n"
+        "# Review\n",
+        encoding="utf-8",
+    )
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+    loader = SkillsLoader(workspace, builtin_skills_dir=builtin)
+
+    assert {entry["name"] for entry in loader.list_skills()} == {"deploy", "review"}
+    assert loader.is_model_invocable("deploy") is False
+    assert loader.is_model_invocable("review") is True
+    assert "deploy" not in loader.build_skills_summary()
+    assert "review" in loader.build_skills_summary()
+    assert loader.get_always_skills() == ["review"]
+    assert loader.get_explicitly_invoked_skills("Please $deploy now.") == ["deploy"]
+
+
 # -- multiline description tests (YAML folded > and literal |) -----------------
 
 

--- a/tests/tools/test_search_tools.py
+++ b/tests/tools/test_search_tools.py
@@ -795,3 +795,29 @@ def test_subagent_prompt_respects_disabled_skills(tmp_path: Path) -> None:
 
     assert "alpha" not in prompt
     assert "beta" in prompt
+
+
+def test_subagent_prompt_omits_manual_only_skills(tmp_path: Path) -> None:
+    bus = MessageBus()
+    skill_dir = tmp_path / "skills" / "deploy"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: deploy\n"
+        "description: Deploy the current project.\n"
+        "disable-model-invocation: true\n"
+        "---\n\n"
+        "# Deploy\n\nRun the private deployment workflow.\n",
+        encoding="utf-8",
+    )
+
+    mgr = SubagentManager(
+        workspace=tmp_path,
+        bus=bus,
+        max_tool_result_chars=4096,
+    )
+
+    prompt = mgr._build_subagent_prompt()
+
+    assert "Deploy the current project." not in prompt
+    assert "private deployment workflow" not in prompt


### PR DESCRIPTION
## Why

Skills that perform side effects, such as deployment or publishing, need an explicit user-only mode. Currently every enabled skill can be advertised to the model, and `always: true` can preload it automatically.

## What changed

- support `disable-model-invocation: true` in skill frontmatter
- omit manual-only skills from main-agent and subagent skill summaries
- keep manual-only skills available through explicit `$skill-name` invocation and `/skill` listing
- make manual-only mode take precedence over `always: true`
- validate the field as a boolean and document the behavior

This controls automatic skill discovery and loading; it does not change filesystem or tool permissions.

## Verification

- focused skill and context tests: 108 passed
- `pytest -q -n auto`: 6117 passed, 24 skipped
- `ruff check`: passed
- `basedpyright`: 0 errors
- GitHub Test Suite: 8/8 passed

Closes #5404