### PR TITLE
feat(web-search): add Serply (Google Search API) provider

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1737,6 +1737,7 @@ By default, web search uses `duckduckgo`, and it works out of the box without an
 | `bocha` | `apiKey` | `BOCHA_API_KEY` | Free tier (1M calls for startups) |
 | `volcengine` | `apiKey` | `VOLCENGINE_SEARCH_API_KEY` or `WEB_SEARCH_API_KEY` | Monthly quota, then paid |
 | `keenable` | `apiKey` (optional) | `KEENABLE_API_KEY` | Yes (no key needed; key raises limits) |
+| `serply` | `apiKey` | `SERPLY_API_KEY` | No |
 | `searxng` | `baseUrl` | `SEARXNG_BASE_URL` | Yes (self-hosted) |
 | `duckduckgo` (default) | — | — | Yes |
 
@@ -1877,6 +1878,22 @@ Keenable search works out of the box with no account, via its token-less public 
 
 Create a key at [serper.dev](https://serper.dev). You can also set `SERPER_API_KEY` in the environment instead of storing it in config.
 
+**Serply** (Google Search API):
+```json
+{
+  "tools": {
+    "web": {
+      "search": {
+        "provider": "serply",
+        "apiKey": "${SERPLY_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Create a key at [serply.io](https://serply.io). You can also set `SERPLY_API_KEY` in the environment instead of storing it in config. See the [Serply documentation](https://serply.io/docs) for available result fields.
+
 **SearXNG** (self-hosted, no API key needed):
 ```json
 {
@@ -1923,7 +1940,7 @@ AnySearch works out of the box with no key, via its anonymous quota (lower rate 
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `provider` | string | `"duckduckgo"` | Search backend: `brave`, `tavily`, `jina`, `kagi`, `olostep`, `bocha`, `volcengine`, `keenable`, `serper`, `anysearch`, `searxng`, `duckduckgo` |
+| `provider` | string | `"duckduckgo"` | Search backend: `brave`, `tavily`, `jina`, `kagi`, `olostep`, `bocha`, `volcengine`, `keenable`, `serper`, `anysearch`, `serply`, `searxng`, `duckduckgo` |
 | `apiKey` | string | `""` | API key for API-backed search providers |
 | `baseUrl` | string | `""` | Base URL for SearXNG |
 | `maxResults` | integer | `5` | Results per search (1–10) |

--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -57,6 +57,7 @@ SEARCH_PROVIDER_OPTIONS: tuple[dict[str, str], ...] = (
     {"name": "volcengine", "label": "Volcengine Search", "credential": "api_key"},
     {"name": "keenable", "label": "Keenable", "credential": "optional_api_key"},
     {"name": "anysearch", "label": "AnySearch", "credential": "optional_api_key"},
+    {"name": "serply", "label": "Serply", "credential": "api_key"},
 )
 
 
@@ -461,6 +462,9 @@ class WebSearchTool(Tool):
         if provider == "serper":
             api_key = self.config.api_key or os.environ.get("SERPER_API_KEY", "")
             return "serper" if api_key else "duckduckgo"
+        if provider == "serply":
+            api_key = self.config.api_key or os.environ.get("SERPLY_API_KEY", "")
+            return "serply" if api_key else "duckduckgo"
         return provider
 
     @property
@@ -521,6 +525,8 @@ class WebSearchTool(Tool):
             return await self._search_anysearch(query, n)
         elif provider == "serper":
             return await self._search_serper(query, n)
+        elif provider == "serply":
+            return await self._search_serply(query, n)
         else:
             return ToolResult.error(f"Error: unknown search provider '{provider}'")
 
@@ -896,6 +902,47 @@ class WebSearchTool(Tool):
             return ToolResult.error(f"Error: AnySearch search failed ({e.response.status_code}): {e}")
         except Exception as e:
             return ToolResult.error(f"Error: AnySearch search failed: {e}")
+
+    async def _search_serply(self, query: str, n: int) -> str:
+        """Search via Serply (Google Search API)."""
+        api_key = self.config.api_key or os.environ.get("SERPLY_API_KEY", "")
+        if not api_key:
+            logger.warning("SERPLY_API_KEY not set, falling back to DuckDuckGo")
+            return await self._search_duckduckgo(query, n)
+        try:
+            # Serply sits behind Cloudflare, which rejects requests without a User-Agent.
+            headers = {
+                "X-Api-Key": api_key,
+                "Accept": "application/json",
+                "User-Agent": self.user_agent,
+            }
+            async with httpx.AsyncClient(proxy=self.proxy) as client:
+                r = await client.get(
+                    "https://api.serply.io/v1/search/",
+                    params={"q": query, "num": n},
+                    headers=headers,
+                    timeout=float(self.config.timeout),
+                )
+                r.raise_for_status()
+            data = cast(dict[str, Any], r.json())
+            results = cast(list[object], data.get("results", []))
+            items: list[dict[str, Any]] = [
+                {
+                    "title": result.get("title", ""),
+                    "url": result.get("link", ""),
+                    "content": result.get("description", ""),
+                }
+                for result_value in results
+                if isinstance(result_value, dict)
+                for result in (cast(dict[str, Any], result_value),)
+            ]
+            return _format_results(query, items, n)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 429:
+                return ToolResult.error("Error: Serply search rate limited. Try again later or reduce search frequency.")
+            return ToolResult.error(f"Error: Serply search failed ({e.response.status_code}): {e}")
+        except Exception as e:
+            return ToolResult.error(f"Error: Serply search failed: {e}")
 
     async def _search_volcengine(
         self,

--- a/tests/tools/test_web_search_tool.py
+++ b/tests/tools/test_web_search_tool.py
@@ -385,6 +385,90 @@ async def test_anysearch_search_rate_limited(monkeypatch):
     assert is_tool_error_result(result)
 
 
+def test_serply_without_api_key_is_treated_as_duckduckgo(monkeypatch):
+    # Serply requires a key; without one we fall back to DuckDuckGo for concurrency.
+    monkeypatch.delenv("SERPLY_API_KEY", raising=False)
+    tool = _tool(provider="serply", api_key="")
+    assert tool.exclusive is True
+    assert tool.concurrency_safe is False
+
+
+@pytest.mark.asyncio
+async def test_serply_search(monkeypatch):
+    async def mock_get(self, url, **kw):
+        assert url == "https://api.serply.io/v1/search/"
+        assert kw["headers"]["X-Api-Key"] == "serply-key"
+        assert kw["headers"]["User-Agent"] == "nanobot-search-test"
+        assert kw["params"] == {"q": "serply", "num": 1}
+        return _response(json={
+            "results": [
+                {"title": "Serply", "link": "https://serply.io", "description": "Google Search API"}
+            ]
+        })
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", mock_get)
+    tool = _tool(provider="serply", api_key="serply-key", user_agent="nanobot-search-test")
+    result = await tool.execute(query="serply", count=1)
+    assert "Serply" in result
+    assert "https://serply.io" in result
+    assert "Google Search API" in result
+
+
+@pytest.mark.asyncio
+async def test_serply_search_uses_env_api_key(monkeypatch):
+    async def mock_get(self, url, **kw):
+        assert kw["headers"]["X-Api-Key"] == "env-serply-key"
+        return _response(json={
+            "results": [{"title": "Env", "link": "https://serply.io/env", "description": "ok"}]
+        })
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", mock_get)
+    monkeypatch.setenv("SERPLY_API_KEY", "env-serply-key")
+    tool = _tool(provider="serply", api_key="")
+    result = await tool.execute(query="serply", count=1)
+    assert "Env" in result
+
+
+@pytest.mark.asyncio
+async def test_serply_fallback_to_duckduckgo_when_no_key(monkeypatch):
+    class MockDDGS:
+        def __init__(self, **kw):
+            pass
+
+        def text(self, query, max_results=5):
+            return [{"title": "Fallback", "href": "https://ddg.example", "body": "DuckDuckGo fallback"}]
+
+    monkeypatch.setattr("ddgs.DDGS", MockDDGS)
+    monkeypatch.delenv("SERPLY_API_KEY", raising=False)
+    tool = _tool(provider="serply", api_key="")
+    result = await tool.execute(query="serply", count=1)
+    assert "DuckDuckGo fallback" in result
+
+
+@pytest.mark.asyncio
+async def test_serply_search_http_error(monkeypatch):
+    async def mock_get(self, url, **kw):
+        return _response(status=403, json={"message": "Unauthorized"})
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", mock_get)
+    tool = _tool(provider="serply", api_key="bad-serply-key")
+    result = await tool.execute(query="serply")
+    assert "Error: Serply search failed (403)" in result
+    assert is_tool_error_result(result)
+
+
+@pytest.mark.asyncio
+async def test_serply_search_rate_limited(monkeypatch):
+    async def mock_get(self, url, **kw):
+        return _response(status=429, json={"message": "rate limited"})
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", mock_get)
+    tool = _tool(provider="serply", api_key="serply-key")
+    result = await tool.execute(query="serply")
+    assert "Serply search rate limited" in result
+    assert is_tool_error_result(result)
+
+
 @pytest.mark.asyncio
 async def test_bocha_search(monkeypatch):
     async def mock_post(self, url, **kw):


### PR DESCRIPTION
## What

Adds [Serply](https://serply.io) as a web search provider, following the same pattern as the existing Serper provider (#4406). Serply is a Google SERP API; selecting it routes the `web_search` tool through `https://api.serply.io/v1/search/` with the user's own API key.

## Why

Gives users another API-key-backed Google search option alongside Serper, useful when they already hold a Serply key or want an alternative to avoid rate limits on free backends. Like every other keyed provider, it falls back to DuckDuckGo when no key is configured.

## Notes

- Serply support is optional, and behavior is unchanged when `SERPLY_API_KEY` is unset. The provider falls back to DuckDuckGo without a key, matching Serper and the other keyed providers.
- Follows the existing provider pattern in `nanobot/agent/tools/web.py`: an entry in `SEARCH_PROVIDER_OPTIONS` (which feeds the WebUI settings picker and CLI onboarding), a branch in `_effective_provider`, and a `_search_serply` method mirroring `_search_serper`. The request sends an explicit `User-Agent` because Serply sits behind Cloudflare, which rejects requests without one.
- Tests added in `tests/tools/test_web_search_tool.py`, mirroring the six Serper tests: keyless concurrency fallback, mocked search (URL, headers, params, formatting), env key resolution, DuckDuckGo fallback, HTTP error, and rate limiting. Network is mocked.
- Docs updated in `docs/configuration.md`: provider table row, config example, and the provider enum. See the [Serply documentation](https://serply.io/docs) for the response fields used (`results[].title/link/description`).

## Testing

- `uv run python -m pytest tests/tools/test_web_search_tool.py -q`: 51 passed (45 existing plus 6 new).
- `uv run ruff check nanobot/agent/tools/web.py tests/tools/test_web_search_tool.py`: all checks passed.
- `uv run basedpyright nanobot/agent/tools/web.py`: 0 errors, 0 warnings.
- Live-tested against the real Serply API with a valid key: `execute(query="retrieval augmented generation", count=3)` returned three normalized results in the shared plaintext format, and `_effective_provider()` resolved to `serply` with a key and `duckduckgo` without one.

Disclosure: I work with Serply. Happy to adjust scope, naming, or drop this
entirely if it isn't a direction you want for the project.
