### PR TITLE
fix(signal): honor wildcard in inbound allowlists

### DIFF
--- a/nanobot/channels/signal/runtime.py
+++ b/nanobot/channels/signal/runtime.py
@@ -862,6 +862,7 @@ class SignalChannel(BaseChannel):
                 return False, chat_id
             if (
                 self.config.group.policy == "allowlist"
+                and "*" not in self.config.group.allow_from
                 and chat_id not in self.config.group.allow_from
             ):
                 self.logger.info(
@@ -1061,6 +1062,9 @@ class SignalChannel(BaseChannel):
     def _sender_matches_allowlist(cls, sender_id: str, allow_list: list[str]) -> bool:
         """Return True if any normalized variant of sender_id is on allow_list.
 
+        A ``"*"`` entry allows every sender, matching the channel-wide
+        allowlist contract.
+
         Both ``sender_id`` and each allow_list entry can be a single
         identifier or a pipe-joined composite of several (e.g.
         ``"+1234567890|uuid-abc"``); both sides are split on ``|`` and each
@@ -1070,6 +1074,8 @@ class SignalChannel(BaseChannel):
         """
         if not allow_list:
             return False
+        if "*" in allow_list:
+            return True
         sender_variants: set[str] = set()
         for part in str(sender_id).split("|"):
             sender_variants.update(cls._normalize_signal_id(part))

--- a/nanobot/channels/signal/tests/test_signal_channel.py
+++ b/nanobot/channels/signal/tests/test_signal_channel.py
@@ -791,6 +791,14 @@ class TestHandleDataMessageDM:
         assert len(handled) == 1
 
     @pytest.mark.asyncio
+    async def test_dm_allowlist_wildcard_preserves_content(self):
+        ch, handled = self._make_dm_channel(policy="allowlist", allow_from=["*"])
+        params = _dm_envelope(source_number="+19995550001", message="wildcard DM")
+        await ch._handle_receive_notification(params)
+        assert len(handled) == 1
+        assert handled[0]["content"] == "wildcard DM"
+
+    @pytest.mark.asyncio
     async def test_dm_allowlist_rejected_triggers_pairing(self):
         # Denied DM senders go through super()._handle_message which checks
         # is_allowed → sends pairing code via self.send().
@@ -1024,6 +1032,16 @@ class TestHandleDataMessageGroup:
         params = _group_envelope(group_id="grp==", message="hi")
         await ch._handle_receive_notification(params)
         assert len(handled) == 1
+
+    @pytest.mark.asyncio
+    async def test_group_allowlist_wildcard_preserves_content(self):
+        ch, handled = self._make_group_channel(
+            policy="allowlist", allow_from=["*"], require_mention=False
+        )
+        params = _group_envelope(group_id="grp==", source_name="Alice", message="wildcard group")
+        await ch._handle_receive_notification(params)
+        assert len(handled) == 1
+        assert "[Alice]: wildcard group" in handled[0]["content"]
 
     @pytest.mark.asyncio
     async def test_group_allowlist_rejected(self):


### PR DESCRIPTION
## Summary

- honor `*` in Signal DM and group allowlist policy gates
- preserve existing normalized sender matching and exact group ID matching
- add receive-path regression tests that verify message content is preserved

## Reproduction

Configure Signal with wildcard allowlists:

```json
{
  channels: {
    signal: {
      enabled: true,
      phoneNumber: +10000000000,
      dm: {
        enabled: true,
        policy: allowlist,
        allowFrom: [*]
      },
      group: {
        enabled: true,
        policy: allowlist,
        allowFrom: [*],
        requireMention: false
      }
    }
  }
}
```

Send the bot a DM and a group message from identifiers not explicitly listed.

## Actual behavior

The Signal-specific policy gate treats `*` as a literal identifier:

- DMs are rejected by the nested policy gate. The pairing fallback then passes
  the channel-wide wildcard check with an empty payload, losing the original
  message content.
- Group messages are dropped because the group ID does not equal `*`.

## Expected behavior

`*` should retain the channel-wide allowlist meaning of allowing every sender
or group, and the original message content should reach the inbound bus.

## Testing

- `uv run --no-sync pytest nanobot/channels/signal/tests/test_signal_channel.py nanobot/channels/signal/tests/test_signal_markdown.py -q` — 190 passed
- `uv run --no-sync ruff check nanobot/channels/signal/runtime.py nanobot/channels/signal/tests/test_signal_channel.py`
- `uv run --no-sync basedpyright nanobot/channels/signal/runtime.py nanobot/channels/signal/tests/test_signal_channel.py`
- `git diff --check`