### PR TITLE
fix(gitstore): detect rapid same-size rewrites

### DIFF
--- a/nanobot/utils/gitstore.py
+++ b/nanobot/utils/gitstore.py
@@ -133,12 +133,13 @@ class GitStore:
         try:
             from dulwich import porcelain
 
-            # .gitignore excludes everything except tracked files,
-            # so any staged/unstaged change must be in our files.
+            # Stage first so Dulwich refreshes the content hashes.  A status
+            # check can miss rapid same-size rewrites when the filesystem also
+            # preserves the file's mtime.
+            porcelain.add(str(self._workspace), paths=self._staging_paths(*self._tracked_files))
             st = porcelain.status(str(self._workspace))
-            unstaged = cast(list[object], st.unstaged)
             staged = cast(dict[object, list[object]], st.staged)
-            if not unstaged and not any(staged.values()):
+            if not any(staged.values()):
                 return None
 
             message_value = cast(object, message)
@@ -147,7 +148,6 @@ class GitStore:
                 if isinstance(message_value, str)
                 else cast(bytes, message_value)
             )
-            porcelain.add(str(self._workspace), paths=self._staging_paths(*self._tracked_files))
             sha_bytes = porcelain.commit(
                 str(self._workspace),
                 message=msg_bytes,

--- a/tests/agent/test_git_store.py
+++ b/tests/agent/test_git_store.py
@@ -1,5 +1,6 @@
 """Tests for GitStore — git-backed version control for memory files."""
 
+import os
 from unittest.mock import patch
 
 import pytest
@@ -97,6 +98,18 @@ class TestAutoCommit:
         commits = git_ready.log()
         assert len(commits) == 2
         assert commits[0].sha == sha
+
+    def test_commits_same_size_rewrite_with_unchanged_mtime(self, git_ready):
+        path = git_ready._workspace / "SOUL.md"
+        path.write_text("v1", encoding="utf-8")
+        git_ready.auto_commit("v1")
+        previous_stat = path.stat()
+
+        path.write_text("v2", encoding="utf-8")
+        os.utime(path, ns=(previous_stat.st_atime_ns, previous_stat.st_mtime_ns))
+
+        assert git_ready.auto_commit("v2") is not None
+        assert [commit.message for commit in git_ready.log()[:2]] == ["v2", "v1"]
 
     def test_does_not_create_empty_commits(self, git_ready):
         git_ready.auto_commit("nothing 1")


### PR DESCRIPTION
## Summary

- Stage tracked memory files before checking repository status so Dulwich refreshes their content hashes.
- Add regression coverage for same-size rewrites whose mtime remains unchanged.
- Preserve the existing behavior of skipping empty commits.

## Problem

On Windows, rapid rewrites can keep the same file size and modification time. Dulwich may then treat the file as unchanged based on its cached stat metadata without reading the new content.

As a result, `GitStore.auto_commit()` returns `None` and silently omits the new Dream memory version from history, diff, and rollback operations.

A deterministic reproduction is:

```python
path.write_text("v1", encoding="utf-8")
git.auto_commit("v1")
previous_stat = path.stat()

path.write_text("v2", encoding="utf-8")
os.utime(path, ns=(previous_stat.st_atime_ns, previous_stat.st_mtime_ns))

assert git.auto_commit("v2") is not None
```

The assertion fails before this change.

## Fix

Stage the configured tracked files first, forcing Dulwich to calculate their current blob IDs. Then inspect staged changes against `HEAD` and commit only when the content differs.

## Validation

- `uv run --no-sync pytest tests/agent/test_git_store.py -q` — 38 passed
- `uv run --no-sync pytest tests/utils/test_gitstore.py -q` — 16 passed, 1 skipped
- `uv run --no-sync ruff check nanobot/utils/gitstore.py tests/agent/test_git_store.py` — passed
- `git diff --check` — passed
