### PR TITLE
fix(gateway): stabilize process identities

### DIFF
--- a/nanobot/gateway/runtime.py
+++ b/nanobot/gateway/runtime.py
@@ -535,12 +535,7 @@ class GatewayClientLease:
             if not isinstance(pid, int) or not self._process_is_running(pid):
                 stale.append(token)
                 continue
-            current_identity = self._process_identity(pid)
-            if (
-                identity is not None
-                and current_identity is not None
-                and identity != current_identity
-            ):
+            if self._process_identity_match(identity, pid) == "mismatch":
                 stale.append(token)
         for token in stale:
             clients.pop(token, None)
@@ -550,6 +545,23 @@ class GatewayClientLease:
         resolver = getattr(self.runtime, "process_identity", None)
         value = resolver(pid) if callable(resolver) else None
         return value if isinstance(value, (str, int)) else None
+
+    def _process_identity_match(
+        self,
+        recorded: object,
+        pid: int,
+    ) -> Literal["match", "mismatch", "unknown"]:
+        matcher = getattr(self.runtime, "process_identity_match", None)
+        if callable(matcher):
+            result = matcher(recorded, pid)
+            if result in {"match", "mismatch", "unknown"}:
+                return cast(Literal["match", "mismatch", "unknown"], result)
+        if recorded is None:
+            return "match"
+        current = self._process_identity(pid)
+        if current is None:
+            return "unknown"
+        return "match" if recorded == current else "mismatch"
 
     def _process_is_running(self, pid: int) -> bool:
         checker = getattr(self.runtime, "process_is_running", None)

--- a/nanobot/gateway/runtime.py
+++ b/nanobot/gateway/runtime.py
@@ -28,6 +28,7 @@ from nanobot.process_runtime import (
     ProcessRuntimePaths,
     ProcessStartOptions,
     ProcessStatus,
+    process_identity_record,
     process_is_running,
 )
 
@@ -300,7 +301,6 @@ class GatewayRuntime(ManagedProcessRuntime[ProcessStartOptions]):
                 state.update(
                     {
                         "pid": pid,
-                        "identity": self._process_identity(pid),
                         "started_at": datetime.now(UTC).isoformat(),
                         "platform": self.platform_name,
                         "port": options.port,
@@ -311,6 +311,8 @@ class GatewayRuntime(ManagedProcessRuntime[ProcessStartOptions]):
                         "launch_mode": launch_mode,
                     }
                 )
+                state.pop("stable_identity", None)
+                state.update(self.process_identity_record(pid))
                 self._write_state(state)
                 if launch_mode == "foreground":
                     lease._try_mark_persistent_locked()
@@ -513,11 +515,12 @@ class GatewayClientLease:
 
     def _register(self, state: dict[str, object]) -> None:
         clients = self._clients(state)
-        clients[self.token] = {
+        record: dict[str, object] = {
             "pid": self.pid,
             "kind": self.kind,
-            "identity": self._process_identity(self.pid),
         }
+        record.update(process_identity_record(self._process_identity(self.pid), lease=True))
+        clients[self.token] = record
         self._write_state(state)
         self._acquired = True
 
@@ -531,7 +534,9 @@ class GatewayClientLease:
                 continue
             record = cast(dict[str, object], value)
             pid = record.get("pid")
-            identity = record.get("identity")
+            identity = record.get("stable_identity")
+            if identity is None:
+                identity = record.get("identity")
             if not isinstance(pid, int) or not self._process_is_running(pid):
                 stale.append(token)
                 continue

--- a/nanobot/process_runtime.py
+++ b/nanobot/process_runtime.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import ctypes
 import json
 import os
+import re
 import signal
+import struct
 import subprocess
 import sys
 import tempfile
@@ -15,6 +17,7 @@ from contextlib import suppress
 from ctypes import wintypes
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Generic, Literal, TypeVar, cast
 
@@ -270,6 +273,33 @@ class ManagedProcessRuntime(Generic[_StartOptionsT]):
         """Return an identity that changes when an operating-system PID is reused."""
         return self._process_identity(pid)
 
+    def process_identity_match(
+        self,
+        recorded: object,
+        pid: int,
+    ) -> Literal["match", "mismatch", "unknown"]:
+        """Compare a recorded identity with the current process safely."""
+        if recorded is None:
+            return "match"
+        current = self._process_identity(pid)
+        if current is None:
+            return "unknown"
+        if recorded == current:
+            return "match"
+        # Older POSIX state files stored only the process group id.
+        if (
+            isinstance(recorded, int)
+            and isinstance(current, str)
+            and (
+                current.startswith(f"{recorded}:")
+                or current.startswith(f"darwin:{recorded}:")
+            )
+        ):
+            return "match"
+        if self.platform_name == "Darwin":
+            return _darwin_identity_match(recorded, current)
+        return "mismatch"
+
     def process_is_running(self, pid: int) -> bool:
         """Return whether the recorded operating-system process is still live."""
         return self._is_pid_running(pid)
@@ -365,8 +395,18 @@ class ManagedProcessRuntime(Generic[_StartOptionsT]):
         # Process inspection must follow the host API even when tests inject a
         # target platform.  On Windows, falling through to POSIX calls is not
         # merely unsupported: ``os.kill(pid, 0)`` broadcasts CTRL_C_EVENT.
-        if _platform_name() == "Windows" or self.platform_name == "Windows":
+        host_platform = _platform_name()
+        if host_platform == "Windows" or self.platform_name == "Windows":
             return _windows_process_identity(pid)
+        if self.platform_name == "Darwin":
+            birth = _darwin_process_birth(pid)
+            if birth is None:
+                return None
+            process_group, started_at_seconds, started_at_microseconds = birth
+            return (
+                f"darwin:{process_group}:{started_at_seconds}:"
+                f"{started_at_microseconds}"
+            )
         try:
             process_group = os.getpgid(pid)
         except OSError:
@@ -384,19 +424,6 @@ class ManagedProcessRuntime(Generic[_StartOptionsT]):
             fields = stat[closing_paren + 2 :].split() if closing_paren >= 0 else []
             # /proc/<pid>/stat fields after comm begin at field 3; starttime is field 22.
             return fields[19] if len(fields) > 19 else None
-        if self.platform_name == "Darwin":
-            try:
-                result = self._subprocess_run(
-                    ["ps", "-o", "lstart=", "-p", str(pid)],
-                    check=False,
-                    capture_output=True,
-                    text=True,
-                    timeout=1,
-                )
-            except (OSError, subprocess.SubprocessError):
-                return None
-            started_at = getattr(result, "stdout", "").strip()
-            return started_at or None
         return None
 
     def _record_matches_process(self, state: dict[str, Any] | None, pid: int) -> bool:
@@ -410,21 +437,7 @@ class ManagedProcessRuntime(Generic[_StartOptionsT]):
         if not state:
             return "mismatch"
         recorded = state.get("identity")
-        if recorded is None:
-            return "match"
-        current = self._process_identity(pid)
-        if current is None:
-            return "unknown"
-        if recorded == current:
-            return "match"
-        # Older POSIX state files stored only the process group id.
-        if (
-            isinstance(recorded, int)
-            and isinstance(current, str)
-            and current.startswith(f"{recorded}:")
-        ):
-            return "match"
-        return "mismatch"
+        return self.process_identity_match(recorded, pid)
 
     def _read_state(self) -> dict[str, Any] | None:
         try:
@@ -527,6 +540,116 @@ def _as_int(value: object) -> int | None:
 
 def _as_str(value: object) -> str | None:
     return value if isinstance(value, str) else None
+
+
+def _darwin_identity_match(
+    recorded: object,
+    current: object,
+) -> Literal["match", "mismatch", "unknown"]:
+    """Compare the new numeric identity with a pre-upgrade ``ps`` identity."""
+    if not isinstance(recorded, str) or not isinstance(current, str):
+        return "mismatch"
+    current_match = re.fullmatch(r"darwin:(\d+):(\d+):(\d+)", current)
+    if current_match is None:
+        return "mismatch"
+    recorded_group, separator, recorded_started_at = recorded.partition(":")
+    if not separator or not recorded_group.isdigit():
+        return "mismatch"
+    if int(recorded_group) != int(current_match.group(1)):
+        return "mismatch"
+    legacy_epoch = _legacy_darwin_started_at(recorded_started_at)
+    if legacy_epoch is None:
+        # The PID is alive and its process group still matches, but an older
+        # locale produced a date we cannot safely parse. Keep the record until
+        # the owning client exits instead of killing a live gateway.
+        return "unknown"
+    return "match" if legacy_epoch == int(current_match.group(2)) else "mismatch"
+
+
+def _legacy_darwin_started_at(value: str) -> int | None:
+    """Parse the English and numeric macOS ``ps lstart`` formats we released."""
+    english = re.fullmatch(
+        r"[A-Za-z]{3}\s+([A-Za-z]{3})\s+(\d{1,2})\s+"
+        r"(\d{2}):(\d{2}):(\d{2})\s+(\d{4})",
+        value.strip(),
+    )
+    months = {
+        "Jan": 1,
+        "Feb": 2,
+        "Mar": 3,
+        "Apr": 4,
+        "May": 5,
+        "Jun": 6,
+        "Jul": 7,
+        "Aug": 8,
+        "Sep": 9,
+        "Oct": 10,
+        "Nov": 11,
+        "Dec": 12,
+    }
+    if english is not None:
+        month = months.get(english.group(1))
+        if month is None:
+            return None
+        day, hour, minute, second, year = map(int, english.groups()[1:])
+    else:
+        numeric = re.fullmatch(
+            r"\S+\s+(\d{1,2})/(\d{1,2})\s+"
+            r"(\d{2}):(\d{2}):(\d{2})\s+(\d{4})",
+            value.strip(),
+        )
+        if numeric is None:
+            return None
+        month, day, hour, minute, second, year = map(int, numeric.groups())
+    try:
+        return int(time.mktime((year, month, day, hour, minute, second, -1, -1, -1)))
+    except (OverflowError, ValueError):
+        return None
+
+
+@lru_cache(maxsize=1)
+def _darwin_proc_pidinfo() -> Any | None:
+    if sys.platform != "darwin":
+        return None
+    try:
+        proc_pidinfo = ctypes.CDLL(
+            "/usr/lib/libproc.dylib",
+            use_errno=True,
+        ).proc_pidinfo
+    except (AttributeError, OSError):
+        return None
+    proc_pidinfo.argtypes = [
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_uint64,
+        ctypes.c_void_p,
+        ctypes.c_int,
+    ]
+    proc_pidinfo.restype = ctypes.c_int
+    return proc_pidinfo
+
+
+def _darwin_process_birth(pid: int) -> tuple[int, int, int] | None:
+    """Read PGID and microsecond process birth time from ``proc_bsdinfo``."""
+    proc_pidinfo = _darwin_proc_pidinfo()
+    if proc_pidinfo is None:
+        return None
+    # ``proc_bsdinfo`` is 136 bytes on supported macOS versions. These stable
+    # field offsets come from ``sys/proc_info.h``: pid=12, pgid=100,
+    # start_tvsec=120, and start_tvusec=128.
+    buffer = ctypes.create_string_buffer(136)
+    try:
+        written = proc_pidinfo(pid, 3, 0, buffer, len(buffer))
+    except (OSError, ValueError):
+        return None
+    if written != len(buffer) or struct.unpack_from("=I", buffer, 12)[0] != pid:
+        return None
+    process_group = struct.unpack_from("=I", buffer, 100)[0]
+    started_at_seconds = struct.unpack_from("=Q", buffer, 120)[0]
+    started_at_microseconds = struct.unpack_from("=Q", buffer, 128)[0]
+    if started_at_seconds <= 0:
+        return None
+    return process_group, started_at_seconds, started_at_microseconds
 
 
 def _windows_process_identity(pid: int) -> str | None:

--- a/nanobot/process_runtime.py
+++ b/nanobot/process_runtime.py
@@ -107,7 +107,8 @@ class ManagedProcessRuntime(Generic[_StartOptionsT]):
             return
         state["pid"] = os.getpid()
         runtime = cls(paths=paths)
-        state["identity"] = runtime._process_identity(os.getpid())
+        state.pop("stable_identity", None)
+        state.update(runtime.process_identity_record(os.getpid()))
         state["started_at"] = _utc_now()
         runtime._write_state(state)
 
@@ -140,19 +141,18 @@ class ManagedProcessRuntime(Generic[_StartOptionsT]):
         if not self._is_pid_running(pid):
             return ProcessResult(False, self._message("exited_during_startup"), self.status())
 
-        self._write_state(
-            {
-                "pid": pid,
-                "identity": self._process_identity(pid),
-                "started_at": _utc_now(),
-                "platform": self.platform_name,
-                "port": options.port,
-                "workspace": options.workspace,
-                "config_path": options.config_path,
-                "command": command,
-                "log_path": str(self.paths.log_path),
-            }
-        )
+        state: dict[str, object] = {
+            "pid": pid,
+            "started_at": _utc_now(),
+            "platform": self.platform_name,
+            "port": options.port,
+            "workspace": options.workspace,
+            "config_path": options.config_path,
+            "command": command,
+            "log_path": str(self.paths.log_path),
+        }
+        state.update(self.process_identity_record(pid))
+        self._write_state(state)
         return ProcessResult(True, self._message("started_background"), self.status())
 
     def stop(self, *, timeout_s: int = 20) -> ProcessResult:
@@ -272,6 +272,15 @@ class ManagedProcessRuntime(Generic[_StartOptionsT]):
     def process_identity(self, pid: int) -> str | int | None:
         """Return an identity that changes when an operating-system PID is reused."""
         return self._process_identity(pid)
+
+    def process_identity_record(
+        self,
+        pid: int,
+        *,
+        lease: bool = False,
+    ) -> dict[str, str | int | None]:
+        """Serialize an identity without breaking pre-upgrade macOS readers."""
+        return process_identity_record(self._process_identity(pid), lease=lease)
 
     def process_identity_match(
         self,
@@ -436,7 +445,9 @@ class ManagedProcessRuntime(Generic[_StartOptionsT]):
     ) -> Literal["match", "mismatch", "unknown"]:
         if not state:
             return "mismatch"
-        recorded = state.get("identity")
+        recorded = state.get("stable_identity")
+        if recorded is None:
+            recorded = state.get("identity")
         return self.process_identity_match(recorded, pid)
 
     def _read_state(self) -> dict[str, Any] | None:
@@ -549,13 +560,14 @@ def _darwin_identity_match(
     """Compare the new numeric identity with a pre-upgrade ``ps`` identity."""
     if not isinstance(recorded, str) or not isinstance(current, str):
         return "mismatch"
-    current_match = re.fullmatch(r"darwin:(\d+):(\d+):(\d+)", current)
-    if current_match is None:
+    current_identity = _parse_darwin_identity(current)
+    if current_identity is None:
         return "mismatch"
+    current_group, current_seconds, _ = current_identity
     recorded_group, separator, recorded_started_at = recorded.partition(":")
     if not separator or not recorded_group.isdigit():
         return "mismatch"
-    if int(recorded_group) != int(current_match.group(1)):
+    if int(recorded_group) != current_group:
         return "mismatch"
     legacy_epoch = _legacy_darwin_started_at(recorded_started_at)
     if legacy_epoch is None:
@@ -563,7 +575,35 @@ def _darwin_identity_match(
         # locale produced a date we cannot safely parse. Keep the record until
         # the owning client exits instead of killing a live gateway.
         return "unknown"
-    return "match" if legacy_epoch == int(current_match.group(2)) else "mismatch"
+    return "match" if legacy_epoch == current_seconds else "mismatch"
+
+
+def _parse_darwin_identity(value: object) -> tuple[int, int, int] | None:
+    if not isinstance(value, str):
+        return None
+    match = re.fullmatch(r"darwin:(\d+):(\d+):(\d+)", value)
+    if match is None:
+        return None
+    return int(match.group(1)), int(match.group(2)), int(match.group(3))
+
+
+def process_identity_record(
+    identity: str | int | None,
+    *,
+    lease: bool = False,
+) -> dict[str, str | int | None]:
+    """Serialize an identity without breaking pre-upgrade macOS readers."""
+    darwin = _parse_darwin_identity(identity)
+    if darwin is None:
+        return {"identity": identity}
+    process_group, _, _ = darwin
+    # Old process-state readers understand a PGID-only integer. Old lease
+    # readers raw-compare identities, so ``None`` asks them to rely on the
+    # still-live PID while upgraded readers use the stable native value.
+    return {
+        "identity": None if lease else process_group,
+        "stable_identity": identity,
+    }
 
 
 def _legacy_darwin_started_at(value: str) -> int | None:
@@ -603,7 +643,7 @@ def _legacy_darwin_started_at(value: str) -> int | None:
         month, day, hour, minute, second, year = map(int, numeric.groups())
     try:
         return int(time.mktime((year, month, day, hour, minute, second, -1, -1, -1)))
-    except (OverflowError, ValueError):
+    except (OSError, OverflowError, ValueError):
         return None
 
 

--- a/tests/gateway/test_runtime.py
+++ b/tests/gateway/test_runtime.py
@@ -660,6 +660,28 @@ def test_lease_snapshot_keeps_a_legacy_localized_darwin_client(tmp_path, monkeyp
     assert snapshot.clients == 1
 
 
+def test_darwin_lease_keeps_old_readers_compatible_and_detects_pid_reuse(
+    tmp_path,
+    monkeypatch,
+):
+    runtime = GatewayRuntime(paths=_paths(tmp_path), platform_name="Darwin")
+    identity = "darwin:42:1786992348:123456"
+    monkeypatch.setattr(runtime, "_is_pid_running", lambda _pid: True)
+    monkeypatch.setattr(runtime, "_process_identity", lambda _pid: identity)
+    client = GatewayClientLease(runtime, kind="tui", pid=12345, token="client")
+
+    client.acquire()
+    client.mark_ephemeral()
+    state = json.loads(client.state_path.read_text(encoding="utf-8"))
+    record = state["clients"]["client"]
+
+    assert record["identity"] is None  # Pre-upgrade lease readers keep the live PID.
+    assert record["stable_identity"] == identity
+
+    identity = "darwin:42:1786992348:654321"
+    assert client.snapshot().clients == 0
+
+
 def test_lease_snapshot_keeps_a_client_when_identity_probe_is_unavailable(
     tmp_path,
     monkeypatch,
@@ -925,14 +947,72 @@ def test_darwin_process_identity_is_locale_independent(tmp_path, monkeypatch):
     )
     monkeypatch.setenv("LANG", "zh_CN.UTF-8")
     monkeypatch.setenv("LC_ALL", "zh_CN.UTF-8")
+    monkeypatch.setattr("nanobot.process_runtime._platform_name", lambda: "Darwin")
     started_at = int(time.mktime((2026, 8, 18, 2, 17, 54, -1, -1, -1)))
     monkeypatch.setattr(
         "nanobot.process_runtime._darwin_process_birth",
         lambda _pid: (42, started_at, 123456),
     )
 
-    assert runtime.process_identity(12345) == f"darwin:42:{started_at}:123456"
+    identity = f"darwin:42:{started_at}:123456"
+    assert runtime.process_identity(12345) == identity
+    assert runtime.process_identity_record(12345) == {
+        "identity": 42,
+        "stable_identity": identity,
+    }
     assert runtime._record_matches_process({"identity": 42}, 12345) is True
+
+
+def test_darwin_status_discovers_a_legacy_localized_state(tmp_path, monkeypatch):
+    runtime = GatewayRuntime(paths=_paths(tmp_path), platform_name="Darwin")
+    started_at = int(time.mktime((2026, 8, 18, 2, 17, 54, -1, -1, -1)))
+    runtime.paths.run_dir.mkdir(parents=True)
+    runtime.paths.state_path.write_text(
+        '{"pid": 12345, "identity": "42:二  8/18 02:17:54 2026"}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(runtime, "_is_pid_running", lambda _pid: True)
+    monkeypatch.setattr(
+        runtime,
+        "_process_identity",
+        lambda _pid: f"darwin:42:{started_at}:123456",
+    )
+
+    status = runtime.status()
+
+    assert status.running is True
+    assert status.reason == "running"
+    assert runtime.paths.state_path.exists()
+
+
+def test_darwin_status_prefers_stable_identity_over_compatibility_pgid(
+    tmp_path,
+    monkeypatch,
+):
+    runtime = GatewayRuntime(paths=_paths(tmp_path), platform_name="Darwin")
+    runtime.paths.run_dir.mkdir(parents=True)
+    runtime.paths.state_path.write_text(
+        json.dumps(
+            {
+                "pid": 12345,
+                "identity": 42,
+                "stable_identity": "darwin:42:1786992348:123456",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(runtime, "_is_pid_running", lambda _pid: True)
+    monkeypatch.setattr(
+        runtime,
+        "_process_identity",
+        lambda _pid: "darwin:42:1786992348:654321",
+    )
+
+    status = runtime.status()
+
+    assert status.running is False
+    assert status.reason == "stale_state"
+    assert not runtime.paths.state_path.exists()
 
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="requires macOS proc_pidinfo")

--- a/tests/gateway/test_runtime.py
+++ b/tests/gateway/test_runtime.py
@@ -642,6 +642,24 @@ def test_lease_snapshot_prunes_a_reused_client_pid(tmp_path, monkeypatch):
     }
 
 
+def test_lease_snapshot_keeps_a_legacy_localized_darwin_client(tmp_path, monkeypatch):
+    runtime = GatewayRuntime(paths=_paths(tmp_path), platform_name="Darwin")
+    started_at = int(time.mktime((2026, 8, 18, 2, 17, 54, -1, -1, -1)))
+    identity = "42:二  8/18 02:17:54 2026"
+    monkeypatch.setattr(runtime, "_is_pid_running", lambda _pid: True)
+    monkeypatch.setattr(runtime, "_process_identity", lambda _pid: identity)
+    client = GatewayClientLease(runtime, kind="webui", pid=12345, token="client")
+
+    client.acquire()
+    client.mark_ephemeral()
+    identity = f"darwin:42:{started_at}:123456"
+
+    snapshot = client.snapshot()
+
+    assert snapshot.auto_stop is True
+    assert snapshot.clients == 1
+
+
 def test_lease_snapshot_keeps_a_client_when_identity_probe_is_unavailable(
     tmp_path,
     monkeypatch,
@@ -791,6 +809,26 @@ def test_windows_host_identity_stays_safe_when_target_platform_is_posix(tmp_path
     assert runtime.process_identity(12345) == "created-at"
 
 
+def test_windows_lease_prunes_a_reused_pid_by_creation_time(tmp_path, monkeypatch):
+    runtime = GatewayRuntime(paths=_paths(tmp_path), platform_name="Windows")
+    identity = "filetime:first-process"
+    monkeypatch.setattr("nanobot.process_runtime._platform_name", lambda: "Windows")
+    monkeypatch.setattr(
+        "nanobot.process_runtime._windows_process_identity",
+        lambda _pid: identity,
+    )
+    client = GatewayClientLease(runtime, kind="tui", pid=12345, token="client")
+
+    client.acquire()
+    client.mark_ephemeral()
+    identity = "filetime:replacement-process"
+
+    snapshot = client.snapshot()
+
+    assert snapshot.auto_stop is True
+    assert snapshot.clients == 0
+
+
 def test_status_clears_stale_state(tmp_path, monkeypatch):
     runtime = GatewayRuntime(paths=_paths(tmp_path), platform_name="Linux")
     runtime.paths.run_dir.mkdir(parents=True)
@@ -875,6 +913,38 @@ def test_posix_process_identity_includes_start_time_and_accepts_legacy_state(
 
     assert runtime.process_identity(12345) == "42:987654"
     assert runtime._record_matches_process({"identity": 42}, 12345) is True
+
+
+def test_darwin_process_identity_is_locale_independent(tmp_path, monkeypatch):
+    runtime = GatewayRuntime(
+        paths=_paths(tmp_path),
+        platform_name="Darwin",
+        subprocess_run=lambda *_args, **_kwargs: pytest.fail(
+            "Darwin identities must not depend on localized subprocess output"
+        ),
+    )
+    monkeypatch.setenv("LANG", "zh_CN.UTF-8")
+    monkeypatch.setenv("LC_ALL", "zh_CN.UTF-8")
+    started_at = int(time.mktime((2026, 8, 18, 2, 17, 54, -1, -1, -1)))
+    monkeypatch.setattr(
+        "nanobot.process_runtime._darwin_process_birth",
+        lambda _pid: (42, started_at, 123456),
+    )
+
+    assert runtime.process_identity(12345) == f"darwin:42:{started_at}:123456"
+    assert runtime._record_matches_process({"identity": 42}, 12345) is True
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires macOS proc_pidinfo")
+def test_darwin_live_process_identity_is_stable(tmp_path):
+    runtime = GatewayRuntime(paths=_paths(tmp_path), platform_name="Darwin")
+
+    first = runtime.process_identity(os.getpid())
+    second = runtime.process_identity(os.getpid())
+
+    assert isinstance(first, str)
+    assert first.startswith("darwin:")
+    assert second == first
 
 
 def test_stop_terminates_recorded_process(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- replace locale-dependent macOS `ps lstart` identities with native `proc_pidinfo` birth timestamps
- compare gateway client leases through the shared process-identity contract instead of raw strings
- preserve legacy PGID and localized macOS state while keeping Windows FILETIME and Linux `/proc` PID-reuse protection

## Why

macOS localizes `ps -o lstart`. A WebUI and TUI running under different locale environments could compute different identities for the same live process, prune its lease, and stop the shared gateway while clients were still attached.

## Compatibility

No user-facing configuration or protocol changes. Existing integer PGID state and previously persisted macOS timestamp identities remain readable during migration.

## Validation

- `ruff check nanobot/process_runtime.py nanobot/gateway/runtime.py tests/gateway/test_runtime.py`
- `basedpyright` — 0 errors
- `pytest -q` — 6587 passed, 11 skipped
- real macOS `proc_pidinfo` smoke test confirms stable PGID + microsecond birth time
- Windows creation-time PID reuse regression coverage
