### PR TITLE
fix(providers): apply fallback policy to raised errors

### DIFF
--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -987,14 +987,16 @@ class LLMProvider(ABC):
         except (TypeError, ValueError):
             error_status_code = None
 
+        raw_error_type = getattr(exc, "error_type", None)
+        raw_error_code = getattr(exc, "error_code", None)
         detail = str(exc).strip() or type(exc).__name__
         return LLMResponse(
             content=f"Error calling LLM: {detail}",
             finish_reason="error",
             error_status_code=error_status_code,
             error_kind=error_kind,
-            error_type=getattr(exc, "error_type", None),
-            error_code=getattr(exc, "error_code", None),
+            error_type=str(raw_error_type) if raw_error_type is not None else None,
+            error_code=str(raw_error_code) if raw_error_code is not None else None,
             error_should_retry=error_should_retry,
         )
 

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -943,6 +943,61 @@ class LLMProvider(ABC):
         """
         pass
 
+    @staticmethod
+    def _error_response_from_exception(exc: Exception) -> LLMResponse:
+        """Convert an unexpected exception while retaining retry metadata."""
+        error_names = tuple(cls.__name__.lower() for cls in type(exc).__mro__)
+        error_kind: str | None = None
+        error_should_retry: bool | None = None
+        if any("timeout" in name for name in error_names):
+            error_kind = "timeout"
+            error_should_retry = True
+        elif any(
+            token in name
+            for name in error_names
+            for token in ("connect", "connection", "network", "protocol", "transport")
+        ):
+            error_kind = "connection"
+            error_should_retry = True
+        elif any(
+            "ratelimit" in name or "throttl" in name
+            for name in error_names
+        ):
+            error_kind = "rate_limit"
+            error_should_retry = True
+        elif any(
+            "server" in name or "internal" in name
+            for name in error_names
+        ):
+            error_kind = "server_error"
+            error_should_retry = True
+        elif any(
+            token in name
+            for name in error_names
+            for token in ("auth", "credential", "permissiondenied", "unauthor")
+        ):
+            error_kind = "authentication"
+
+        response = getattr(exc, "response", None)
+        raw_status = getattr(exc, "status_code", None)
+        if raw_status is None and response is not None:
+            raw_status = getattr(response, "status_code", None)
+        try:
+            error_status_code = int(raw_status) if raw_status is not None else None
+        except (TypeError, ValueError):
+            error_status_code = None
+
+        detail = str(exc).strip() or type(exc).__name__
+        return LLMResponse(
+            content=f"Error calling LLM: {detail}",
+            finish_reason="error",
+            error_status_code=error_status_code,
+            error_kind=error_kind,
+            error_type=getattr(exc, "error_type", None),
+            error_code=getattr(exc, "error_code", None),
+            error_should_retry=error_should_retry,
+        )
+
     @classmethod
     def _is_transient_error(cls, content: str | None) -> bool:
         err = (content or "").lower()
@@ -1226,7 +1281,7 @@ class LLMProvider(ABC):
             )
             raise
         except Exception as exc:
-            response = LLMResponse(content=f"Error calling LLM: {exc}", finish_reason="error")
+            response = self._error_response_from_exception(exc)
         return self._observe_llm_call(
             response,
             kwargs,
@@ -1368,7 +1423,7 @@ class LLMProvider(ABC):
             )
             raise
         except Exception as exc:
-            response = LLMResponse(content=f"Error calling LLM: {exc}", finish_reason="error")
+            response = self._error_response_from_exception(exc)
         return self._observe_llm_call(
             _attach_stream_timing(response),
             kwargs,

--- a/nanobot/providers/fallback_provider.py
+++ b/nanobot/providers/fallback_provider.py
@@ -623,6 +623,8 @@ class FallbackProvider(LLMProvider):
             raise
         except Exception as exc:
             error_name = type(exc).__name__.lower()
+            detail = str(exc).strip() or type(exc).__name__
+            detail_lower = detail.lower()
             error_kind: str | None = None
             error_should_retry: bool | None = None
             if isinstance(exc, (httpx.TimeoutException, asyncio.TimeoutError)):
@@ -634,7 +636,7 @@ class FallbackProvider(LLMProvider):
             elif any(
                 token in error_name
                 for token in ("auth", "credential", "permissiondenied", "unauthor")
-            ):
+            ) or any(token in detail_lower for token in _AUTHENTICATION_ERROR_TOKENS):
                 error_kind = "authentication"
             elif "ratelimit" in error_name or "throttl" in error_name:
                 error_kind = "rate_limit"
@@ -652,7 +654,6 @@ class FallbackProvider(LLMProvider):
             except (TypeError, ValueError):
                 error_status_code = None
 
-            detail = str(exc).strip() or type(exc).__name__
             return LLMResponse(
                 content=f"Error calling LLM: {detail}",
                 finish_reason="error",

--- a/nanobot/providers/fallback_provider.py
+++ b/nanobot/providers/fallback_provider.py
@@ -10,7 +10,6 @@ from collections.abc import Awaitable, Callable
 from dataclasses import replace
 from typing import Any
 
-import httpx
 from loguru import logger
 
 from nanobot.providers.base import (
@@ -622,45 +621,13 @@ class FallbackProvider(LLMProvider):
         except asyncio.CancelledError:
             raise
         except Exception as exc:
-            error_name = type(exc).__name__.lower()
-            detail = str(exc).strip() or type(exc).__name__
-            detail_lower = detail.lower()
-            error_kind: str | None = None
-            error_should_retry: bool | None = None
-            if isinstance(exc, (httpx.TimeoutException, asyncio.TimeoutError)):
-                error_kind = "timeout"
-                error_should_retry = True
-            elif isinstance(exc, (httpx.NetworkError, httpx.TransportError, ConnectionError)):
-                error_kind = "connection"
-                error_should_retry = True
-            elif any(
-                token in error_name
-                for token in ("auth", "credential", "permissiondenied", "unauthor")
-            ) or any(token in detail_lower for token in _AUTHENTICATION_ERROR_TOKENS):
-                error_kind = "authentication"
-            elif "ratelimit" in error_name or "throttl" in error_name:
-                error_kind = "rate_limit"
-                error_should_retry = True
-            elif "server" in error_name or "internal" in error_name:
-                error_kind = "server_error"
-                error_should_retry = True
-
-            response = getattr(exc, "response", None)
-            raw_status = getattr(exc, "status_code", None)
-            if raw_status is None and response is not None:
-                raw_status = getattr(response, "status_code", None)
-            try:
-                error_status_code = int(raw_status) if raw_status is not None else None
-            except (TypeError, ValueError):
-                error_status_code = None
-
-            return LLMResponse(
-                content=f"Error calling LLM: {detail}",
-                finish_reason="error",
-                error_status_code=error_status_code,
-                error_kind=error_kind,
-                error_should_retry=error_should_retry,
-            ), exc
+            response = LLMProvider._error_response_from_exception(exc)
+            if response.error_kind is None and any(
+                token in (str(exc).strip() or type(exc).__name__).lower()
+                for token in _AUTHENTICATION_ERROR_TOKENS
+            ):
+                response.error_kind = "authentication"
+            return response, exc
 
     async def _notify_fallback_model(self, model: str) -> None:
         if self._fallback_model_observer is None:

--- a/nanobot/providers/fallback_provider.py
+++ b/nanobot/providers/fallback_provider.py
@@ -4,11 +4,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import replace
 from typing import Any
 
+import httpx
 from loguru import logger
 
 from nanobot.providers.base import (
@@ -59,6 +61,7 @@ _AUTHENTICATION_ERROR_TOKENS = (
     "access_denied",
     "account_deactivated",
     "organization_deactivated",
+    "not logged in",
 )
 _NON_FALLBACK_ERROR_KINDS = frozenset({
     "content_filter",
@@ -428,7 +431,14 @@ class FallbackProvider(LLMProvider):
 
         if self._primary_available():
             primary_was_attempted = True
-            response = await call(self._primary, kwargs)
+            response, primary_exception = await self._call_provider(
+                call, self._primary, kwargs
+            )
+            if primary_exception is not None:
+                logger.warning(
+                    "Primary model '{}' raised {} before responding",
+                    primary_model, type(primary_exception).__name__,
+                )
             if response.finish_reason != "error":
                 self._primary_failures = 0
                 self._primary_tripped_at = None
@@ -457,7 +467,7 @@ class FallbackProvider(LLMProvider):
 
             if not self._should_fallback(response):
                 logger.warning(
-                    "Primary model '{}' returned non-fallbackable error: {}",
+                    "Primary model '{}' failed with non-fallbackable error: {}",
                     primary_model,
                     (response.content or "")[:120],
                 )
@@ -544,7 +554,14 @@ class FallbackProvider(LLMProvider):
                 fallback_kwargs.pop("reasoning_effort", None)
             else:
                 fallback_kwargs["reasoning_effort"] = fallback.reasoning_effort
-            fallback_response = await call(fallback_provider, fallback_kwargs)
+            fallback_response, fallback_exception = await self._call_provider(
+                call, fallback_provider, fallback_kwargs
+            )
+            if fallback_exception is not None:
+                logger.warning(
+                    "Fallback '{}' raised {}",
+                    fallback_model, type(fallback_exception).__name__,
+                )
 
             if fallback_response.finish_reason != "error":
                 # Do not publish a model switch merely because a fallback was
@@ -592,6 +609,57 @@ class FallbackProvider(LLMProvider):
             error_retry_after_s=retry_after_s,
             error_should_retry=True,
         )
+
+    @staticmethod
+    async def _call_provider(
+        call: Callable[[LLMProvider, dict[str, Any]], Awaitable[LLMResponse]],
+        provider: LLMProvider,
+        kwargs: dict[str, Any],
+    ) -> tuple[LLMResponse, Exception | None]:
+        """Turn provider exceptions into error responses without swallowing cancellation."""
+        try:
+            return await call(provider, kwargs), None
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            error_name = type(exc).__name__.lower()
+            error_kind: str | None = None
+            error_should_retry: bool | None = None
+            if isinstance(exc, (httpx.TimeoutException, asyncio.TimeoutError)):
+                error_kind = "timeout"
+                error_should_retry = True
+            elif isinstance(exc, (httpx.NetworkError, httpx.TransportError, ConnectionError)):
+                error_kind = "connection"
+                error_should_retry = True
+            elif any(
+                token in error_name
+                for token in ("auth", "credential", "permissiondenied", "unauthor")
+            ):
+                error_kind = "authentication"
+            elif "ratelimit" in error_name or "throttl" in error_name:
+                error_kind = "rate_limit"
+                error_should_retry = True
+            elif "server" in error_name or "internal" in error_name:
+                error_kind = "server_error"
+                error_should_retry = True
+
+            response = getattr(exc, "response", None)
+            raw_status = getattr(exc, "status_code", None)
+            if raw_status is None and response is not None:
+                raw_status = getattr(response, "status_code", None)
+            try:
+                error_status_code = int(raw_status) if raw_status is not None else None
+            except (TypeError, ValueError):
+                error_status_code = None
+
+            detail = str(exc).strip() or type(exc).__name__
+            return LLMResponse(
+                content=f"Error calling LLM: {detail}",
+                finish_reason="error",
+                error_status_code=error_status_code,
+                error_kind=error_kind,
+                error_should_retry=error_should_retry,
+            ), exc
 
     async def _notify_fallback_model(self, model: str) -> None:
         if self._fallback_model_observer is None:

--- a/tests/agent/test_runner_fallback.py
+++ b/tests/agent/test_runner_fallback.py
@@ -423,6 +423,19 @@ class TestFallbackWhenPrimaryRaises:
         assert result.finish_reason == "stop"
         factory.assert_called_once_with(_fallback("fallback-a"))
 
+    @pytest.mark.asyncio
+    async def test_authentication_exception_message_is_classified(self) -> None:
+        primary = _RaisingProvider("primary")
+
+        response, exception = await FallbackProvider._call_provider(
+            lambda provider, kwargs: provider.chat(**kwargs),
+            primary,
+            {},
+        )
+
+        assert exception is primary._exc
+        assert response.error_kind == "authentication"
+
     @pytest.mark.parametrize(
         "exc",
         [

--- a/tests/agent/test_runner_fallback.py
+++ b/tests/agent/test_runner_fallback.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from loguru import logger
 
@@ -346,6 +348,190 @@ class TestNoFallbackWhenPrimarySucceeds:
         assert result.finish_reason == "stop"
         factory.assert_not_called()
 
+
+class _RaisingProvider(LLMProvider):
+    """Provider whose chat/chat_stream raise, like an auth/setup failure."""
+
+    def __init__(self, name: str = "raiser", exc: BaseException | None = None):
+        super().__init__()
+        self.name = name
+        self._exc = exc if exc is not None else RuntimeError("GitHub Copilot is not logged in.")
+
+    def get_default_model(self) -> str:
+        return f"{self.name}/model"
+
+    async def chat(self, **kwargs: Any) -> LLMResponse:
+        raise self._exc
+
+    async def chat_stream(self, **kwargs: Any) -> LLMResponse:
+        raise self._exc
+
+
+class _StreamingThenRaisingProvider(_RaisingProvider):
+    async def chat_stream(self, **kwargs: Any) -> LLMResponse:
+        on_content_delta = kwargs.get("on_content_delta")
+        if on_content_delta:
+            await on_content_delta("partial")
+        raise self._exc
+
+
+class TestFallbackWhenPrimaryRaises:
+    @pytest.mark.parametrize(
+        "exc",
+        [TimeoutError(), httpx.ReadTimeout(""), httpx.ConnectError("")],
+        ids=["asyncio-timeout", "httpx-timeout", "connection"],
+    )
+    @pytest.mark.asyncio
+    async def test_transient_exception_triggers_fallback(self, exc: Exception) -> None:
+        """Transient exceptions remain eligible even when their messages are empty."""
+        primary = _RaisingProvider("primary", exc)
+        fallback = _FakeProvider("fallback", _make_response("fallback ok"))
+        factory = MagicMock(return_value=fallback)
+
+        fb = FallbackProvider(
+            primary=primary,
+            fallback_presets=[_fallback("fallback-a")],
+            provider_factory=factory,
+        )
+
+        result = await fb.chat(messages=[{"role": "user", "content": "hi"}], model="primary-model")
+
+        assert result.content == "fallback ok"
+        assert result.finish_reason == "stop"
+        factory.assert_called_once_with(_fallback("fallback-a"))
+
+    @pytest.mark.asyncio
+    async def test_primary_exception_triggers_fallback(self) -> None:
+        """A primary whose chat() raises must not abort failover.
+
+        GitHubCopilotProvider.chat refreshes its token before the request and
+        raises when not logged in; the exception must be treated as a
+        fallbackable primary error, not swallow the whole fallback chain.
+        """
+        primary = _RaisingProvider("primary")
+        fallback = _FakeProvider("fallback", _make_response("fallback ok"))
+        factory = MagicMock(return_value=fallback)
+
+        fb = FallbackProvider(
+            primary=primary,
+            fallback_presets=[_fallback("fallback-a")],
+            provider_factory=factory,
+        )
+
+        result = await fb.chat(messages=[{"role": "user", "content": "hi"}], model="primary-model")
+        assert result.content == "fallback ok"
+        assert result.finish_reason == "stop"
+        factory.assert_called_once_with(_fallback("fallback-a"))
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            ValueError("unexpected response shape"),
+            PermissionError("local provider file access failed"),
+        ],
+        ids=["value-error", "local-permission-error"],
+    )
+    @pytest.mark.asyncio
+    async def test_non_fallbackable_primary_exception_does_not_trigger_fallback(
+        self, exc: Exception,
+    ) -> None:
+        """An unrelated provider bug must not silently switch models."""
+        primary = _RaisingProvider("primary", exc)
+        factory = MagicMock(
+            return_value=_FakeProvider("fallback", _make_response("fallback"))
+        )
+        fb = FallbackProvider(
+            primary=primary,
+            fallback_presets=[_fallback("fallback-a")],
+            provider_factory=factory,
+        )
+
+        result = await fb.chat(
+            messages=[{"role": "user", "content": "hi"}],
+            model="primary-model",
+        )
+
+        assert result.finish_reason == "error"
+        assert result.content is not None
+        assert str(exc) in result.content
+        factory.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fallback_exception_advances_to_next_fallback(self) -> None:
+        """A fallback whose chat() raises must advance to the next fallback."""
+        primary = _FakeProvider("primary", _error_response())
+        raising_fb = _RaisingProvider("fb1")
+        ok_fb = _FakeProvider("fb2", _make_response("second fallback ok"))
+        factory = MagicMock(side_effect=[raising_fb, ok_fb])
+
+        fb = FallbackProvider(
+            primary=primary,
+            fallback_presets=[_fallback("fallback-a"), _fallback("fallback-b")],
+            provider_factory=factory,
+        )
+
+        result = await fb.chat(messages=[{"role": "user", "content": "hi"}], model="primary-model")
+        assert result.content == "second fallback ok"
+        assert result.finish_reason == "stop"
+
+    @pytest.mark.asyncio
+    async def test_primary_exception_stream_triggers_fallback(self) -> None:
+        """Streaming path: a raising primary still fails over when nothing streamed."""
+        primary = _RaisingProvider("primary")
+        fallback = _FakeProvider("fallback", _make_response("fallback ok"))
+        factory = MagicMock(return_value=fallback)
+
+        fb = FallbackProvider(
+            primary=primary,
+            fallback_presets=[_fallback("fallback-a")],
+            provider_factory=factory,
+        )
+
+        result = await fb.chat_stream(messages=[{"role": "user", "content": "hi"}], model="primary-model")
+        assert result.content == "fallback ok"
+        assert result.finish_reason == "stop"
+
+    @pytest.mark.asyncio
+    async def test_primary_exception_after_streaming_does_not_duplicate_output(self) -> None:
+        """Once content was emitted, an exception must not start a replacement stream."""
+        primary = _StreamingThenRaisingProvider("primary")
+        factory = MagicMock(return_value=_FakeProvider("fallback", _make_response("duplicate")))
+        deltas: list[str] = []
+
+        fb = FallbackProvider(
+            primary=primary,
+            fallback_presets=[_fallback("fallback-a")],
+            provider_factory=factory,
+        )
+
+        async def collect_delta(text: str) -> None:
+            deltas.append(text)
+
+        result = await fb.chat_stream(
+            messages=[{"role": "user", "content": "hi"}],
+            model="primary-model",
+            on_content_delta=collect_delta,
+        )
+
+        assert deltas == ["partial"]
+        assert result.finish_reason == "error"
+        factory.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_primary_cancellation_is_not_converted_to_failover(self) -> None:
+        """Task cancellation must retain asyncio cancellation semantics."""
+        primary = _RaisingProvider("primary", asyncio.CancelledError())
+        factory = MagicMock(return_value=_FakeProvider("fallback", _make_response("fallback")))
+        fb = FallbackProvider(
+            primary=primary,
+            fallback_presets=[_fallback("fallback-a")],
+            provider_factory=factory,
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await fb.chat(messages=[{"role": "user", "content": "hi"}])
+
+        factory.assert_not_called()
 
 class TestFallbackOnPrimaryError:
     @pytest.mark.asyncio

--- a/tests/agent/test_runner_fallback.py
+++ b/tests/agent/test_runner_fallback.py
@@ -460,6 +460,28 @@ class TestFallbackWhenPrimaryRaises:
         assert exception is primary._exc
         assert response.error_kind == "authentication"
 
+    @pytest.mark.asyncio
+    async def test_non_string_exception_metadata_is_normalized_before_fallback(self) -> None:
+        """Provider exception metadata must be string-like before fallback consumes it."""
+
+        class NumericMetadataError(Exception):
+            error_type = 429
+            error_code = 429
+            status_code = 429
+
+        primary = _RaisingProvider("primary", NumericMetadataError("rate limited"))
+
+        response, exception = await FallbackProvider._call_provider(
+            lambda provider, kwargs: provider.chat(**kwargs),
+            primary,
+            {},
+        )
+
+        assert exception is primary._exc
+        assert response.error_type == "429"
+        assert response.error_code == "429"
+        assert FallbackProvider._should_fallback(response) is True
+
     @pytest.mark.parametrize(
         "exc",
         [

--- a/tests/agent/test_runner_fallback.py
+++ b/tests/agent/test_runner_fallback.py
@@ -353,7 +353,7 @@ class _RaisingProvider(LLMProvider):
     """Provider whose chat/chat_stream raise, like an auth/setup failure."""
 
     def __init__(self, name: str = "raiser", exc: BaseException | None = None):
-        super().__init__()
+        super().__init__(provider_name=name)
         self.name = name
         self._exc = exc if exc is not None else RuntimeError("GitHub Copilot is not logged in.")
 
@@ -378,8 +378,8 @@ class _StreamingThenRaisingProvider(_RaisingProvider):
 class TestFallbackWhenPrimaryRaises:
     @pytest.mark.parametrize(
         "exc",
-        [TimeoutError(), httpx.ReadTimeout(""), httpx.ConnectError("")],
-        ids=["asyncio-timeout", "httpx-timeout", "connection"],
+        [TimeoutError(), httpx.ReadTimeout(""), httpx.ConnectError(""), httpx.ReadError("")],
+        ids=["asyncio-timeout", "httpx-timeout", "connection", "httpx-network-error"],
     )
     @pytest.mark.asyncio
     async def test_transient_exception_triggers_fallback(self, exc: Exception) -> None:
@@ -419,6 +419,30 @@ class TestFallbackWhenPrimaryRaises:
         )
 
         result = await fb.chat(messages=[{"role": "user", "content": "hi"}], model="primary-model")
+        assert result.content == "fallback ok"
+        assert result.finish_reason == "stop"
+        factory.assert_called_once_with(_fallback("fallback-a"))
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("stream", [False, True], ids=["chat", "stream"])
+    async def test_retry_entry_point_preserves_transient_exception_metadata(
+        self,
+        stream: bool,
+    ) -> None:
+        """A retry wrapper must not hide an empty transient exception from failover."""
+        primary = _RaisingProvider("primary", TimeoutError())
+        fallback = _FakeProvider("fallback", _make_response("fallback ok"))
+        factory = MagicMock(return_value=fallback)
+
+        fb = FallbackProvider(
+            primary=primary,
+            fallback_presets=[_fallback("fallback-a")],
+            provider_factory=factory,
+        )
+
+        retry = fb.chat_stream_with_retry if stream else fb.chat_with_retry
+        result = await retry(messages=[{"role": "user", "content": "hi"}], model="primary-model")
+
         assert result.content == "fallback ok"
         assert result.finish_reason == "stop"
         factory.assert_called_once_with(_fallback("fallback-a"))


### PR DESCRIPTION
## Summary

When an LLM provider raises an exception instead of returning an error response, the fallback chain now applies its existing error policy.

## Problem

The fallback loop expects provider failures to be represented by `LLMResponse(finish_reason="error")`. A provider exception could escape that path, so a configured fallback was never tried. This can happen while GitHub Copilot is handling an unauthenticated token.

Some exceptions also expose `error_type` or `error_code` as non-string values. Passing those values through unchanged caused fallback classification to call `.lower()` on them. For example, `error_code=429` could raise a second `AttributeError` and stop failover.

## Changes

- Convert ordinary provider exceptions into error responses with retry metadata.
- Normalize `error_type` and `error_code` to `str | None` at the response boundary.
- Preserve `asyncio.CancelledError` instead of treating cancellation as a failover condition.
- Apply the handling to primary and fallback providers, while avoiding duplicate failover after a stream has emitted content.

## Testing

- `uv run --no-sync pytest tests/agent/test_runner_fallback.py tests/providers/test_provider_retry.py tests/providers/test_provider_error_metadata.py -q` (114 passed)
- Added coverage for numeric exception metadata, authentication errors, transient failures, cancellation, streaming, and non-fallbackable errors.
- Ruff passed.
- Targeted BasedPyright passed with 0 errors, 0 warnings, and 0 notes.

## Scope

This makes raised exceptions follow the existing fallback policy. It does not change provider configuration, retry limits, or the public provider API.