### PR TITLE
fix(docker): persist OAuth client data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,12 @@ RUN sed -i 's/\r$//' /usr/local/bin/entrypoint.sh && chmod +x /usr/local/bin/ent
 # and fails closed if it cannot, so the agent never runs as root (see
 # entrypoint.sh).
 USER root
-ENV HOME=/home/nanobot
+# Keep OAuth client data on the writable, persisted instance mount.  In
+# particular, oauth-cli-kit follows XDG_DATA_HOME for its token file; leaving it
+# at the default under $HOME/.local makes container logins both ephemeral and
+# vulnerable to ownership mismatches on deployments that only mount .nanobot.
+ENV HOME=/home/nanobot \
+    XDG_DATA_HOME=/home/nanobot/.nanobot/data
 # Ensure crash output reaches Render logs (app output is otherwise swallowed on
 # non-graceful exit).
 ENV PYTHONUNBUFFERED=1 PYTHONFAULTHANDLER=1

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -60,7 +60,7 @@ If deployment fails, open the service **Logs** page first. A missing model key f
 
 > [!TIP]
 > The `-v ~/.nanobot:/home/nanobot/.nanobot` flag mounts your local config directory into the container, so your config and workspace persist across container restarts.
-> The container runs as the non-root user `nanobot` (UID 1000) and reads config from `/home/nanobot/.nanobot`. Always mount your host config directory to `/home/nanobot/.nanobot`, not `/root/.nanobot`.
+> The container runs as the non-root user `nanobot` (UID 1000) and reads config from `/home/nanobot/.nanobot`. Always mount your host config directory to `/home/nanobot/.nanobot`, not `/root/.nanobot`. OAuth credentials created in the container are stored under that mounted directory as well, so they survive container replacement.
 > If you get **Permission denied**, fix ownership on the host first: `sudo chown -R 1000:1000 ~/.nanobot`, or pass `--user $(id -u):$(id -g)` to match your host UID. Podman users can use `--userns=keep-id` instead.
 >
 > [!IMPORTANT]


### PR DESCRIPTION
## Summary

- direct XDG application data to the mounted Nanobot instance directory in the Docker image
- keep OAuth credentials writable after the entrypoint drops to the non-root `nanobot` user
- document that container-created OAuth credentials persist across replacement

## Root cause

`oauth-cli-kit` stores its token file under the XDG data directory. The image previously left that at `$HOME/.local/share`, outside the directory mounted and ownership-fixed by the container entrypoint. Docker deployments could therefore fail to write the token or lose it when the container was replaced.

## Validation

- `git diff --check`
- Docker image build could not be run locally because the Docker daemon is unavailable in this environment.

Fixes #5444
