### PR TITLE
fix(goal): stop repeating clarification replies

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -71,7 +71,6 @@ from nanobot.session.automation_turns import automation_history_overrides
 from nanobot.session.goal_state import (
     goal_state_runtime_lines,
     runner_wall_llm_timeout_s,
-    sustained_goal_active,
 )
 from nanobot.session.history_visibility import HIDDEN_HISTORY_META
 from nanobot.session.keys import UNIFIED_SESSION_KEY, remember_last_channel
@@ -1118,8 +1117,6 @@ class AgentLoop:
                     metadata=session_metadata,
                     message_metadata=metadata,
                 ),
-                goal_active_predicate=lambda: sustained_goal_active(session.metadata) if session is not None else False,
-                goal_continue_message=_goal_continue,
                 finalize_on_max_iterations=turn_continuation.should_finalize_on_max_iterations(
                     pending_queue_available=pending_queue is not None and session is not None,
                     session_metadata=session_metadata,

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -51,14 +51,12 @@ from nanobot.utils.runtime import (
     EMPTY_FINAL_RESPONSE_MESSAGE,
     build_budget_exhausted_finalization_message,
     build_finalization_retry_message,
-    build_goal_continue_message,
     build_length_recovery_message,
     is_blank_text,
     repeated_external_lookup_error,
     repeated_workspace_violation_error,
 )
 
-GoalContinueMessage = str | Callable[[], str | None]
 ProgressCallback = Callable[[str], Awaitable[None]]
 RetryWaitCallback = Callable[[str], Awaitable[None]]
 CheckpointCallback = Callable[[dict[str, Any]], Awaitable[None]]
@@ -111,8 +109,6 @@ class AgentRunSpec:
     checkpoint_callback: CheckpointCallback | None = None
     injection_callback: InjectionCallback | None = None
     llm_timeout_s: float | None = None
-    goal_active_predicate: Callable[[], bool] | None = None
-    goal_continue_message: GoalContinueMessage | None = None
     finalize_on_max_iterations: bool = True
     provider_state: ProviderConversationState | None = None
 
@@ -247,7 +243,6 @@ class AgentRunner:
         conversation_state: ProviderConversationStateController | None = None,
         phase: str = "after error",
         iteration: int | None = None,
-        allow_goal_continue: bool = False,
     ) -> tuple[bool, int]:
         """Drain pending injections. Returns (should_continue, updated_cycles).
 
@@ -261,10 +256,6 @@ class AgentRunner:
         if injection_cycles < _MAX_INJECTION_CYCLES:
             injections = await self._drain_injections(spec)
             real_injection = bool(injections)
-        if not injections and allow_goal_continue and assistant_message is not None:
-            predicate = spec.goal_active_predicate
-            if predicate is not None and predicate():
-                injections = [self._build_goal_continue_message(spec)]
         if not injections:
             return False, injection_cycles
         if real_injection:
@@ -294,19 +285,7 @@ class AgentRunner:
                 "Injected {} follow-up message(s) {} ({}/{})",
                 len(injections), phase, injection_cycles, _MAX_INJECTION_CYCLES,
             )
-        else:
-            logger.info("Injected sustained-goal continuation {}", phase)
         return True, injection_cycles
-
-    def _build_goal_continue_message(self, spec: AgentRunSpec) -> dict[str, str]:
-        custom = spec.goal_continue_message
-        if callable(custom):
-            try:
-                custom = custom()
-            except Exception:
-                logger.exception("goal_continue_message callback failed")
-                custom = None
-        return build_goal_continue_message(custom)
 
     async def _drain_injections(self, spec: AgentRunSpec) -> list[dict[str, Any]]:
         """Drain pending user messages via the injection callback.
@@ -736,9 +715,6 @@ class AgentRunner:
                 conversation_state=conversation_state,
                 phase="after final response",
                 iteration=iteration,
-                allow_goal_continue=(
-                    response.finish_reason not in {"refusal", "content_filter"}
-                ),
             )
             if should_continue:
                 had_injections = True

--- a/nanobot/utils/runtime.py
+++ b/nanobot/utils/runtime.py
@@ -40,13 +40,6 @@ LENGTH_RECOVERY_PROMPT = (
     "existing text, recap, or apologize."
 )
 
-SUSTAINED_GOAL_CONTINUE_PROMPT = (
-    "You have an active sustained goal. Please continue working toward the "
-    "objective using your tools, or call update_goal with action='complete' "
-    "if the work is truly finished."
-)
-
-
 def empty_tool_result_message(tool_name: str) -> str:
     """Short prompt-safe marker for tools that completed without visible output."""
     return f"({tool_name} completed with no output)"
@@ -95,11 +88,6 @@ def build_length_recovery_message(content: str) -> dict[str, str]:
         "Begin with the text that belongs immediately after this tail."
     )
     return {"role": "user", "content": prompt}
-
-
-def build_goal_continue_message(custom: str | None = None) -> dict[str, str]:
-    """Prompt the model to continue when a sustained goal is still active."""
-    return {"role": "user", "content": custom or SUSTAINED_GOAL_CONTINUE_PROMPT}
 
 
 def external_lookup_signature(tool_name: str, arguments: Any) -> str | None:

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -1481,42 +1481,6 @@ async def test_process_message_uses_explicit_session_for_goal_context(
 
 
 @pytest.mark.asyncio
-async def test_run_agent_loop_goal_continue_message_reads_latest_metadata(
-    tmp_path: Path,
-) -> None:
-    from nanobot.agent.runner import AgentRunResult
-
-    loop = _make_full_loop(tmp_path)
-    session = loop.sessions.get_or_create("websocket:late-goal")
-    seen: dict[str, str | None] = {}
-
-    async def fake_run(spec):
-        assert callable(spec.goal_continue_message)
-        session.metadata[GOAL_STATE_KEY] = {
-            "status": "active",
-            "objective": "Goal created during this runner call.",
-        }
-        seen["goal_continue"] = spec.goal_continue_message()
-        return AgentRunResult(
-            final_content="ok",
-            messages=[{"role": "assistant", "content": "ok"}],
-        )
-
-    loop.runner.run = fake_run  # type: ignore[method-assign]
-
-    await loop._run_agent_loop(
-        [],
-        runtime=loop.llm_runtime(),
-        session=session,
-        channel="websocket",
-        chat_id="late-goal",
-        session_key=session.key,
-    )
-
-    assert "Goal created during this runner call." in (seen["goal_continue"] or "")
-
-
-@pytest.mark.asyncio
 async def test_process_direct_rejects_reserved_system_channel(tmp_path: Path) -> None:
     loop = _make_full_loop(tmp_path)
     loop._process_message = AsyncMock(return_value=None)  # type: ignore[method-assign]

--- a/tests/agent/test_runner_core.py
+++ b/tests/agent/test_runner_core.py
@@ -765,7 +765,7 @@ async def test_runner_does_not_retry_blank_policy_terminal(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("finish_reason", ["refusal", "content_filter"])
-async def test_runner_does_not_auto_continue_goal_after_policy_terminal(
+async def test_runner_stops_after_policy_terminal(
     finish_reason: str,
 ) -> None:
     from nanobot.agent.runner import AgentRunner
@@ -785,7 +785,6 @@ async def test_runner_does_not_auto_continue_goal_after_policy_terminal(
         model="test-model",
         max_iterations=3,
         max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
-        goal_active_predicate=lambda: True,
     ))
 
     assert provider.chat_with_retry.await_count == 1

--- a/tests/agent/test_runner_goal_continue.py
+++ b/tests/agent/test_runner_goal_continue.py
@@ -1,8 +1,8 @@
-"""Tests for sustained-goal continuation in AgentRunner.
+"""Regression coverage for sustained-goal completion in AgentRunner.
 
-When a goal_active_predicate returns True, the runner must not exit with
-stop_reason="completed" after a plain-text final response. Instead it should
-inject a continuation message and keep looping (similar to mid-turn injection).
+An active goal continues internally only after a tool-call budget boundary.
+When the model responds with plain text, including a clarification question,
+the turn must end and the user must receive exactly one reply.
 """
 
 from __future__ import annotations
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from agent.runner_helpers import make_run_spec
+from nanobot.agent.runner import AgentRunner
 from nanobot.config.schema import AgentDefaults
 from nanobot.providers.base import LLMProvider, LLMResponse
 
@@ -19,19 +20,16 @@ _MAX_TOOL_RESULT_CHARS = AgentDefaults().max_tool_result_chars
 
 
 @pytest.mark.asyncio
-async def test_runner_exits_normally_without_predicate():
-    """Baseline: no predicate, runner exits with completed on final text."""
-    from nanobot.agent.runner import AgentRunner
-
+async def test_runner_exits_normally_after_plain_final_response() -> None:
     provider = MagicMock(spec=LLMProvider)
     provider.chat_with_retry = AsyncMock(return_value=LLMResponse(
-        content="all done", tool_calls=[], usage={},
+        content="All done.", tool_calls=[], usage={},
     ))
     tools = MagicMock()
     tools.get_definitions.return_value = []
 
-    runner = AgentRunner()
-    result = await runner.run(make_run_spec(provider,
+    result = await AgentRunner().run(make_run_spec(
+        provider,
         initial_messages=[{"role": "user", "content": "do task"}],
         tools=tools,
         model="test-model",
@@ -40,208 +38,28 @@ async def test_runner_exits_normally_without_predicate():
     ))
 
     assert result.stop_reason == "completed"
-    assert result.final_content == "all done"
+    assert result.final_content == "All done."
+    assert provider.chat_with_retry.await_count == 1
 
 
 @pytest.mark.asyncio
-async def test_runner_exits_normally_with_inactive_goal():
-    """Predicate returns False, runner should exit normally."""
-    from nanobot.agent.runner import AgentRunner
-
+async def test_runner_does_not_repeat_clarification_for_active_goal() -> None:
     provider = MagicMock(spec=LLMProvider)
     provider.chat_with_retry = AsyncMock(return_value=LLMResponse(
-        content="all done", tool_calls=[], usage={},
+        content="Which day should I start?", tool_calls=[], usage={},
     ))
     tools = MagicMock()
     tools.get_definitions.return_value = []
 
-    runner = AgentRunner()
-    result = await runner.run(make_run_spec(provider,
-        initial_messages=[{"role": "user", "content": "do task"}],
-        tools=tools,
-        model="test-model",
-        max_iterations=2,
-        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
-        goal_active_predicate=lambda: False,
-    ))
-
-    assert result.stop_reason == "completed"
-    assert result.final_content == "all done"
-
-
-@pytest.mark.asyncio
-async def test_runner_forces_continue_when_goal_active():
-    """Predicate returns True on final text → runner injects continuation and loops.
-
-    We set max_iterations=3 and let the provider return final text every time.
-    Without the fix this would exit on the first iteration with stop_reason
-    "completed". With the fix the runner is forced to continue until
-    max_iterations is hit.
-    """
-    from nanobot.agent.runner import AgentRunner
-
-    provider = MagicMock(spec=LLMProvider)
-    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(
-        content="still working", tool_calls=[], usage={},
-    ))
-    tools = MagicMock()
-    tools.get_definitions.return_value = []
-
-    runner = AgentRunner()
-    result = await runner.run(make_run_spec(provider,
-        initial_messages=[{"role": "user", "content": "do task"}],
+    result = await AgentRunner().run(make_run_spec(
+        provider,
+        initial_messages=[{"role": "user", "content": "/goal make a study plan"}],
         tools=tools,
         model="test-model",
         max_iterations=3,
         max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
-        goal_active_predicate=lambda: True,
     ))
 
-    # Because the predicate keeps returning True, the runner should never
-    # naturally complete. It loops until max_iterations is exhausted.
-    assert result.stop_reason == "max_iterations"
-    # The injected continuation message should be present in the message list.
-    user_msgs = [m for m in result.messages if m.get("role") == "user"]
-    assert any("active sustained goal" in str(m.get("content", "")) for m in user_msgs)
-
-
-@pytest.mark.asyncio
-async def test_runner_respects_max_iterations_even_with_active_goal():
-    """A single iteration with active goal still hits max_iterations."""
-    from nanobot.agent.runner import AgentRunner
-
-    provider = MagicMock(spec=LLMProvider)
-    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(
-        content="still working", tool_calls=[], usage={},
-    ))
-    tools = MagicMock()
-    tools.get_definitions.return_value = []
-
-    runner = AgentRunner()
-    result = await runner.run(make_run_spec(provider,
-        initial_messages=[{"role": "user", "content": "do task"}],
-        tools=tools,
-        model="test-model",
-        max_iterations=1,
-        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
-        goal_active_predicate=lambda: True,
-    ))
-
-    assert result.stop_reason == "max_iterations"
-
-
-@pytest.mark.asyncio
-async def test_runner_goal_continue_not_limited_by_injection_cycle_cap():
-    """Synthetic goal continuation should be governed by max_iterations."""
-    from nanobot.agent.runner import _MAX_INJECTION_CYCLES, AgentRunner
-
-    provider = MagicMock(spec=LLMProvider)
-    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(
-        content="still working", tool_calls=[], usage={},
-    ))
-    tools = MagicMock()
-    tools.get_definitions.return_value = []
-    max_iterations = _MAX_INJECTION_CYCLES + 3
-
-    runner = AgentRunner()
-    result = await runner.run(make_run_spec(provider,
-        initial_messages=[{"role": "user", "content": "do task"}],
-        tools=tools,
-        model="test-model",
-        max_iterations=max_iterations,
-        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
-        goal_active_predicate=lambda: True,
-        finalize_on_max_iterations=False,
-    ))
-
-    assert result.stop_reason == "max_iterations"
-    assert provider.chat_with_retry.await_count == max_iterations
-
-
-@pytest.mark.asyncio
-async def test_runner_does_not_force_continue_on_error():
-    """Even with active goal, an LLM error should exit with stop_reason="error"."""
-    from nanobot.agent.runner import AgentRunner
-
-    provider = MagicMock(spec=LLMProvider)
-    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(
-        content=None, tool_calls=[], usage={},
-        finish_reason="error",
-    ))
-    tools = MagicMock()
-    tools.get_definitions.return_value = []
-
-    runner = AgentRunner()
-    result = await runner.run(make_run_spec(provider,
-        initial_messages=[{"role": "user", "content": "do task"}],
-        tools=tools,
-        model="test-model",
-        max_iterations=2,
-        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
-        goal_active_predicate=lambda: True,
-    ))
-
-    assert result.stop_reason == "error"
-
-
-@pytest.mark.asyncio
-async def test_runner_uses_custom_goal_continue_message():
-    """Custom goal_continue_message should be injected instead of the default."""
-    from nanobot.agent.runner import AgentRunner
-
-    provider = MagicMock(spec=LLMProvider)
-    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(
-        content="still working", tool_calls=[], usage={},
-    ))
-    tools = MagicMock()
-    tools.get_definitions.return_value = []
-
-    custom_msg = "CUSTOM_CONTINUE_PLEASE"
-
-    runner = AgentRunner()
-    result = await runner.run(make_run_spec(provider,
-        initial_messages=[{"role": "user", "content": "do task"}],
-        tools=tools,
-        model="test-model",
-        max_iterations=2,
-        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
-        goal_active_predicate=lambda: True,
-        goal_continue_message=custom_msg,
-    ))
-
-    user_msgs = [m for m in result.messages if m.get("role") == "user"]
-    assert any(custom_msg in str(m.get("content", "")) for m in user_msgs)
-
-
-@pytest.mark.asyncio
-async def test_runner_resolves_goal_continue_message_lazily():
-    """The continuation text can depend on goal metadata created during the run."""
-    from nanobot.agent.runner import AgentRunner
-
-    provider = MagicMock(spec=LLMProvider)
-    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(
-        content="still working", tool_calls=[], usage={},
-    ))
-    tools = MagicMock()
-    tools.get_definitions.return_value = []
-    calls = {"n": 0}
-
-    def dynamic_msg() -> str:
-        calls["n"] += 1
-        return "Goal (active):\nWrite the article draft."
-
-    runner = AgentRunner()
-    result = await runner.run(make_run_spec(provider,
-        initial_messages=[{"role": "user", "content": "do task"}],
-        tools=tools,
-        model="test-model",
-        max_iterations=1,
-        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
-        goal_active_predicate=lambda: True,
-        goal_continue_message=dynamic_msg,
-        finalize_on_max_iterations=False,
-    ))
-
-    user_msgs = [m for m in result.messages if m.get("role") == "user"]
-    assert calls["n"] == 1
-    assert any("Write the article draft." in str(m.get("content", "")) for m in user_msgs)
+    assert result.stop_reason == "completed"
+    assert result.final_content == "Which day should I start?"
+    assert provider.chat_with_retry.await_count == 1


### PR DESCRIPTION
## Summary

- Stop automatically re-injecting sustained-goal continuation after a normal model response.
- Preserve continuation at the actual tool-call budget boundary.

## Root cause and impact

When a sustained goal was active, `AgentRunner` treated every plain-text final response as a reason to prompt the model again. If the model asked the user for clarification, the runner generated duplicate visible replies until its iteration budget was exhausted. A normal clarification now ends the turn so the user can answer.

## Verification

- `pytest tests/agent/test_runner_goal_continue.py tests/agent/test_runner_core.py tests/agent/test_loop_save_turn.py tests/session/test_turn_continuation.py -q` (101 passed)
- `ruff check` on all changed files

Fixes #5256
