### PR TITLE
Support legacy socks:// proxy URLs for custom OpenAI-compatible providers

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -388,6 +388,75 @@ def _is_local_endpoint(
     return addr.is_loopback or addr.is_private
 
 
+def _normalize_socks_proxy_url(url: str) -> str:
+    """Normalize the legacy ``socks://`` proxy alias to ``socks5://``.
+
+    httpx only accepts http/https/socks5/socks5h proxy schemes; ``socks://``
+    is a common alias exported by proxy tools (e.g. via ``ALL_PROXY``) but is
+    rejected outright, raising ``ValueError`` during client construction.
+    """
+    if url.lower().startswith("socks://"):
+        return "socks5://" + url[len("socks://") :]
+    return url
+
+
+def _no_proxy_matches(host: str, no_proxy: str) -> bool:
+    """Return True when ``host`` is covered by a NO_PROXY-style pattern list."""
+    host = host.lower()
+    for pattern in no_proxy.split(","):
+        pattern = pattern.strip().lower().lstrip(".")
+        if not pattern:
+            continue
+        if pattern == "*" or host == pattern or host.endswith(f".{pattern}"):
+            return True
+    return False
+
+
+def _env_first(*names: str) -> str | None:
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            return value
+    return None
+
+
+def _resolve_legacy_proxy_env(api_base: str | None) -> str | None:
+    """Resolve a proxy URL from the environment when it uses the legacy
+    ``socks://`` alias.
+
+    httpx parses the full proxy environment (HTTP_PROXY/HTTPS_PROXY/
+    ALL_PROXY) eagerly when building its default client, so an invalid
+    ``ALL_PROXY=socks://...`` breaks client construction even when a valid
+    scheme-specific proxy is also set. When that alias is present, this
+    resolves the proxy nanobot should actually use: the endpoint's
+    scheme-specific ``HTTP_PROXY``/``HTTPS_PROXY``, falling back to a
+    normalized ``ALL_PROXY``, and honoring ``NO_PROXY``.
+
+    Returns ``None`` when the environment doesn't use the legacy alias, in
+    which case httpx's normal env-trusting behavior should apply unchanged.
+    Returns ``""`` when the legacy alias is present but no proxy should be
+    used for this request (host excluded via NO_PROXY, or no proxy is
+    configured for the endpoint's scheme).
+    """
+    http_proxy = _env_first("HTTP_PROXY", "http_proxy")
+    https_proxy = _env_first("HTTPS_PROXY", "https_proxy")
+    all_proxy = _env_first("ALL_PROXY", "all_proxy")
+    if not any(
+        (value or "").lower().startswith("socks://") for value in (http_proxy, https_proxy, all_proxy)
+    ):
+        return None
+
+    host = urlparse(api_base).hostname if api_base else None
+    no_proxy = _env_first("NO_PROXY", "no_proxy")
+    if host and no_proxy and _no_proxy_matches(host, no_proxy):
+        return ""
+
+    scheme = urlparse(api_base).scheme if api_base else "https"
+    scoped = http_proxy if scheme == "http" else https_proxy
+    chosen = scoped or all_proxy
+    return _normalize_socks_proxy_url(chosen) if chosen else ""
+
+
 def _is_direct_openai_base(api_base: str | None) -> bool:
     """Return True for direct OpenAI endpoints, not generic OpenAI-compatible gateways."""
     if not api_base:
@@ -554,7 +623,7 @@ class OpenAICompatProvider(LLMProvider):
         if self._proxy:
             http_client = httpx.AsyncClient(
                 timeout=timeout_s,
-                proxy=self._proxy,
+                proxy=_normalize_socks_proxy_url(self._proxy),
                 trust_env=False,
                 follow_redirects=True,
             )
@@ -579,6 +648,20 @@ class OpenAICompatProvider(LLMProvider):
                 timeout=timeout_s,
                 transport=httpx.AsyncHTTPTransport(proxy=None, limits=_local_limits),
             )
+        else:
+            # httpx eagerly parses the whole proxy environment at client
+            # construction time, so a legacy ALL_PROXY=socks:// alias would
+            # crash construction even when HTTPS_PROXY is a valid scheme.
+            # Build an explicit client ourselves in that case; otherwise let
+            # the SDK's DefaultAsyncHttpxClient trust the environment as usual.
+            legacy_proxy = _resolve_legacy_proxy_env(self._effective_base)
+            if legacy_proxy is not None:
+                http_client = httpx.AsyncClient(
+                    timeout=timeout_s,
+                    proxy=legacy_proxy or None,
+                    trust_env=False,
+                    follow_redirects=True,
+                )
         # else: http_client stays None → SDK creates DefaultAsyncHttpxClient
         # which already reads proxy env vars via trust_env=True, has proper
         # connection limits, and follows redirects.

--- a/tests/providers/test_proxy_env.py
+++ b/tests/providers/test_proxy_env.py
@@ -84,3 +84,114 @@ class TestCloudEndpointProxyEnabled:
             follow_redirects=True,
         )
         assert openai_client.call_args.kwargs["http_client"] is http_client
+
+    async def test_explicit_provider_proxy_normalizes_socks_alias(self, monkeypatch):
+        spec = _make_spec(is_local=False)
+        spec.env_key = ""
+        spec.default_api_base = "https://api.openai.com/v1"
+        monkeypatch.delenv("NANOBOT_OPENAI_COMPAT_TIMEOUT_S", raising=False)
+
+        http_client = MagicMock()
+        async_client = MagicMock(return_value=http_client)
+        openai_client = MagicMock(return_value=object())
+        monkeypatch.setattr(httpx, "AsyncClient", async_client)
+        monkeypatch.setattr(openai_compat_provider, "AsyncOpenAI", openai_client)
+
+        provider = OpenAICompatProvider(
+            api_key="test",
+            api_base=None,
+            spec=spec,
+            proxy="socks://127.0.0.1:7892",
+        )
+        provider._build_client()
+
+        async_client.assert_called_once_with(
+            timeout=120.0,
+            proxy="socks5://127.0.0.1:7892",
+            trust_env=False,
+            follow_redirects=True,
+        )
+
+
+class TestLegacySocksProxyEnvAlias:
+    """A legacy ``socks://`` alias in the process environment (commonly via
+    ALL_PROXY) must not crash client construction, even when a valid
+    scheme-specific proxy is also set for the target endpoint."""
+
+    def _clear_proxy_env(self, monkeypatch):
+        for name in (
+            "HTTP_PROXY", "http_proxy",
+            "HTTPS_PROXY", "https_proxy",
+            "ALL_PROXY", "all_proxy",
+            "NO_PROXY", "no_proxy",
+        ):
+            monkeypatch.delenv(name, raising=False)
+
+    def _patch_clients(self, monkeypatch):
+        http_client = MagicMock()
+        async_client = MagicMock(return_value=http_client)
+        openai_client = MagicMock(return_value=object())
+        monkeypatch.setattr(httpx, "AsyncClient", async_client)
+        monkeypatch.setattr(openai_compat_provider, "AsyncOpenAI", openai_client)
+        monkeypatch.delenv("NANOBOT_OPENAI_COMPAT_TIMEOUT_S", raising=False)
+        return async_client, openai_client
+
+    def _make_provider(self) -> OpenAICompatProvider:
+        spec = _make_spec(is_local=False)
+        spec.env_key = ""
+        spec.default_api_base = "https://api.openai.com/v1"
+        return OpenAICompatProvider(api_key="test", api_base=None, spec=spec)
+
+    def test_all_proxy_alias_normalized_when_no_scoped_proxy(self, monkeypatch):
+        self._clear_proxy_env(monkeypatch)
+        monkeypatch.setenv("ALL_PROXY", "socks://127.0.0.1:7892")
+        async_client, _ = self._patch_clients(monkeypatch)
+
+        self._make_provider()._build_client()
+
+        async_client.assert_called_once_with(
+            timeout=120.0,
+            proxy="socks5://127.0.0.1:7892",
+            trust_env=False,
+            follow_redirects=True,
+        )
+
+    def test_scheme_specific_https_proxy_preferred_over_all_proxy_alias(self, monkeypatch):
+        self._clear_proxy_env(monkeypatch)
+        monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7893")
+        monkeypatch.setenv("ALL_PROXY", "socks://127.0.0.1:7892")
+        async_client, _ = self._patch_clients(monkeypatch)
+
+        self._make_provider()._build_client()
+
+        async_client.assert_called_once_with(
+            timeout=120.0,
+            proxy="http://127.0.0.1:7893",
+            trust_env=False,
+            follow_redirects=True,
+        )
+
+    def test_no_proxy_excludes_matching_host(self, monkeypatch):
+        self._clear_proxy_env(monkeypatch)
+        monkeypatch.setenv("ALL_PROXY", "socks://127.0.0.1:7892")
+        monkeypatch.setenv("NO_PROXY", "api.openai.com")
+        async_client, _ = self._patch_clients(monkeypatch)
+
+        self._make_provider()._build_client()
+
+        async_client.assert_called_once_with(
+            timeout=120.0,
+            proxy=None,
+            trust_env=False,
+            follow_redirects=True,
+        )
+
+    def test_no_legacy_alias_keeps_default_trust_env_behavior(self, monkeypatch):
+        self._clear_proxy_env(monkeypatch)
+        monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7893")
+        async_client, openai_client = self._patch_clients(monkeypatch)
+
+        self._make_provider()._build_client()
+
+        async_client.assert_not_called()
+        assert openai_client.call_args.kwargs["http_client"] is None

--- a/tui/package-lock.json
+++ b/tui/package-lock.json
@@ -1,0 +1,306 @@
+{
+  "name": "@nanobot/tui",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@nanobot/tui",
+      "version": "0.1.0",
+      "dependencies": {
+        "@opentui/core": "0.5.3"
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.13",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@opentui/core": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@opentui/core/-/core-0.5.3.tgz",
+      "integrity": "sha512-K8EQu44cx0rhnn3v3baCQW18Bpci3GltZayOwVpGGsbiAGL1WUYqwQjuaWsmS0c4dCa9rQ5xCEoHB1C4936nDg==",
+      "license": "MIT",
+      "dependencies": {
+        "bun-ffi-structs": "0.3.1",
+        "diff": "9.0.0",
+        "marked": "17.0.1",
+        "string-width": "7.2.0",
+        "strip-ansi": "7.1.2"
+      },
+      "optionalDependencies": {
+        "@opentui/core-darwin-arm64": "0.5.3",
+        "@opentui/core-darwin-x64": "0.5.3",
+        "@opentui/core-linux-arm64": "0.5.3",
+        "@opentui/core-linux-arm64-musl": "0.5.3",
+        "@opentui/core-linux-x64": "0.5.3",
+        "@opentui/core-linux-x64-musl": "0.5.3",
+        "@opentui/core-win32-arm64": "0.5.3",
+        "@opentui/core-win32-x64": "0.5.3"
+      },
+      "peerDependencies": {
+        "web-tree-sitter": "0.25.10"
+      }
+    },
+    "node_modules/@opentui/core-darwin-arm64": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-arm64/-/core-darwin-arm64-0.5.3.tgz",
+      "integrity": "sha512-R39YeUqaMb/rH1h6G4MkB4MLVKIrRaUaXLfVqorZM4xgU5BxnfPetRk1vWR9vuLCvDwskg+kQ589kULw0o6AWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@opentui/core-darwin-x64": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-x64/-/core-darwin-x64-0.5.3.tgz",
+      "integrity": "sha512-1pmUas/chTVFGeiN19kaOx+5Xbte/DLhcgKyACwWO0M3+xE3z1v/6QGSyX6CoP5HBpmDroiX+JHv1ic/JlGd/g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@opentui/core-linux-arm64": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-arm64/-/core-linux-arm64-0.5.3.tgz",
+      "integrity": "sha512-0nMo9Q9VIaQVdw2SNKlwIEWMmf3z+cI4jRdCkh36e2RU1FO7LrIBAEmV1ZuRp1CIFVGPkqCXIizCeckZHTr4yQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@opentui/core-linux-arm64-musl": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-arm64-musl/-/core-linux-arm64-musl-0.5.3.tgz",
+      "integrity": "sha512-QOYAxbbWrhYo27Cd6m0ATzpEx9YCAKAq82LgfUn0xu+VKXLNu+Q3hMNSVbG0SepUQQZil5rz228R9o9Cs8995w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@opentui/core-linux-x64": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-x64/-/core-linux-x64-0.5.3.tgz",
+      "integrity": "sha512-hdAYLriLpTj3lvpMyL25GPBzvM2w/n2KCSbIwTmgS2F/dPZYCKJxHEETj2lCvtStSp7KuY8tkg3Xl5RAq1v7gA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@opentui/core-linux-x64-musl": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-x64-musl/-/core-linux-x64-musl-0.5.3.tgz",
+      "integrity": "sha512-BkVIiPQ1TOf5/FfmIpf7DQU5rT/FO6ASW5R/o/wonI5Pdul7XiDCu86gzGyk1x5k9Sbh6GLeq1fe8/tPmI7IaA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@opentui/core-win32-arm64": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@opentui/core-win32-arm64/-/core-win32-arm64-0.5.3.tgz",
+      "integrity": "sha512-AjObTyZPU0xsK3Yk8GmhkboK6OcMoHBbydqYAybeHD4+v6axScSuZ3OEI9J05JJ9T7H2nZNky75tsdnjsvZJmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@opentui/core-win32-x64": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@opentui/core-win32-x64/-/core-win32-x64-0.5.3.tgz",
+      "integrity": "sha512-e3nRlF2nSkLKCUPBF32OL9EDgtQDIh2pBo7tjhumpTyJ3qoNOa3us7DsM290Vw4xnakM6jpk9r9NzRf72CuMVg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/bun": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.14.tgz",
+      "integrity": "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bun-types": "1.3.14"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/bun-ffi-structs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/bun-ffi-structs/-/bun-ffi-structs-0.3.1.tgz",
+      "integrity": "sha512-3gM7PpVWLyrwxWjcilSiGuhWanhZivvo6l0u573NziPH6f/gwk6McbaYgn7oJWov6pKGRTDbrg94W5DcJsKTtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5"
+      }
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.14.tgz",
+      "integrity": "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
+      "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.10.tgz",
+      "integrity": "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/emscripten": "^1.40.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/emscripten": {
+          "optional": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #5425.

## What changed
- `nanobot/providers/openai_compat_provider.py`
- `tests/providers/test_proxy_env.py`
- `tui/package-lock.json`

## Verification
The project's own test suite was run before and after this change; it introduces no new test failures or lint violations.