### PR TITLE
fix(provider): retry Codex server_error

### DIFF
--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -326,6 +326,7 @@ class LLMProvider(ABC):
         "timed out",
         "connection",
         "server error",
+        "server_error",
         "temporarily unavailable",
         "速率限制",
         "访问量过大",

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -320,6 +320,25 @@ async def test_codex_timeout_error_is_typed_and_retryable(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_codex_mid_stream_server_error_is_treated_as_transient(monkeypatch) -> None:
+    _mock_codex_token(monkeypatch)
+
+    async def fake_request(*args, **kwargs):
+        raise RuntimeError(
+            "Response failed: {'type': 'server_error', 'code': 'server_error', "
+            "'message': 'An error occurred while processing your request.'}"
+        )
+
+    monkeypatch.setattr("nanobot.providers.openai_codex_provider._request_codex", fake_request)
+
+    provider = OpenAICodexProvider()
+    response = await provider.chat([{"role": "user", "content": "hello"}])
+
+    assert response.finish_reason == "error"
+    assert provider_base.LLMProvider.is_transient_response(response) is True
+
+
+@pytest.mark.asyncio
 async def test_codex_provider_passes_proxy_to_oauth_and_response_request(monkeypatch) -> None:
     proxy = "http://127.0.0.1:23458"
     seen: dict[str, object] = {}


### PR DESCRIPTION
Fixes #5454

## Summary

- add `"server_error"` to `_TRANSIENT_ERROR_MARKERS` in `nanobot/providers/base.py`, alongside the existing `"server error"`

Scope: this fixes the case where `server_error` arrives before any content/reasoning has streamed for the turn.

## Root cause

- OpenAI's Codex provider raises a plain `RuntimeError` for a mid-stream `response.failed` event (`openai_responses/parsing.py:511,800`), with no structured status_code/error_kind — so `is_transient_response()` fell back to text matching and missed it (space vs underscore)
- this made the retry loop give up immediately instead of using its normal 1s/2s/4s backoff

## Verification

- [x] confirmed red before the fix: reverting the one-line marker addition makes `test_codex_mid_stream_server_error_is_treated_as_transient` fail
- [x] `pytest -q`
- [x] `ruff check nanobot/providers/base.py tests/providers/test_openai_codex_provider.py`