### PR TITLE
fix(tui): clarify input cache telemetry

### DIFF
--- a/tui/src/app.test.ts
+++ b/tui/src/app.test.ts
@@ -1529,8 +1529,7 @@ describe("NanobotTui layout", () => {
     const footer = setup.captureCharFrame().split("\n").find((line) => line.includes("Ready · 1.7s")) || ""
     expect(footer).toContain("Ready · 1.7s")
     expect(footer).toContain("50 tok/s")
-    expect(footer).toContain("1.2K in · 80 out")
-    expect(footer).toContain("75% cached")
+    expect(footer).toContain("1.2K in (75% cached) · 80 out")
     expect(footer).not.toContain("TTFT")
     expect(footer).not.toContain("enter send")
 

--- a/tui/src/footer-hints.test.ts
+++ b/tui/src/footer-hints.test.ts
@@ -29,7 +29,7 @@ describe("footerHints", () => {
     expect(active.chunks).toHaveLength(0)
   })
 
-  test("shows measured throughput, explicit token directions, and cache ratio", () => {
+  test("groups the cache ratio with input telemetry", () => {
     const result = footerTelemetry({
       prompt_tokens: 1200,
       completion_tokens: 80,
@@ -41,7 +41,7 @@ describe("footerHints", () => {
     }, 120, theme)
 
     expect(result.chunks.map(({ text }) => text).join(""))
-      .toBe("50 tok/s · 1.2K in · 80 out · 75% cached")
+      .toBe("50 tok/s · 1.2K in (75% cached) · 80 out")
     expect(result.chunks[0]?.fg?.toInts().slice(0, 3)).toEqual([239, 142, 48])
   })
 
@@ -55,7 +55,7 @@ describe("footerHints", () => {
     }, 120, theme)
 
     expect(result.chunks.map(({ text }) => text).join(""))
-      .toBe("140 tok/s · 4.5M in · 19K out · 80% cached")
+      .toBe("140 tok/s · 4.5M in (80% cached) · 19K out")
   })
 
   test("degrades telemetry instead of guessing missing provider metrics", () => {

--- a/tui/src/footer-hints.ts
+++ b/tui/src/footer-hints.ts
@@ -52,23 +52,25 @@ export function footerTelemetry(
     const estimated = (usage.estimated_tokens || 0) > 0 ? "~" : ""
     parts.push(`${estimated}${value} tok/s`)
   }
+  const cacheHitRate = (
+    typeof usage.cached_tokens === "number"
+    && typeof usage.prompt_tokens === "number"
+    && usage.prompt_tokens > 0
+  )
+    ? Math.min(100, Math.max(0, Math.round(
+        usage.cached_tokens * 100 / usage.prompt_tokens,
+      )))
+    : null
   if (width >= 72) {
     const prompt = usage.prompt_tokens
     const completion = usage.completion_tokens
     if (typeof prompt === "number" || typeof completion === "number") {
-      parts.push(`${formatTelemetryTokens(prompt || 0)} in`)
+      const cache = cacheHitRate === null ? "" : ` (${cacheHitRate}% cached)`
+      parts.push(`${formatTelemetryTokens(prompt || 0)} in${cache}`)
       parts.push(`${formatTelemetryTokens(completion || 0)} out`)
     }
-  }
-  if (
-    typeof usage.cached_tokens === "number"
-    && typeof usage.prompt_tokens === "number"
-    && usage.prompt_tokens > 0
-  ) {
-    const hitRate = Math.min(100, Math.max(0, Math.round(
-      usage.cached_tokens * 100 / usage.prompt_tokens,
-    )))
-    parts.push(`${hitRate}% cached`)
+  } else if (cacheHitRate !== null) {
+    parts.push(`${cacheHitRate}% cached`)
   }
   if (width >= 128 && typeof usage.cost_usd === "number" && usage.cost_usd > 0) {
     parts.push(`$${usage.cost_usd < 0.01 ? usage.cost_usd.toFixed(4) : usage.cost_usd.toFixed(2)}`)


### PR DESCRIPTION
## Summary

- group the prompt-cache percentage with the input token count in the TUI footer
- keep the standalone cache percentage on narrow terminals where token directions are hidden
- update footer and layout coverage for the revised telemetry copy

Before:

```text
43 tok/s · 66K in · 40 out · 94% cached
```

After:

```text
43 tok/s · 66K in (94% cached) · 40 out
```

## Testing

- `cd tui && bun test src/footer-hints.test.ts src/app.test.ts`
- `cd tui && bun run check`
- `git diff --check origin/main...HEAD`