### PR TITLE
fix(webui): keep iOS PWA controls inside safe area

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -12,8 +12,12 @@
       content="nanobot web UI — chat with your nanobot workspace."
       data-i18n-meta="description"
     />
-    <meta name="theme-color" content="#fafaf9" media="(prefers-color-scheme: light)" />
-    <meta name="theme-color" content="#303030" media="(prefers-color-scheme: dark)" />
+    <meta
+      name="theme-color"
+      content="#ffffff"
+      data-theme-color-light="#ffffff"
+      data-theme-color-dark="#303030"
+    />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
@@ -96,13 +100,23 @@
     <script>
       (function () {
         try {
-          var stored = localStorage.getItem("nanobot-webui.theme");
+          var stored = null;
+          try {
+            stored = localStorage.getItem("nanobot-webui.theme");
+          } catch {}
           var dark =
             stored === "dark" ||
-            (!stored &&
+            (stored !== "light" &&
               window.matchMedia &&
               window.matchMedia("(prefers-color-scheme: dark)").matches);
           if (dark) document.documentElement.classList.add("dark");
+          var themeColor = document.querySelector('meta[name="theme-color"]');
+          if (themeColor) {
+            var color = themeColor.getAttribute(
+              dark ? "data-theme-color-dark" : "data-theme-color-light"
+            );
+            if (color) themeColor.setAttribute("content", color);
+          }
         } catch {}
       })();
     </script>

--- a/webui/index.html
+++ b/webui/index.html
@@ -13,7 +13,7 @@
       data-i18n-meta="description"
     />
     <meta name="theme-color" content="#fafaf9" media="(prefers-color-scheme: light)" />
-    <meta name="theme-color" content="#161618" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#303030" media="(prefers-color-scheme: dark)" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
@@ -49,7 +49,7 @@
       }
 
       html.dark body {
-        background: #1a1a1a;
+        background: #303030;
         color: #fafafa;
       }
 

--- a/webui/index.html
+++ b/webui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+      content="width=device-width, initial-scale=1.0, viewport-fit=auto"
     />
     <meta name="color-scheme" content="light dark" />
     <meta

--- a/webui/public/manifest.json
+++ b/webui/public/manifest.json
@@ -4,8 +4,8 @@
   "description": "nanobot AI assistant",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#161618",
-  "theme_color": "#161618",
+  "background_color": "#303030",
+  "theme_color": "#303030",
   "orientation": "any",
   "icons": [
     {

--- a/webui/public/manifest.json
+++ b/webui/public/manifest.json
@@ -4,8 +4,12 @@
   "description": "nanobot AI assistant",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#303030",
-  "theme_color": "#303030",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "color_scheme_dark": {
+    "background_color": "#303030",
+    "theme_color": "#303030"
+  },
   "orientation": "any",
   "icons": [
     {

--- a/webui/src/hooks/useTheme.ts
+++ b/webui/src/hooks/useTheme.ts
@@ -25,6 +25,13 @@ function applyTheme(theme: Theme): void {
   const root = document.documentElement;
   if (theme === "dark") root.classList.add("dark");
   else root.classList.remove("dark");
+
+  const themeColor = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+  const color =
+    theme === "dark"
+      ? themeColor?.dataset.themeColorDark
+      : themeColor?.dataset.themeColorLight;
+  if (themeColor && color) themeColor.content = color;
 }
 
 export function useTheme(): {

--- a/webui/src/tests/index-html.test.ts
+++ b/webui/src/tests/index-html.test.ts
@@ -12,4 +12,12 @@ describe("index.html", () => {
     expect(viewport).not.toContain("user-scalable=no");
     expect(viewport).not.toMatch(/maximum-scale\s*=\s*1(?:\.0)?(?:,|$)/);
   });
+
+  it("lets iOS keep standalone content inside the safe area", () => {
+    const html = readFileSync(resolve(process.cwd(), "index.html"), "utf8");
+    const viewport = html.match(/<meta\s+name="viewport"\s+content="([^"]+)"/i)?.[1];
+
+    expect(viewport).toContain("viewport-fit=auto");
+    expect(viewport).not.toContain("viewport-fit=cover");
+  });
 });

--- a/webui/src/tests/index-html.test.ts
+++ b/webui/src/tests/index-html.test.ts
@@ -21,21 +21,30 @@ describe("index.html", () => {
     expect(viewport).not.toContain("viewport-fit=cover");
   });
 
-  it("matches dark PWA chrome to the app canvas", () => {
+  it("provides light and dark PWA chrome colors", () => {
     const html = readFileSync(resolve(process.cwd(), "index.html"), "utf8");
     const manifest = JSON.parse(
       readFileSync(resolve(process.cwd(), "public/manifest.json"), "utf8"),
-    ) as { background_color?: string; theme_color?: string };
-    const darkThemeColor = html.match(
-      /<meta\s+name="theme-color"\s+content="([^"]+)"\s+media="\(prefers-color-scheme:\s*dark\)"/i,
-    )?.[1];
+    ) as {
+      background_color?: string;
+      theme_color?: string;
+      color_scheme_dark?: { background_color?: string; theme_color?: string };
+    };
+    const document = new DOMParser().parseFromString(html, "text/html");
+    const themeColor = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+    const lightBodyBackground = html.match(/body\s*{[^}]*background:\s*([^;]+);/s)?.[1]?.trim();
     const darkBodyBackground = html.match(
       /html\.dark body\s*{[^}]*background:\s*([^;]+);/s,
     )?.[1]?.trim();
 
-    expect(darkThemeColor).toBe("#303030");
+    expect(themeColor?.content).toBe("#ffffff");
+    expect(themeColor?.dataset.themeColorLight).toBe("#ffffff");
+    expect(themeColor?.dataset.themeColorDark).toBe("#303030");
+    expect(lightBodyBackground).toBe("#ffffff");
     expect(darkBodyBackground).toBe("#303030");
-    expect(manifest.background_color).toBe("#303030");
-    expect(manifest.theme_color).toBe("#303030");
+    expect(manifest.background_color).toBe("#ffffff");
+    expect(manifest.theme_color).toBe("#ffffff");
+    expect(manifest.color_scheme_dark?.background_color).toBe("#303030");
+    expect(manifest.color_scheme_dark?.theme_color).toBe("#303030");
   });
 });

--- a/webui/src/tests/index-html.test.ts
+++ b/webui/src/tests/index-html.test.ts
@@ -20,4 +20,22 @@ describe("index.html", () => {
     expect(viewport).toContain("viewport-fit=auto");
     expect(viewport).not.toContain("viewport-fit=cover");
   });
+
+  it("matches dark PWA chrome to the app canvas", () => {
+    const html = readFileSync(resolve(process.cwd(), "index.html"), "utf8");
+    const manifest = JSON.parse(
+      readFileSync(resolve(process.cwd(), "public/manifest.json"), "utf8"),
+    ) as { background_color?: string; theme_color?: string };
+    const darkThemeColor = html.match(
+      /<meta\s+name="theme-color"\s+content="([^"]+)"\s+media="\(prefers-color-scheme:\s*dark\)"/i,
+    )?.[1];
+    const darkBodyBackground = html.match(
+      /html\.dark body\s*{[^}]*background:\s*([^;]+);/s,
+    )?.[1]?.trim();
+
+    expect(darkThemeColor).toBe("#303030");
+    expect(darkBodyBackground).toBe("#303030");
+    expect(manifest.background_color).toBe("#303030");
+    expect(manifest.theme_color).toBe("#303030");
+  });
 });

--- a/webui/src/tests/useTheme.test.tsx
+++ b/webui/src/tests/useTheme.test.tsx
@@ -1,0 +1,39 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useTheme } from "@/hooks/useTheme";
+
+describe("useTheme", () => {
+  beforeEach(() => {
+    localStorage.removeItem("nanobot-webui.theme");
+    document.documentElement.classList.remove("dark");
+
+    const themeColor = document.createElement("meta");
+    themeColor.name = "theme-color";
+    themeColor.content = "#ffffff";
+    themeColor.dataset.themeColorLight = "#ffffff";
+    themeColor.dataset.themeColorDark = "#303030";
+    document.head.append(themeColor);
+  });
+
+  afterEach(() => {
+    document.querySelector('meta[name="theme-color"]')?.remove();
+    document.documentElement.classList.remove("dark");
+    localStorage.removeItem("nanobot-webui.theme");
+  });
+
+  it("keeps browser chrome in sync with the selected app theme", () => {
+    localStorage.setItem("nanobot-webui.theme", "dark");
+    const { result } = renderHook(useTheme);
+    const themeColor = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+
+    expect(document.documentElement).toHaveClass("dark");
+    expect(themeColor?.content).toBe("#303030");
+
+    act(() => result.current.setTheme("light"));
+
+    expect(document.documentElement).not.toHaveClass("dark");
+    expect(themeColor?.content).toBe("#ffffff");
+    expect(localStorage.getItem("nanobot-webui.theme")).toBe("light");
+  });
+});


### PR DESCRIPTION
## Summary

- restore `viewport-fit=auto` so installed PWAs keep controls inside the platform safe area
- resolve the active light/dark theme before React starts and keep the page `theme-color` synchronized with in-app theme changes
- use light manifest defaults plus the standard `color_scheme_dark` override for Android, iOS, and desktop PWA launch chrome
- add focused regression coverage for safe-area mode, manifest appearance colors, and runtime theme synchronization

## Why

The WebUI enabled `viewport-fit=cover` while its primary header did not consume `safe-area-inset-top`. On iOS standalone PWAs, that placed the sidebar and theme controls beneath the status bar. The landing layout also consumed `safe-area-inset-bottom` at the grid boundary, which exposed a large empty band below the composer.

Using automatic viewport fitting is the smallest cross-page fix: the browser keeps the app inside the usable area without separate inset handling in every header, sidebar, settings view, and composer. It also avoids the currently open iOS standalone viewport regression: https://bugs.webkit.org/show_bug.cgi?id=301994

System chrome now follows nanobot's actual selected theme instead of relying only on `prefers-color-scheme`. The boot script uses the saved theme when valid, otherwise falls back to the OS preference; the React theme hook updates the same meta tag after an in-app toggle. The manifest supplies `#ffffff` as the portable base fallback and `#303030` through `color_scheme_dark`, matching the app canvas in both appearances.

## Verification

- `bun run test -- src/tests/index-html.test.ts src/tests/useTheme.test.tsx src/tests/sw.test.ts src/tests/main-pwa-registration.test.tsx src/tests/main-pwa-registration-unavailable.test.tsx` (19 passed)
- `bun run build`
- `bun run lint`
- real gateway at 390x844: `viewport-fit=auto`; saved dark theme resolved body, main canvas, and theme metadata to `rgb(48, 48, 48)` / `#303030`; the actual header theme button switched all three back to white; sidebar control opened successfully
- dark OS preference plus an invalid legacy stored value correctly resolved to dark on reload
- manifest returned light base colors and the `color_scheme_dark` pair; browser console had 0 errors / 0 warnings
- isolated gateway cleanup passed with `runtime_removed=true` and `ports_released=true`

## Limitations

- Desktop Chromium cannot emulate the non-zero safe-area values or system status-bar rendering of an installed iOS Home Screen PWA, so final iOS device confirmation after a full app relaunch is still recommended.
- Browsers that do not yet implement `color_scheme_dark` use the light manifest launch fallback; the document switches to the selected dark color as soon as its boot script runs.