### PR TITLE
fix(mcp): flag business-error envelopes returned with isError=false

### DIFF
--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -59,6 +59,45 @@ MCPServerLoader = Callable[[], Mapping[str, "MCPServerConfig"]]
 MCPRuntimeStatus = Literal["connecting", "connected", "failed"]
 
 
+def _looks_like_error_envelope(rendered: str) -> bool:
+    """Detect a business-error envelope returned with ``isError=False``.
+
+    Some MCP servers report failures by embedding an error payload in the
+    result content (``{"code": 404, "msg": "data not exist", "data": null}``)
+    while leaving ``CallToolResult.isError`` False. nanobot would otherwise
+    treat the call as successful and the agent would keep retrying until the
+    tool timeout, and the generic timeout message would hide the real cause.
+
+    Flag such payloads so they surface as a tool error. The check is
+    deliberately conservative: it only triggers on a single JSON object that
+    explicitly signals failure (HTTP-style ``code >= 400``, ``success: false``,
+    ``isError: true``, or a non-empty scalar ``error`` field), so ordinary
+    prose or success envelopes (e.g. ``{"code": 0, "data": {...}}``) are
+    unaffected.
+    """
+    text = rendered.strip()
+    if not text or text[0] not in "{[":
+        return False
+    try:
+        parsed = json.loads(text)
+    except (ValueError, TypeError):
+        return False
+    if not isinstance(parsed, dict):
+        return False
+    payload = cast(dict[str, Any], parsed)
+    code = payload.get("code")
+    if isinstance(code, int) and code >= 400:
+        return True
+    if payload.get("success") is False:
+        return True
+    if payload.get("isError") is True:
+        return True
+    error = payload.get("error")
+    if error is not None and not isinstance(error, (dict, list)):
+        return True
+    return False
+
+
 class MCPConnection(Protocol):
     async def aclose(self) -> None: ...
 
@@ -687,9 +726,6 @@ class MCPToolWrapper(_MCPWrapperBase):
                 # Success — extract text and persist any image content as artifacts.
                 try:
                     rendered = self._render_call_result(result.content, kwargs)
-                    if getattr(result, "isError", False):
-                        return ToolResult.error(rendered)
-                    return rendered
                 except Exception as exc:
                     logger.exception(
                         "MCP tool '{}' failed while rendering result: {}: {}",
@@ -700,6 +736,13 @@ class MCPToolWrapper(_MCPWrapperBase):
                     return ToolResult.error(
                         f"(MCP tool returned malformed content: {type(exc).__name__})"
                     )
+                # Some servers embed a business-error envelope in the result
+                # content while leaving ``isError`` False. Surface those as
+                # failures so the agent can react instead of looping until the
+                # tool timeout overwrites the real cause.
+                if getattr(result, "isError", False) or _looks_like_error_envelope(rendered):
+                    return ToolResult.error(rendered)
+                return rendered
 
     def _render_call_result(self, content: Any, arguments: Mapping[str, Any]) -> str:
         """Turn MCP content blocks into a tool result string.

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -564,6 +564,40 @@ async def test_execute_preserves_success_text_that_starts_with_error() -> None:
     assert not is_tool_error_result(result)
 
 
+@pytest.mark.asyncio
+async def test_execute_flags_error_envelope_returned_with_is_error_false() -> None:
+    async def call_tool(_name: str, arguments: dict) -> object:
+        return SimpleNamespace(
+            content=[
+                _FakeTextContent('{"code": 404, "msg": "data not exist", "data": null}')
+            ],
+            isError=False,
+        )
+
+    wrapper = _make_wrapper(SimpleNamespace(call_tool=call_tool))
+
+    result = await wrapper.execute()
+
+    assert result == '{"code": 404, "msg": "data not exist", "data": null}'
+    assert is_tool_error_result(result)
+
+
+@pytest.mark.asyncio
+async def test_execute_keeps_success_envelope_as_success() -> None:
+    async def call_tool(_name: str, arguments: dict) -> object:
+        return SimpleNamespace(
+            content=[_FakeTextContent('{"code": 0, "msg": "ok", "data": {"id": 1}}')],
+            isError=False,
+        )
+
+    wrapper = _make_wrapper(SimpleNamespace(call_tool=call_tool))
+
+    result = await wrapper.execute()
+
+    assert result == '{"code": 0, "msg": "ok", "data": {"id": 1}}'
+    assert not is_tool_error_result(result)
+
+
 # Smallest valid 1x1 PNG, base64 without the data: prefix.
 _PNG_B64 = (
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8"


### PR DESCRIPTION
## Problem

Some MCP servers report failures by embedding an error payload in the tool
result content — for example:

```json
{"code": 404, "msg": "data not exist", "data": null}
```

— while leaving `CallToolResult.isError` set to `False`. nanobot then treats
the call as successful, so the agent keeps retrying the same tool call until
the tool timeout fires. The generic timeout message (`... timed out`) hides
the real cause, making the failure confusing and wasting tokens.

See issue #5237.

## Solution

After rendering a successful `CallToolResult`, detect a business-error
envelope and surface it as a tool error so the agent can react to the real
failure instead of looping.

The detector (`_looks_like_error_envelope`) is deliberately conservative: it
only fires on a single JSON object that explicitly signals failure:
- an HTTP-style `code >= 400`, or
- `success: false`, or
- `isError: true`, or
- a non-empty scalar `error` field.

Normal prose and success envelopes such as `{"code": 0, "data": {...}}`
(including text that merely *starts with* "Error:") remain successful, so
existing behavior is preserved.

## Testing

Added two focused tests in `tests/tools/test_mcp_tool.py`:
- `test_execute_flags_error_envelope_returned_with_is_error_false` — a
  `{"code":404,...}` envelope with `isError=False` is now reported as a tool
  error.
- `test_execute_keeps_success_envelope_as_success` — a `{"code":0,...}`
  envelope stays a successful result.

`ruff check` passes and the full `tests/tools/test_mcp_tool.py` suite passes
(91 passed; the 2 unrelated `test_connect_mcp_servers_http_clients_reject_unsafe_redirect_targets`
tests fail identically on unmodified `main` due to an environment/mock issue
and are untouched by this change).

## Scope

- 2 files changed, +79 / -3 lines.
- No new dependencies, no architectural changes — localized to the MCP tool
  result handling.
