### PR TITLE
fix(channels): scope dispatcher exception boundary to message processing

### DIFF
--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -698,7 +698,12 @@ class ChannelManager:
                         self.bus.consume_outbound(),
                         timeout=1.0
                     )
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
 
+            try:
                 event = outbound_event_from_message(msg)
                 progress_event = event if isinstance(event, ProgressEvent) else None
                 if progress_event and (
@@ -759,11 +764,15 @@ class ChannelManager:
                     await self._send_with_retry(channel, msg)
                 else:
                     logger.warning("Unknown channel: {}", msg.channel)
-
-            except asyncio.TimeoutError:
-                continue
             except asyncio.CancelledError:
                 break
+            except Exception:
+                logger.exception(
+                    "Outbound dispatcher failed processing message for {}:{}; dropping it",
+                    msg.channel,
+                    msg.chat_id,
+                )
+                continue
 
     @staticmethod
     async def _send_reasoning_delta(

--- a/tests/channels/test_channel_manager_delta_coalescing.py
+++ b/tests/channels/test_channel_manager_delta_coalescing.py
@@ -89,6 +89,23 @@ def _delta(content: str, *, chat_id: str = "chat1", stream_id: str | None = None
     )
 
 
+def _delta_with_none_content(*, chat_id: str = "chat1", stream_id: str | None = None):
+    """A malformed stream-delta message with ``content=None``.
+
+    ``OutboundMessage`` is a plain dataclass with no runtime validation, so
+    this is constructible despite the ``content: str`` type hint -- it
+    reproduces the real trigger that used to kill ``_dispatch_outbound``
+    (``_coalesce_stream_deltas`` does ``combined_content += next_msg.content``
+    unconditionally).
+    """
+    return OutboundMessage(
+        channel="mock",
+        chat_id=chat_id,
+        content=None,  # type: ignore[arg-type]
+        event=StreamDeltaEvent(stream_id=stream_id),
+    )
+
+
 def _end(
     content: str = "",
     *,
@@ -489,3 +506,64 @@ class TestRetryWaitFiltering:
         sent = send_mock.await_args_list[0].args[0]
         assert sent.content == "final answer"
         assert sent.event is None
+
+
+class TestDispatcherExceptionBoundary:
+    """A failure while processing one message must not kill the dispatcher (#5376-class bug)."""
+
+    @pytest.mark.asyncio
+    async def test_malformed_message_does_not_kill_dispatcher(self, manager, bus):
+        # A matching second delta must be queued right behind the malformed one:
+        # _coalesce_stream_deltas only hits the crashing ``+=`` once it pulls a
+        # second message for the same (channel, chat_id, stream_id) via
+        # get_nowait() -- a lone malformed delta with an empty queue behind it
+        # returns without ever reaching that line.
+        await bus.publish_outbound(_delta_with_none_content(stream_id="s1"))
+        await bus.publish_outbound(_delta("more", stream_id="s1"))
+
+        task = asyncio.create_task(manager._dispatch_outbound())
+        try:
+            await asyncio.sleep(0.2)
+            assert not task.done(), "dispatcher died processing a malformed message"
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_subsequent_valid_message_still_delivered(self, manager, bus):
+        await bus.publish_outbound(_delta_with_none_content(stream_id="s1"))
+        await bus.publish_outbound(_delta("more", stream_id="s1"))
+        await bus.publish_outbound(OutboundMessage(
+            channel="mock",
+            chat_id="chat1",
+            content="still alive",
+        ))
+
+        task = asyncio.create_task(manager._dispatch_outbound())
+        try:
+            for _ in range(30):
+                if manager.channels["mock"]._send_mock.await_count >= 1:
+                    break
+                await asyncio.sleep(0.05)
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        send_mock = manager.channels["mock"]._send_mock
+        assert send_mock.await_count == 1
+        assert send_mock.await_args_list[0].args[0].content == "still alive"
+
+    @pytest.mark.asyncio
+    async def test_cancellation_still_stops_the_loop_cleanly(self, manager, bus):
+        task = asyncio.create_task(manager._dispatch_outbound())
+        await asyncio.sleep(0.05)  # let it start and enter the idle wait
+
+        task.cancel()
+        await asyncio.wait_for(task, timeout=1.0)  # must complete promptly, not hang
+        assert task.cancelled() is False  # caught internally and broke out cleanly


### PR DESCRIPTION
## Summary

An unexpected error while processing one outbound message could stop `ChannelManager._dispatch_outbound`, the background task responsible for delivering outbound messages. Once the task stopped, no further messages were sent until the process restarted.

## Root Cause

`OutboundMessage` is a standard dataclass, so its `content: str` type hint is not enforced at runtime. A malformed upstream event can therefore create a message with `content=None`.

When `_coalesce_stream_deltas` combines that message with another stream delta, `combined_content += next_msg.content` raises a `TypeError`.

`_dispatch_outbound` handled timeouts and cancellation, but it did not handle unexpected errors during message processing. As a result, the error escaped the loop and stopped the dispatcher.

## Changes

* Split message acquisition and message processing into separate exception-handling blocks.
* Preserve the existing timeout and cancellation handling during message acquisition.
* Log processing failures with the affected channel, chat ID, and traceback.
* Drop only the failed message and continue processing the queue.
* Keep `consume_outbound()` outside the new processing exception boundary so queue-level failures behave as before.
* Add three focused regression tests in `tests/channels/test_channel_manager_delta_coalescing.py`.

## Testing

* [x] Confirmed that a malformed message no longer stops the dispatcher.
* [x] Confirmed that the next valid message is still delivered.
* [x] Confirmed that cancellation still stops the dispatcher cleanly.
* [x] Reproduced the original `TypeError` against the unfixed code.
* [x] Full `tests/channels/` suite passes: 221 passed, 1 skipped.
* [x] `ruff check` passes.
* [x] `basedpyright` passes.
* [x] `git diff --check` passes.

## Compatibility and Risk

Low risk. This change does not modify any public API, configuration option, or successful delivery path.

A message that previously stopped the dispatcher is now logged and dropped, allowing later messages to continue through the queue. Timeout and cancellation behaviour remains unchanged.

## Related Issue

No related issue.
