### PR TITLE
test(exec): wait deterministically for truncation output

### DIFF
--- a/tests/tools/test_exec_session_tools.py
+++ b/tests/tools/test_exec_session_tools.py
@@ -420,7 +420,8 @@ def test_write_stdin_accepts_max_output_tokens_alias(tmp_path):
         sid = _session_id(initial)
         poll = await stdin_tool.execute(
             session_id=sid,
-            yield_time_ms=500,
+            wait_for="\n",
+            wait_timeout_ms=10000,
             max_output_tokens=1000,
         )
         cleanup = await stdin_tool.execute(session_id=sid, terminate=True, yield_time_ms=0)


### PR DESCRIPTION
## Summary

- replace the fixed 500 ms poll in the write_stdin output-limit alias test with an output-aware wait
- keep the original truncation and session-cleanup assertions intact

## Why

The Windows 3.14 job in [run 32126191518](https://github.com/HKUDS/nanobot/actions/runs/32126191518/job/95677229529) sometimes starts PowerShell too slowly for the test's 500 ms process wait plus 100 ms output grace. The test then sees only the running-session status even though the implementation is behaving as specified.

There are no relevant changes between the failed SHA and current main. A later run passed without changing this path, confirming that the fixed startup window is flaky rather than repaired.

## Test plan

- pytest tests/tools/test_exec_session_tools.py::test_write_stdin_accepts_max_output_tokens_alias -q (20 consecutive runs)
- pytest tests/tools/test_exec_session_tools.py -q (37 passed)
- ruff check tests/tools/test_exec_session_tools.py
- manual public-tool check with output delayed by 1.2 seconds (truncation observed and session cleaned up)