### PR TITLE
fix: restore LangSmith tracing for native providers

### DIFF
--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -22,6 +22,7 @@ from nanobot.providers.base import (
     resolve_stream_idle_timeout_s,
     tool_arguments_object_for_replay,
 )
+from nanobot.providers.langsmith_integration import wrap_anthropic_client
 
 _ALNUM = string.ascii_letters + string.digits
 
@@ -109,7 +110,7 @@ class AnthropicProvider(LLMProvider):
             client_kw["default_headers"] = extra_headers
         # Keep retries centralized in LLMProvider._run_with_retry to avoid retry amplification.
         client_kw["max_retries"] = 0
-        self._client = AsyncAnthropic(**client_kw)
+        self._client = wrap_anthropic_client(AsyncAnthropic(**client_kw))
 
     @staticmethod
     def _normalize_base_url(api_base: str) -> str:

--- a/nanobot/providers/langsmith_integration.py
+++ b/nanobot/providers/langsmith_integration.py
@@ -1,0 +1,51 @@
+"""Optional LangSmith tracing for native provider clients."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from typing import Any
+
+from loguru import logger
+
+
+def _configure() -> bool:
+    """Prepare LangSmith's environment and report whether it is available."""
+    api_key = os.environ.get("LANGSMITH_API_KEY")
+    if not api_key:
+        return False
+    if importlib.util.find_spec("langsmith") is None:
+        logger.warning(
+            "LANGSMITH_API_KEY is set but langsmith is not installed; "
+            "run `pip install nanobot-ai[langsmith]` to enable tracing"
+        )
+        return False
+
+    os.environ.setdefault("LANGSMITH_TRACING", "true")
+    return True
+
+
+def wrap_openai_client(client: Any) -> Any:
+    """Wrap an OpenAI-compatible client when LangSmith is configured."""
+    if not _configure():
+        return client
+    try:
+        from langsmith.wrappers import wrap_openai
+
+        return wrap_openai(client)
+    except Exception as exc:
+        logger.warning("Unable to enable LangSmith OpenAI tracing: {}", exc)
+        return client
+
+
+def wrap_anthropic_client(client: Any) -> Any:
+    """Wrap an Anthropic client when LangSmith is configured."""
+    if not _configure():
+        return client
+    try:
+        from langsmith.wrappers import wrap_anthropic
+
+        return wrap_anthropic(client)
+    except Exception as exc:
+        logger.warning("Unable to enable LangSmith Anthropic tracing: {}", exc)
+        return client

--- a/nanobot/providers/langsmith_integration.py
+++ b/nanobot/providers/langsmith_integration.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import importlib.util
 import os
-from typing import Any
+from typing import Any, TypeVar, cast
 
 from loguru import logger
+
+ClientT = TypeVar("ClientT")
 
 
 def _configure() -> bool:
@@ -25,27 +27,27 @@ def _configure() -> bool:
     return True
 
 
-def wrap_openai_client(client: Any) -> Any:
+def wrap_openai_client(client: ClientT) -> ClientT:
     """Wrap an OpenAI-compatible client when LangSmith is configured."""
     if not _configure():
         return client
     try:
         from langsmith.wrappers import wrap_openai
 
-        return wrap_openai(client)
+        return cast(ClientT, wrap_openai(cast(Any, client)))
     except Exception as exc:
         logger.warning("Unable to enable LangSmith OpenAI tracing: {}", exc)
         return client
 
 
-def wrap_anthropic_client(client: Any) -> Any:
+def wrap_anthropic_client(client: ClientT) -> ClientT:
     """Wrap an Anthropic client when LangSmith is configured."""
     if not _configure():
         return client
     try:
         from langsmith.wrappers import wrap_anthropic
 
-        return wrap_anthropic(client)
+        return cast(ClientT, wrap_anthropic(cast(Any, client)))
     except Exception as exc:
         logger.warning("Unable to enable LangSmith Anthropic tracing: {}", exc)
         return client

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -34,6 +34,7 @@ from nanobot.providers.base import (
     resolve_stream_idle_timeout_s,
     tool_arguments_json_for_replay,
 )
+from nanobot.providers.langsmith_integration import wrap_openai_client
 from nanobot.providers.openai_responses import (
     ResponsesStreamCapture,
     build_responses_compaction_state,
@@ -588,7 +589,7 @@ class OpenAICompatProvider(LLMProvider):
         # else: http_client stays None → SDK creates DefaultAsyncHttpxClient
         # which already reads proxy env vars via trust_env=True, has proper
         # connection limits, and follows redirects.
-        self._client = AsyncOpenAI(
+        client = AsyncOpenAI(
             api_key=self._api_key_for_client,
             base_url=self._effective_base,
             default_headers=self._default_headers,
@@ -597,6 +598,7 @@ class OpenAICompatProvider(LLMProvider):
             timeout=timeout_s,
             http_client=http_client,
         )
+        self._client = wrap_openai_client(client)
 
     async def _ensure_client(self) -> AsyncOpenAIType:
         """Return the shared OpenAI client, creating it on first call."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ documents = [
 langfuse = [
     "langfuse>=3.0.0,<4.0.0",
 ]
+langsmith = [
+    "langsmith>=0.3.13,<1.0.0",
+]
 pdf = [
     # Compatibility extra: PDF reading is bundled since v0.2.3.
     "pypdf>=5.0.0,<6.0.0",

--- a/tests/providers/test_langsmith_integration.py
+++ b/tests/providers/test_langsmith_integration.py
@@ -1,0 +1,76 @@
+"""LangSmith tracing remains available after the native SDK migration."""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from nanobot.providers.anthropic_provider import AnthropicProvider
+from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+
+
+def _fake_langsmith_wrappers(**wrappers: object) -> dict[str, ModuleType]:
+    package = ModuleType("langsmith")
+    module = ModuleType("langsmith.wrappers")
+    for name, wrapper in wrappers.items():
+        setattr(module, name, wrapper)
+    package.wrappers = module  # type: ignore[attr-defined]
+    return {"langsmith": package, "langsmith.wrappers": module}
+
+
+def test_openai_client_is_wrapped_when_langsmith_is_configured(monkeypatch) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "lsv2_test")
+    wrapped = object()
+    raw_client = object()
+    wrap = MagicMock(return_value=wrapped)
+    with (
+        patch(
+            "nanobot.providers.langsmith_integration.importlib.util.find_spec",
+            return_value=SimpleNamespace(),
+        ),
+        patch.dict(sys.modules, _fake_langsmith_wrappers(wrap_openai=wrap)),
+        patch("nanobot.providers.openai_compat_provider.AsyncOpenAI", return_value=raw_client),
+    ):
+        provider = OpenAICompatProvider(api_key="sk-test")
+        provider._build_client()
+
+    assert provider._client is wrapped
+    wrap.assert_called_once_with(raw_client)
+    assert os.environ["LANGSMITH_TRACING"] == "true"
+
+
+def test_anthropic_client_is_wrapped_when_langsmith_is_configured(monkeypatch) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "lsv2_test")
+    raw_client = object()
+    wrapped = object()
+    wrap = MagicMock(return_value=wrapped)
+    with (
+        patch(
+            "nanobot.providers.langsmith_integration.importlib.util.find_spec",
+            return_value=SimpleNamespace(),
+        ),
+        patch.dict(sys.modules, _fake_langsmith_wrappers(wrap_anthropic=wrap)),
+        patch("anthropic.AsyncAnthropic", return_value=raw_client),
+    ):
+        provider = AnthropicProvider(api_key="sk-test")
+
+    assert provider._client is wrapped
+    wrap.assert_called_once_with(raw_client)
+
+
+def test_missing_langsmith_keeps_native_client(monkeypatch) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "lsv2_test")
+    raw_client = MagicMock()
+    with (
+        patch(
+            "nanobot.providers.langsmith_integration.importlib.util.find_spec",
+            return_value=None,
+        ),
+        patch("nanobot.providers.openai_compat_provider.AsyncOpenAI", return_value=raw_client),
+    ):
+        provider = OpenAICompatProvider(api_key="sk-test")
+        provider._build_client()
+
+    assert provider._client is raw_client


### PR DESCRIPTION
## Summary

Fixes #2493.

The LiteLLM-to-native-SDK migration removed the callback that previously enabled LangSmith tracing. This restores tracing at the native client boundary:

- wrap OpenAI-compatible clients with `langsmith.wrappers.wrap_openai`
- wrap Anthropic clients with `langsmith.wrappers.wrap_anthropic`
- automatically enable `LANGSMITH_TRACING` when `LANGSMITH_API_KEY` is configured
- keep LangSmith optional and fall back to the native client with a clear install hint
- add a `langsmith` package extra with a version that includes both wrappers

## Verification

- `pytest -q tests/providers` (958 passed, Windows and Linux Docker)
- focused LangSmith/retry/environment tests (9 passed)
- real wrapper construction smoke test for `AsyncOpenAI` and `AsyncAnthropic`
- `ruff check ...` (passed)
- `git diff --check` (passed)

The repository-wide suite was also exercised: provider coverage passed completely. Remaining failures were unrelated platform/tooling prerequisites outside provider code (Windows symlink/network mock behavior; minimal Linux image missing git/Node).
## CI follow-up

The first Python 3.14 job exposed that the optional wrapper helpers returned `Any`, erasing the native client type. Follow-up commit `4cd3a049` makes both wrappers generic (`ClientT -> ClientT`) while keeping the dynamic LangSmith boundary explicitly cast.

Additional verification:

- Docker, Python 3.14.2, all extras and channel dependencies: BasedPyright **0 errors, 0 warnings**
- focused LangSmith tests: **3 passed**
- complete provider suite: **958 passed**
- Ruff: passed