### PR TITLE
fix(tui): prevent local gateway startup stalls

### DIFF
--- a/nanobot/cli/webui_support.py
+++ b/nanobot/cli/webui_support.py
@@ -192,10 +192,9 @@ def _prepare_webui_bundle_for_gateway(
         return typer.confirm(message, default=True)
 
     try:
-        # A source checkout is the development product. Every gateway entrypoint
-        # keeps its browser client in lockstep with Python; only Vite mode skips
-        # the production bundle intentionally.
-        if mode != "skip" and inspect_webui_bundle().source_available:
+        # Interactive WebUI commands keep source and bundle in lockstep.
+        # Warn-only gateway startup must not block on a frontend build.
+        if mode not in {"skip", "warn"} and inspect_webui_bundle().source_available:
             mode = "auto"
         ensure_webui_bundle(
             mode=mode,

--- a/tests/cli/test_webui_support.py
+++ b/tests/cli/test_webui_support.py
@@ -4,7 +4,7 @@ from nanobot.cli.webui_support import _prepare_webui_bundle_for_gateway
 from nanobot.config.schema import Config
 
 
-def test_source_checkout_rebuilds_the_webui_from_every_gateway_entrypoint(monkeypatch) -> None:
+def test_source_checkout_preserves_warn_only_gateway_startup(monkeypatch) -> None:
     modes: list[str] = []
     monkeypatch.setattr(
         "nanobot.cli.webui_support.inspect_webui_bundle",
@@ -18,7 +18,7 @@ def test_source_checkout_rebuilds_the_webui_from_every_gateway_entrypoint(monkey
 
     _prepare_webui_bundle_for_gateway(Config(), mode="warn")
 
-    assert modes == ["auto"]
+    assert modes == ["warn"]
 
 
 def test_vite_mode_does_not_build_the_source_webui_bundle(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Preserve `warn` mode when a gateway starts from a source checkout instead of coercing it to `auto`. This prevents TUI-launched gateways from synchronously running the WebUI install/build before binding their listeners.

Explicit interactive WebUI build modes still keep source and bundled assets in sync.

## Validation

- `uv run --no-sync pytest tests/cli/test_webui_support.py -q` — 2 passed
- `uv run --no-sync pytest tests/cli/test_gateway_commands.py -q` — 20 passed
- Ruff passed
- targeted basedpyright passed