### PR TITLE
fix(session): prevent deleted sessions from being recreated by delayed messages

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1305,7 +1305,11 @@ class AgentLoop:
                     msg.require_existing_session
                     and self.sessions.get_cached(effective_key) is None
                 ):
-                    continue
+                    if await asyncio.to_thread(
+                        self.sessions.read_session_metadata,
+                        effective_key,
+                    ) is None:
+                        continue
                 if msg.is_user_input:
                     await self.runtime_event_publisher.user_input_accepted(msg, effective_key)
                 if msg.channel != "system" and self.commands.is_priority(raw):
@@ -1773,7 +1777,10 @@ class AgentLoop:
 
         if ctx.session is None:
             if msg.require_existing_session:
-                ctx.session = self.sessions.get_cached(ctx.session_key)
+                ctx.session = await asyncio.to_thread(
+                    self.sessions.get_existing,
+                    ctx.session_key,
+                )
                 if ctx.session is None:
                     raise RuntimeError("required session is not active")
             else:

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -532,6 +532,7 @@ class SubagentManager:
             chat_id=f"{origin['channel']}:{origin['chat_id']}",
             content=announce_content,
             session_key_override=override,
+            require_existing_session=True,
             metadata=metadata,
         )
 

--- a/nanobot/agent/tools/session_messages.py
+++ b/nanobot/agent/tools/session_messages.py
@@ -261,6 +261,7 @@ class SendSessionMessageTool(Tool):
                 content=content,
                 metadata={SESSION_MESSAGE_METADATA_KEY: envelope},
                 session_key_override=target.session_key,
+                require_existing_session=True,
                 input_role="user",
             ))
             sent_at.append(now)
@@ -360,5 +361,6 @@ class SendSessionMessageTool(Tool):
                     f"{expected.timeout_seconds} seconds."
                 ),
                 session_key_override=source_session_key,
+                require_existing_session=True,
                 input_role="user",
             ))

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -1758,6 +1758,17 @@ class SessionManager:
         self._remember(session)
         return session
 
+    def get_existing(self, key: str) -> Session | None:
+        """Return a cached or persisted session without creating one."""
+        session = self._cached(key)
+        if session is not None:
+            return session
+
+        session = self._load(key)
+        if session is not None:
+            self._remember(session)
+        return session
+
     def get_or_create_transient(
         self,
         key: str,

--- a/tests/agent/test_session_inputs.py
+++ b/tests/agent/test_session_inputs.py
@@ -44,6 +44,7 @@ def _message(content: str = "Please review") -> InboundMessage:
         content=content,
         metadata={SESSION_MESSAGE_METADATA_KEY: envelope},
         session_key_override="telegram:target",
+        require_existing_session=True,
         input_role="user",
     )
 
@@ -56,6 +57,7 @@ async def test_session_message_runs_as_user_input_and_replies_on_target_route(
     monkeypatch.setattr("nanobot.config.paths.get_data_dir", lambda: tmp_path / "state")
     loop = _loop(tmp_path)
     loop.sessions.save(loop.sessions.get_or_create("telegram:target"))
+    loop.sessions.invalidate("telegram:target")
     msg = _message()
 
     response = await loop._process_message(msg)
@@ -78,6 +80,67 @@ async def test_session_message_runs_as_user_input_and_replies_on_target_route(
     user_row = next(row for row in stored if row.get("role") == "user")
     assert public_history_message(user_row)["content"] == "Please review"
     assert SESSION_MESSAGE_METADATA_KEY not in user_row
+
+
+@pytest.mark.asyncio
+async def test_deleted_queued_session_message_does_not_recreate_target(
+    tmp_path: Path,
+) -> None:
+    loop = _loop(tmp_path)
+    target_key = "telegram:target"
+    loop.sessions.save(loop.sessions.get_or_create(target_key))
+    await loop.bus.publish_inbound(_message())
+
+    assert loop.sessions.delete_session(target_key)
+
+    run_task = asyncio.create_task(loop.run())
+    try:
+        async def wait_for_queue_to_drain() -> None:
+            while not loop.bus.inbound.empty():
+                await asyncio.sleep(0)
+
+        await asyncio.wait_for(wait_for_queue_to_drain(), timeout=2)
+    finally:
+        loop.stop()
+        await asyncio.wait_for(run_task, timeout=2)
+
+    loop.provider.chat_with_retry.assert_not_awaited()
+    assert loop.sessions.read_session_file(target_key) is None
+
+
+@pytest.mark.asyncio
+async def test_session_deleted_after_existence_check_does_not_recreate_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loop = _loop(tmp_path)
+    target_key = "telegram:target"
+    loop.sessions.save(loop.sessions.get_or_create(target_key))
+    loop.sessions.invalidate(target_key)
+
+    original_read_metadata = loop.sessions.read_session_metadata
+
+    def read_then_delete(key: str) -> dict[str, object] | None:
+        metadata = original_read_metadata(key)
+        assert metadata is not None
+        assert loop.sessions.delete_session(key)
+        return metadata
+
+    read_metadata = MagicMock(side_effect=read_then_delete)
+    monkeypatch.setattr(loop.sessions, "read_session_metadata", read_metadata)
+    await loop.bus.publish_inbound(_message())
+
+    run_task = asyncio.create_task(loop.run())
+    try:
+        response = await asyncio.wait_for(loop.bus.consume_outbound(), timeout=2)
+    finally:
+        loop.stop()
+        await asyncio.wait_for(run_task, timeout=2)
+
+    read_metadata.assert_called_once_with(target_key)
+    assert response.content == "Sorry, I encountered an error."
+    loop.provider.chat_with_retry.assert_not_awaited()
+    assert loop.sessions.read_session_file(target_key) is None
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_subagent_followup_lifecycle.py
+++ b/tests/session/test_subagent_followup_lifecycle.py
@@ -1,0 +1,254 @@
+"""Focused regression tests for subagent result require_existing_session.
+
+These three tests cover the essential contracts:
+1. Subagent announcements use require_existing_session=True
+2. Deleted parent sessions are not resurrected by late results
+3. Persisted-but-uncached parents still accept legitimate results
+"""
+import asyncio
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.agent.subagent import SubagentManager
+from nanobot.bus.queue import MessageBus
+from nanobot.providers.base import LLMResponse
+
+
+@pytest.fixture(autouse=True)
+def isolated_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("nanobot.config.paths.get_data_dir", lambda: tmp_path / "state")
+
+
+def _loop(tmp_path: Path) -> AgentLoop:
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.generation = SimpleNamespace(max_tokens=4096)
+    provider.chat_with_retry = AsyncMock(
+        return_value=LLMResponse(content="Reviewed", finish_reason="stop")
+    )
+    return AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+    )
+
+
+# -- TEST 1: Announcement contract -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_announcement_uses_require_existing_session(
+    tmp_path: Path,
+) -> None:
+    """Subagent completion messages must set require_existing_session=True.
+
+    Exercises the real SubagentManager._announce_result() path.
+    Without the fix, require_existing_session defaults to False.
+    """
+    bus = MessageBus()
+    mgr = SubagentManager(
+        workspace=tmp_path,
+        bus=bus,
+        max_tool_result_chars=16_000,
+    )
+
+    origin = {
+        "channel": "telegram",
+        "chat_id": "12345",
+        "session_key": "telegram:12345",
+    }
+    await mgr._announce_result(
+        task_id="task-1",
+        label="test",
+        task="do something",
+        result="done",
+        origin=origin,
+        status="ok",
+    )
+
+    msg = await bus.consume_inbound()
+    assert msg.require_existing_session is True, (
+        "Subagent result must set require_existing_session=True "
+        "so the AgentLoop guard can reject it for deleted sessions."
+    )
+    assert msg.session_key == "telegram:12345"
+
+
+# -- TEST 2: Deleted parent must not be resurrected ---------------------
+
+
+@pytest.mark.asyncio
+async def test_deleted_parent_not_resurrected_by_late_result(
+    tmp_path: Path,
+) -> None:
+    """A late subagent result must not recreate a deleted parent session.
+
+    Uses monkeypatched read_session_metadata with a threading.Event to
+    deterministically observe when the guard has processed the deleted
+    session lookup — no arbitrary sleep.
+    """
+    loop = _loop(tmp_path)
+    session_key = "telegram:target"
+
+    # Create and persist parent
+    session = loop.sessions.get_or_create(session_key)
+    session.add_message("user", "hello")
+    session.add_message("assistant", "hi")
+    loop.sessions.save(session)
+    assert loop.sessions.read_session_file(session_key) is not None
+
+    # Delete parent
+    assert loop.sessions.delete_session(session_key)
+    assert loop.sessions.read_session_file(session_key) is None
+    assert loop.sessions.get_cached(session_key) is None
+
+    # Publish subagent result via SubagentManager
+    bus = loop.bus
+    mgr = SubagentManager(
+        workspace=tmp_path,
+        bus=bus,
+        max_tool_result_chars=16_000,
+    )
+    origin = {
+        "channel": "telegram",
+        "chat_id": "target",
+        "session_key": session_key,
+    }
+    await mgr._announce_result(
+        task_id="task-1",
+        label="test",
+        task="do something",
+        result="subagent answer",
+        origin=origin,
+        status="ok",
+    )
+
+    # Instrument read_session_metadata to observe the guard's lookup.
+    # The guard calls read_session_metadata via asyncio.to_thread, so
+    # the instrumented version runs in a thread pool worker.
+    guard_observed = threading.Event()
+    original_rsm = loop.sessions.read_session_metadata
+
+    def instrumented_rsm(key: str):
+        result = original_rsm(key)
+        if key == session_key:
+            guard_observed.set()
+        return result
+
+    loop.sessions.read_session_metadata = instrumented_rsm  # type: ignore[assignment]
+
+    # Process through AgentLoop
+    run_task = asyncio.create_task(loop.run())
+    try:
+        # Wait in a thread so the asyncio event loop stays free to run.
+        observed = await asyncio.to_thread(guard_observed.wait, 10)
+        assert observed, (
+            "Guard never observed — read_session_metadata was not called"
+        )
+    finally:
+        loop.stop()
+        await asyncio.wait_for(run_task, timeout=5)
+        loop.sessions.read_session_metadata = original_rsm  # type: ignore[assignment]
+
+    # Provider must NOT have been invoked for the deleted session
+    loop.provider.chat_with_retry.assert_not_awaited()  # type: ignore[union-attr]
+
+    # Parent must remain deleted
+    assert loop.sessions.read_session_file(session_key) is None, (
+        "Deleted parent session recreated on disk by late subagent result."
+    )
+    assert loop.sessions.get_cached(session_key) is None, (
+        "Deleted parent session recreated in cache by late subagent result."
+    )
+
+
+# -- TEST 3: Persisted-but-uncached parent still works ------------------
+
+
+@pytest.mark.asyncio
+async def test_persisted_uncached_parent_accepts_result(
+    tmp_path: Path,
+) -> None:
+    """A persisted-but-uncached parent must still accept subagent results.
+
+    This proves require_existing_session != require_cached_session.
+    The #5483 guard checks persisted existence on disk, not just cache.
+    """
+    loop = _loop(tmp_path)
+    session_key = "telegram:target"
+
+    # Create and persist parent
+    session = loop.sessions.get_or_create(session_key)
+    session.add_message("user", "hello")
+    loop.sessions.save(session)
+    assert loop.sessions.read_session_file(session_key) is not None
+
+    # Evict from cache only — durable state remains
+    loop.sessions.invalidate(session_key)
+    assert loop.sessions.get_cached(session_key) is None
+    assert loop.sessions.read_session_file(session_key) is not None, (
+        "Durable session must survive cache invalidation"
+    )
+
+    # Publish real subagent result
+    bus = loop.bus
+    mgr = SubagentManager(
+        workspace=tmp_path,
+        bus=bus,
+        max_tool_result_chars=16_000,
+    )
+    origin = {
+        "channel": "telegram",
+        "chat_id": "target",
+        "session_key": session_key,
+    }
+    await mgr._announce_result(
+        task_id="task-1",
+        label="test",
+        task="do something",
+        result="subagent answer",
+        origin=origin,
+        status="ok",
+    )
+
+    # Process through AgentLoop — should accept the result
+    run_task = asyncio.create_task(loop.run())
+    try:
+        await asyncio.wait_for(loop.bus.consume_outbound(), timeout=10)
+    finally:
+        loop.stop()
+        await asyncio.wait_for(run_task, timeout=5)
+
+    # Provider must have been invoked for the legitimate path
+    loop.provider.chat_with_retry.assert_awaited()  # type: ignore[union-attr]
+
+    # Inspect the persisted durable record.
+    # _persist_subagent_followup stores injected_event and subagent_task_id
+    # as top-level message keys, not inside metadata.
+    loop.sessions.invalidate(session_key)
+    reloaded = loop.sessions.get_or_create(session_key)
+
+    subagent_msgs = [
+        m for m in reloaded.messages
+        if m.get("injected_event") == "subagent_result"
+    ]
+    assert len(subagent_msgs) == 1, (
+        f"Expected exactly 1 subagent result message, found {len(subagent_msgs)}. "
+        f"Roles: {[m.get('role') for m in reloaded.messages]}"
+    )
+
+    sr = subagent_msgs[0]
+    assert sr["role"] == "assistant", (
+        f"Subagent result role should be 'assistant', got '{sr['role']}'"
+    )
+    assert sr["injected_event"] == "subagent_result"
+    assert sr["subagent_task_id"] == "task-1"
+    assert "subagent answer" in sr["content"], (
+        f"Subagent result content missing expected text. Got: {sr['content'][:200]}"
+    )

--- a/tests/tools/test_session_messages_tool.py
+++ b/tests/tools/test_session_messages_tool.py
@@ -114,6 +114,7 @@ async def test_send_publishes_user_input_to_the_existing_target(
     assert inbound.channel == "system"
     assert inbound.chat_id == "telegram:target"
     assert inbound.session_key_override == "telegram:target"
+    assert inbound.require_existing_session is True
     assert inbound.is_user_input
     assert inbound.content == "Please review this."
     assert envelope is not None
@@ -267,6 +268,7 @@ async def test_reply_timeout_injects_a_user_input_back_into_the_source(
         reply_timeout_seconds=5,
     )
     await bus.consume_inbound()
+    assert sessions.delete_session("websocket:source")
     delay, timer = scheduler.calls[0]
 
     assert delay == 5
@@ -274,6 +276,7 @@ async def test_reply_timeout_injects_a_user_input_back_into_the_source(
     await asyncio.sleep(0)
     timeout = await bus.consume_inbound()
     assert timeout.chat_id == "websocket:source"
+    assert timeout.require_existing_session is True
     assert timeout.is_user_input
     assert timeout.content == f"No reply from @{target.name} after 5 seconds."
 


### PR DESCRIPTION
## Summary

Prevent delayed cross-session messages from recreating a session after it has been deleted.

## Changes

- Mark cross-session delivery and timeout messages as requiring an existing session.
- Check persisted session metadata without creating a session.
- Restore only cached or persisted sessions for required messages.
- Add regression coverage for queued delivery after deletion, persisted-but-uncached sessions, and timeout delivery after source deletion.

## Validation

- Full Python suite excluding the pre-existing Windows symlink-permission test: 6565 passed, 49 skipped.
- The excluded test fails locally with WinError 1314 because the runner cannot create directory symlinks.
- Basedpyright: 0 errors, 0 warnings, 0 notes.
- Ruff and git diff --check passed.