### PR TITLE
refactor: remove remaining dead code

### DIFF
--- a/nanobot/channels/discord/tests/test_discord_channel.py
+++ b/nanobot/channels/discord/tests/test_discord_channel.py
@@ -145,14 +145,9 @@ class _FakeChannel:
 class _FakeInteractionResponse:
     def __init__(self) -> None:
         self.messages: list[dict] = []
-        self._done = False
 
     async def send_message(self, content: str, *, ephemeral: bool = False) -> None:
         self.messages.append({"content": content, "ephemeral": ephemeral})
-        self._done = True
-
-    def is_done(self) -> bool:
-        return self._done
 
 
 def _make_interaction(

--- a/nanobot/channels/mattermost/runtime.py
+++ b/nanobot/channels/mattermost/runtime.py
@@ -53,7 +53,6 @@ class MattermostConfig(Base):
     include_thread_context: bool = True
     thread_context_limit: int = 20
     streaming: bool = True
-    streaming_max_chars: int = 16000
     react_emoji: str = "eyes"
     done_emoji: str = "white_check_mark"
     send_progress: bool = True
@@ -106,7 +105,6 @@ class MattermostChannel(BaseChannel):
         self._ws_task: asyncio.Task[None] | None = None
         self._self_id: str | None = None
         self._self_username: str | None = None
-        self._self_email: str | None = None
         self._usernames: dict[str, str] = {}
         self._user_emails: dict[str, str] = {}
         self._channel_types: dict[str, str] = {}
@@ -138,7 +136,6 @@ class MattermostChannel(BaseChannel):
             me = cast(dict[str, Any], resp.json())
             self._self_id = me.get("id")
             self._self_username = me.get("username")
-            self._self_email = me.get("email", "")
             self.logger.info("bot @{} connected", self._self_username)
         except Exception as e:
             self.logger.error("Failed to identify bot user: {}", e)

--- a/nanobot/channels/mattermost/tests/test_mattermost_channel.py
+++ b/nanobot/channels/mattermost/tests/test_mattermost_channel.py
@@ -31,8 +31,6 @@ class _FakeHTTPClient:
         self.delete_calls: list[dict[str, Any]] = []
         self._get_responses: dict[str, Any] = {}
         self._post_responses: dict[str, Any] = {}
-        self._put_responses: dict[str, Any] = {}
-        self._delete_status: int | None = None
 
     def _req(self, method: str, path: str) -> httpx.Request:
         return httpx.Request(method, f"https://chat.example.com{path}")
@@ -45,12 +43,6 @@ class _FakeHTTPClient:
 
     def set_post_response(self, path: str, data: Any) -> None:
         self._post_responses[path] = data
-
-    def set_put_response(self, path: str, data: Any) -> None:
-        self._put_responses[path] = data
-
-    def set_delete_status(self, status: int) -> None:
-        self._delete_status = status
 
     async def get(self, path: str, **kwargs) -> httpx.Response:
         self.get_calls.append({"path": path, **kwargs})
@@ -71,13 +63,11 @@ class _FakeHTTPClient:
 
     async def put(self, path: str, *, json: dict[str, Any] | None = None, **kwargs) -> httpx.Response:
         self.put_calls.append({"path": path, "json": json})
-        data = self._put_responses.get(path, {"id": path.split("/")[-1]})
-        return self._resp(200, data, "PUT", path)
+        return self._resp(200, {"id": path.split("/")[-1]}, "PUT", path)
 
     async def delete(self, path: str, **kwargs) -> httpx.Response:
         self.delete_calls.append({"path": path})
-        status = self._delete_status if self._delete_status is not None else 200
-        return self._resp(status, {}, "DELETE", path)
+        return self._resp(200, {}, "DELETE", path)
 
     async def aclose(self) -> None:
         pass
@@ -119,7 +109,6 @@ def test_config_defaults():
     assert config.server_url == ""
     assert config.token == ""
     assert config.streaming is True
-    assert config.streaming_max_chars == 16000
     assert config.send_tool_hints is True
     assert config.dm.enabled is True
     assert config.dm.policy == "open"
@@ -150,7 +139,6 @@ def test_config_camelcase_aliases():
         "serverUrl": "https://mm.example.com",
         "token": "abc123",
         "allowFromMatchMode": "username",
-        "streamingMaxChars": 8000,
         "replyInThread": False,
         "sendToolHints": False,
     }
@@ -158,7 +146,6 @@ def test_config_camelcase_aliases():
     assert config.server_url == "https://mm.example.com"
     assert config.token == "abc123"
     assert config.allow_from_match_mode == "username"
-    assert config.streaming_max_chars == 8000
     assert config.reply_in_thread is False
     assert config.send_tool_hints is False
 
@@ -194,7 +181,6 @@ async def test_start_identifies_bot():
 
     assert channel._self_id == "botuserid123"
     assert channel._self_username == "nanobot"
-    assert channel._self_email == "bot@example.com"
     assert not start_task.done()
     user_me_calls = [c for c in fake.get_calls[calls_before:] if "/api/v4/users/me" in c["path"]]
     assert len(user_me_calls) == 1

--- a/nanobot/channels/mattermost/tests/test_mattermost_channel.py
+++ b/nanobot/channels/mattermost/tests/test_mattermost_channel.py
@@ -660,7 +660,7 @@ async def test_stream_end_adds_done_emoji():
 
 @pytest.mark.asyncio
 async def test_stream_chunk_boundary_finalizes_and_creates_new():
-    channel, fake = _make_channel({"streamingMaxChars": 10})
+    channel, fake = _make_channel()
     channel._self_id = "bot_id"
     fake.set_post_response("/api/v4/posts", {"id": "post_1"})
 

--- a/nanobot/channels/mochat/runtime.py
+++ b/nanobot/channels/mochat/runtime.py
@@ -277,7 +277,7 @@ class MochatChannel(BaseChannel):
         self.config: MochatConfig = config
         self._http: httpx.AsyncClient | None = None
         self._socket: Any = None
-        self._ws_connected = self._ws_ready = False
+        self._ws_ready = False
 
         self._state_dir = get_runtime_subdir("mochat")
         self._cursor_path = self._state_dir / "session_cursors.json"
@@ -346,7 +346,7 @@ class MochatChannel(BaseChannel):
         if self._http:
             await self._http.aclose()
             self._http = None
-        self._ws_connected = self._ws_ready = False
+        self._ws_ready = False
 
     async def send(self, msg: OutboundMessage) -> None:
         """Send outbound message to session or panel."""
@@ -422,7 +422,7 @@ class MochatChannel(BaseChannel):
         )
 
         async def connect() -> None:
-            self._ws_connected, self._ws_ready = True, False
+            self._ws_ready = False
             self.logger.info("websocket connected")
             subscribed = await self._subscribe_all()
             self._ws_ready = subscribed
@@ -431,7 +431,7 @@ class MochatChannel(BaseChannel):
         async def disconnect() -> None:
             if not self._running:
                 return
-            self._ws_connected = self._ws_ready = False
+            self._ws_ready = False
             self.logger.warning("websocket disconnected")
             await self._ensure_fallback_workers()
 

--- a/nanobot/channels/signal/tests/test_signal_markdown.py
+++ b/nanobot/channels/signal/tests/test_signal_markdown.py
@@ -363,13 +363,6 @@ def test_reported_daily_brief_pattern():
 # ---------------------------------------------------------------------------
 
 
-def _resolve_chunk_styles(text: str, max_len: int) -> tuple[list[str], list[list[str]]]:
-    """Helper: full markdown → signal pipeline, including chunking."""
-    plain, styles = _markdown_to_signal(text)
-    chunks = split_message(plain, max_len) if plain else [""]
-    return chunks, _partition_styles(plain, chunks, styles)
-
-
 def test_partition_styles_single_chunk_passthrough():
     plain, styles = _markdown_to_signal("**bold** plain *it*")
     parts = _partition_styles(plain, [plain], styles)

--- a/nanobot/channels/slack/runtime.py
+++ b/nanobot/channels/slack/runtime.py
@@ -69,7 +69,6 @@ class SlackConfig(Base):
     webhook_path: str = "/slack/events"
     bot_token: str = ""
     app_token: str = ""
-    user_token_read_only: bool = True
     reply_in_thread: bool = True
     react_emoji: str = "eyes"
     done_emoji: str = "white_check_mark"

--- a/nanobot/channels/websocket/tests/test_websocket_http_routes.py
+++ b/nanobot/channels/websocket/tests/test_websocket_http_routes.py
@@ -1244,39 +1244,6 @@ async def test_pairing_routes_require_token_and_approve_or_deny(
     assert "Missing pairing code" in missing_code.text
 
 
-def test_api_service_settings_read_api_key_from_webui_payload(bus: MagicMock) -> None:
-    channel = _ch(bus)
-    request = _FakeReq(path="/api/settings/api-service/start")
-    setattr(
-        request,
-        "_nanobot_webui_mutation_payload",
-        {"host": "0.0.0.0", "port": 8900, "timeout": 120, "api_key": "secret-token"},
-    )
-
-    query = channel.gateway.http.settings_routes._parse_api_service_settings_query(request)
-
-    assert query == {
-        "host": ["0.0.0.0"],
-        "port": ["8900"],
-        "timeout": ["120"],
-        "api_key": ["secret-token"],
-    }
-
-
-def test_api_service_settings_reject_non_string_api_key(bus: MagicMock) -> None:
-    from nanobot.webui.settings_api import WebUISettingsError
-
-    channel = _ch(bus)
-    request = _FakeReq(path="/api/settings/api-service/start")
-    setattr(
-        request,
-        "_nanobot_webui_mutation_payload",
-        {"host": "127.0.0.1", "api_key": 123},
-    )
-
-    with pytest.raises(WebUISettingsError, match="API key must be a string"):
-        channel.gateway.http.settings_routes._parse_api_service_settings_query(request)
-
 @pytest.mark.asyncio
 async def test_nanobot_feature_remote_install_requires_opt_in(
     bus: MagicMock,

--- a/nanobot/channels/websocket/tests/ws_test_client.py
+++ b/nanobot/channels/websocket/tests/ws_test_client.py
@@ -202,12 +202,6 @@ class WsTestClient:
         assert msg.event == "delta", f"Expected 'delta' event, got '{msg.event}'"
         return msg
 
-    async def recv_stream_end(self, timeout: float = 10.0) -> WsMessage:
-        """Receive and validate a 'stream_end' event."""
-        msg = await self.recv(timeout)
-        assert msg.event == "stream_end", f"Expected 'stream_end' event, got '{msg.event}'"
-        return msg
-
     async def collect_stream(self, timeout: float = 10.0) -> list[WsMessage]:
         """Collect all deltas and the final stream_end into a list."""
         messages: list[WsMessage] = []
@@ -231,10 +225,6 @@ class WsTestClient:
     async def send_json(self, data: dict[str, Any]) -> None:
         """Send a JSON frame."""
         await self.ws.send(json.dumps(data, ensure_ascii=False))
-
-    async def send_content(self, content: str) -> None:
-        """Send content in the preferred JSON format ``{"content": ...}``."""
-        await self.send_json({"content": content})
 
     # -- Connection introspection -----------------------------------------
 

--- a/nanobot/process_runtime.py
+++ b/nanobot/process_runtime.py
@@ -96,22 +96,6 @@ class ManagedProcessRuntime(Generic[_StartOptionsT]):
         # it; poll() both reaps it and reports the real lifecycle state.
         self._owned_process: Any | None = None
 
-    @classmethod
-    def refresh_state_pid(cls, *, paths: ProcessRuntimePaths) -> None:
-        """Update a managed state file after the recorded process restarts."""
-        if not paths.state_path.exists():
-            return
-        try:
-            state = json.loads(paths.state_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            return
-        state["pid"] = os.getpid()
-        runtime = cls(paths=paths)
-        state.pop("stable_identity", None)
-        state.update(runtime.process_identity_record(os.getpid()))
-        state["started_at"] = _utc_now()
-        runtime._write_state(state)
-
     def start_background(self, options: _StartOptionsT) -> ProcessResult:
         """Start the configured command as a detached process."""
         with self._lifecycle_lock():

--- a/nanobot/session/webui_turns.py
+++ b/nanobot/session/webui_turns.py
@@ -685,15 +685,6 @@ class WebuiTurnCoordinator:
             )
         )
 
-    async def publish_run_status(
-        self,
-        msg: InboundMessage,
-        status: str,
-        *,
-        started_at: float | None = None,
-    ) -> None:
-        await publish_turn_run_status(self.bus, msg, status, started_at=started_at)
-
     async def handle_turn_end(
         self,
         msg: InboundMessage,

--- a/nanobot/webui/gateway_tokens.py
+++ b/nanobot/webui/gateway_tokens.py
@@ -63,9 +63,6 @@ class GatewayTokenStore:
         self.api_tokens[token_value] = expiry
         return token_value
 
-    def take_issued_token_if_valid(self, token_value: str | None) -> bool:
-        return self.take_issued_token_audience(token_value) is not None
-
     def take_issued_token_audience(
         self,
         token_value: str | None,

--- a/nanobot/webui/settings_routes.py
+++ b/nanobot/webui/settings_routes.py
@@ -36,7 +36,6 @@ from nanobot.webui.nanobot_features_api import (
     nanobot_features_payload,
 )
 from nanobot.webui.settings_api import (
-    WebUISettingsError,
     complete_oauth_provider,
     create_model_configuration,
     create_provider_settings,
@@ -490,17 +489,6 @@ class WebUISettingsRouter:
             lambda: request_image_generation_reload(self.bus),
         )
 
-    async def _apply_image_generation_runtime_change(
-        self,
-        payload: dict[str, Any],
-    ) -> dict[str, Any]:
-        updated, restart_cleared = (
-            await self._apply_image_generation_runtime_change_result(payload)
-        )
-        if restart_cleared:
-            self._restart_sections.discard("image")
-        return updated
-
     async def _reload_mcp_runtime(self) -> dict[str, Any]:
         if self._mcp_reload is None:
             return {
@@ -531,46 +519,8 @@ class WebUISettingsRouter:
     def _parse_mcp_settings_query(self, request: WsRequest) -> QueryParams:
         return self._query(request)
 
-    def _parse_provider_settings_query(self, request: WsRequest) -> QueryParams:
-        return self._query(request)
-
-    def _parse_api_service_settings_query(self, request: WsRequest) -> QueryParams:
-        payload = _mutation_payload(request)
-        if payload is not None:
-            api_key = payload.get("api_key")
-            if api_key is not None and not isinstance(api_key, str):
-                raise WebUISettingsError("API service API key must be a string")
-        return self._query(request)
-
     def _api_runtime(self) -> ApiRuntime:
         return ApiRuntime(paths=api_runtime_paths(self.settings.config.path))
-
-    def _api_service_payload(
-        self,
-        *,
-        last_action: str | None = None,
-    ) -> dict[str, Any]:
-        return capability_domain.api_service_payload(
-            self.settings,
-            self._api_runtime(),
-            last_action=last_action,
-        )
-
-    @staticmethod
-    def _masked_secret(value: str) -> str | None:
-        return capability_domain.masked_api_secret(value)
-
-    @staticmethod
-    def _api_runtime_message(message: str) -> str:
-        return capability_domain.api_runtime_message(message)
-
-    def _parse_channel_values(self, request: WsRequest) -> dict[str, Any]:
-        return self._system.parse_channel_values(
-            SettingsRequest(
-                query=self._query(request),
-                payload=_mutation_payload(request),
-            )
-        )
 
     def _save_channel_config_values(
         self,
@@ -608,17 +558,6 @@ class WebUISettingsRouter:
             action,
             query,
             allow_install=allow_install,
-        )
-
-    @staticmethod
-    def _feature_runtime_fallback(
-        payload: dict[str, Any],
-        *,
-        message: str,
-    ) -> dict[str, Any]:
-        return system_domain.SystemSettingsHandler.feature_runtime_fallback(
-            payload,
-            message=message,
         )
 
     def _allow_feature_package_install(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "pydantic-settings>=2.12.0,<3.0.0",
     # Feishu's lark-oapi currently requires websockets<16; core supports 15 and 16.
     "websockets>=15.0,<17.0",
-    "websocket-client>=1.9.0,<2.0.0",
     "httpx[socks]>=0.28.0,<1.0.0",
     "ddgs>=9.5.5,<10.0.0",
     "oauth-cli-kit>=0.1.6,<1.0.0",

--- a/tui/src/command-menu.ts
+++ b/tui/src/command-menu.ts
@@ -5,7 +5,7 @@ import { PickerMenu, type PickerMenuTheme } from "./picker-menu"
 
 export type CommandMenuTheme = PickerMenuTheme
 
-export type TuiCommandAction =
+type TuiCommandAction =
   | "sessions"
   | "new-chat"
   | "context"

--- a/tui/src/protocol.ts
+++ b/tui/src/protocol.ts
@@ -29,14 +29,14 @@ export interface FileEditEvent {
   diff?: FileDiff
 }
 
-export interface FileDiff {
+interface FileDiff {
   format: "unified" | string
   context?: number
   truncated?: boolean
   text?: string
 }
 
-export interface MediaAttachment {
+interface MediaAttachment {
   kind: "image" | "video" | "file"
   url: string
   name?: string
@@ -225,7 +225,7 @@ export interface SessionContextSnapshot {
   lastUsage: TokenUsage | null
 }
 
-export interface SessionMention {
+interface SessionMention {
   name: string
   session_key: string
   title?: string

--- a/webui/src/channel-plugins/i18n.ts
+++ b/webui/src/channel-plugins/i18n.ts
@@ -1,6 +1,6 @@
 import type { TFunction } from "i18next";
 
-export type ChannelFieldMessages = {
+type ChannelFieldMessages = {
   label: string;
   placeholder?: string;
   help?: string;

--- a/webui/src/components/CliAppMentionText.tsx
+++ b/webui/src/components/CliAppMentionText.tsx
@@ -137,7 +137,7 @@ export function CapabilityMentionToken({
   return <SessionMentionToken mention={segment.mention} label={segment.text} variant={variant} />;
 }
 
-export function SessionMentionToken({
+function SessionMentionToken({
   mention,
   label,
   variant,
@@ -172,7 +172,7 @@ export function SessionMentionToken({
   );
 }
 
-export function CliAppMentionToken({
+function CliAppMentionToken({
   app,
   label,
   variant,
@@ -229,7 +229,7 @@ export function CliAppMentionToken({
   );
 }
 
-export function McpPresetMentionToken({
+function McpPresetMentionToken({
   preset,
   label,
   variant,

--- a/webui/src/components/FileReferenceChip.tsx
+++ b/webui/src/components/FileReferenceChip.tsx
@@ -151,7 +151,7 @@ export function splitFilePath(path: string): { directory: string; name: string }
   };
 }
 
-export function fileKindForPath(path: string): FileReferenceKind {
+function fileKindForPath(path: string): FileReferenceKind {
   const normalized = path.toLowerCase();
   const name = normalized.split(/[\\/]/).pop() ?? normalized;
   const ext = name.includes(".") ? name.split(".").pop() ?? "" : "";
@@ -193,7 +193,7 @@ export function fileKindForPath(path: string): FileReferenceKind {
   }
 }
 
-export function FileReferenceIcon({ kind }: { kind: FileReferenceKind }) {
+function FileReferenceIcon({ kind }: { kind: FileReferenceKind }) {
   if (kind === "python") {
     return (
       <svg

--- a/webui/src/components/MessageBubble.tsx
+++ b/webui/src/components/MessageBubble.tsx
@@ -967,7 +967,7 @@ interface ReasoningBubbleProps {
   hasBodyBelow: boolean;
 }
 
-export function ReasoningBubble({
+function ReasoningBubble({
   text,
   streaming,
   hasBodyBelow,
@@ -993,7 +993,7 @@ interface TraceGroupProps {
  * collapsed because tool traces are supporting evidence, not the answer.
  * A single click expands the exact calls when the user wants details.
  */
-export function TraceGroup({ message }: TraceGroupProps) {
+function TraceGroup({ message }: TraceGroupProps) {
   const { t } = useTranslation();
   const lines = message.traces ?? [message.content];
   const count = lines.length;

--- a/webui/src/components/settings/channels/ChannelIdentity.tsx
+++ b/webui/src/components/settings/channels/ChannelIdentity.tsx
@@ -174,7 +174,7 @@ export function ChannelLogo({
   );
 }
 
-export function channelDisplayName(feature: NanobotFeatureInfo): string {
+function channelDisplayName(feature: NanobotFeatureInfo): string {
   return channelUiPresentation(feature.name, feature.webui)?.displayName ?? feature.display_name;
 }
 

--- a/webui/src/components/settings/channels/ChannelSetupParts.tsx
+++ b/webui/src/components/settings/channels/ChannelSetupParts.tsx
@@ -112,7 +112,7 @@ export function ChannelSetupLinks({
   );
 }
 
-export function ChannelOfficialLink({
+function ChannelOfficialLink({
   feature,
   setup,
 }: {

--- a/webui/src/components/settings/channels/CredentialForm.tsx
+++ b/webui/src/components/settings/channels/CredentialForm.tsx
@@ -6,7 +6,7 @@ import { Input } from "@/components/ui/input";
 import type { ChannelConfigField } from "@/components/settings/channels/catalog";
 import { cn } from "@/lib/utils";
 
-export function channelFieldValue(field: ChannelConfigField, values: Record<string, string>): string {
+function channelFieldValue(field: ChannelConfigField, values: Record<string, string>): string {
   return values[field.key] ?? field.defaultValue ?? field.options?.[0]?.value ?? "";
 }
 

--- a/webui/src/components/settings/channels/catalog.ts
+++ b/webui/src/components/settings/channels/catalog.ts
@@ -27,7 +27,7 @@ export type ChannelSetupPresentation = {
   presets?: ChannelProviderPreset[];
 };
 
-export type ChannelCatalogSetupPresentation = {
+type ChannelCatalogSetupPresentation = {
   mode?: "webui" | "credentials" | "connect";
   command?: string;
   docsUrl?: string;
@@ -38,15 +38,15 @@ export type ChannelCatalogSetupPresentation = {
   presets?: ChannelProviderPresetDefinition[];
 };
 
-export type ChannelFieldPresentation = {
+type ChannelFieldPresentation = {
   key: string;
 };
 
-export type ChannelSetupActionDefinition = Omit<ChannelSetupAction, "label">;
+type ChannelSetupActionDefinition = Omit<ChannelSetupAction, "label">;
 
 export type ChannelProviderPresetDefinition = Omit<ChannelProviderPreset, "label">;
 
-export type ChannelSetupAction = {
+type ChannelSetupAction = {
   id: string;
   label: string;
   url?: string;
@@ -72,7 +72,7 @@ export type ChannelConfigField = {
   options?: ChannelConfigOption[];
 };
 
-export type ChannelConfigOption = {
+type ChannelConfigOption = {
   value: string;
   label: string;
 };

--- a/webui/src/components/settings/contracts.ts
+++ b/webui/src/components/settings/contracts.ts
@@ -14,7 +14,7 @@ export type SettingsSectionKey =
   | "runtime"
   | "advanced";
 
-export type PendingRestartSection = "runtime" | "browser" | "image";
+type PendingRestartSection = "runtime" | "browser" | "image";
 export type PendingRestartSections = Record<PendingRestartSection, boolean>;
 
 export type RestartAwarePayload = {

--- a/webui/src/components/thread/AgentActivityCluster.tsx
+++ b/webui/src/components/thread/AgentActivityCluster.tsx
@@ -51,7 +51,7 @@ import type { CliAppInfo, McpPresetInfo, ToolProgressEvent, UIFileEdit, UIMessag
 
 const ACTIVITY_SCROLL_NEAR_BOTTOM_PX = 24;
 
-export { isAgentActivityMember, isReasoningOnlyAssistant };
+export { isAgentActivityMember };
 
 interface ActivityCounts {
   reasoningSteps: number;

--- a/webui/src/components/thread/activity/FileEditRow.tsx
+++ b/webui/src/components/thread/activity/FileEditRow.tsx
@@ -155,7 +155,7 @@ function FileEditRow({
   );
 }
 
-export function hasVisibleDiffStats(edit: Pick<FileEditSummary, "added" | "deleted">): boolean {
+function hasVisibleDiffStats(edit: Pick<FileEditSummary, "added" | "deleted">): boolean {
   return edit.added > 0 || edit.deleted > 0;
 }
 

--- a/webui/src/components/thread/activity/generic-tool-model.ts
+++ b/webui/src/components/thread/activity/generic-tool-model.ts
@@ -3,7 +3,7 @@ import { compactActivityPath, redactActivityText } from "./activity-text";
 export type GenericToolStatus = "running" | "done" | "error";
 export type ToolFamily = "content-search" | "file-search" | "list" | "read" | "memory" | "generic";
 
-export interface ToolField {
+interface ToolField {
   key:
     | "query"
     | "pattern"

--- a/webui/src/components/thread/activity/web-search-model.ts
+++ b/webui/src/components/thread/activity/web-search-model.ts
@@ -7,7 +7,7 @@ import { displayWebHost, formatCompactWebUrl, parseSafeActivityHttpUrl } from ".
 export type WebSearchStatus = "running" | "done" | "error";
 export type WebSearchTarget = "web" | "x";
 
-export interface WebSearchSource {
+interface WebSearchSource {
   title: string;
   href: string;
   host: string;

--- a/webui/src/components/thread/promptNavigation.ts
+++ b/webui/src/components/thread/promptNavigation.ts
@@ -26,13 +26,13 @@ export function userPromptAnchors(messages: UIMessage[]): PromptAnchor[] {
   });
 }
 
-export function promptLabel(content: string, index: number): string {
+function promptLabel(content: string, index: number): string {
   const text = content.replace(/\s+/g, " ").trim();
   if (!text) return `Prompt ${index + 1}`;
   return truncatePreview(text, 80);
 }
 
-export function promptPreview(content: string, index: number): string {
+function promptPreview(content: string, index: number): string {
   const text = compactPreview(content);
   if (!text) return `Prompt ${index + 1}`;
   return truncatePreview(text, 320);

--- a/webui/src/components/ui/button.tsx
+++ b/webui/src/components/ui/button.tsx
@@ -33,7 +33,7 @@ const buttonVariants = cva(
   },
 );
 
-export interface ButtonProps
+interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;

--- a/webui/src/components/ui/input.tsx
+++ b/webui/src/components/ui/input.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { formControlFocusClassName } from "@/components/ui/form-control";
 import { cn } from "@/lib/utils";
 
-export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {

--- a/webui/src/components/ui/textarea.tsx
+++ b/webui/src/components/ui/textarea.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { formControlFocusClassName } from "@/components/ui/form-control";
 import { cn } from "@/lib/utils";
 
-export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/webui/src/components/workbench/workbench-model.ts
+++ b/webui/src/components/workbench/workbench-model.ts
@@ -12,7 +12,7 @@ export type {
 
 export const MAX_WORKBENCH_PANES = 4;
 
-export const WORKBENCH_LAYOUTS = [
+const WORKBENCH_LAYOUTS = [
   "columns",
   "rows",
   "grid",

--- a/webui/src/hooks/useAttachedImages.ts
+++ b/webui/src/hooks/useAttachedImages.ts
@@ -9,10 +9,10 @@ import type { WebUIIngressLimits } from "@/lib/types";
  * - ``ready``     — ``dataUrl`` available; safe to submit
  * - ``error``     — validation / decode failure; chip shows inline error
  */
-export type AttachmentStatus = "encoding" | "ready" | "error";
+type AttachmentStatus = "encoding" | "ready" | "error";
 export type AttachmentKind = "image" | "file";
 
-export interface AttachedAttachment {
+interface AttachedAttachment {
   id: string;
   kind: AttachmentKind;
   file: File;
@@ -32,7 +32,7 @@ export interface AttachedAttachment {
 
 export type AttachedImage = AttachedAttachment;
 
-export interface RestoredReadyAttachment {
+interface RestoredReadyAttachment {
   dataUrl: string;
   name?: string;
   kind?: AttachmentKind;
@@ -55,8 +55,8 @@ export type AttachmentError =
   | "io";                // file read failed at the browser layer
 
 export const MAX_ATTACHMENTS_PER_MESSAGE = 4;
-export const MAX_ATTACHMENT_BYTES = 6 * 1024 * 1024;
-export const MAX_TOTAL_ATTACHMENT_BYTES = 24 * 1024 * 1024;
+const MAX_ATTACHMENT_BYTES = 6 * 1024 * 1024;
+const MAX_TOTAL_ATTACHMENT_BYTES = 24 * 1024 * 1024;
 
 /** MIME whitelist — mirrors the server's and the ``<input accept>`` attr. */
 const ACCEPTED_IMAGE_MIMES: ReadonlySet<string> = new Set([

--- a/webui/src/hooks/useClipboardAndDrop.ts
+++ b/webui/src/hooks/useClipboardAndDrop.ts
@@ -11,7 +11,7 @@ import { acceptedAttachmentKind } from "@/hooks/useAttachedImages";
  *   - Plain text pasted alongside attachments is *not* consumed by this helper,
  *     so the caller can still let the textarea receive it naturally.
  */
-export function extractImageFilesFromPaste(
+function extractImageFilesFromPaste(
   event: ClipboardEvent | React.ClipboardEvent,
 ): File[] {
   const clipboard = (event as ClipboardEvent).clipboardData
@@ -27,7 +27,7 @@ export function extractImageFilesFromPaste(
 }
 
 /** Extract dropped attachment files, mirroring ``extractImageFilesFromPaste``. */
-export function extractImageFilesFromDrop(
+function extractImageFilesFromDrop(
   event: DragEvent | React.DragEvent,
 ): File[] {
   const dt = (event as DragEvent).dataTransfer

--- a/webui/src/hooks/useSidebarState.ts
+++ b/webui/src/hooks/useSidebarState.ts
@@ -5,7 +5,7 @@ import { normalizeWorkbenchState } from "@/components/workbench/workbench-model"
 import { fetchSidebarState } from "@/lib/api";
 import type { ChatSummary, SidebarStatePayload } from "@/lib/types";
 
-export const DEFAULT_SIDEBAR_STATE: SidebarStatePayload = {
+const DEFAULT_SIDEBAR_STATE: SidebarStatePayload = {
   schema_version: 1,
   pinned_keys: [],
   archived_keys: [],
@@ -74,7 +74,7 @@ function boolMap(value: unknown): Record<string, boolean> {
   return out;
 }
 
-export function normalizeSidebarState(raw: unknown): SidebarStatePayload {
+function normalizeSidebarState(raw: unknown): SidebarStatePayload {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
     return { ...DEFAULT_SIDEBAR_STATE, view: { ...DEFAULT_SIDEBAR_STATE.view } };
   }

--- a/webui/src/i18n/config.ts
+++ b/webui/src/i18n/config.ts
@@ -51,7 +51,7 @@ export function normalizeLocale(
   return baseMatch?.code ?? defaultLocale;
 }
 
-export function readStoredLocale(): SupportedLocale | null {
+function readStoredLocale(): SupportedLocale | null {
   if (typeof window === "undefined") return null;
   try {
     const raw = window.localStorage.getItem(LOCALE_STORAGE_KEY);

--- a/webui/src/i18n/index.ts
+++ b/webui/src/i18n/index.ts
@@ -10,7 +10,6 @@ import {
   applyDocumentLocale,
   defaultLocale,
   fallbackLocale,
-  LOCALE_STORAGE_KEY,
   normalizeLocale,
   persistLocale,
   resolveInitialLocale,
@@ -47,7 +46,7 @@ export function currentLocale(): SupportedLocale {
   return normalizeLocale(i18n.resolvedLanguage ?? i18n.language ?? defaultLocale);
 }
 
-export async function loadLocaleResources(
+async function loadLocaleResources(
   locale: SupportedLocale,
 ): Promise<LocaleResource> {
   const existing = resourcePromises.get(locale);
@@ -131,5 +130,4 @@ function syncLocaleSideEffects(language: string) {
   persistLocale(locale);
 }
 
-export { LOCALE_STORAGE_KEY };
 export default i18n;

--- a/webui/src/lib/ansi.ts
+++ b/webui/src/lib/ansi.ts
@@ -3,7 +3,7 @@ export type AnsiSegment = {
   style?: AnsiStyle;
 };
 
-export type AnsiStyle = {
+type AnsiStyle = {
   backgroundColor?: string;
   color?: string;
   fontStyle?: "italic";

--- a/webui/src/lib/http.ts
+++ b/webui/src/lib/http.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_HTTP_TIMEOUT_MS = 20_000;
+const DEFAULT_HTTP_TIMEOUT_MS = 20_000;
 
 export async function fetchWithTimeout(
   input: RequestInfo | URL,

--- a/webui/src/lib/imageEncode.ts
+++ b/webui/src/lib/imageEncode.ts
@@ -11,7 +11,7 @@ import {
   type EncodeResponse,
 } from "@/workers/imageEncode.worker";
 
-export type { EncodeResponse, EncodeSuccess, EncodeFailure } from "@/workers/imageEncode.worker";
+export type { EncodeResponse, EncodeFailure } from "@/workers/imageEncode.worker";
 
 type Pending = {
   resolve: (r: EncodeResponse) => void;

--- a/webui/src/lib/nanobot-client.ts
+++ b/webui/src/lib/nanobot-client.ts
@@ -113,7 +113,7 @@ interface PendingWebUIRequest extends PendingRequest<unknown> {
   serializedFrame: string;
 }
 
-export class WebUIMutationError extends Error {
+class WebUIMutationError extends Error {
   status: number;
 
   constructor(status: number, message: string) {

--- a/webui/src/lib/provider-brand.ts
+++ b/webui/src/lib/provider-brand.ts
@@ -124,7 +124,7 @@ export function logoFallbackUrls(logoUrl: string | null | undefined): string[] {
   return urls;
 }
 
-export const PROVIDER_BRAND_ALIASES: Record<string, string> = {
+const PROVIDER_BRAND_ALIASES: Record<string, string> = {
   brave_search: "brave",
   byteplus_coding_plan: "byteplus",
   mimo: "xiaomi_mimo",
@@ -137,7 +137,7 @@ export const PROVIDER_BRAND_ALIASES: Record<string, string> = {
   volcengine_coding_plan: "volcengine",
 };
 
-export const PROVIDER_LABEL_ALIASES: Record<string, string> = {
+const PROVIDER_LABEL_ALIASES: Record<string, string> = {
   brave_search: "Brave Search",
   byteplus_coding_plan: "BytePlus",
   minimaxAnthropic: "MiniMax",

--- a/webui/src/lib/runtime.ts
+++ b/webui/src/lib/runtime.ts
@@ -10,7 +10,7 @@ export interface RuntimeHost {
   exportDiagnostics?: () => Promise<string>;
 }
 
-export interface HostRuntimeInfo {
+interface HostRuntimeInfo {
   surface: "native";
   app_version: string;
   engine_status: "starting" | "ready" | "restarting" | "stopped" | "crashed";
@@ -23,7 +23,7 @@ export interface HostRuntimeInfo {
   engine_transport?: "unix_socket";
 }
 
-export interface NanobotHostApi {
+interface NanobotHostApi {
   getRuntimeInfo?(): Promise<HostRuntimeInfo>;
   restartEngine?(): Promise<void>;
   pickFolder?(): Promise<string | null>;
@@ -40,7 +40,7 @@ export interface NanobotHostApi {
   ): () => void;
 }
 
-export type HostSocketEvent =
+type HostSocketEvent =
   | { id: string; type: "open" }
   | { data: string; id: string; type: "message" }
   | { id: string; message: string; type: "error" }

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1,8 +1,8 @@
-export type Role = "user" | "assistant" | "tool" | "system";
+type Role = "user" | "assistant" | "tool" | "system";
 
 /** "trace" rows are intermediate agent breadcrumbs (tool-call hints,
  * progress pings) that should not be rendered as conversational replies. */
-export type MessageKind = "message" | "trace";
+type MessageKind = "message" | "trace";
 
 export type UITurnPhase = "user" | "reasoning" | "activity" | "answer" | "complete";
 export type MessageDeliveryStatus = "sending" | "accepted" | "failed";
@@ -37,7 +37,7 @@ export interface UIMediaAttachment {
   name?: string;
 }
 
-export interface UIMessageSource { kind: "cron" | "local_trigger" | "trigger" | string; label?: string; }
+interface UIMessageSource { kind: "cron" | "local_trigger" | "trigger" | string; label?: string; }
 
 export interface TurnUsage {
   prompt_tokens?: number;
@@ -144,7 +144,7 @@ export interface SessionHandle {
   name: string;
 }
 
-export interface UISessionMessage {
+interface UISessionMessage {
   message_id: string;
   session: SessionHandle;
 }
@@ -226,14 +226,14 @@ export interface SkillSummary {
   unavailable_reason?: string;
 }
 
-export interface SkillRequirements {
+interface SkillRequirements {
   bins: string[];
   env: string[];
   missing_bins: string[];
   missing_env: string[];
 }
 
-export interface SkillInstallOption {
+interface SkillInstallOption {
   id: string;
   kind: string;
   label: string;
@@ -303,7 +303,7 @@ export interface SkillInstallPayload extends SkillsPayload {
 }
 
 /** Structured UI blob on ``progress`` WS frames; channels may add more ``kind`` values later. */
-export interface AgentUIBlob {
+interface AgentUIBlob {
   kind: string;
   data?: unknown;
 }
@@ -455,16 +455,16 @@ export interface BootstrapResponse {
   runtime_capabilities?: RuntimeCapabilities;
 }
 
-export interface WebUITransportLimits {
+interface WebUITransportLimits {
   max_frame_bytes: number;
   envelope_reserve_bytes: number;
 }
 
-export interface WebUIMessageLimits {
+interface WebUIMessageLimits {
   max_text_bytes: number;
 }
 
-export interface WebUIAttachmentLimits {
+interface WebUIAttachmentLimits {
   max_count: number;
   max_file_bytes: number;
   max_total_bytes: number;
@@ -477,8 +477,8 @@ export interface WebUIIngressLimits {
 }
 
 export type RuntimeSurface = "browser" | "native";
-export type RestartBehavior = "none" | "nextTurn" | "engineRestart" | "appRestart";
-export type SettingsApplyStatus =
+type RestartBehavior = "none" | "nextTurn" | "engineRestart" | "appRestart";
+type SettingsApplyStatus =
   | "idle"
   | "pending"
   | "applying"
@@ -492,7 +492,7 @@ export interface RuntimeCapabilities {
   can_export_diagnostics: boolean;
 }
 
-export interface ProviderModelInfo {
+interface ProviderModelInfo {
   id: string;
   label?: string | null;
   description?: string | null;
@@ -783,12 +783,12 @@ export interface ApiServicePayload {
   last_action?: "started" | "stopped" | string;
 }
 
-export interface AppPackageRef {
+interface AppPackageRef {
   manager: string;
   name?: string;
 }
 
-export interface AppCapability {
+interface AppCapability {
   type: "cli" | "mcp" | "skill" | string;
   entry_point?: string;
   package?: AppPackageRef;
@@ -806,20 +806,20 @@ export interface AppCapability {
   }>;
 }
 
-export interface AppPlan {
+interface AppPlan {
   supported: boolean;
   strategy?: string;
   managed_paths?: string[];
   verification?: string[];
 }
 
-export interface AppTrust {
+interface AppTrust {
   registry: string;
   level: string;
   review_status: string;
 }
 
-export interface AppManifest {
+interface AppManifest {
   schema: "agent-app.v1" | string;
   id: string;
   display_name: string;
@@ -935,7 +935,7 @@ export interface NanobotFeaturesPayload {
   };
 }
 
-export type ChannelSetupStatus =
+type ChannelSetupStatus =
   | "connected"
   | "configured"
   | "needs_setup"
@@ -943,9 +943,9 @@ export type ChannelSetupStatus =
   | "unsupported"
   | string;
 
-export type ChannelValidationCheckStatus = "pass" | "warn" | "fail" | "skipped" | string;
+type ChannelValidationCheckStatus = "pass" | "warn" | "fail" | "skipped" | string;
 
-export interface ChannelValidationCheck {
+interface ChannelValidationCheck {
   id: string;
   label: string;
   status: ChannelValidationCheckStatus;
@@ -953,7 +953,7 @@ export interface ChannelValidationCheck {
   action_url?: string;
 }
 
-export interface ChannelIdentity {
+interface ChannelIdentity {
   name?: string;
   workspace?: string;
   account?: string;
@@ -993,7 +993,7 @@ export interface PairingPayload {
   };
 }
 
-export interface McpPresetField {
+interface McpPresetField {
   name: string;
   label: string;
   secret: boolean;
@@ -1033,7 +1033,7 @@ export interface McpPresetInfo {
   manifest?: AppManifest;
 }
 
-export type McpOAuthFlowStatus =
+type McpOAuthFlowStatus =
   | "starting"
   | "authorization_required"
   | "connecting"
@@ -1089,7 +1089,7 @@ export interface McpPresetsPayload {
   };
 }
 
-export type ChannelConnectStatus = "pending" | "succeeded" | "expired" | "cancelled" | "failed";
+type ChannelConnectStatus = "pending" | "succeeded" | "expired" | "cancelled" | "failed";
 
 export interface ChannelConnectPayload {
   session_id: string;
@@ -1234,7 +1234,7 @@ export type ConnectionStatus =
   | "closed"
   | "error";
 
-export interface InboundTurnMetadata {
+interface InboundTurnMetadata {
   turn_id?: string;
   turn_phase?: UITurnPhase;
   turn_seq?: number;
@@ -1430,7 +1430,7 @@ export interface OutboundMcpPresetMention {
 }
 
 /** Response shape for ``GET .../webui-thread`` (server-built transcript replay). */
-export interface WebuiThreadPagePayload {
+interface WebuiThreadPagePayload {
   before_cursor?: string | null;
   has_more_before?: boolean;
   loaded_message_count?: number;

--- a/webui/src/workers/imageEncode.worker.ts
+++ b/webui/src/workers/imageEncode.worker.ts
@@ -23,7 +23,7 @@ export type EncodeInput = {
   file: File;
 };
 
-export type EncodeSuccess = {
+type EncodeSuccess = {
   id: string;
   ok: true;
   dataUrl: string;


### PR DESCRIPTION
## Summary

- remove zero-consumer runtime, settings, channel, and test helpers plus unread state and ineffective config fields
- drop the unused `websocket-client` dependency
- narrow WebUI and TUI exports to the symbols that have real consumers
- preserve dynamic entrypoints and public compatibility surfaces identified during the audit

## Verification

- `uv run --no-sync ruff check nanobot tests`
- `uv run --no-sync basedpyright`
- targeted Python suites: 531 passed
- full Python suite: 6580 passed, 49 skipped; one Windows-only symlink test could not run because the current process lacks symlink privileges (`WinError 1314`)
- WebUI: lint, production build, and 1084 tests passed
- TUI: type check and 111 tests passed
- `uv lock --check`
- `git diff --check`