### PR TITLE
fix(cron): retire persisted heartbeat/dream system jobs when disabled

### DIFF
--- a/nanobot/cli/gateway_runtime.py
+++ b/nanobot/cli/gateway_runtime.py
@@ -706,11 +706,6 @@ def _run_gateway(
     else:
         console.print("[yellow]Warning: No channels enabled[/yellow]")
 
-    cron_status = cron.status()
-    cron_job_count = cast(int, cron_status["jobs"])
-    if cron_job_count > 0:
-        console.print(f"[green]✓[/green] Cron: {cron_job_count} scheduled jobs")
-
     hb_cfg = config.gateway.heartbeat
     if hb_cfg.enabled:
         console.print(f"[green]✓[/green] Heartbeat: every {hb_cfg.interval_s}s")
@@ -785,8 +780,7 @@ def _run_gateway(
         console.print(f"[green]✓[/green] Dream: {dream_cfg.describe_schedule()}")
     else:
         console.print("[yellow]○[/yellow] Dream: disabled")
-        # Advance the cursor first: it must happen unconditionally (issue
-        # #4242), even if the cron store turns out to be corrupt below.
+        # Cursor repair must not depend on a healthy cron store.
         _advance_dream_cursor_if_behind(agent.context.memory)
         cron.remove_system_job("dream")
 
@@ -803,9 +797,12 @@ def _run_gateway(
             payload=CronPayload(kind="system_event"),
         ))
     else:
-        # Retire any previously persisted heartbeat job so that disabling
-        # gateway.heartbeat in config takes effect after restart.
         cron.remove_system_job("heartbeat")
+
+    cron_status = cron.status()
+    cron_job_count = cast(int, cron_status["jobs"])
+    if cron_job_count > 0:
+        console.print(f"[green]✓[/green] Cron: {cron_job_count} scheduled jobs")
 
     async def _open_browser_when_ready() -> None:
         """Wait for the gateway to bind, then point the user's browser at the webui."""

--- a/nanobot/cli/gateway_runtime.py
+++ b/nanobot/cli/gateway_runtime.py
@@ -785,6 +785,7 @@ def _run_gateway(
         console.print(f"[green]✓[/green] Dream: {dream_cfg.describe_schedule()}")
     else:
         console.print("[yellow]○[/yellow] Dream: disabled")
+        cron.remove_system_job("dream")
         _advance_dream_cursor_if_behind(agent.context.memory)
 
     # Register Heartbeat system job (idempotent on restart)
@@ -799,6 +800,10 @@ def _run_gateway(
             ),
             payload=CronPayload(kind="system_event"),
         ))
+    else:
+        # Retire any previously persisted heartbeat job so that disabling
+        # gateway.heartbeat in config takes effect after restart.
+        cron.remove_system_job("heartbeat")
 
     async def _open_browser_when_ready() -> None:
         """Wait for the gateway to bind, then point the user's browser at the webui."""

--- a/nanobot/cli/gateway_runtime.py
+++ b/nanobot/cli/gateway_runtime.py
@@ -785,8 +785,10 @@ def _run_gateway(
         console.print(f"[green]✓[/green] Dream: {dream_cfg.describe_schedule()}")
     else:
         console.print("[yellow]○[/yellow] Dream: disabled")
-        cron.remove_system_job("dream")
+        # Advance the cursor first: it must happen unconditionally (issue
+        # #4242), even if the cron store turns out to be corrupt below.
         _advance_dream_cursor_if_behind(agent.context.memory)
+        cron.remove_system_job("dream")
 
     # Register Heartbeat system job (idempotent on restart)
     if hb_cfg.enabled:

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -718,6 +718,25 @@ class CronService:
         logger.info("Cron: registered system job '{}' ({})", job.name, job.id)
         return job
 
+    def remove_system_job(self, job_id: str) -> bool:
+        """Remove an internal system job by id (startup reconciliation).
+
+        Unlike ``remove_job``, this bypasses the protected-system-job guard:
+        the gateway retires a persisted system job whose config has been
+        disabled, so e.g. ``gateway.heartbeat.enabled=false`` actually takes
+        effect after restart instead of the leftover job firing forever.
+        Returns True when a job was removed.
+        """
+        store = self._require_store()
+        before = len(store.jobs)
+        store.jobs = [j for j in store.jobs if j.id != job_id]
+        removed = len(store.jobs) < before
+        if removed:
+            self._save_store()
+            self._arm_timer()
+            logger.info("Cron: removed system job {}", job_id)
+        return removed
+
     def remove_job(self, job_id: str) -> Literal["removed", "protected", "not_found"]:
         """Remove a job by ID, unless it is a protected system job."""
         store = self._require_store()

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -719,14 +719,7 @@ class CronService:
         return job
 
     def remove_system_job(self, job_id: str) -> bool:
-        """Remove an internal system job by id (startup reconciliation).
-
-        Unlike ``remove_job``, this bypasses the protected-system-job guard:
-        the gateway retires a persisted system job whose config has been
-        disabled, so e.g. ``gateway.heartbeat.enabled=false`` actually takes
-        effect after restart instead of the leftover job firing forever.
-        Returns True when a job was removed.
-        """
+        """Remove a protected system job during startup reconciliation."""
         store = self._require_store()
         before = len(store.jobs)
         store.jobs = [j for j in store.jobs if j.id != job_id]

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -3229,7 +3229,8 @@ def test_gateway_local_trigger_queue_submits_agent_turns(
         def register_system_job(self, _job) -> None:
             return None
 
-        def remove_system_job(self, _job_id: str) -> bool:
+        def remove_system_job(self, job_id: str) -> bool:
+            seen.setdefault("removed_system_jobs", []).append(job_id)
             return False
 
     class _FakeAgentLoop(_GatewayAgentContractStub):
@@ -3308,6 +3309,8 @@ def test_gateway_local_trigger_queue_submits_agent_turns(
     turn_delivery_factory = agent_kwargs["turn_delivery_factory"]
     assert isinstance(turn_delivery_factory, TurnDeliveryFactory)
     assert turn_delivery_factory.bus is bus
+    # Disabled system jobs must be retired on startup, not just unregistered.
+    assert seen["removed_system_jobs"] == ["dream", "heartbeat"]
     assert isinstance(turn_delivery_factory.route_policy, WebuiTurnRoutePolicy)
     assert turn_delivery_factory.route_policy.sessions is agent.sessions
 

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -3229,6 +3229,9 @@ def test_gateway_local_trigger_queue_submits_agent_turns(
         def register_system_job(self, _job) -> None:
             return None
 
+        def remove_system_job(self, _job_id: str) -> bool:
+            return False
+
     class _FakeAgentLoop(_GatewayAgentContractStub):
         @classmethod
         def from_config(cls, config, bus=None, **extra):

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -3224,13 +3224,14 @@ def test_gateway_local_trigger_queue_submits_agent_turns(
             return None
 
         def status(self) -> dict[str, int]:
+            seen.setdefault("cron_reconciliation", []).append("status")
             return {"jobs": 0}
 
         def register_system_job(self, _job) -> None:
             return None
 
         def remove_system_job(self, job_id: str) -> bool:
-            seen.setdefault("removed_system_jobs", []).append(job_id)
+            seen.setdefault("cron_reconciliation", []).append(f"remove:{job_id}")
             return False
 
     class _FakeAgentLoop(_GatewayAgentContractStub):
@@ -3309,8 +3310,7 @@ def test_gateway_local_trigger_queue_submits_agent_turns(
     turn_delivery_factory = agent_kwargs["turn_delivery_factory"]
     assert isinstance(turn_delivery_factory, TurnDeliveryFactory)
     assert turn_delivery_factory.bus is bus
-    # Disabled system jobs must be retired on startup, not just unregistered.
-    assert seen["removed_system_jobs"] == ["dream", "heartbeat"]
+    assert seen["cron_reconciliation"] == ["remove:dream", "remove:heartbeat", "status"]
     assert isinstance(turn_delivery_factory.route_policy, WebuiTurnRoutePolicy)
     assert turn_delivery_factory.route_policy.sessions is agent.sessions
 

--- a/tests/cron/test_cron_persistence.py
+++ b/tests/cron/test_cron_persistence.py
@@ -211,6 +211,7 @@ def test_load_store_falls_back_to_in_memory_on_corruption_after_start(
         ("enable_job", lambda service: service.enable_job("missing", enabled=False)),
         ("update_job", lambda service: service.update_job("missing", name="new name")),
         ("register_system_job", lambda service: service.register_system_job(_system_job())),
+        ("remove_system_job", lambda service: service.remove_system_job("heartbeat")),
     ],
 )
 def test_public_apis_raise_clear_error_for_unavailable_corrupt_store(

--- a/tests/cron/test_cron_service.py
+++ b/tests/cron/test_cron_service.py
@@ -786,8 +786,6 @@ def test_remove_job_refuses_system_jobs(tmp_path) -> None:
 
 
 def test_remove_system_job_retires_persisted_system_job(tmp_path) -> None:
-    """Disabling a system job (e.g. gateway.heartbeat.enabled=false) must
-    actually retire the previously persisted job, not just skip registration."""
     store_path = tmp_path / "cron" / "jobs.json"
     service = CronService(store_path)
     service.register_system_job(CronJob(
@@ -802,12 +800,8 @@ def test_remove_system_job_retires_persisted_system_job(tmp_path) -> None:
 
     assert removed is True
     assert service.get_job("heartbeat") is None
-    # Removal must persist: a fresh instance (next gateway start) must not
-    # resurrect the job from the on-disk store.
     assert CronService(store_path).get_job("heartbeat") is None
-    # Idempotent: removing a missing system job reports False without raising.
     assert service.remove_system_job("heartbeat") is False
-    # User-facing removal still protects remaining system jobs.
     other = CronService(store_path)
     other.register_system_job(CronJob(
         id="dream",
@@ -819,7 +813,6 @@ def test_remove_system_job_retires_persisted_system_job(tmp_path) -> None:
 
 
 def test_remove_system_job_without_store_file(tmp_path) -> None:
-    """Fresh install with the system job disabled: no jobs.json exists yet."""
     store_path = tmp_path / "cron" / "jobs.json"
     service = CronService(store_path)
 

--- a/tests/cron/test_cron_service.py
+++ b/tests/cron/test_cron_service.py
@@ -818,6 +818,15 @@ def test_remove_system_job_retires_persisted_system_job(tmp_path) -> None:
     assert other.remove_job("dream") == "protected"
 
 
+def test_remove_system_job_without_store_file(tmp_path) -> None:
+    """Fresh install with the system job disabled: no jobs.json exists yet."""
+    store_path = tmp_path / "cron" / "jobs.json"
+    service = CronService(store_path)
+
+    assert service.remove_system_job("heartbeat") is False
+    assert not store_path.exists()
+
+
 @pytest.mark.asyncio
 async def test_start_server_not_jobs(tmp_path):
     store_path = tmp_path / "cron" / "jobs.json"

--- a/tests/cron/test_cron_service.py
+++ b/tests/cron/test_cron_service.py
@@ -785,6 +785,39 @@ def test_remove_job_refuses_system_jobs(tmp_path) -> None:
     assert service.get_job("dream") is not None
 
 
+def test_remove_system_job_retires_persisted_system_job(tmp_path) -> None:
+    """Disabling a system job (e.g. gateway.heartbeat.enabled=false) must
+    actually retire the previously persisted job, not just skip registration."""
+    store_path = tmp_path / "cron" / "jobs.json"
+    service = CronService(store_path)
+    service.register_system_job(CronJob(
+        id="heartbeat",
+        name="heartbeat",
+        schedule=CronSchedule(kind="every", every_ms=1_800_000, tz="UTC"),
+        payload=CronPayload(kind="system_event"),
+    ))
+    assert service.get_job("heartbeat") is not None
+
+    removed = service.remove_system_job("heartbeat")
+
+    assert removed is True
+    assert service.get_job("heartbeat") is None
+    # Removal must persist: a fresh instance (next gateway start) must not
+    # resurrect the job from the on-disk store.
+    assert CronService(store_path).get_job("heartbeat") is None
+    # Idempotent: removing a missing system job reports False without raising.
+    assert service.remove_system_job("heartbeat") is False
+    # User-facing removal still protects remaining system jobs.
+    other = CronService(store_path)
+    other.register_system_job(CronJob(
+        id="dream",
+        name="dream",
+        schedule=CronSchedule(kind="cron", expr="0 */2 * * *", tz="UTC"),
+        payload=CronPayload(kind="system_event"),
+    ))
+    assert other.remove_job("dream") == "protected"
+
+
 @pytest.mark.asyncio
 async def test_start_server_not_jobs(tmp_path):
     store_path = tmp_path / "cron" / "jobs.json"


### PR DESCRIPTION
Setting `gateway.heartbeat.enabled` to `false` (or `agents.defaults.dream.enabled`) and restarting the gateway did not actually stop the job: startup printed `✗ Heartbeat: disabled` while the previously persisted system job in `<workspace>/cron/jobs.json` kept firing on its schedule, burning tokens and running checks the user had explicitly turned off. The toggle only skipped registration on startup — nothing retired the leftover persisted job, and `remove_job` refuses to touch protected system jobs, so the only workaround was hand-editing `jobs.json` (as community reports around #4069 and #4242 have noted, the persisted store is the real source of truth over config).

This adds `CronService.remove_system_job()`, a startup-reconciliation counterpart to `register_system_job()`, and calls it from the gateway's disabled branches for both heartbeat and dream. One restart with the toggle off now genuinely retires the persisted job; re-enabling later re-registers it as before. The disabled-path dream cursor advancement for #4242 still runs, and now runs before the cron store is touched so it applies even when `jobs.json` is corrupt.

Test plan: new regression test covers register → remove → fresh `CronService` instance confirming the job does not resurrect from disk, plus idempotent removal, continued `remove_job` protection for remaining system jobs, and the fresh-install case with no store file; `remove_system_job` added to the corrupt-store parametrized cases; the in-process gateway test now asserts the disabled path actually requests retirement of both `dream` and `heartbeat` (not just skip-registration); the end-to-end gateway smoke test (real subprocess with `heartbeat.enabled=false`) passes. Full cron suite (110 tests) and `ruff check` pass.