### PR TITLE
chore(deps): drop websocket-client, add certifi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ olostep = [
 dev = [
     "pytest>=9.0.0,<10.0.0",
     "pytest-asyncio>=1.3.0,<2.0.0",
+    "certifi>=2025.1.1",
     "aiohttp>=3.9.0,<4.0.0",
     "pytest-cov>=6.0.0,<7.0.0",
     "pytest-xdist>=3.8.0,<4.0.0",


### PR DESCRIPTION
- remove `websocket-client`: not used anywhere in the code, and no dependency needs it either
- add `certifi` to dev deps: used directly in `conftest.py`, but was never declared. It's a transitive dependency of `httpx`
  (httpx depends on it), so this adds no new install, just makes an existing implicit dependency explicit

## Verification

- `pytest -q` (6602 passed, 13 skipped)
- `uv build` (wheel + sdist build fine)