### PR TITLE
fix(tui): show measured request context

### DIFF
--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -75,6 +75,14 @@ _MAX_EMPTY_RETRIES = 2
 _MAX_LENGTH_RECOVERIES = 3
 _MAX_INJECTIONS_PER_TURN = 3
 _MAX_INJECTION_CYCLES = 5
+_LAST_REQUEST_USAGE_KEYS = (
+    "prompt_tokens",
+    "completion_tokens",
+    "cached_tokens",
+    "provider_tokens",
+    "generation_ms",
+    "measured_completion_tokens",
+)
 
 
 def _restore_outer_whitespace(content: str, original: str | None) -> str:
@@ -860,6 +868,9 @@ class AgentRunner:
                 final_content = terminal_content
             self._append_final_message(messages, terminal_content)
 
+        if usage.get("last_request_provider_tokens", 0) > 0:
+            usage["last_request_context_window_tokens"] = spec.runtime.context_window_tokens
+
         return AgentRunResult(
             final_content=final_content,
             messages=messages,
@@ -1386,8 +1397,19 @@ class AgentRunner:
 
     @staticmethod
     def _accumulate_usage(target: dict[str, int], addition: dict[str, int]) -> None:
+        if not addition:
+            return
         for key, value in addition.items():
             target[key] = target.get(key, 0) + value
+        # Billing/accounting stays turn-aggregate, while latency-sensitive UIs
+        # need the provider-reported shape of the most recent model request.
+        # Clear optional fields first so an older request's cache/timing data
+        # cannot be mistaken for the latest request's telemetry.
+        for key in _LAST_REQUEST_USAGE_KEYS:
+            target.pop(f"last_request_{key}", None)
+        for key in _LAST_REQUEST_USAGE_KEYS:
+            if key in addition:
+                target[f"last_request_{key}"] = addition[key]
 
     @staticmethod
     def _merge_usage(left: dict[str, int], right: dict[str, int]) -> dict[str, int]:

--- a/tests/agent/test_runner_core.py
+++ b/tests/agent/test_runner_core.py
@@ -1066,10 +1066,16 @@ async def test_runner_accumulates_usage_and_preserves_cached_tokens():
         max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
     ))
 
-    # Usage should be accumulated across iterations
+    # Accounting remains cumulative, while UI telemetry retains the latest
+    # provider-reported request instead of presenting the sum as context size.
     assert result.usage["prompt_tokens"] == 300  # 100 + 200
     assert result.usage["completion_tokens"] == 30  # 10 + 20
     assert result.usage["cached_tokens"] == 230  # 80 + 150
+    assert result.usage["last_request_prompt_tokens"] == 200
+    assert result.usage["last_request_completion_tokens"] == 20
+    assert result.usage["last_request_cached_tokens"] == 150
+    assert result.usage["last_request_provider_tokens"] == 220
+    assert result.usage["last_request_context_window_tokens"] == 200_000
 
 
 @pytest.mark.asyncio
@@ -1204,3 +1210,26 @@ async def test_runner_passes_reasoning_effort_to_provider():
     ))
 
     assert captured["reasoning_effort"] == "high"
+
+
+def test_runner_last_request_usage_drops_stale_optional_metrics():
+    """A later uncached/untimed response must not inherit older request telemetry."""
+    from nanobot.agent.runner import AgentRunner
+
+    usage: dict[str, int] = {}
+    AgentRunner._accumulate_usage(usage, {
+        "prompt_tokens": 100,
+        "completion_tokens": 10,
+        "cached_tokens": 80,
+        "provider_tokens": 110,
+    })
+    AgentRunner._accumulate_usage(usage, {
+        "prompt_tokens": 200,
+        "completion_tokens": 20,
+        "provider_tokens": 220,
+    })
+
+    assert usage["prompt_tokens"] == 300
+    assert usage["cached_tokens"] == 80
+    assert usage["last_request_prompt_tokens"] == 200
+    assert "last_request_cached_tokens" not in usage

--- a/tui/src/app.test.ts
+++ b/tui/src/app.test.ts
@@ -752,7 +752,6 @@ describe("NanobotTui layout", () => {
       runtimeControls: {
         modelText: TextRenderable
         accessText: TextRenderable
-        contextText: TextRenderable
         visible: boolean
         menuRoot: { getChildren(): unknown[] }
       }
@@ -771,7 +770,6 @@ describe("NanobotTui layout", () => {
       })
       expect(ui.runtimeControls.modelText.selectable).toBe(false)
       expect(ui.runtimeControls.accessText.selectable).toBe(false)
-      expect(ui.runtimeControls.contextText.selectable).toBe(false)
       expect(ui.titleText.selectable).toBe(false)
       expect(ui.status.selectable).toBe(false)
       expect(ui.meta.selectable).toBe(false)
@@ -1074,7 +1072,6 @@ describe("NanobotTui layout", () => {
     const ui = app as unknown as {
       composer: TextareaRenderable
       contextPanel: { visible: boolean }
-      runtimeControls: { contextText: { plainText: string } }
     }
 
     try {
@@ -1082,9 +1079,9 @@ describe("NanobotTui layout", () => {
       ui.composer.submit()
       await waitUntil(() => ui.contextPanel.visible)
       await setup.flush()
-      expect(ui.runtimeControls.contextText.plainText).toContain("~2.2k ctx")
       const frame = setup.captureCharFrame()
 
+      expect(frame).not.toContain("~2.2k ctx")
       expect(frame).toContain("~2.2k tokens · 10 replay · 16 archived")
       expect(frame).toContain("The earlier turns agreed on a release plan.")
       expect(frame).not.toContain("Agent context")
@@ -1514,13 +1511,19 @@ describe("NanobotTui layout", () => {
       chat_id: "chat",
       latency_ms: 1700,
       usage: {
-        prompt_tokens: 1200,
-        completion_tokens: 80,
-        cached_tokens: 900,
-        generation_ms: 1600,
-        measured_completion_tokens: 80,
-        ttft_ms: 240,
-        timed_requests: 1,
+        prompt_tokens: 12_000,
+        completion_tokens: 400,
+        cached_tokens: 9000,
+        generation_ms: 8000,
+        measured_completion_tokens: 400,
+        timed_requests: 5,
+        last_request_prompt_tokens: 1200,
+        last_request_completion_tokens: 80,
+        last_request_cached_tokens: 900,
+        last_request_provider_tokens: 1280,
+        last_request_context_window_tokens: 128_000,
+        last_request_generation_ms: 1600,
+        last_request_measured_completion_tokens: 80,
       },
       context_window_tokens: 128_000,
     })
@@ -1529,7 +1532,8 @@ describe("NanobotTui layout", () => {
     const footer = setup.captureCharFrame().split("\n").find((line) => line.includes("Ready · 1.7s")) || ""
     expect(footer).toContain("Ready · 1.7s")
     expect(footer).toContain("50 tok/s")
-    expect(footer).toContain("1.2K in (75% cached) · 80 out")
+    expect(footer).toContain("1.2K/128K ctx (75% cached) · 80 out")
+    expect(footer).not.toContain("12K")
     expect(footer).not.toContain("TTFT")
     expect(footer).not.toContain("enter send")
 

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -47,7 +47,7 @@ import {
   type TuiCommand,
 } from "./command-menu"
 import { SessionMenu, sessionLabel } from "./session-menu"
-import { ContextPanel, formatTokenCount, type ContextPanelTheme } from "./context-panel"
+import { ContextPanel, type ContextPanelTheme } from "./context-panel"
 import {
   DiffViewer,
   latestTurnFileEdits,
@@ -423,8 +423,6 @@ export class NanobotTui {
   private sessionModelPreset: string | null | undefined
   private sessionTitle = ""
   private sessionMetadataId = 0
-  private contextTokens: number | null = null
-  private contextWindowTokens: number | null = null
   private lastUsage: TokenUsage | null = null
   private readyDetail = ""
   private mentionCandidates: MentionCandidate[] = []
@@ -627,7 +625,6 @@ export class NanobotTui {
     if (!host.hosted) {
       this.title.add(this.runtimeControls.modelText)
       this.title.add(this.runtimeControls.accessText)
-      this.title.add(this.runtimeControls.contextText)
     }
     const composerSurface = this.composerSurface()
     this.composerFrame = new BoxRenderable(renderer, {
@@ -1049,9 +1046,6 @@ export class NanobotTui {
         this.turnHadAnswer = false
         this.activeTurnId = null
         if (event.usage) this.lastUsage = event.usage
-        if (typeof event.context_window_tokens === "number") {
-          this.contextWindowTokens = event.context_window_tokens
-        }
         this.applyHostGoalState(event.goal_state)
         this.updateTitle()
         this.setActive(false)
@@ -1063,7 +1057,6 @@ export class NanobotTui {
           : ""
         this.status.content = this.readyStatus()
         this.reportHostResting()
-        if (this.contextTokens !== null) void this.refreshContextEstimate(event.chat_id)
         this.sendNextFollowUp()
         return
       case "goal_status":
@@ -1084,9 +1077,6 @@ export class NanobotTui {
         if (!this.activeTurn) this.reportHostResting()
         return
       case "turn_model_updated":
-        if (typeof event.context_window_tokens === "number") {
-          this.contextWindowTokens = event.context_window_tokens
-        }
         this.setTurnModel(event.model_name, event.model_preset)
         return
       case "runtime_model_updated":
@@ -1665,13 +1655,7 @@ export class NanobotTui {
     const identity = this.sessionTitle.trim() || "nanobot"
     this.titleText.maxWidth = Math.max(8, Math.floor(this.renderer.width * 0.38))
     this.titleText.content = identity
-    const context = this.contextTokens === null
-      ? ""
-      : `  ·  ~${formatTokenCount(this.contextTokens)}${this.contextWindowTokens
-        ? `/${formatTokenCount(this.contextWindowTokens)}`
-        : ""} ctx`
     this.runtimeControls.updateModel(this.modelName, this.modelPreset)
-    this.runtimeControls.updateContext(context)
     this.syncHostMetadata()
   }
 
@@ -1949,7 +1933,6 @@ export class NanobotTui {
       this.sessionTitle = `Fork · ${preview.slice(0, 48)}`
       this.clearHostContext()
       this.setCurrentTask(preview)
-      this.contextTokens = null
       this.lastUsage = null
       this.readyDetail = ""
       this.updateTitle()
@@ -2045,7 +2028,6 @@ export class NanobotTui {
       this.sessionTitle = sessionLabel(session)
       this.applySessionModel(session)
       this.applySessionScope(session)
-      this.contextTokens = null
       this.lastUsage = null
       this.readyDetail = ""
       this.updateTitle()
@@ -2080,7 +2062,6 @@ export class NanobotTui {
       this.sessionModelPreset = null
       this.modelName = this.defaultModelName
       this.modelPreset = this.defaultModelPreset
-      this.contextTokens = null
       this.lastUsage = null
       this.readyDetail = ""
       this.updateTitle()
@@ -2200,9 +2181,7 @@ export class NanobotTui {
         this.status.content = "Context unavailable · new session or older gateway"
         return
       }
-      this.contextTokens = context.estimatedSessionTokens
       this.lastUsage = context.lastUsage
-      this.updateTitle()
       this.contextPanel.show(context)
       this.status.content = "Context snapshot"
       this.updateMeta()
@@ -2232,25 +2211,6 @@ export class NanobotTui {
       this.updateTitle()
     } catch {
       // Session metadata is decorative; conversation transport stays authoritative.
-    }
-  }
-
-  private async refreshContextEstimate(chatId: string): Promise<void> {
-    try {
-      const context = await fetchSessionContext(
-        this.options.apiUrl,
-        this.options.apiToken,
-        chatId,
-        this.apiReauthenticator,
-      )
-      if (!context || chatId !== this.client.activeChatId) return
-      this.contextTokens = context.estimatedSessionTokens
-      this.lastUsage = context.lastUsage || this.lastUsage
-      this.updateTitle()
-      if (!this.activeTurn) this.status.content = this.readyStatus()
-      this.updateMeta()
-    } catch {
-      // Keep the last known estimate; it is intentionally informational.
     }
   }
 

--- a/tui/src/footer-hints.test.ts
+++ b/tui/src/footer-hints.test.ts
@@ -29,44 +29,57 @@ describe("footerHints", () => {
     expect(active.chunks).toHaveLength(0)
   })
 
-  test("groups the cache ratio with input telemetry", () => {
+  test("shows the latest measured request instead of aggregate turn usage", () => {
     const result = footerTelemetry({
-      prompt_tokens: 1200,
-      completion_tokens: 80,
-      cached_tokens: 900,
-      generation_ms: 1600,
-      measured_completion_tokens: 80,
-      ttft_ms: 500,
-      timed_requests: 2,
+      prompt_tokens: 1_400_000,
+      completion_tokens: 3200,
+      cached_tokens: 1_330_000,
+      generation_ms: 49_000,
+      measured_completion_tokens: 3200,
+      last_request_prompt_tokens: 148_000,
+      last_request_completion_tokens: 400,
+      last_request_cached_tokens: 140_600,
+      last_request_provider_tokens: 148_400,
+      last_request_generation_ms: 6154,
+      last_request_measured_completion_tokens: 400,
+      last_request_context_window_tokens: 300_000,
     }, 120, theme)
 
     expect(result.chunks.map(({ text }) => text).join(""))
-      .toBe("50 tok/s · 1.2K in (75% cached) · 80 out")
+      .toBe("65 tok/s · 148K/300K ctx (95% cached) · 400 out")
     expect(result.chunks[0]?.fg?.toInts().slice(0, 3)).toEqual([239, 142, 48])
   })
 
-  test("uses familiar compact units for large token counts", () => {
-    const result = footerTelemetry({
-      prompt_tokens: 4_500_000,
-      completion_tokens: 19_000,
-      cached_tokens: 3_600_000,
-      generation_ms: 135_714,
-      measured_completion_tokens: 19_000,
-    }, 120, theme)
+  test("keeps real context visible while compacting secondary metrics", () => {
+    const usage = {
+      last_request_prompt_tokens: 148_000,
+      last_request_completion_tokens: 400,
+      last_request_cached_tokens: 140_600,
+      last_request_provider_tokens: 148_400,
+      last_request_generation_ms: 6154,
+      last_request_measured_completion_tokens: 400,
+      last_request_context_window_tokens: 300_000,
+    }
+
+    const result = footerTelemetry(usage, 60, theme)
 
     expect(result.chunks.map(({ text }) => text).join(""))
-      .toBe("140 tok/s · 4.5M in (80% cached) · 19K out")
+      .toBe("65 tok/s · 148K/300K ctx")
   })
 
-  test("degrades telemetry instead of guessing missing provider metrics", () => {
-    const compact = footerTelemetry({
-      prompt_tokens: 1000,
-      completion_tokens: 20,
-      cached_tokens: 0,
-    }, 60, theme)
-    const unsupported = footerTelemetry({ prompt_tokens: 1000, completion_tokens: 20 }, 60, theme)
+  test("does not present aggregate or estimated usage as real context", () => {
+    const aggregate = footerTelemetry({
+      prompt_tokens: 1_400_000,
+      completion_tokens: 3200,
+      cached_tokens: 1_330_000,
+    }, 120, theme)
+    const estimated = footerTelemetry({
+      last_request_prompt_tokens: 148_000,
+      estimated_tokens: 148_400,
+      last_request_context_window_tokens: 300_000,
+    }, 120, theme)
 
-    expect(compact.chunks.map(({ text }) => text).join("")).toBe("0% cached")
-    expect(unsupported.chunks).toHaveLength(0)
+    expect(aggregate.chunks).toHaveLength(0)
+    expect(estimated.chunks).toHaveLength(0)
   })
 })

--- a/tui/src/footer-hints.ts
+++ b/tui/src/footer-hints.ts
@@ -36,44 +36,45 @@ export function contextualFooterHints(
   return footerHints(hintsFor(mode, width), theme)
 }
 
-/** Last-turn model telemetry. Passive chrome reports the system, not its manual. */
+/** Latest provider-measured request telemetry, never turn-aggregate accounting. */
 export function footerTelemetry(
   usage: TokenUsage | null,
   width: number,
   theme: FooterHintTheme,
 ): StyledText {
-  if (!usage) return new StyledText([])
+  if (!usage || (usage.last_request_provider_tokens || 0) <= 0) {
+    return new StyledText([])
+  }
   const parts: string[] = []
-  const duration = usage.generation_ms
-  const measured = usage.measured_completion_tokens
+  const duration = usage.last_request_generation_ms
+  const measured = usage.last_request_measured_completion_tokens
   if (typeof duration === "number" && duration > 0 && typeof measured === "number") {
     const rate = measured * 1000 / duration
     const value = rate < 10 ? rate.toFixed(1) : String(Math.round(rate))
-    const estimated = (usage.estimated_tokens || 0) > 0 ? "~" : ""
-    parts.push(`${estimated}${value} tok/s`)
+    parts.push(`${value} tok/s`)
   }
+  const prompt = usage.last_request_prompt_tokens
+  const cached = usage.last_request_cached_tokens
   const cacheHitRate = (
-    typeof usage.cached_tokens === "number"
-    && typeof usage.prompt_tokens === "number"
-    && usage.prompt_tokens > 0
+    typeof cached === "number"
+    && typeof prompt === "number"
+    && prompt > 0
   )
-    ? Math.min(100, Math.max(0, Math.round(
-        usage.cached_tokens * 100 / usage.prompt_tokens,
-      )))
+    ? Math.min(100, Math.max(0, Math.round(cached * 100 / prompt)))
     : null
-  if (width >= 72) {
-    const prompt = usage.prompt_tokens
-    const completion = usage.completion_tokens
-    if (typeof prompt === "number" || typeof completion === "number") {
-      const cache = cacheHitRate === null ? "" : ` (${cacheHitRate}% cached)`
-      parts.push(`${formatTelemetryTokens(prompt || 0)} in${cache}`)
-      parts.push(`${formatTelemetryTokens(completion || 0)} out`)
-    }
-  } else if (cacheHitRate !== null) {
-    parts.push(`${cacheHitRate}% cached`)
+  if (typeof prompt === "number") {
+    const contextWindowTokens = usage.last_request_context_window_tokens
+    const window = contextWindowTokens && contextWindowTokens > 0
+      ? `/${formatTelemetryTokens(contextWindowTokens)}`
+      : ""
+    const cache = width >= 72 && cacheHitRate !== null
+      ? ` (${cacheHitRate}% cached)`
+      : ""
+    parts.push(`${formatTelemetryTokens(prompt)}${window} ctx${cache}`)
   }
-  if (width >= 128 && typeof usage.cost_usd === "number" && usage.cost_usd > 0) {
-    parts.push(`$${usage.cost_usd < 0.01 ? usage.cost_usd.toFixed(4) : usage.cost_usd.toFixed(2)}`)
+  const completion = usage.last_request_completion_tokens
+  if (width >= 72 && typeof completion === "number") {
+    parts.push(`${formatTelemetryTokens(completion)} out`)
   }
   return footerMetrics(parts, theme)
 }

--- a/tui/src/protocol.ts
+++ b/tui/src/protocol.ts
@@ -211,6 +211,13 @@ export interface TokenUsage {
   measured_completion_tokens?: number
   ttft_ms?: number
   timed_requests?: number
+  last_request_prompt_tokens?: number
+  last_request_completion_tokens?: number
+  last_request_cached_tokens?: number
+  last_request_provider_tokens?: number
+  last_request_generation_ms?: number
+  last_request_measured_completion_tokens?: number
+  last_request_context_window_tokens?: number
 }
 
 export interface SessionContextSnapshot {
@@ -359,6 +366,13 @@ function isTokenUsage(value: unknown): value is TokenUsage {
     "measured_completion_tokens",
     "ttft_ms",
     "timed_requests",
+    "last_request_prompt_tokens",
+    "last_request_completion_tokens",
+    "last_request_cached_tokens",
+    "last_request_provider_tokens",
+    "last_request_generation_ms",
+    "last_request_measured_completion_tokens",
+    "last_request_context_window_tokens",
   ].every((key) => optional(value[key], "number"))
 }
 

--- a/tui/src/runtime-controls.ts
+++ b/tui/src/runtime-controls.ts
@@ -44,7 +44,6 @@ interface RuntimeControlsOptions {
 export class RuntimeControls {
   readonly modelText: TextRenderable
   readonly accessText: TextRenderable
-  readonly contextText: TextRenderable
   readonly menuRoot: BoxRenderable
   private readonly menu: PickerMenu<Choice>
   private kind: Choice["kind"] | null = null
@@ -80,14 +79,6 @@ export class RuntimeControls {
     this.menuRoot = this.menu.root
     this.modelText = this.controlText(renderer, "model", () => void this.openModel())
     this.accessText = this.controlText(renderer, "access", () => void this.openAccess())
-    this.contextText = new TextRenderable(renderer, {
-      id: "nanobot-tui-context-text",
-      content: "",
-      height: 1,
-      flexShrink: 0,
-      fg: theme.faint,
-      selectable: false,
-    })
     this.render()
   }
 
@@ -103,10 +94,6 @@ export class RuntimeControls {
     this.model = model
     this.modelPreset = preset
     this.render()
-  }
-
-  updateContext(text: string): void {
-    this.contextText.content = text
   }
 
   /** Warm the small settings payload while the user is reading the first frame. */
@@ -129,7 +116,6 @@ export class RuntimeControls {
 
   resize(width: number): void {
     this.accessText.visible = width >= 58
-    this.contextText.visible = width >= 96
   }
 
   choose(): boolean {
@@ -163,7 +149,6 @@ export class RuntimeControls {
   setTheme(theme: RuntimeControlsTheme): void {
     this.theme = theme
     this.menu.setTheme(theme)
-    this.contextText.fg = theme.faint
     this.renderColors()
   }
 


### PR DESCRIPTION
## Summary

- keep cumulative per-turn token usage for backend accounting, but retain the latest provider-reported request separately for UI telemetry
- show only that measured request in the idle TUI footer: prompt context/window, matching cache ratio, output tokens, and generation rate
- remove the persistent estimated session-context label from the title so context appears only once
- hide context telemetry when a provider does not report real usage instead of presenting an estimate as measured data

Before, a tool-heavy turn could mix two incompatible scopes:

```text
title:  ~148k/300k ctx
footer: 65 tok/s · 1.4M in (95% cached) · 3.2K out
```

The title was a session-history estimate, while `1.4M` was input accumulated across every model call in the turn.

After:

```text
title:  no context duplicate
footer: 65 tok/s · 148K/300K ctx (95% cached) · 400 out
```

All footer values now describe the same latest provider-measured request. The explicit `/context` panel remains available for inspecting estimated replay/archive state.

Follow-up to #5468.

## Testing

- `cd tui && bun test` (110 passed)
- `cd tui && bun run check`
- `pytest tests/agent/test_runner_core.py -q` (30 passed)
- `ruff check nanobot/agent/runner.py tests/agent/test_runner_core.py`
- `git diff --check`