### PR TITLE
fix(sdk): make ephemeral runs leave session state unchanged

### DIFF
--- a/nanobot/agent/autocompact.py
+++ b/nanobot/agent/autocompact.py
@@ -107,6 +107,13 @@ class AutoCompact:
             self._archiving.discard(key)
             self._summaries.pop(key, None)
             return session, None
+        if not session.policy.persist:
+            # Non-persistent sessions (SDK ephemeral reads, temporary chats)
+            # are isolated views of the workspace: never swap them for stored
+            # state and never consume one-shot summaries reserved for the
+            # persistent session's next turn.
+            self._archiving.discard(key)
+            return session, self._peek_summary(session, key)
         if key in self._archiving or self._is_expired(session.updated_at):
             logger.info("Auto-compact: reloading session {} (archiving={})", key, key in self._archiving)
             session = self.sessions.get_or_create(key)
@@ -118,6 +125,16 @@ class AutoCompact:
         # Persisted metadata may outlive schema changes; a malformed summary must
         # not abort turn preparation.
         return session, session_summary_from_metadata(
+            session.metadata,
+            fallback_last_active=session.updated_at,
+        )
+
+    def _peek_summary(self, session: Session, key: str) -> SessionSummary | None:
+        """Summary for an isolated session; consumes nothing."""
+        entry = self._summaries.get(key)
+        if entry is not None:
+            return entry
+        return session_summary_from_metadata(
             session.metadata,
             fallback_last_active=session.updated_at,
         )

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import dataclasses
 import inspect
 import os
@@ -150,6 +151,7 @@ class TurnContext:
 
     ephemeral: bool = False
     run_extra_hooks_for_ephemeral: bool = False
+    read_only_session: bool = False
     hooks: list[AgentHook] = field(default_factory=list)
     hook_factories: list[AgentTurnHookFactory] = field(default_factory=list)
     turn_scopes: list[AbstractContextManager[Any]] = field(default_factory=list)
@@ -1513,6 +1515,7 @@ class AgentLoop:
         pending_queue: asyncio.Queue[InboundMessage] | None = None,
         ephemeral: bool = False,
         run_extra_hooks_for_ephemeral: bool = False,
+        read_only_session: bool = False,
         hooks: list[AgentHook] | None = None,
         hook_factories: list[AgentTurnHookFactory] | None = None,
         tools: ToolRegistry | None = None,
@@ -1564,6 +1567,7 @@ class AgentLoop:
             pending_queue=pending_queue,
             ephemeral=ephemeral,
             run_extra_hooks_for_ephemeral=run_extra_hooks_for_ephemeral,
+            read_only_session=read_only_session,
             hooks=list(hooks or []),
             hook_factories=list(hook_factories or []),
             tools=tools,
@@ -1706,7 +1710,17 @@ class AgentLoop:
                 if ctx.session is None:
                     raise RuntimeError("required session is not active")
             else:
-                ctx.session = self.sessions.get_or_create(ctx.session_key)
+                base = self.sessions.get_or_create(ctx.session_key)
+                if ctx.read_only_session:
+                    # Read-only continuation (SDK ephemeral runs): turn against a
+                    # detached snapshot whose policy does not persist, so every
+                    # sessions.save() below is a no-op and the stored file plus
+                    # cached session remain byte-for-byte/semantically unchanged.
+                    working = copy.deepcopy(base)
+                    working.policy = dataclasses.replace(working.policy, persist=False)
+                    ctx.session = working
+                else:
+                    ctx.session = base
         session = ctx.session
         ctx.ephemeral = ctx.ephemeral or not session.policy.persist
         tools = ctx.tools or self.tools
@@ -2350,6 +2364,7 @@ class AgentLoop:
         on_stream: Callable[[str], Awaitable[None]] | None = None,
         on_stream_end: Callable[..., Awaitable[None]] | None = None,
         ephemeral: bool = False,
+        read_only_session: bool = False,
         _run_extra_hooks_for_ephemeral: bool = False,
         hooks: list[AgentHook] | None = None,
         hook_factories: list[AgentTurnHookFactory] | None = None,
@@ -2359,7 +2374,13 @@ class AgentLoop:
         on_runtime_admitted: Callable[[LLMRuntime], Awaitable[None]] | None = None,
         attributes: Mapping[str, Any] | None = None,
     ) -> OutboundMessage | None:
-        """Process an external message directly and return the outbound payload."""
+        """Process an external message directly and return the outbound payload.
+
+        *read_only_session*: run against a detached snapshot of the session so
+        the stored file and cached entry are left unchanged. Callers must set
+        this explicitly; internal ephemeral turns (Dream) keep their own
+        save semantics.
+        """
         if channel == "system":
             raise ValueError("channel 'system' is reserved for internal messages")
         metadata: dict[str, Any] = {}
@@ -2380,6 +2401,8 @@ class AgentLoop:
                     "on_stream_end": on_stream_end,
                     "ephemeral": ephemeral,
                 }
+                if read_only_session:
+                    kwargs["read_only_session"] = True
                 if _run_extra_hooks_for_ephemeral:
                     kwargs["run_extra_hooks_for_ephemeral"] = True
                 if hooks is not None:

--- a/nanobot/nanobot.py
+++ b/nanobot/nanobot.py
@@ -164,7 +164,10 @@ class Nanobot:
             chat_id: Logical chat identifier for runtime context.
             sender_id: Logical sender identifier for runtime context.
             media: Optional local media paths attached to the message.
-            ephemeral: If true, do not persist the turn or compact session history.
+            ephemeral: If true, do not persist the turn or compact session
+                history. The stored session is left unchanged: prior history is
+                still read for context, but messages, metadata, provider state,
+                and session files are not modified by this run.
             attributes: Optional caller-owned request data exposed to context
                 providers and turn-hook factories. Attributes are kept separate
                 from nanobot's trusted internal message metadata.

--- a/nanobot/sdk/runtime.py
+++ b/nanobot/sdk/runtime.py
@@ -39,6 +39,10 @@ def build_process_direct_kwargs(
     if ephemeral:
         kwargs["ephemeral"] = True
         kwargs["_run_extra_hooks_for_ephemeral"] = True
+        # SDK contract: ephemeral runs read prior context but leave the stored
+        # session (file, cache, provider state) untouched. Internal ephemeral
+        # turns such as Dream keep their own save semantics.
+        kwargs["read_only_session"] = True
     if attributes is not None:
         kwargs["attributes"] = dict(attributes)
     if on_stream is not None:

--- a/tests/agent/test_autocompact_unit.py
+++ b/tests/agent/test_autocompact_unit.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from nanobot.agent.autocompact import AutoCompact
-from nanobot.session.manager import Session, SessionManager
+from nanobot.session.manager import Session, SessionManager, SessionPolicy
 
 
 def _runtime(_session: Session | None = None):
@@ -722,3 +722,41 @@ class TestPrepareSession:
         assert summary is not None
         assert summary["text"] == "Hot summary."
         # After hot path pops, cold path would kick in on next call
+
+    def test_non_persistent_session_is_never_reloaded(self):
+        """Non-persistent sessions are isolated: never swap in stored state."""
+        ac = _make_autocompact(ttl=15)
+        mock_sm = MagicMock(spec=SessionManager)
+        ac.sessions = mock_sm
+        ac._archiving.add("sdk:iso")
+        transient = Session(key="sdk:iso", policy=SessionPolicy(persist=False))
+        transient.updated_at = datetime.now() - timedelta(minutes=20)
+
+        result_session, summary = ac.prepare_session(transient, "sdk:iso")
+
+        mock_sm.get_or_create.assert_not_called()
+        assert result_session is transient
+        assert summary is None
+        # The stale archival marker must not leak into later persistent turns.
+        assert "sdk:iso" not in ac._archiving
+
+    def test_non_persistent_session_peeks_without_consuming_summaries(self):
+        """Isolated turns may see a pending summary but must not consume it."""
+        ac = _make_autocompact()
+        transient = Session(key="sdk:iso", policy=SessionPolicy(persist=False))
+        ac._summaries["sdk:iso"] = {
+            "text": "Pending summary.",
+            "last_active": datetime(2026, 5, 13, 14, 0, 0).isoformat(),
+        }
+
+        _, summary = ac.prepare_session(transient, "sdk:iso")
+
+        assert summary is not None
+        assert summary["text"] == "Pending summary."
+        # A later ordinary turn must still receive this one-shot summary.
+        assert "sdk:iso" in ac._summaries
+
+        persistent = _make_session(key="sdk:iso")
+        _, consumed = ac.prepare_session(persistent, "sdk:iso")
+        assert consumed is not None
+        assert "sdk:iso" not in ac._summaries

--- a/tests/test_nanobot_facade.py
+++ b/tests/test_nanobot_facade.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -674,6 +675,197 @@ async def test_run_ephemeral_still_captures_runner_observability(tmp_path):
     assert result.usage["provider_tokens"] == 3
 
 
+def _ephemeral_test_bot(tmp_path, *, provider: MagicMock | None = None) -> Nanobot:
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+    from nanobot.providers.base import LLMResponse
+
+    provider = provider if provider is not None else MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.generation = SimpleNamespace(
+        max_tokens=8192,
+        temperature=0.1,
+        reasoning_effort=None,
+    )
+    provider.estimate_prompt_tokens.return_value = (10_000, "test")
+    if not isinstance(provider.chat_with_retry, AsyncMock):
+        provider.chat_with_retry = AsyncMock(return_value=LLMResponse(
+            content="saved reply",
+            tool_calls=[],
+            usage={"total_tokens": 3},
+        ))
+    return Nanobot(AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+    ))
+
+
+def _session_file(bot: Nanobot, key: str) -> Path:
+    return bot._loop.sessions._get_session_path(key)
+
+
+def _assert_session_state_unchanged(bot: Nanobot, key: str, path: Path, *, bytes_before: bytes, cached_before) -> None:
+    assert path.read_bytes() == bytes_before
+    cached_after = bot._loop.sessions.get_or_create(key)
+    assert cached_after.messages == cached_before.messages
+    assert cached_after.metadata == cached_before.metadata
+    assert cached_after.last_consolidated == cached_before.last_consolidated
+    assert cached_after.provider_state == cached_before.provider_state
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_run_leaves_persisted_session_unchanged(tmp_path):
+    from nanobot.providers.base import LLMResponse
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    bot = _ephemeral_test_bot(tmp_path, provider=provider)
+    key = "sdk:iso"
+
+    await bot.run("hello", session_key=key)
+
+    path = _session_file(bot, key)
+    assert path.exists()
+    bytes_before = path.read_bytes()
+    cached_before = copy.deepcopy(bot._loop.sessions.get_or_create(key))
+
+    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(
+        content="ephemeral reply",
+        tool_calls=[],
+        usage={"total_tokens": 3},
+    ))
+    result = await bot.run("forgotten", session_key=key, ephemeral=True)
+
+    assert result.content == "ephemeral reply"
+    _assert_session_state_unchanged(bot, key, path, bytes_before=bytes_before, cached_before=cached_before)
+
+    # A later ordinary run continues exactly from the pre-ephemeral state.
+    await bot.run("again", session_key=key)
+    snapshot = bot.sessions.export(key)
+    assert snapshot is not None
+    contents = [message["content"] for message in snapshot.messages]
+    assert contents == ["hello", "saved reply", "again", "ephemeral reply"]
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_run_on_new_key_writes_no_session_file(tmp_path):
+    bot = _ephemeral_test_bot(tmp_path)
+    key = "sdk:fresh-iso"
+
+    path = _session_file(bot, key)
+    assert not path.exists()
+
+    await bot.run("hi", session_key=key, ephemeral=True)
+
+    assert not path.exists()
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_run_provider_failure_leaves_persisted_session_unchanged(tmp_path):
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    bot = _ephemeral_test_bot(tmp_path, provider=provider)
+    key = "sdk:iso-failure"
+
+    await bot.run("hello", session_key=key)
+
+    path = _session_file(bot, key)
+    bytes_before = path.read_bytes()
+    cached_before = copy.deepcopy(bot._loop.sessions.get_or_create(key))
+
+    provider.chat_with_retry = AsyncMock(side_effect=RuntimeError("provider exploded"))
+    try:
+        await bot.run("forgotten", session_key=key, ephemeral=True)
+    except RuntimeError:
+        pass
+
+    _assert_session_state_unchanged(bot, key, path, bytes_before=bytes_before, cached_before=cached_before)
+
+
+@pytest.mark.asyncio
+async def test_cancelling_ephemeral_direct_run_leaves_persisted_session_unchanged(tmp_path):
+    entered = asyncio.Event()
+
+    async def slow_chat(*args, **kwargs):
+        entered.set()
+        await asyncio.sleep(3600)
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    bot = _ephemeral_test_bot(tmp_path, provider=provider)
+    key = "sdk:cancel-iso"
+
+    await bot.run("hello", session_key=key)
+
+    path = _session_file(bot, key)
+    bytes_before = path.read_bytes()
+    cached_before = copy.deepcopy(bot._loop.sessions.get_or_create(key))
+
+    provider.chat_with_retry = AsyncMock(side_effect=slow_chat)
+    task = asyncio.create_task(bot.run("forgotten", session_key=key, ephemeral=True))
+    await asyncio.wait_for(entered.wait(), timeout=5)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    _assert_session_state_unchanged(bot, key, path, bytes_before=bytes_before, cached_before=cached_before)
+
+
+@pytest.mark.asyncio
+async def test_internal_loop_ephemeral_turn_still_persists_session(tmp_path):
+    """Dream-style direct ephemeral turns intentionally save their own session."""
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+    from nanobot.providers.base import LLMResponse
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(
+        content="dream reply",
+        tool_calls=[],
+        usage={"total_tokens": 3},
+    ))
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+    )
+
+    await loop.process_direct("dream work", session_key="dream:test-save", ephemeral=True)
+
+    path = loop.sessions._get_session_path("dream:test-save")
+    assert path.exists()
+    roles = [
+        record["role"]
+        for record in (
+            json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
+        )
+        if "_type" not in record
+    ]
+    assert roles == ["user", "assistant"]
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_slash_command_short_circuit_leaves_persisted_session_unchanged(tmp_path):
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    bot = _ephemeral_test_bot(tmp_path, provider=provider)
+    key = "sdk:iso-command"
+
+    await bot.run("hello", session_key=key)
+
+    path = _session_file(bot, key)
+    bytes_before = path.read_bytes()
+    cached_before = copy.deepcopy(bot._loop.sessions.get_or_create(key))
+
+    await bot.run("/help", session_key=key, ephemeral=True)
+
+    _assert_session_state_unchanged(bot, key, path, bytes_before=bytes_before, cached_before=cached_before)
+
+
 @pytest.mark.asyncio
 async def test_run_forwards_non_default_runtime_options(tmp_path):
     from nanobot.bus.events import OutboundMessage
@@ -702,6 +894,7 @@ async def test_run_forwards_non_default_runtime_options(tmp_path):
         sender_id="alice",
         media=["/tmp/image.png"],
         ephemeral=True,
+        read_only_session=True,
         _run_extra_hooks_for_ephemeral=True,
         hooks=ANY,
     )


### PR DESCRIPTION
# fix(sdk): make ephemeral runs leave session state unchanged

## Summary

`Nanobot.run(ephemeral=True)` and `run_streamed(ephemeral=True)` document that the
run should "not persist the turn or compact session history". At `af52fbcb`, the
implementation did not honor this: an ephemeral SDK run still

- persisted the user message early (`_persist_user_message_early`),
- saved the completed turn and cleared checkpoint/pending metadata to disk
  (`_persist_turn` → `SessionManager.save`),
- wrote mid-turn tool checkpoints to the persistent session file
  (`_set_runtime_checkpoint`), and
- mutated the cached session's messages, metadata, and workspace-scope state.

Only the `SessionTurnPersisted` event was suppressed — existing coverage checked
the missing event, not storage/cache non-mutation. The result was a public SDK
contract mismatch with privacy consequences: callers told the turn is not
persisted could still leave traces in session files.

This PR makes SDK ephemeral runs **read-only continuations**: they read prior
history for context, but every write path becomes a no-op, leaving stored
session files, cache entries, and provider state byte-for-byte unchanged.

## Why this shape

Two meanings currently share one internal flag:

1. **SDK `ephemeral=True`** — documented as non-persistent.
2. **Internal ephemeral turns (Dream)** — commit `d1a94dae` intentionally *saves*
   the Dream session while skipping history/consolidation side effects.

Globally changing `process_direct(ephemeral=True)` would regress Dream, and
blindly calling `get_or_create_transient()` under an existing key would replace
the cached persistent session. Instead, this change adds an explicit,
SDK-only `read_only_session` policy alongside the existing flag:

- `nanobot/sdk/runtime.py::build_process_direct_kwargs` forwards
  `read_only_session=True` whenever the public `ephemeral=True` is used.
- `AgentLoop.process_direct(..., read_only_session=)` threads it into the turn.
- In `_restore_turn`, a read-only turn runs against a detached deep copy of the
  loaded session whose `policy.persist=False`. Every downstream
  `sessions.save()` call then no-ops automatically (existing
  `SessionManager.save` behavior), so no persistence call sites needed to change.
- Internal ephemeral turns (Dream, gateway paths) do not pass the new flag and
  keep their exact current semantics.

### AutoCompact guard

While implementing, two leaks were found in `AutoCompact.prepare_session` for
non-persist sessions (SDK isolated reads, WebUI temporary chats):

1. If the key was mid-archival or idle-expired, `prepare_session` swapped the
   isolated session for the cached persistent one via `get_or_create`,
   re-enabling disk writes for the rest of the turn.
2. The one-shot hot-path summary was popped from `_summaries`, stealing a
   summary reserved for the next *persistent* turn.

Non-persist sessions are now never reloaded from storage; they peek at pending
summaries without consuming them (`_peek_summary`), and stale archival markers
are discarded so they cannot leak into later turns.

## Semantics chosen

**Read-only continuation** (option 2 of the possible contracts): prior
transcript/provider state still informs context, but nothing is written.
This preserves current visible model behavior minus persistence; a
fresh/stateless contract would silently change responses for existing callers.

Known caveat, flagged for maintainer review: slash commands issued through an
ephemeral run short-circuit before BUILD/SAVE and their own persistence path now
no-ops on the snapshot — but builtins that deliberately mutate other subsystem
state (e.g. `/model`) still do so by explicit user request.

## Changes

- `nanobot/agent/loop.py`
  - `TurnContext.read_only_session` field; threaded through
    `_process_message` / `process_direct`.
  - `_restore_turn`: build detached non-persist working copy when
    `read_only_session` is set.
- `nanobot/agent/autocompact.py`: isolation guard in `prepare_session`;
  new `_peek_summary` / `_summary_from_metadata` helpers.
- `nanobot/sdk/runtime.py`: forward `read_only_session=True` with
  `ephemeral=True`.
- `nanobot/nanobot.py`: docstring now states the actual guarantee.
- `tests/test_nanobot_facade.py`: six new tests (below).
- `tests/agent/test_autocompact_unit.py`: two isolation-guard tests.

## Tests

New facade coverage (all fail on `af52fbcb`, pass with this patch):

- `test_ephemeral_run_leaves_persisted_session_unchanged` — success case:
  file bytes identical, cached messages/metadata/provider-state/
  last_consolidated unchanged, later ordinary run continues exactly from the
  pre-ephemeral transcript.
- `test_ephemeral_run_on_new_key_writes_no_session_file`.
- `test_ephemeral_run_provider_failure_leaves_persisted_session_unchanged`.
- `test_cancelling_ephemeral_direct_run_leaves_persisted_session_unchanged` —
  event-gated provider, task cancelled mid-provider-call.
- `test_ephemeral_slash_command_short_circuit_leaves_persisted_session_unchanged`.
- `test_internal_loop_ephemeral_turn_still_persists_session` — regression
  guard: Dream-style direct `process_direct(ephemeral=True)` keeps saving its
  session.

AutoCompact unit coverage:

- non-persist sessions are never reloaded (archiving/expired keys),
- summaries are peeked without consumption; the next persistent turn still
  receives them.

## Verification

```
ruff check <changed files>                 # clean
basedpyright <changed nanobot modules>     # 0 errors, 0 warnings, 0 notes
pytest                                     # 5692 passed, 48 skipped
```

Focused anchors: `tests/test_nanobot_facade.py`,
`tests/agent/test_autocompact_unit.py`, `tests/agent/test_auto_compact.py`,
`tests/agent/test_dream.py`, `tests/agent/test_loop_session_policy.py`,
`tests/session`.

## Compatibility & security notes

- Public API surface grows by one `process_direct` keyword; defaults keep all
  existing callers (gateway, Dream, API server) byte-compatible.
- No persisted-schema changes; no migration needed.
- Deep-copying a large session adds per-ephemeral-run cost proportional to
  session size; sessions are already bounded by replay/file-cap limits.
- Closes the privacy gap where "ephemeral" SDK calls left durable traces.
