### PR TITLE
fix(providers): support legacy socks:// proxy URLs for custom OpenAI-…

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -19,6 +19,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
 from ipaddress import ip_address
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlparse
+from urllib.request import getproxies, proxy_bypass
 
 from loguru import logger
 from pydantic.alias_generators import to_snake
@@ -57,6 +58,48 @@ if TYPE_CHECKING:
 AsyncOpenAI: Any = None
 
 _GEMINI_SKIP_THOUGHT_SIGNATURE = "skip_thought_signature_validator"
+_PROXY_ENV_KEYS = (
+    "ALL_PROXY",
+    "HTTPS_PROXY",
+    "HTTP_PROXY",
+    "all_proxy",
+    "https_proxy",
+    "http_proxy",
+)
+
+
+def _normalize_proxy_url(proxy: str) -> str:
+    """Normalize proxy URL aliases accepted by common proxy clients."""
+    value = proxy.strip()
+    scheme, separator, remainder = value.partition("://")
+    if separator and scheme.lower() == "socks":
+        return f"socks5://{remainder}"
+    return value
+
+
+def _legacy_socks_env_proxy(api_base: str | None) -> tuple[bool, str | None]:
+    """Resolve env proxy settings when a legacy ``socks://`` URL is present.
+
+    httpx rejects the generic ``socks://`` alias while many desktop proxy
+    applications export it.  Creating an explicit client avoids the SDK
+    parsing the invalid alias, while still preferring the scheme-specific
+    HTTP(S) proxy and respecting ``NO_PROXY`` for the provider endpoint.
+    """
+    if not any(
+        (value := os.environ.get(key))
+        and value.strip().lower().startswith("socks://")
+        for key in _PROXY_ENV_KEYS
+    ):
+        return False, None
+
+    parsed = urlparse(api_base or "https://api.openai.com")
+    if parsed.hostname and proxy_bypass(parsed.hostname):
+        return True, None
+
+    proxies = getproxies()
+    scheme = parsed.scheme.lower() or "https"
+    proxy = proxies.get(scheme) or proxies.get("all")
+    return True, _normalize_proxy_url(proxy) if proxy else None
 
 
 def _is_hosted_web_search_type(value: object) -> bool:
@@ -554,7 +597,7 @@ class OpenAICompatProvider(LLMProvider):
         if self._proxy:
             http_client = httpx.AsyncClient(
                 timeout=timeout_s,
-                proxy=self._proxy,
+                proxy=_normalize_proxy_url(self._proxy),
                 trust_env=False,
                 follow_redirects=True,
             )
@@ -579,9 +622,18 @@ class OpenAICompatProvider(LLMProvider):
                 timeout=timeout_s,
                 transport=httpx.AsyncHTTPTransport(proxy=None, limits=_local_limits),
             )
-        # else: http_client stays None → SDK creates DefaultAsyncHttpxClient
-        # which already reads proxy env vars via trust_env=True, has proper
-        # connection limits, and follows redirects.
+        else:
+            has_legacy_socks_env, env_proxy = _legacy_socks_env_proxy(self._effective_base)
+            if has_legacy_socks_env:
+                http_client = httpx.AsyncClient(
+                    timeout=timeout_s,
+                    proxy=env_proxy,
+                    trust_env=False,
+                    follow_redirects=True,
+                )
+        # When http_client stays None, the SDK creates DefaultAsyncHttpxClient,
+        # which reads normal proxy env vars via trust_env=True and supplies its
+        # own connection limits and redirect handling.
         self._client = AsyncOpenAI(
             api_key=self._api_key_for_client,
             base_url=self._effective_base,

--- a/tests/providers/test_openai_compat_timeout.py
+++ b/tests/providers/test_openai_compat_timeout.py
@@ -10,7 +10,13 @@ def _assert_openai_compat_timeout(timeout) -> None:
 
 
 async def test_openai_compat_provider_defers_sdk_client_until_first_use() -> None:
-    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI") as mock_async_openai:
+    with (
+        patch("nanobot.providers.openai_compat_provider.AsyncOpenAI") as mock_async_openai,
+        patch(
+            "nanobot.providers.openai_compat_provider._legacy_socks_env_proxy",
+            return_value=(False, None),
+        ),
+    ):
         provider = OpenAICompatProvider(api_key="test-key", api_base="https://example.com/v1")
         mock_async_openai.assert_not_called()
         await provider._ensure_client()

--- a/tests/providers/test_proxy_env.py
+++ b/tests/providers/test_proxy_env.py
@@ -7,6 +7,22 @@ import httpx
 import nanobot.providers.openai_compat_provider as openai_compat_provider
 from nanobot.providers.openai_compat_provider import OpenAICompatProvider
 
+_PROXY_ENV_KEYS = (
+    "ALL_PROXY",
+    "HTTPS_PROXY",
+    "HTTP_PROXY",
+    "NO_PROXY",
+    "all_proxy",
+    "https_proxy",
+    "http_proxy",
+    "no_proxy",
+)
+
+
+def _clear_proxy_env(monkeypatch) -> None:
+    for key in _PROXY_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
 
 def _make_spec(is_local: bool = False) -> MagicMock:
     spec = MagicMock()
@@ -44,7 +60,8 @@ class TestLocalEndpointProxyDisabled:
 class TestCloudEndpointProxyEnabled:
     """Cloud endpoints must respect proxy env vars for corporate/VPN proxies."""
 
-    async def test_cloud_respects_trust_env(self):
+    async def test_cloud_respects_trust_env(self, monkeypatch):
+        _clear_proxy_env(monkeypatch)
         spec = _make_spec(is_local=False)
         spec.env_key = ""
         spec.default_api_base = "https://api.openai.com/v1"
@@ -83,4 +100,90 @@ class TestCloudEndpointProxyEnabled:
             trust_env=False,
             follow_redirects=True,
         )
+        assert openai_client.call_args.kwargs["http_client"] is http_client
+
+    async def test_explicit_legacy_socks_proxy_is_normalized(self, monkeypatch):
+        _clear_proxy_env(monkeypatch)
+        spec = _make_spec(is_local=False)
+        spec.env_key = ""
+        spec.default_api_base = "https://api.openai.com/v1"
+
+        http_client = MagicMock()
+        async_client = MagicMock(return_value=http_client)
+        openai_client = MagicMock(return_value=object())
+        monkeypatch.setattr(httpx, "AsyncClient", async_client)
+        monkeypatch.setattr(openai_compat_provider, "AsyncOpenAI", openai_client)
+
+        provider = OpenAICompatProvider(
+            api_key="test",
+            api_base=None,
+            spec=spec,
+            proxy="socks://127.0.0.1:1080",
+        )
+        provider._build_client()
+
+        assert async_client.call_args.kwargs["proxy"] == "socks5://127.0.0.1:1080"
+        assert async_client.call_args.kwargs["trust_env"] is False
+        assert openai_client.call_args.kwargs["http_client"] is http_client
+
+    async def test_legacy_all_proxy_prefers_https_proxy(self, monkeypatch):
+        _clear_proxy_env(monkeypatch)
+        monkeypatch.setenv("ALL_PROXY", "socks://127.0.0.1:1080")
+        monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:8080")
+        spec = _make_spec(is_local=False)
+        spec.env_key = ""
+        spec.default_api_base = "https://api.openai.com/v1"
+
+        http_client = MagicMock()
+        async_client = MagicMock(return_value=http_client)
+        openai_client = MagicMock(return_value=object())
+        monkeypatch.setattr(httpx, "AsyncClient", async_client)
+        monkeypatch.setattr(openai_compat_provider, "AsyncOpenAI", openai_client)
+
+        provider = OpenAICompatProvider(api_key="test", api_base=None, spec=spec)
+        provider._build_client()
+
+        assert async_client.call_args.kwargs["proxy"] == "http://127.0.0.1:8080"
+        assert async_client.call_args.kwargs["trust_env"] is False
+        assert openai_client.call_args.kwargs["http_client"] is http_client
+
+    async def test_legacy_all_proxy_is_normalized_when_no_https_proxy(self, monkeypatch):
+        _clear_proxy_env(monkeypatch)
+        monkeypatch.setenv("ALL_PROXY", "socks://127.0.0.1:1080")
+        spec = _make_spec(is_local=False)
+        spec.env_key = ""
+        spec.default_api_base = "https://api.openai.com/v1"
+
+        http_client = MagicMock()
+        async_client = MagicMock(return_value=http_client)
+        openai_client = MagicMock(return_value=object())
+        monkeypatch.setattr(httpx, "AsyncClient", async_client)
+        monkeypatch.setattr(openai_compat_provider, "AsyncOpenAI", openai_client)
+
+        provider = OpenAICompatProvider(api_key="test", api_base=None, spec=spec)
+        provider._build_client()
+
+        assert async_client.call_args.kwargs["proxy"] == "socks5://127.0.0.1:1080"
+        assert async_client.call_args.kwargs["trust_env"] is False
+        assert openai_client.call_args.kwargs["http_client"] is http_client
+
+    async def test_legacy_all_proxy_respects_no_proxy(self, monkeypatch):
+        _clear_proxy_env(monkeypatch)
+        monkeypatch.setenv("ALL_PROXY", "socks://127.0.0.1:1080")
+        monkeypatch.setenv("NO_PROXY", "api.openai.com")
+        spec = _make_spec(is_local=False)
+        spec.env_key = ""
+        spec.default_api_base = "https://api.openai.com/v1"
+
+        http_client = MagicMock()
+        async_client = MagicMock(return_value=http_client)
+        openai_client = MagicMock(return_value=object())
+        monkeypatch.setattr(httpx, "AsyncClient", async_client)
+        monkeypatch.setattr(openai_compat_provider, "AsyncOpenAI", openai_client)
+
+        provider = OpenAICompatProvider(api_key="test", api_base=None, spec=spec)
+        provider._build_client()
+
+        assert async_client.call_args.kwargs["proxy"] is None
+        assert async_client.call_args.kwargs["trust_env"] is False
         assert openai_client.call_args.kwargs["http_client"] is http_client


### PR DESCRIPTION
## Summary

A custom OpenAI-compatible provider can be configured correctly with `apiKey` and `apiBase`, but the request fails before reaching the provider when either the provider config or process environment contains a proxy URL using the common `socks://` alias.

The configuration resolver and provider factory correctly select the custom provider and preserve its key/base URL. The failure happens while constructing the HTTP client.

## Reproduction

Configure a custom provider:

```json
{
  "agents": {
    "defaults": {
      "modelPreset": "custom-model"
    }
  },
  "providers": {
    "custom": {
      "apiKey": "<redacted>",
      "apiBase": "https://example.invalid/v1"
    }
  },
  "modelPresets": {
    "custom-model": {
      "model": "provider-model-id",
      "provider": "custom"
    }
  }
}
```

Then set a proxy using the generic SOCKS alias, either explicitly or through the environment:

```bash
export ALL_PROXY=socks://127.0.0.1:7892
export HTTPS_PROXY=http://127.0.0.1:7892
nanobot gateway
```

Sending a message fails with:

```text
Error calling LLM: Unknown scheme for proxy URL URL('socks://127.0.0.1:7892')
```

The same failure can occur when `providers.custom.proxy` is set to a `socks://` URL.

## Root cause

`httpx` accepts `socks5://`/`socks5h://`, but rejects the frequently exported generic `socks://` alias. The SDK default HTTP client parses the full proxy environment during initialization, so an invalid `ALL_PROXY` can prevent client construction even when a valid scheme-specific `HTTPS_PROXY` is present.

This makes the problem appear to be an invalid custom provider or API key, although neither credential nor provider resolution is the failing component.

## Expected behavior

- Normalize `socks://` to `socks5://` for explicitly configured OpenAI-compatible provider proxies.
- When the environment contains the legacy alias, create an explicit HTTP client that:
  - prefers the endpoint's scheme-specific `HTTP_PROXY`/`HTTPS_PROXY`;
  - falls back to normalized `ALL_PROXY`;
  - respects `NO_PROXY`;
  - disables further environment proxy parsing with `trust_env=False`.
- Preserve the existing direct-connection behavior for localhost/LAN providers.
- Do not log API keys or proxy credentials.

## Proposed implementation

Update `nanobot/providers/openai_compat_provider.py` with:

1. A small proxy URL normalizer for the `socks://` alias.
2. Environment proxy resolution used only when a legacy SOCKS alias is detected.
3. Explicit HTTP-client construction for that compatibility path.

Add regression coverage in:

- `tests/providers/test_proxy_env.py`
- `tests/providers/test_openai_compat_timeout.py`

Coverage should include:

- explicit `socks://` provider proxy normalization;
- `ALL_PROXY=socks://...` with a valid `HTTPS_PROXY`;
- fallback to normalized `ALL_PROXY`;
- `NO_PROXY` bypass;
- unchanged default SDK client behavior when no legacy alias is present.

## Local validation

A local implementation has been validated with:

- 56 focused tests passing;
- `ruff check` passing;
- strict BasedPyright check for the changed source file reporting 0 errors;
- a real request through a configured custom provider completing successfully after using a provider-listed model ID.

A separate local `model_not_found` error was traced to a misspelled model ID in `~/.nanobot/config.json`; that configuration correction is not part of this upstream code issue.