### PR TITLE
fix(tui): keep navigation commands in Herdr panes

### DIFF
--- a/tui/README.md
+++ b/tui/README.md
@@ -15,7 +15,7 @@ Standalone terminals use OpenTUI's retained full-screen layout: the transcript r
 
 ## Herdr host mode
 
-When Herdr supplies `HERDR_ENV=1` and `HERDR_PANE_ID`, nanobot becomes a quiet hosted client. It uses OpenTUI's main-screen mode instead of hiding the whole run in a temporary alternate screen, removes the launch card and persistent session/model chrome, and keeps only the transcript, last user task, current progress, and composer. Herdr remains responsible for workspace, tab, pane, and attention navigation; hosted command discovery therefore omits the duplicate session/new-chat/branch controls.
+When Herdr supplies `HERDR_ENV=1` and `HERDR_PANE_ID`, nanobot becomes a quiet hosted client. It uses OpenTUI's main-screen mode instead of hiding the whole run in a temporary alternate screen, removes the launch card and persistent session/model chrome, and keeps only the transcript, last user task, current progress, and composer. Herdr remains responsible for workspace, tab, pane, and attention navigation, while nanobot keeps its application-level session, new-chat, and branch commands.
 
 The TUI reports its WebSocket session ID, model, Git branch, workspace, last task, and current action through Herdr's supported pane CLI. Sending work reports `working`; a persisted explicit nanobot goal block reports `blocked`; a completed turn reports `idle`; exit releases lifecycle authority. The gateway session remains the durable transcript and resume path. Standalone terminals keep the richer full-screen navigation described below.
 

--- a/tui/src/app.test.ts
+++ b/tui/src/app.test.ts
@@ -2139,7 +2139,7 @@ describe("NanobotTui layout", () => {
 })
 
 describe("NanobotTui in a Herdr pane", () => {
-  test("stays quiet while reporting task, session, lifecycle, and metadata", async () => {
+  test("keeps local navigation while reporting task, session, lifecycle, and metadata", async () => {
     const setup = await createTestRenderer({ width: 80, height: 22, screenMode: "main-screen" })
     const states: Array<{ state: HostAgentState; message?: string }> = []
     const metadata: HostMetadata[] = []
@@ -2159,6 +2159,14 @@ describe("NanobotTui in a Herdr pane", () => {
       new MockTreeSitterClient({ autoResolveTimeout: 0 }),
       host,
     )
+
+    await setup.mockInput.typeText("/")
+    await setup.flush()
+    const commandFrame = setup.captureCharFrame()
+    expect(commandFrame).toContain("/sessions")
+    expect(commandFrame).toContain("/new-chat")
+    expect(commandFrame).toContain("/branch")
+    setup.mockInput.pressEscape()
 
     app.accept({ event: "attached", chat_id: "chat" })
     app.accept({

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -376,7 +376,6 @@ export class NanobotTui {
   private readonly status: TextRenderable
   private readonly meta: TextRenderable
   private readonly host: TuiHost
-  private readonly localCommands: TuiCommand[]
   private readonly draft = new ComposerDraft()
   private readonly promptQueue = new PromptQueue()
   private palette: Palette
@@ -459,7 +458,6 @@ export class NanobotTui {
     this.activeThemeMode = this.resolveThemeMode(renderer.themeMode)
     this.palette = this.activeThemeMode === "light" ? LIGHT : DARK
     this.host = host
-    this.localCommands = LOCAL_COMMANDS
     this.transcript = new Transcript(
       renderer,
       transcriptTheme(this.palette, this.backgroundKnown),
@@ -468,7 +466,7 @@ export class NanobotTui {
       !host.hosted,
     )
     this.commandMenu = new CommandMenu(renderer, commandMenuTheme(this.palette))
-    this.commandMenu.setCommands([], this.localCommands)
+    this.commandMenu.setCommands([], LOCAL_COMMANDS)
     this.sessionMenu = new SessionMenu(
       renderer,
       commandMenuTheme(this.palette),
@@ -1844,7 +1842,7 @@ export class NanobotTui {
       // Local navigation remains available against older gateways.
     }
     const commands = new Map(discovered.map((command) => [command.command, command]))
-    this.commandMenu.setCommands([...commands.values()], this.localCommands)
+    this.commandMenu.setCommands([...commands.values()], LOCAL_COMMANDS)
     this.syncCommandMenu()
   }
 

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -459,11 +459,7 @@ export class NanobotTui {
     this.activeThemeMode = this.resolveThemeMode(renderer.themeMode)
     this.palette = this.activeThemeMode === "light" ? LIGHT : DARK
     this.host = host
-    this.localCommands = host.hosted
-      ? LOCAL_COMMANDS.filter(({ command }) => (
-        command === "/context" || command === "/diff" || command === "/exit"
-      ))
-      : LOCAL_COMMANDS
+    this.localCommands = LOCAL_COMMANDS
     this.transcript = new Transcript(
       renderer,
       transcriptTheme(this.palette, this.backgroundKnown),


### PR DESCRIPTION
## Summary

- keep native TUI conversation navigation commands available in Herdr-hosted panes
- clarify that Herdr owns terminal topology while nanobot still owns sessions, new chats, and branches
- cover `/sessions`, `/new-chat`, and `/branch` in the hosted command palette regression test

## Testing

- `cd tui && bun run test` (103 passed)
- `cd tui && bun run check`
- black-box verification in a real right-side Herdr pane: `/sessions` opened the picker, `/new-chat` created a second isolated session, and `/branch` stayed on the local empty-branch path without being persisted as an agent prompt
