### PR TITLE
fix(gateway): adopt Windows venv child process

### DIFF
--- a/nanobot/gateway/runtime.py
+++ b/nanobot/gateway/runtime.py
@@ -287,14 +287,24 @@ class GatewayRuntime(ManagedProcessRuntime[ProcessStartOptions]):
             lease.wait_for_shutdown()
             with self._transition_lock(), self._lifecycle_lock():
                 current = self.status()
-                if current.running and current.pid != pid:
+                # A Windows venv launcher stays alive as the managed Popen child
+                # while the real Python interpreter runs as its direct child.
+                # Let that interpreter adopt only its recorded background launch.
+                adopting_windows_launcher = (
+                    self.platform_name == "Windows"
+                    and current.running
+                    and current.launch_mode == "background"
+                    and current.pid == os.getppid()
+                )
+                if current.running and current.pid != pid and not adopting_windows_launcher:
                     raise GatewayAlreadyRunningError(current)
                 if lease._shutdown_pending_locked():
                     continue
                 state = self._read_state() or {}
                 launch_mode: GatewayLaunchMode = (
                     "background"
-                    if state.get("pid") == pid and state.get("launch_mode") == "background"
+                    if state.get("launch_mode") == "background"
+                    and (state.get("pid") == pid or adopting_windows_launcher)
                     else "foreground"
                 )
                 state.update(

--- a/tests/gateway/test_runtime.py
+++ b/tests/gateway/test_runtime.py
@@ -245,6 +245,33 @@ def test_foreground_gateway_claim_is_discoverable_and_released(tmp_path, monkeyp
     assert not runtime.paths.state_path.exists()
 
 
+def test_windows_gateway_adopts_its_managed_venv_launcher(tmp_path, monkeypatch):
+    launcher_pid = 12345
+    gateway_pid = 54321
+    runtime = GatewayRuntime(paths=_paths(tmp_path), platform_name="Windows")
+    monkeypatch.setattr("nanobot.gateway.runtime.os.getpid", lambda: gateway_pid)
+    monkeypatch.setattr("nanobot.gateway.runtime.os.getppid", lambda: launcher_pid)
+    monkeypatch.setattr(runtime, "_is_pid_running", lambda _pid: True)
+    monkeypatch.setattr(runtime, "_process_identity", lambda pid: f"created-at:{pid}")
+    GatewayClientLease(runtime, kind="tui").mark_ephemeral()
+    runtime._write_state(
+        {
+            "pid": launcher_pid,
+            "identity": f"created-at:{launcher_pid}",
+            "launch_mode": "background",
+        }
+    )
+
+    with runtime.foreground_instance(GatewayStartOptions(port=18790)):
+        status = runtime.status()
+        assert status.running is True
+        assert status.pid == gateway_pid
+        assert status.launch_mode == "background"
+        assert status.lifetime == "on_demand"
+
+    assert not runtime.paths.state_path.exists()
+
+
 def test_explicit_foreground_gateway_clears_stale_auto_stop_state(tmp_path, monkeypatch):
     runtime = GatewayRuntime(paths=_paths(tmp_path), platform_name="Darwin")
     monkeypatch.setattr(runtime, "_process_identity", lambda pid: pid)


### PR DESCRIPTION
## Summary

- allow a managed Windows gateway interpreter to adopt the recorded PID of its direct venv launcher
- preserve the gateway's background and on-demand lifecycle during PID handoff
- add a regression test for the uv/venv launcher process layout

## Problem

On Windows, a virtual-environment `python.exe` can remain as a launcher while the real interpreter runs as its child. The background runtime records `Popen.pid`, but the gateway compares that launcher PID with its own interpreter PID and incorrectly reports that another gateway is already running.

## Tests

- `uv run pytest tests/gateway/test_runtime.py -q` (`38 passed, 2 skipped`)
- `uv run ruff check nanobot/gateway/runtime.py tests/gateway/test_runtime.py`
- `git diff --check`