### PR TITLE
fix(mattermost): ignore system posts

### DIFF
--- a/nanobot/channels/mattermost/runtime.py
+++ b/nanobot/channels/mattermost/runtime.py
@@ -221,6 +221,10 @@ class MattermostChannel(BaseChannel):
             self.logger.warning("failed to parse post json")
             return
 
+        post_type = post.get("type")
+        if isinstance(post_type, str) and post_type.startswith("system_"):
+            return
+
         sender_id = post.get("user_id", "")
         channel_id = post.get("channel_id", "")
         message_text = post.get("message", "")

--- a/nanobot/channels/mattermost/tests/test_mattermost_channel.py
+++ b/nanobot/channels/mattermost/tests/test_mattermost_channel.py
@@ -464,6 +464,32 @@ async def test_posted_thread_event_uses_thread_policy():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("post_type", ["system_join_channel", "system_leave_channel"])
+async def test_posted_event_ignores_system_posts(post_type: str):
+    channel, _ = _make_channel({"groupPolicy": "open"})
+    channel._self_id = "bot_id"
+    with patch.object(channel, "_handle_message", AsyncMock()) as mock_handle:
+        ws_msg = {
+            "event": "posted",
+            "data": {
+                "channel_type": "O",
+                "post": json.dumps({
+                    "id": "system_post_1",
+                    "user_id": "user_1",
+                    "channel_id": "channel_1",
+                    "message": "A user joined or left the channel.",
+                    "type": post_type,
+                }),
+            },
+            "broadcast": {},
+        }
+
+        await channel._handle_ws_message(ws_msg)
+
+    mock_handle.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_group_policy_in_thread_allowlist():
     """Thread uses allowlist policy when configured."""
     channel, fake = _make_channel({


### PR DESCRIPTION
## Summary

Prevent Mattermost system-generated posts, such as channel join and leave notifications, from being processed as user messages.

## Problem

Mattermost sends system events through the same `posted` WebSocket event used for normal user messages. Nanobot currently forwards these posts to the agent, which can cause unnecessary or confusing responses.

## Root Cause

The Mattermost channel handler parses incoming posts but does not check the post `type`. Mattermost identifies system-generated posts using types beginning with `system_`.

## Changes

* Ignore posts whose type begins with `system_`
* Add regression tests covering `system_join_channel` and `system_leave_channel`
* Preserve the existing behaviour for normal user messages

## Testing

* [x] Mattermost tests: 61 passed
* [x] Channel tests: 287 passed
* [x] Regression tests cover `system_join_channel` and `system_leave_channel`
* [x] Regression test confirmed the failure before the fix and passed afterwards
* [x] `ruff check` passed
* [x] `basedpyright` passed with no errors or warnings
* [x] `git diff --check` passed

## Compatibility and Risk

The change is limited to Mattermost system posts. Normal user messages and other Mattermost events are unaffected. The risk is low because the filter follows Mattermost’s documented system-post naming convention.

## Related Issue

No existing issue. 
