### PR TITLE
feat(providers): add SenseNova (商汤日日新) provider

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -298,6 +298,7 @@ Tracing covers the providers that go through nanobot's OpenAI-compatible client 
 | `zhipu` | LLM (Zhipu GLM) | [open.bigmodel.cn](https://open.bigmodel.cn) |
 | `xiaomi_mimo` | LLM (MiMo) | [platform.xiaomimimo.com](https://platform.xiaomimimo.com) |
 | `longcat` | LLM (LongCat) | [longcat.chat](https://longcat.chat/platform/docs/zh/) |
+| `sensenova` | LLM (SenseNova/商汤日日新) | [platform.sensenova.cn](https://platform.sensenova.cn) |
 | `ant_ling` | LLM (Ant Ling / 蚂蚁百灵) | [developer.ant-ling.com](https://developer.ant-ling.com/en/docs/api-reference/openai/) |
 | `ollama` | LLM (local, Ollama) | — |
 | `lm_studio` | LLM (local, LM Studio) | — |
@@ -950,6 +951,36 @@ LongCat is available through nanobot's built-in OpenAI-compatible provider flow.
 ```
 
 Current LongCat API docs list `LongCat-2.0-Preview` as the supported model. The older `LongCat-Flash-*` models were retired by LongCat on 2026-05-29.
+
+</details>
+
+<details>
+<summary><b>SenseNova (商汤日日新)</b></summary>
+
+SenseNova is available through nanobot's built-in OpenAI-compatible provider flow. The default API base already points to `https://token.sensenova.cn/v1`, so you usually only need to set `apiKey`.
+
+```json
+{
+  "providers": {
+    "sensenova": {
+      "apiKey": "${SENSENOVA_API_KEY}"
+    }
+  },
+  "modelPresets": {
+    "sensenova": {
+      "provider": "sensenova",
+      "model": "sensenova-6.8-flash-lite"
+    }
+  },
+  "agents": {
+    "defaults": {
+      "modelPreset": "sensenova"
+    }
+  }
+}
+```
+
+Supported models include `sensenova-6.8-flash-lite`, `deepseek-v4-flash`, and `glm-5.2`.
 
 </details>
 

--- a/nanobot/cli/onboard.py
+++ b/nanobot/cli/onboard.py
@@ -111,6 +111,9 @@ _QUICK_START_ENDPOINT_CHOICES: dict[str, tuple[_QuickStartEndpointChoice, ...]] 
         _QuickStartEndpointChoice("Standard API", "https://api.stepfun.com/v1"),
         _QuickStartEndpointChoice("Step Plan", "https://api.stepfun.ai/step_plan/v1"),
     ),
+    "sensenova": (
+        _QuickStartEndpointChoice("Standard API", "https://token.sensenova.cn/v1"),
+    ),
     "xiaomi_mimo": (
         _QuickStartEndpointChoice("Standard API", "https://api.xiaomimimo.com/v1"),
         _QuickStartEndpointChoice("Token Plan", "https://token-plan-sgp.xiaomimimo.com/v1"),

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -282,6 +282,7 @@ class ProvidersConfig(Base):
     minimax_anthropic: ProviderConfig = Field(default_factory=ProviderConfig)  # MiniMax Anthropic endpoint (thinking)
     mistral: ProviderConfig = Field(default_factory=ProviderConfig)
     stepfun: ProviderConfig = Field(default_factory=ProviderConfig)  # Step Fun (阶跃星辰) — LLM + ASR (set apiBase to Plan URL for ASR)
+    sensenova: ProviderConfig = Field(default_factory=ProviderConfig)  # SenseNova (商汤日日新)
     xiaomi_mimo: ProviderConfig = Field(default_factory=ProviderConfig)  # Xiaomi MIMO (小米)
     longcat: ProviderConfig = Field(default_factory=ProviderConfig)  # LongCat
     ant_ling: ProviderConfig = Field(default_factory=ProviderConfig)  # Ant Ling

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -618,6 +618,15 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="https://api.stepfun.com/v1",
         reasoning_as_content=True,
     ),
+    # SenseNova (商汤日日新): OpenAI-compatible API
+    ProviderSpec(
+        name="sensenova",
+        keywords=("sensenova",),
+        env_key="SENSENOVA_API_KEY",
+        display_name="SenseNova",
+        backend="openai_compat",
+        default_api_base="https://token.sensenova.cn/v1",
+    ),
     # Xiaomi MIMO (小米): OpenAI-compatible API
     # Hosted API (api.xiaomimimo.com) accepts {"thinking": {"type": "enabled"|"disabled"}}
     # to toggle reasoning, matching the existing thinking_type style.

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1128,6 +1128,63 @@ def test_config_explicit_minimax_anthropic_provider_uses_default_api_base():
     assert config.get_api_base() == "https://api.minimax.io/anthropic"
 
 
+def test_config_explicit_sensenova_provider_uses_default_api_base():
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {
+                    "provider": "sensenova",
+                    "model": "sensenova-6.8-flash-lite",
+                }
+            },
+            "providers": {
+                "sensenova": {
+                    "apiKey": "test-key",
+                }
+            },
+        }
+    )
+
+    assert config.get_provider_name() == "sensenova"
+    assert config.get_api_key() == "test-key"
+    assert config.get_api_base() == "https://token.sensenova.cn/v1"
+
+
+def test_config_sensenova_provider_uses_custom_api_base_when_set():
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {
+                    "provider": "sensenova",
+                    "model": "sensenova-6.8-flash-lite",
+                }
+            },
+            "providers": {
+                "sensenova": {
+                    "apiKey": "test-key",
+                    "apiBase": "https://custom.example.com/v1",
+                }
+            },
+        }
+    )
+
+    assert config.get_provider_name() == "sensenova"
+    assert config.get_api_key() == "test-key"
+    assert config.get_api_base() == "https://custom.example.com/v1"
+
+
+def test_config_auto_detects_sensenova_from_model_keyword():
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "auto", "model": "sensenova-6.8-flash-lite"}},
+            "providers": {"sensenova": {"apiKey": "test-key"}},
+        }
+    )
+
+    assert config.get_provider_name() == "sensenova"
+    assert config.get_api_base() == "https://token.sensenova.cn/v1"
+
+
 def test_config_auto_detects_ollama_from_local_api_base():
     config = Config.model_validate(
         {

--- a/webui/src/lib/provider-brand.ts
+++ b/webui/src/lib/provider-brand.ts
@@ -188,6 +188,7 @@ const PROVIDER_BRANDS: Record<string, ProviderBrand> = {
   ovms: brand("openvino.ai", "#0071C5", "OV"),
   qianfan: brand("cloud.baidu.com", "#2932E1", "QF"),
   searxng: brand("searxng.org", "#3050FF", "SX"),
+  sensenova: brand("sensenova.cn", "#0052D9", "SN"),
   siliconflow: brand("siliconflow.cn", "#111827", "SF"),
   skywork: brand("skywork.ai", "#5B5BF6", "SW"),
   stepfun: brand("stepfun.com", "#2F6BFF", "SF", [

--- a/webui/src/tests/provider-brand.test.ts
+++ b/webui/src/tests/provider-brand.test.ts
@@ -69,6 +69,11 @@ describe("provider brand logos", () => {
     expect(providerBrand("xiaomi")?.logoUrls[0]).toBe("https://mimo.xiaomi.com/mimo-v2-pro/assets/logo.svg");
   });
 
+  it("resolves SenseNova brand color and initials", () => {
+    expect(providerBrand("sensenova")?.color).toBe("#0052D9");
+    expect(providerBrand("sensenova")?.initials).toBe("SN");
+  });
+
   it("keeps OpenRouter voice settings on the first-party brand domain", () => {
     expect(providerBrand("openrouter")?.logoUrls).toContain("https://openrouter.ai/favicon.ico");
     expect(providerBrand("openrouter")?.initials).toBe("OR");


### PR DESCRIPTION
## Summary

Adds SenseNova (商汤日日新) as a native LLM provider using the standard OpenAI-compatible endpoint at `https://token.sensenova.cn/v1`.

## Supported Models

- `sensenova-6.8-flash-lite` (multimodal)
- `deepseek-v4-flash`
- `glm-5.2`

## Configuration

```json
{
  "providers": {
    "sensenova": {
      "apiKey": "${SENSENOVA_API_KEY}"
    }
  },
  "agents": {
    "defaults": {
      "model": "sensenova-6.8-flash-lite",
      "provider": "sensenova"
    }
  }
}
```

## Routing Note

`sensenova-6.8-flash-lite` auto-routes via the "sensenova" keyword — no prefix or explicit provider needed. Only `deepseek-v4-flash` and `glm-5.2` bare model names first match the built-in `deepseek`/`zhipu` providers; to route those through SenseNova, use the `sensenova/` prefix (e.g. `sensenova/glm-5.2`) or set `provider: "sensenova"`.

## Files Changed

- `nanobot/providers/registry.py` — new `ProviderSpec` entry
- `nanobot/config/schema.py` — new provider config field
- `nanobot/cli/onboard.py` — Quick Start endpoint choice
- `webui/src/lib/provider-brand.ts` — brand color + initials
- `tests/cli/test_commands.py` — 3 tests (explicit provider, keyword routing, custom `apiBase` override)
- `webui/src/tests/provider-brand.test.ts` — brand assertion
- `docs/configuration.md` — provider table entry + setup example

## Testing

- `pytest -k sensenova` — 3 passed
- BasedPyright (changed files) — 0 errors / 0 warnings