### PR TITLE
fix(gateway): flush background child output to logs

### DIFF
--- a/nanobot/process_runtime.py
+++ b/nanobot/process_runtime.py
@@ -128,6 +128,7 @@ class ManagedProcessRuntime(Generic[_StartOptionsT]):
                 stdin=subprocess.DEVNULL,
                 stdout=log_handle,
                 stderr=subprocess.STDOUT,
+                env={**os.environ, "PYTHONUNBUFFERED": "1"},
                 **self._popen_platform_kwargs(),
             )
         self._owned_process = process

--- a/tests/gateway/test_runtime.py
+++ b/tests/gateway/test_runtime.py
@@ -169,6 +169,7 @@ def test_custom_instance_round_trips_the_same_child_selectors(tmp_path: Path) ->
 
 def test_start_background_writes_state_and_child_command(tmp_path, monkeypatch):
     calls: list[dict] = []
+    monkeypatch.setenv("NANOBOT_TEST_INHERITED_ENV", "preserved")
 
     def fake_popen(command, **kwargs):
         calls.append({"command": command, "kwargs": kwargs})
@@ -210,6 +211,8 @@ def test_start_background_writes_state_and_child_command(tmp_path, monkeypatch):
         "/tmp/config.json",
     ]
     assert calls[0]["kwargs"]["start_new_session"] is True
+    assert calls[0]["kwargs"]["env"]["PYTHONUNBUFFERED"] == "1"
+    assert calls[0]["kwargs"]["env"]["NANOBOT_TEST_INHERITED_ENV"] == "preserved"
     state = json.loads(runtime.paths.state_path.read_text(encoding="utf-8"))
     assert state["pid"] == 12345
     assert state["identity"] == 12345


### PR DESCRIPTION
## Summary

Make early output from background gateway/API processes available in their log files promptly.

## Problem

`ManagedProcessRuntime` redirects background Python process output to a file. Because the file is not a TTY, Python can block-buffer stdout, so startup messages may remain in memory. If the child hangs or exits before flushing, the log can be empty and provide no useful diagnosis.

I ran into this while using nanobot: a background startup failed while its log stayed empty, making the failure difficult to investigate.

## Change

- Set `PYTHONUNBUFFERED=1` for background child processes.
- Preserve the parent environment and leave readiness and health behavior unchanged.

## Testing

- `uv run --no-sync pytest tests/gateway -q` — 48 passed, 2 skipped
- Gateway CLI tests — 28 passed
- Targeted BasedPyright — passed
- Ruff — passed

## Scope

This only fixes output buffering at the background process boundary. It does not add a readiness probe or change the process-management contract.
