### PR TITLE
feat(webui): file preview path fixes + subagent activity & lifecycle replay

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -394,6 +394,8 @@ class AgentLoop:
             max_concurrent_subagents=max_concurrent_subagents,
             fail_on_tool_error=fail_on_tool_error,
             llm_wall_timeout_for_session=lambda sk: runner_wall_llm_timeout_s(self.sessions, sk),
+            runtime_events=self.runtime_events,
+            session_manager=self.sessions,
         )
         self._unified_session = unified_session
         self._running = False

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -5,7 +5,7 @@ import json
 import time
 import uuid
 import warnings
-from collections.abc import Mapping
+from collections.abc import Awaitable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, TypedDict
@@ -26,7 +26,14 @@ from nanobot.agent.tools.file_state import FileStates
 from nanobot.agent.tools.loader import ToolLoader
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.bus.events import InboundMessage
+from nanobot.bus.outbound_events import SubagentStateEvent, outbound_message_for_event
 from nanobot.bus.queue import MessageBus
+from nanobot.bus.runtime_events import (
+    RuntimeEventBus,
+    RuntimeEventContext,
+    SubagentStatusChanged,
+    SubagentTraceChanged,
+)
 from nanobot.config.schema import AgentDefaults, ToolsConfig
 from nanobot.providers.base import LLMProvider
 from nanobot.security.workspace_access import (
@@ -35,6 +42,8 @@ from nanobot.security.workspace_access import (
     reset_workspace_scope,
     workspace_sandbox_status,
 )
+from nanobot.session.manager import SessionManager
+from nanobot.session.subagent_state import SubagentDetailRecord, SubagentDetailStore
 from nanobot.utils.llm_runtime import LLMRuntime
 from nanobot.utils.prompt_templates import render_template
 
@@ -43,6 +52,22 @@ class _SubagentOrigin(TypedDict):
     channel: str
     chat_id: str
     session_key: str | None
+    turn_id: str | None
+
+
+@dataclass(slots=True)
+class _SubagentDetail:
+    task_id: str
+    label: str
+    task: str
+    turn_id: str | None
+    status: str = "running"
+    revision: int = 0
+    seq: int = 0
+    steps: list[dict[str, Any]] = field(default_factory=list)
+    output: str = ""
+    stop_reason: str | None = None
+    error: str | None = None
 
 
 @dataclass(slots=True)
@@ -59,23 +84,118 @@ class SubagentStatus:
     usage: dict[str, int] = field(default_factory=dict)
     stop_reason: str | None = None
     error: str | None = None
+    origin_channel: str = "cli"
+    origin_chat_id: str = "direct"
+    finished_at: float | None = None
+
+
+def _subagent_status_snapshot(status: SubagentStatus) -> dict[str, Any]:
+    """Project only bounded, non-sensitive fields for the WebUI."""
+    terminal = status.phase == "error" or status.stop_reason in {"error", "tool_error"}
+    state = "failed" if terminal else "completed" if status.phase == "done" else "running"
+    now = status.finished_at or time.monotonic()
+    recent_tools: list[dict[str, str]] = []
+    for event in status.tool_events[-5:]:
+        name = event.get("name")
+        phase = event.get("phase")
+        if isinstance(name, str) and name:
+            recent_tools.append({
+                "name": name[:80],
+                "phase": phase[:20] if isinstance(phase, str) else "",
+            })
+    safe_label = " ".join(status.label.split())[:120] or "Subagent"
+    latest_tool = recent_tools[-1] if recent_tools else None
+    return {
+        "task_id": status.task_id,
+        "label": safe_label,
+        "status": state,
+        "phase": status.phase[:32],
+        "iteration": max(0, int(status.iteration)),
+        "elapsed_ms": max(0, round((now - status.started_at) * 1000)),
+        "latest_tool": latest_tool,
+        "recent_tools": recent_tools,
+        "error": "Subagent failed" if terminal else None,
+    }
 
 
 class _SubagentHook(AgentHook):
     """Hook for subagent execution — logs tool calls and updates status."""
 
-    def __init__(self, task_id: str, status: SubagentStatus | None = None) -> None:
+    def __init__(
+        self,
+        task_id: str,
+        status: SubagentStatus | None = None,
+        on_status: Callable[[SubagentStatus], Any] | None = None,
+        trace: Callable[[str, dict[str, Any]], Awaitable[None]] | None = None,
+    ) -> None:
         super().__init__()
         self._task_id = task_id
         self._status = status
+        self._on_status = on_status
+        self._trace = trace
+        self._reasoning_seen = False
+
+    def wants_streaming(self) -> bool:
+        return self._trace is not None
+
+    async def _emit(self, kind: str, payload: dict[str, Any]) -> None:
+        if self._trace is not None:
+            await self._trace(kind, payload)
+
+    async def _notify(self) -> None:
+        if self._status is None or self._on_status is None:
+            return
+        result = self._on_status(self._status)
+        if asyncio.iscoroutine(result):
+            await result
 
     async def before_execute_tools(self, context: AgentHookContext) -> None:
+        await self._emit("phase", {"name": "tools", "iteration": context.iteration})
+        if self._status is not None:
+            self._status.phase = "awaiting_tools"
+            await self._notify()
         for tool_call in context.tool_calls:
             args_str = json.dumps(tool_call.arguments, ensure_ascii=False)
             logger.debug(
                 "Subagent [{}] executing: {} with arguments: {}",
                 self._task_id, tool_call.name, args_str,
             )
+            await self._emit("tool_start", {"call_id": tool_call.id, "name": tool_call.name})
+
+    async def before_iteration(self, context: AgentHookContext) -> None:
+        await self._emit("phase", {"name": "thinking", "iteration": context.iteration})
+
+    async def on_stream(self, context: AgentHookContext, delta: str) -> None:
+        if delta:
+            await self._emit("delta", {"text": delta})
+
+    async def on_stream_end(self, context: AgentHookContext, *, resuming: bool) -> None:
+        await self._emit("phase", {"name": "final_response", "resuming": resuming})
+
+    async def emit_reasoning(self, reasoning_content: str | None) -> None:
+        if reasoning_content and not self._reasoning_seen:
+            self._reasoning_seen = True
+            await self._emit("phase", {"name": "reasoning"})
+
+    async def after_execute_tool(
+        self,
+        context: AgentHookContext,
+        tool_call: Any,
+        tool: Any,
+        params: Any,
+        result: Any,
+    ) -> None:
+        await self._emit("tool_end", {"call_id": tool_call.id, "name": tool_call.name, "status": "ok"})
+
+    async def on_execute_tool_error(
+        self,
+        context: AgentHookContext,
+        tool_call: Any,
+        tool: Any,
+        params: Any,
+        error: Any,
+    ) -> None:
+        await self._emit("tool_end", {"call_id": tool_call.id, "name": tool_call.name, "status": "error"})
 
     async def after_iteration(self, context: AgentHookContext) -> None:
         if self._status is None:
@@ -85,6 +205,7 @@ class _SubagentHook(AgentHook):
         self._status.usage = dict(context.usage)
         if context.error:
             self._status.error = str(context.error)
+        await self._notify()
 
 
 class SubagentManager:
@@ -104,6 +225,8 @@ class SubagentManager:
         max_concurrent_subagents: int | None = None,
         fail_on_tool_error: bool | None = None,
         llm_wall_timeout_for_session: Callable[[str | None], float | None] | None = None,
+        runtime_events: RuntimeEventBus | None = None,
+        session_manager: SessionManager | None = None,
     ):
         if workspace is None:
             raise TypeError("SubagentManager.__init__() missing required argument: 'workspace'")
@@ -151,12 +274,15 @@ class SubagentManager:
             if fail_on_tool_error is not None
             else defaults.fail_on_tool_error
         )
+        self.runtime_events = runtime_events
+        self._detail_store = SubagentDetailStore(session_manager)
         self.runner = AgentRunner()
         self._exec_session_manager = ExecSessionManager()
         self._llm_wall_timeout_for_session = llm_wall_timeout_for_session
         self._running_tasks: dict[str, asyncio.Task[str]] = {}
         self._task_statuses: dict[str, SubagentStatus] = {}
         self._session_tasks: dict[str, set[str]] = {}  # session_key -> {task_id, ...}
+        self._detail_states: dict[str, _SubagentDetail] = {}
 
     def runtime_statuses(self) -> Mapping[str, SubagentStatus]:
         """Return the observable task statuses used by runtime-control snapshots."""
@@ -228,6 +354,107 @@ class SubagentManager:
         ToolLoader().load(ctx, registry, scope="subagent")
         return registry
 
+    def _runtime_context(self, origin: _SubagentOrigin) -> RuntimeEventContext:
+        channel = origin.get("channel") or "cli"
+        chat_id = origin.get("chat_id") or "direct"
+        return RuntimeEventContext(
+            channel=channel,
+            chat_id=chat_id,
+            session_key=origin.get("session_key") or f"{channel}:{chat_id}",
+        )
+
+    def _publish_status_event(
+        self,
+        origin: _SubagentOrigin,
+        task_id: str,
+        label: str,
+        status: str,
+        *,
+        stop_reason: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        if self.runtime_events is None:
+            return
+        self.runtime_events.publish_nowait(SubagentStatusChanged(
+            context=self._runtime_context(origin),
+            subagent_id=task_id,
+            label=label,
+            status=status,
+            turn_id=origin.get("turn_id"),
+            stop_reason=stop_reason,
+            error=error,
+        ))
+
+    async def _publish_trace(
+        self,
+        origin: _SubagentOrigin,
+        detail: _SubagentDetail,
+        kind: str,
+        payload: dict[str, Any],
+    ) -> None:
+        detail.seq += 1
+        text = payload.get("text")
+        if kind == "delta" and isinstance(text, str):
+            detail.output = (detail.output + text)[-12000:]
+        elif kind in {"phase", "tool_start", "tool_end"}:
+            detail.steps = [*detail.steps, {"kind": kind, **payload}][-100:]
+        if kind in {"completed", "failed", "cancelled"}:
+            self._persist_detail(origin, detail)
+        if self.runtime_events is not None:
+            self.runtime_events.publish_nowait(SubagentTraceChanged(
+                context=self._runtime_context(origin),
+                subagent_id=detail.task_id,
+                label=detail.label,
+                turn_id=detail.turn_id,
+                seq=detail.seq,
+                revision=detail.revision,
+                kind=kind,
+                payload=payload,
+            ))
+
+    def _detail_snapshot(self, detail: _SubagentDetail) -> dict[str, Any]:
+        return {
+            "task_id": detail.task_id,
+            "label": detail.label,
+            "turn_id": detail.turn_id,
+            "status": detail.status,
+            "revision": detail.revision,
+            "seq": detail.seq,
+            "input": detail.task[-12000:],
+            "steps": detail.steps[-100:],
+            "output": detail.output[-12000:],
+            "stop_reason": detail.stop_reason,
+            "error": detail.error,
+        }
+
+    def _persist_detail(self, origin: _SubagentOrigin, detail: _SubagentDetail) -> None:
+        session_key = origin.get("session_key") or f"{origin['channel']}:{origin['chat_id']}"
+        self._detail_store.upsert(
+            session_key,
+            SubagentDetailRecord(
+                task_id=detail.task_id,
+                label=detail.label,
+                turn_id=detail.turn_id,
+                status=detail.status,
+                revision=detail.revision,
+                seq=detail.seq,
+                input=detail.task,
+                steps=list(detail.steps),
+                output=detail.output,
+                stop_reason=detail.stop_reason,
+                error=detail.error,
+            ),
+        )
+
+    def webui_detail_snapshot(self, session_key: str) -> list[dict[str, Any]]:
+        result = self._detail_store.snapshot(session_key)
+        known = {str(item.get("task_id")) for item in result}
+        for task_id in self._session_tasks.get(session_key, set()):
+            detail = self._detail_states.get(task_id)
+            if detail is not None and task_id not in known:
+                result.insert(0, self._detail_snapshot(detail))
+        return result[:50]
+
     async def spawn(
         self,
         task: str,
@@ -236,6 +463,7 @@ class SubagentManager:
         origin_chat_id: str = "direct",
         session_key: str | None = None,
         origin_message_id: str | None = None,
+        origin_turn_id: str | None = None,
         temperature: float | None = None,
         workspace_scope: WorkspaceScope | None = None,
         *,
@@ -252,13 +480,21 @@ class SubagentManager:
             "channel": origin_channel,
             "chat_id": origin_chat_id,
             "session_key": session_key,
+            "turn_id": origin_turn_id,
         }
+        detail = _SubagentDetail(task_id, display_label, task, origin_turn_id)
+        self._detail_states[task_id] = detail
+        self._persist_detail(origin, detail)
+        self._publish_status_event(origin, task_id, display_label, "started")
+        await self._publish_trace(origin, detail, "input", {"text": task})
 
         status = SubagentStatus(
             task_id=task_id,
             label=display_label,
             task_description=task,
             started_at=time.monotonic(),
+            origin_channel=origin_channel,
+            origin_chat_id=origin_chat_id,
         )
         self._task_statuses[task_id] = status
 
@@ -272,11 +508,14 @@ class SubagentManager:
                 runtime,
                 origin_message_id,
                 workspace_scope,
+                detail=detail,
             )
         )
         self._running_tasks[task_id] = bg_task
         if session_key:
             self._session_tasks.setdefault(session_key, set()).add(task_id)
+
+        await self._notify_status(status)
 
         def _cleanup(_: asyncio.Task[str]) -> None:
             self._running_tasks.pop(task_id, None)
@@ -299,6 +538,7 @@ class SubagentManager:
         origin_chat_id: str = "direct",
         session_key: str | None = None,
         origin_message_id: str | None = None,
+        origin_turn_id: str | None = None,
         temperature: float | None = None,
         workspace_scope: WorkspaceScope | None = None,
         *,
@@ -315,14 +555,23 @@ class SubagentManager:
             "channel": origin_channel,
             "chat_id": origin_chat_id,
             "session_key": session_key,
+            "turn_id": origin_turn_id,
         }
+        detail = _SubagentDetail(task_id, display_label, task, origin_turn_id)
+        self._detail_states[task_id] = detail
+        self._persist_detail(origin, detail)
+        self._publish_status_event(origin, task_id, display_label, "started")
+        await self._publish_trace(origin, detail, "input", {"text": task})
         status = SubagentStatus(
             task_id=task_id,
             label=display_label,
             task_description=task,
             started_at=time.monotonic(),
+            origin_channel=origin_channel,
+            origin_chat_id=origin_chat_id,
         )
         self._task_statuses[task_id] = status
+        await self._notify_status(status)
         logger.info("Running inline subagent [{}]: {}", task_id, display_label)
         inline_task = asyncio.create_task(
             self._run_subagent(
@@ -335,6 +584,7 @@ class SubagentManager:
                 origin_message_id,
                 workspace_scope,
                 announce=False,
+                detail=detail,
             )
         )
         self._running_tasks[task_id] = inline_task
@@ -365,6 +615,7 @@ class SubagentManager:
         workspace_scope: WorkspaceScope | None = None,
         *,
         announce: bool = True,
+        detail: _SubagentDetail | None = None,
     ) -> str:
         """Execute the subagent task and announce the result."""
         logger.info("Subagent [{}] starting task: {}", task_id, label)
@@ -372,6 +623,7 @@ class SubagentManager:
         async def _on_checkpoint(payload: dict[str, Any]) -> None:
             status.phase = payload.get("phase", status.phase)
             status.iteration = payload.get("iteration", status.iteration)
+            await self._notify_status(status)
 
         try:
             root = workspace_scope.project_path if workspace_scope is not None else self.workspace
@@ -399,6 +651,7 @@ class SubagentManager:
                 message_id=origin_message_id,
                 session_key=sess_key,
                 runtime=runtime,
+                turn_id=origin.get("turn_id"),
             ))
             token = bind_workspace_scope(workspace_scope) if workspace_scope is not None else None
             try:
@@ -408,7 +661,15 @@ class SubagentManager:
                     runtime=runtime,
                     max_iterations=self.max_iterations,
                     max_tool_result_chars=self.max_tool_result_chars,
-                    hook=_SubagentHook(task_id, status),
+                    hook=_SubagentHook(
+                        task_id,
+                        status,
+                        self._notify_status,
+                        trace=(
+                            lambda kind, payload: self._publish_trace(origin, detail, kind, payload)
+                            if detail is not None else None
+                        ),
+                    ),
                     max_iterations_message="Task completed but no final response was generated.",
                     finalize_on_max_iterations=False,
                     error_message=None,
@@ -424,6 +685,8 @@ class SubagentManager:
                 reset_request_context(request_token)
             status.phase = "done"
             status.stop_reason = result.stop_reason
+            status.finished_at = time.monotonic()
+            await self._notify_status(status)
 
             if result.stop_reason == "tool_error":
                 status.tool_events = list(result.tool_events)
@@ -436,6 +699,23 @@ class SubagentManager:
                 final_result = result.final_content or "Task completed but no final response was generated."
                 final_status = "ok"
                 logger.info("Subagent [{}] completed successfully", task_id)
+            if detail is not None:
+                detail.status = "failed" if final_status != "ok" else "completed"
+                detail.stop_reason = result.stop_reason
+                detail.output = final_result[-12000:]
+                await self._publish_trace(
+                    origin,
+                    detail,
+                    "failed" if final_status != "ok" else "completed",
+                    {"status": detail.status, "text": final_result, "stop_reason": result.stop_reason},
+                )
+            self._publish_status_event(
+                origin,
+                task_id,
+                label,
+                "failed" if final_status != "ok" else "completed",
+                stop_reason=result.stop_reason,
+            )
             if announce:
                 await self._announce_result(
                     task_id,
@@ -451,8 +731,21 @@ class SubagentManager:
         except Exception as e:
             status.phase = "error"
             status.error = str(e)
-            logger.exception("Subagent [{}] failed", task_id)
+            status.finished_at = time.monotonic()
+            await self._notify_status(status)
             final_result = f"Error: {e}"
+            if detail is not None:
+                detail.status = "failed"
+                detail.error = str(e)
+                detail.output = final_result[-12000:]
+                await self._publish_trace(
+                    origin,
+                    detail,
+                    "failed",
+                    {"status": "failed", "text": final_result, "error": str(e)},
+                )
+            self._publish_status_event(origin, task_id, label, "failed", error=str(e))
+            logger.exception("Subagent [{}] failed", task_id)
             if announce:
                 await self._announce_result(
                     task_id,
@@ -464,6 +757,29 @@ class SubagentManager:
                     origin_message_id,
                 )
             return final_result
+
+    async def _notify_status(self, status: SubagentStatus) -> None:
+        """Publish a fail-open, redacted status projection for WebUI clients."""
+        if status.origin_channel != "websocket":
+            return
+        try:
+            await self.bus.publish_outbound(
+                outbound_message_for_event(
+                    channel=status.origin_channel,
+                    chat_id=status.origin_chat_id,
+                    event=SubagentStateEvent(tasks=[_subagent_status_snapshot(status)]),
+                    metadata={"subagent_task_id": status.task_id},
+                )
+            )
+        except Exception:
+            logger.exception("Subagent [{}] status observer failed", status.task_id)
+
+    def status_snapshot_for_chat(self, chat_id: str) -> list[dict[str, Any]]:
+        return [
+            _subagent_status_snapshot(status)
+            for status in self._task_statuses.values()
+            if status.origin_channel == "websocket" and status.origin_chat_id == chat_id
+        ]
 
     async def _announce_result(
         self,

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -15,6 +15,7 @@ from nanobot.agent.tools.schema import (
     tool_parameters_schema,
 )
 from nanobot.security.workspace_access import current_workspace_scope
+from nanobot.webui.metadata import WEBUI_TURN_METADATA_KEY
 
 if TYPE_CHECKING:
     from nanobot.agent.subagent import SubagentManager
@@ -96,6 +97,11 @@ class SpawnTool(Tool):
         origin_channel = request_ctx.channel
         origin_chat_id = request_ctx.chat_id
         session_key = request_ctx.session_key or f"{origin_channel}:{origin_chat_id}"
+        origin_turn_id = request_ctx.turn_id
+        if origin_channel == "websocket":
+            webui_turn_id = request_ctx.metadata.get(WEBUI_TURN_METADATA_KEY)
+            if isinstance(webui_turn_id, str) and webui_turn_id:
+                origin_turn_id = webui_turn_id
         method = self._manager.run_inline if wait else self._manager.spawn
         return await method(
             task=task,
@@ -105,6 +111,7 @@ class SpawnTool(Tool):
             origin_chat_id=origin_chat_id,
             session_key=session_key,
             origin_message_id=request_ctx.message_id,
+            origin_turn_id=origin_turn_id,
             temperature=temperature,
             workspace_scope=current_workspace_scope(),
         )

--- a/nanobot/bus/outbound_events.py
+++ b/nanobot/bus/outbound_events.py
@@ -74,6 +74,47 @@ class GoalStateSyncEvent(OutboundEvent):
 
 
 @dataclass(frozen=True)
+class SubagentStateEvent(OutboundEvent):
+    """Safe runtime projection for one WebUI-visible subagent update."""
+
+    tasks: list[dict[str, Any]]
+    snapshot: bool = False
+
+
+@dataclass(frozen=True)
+class SubagentStatusEvent(OutboundEvent):
+    """Lifecycle status of a WebUI-visible subagent."""
+
+    subagent_id: str
+    label: str
+    status: str
+    turn_id: str | None = None
+    revision: int = 0
+    stop_reason: str | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class SubagentTraceEvent(OutboundEvent):
+    """Live bounded trace item for a WebUI-visible subagent."""
+
+    subagent_id: str
+    label: str
+    turn_id: str | None
+    seq: int
+    revision: int
+    kind: str
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class SubagentDetailSnapshotEvent(OutboundEvent):
+    """Persisted detail snapshot sent on WebSocket attach/reconnect."""
+
+    items: list[dict[str, Any]]
+
+
+@dataclass(frozen=True)
 class SessionUpdatedEvent(OutboundEvent):
     scope: str | None = None
 

--- a/nanobot/bus/runtime_events.py
+++ b/nanobot/bus/runtime_events.py
@@ -93,6 +93,34 @@ class GoalStateChanged:
 
 
 @dataclass(frozen=True)
+class SubagentStatusChanged:
+    """A subagent lifecycle state changed."""
+
+    context: RuntimeEventContext
+    subagent_id: str
+    label: str
+    status: str
+    turn_id: str | None = None
+    revision: int = 0
+    stop_reason: str | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class SubagentTraceChanged:
+    """A bounded, user-visible subagent execution trace item."""
+
+    context: RuntimeEventContext
+    subagent_id: str
+    label: str
+    turn_id: str | None
+    seq: int
+    revision: int
+    kind: str
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
 class RuntimeModelChanged:
     """The active runtime model/preset changed."""
 
@@ -108,6 +136,8 @@ RuntimeEvent = (
     | TurnRunStatusChanged
     | TurnCompleted
     | GoalStateChanged
+    | SubagentStatusChanged
+    | SubagentTraceChanged
     | RuntimeModelChanged
 )
 RuntimeEventType = (
@@ -118,6 +148,8 @@ RuntimeEventType = (
     | type[TurnRunStatusChanged]
     | type[TurnCompleted]
     | type[GoalStateChanged]
+    | type[SubagentStatusChanged]
+    | type[SubagentTraceChanged]
     | type[RuntimeModelChanged]
 )
 RuntimeEventHandler = Callable[[Any], Awaitable[None] | None]

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -104,6 +104,8 @@ class ChannelManager:
         webui_mcp_runtime_status: Callable[[], Mapping[str, str]] | None = None,
         webui_mcp_reload: Callable[[], Awaitable[dict[str, Any]]] | None = None,
         webui_skill_state_action: Callable[[set[str]], None] | None = None,
+        webui_subagent_statuses_for_chat: Callable[[str], list[dict[str, Any]]] | None = None,
+        webui_subagent_detail_snapshot: Callable[[str], list[dict[str, Any]]] | None = None,
         config_path: Path | None = None,
     ):
         if config_path is None:
@@ -126,6 +128,8 @@ class ChannelManager:
         self._webui_mcp_runtime_status = webui_mcp_runtime_status
         self._webui_mcp_reload = webui_mcp_reload
         self._webui_skill_state_action = webui_skill_state_action
+        self._webui_subagent_statuses_for_chat = webui_subagent_statuses_for_chat
+        self._webui_subagent_detail_snapshot = webui_subagent_detail_snapshot
         self.channels: dict[str, BaseChannel] = {}
         self._channel_owners: dict[str, str] = {}
         self._channel_runtime_specs: dict[str, tuple[str, str]] = {}
@@ -197,6 +201,8 @@ class ChannelManager:
                 mcp_runtime_status=self._webui_mcp_runtime_status,
                 mcp_reload=self._webui_mcp_reload,
                 skill_state_action=self._webui_skill_state_action,
+                subagent_statuses_for_chat=self._webui_subagent_statuses_for_chat,
+                subagent_detail_snapshot=self._webui_subagent_detail_snapshot,
                 logger=logger,
             )
             kwargs["gateway"] = gateway

--- a/nanobot/channels/websocket/runtime.py
+++ b/nanobot/channels/websocket/runtime.py
@@ -34,6 +34,10 @@ from nanobot.bus.outbound_events import (
     ProgressEvent,
     RuntimeModelUpdatedEvent,
     SessionUpdatedEvent,
+    SubagentDetailSnapshotEvent,
+    SubagentStateEvent,
+    SubagentStatusEvent,
+    SubagentTraceEvent,
     TurnEndEvent,
     TurnModelUpdatedEvent,
     UserInputEvent,
@@ -575,6 +579,18 @@ class WebSocketChannel(BaseChannel):
         """Replay persisted or actively running per-chat state after subscribe."""
         await self._maybe_push_persisted_goal_state(chat_id)
         await self._maybe_push_turn_run_wall_clock(chat_id)
+        snapshot = self.gateway.subagent_statuses_for_chat
+        if snapshot is not None:
+            tasks = snapshot(chat_id)
+            if tasks:
+                await self.send_subagent_state(chat_id, tasks, snapshot=True)
+        details = self.gateway.subagent_detail_snapshot
+        if details is not None:
+            # Detail records are persisted under the full WebSocket session key,
+            # while the wire protocol identifies a chat by its bare UUID.
+            items = details(f"websocket:{chat_id}")
+            if items:
+                await self.send_subagent_detail_snapshot(chat_id, items=items)
 
     async def _send_event(
         self,
@@ -1656,15 +1672,53 @@ class WebSocketChannel(BaseChannel):
     async def send(self, msg: OutboundMessage) -> None:
         event = outbound_event_from_message(msg)
         progress_event = event if isinstance(event, ProgressEvent) else None
+        # Snapshot the subscriber set before handling specialized events.
+        conns = list(self._subs.get(msg.chat_id, ()))
         if isinstance(event, RuntimeModelUpdatedEvent):
             await self.send_runtime_model_updated(
                 model_name=event.model,
                 model_preset=event.model_preset,
             )
             return
+        if isinstance(event, SubagentStateEvent):
+            await self.send_subagent_state(
+                msg.chat_id,
+                event.tasks,
+                snapshot=event.snapshot,
+            )
+            return
+        if isinstance(event, SubagentStatusEvent):
+            if conns:
+                await self.send_subagent_status(
+                    msg.chat_id,
+                    subagent_id=event.subagent_id,
+                    label=event.label,
+                    status=event.status,
+                    turn_id=event.turn_id,
+                    revision=event.revision,
+                    stop_reason=event.stop_reason,
+                    error=event.error,
+                )
+            return
+        if isinstance(event, SubagentTraceEvent):
+            if conns:
+                await self.send_subagent_trace(
+                    msg.chat_id,
+                    subagent_id=event.subagent_id,
+                    label=event.label,
+                    turn_id=event.turn_id,
+                    seq=event.seq,
+                    revision=event.revision,
+                    kind=event.kind,
+                    payload=event.payload,
+                )
+            return
+        if isinstance(event, SubagentDetailSnapshotEvent):
+            if conns:
+                await self.send_subagent_detail_snapshot(msg.chat_id, items=event.items)
+            return
 
         # Snapshot the subscriber set so ConnectionClosed cleanups mid-iteration are safe.
-        conns = list(self._subs.get(msg.chat_id, ()))
         if not conns:
             if isinstance(
                 event,
@@ -2012,6 +2066,107 @@ class WebSocketChannel(BaseChannel):
         raw = json.dumps(body, ensure_ascii=False)
         for connection in conns:
             await self._safe_send_to(connection, raw, label=" goal_state ")
+
+    async def send_subagent_state(
+        self,
+        chat_id: str,
+        tasks: list[dict[str, Any]],
+        *,
+        snapshot: bool = False,
+    ) -> None:
+        """Push an allowlisted subagent runtime projection to one chat."""
+        conns = list(self._subs.get(chat_id, ()))
+        if not conns:
+            return
+        body = {
+            "event": "subagent_state_sync" if snapshot else "subagent_state",
+            "chat_id": chat_id,
+            "tasks": tasks,
+        }
+        raw = json.dumps(body, ensure_ascii=False)
+        for connection in conns:
+            await self._safe_send_to(connection, raw, label=" subagent_state ")
+
+    async def send_subagent_status(
+        self,
+        chat_id: str,
+        *,
+        subagent_id: str,
+        label: str,
+        status: str,
+        turn_id: str | None = None,
+        revision: int = 0,
+        stop_reason: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        conns = list(self._subs.get(chat_id, ()))
+        if not conns:
+            return
+        body: dict[str, Any] = {
+            "event": "subagent_status",
+            "chat_id": chat_id,
+            "subagent_id": subagent_id,
+            "label": label,
+            "status": status,
+        }
+        if turn_id:
+            body["turn_id"] = turn_id
+        if revision:
+            body["revision"] = revision
+        if stop_reason:
+            body["stop_reason"] = stop_reason
+        if error:
+            body["error"] = error
+        raw = json.dumps(body, ensure_ascii=False)
+        for connection in conns:
+            await self._safe_send_to(connection, raw, label=" subagent_status ")
+
+    async def send_subagent_trace(
+        self,
+        chat_id: str,
+        *,
+        subagent_id: str,
+        label: str,
+        turn_id: str | None,
+        seq: int,
+        revision: int,
+        kind: str,
+        payload: dict[str, Any],
+    ) -> None:
+        conns = list(self._subs.get(chat_id, ()))
+        if not conns:
+            return
+        body: dict[str, Any] = {
+            "event": "subagent_trace",
+            "chat_id": chat_id,
+            "subagent_id": subagent_id,
+            "label": label,
+            "seq": seq,
+            "revision": revision,
+            "kind": kind,
+            "payload": payload,
+        }
+        if turn_id:
+            body["turn_id"] = turn_id
+        raw = json.dumps(body, ensure_ascii=False)
+        for connection in conns:
+            await self._safe_send_to(connection, raw, label=" subagent_trace ")
+
+    async def send_subagent_detail_snapshot(
+        self,
+        chat_id: str,
+        *,
+        items: list[dict[str, Any]],
+    ) -> None:
+        conns = list(self._subs.get(chat_id, ()))
+        if not conns:
+            return
+        raw = json.dumps(
+            {"event": "subagent_detail_snapshot", "chat_id": chat_id, "items": items},
+            ensure_ascii=False,
+        )
+        for connection in conns:
+            await self._safe_send_to(connection, raw, label=" subagent_detail_snapshot ")
 
     async def send_goal_status(
         self,

--- a/nanobot/channels/websocket/tests/test_websocket_channel.py
+++ b/nanobot/channels/websocket/tests/test_websocket_channel.py
@@ -29,6 +29,7 @@ from nanobot.bus.outbound_events import (
     ProgressEvent,
     RuntimeModelUpdatedEvent,
     SessionUpdatedEvent,
+    SubagentStateEvent,
     TurnEndEvent,
     TurnModelUpdatedEvent,
     UserInputEvent,
@@ -2284,6 +2285,39 @@ async def test_send_progress_includes_agent_ui_blob() -> None:
     assert payload["event"] == "message"
     assert payload["kind"] == "progress"
     assert payload["agent_ui"] == blob
+
+
+def test_send_subagent_state_uses_safe_runtime_projection() -> None:
+    async def run() -> None:
+        bus = MagicMock()
+        channel = WebSocketChannel({"enabled": True, "allowFrom": ["*"]}, bus, gateway=_basic_handler(bus))
+        mock_ws = AsyncMock()
+        channel._attach(mock_ws, "chat-1")
+
+        await channel.send(OutboundMessage(
+            channel="websocket",
+            chat_id="chat-1",
+            content="",
+            event=SubagentStateEvent(tasks=[{
+                "task_id": "a1",
+                "label": "检查 WebUI",
+                "status": "running",
+                "phase": "awaiting_tools",
+                "iteration": 2,
+                "elapsed_ms": 1800,
+                "latest_tool": {"name": "read_file", "phase": "start"},
+                "recent_tools": [{"name": "read_file", "phase": "start"}],
+                "error": None,
+            }]),
+        ))
+
+        payload = json.loads(mock_ws.send.await_args.args[0])
+        assert payload["event"] == "subagent_state"
+        assert payload["tasks"][0]["task_id"] == "a1"
+        assert "arguments" not in payload["tasks"][0]
+        assert "result" not in payload["tasks"][0]
+
+    asyncio.run(run())
 
 
 @pytest.mark.asyncio

--- a/nanobot/channels/websocket/tests/test_websocket_channel.py
+++ b/nanobot/channels/websocket/tests/test_websocket_channel.py
@@ -5468,7 +5468,13 @@ def test_handle_file_preview_probe_reports_missing_file_as_unavailable(tmp_path)
     resp = gateway.http._handle_file_preview(req, enc)
 
     assert resp.status_code == 200
-    assert json.loads(resp.body.decode()) == {"available": False}
+    payload = json.loads(resp.body.decode())
+    assert payload == {
+        "available": False,
+        "reason": "not_found",
+        "project_path": str(workspace),
+        "requested": "notes/missing.md",
+    }
 
 
 def test_handle_file_preview_probe_reports_binary_file_as_unavailable(tmp_path) -> None:

--- a/nanobot/channels/websocket/tests/test_websocket_reconnect_idle.py
+++ b/nanobot/channels/websocket/tests/test_websocket_reconnect_idle.py
@@ -14,6 +14,8 @@ async def test_hydrate_after_subscribe_is_quiet_when_no_turn_active():
     channel.gateway = MagicMock()
     channel.gateway.session_manager = MagicMock()
     channel.gateway.session_manager.read_session_file = MagicMock(return_value={})
+    channel.gateway.subagent_statuses_for_chat = None
+    channel.gateway.subagent_detail_snapshot = None
     channel._turn_models = {}
 
     sent_events = []
@@ -40,6 +42,8 @@ async def test_hydrate_after_subscribe_pushes_running_when_turn_active():
     channel.gateway = MagicMock()
     channel.gateway.session_manager = MagicMock()
     channel.gateway.session_manager.read_session_file = MagicMock(return_value={})
+    channel.gateway.subagent_statuses_for_chat = None
+    channel.gateway.subagent_detail_snapshot = None
     channel._turn_models = {}
 
     sent_events = []
@@ -69,3 +73,31 @@ async def test_hydrate_after_subscribe_pushes_running_when_turn_active():
     assert len(running_events) == 1
     assert running_events[0][3]["started_at"] == 1234567890.0
     assert running_events[0][3]["turn_id"] == "turn-active"
+
+
+@pytest.mark.asyncio
+async def test_hydrate_after_subscribe_replays_details_from_websocket_session_key():
+    """Persisted detail records use the full session key, not the wire chat UUID."""
+    channel = WebSocketChannel.__new__(WebSocketChannel)
+    channel.gateway = MagicMock()
+    channel.gateway.session_manager = MagicMock()
+    channel.gateway.session_manager.read_session_file = MagicMock(return_value={})
+    channel.gateway.subagent_statuses_for_chat = None
+    channel.gateway.subagent_detail_snapshot = MagicMock(
+        return_value=[{"task_id": "task-1", "label": "第一轮任务", "status": "completed"}],
+    )
+    channel._turn_models = {}
+
+    sent_events = []
+
+    async def mock_send_detail_snapshot(chat_id, *, items):
+        sent_events.append((chat_id, items))
+
+    channel.send_subagent_detail_snapshot = mock_send_detail_snapshot
+
+    await channel._hydrate_after_subscribe("test-chat")
+
+    channel.gateway.subagent_detail_snapshot.assert_called_once_with("websocket:test-chat")
+    assert sent_events == [
+        ("test-chat", [{"task_id": "task-1", "label": "第一轮任务", "status": "completed"}]),
+    ]

--- a/nanobot/cli/gateway_runtime.py
+++ b/nanobot/cli/gateway_runtime.py
@@ -686,6 +686,8 @@ def _run_gateway(
         webui_mcp_runtime_status=mcp_provider.runtime_status,
         webui_mcp_reload=mcp_provider.reload,
         webui_skill_state_action=_webui_skill_state_action,
+        webui_subagent_statuses_for_chat=agent.subagents.status_snapshot_for_chat,
+        webui_subagent_detail_snapshot=agent.subagents.webui_detail_snapshot,
         config_path=Path(config_path),
     )
 

--- a/nanobot/session/subagent_state.py
+++ b/nanobot/session/subagent_state.py
@@ -1,0 +1,238 @@
+"""Durable lifecycle records for subagent tasks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+from nanobot.session.manager import SessionManager
+
+SUBAGENT_TASKS_METADATA_KEY = "subagent_tasks.v1"
+SUBAGENT_DETAILS_METADATA_KEY = "subagent_details.v1"
+SUBAGENT_TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled", "interrupted"})
+SUBAGENT_ACTIVE_STATUSES = frozenset({"queued", "running"})
+MAX_PERSISTED_SUBAGENT_TASKS = 100
+MAX_PERSISTED_SUBAGENT_DETAILS = 50
+MAX_DETAIL_STEPS = 100
+MAX_DETAIL_TEXT = 12000
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True)
+class SubagentTaskRecord:
+    task_id: str
+    label: str
+    task_description: str
+    status: str
+    channel: str
+    chat_id: str
+    session_key: str
+    turn_id: str | None
+    created_at: str
+    updated_at: str
+    revision: int = 0
+    stop_reason: str | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "label": self.label,
+            "task_description": self.task_description,
+            "status": self.status,
+            "channel": self.channel,
+            "chat_id": self.chat_id,
+            "session_key": self.session_key,
+            "turn_id": self.turn_id,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "revision": self.revision,
+            "stop_reason": self.stop_reason,
+            "error": self.error,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> "SubagentTaskRecord | None":
+        if not isinstance(value, dict):
+            return None
+        required = ("task_id", "label", "task_description", "status", "channel", "chat_id", "session_key")
+        if any(not isinstance(value.get(key), str) or not value[key] for key in required):
+            return None
+        status = value["status"]
+        if status not in SUBAGENT_ACTIVE_STATUSES | SUBAGENT_TERMINAL_STATUSES:
+            return None
+        revision = value.get("revision", 0)
+        if not isinstance(revision, int) or isinstance(revision, bool) or revision < 0:
+            revision = 0
+        turn_id = value.get("turn_id")
+        return cls(
+            task_id=value["task_id"],
+            label=value["label"],
+            task_description=value["task_description"],
+            status=status,
+            channel=value["channel"],
+            chat_id=value["chat_id"],
+            session_key=value["session_key"],
+            turn_id=turn_id if isinstance(turn_id, str) and turn_id else None,
+            created_at=value.get("created_at") if isinstance(value.get("created_at"), str) else _now(),
+            updated_at=value.get("updated_at") if isinstance(value.get("updated_at"), str) else _now(),
+            revision=revision,
+            stop_reason=value.get("stop_reason") if isinstance(value.get("stop_reason"), str) else None,
+            error=value.get("error") if isinstance(value.get("error"), str) else None,
+        )
+
+
+class SubagentTaskStore:
+    """Persist task records in the existing session metadata JSONL."""
+
+    def __init__(self, sessions: SessionManager | None) -> None:
+        self.sessions = sessions
+
+    def _load(self, session_key: str) -> list[SubagentTaskRecord]:
+        if self.sessions is None:
+            return []
+        session = self.sessions.get_or_create(session_key)
+        raw = session.metadata.get(SUBAGENT_TASKS_METADATA_KEY, [])
+        if not isinstance(raw, list):
+            return []
+        return [record for value in raw if (record := SubagentTaskRecord.from_dict(value)) is not None]
+
+    def _save(self, session_key: str, records: Iterable[SubagentTaskRecord]) -> None:
+        if self.sessions is None:
+            return
+        session = self.sessions.get_or_create(session_key)
+        session.metadata[SUBAGENT_TASKS_METADATA_KEY] = [record.to_dict() for record in records]
+        self.sessions.save(session)
+
+    def upsert(self, record: SubagentTaskRecord) -> SubagentTaskRecord:
+        records = self._load(record.session_key)
+        if not record.created_at or not record.updated_at:
+            timestamp = _now()
+            record = replace(
+                record,
+                created_at=record.created_at or timestamp,
+                updated_at=record.updated_at or timestamp,
+            )
+        next_record = record
+        for index, existing in enumerate(records):
+            if existing.task_id == record.task_id:
+                next_record = replace(record, revision=existing.revision + 1, updated_at=_now())
+                records[index] = next_record
+                break
+        else:
+            records.append(record)
+        records.sort(key=lambda item: (item.updated_at, item.task_id), reverse=True)
+        self._save(record.session_key, records[:MAX_PERSISTED_SUBAGENT_TASKS])
+        return next_record
+
+    def snapshot(self, session_key: str, active_task_ids: set[str] | None = None) -> list[SubagentTaskRecord]:
+        records = self._load(session_key)
+        changed = False
+        if active_task_ids is not None:
+            repaired: list[SubagentTaskRecord] = []
+            for record in records:
+                if record.status in SUBAGENT_ACTIVE_STATUSES and record.task_id not in active_task_ids:
+                    record = replace(
+                        record,
+                        status="interrupted",
+                        stop_reason="gateway_restart_or_runtime_loss",
+                        updated_at=_now(),
+                        revision=record.revision + 1,
+                    )
+                    changed = True
+                repaired.append(record)
+            records = repaired
+            if changed:
+                self._save(session_key, records)
+        return records
+
+
+@dataclass(frozen=True)
+class SubagentDetailRecord:
+    """Bounded replayable detail; live deltas remain process-local."""
+
+    task_id: str
+    label: str
+    turn_id: str | None
+    status: str
+    revision: int
+    seq: int
+    input: str
+    steps: list[dict[str, Any]]
+    output: str
+    stop_reason: str | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "label": self.label,
+            "turn_id": self.turn_id,
+            "status": self.status,
+            "revision": self.revision,
+            "seq": self.seq,
+            "input": self.input[-MAX_DETAIL_TEXT:],
+            "steps": self.steps[-MAX_DETAIL_STEPS:],
+            "output": self.output[-MAX_DETAIL_TEXT:],
+            "stop_reason": self.stop_reason,
+            "error": self.error,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> "SubagentDetailRecord | None":
+        if not isinstance(value, dict):
+            return None
+        task_id = value.get("task_id")
+        label = value.get("label")
+        if not isinstance(task_id, str) or not task_id or not isinstance(label, str):
+            return None
+        steps = value.get("steps")
+        return cls(
+            task_id=task_id,
+            label=label,
+            turn_id=value.get("turn_id") if isinstance(value.get("turn_id"), str) else None,
+            status=value.get("status") if isinstance(value.get("status"), str) else "interrupted",
+            revision=int(value.get("revision", 0)) if isinstance(value.get("revision", 0), int) else 0,
+            seq=int(value.get("seq", 0)) if isinstance(value.get("seq", 0), int) else 0,
+            input=value.get("input") if isinstance(value.get("input"), str) else "",
+            steps=[item for item in steps if isinstance(item, dict)][-MAX_DETAIL_STEPS:]
+            if isinstance(steps, list) else [],
+            output=value.get("output") if isinstance(value.get("output"), str) else "",
+            stop_reason=value.get("stop_reason") if isinstance(value.get("stop_reason"), str) else None,
+            error=value.get("error") if isinstance(value.get("error"), str) else None,
+        )
+
+
+class SubagentDetailStore:
+    """Persist only terminal/bounded detail snapshots in session metadata."""
+
+    def __init__(self, sessions: SessionManager | None) -> None:
+        self.sessions = sessions
+
+    def _load(self, session_key: str) -> list[SubagentDetailRecord]:
+        if self.sessions is None:
+            return []
+        session = self.sessions.get_or_create(session_key)
+        raw = session.metadata.get(SUBAGENT_DETAILS_METADATA_KEY, [])
+        if not isinstance(raw, list):
+            return []
+        return [record for value in raw if (record := SubagentDetailRecord.from_dict(value)) is not None]
+
+    def upsert(self, session_key: str, record: SubagentDetailRecord) -> None:
+        if self.sessions is None:
+            return
+        records = self._load(session_key)
+        records = [item for item in records if item.task_id != record.task_id]
+        records.insert(0, record)
+        session = self.sessions.get_or_create(session_key)
+        session.metadata[SUBAGENT_DETAILS_METADATA_KEY] = [
+            item.to_dict() for item in records[:MAX_PERSISTED_SUBAGENT_DETAILS]
+        ]
+        self.sessions.save(session)
+
+    def snapshot(self, session_key: str) -> list[dict[str, Any]]:
+        return [record.to_dict() for record in self._load(session_key)]

--- a/nanobot/session/webui_turns.py
+++ b/nanobot/session/webui_turns.py
@@ -20,6 +20,8 @@ from nanobot.bus.outbound_events import (
     GoalStatusEvent,
     RuntimeModelUpdatedEvent,
     SessionUpdatedEvent,
+    SubagentStatusEvent,
+    SubagentTraceEvent,
     TurnEndEvent,
     TurnModelUpdatedEvent,
     UserInputEvent,
@@ -32,6 +34,8 @@ from nanobot.bus.runtime_events import (
     RuntimeEventContext,
     RuntimeModelChanged,
     SessionTurnStarted,
+    SubagentStatusChanged,
+    SubagentTraceChanged,
     TurnCompleted,
     TurnRunStatusChanged,
     TurnRuntimeAdmitted,
@@ -539,6 +543,14 @@ class WebuiTurnCoordinator:
                 GoalStateChanged,
             ),
             runtime_events.subscribe(
+                self._handle_subagent_status_changed,
+                SubagentStatusChanged,
+            ),
+            runtime_events.subscribe(
+                self._handle_subagent_trace_changed,
+                SubagentTraceChanged,
+            ),
+            runtime_events.subscribe(
                 self._handle_runtime_model_changed,
                 RuntimeModelChanged,
             ),
@@ -681,6 +693,52 @@ class WebuiTurnCoordinator:
                     model=event.model,
                     model_preset=event.model_preset,
                 ),
+            )
+        )
+
+    async def _handle_subagent_status_changed(self, event: SubagentStatusChanged) -> None:
+        if not self._is_websocket_event(event.context):
+            return
+        chat_id = str(event.context.chat_id or "").strip()
+        if not chat_id:
+            return
+        await self.bus.publish_outbound(
+            outbound_message_for_event(
+                channel=event.context.channel,
+                chat_id=chat_id,
+                event=SubagentStatusEvent(
+                    subagent_id=event.subagent_id,
+                    label=event.label,
+                    status=event.status,
+                    turn_id=event.turn_id,
+                    revision=event.revision,
+                    stop_reason=event.stop_reason,
+                    error=event.error,
+                ),
+                metadata=event.context.metadata,
+            )
+        )
+
+    async def _handle_subagent_trace_changed(self, event: SubagentTraceChanged) -> None:
+        if not self._is_websocket_event(event.context):
+            return
+        chat_id = str(event.context.chat_id or "").strip()
+        if not chat_id:
+            return
+        await self.bus.publish_outbound(
+            outbound_message_for_event(
+                channel=event.context.channel,
+                chat_id=chat_id,
+                event=SubagentTraceEvent(
+                    subagent_id=event.subagent_id,
+                    label=event.label,
+                    turn_id=event.turn_id,
+                    seq=event.seq,
+                    revision=event.revision,
+                    kind=event.kind,
+                    payload=event.payload,
+                ),
+                metadata=event.context.metadata,
             )
         )
 

--- a/nanobot/templates/agent/tool_contract.md
+++ b/nanobot/templates/agent/tool_contract.md
@@ -25,6 +25,12 @@
 - Use `output_mode="count"` to size a broad search before reading full matches.
 - Use `head_limit` and `offset` to page across large result sets.
 - Search tools enforce binary and file-size limits and report skipped files in the result.
+- When referencing a local file in your reply, always use a markdown link with an
+  absolute path: `[file name](/absolute/path/to/file.md)` (optionally with `:line`).
+  Do not use backtick-relative paths like `relative/path.md` — in the WebUI a
+  relative path is resolved against the session's bound project root, so a path
+  relative to any other directory will not open. Absolute paths are self-contained
+  and always work.
 
 ## File and Coding Workflows
 

--- a/nanobot/webui/file_preview.py
+++ b/nanobot/webui/file_preview.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 from urllib.parse import unquote, urlparse
 
 from nanobot.config.paths import get_media_dir
 from nanobot.security.workspace_access import WorkspaceScope
 from nanobot.security.workspace_policy import WorkspaceBoundaryError, resolve_allowed_path
+from nanobot.webui.path_evidence import resolve_with_evidence
 
 MAX_FILE_PREVIEW_BYTES = 384 * 1024
 
@@ -27,11 +28,12 @@ def file_preview_payload(
     raw_path: str | None,
     *,
     scope: WorkspaceScope,
+    evidence_provider: Callable[[], list[Path]] | None = None,
     max_bytes: int = MAX_FILE_PREVIEW_BYTES,
 ) -> dict[str, Any]:
     """Return a text preview for a file allowed by the session workspace scope."""
 
-    resolved = _resolve_preview_path(raw_path, scope=scope)
+    resolved = _resolve_preview_path(raw_path, scope=scope, evidence_provider=evidence_provider)
 
     try:
         with open(resolved, "rb") as f:
@@ -65,10 +67,11 @@ def file_preview_availability_payload(
     raw_path: str | None,
     *,
     scope: WorkspaceScope,
+    evidence_provider: Callable[[], list[Path]] | None = None,
 ) -> dict[str, bool]:
     """Confirm that a path is a readable text preview candidate without loading it fully."""
 
-    resolved = _resolve_preview_path(raw_path, scope=scope)
+    resolved = _resolve_preview_path(raw_path, scope=scope, evidence_provider=evidence_provider)
     try:
         with open(resolved, "rb") as f:
             prefix = f.read(4096)
@@ -79,24 +82,65 @@ def file_preview_availability_payload(
     return {"available": True}
 
 
-def _resolve_preview_path(raw_path: str | None, *, scope: WorkspaceScope) -> Path:
+def _resolve_preview_path(
+    raw_path: str | None,
+    *,
+    scope: WorkspaceScope,
+    evidence_provider: Callable[[], list[Path]] | None = None,
+) -> Path:
     path = _clean_preview_path(raw_path)
     if not path:
         raise WebUIFilePreviewError(400, "missing path")
     if len(path) > 4096:
         raise WebUIFilePreviewError(400, "path is too long")
 
-    try:
+    def _resolve(candidate: str) -> Path:
         extra_roots = [get_media_dir()] if scope.restrict_to_workspace else None
-        resolved = resolve_allowed_path(
-            path,
+        return resolve_allowed_path(
+            candidate,
             workspace=scope.project_path,
             allowed_root=scope.project_path if scope.restrict_to_workspace else None,
             extra_allowed_roots=extra_roots,
             strict=True,
         )
-    except FileNotFoundError as e:
-        raise WebUIFilePreviewError(404, "file not found") from e
+
+    def _resolve_retry(candidate: str) -> Path:
+        try:
+            return _resolve(candidate)
+        except FileNotFoundError as e:
+            raise WebUIFilePreviewError(404, "file not found") from e
+        except WorkspaceBoundaryError as e:
+            raise WebUIFilePreviewError(403, "file is outside the current workspace") from e
+        except OSError as e:
+            raise WebUIFilePreviewError(400, "invalid path") from e
+
+    def _fallback_evidence() -> Path:
+        """Try session tool-activity evidence dirs when the project-root base misses."""
+        evidence_dirs = evidence_provider() if evidence_provider is not None else None
+        if not evidence_dirs:
+            raise WebUIFilePreviewError(404, "file not found")
+        resolved = resolve_with_evidence(path, evidence_dirs, scope=scope)
+        if resolved is None:
+            raise WebUIFilePreviewError(404, "file not found")
+        return resolved
+
+    try:
+        resolved = _resolve(path)
+    except FileNotFoundError:
+        # Tolerate references that repeat the project directory name as a
+        # prefix (e.g. "qizicheng-skill管理删除优化/01_docs/..." when the
+        # session project_path is ".../qizicheng-skill管理删除优化"): strip
+        # one leading "<project name>/" and retry once.  First-resolution
+        # behavior for normal relative/absolute paths is unchanged.
+        project_name = scope.project_path.name
+        project_prefix = f"{project_name}/"
+        if project_name and path.startswith(project_prefix):
+            try:
+                resolved = _resolve_retry(path[len(project_prefix):])
+            except WebUIFilePreviewError:
+                resolved = _fallback_evidence()
+        else:
+            resolved = _fallback_evidence()
     except WorkspaceBoundaryError as e:
         raise WebUIFilePreviewError(403, "file is outside the current workspace") from e
     except OSError as e:

--- a/nanobot/webui/gateway_services.py
+++ b/nanobot/webui/gateway_services.py
@@ -44,6 +44,8 @@ class GatewayServices:
     local_trigger_store: LocalTriggerStore | None
     cron_pending_job_ids: Callable[[str], set[str]] | None
     local_trigger_pending_ids: Callable[[str], set[str]] | None
+    subagent_statuses_for_chat: Callable[[str], list[dict[str, Any]]] | None
+    subagent_detail_snapshot: Callable[[str], list[dict[str, Any]]] | None
 
 
 def build_gateway_services(
@@ -64,6 +66,8 @@ def build_gateway_services(
     local_trigger_store: LocalTriggerStore | None = None,
     cron_pending_job_ids: Callable[[str], set[str]] | None = None,
     local_trigger_pending_ids: Callable[[str], set[str]] | None = None,
+    subagent_statuses_for_chat: Callable[[str], list[dict[str, Any]]] | None = None,
+    subagent_detail_snapshot: Callable[[str], list[dict[str, Any]]] | None = None,
     channel_feature_action: Callable[..., Any] | None = None,
     channel_runtime_status: Callable[[], dict[str, Any]] | None = None,
     mcp_runtime_status: Callable[[], Mapping[str, str]] | None = None,
@@ -147,4 +151,6 @@ def build_gateway_services(
         local_trigger_store=local_trigger_store,
         cron_pending_job_ids=cron_pending_job_ids,
         local_trigger_pending_ids=local_trigger_pending_ids,
+        subagent_statuses_for_chat=subagent_statuses_for_chat,
+        subagent_detail_snapshot=subagent_detail_snapshot,
     )

--- a/nanobot/webui/path_evidence.py
+++ b/nanobot/webui/path_evidence.py
@@ -1,0 +1,167 @@
+"""Path evidence extraction for WebUI file preview resolution.
+
+When the LLM references a local file with a relative path whose implied base
+(the directory it actually worked in) differs from the session's bound project
+root, the preview resolver falls back to directories the agent actually
+touched during the turn. The evidence comes from tool call arguments already
+persisted in the session transcript, so the fallback is deterministic and
+needs no extra storage.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+from typing import Any, cast
+
+from nanobot.security.workspace_access import WorkspaceScope
+from nanobot.security.workspace_policy import (
+    WorkspaceBoundaryError,
+    resolve_allowed_path,
+)
+
+logger = logging.getLogger(__name__)
+
+# File-like tools whose arguments carry a filesystem path that establishes the
+# directory the agent is actually working in.  `exec` is deliberately excluded:
+# its `command` argument is a shell string, not a reliable path base.
+EVIDENCE_TOOLS = frozenset(
+    {
+        "read_file",
+        "write_file",
+        "edit_file",
+        "apply_patch",
+        "list_dir",
+        "find_files",
+    }
+)
+
+# How many recent messages to scan for evidence.  The reference base shifts as
+# the turn changes, so only the most recent activity is meaningful.  This keeps
+# the scan bounded for long sessions.
+MAX_EVIDENCE_MESSAGES = 80
+
+# How many ancestor levels of a touched path are kept as candidate bases.
+# A tool call under .../project/sub/dir/file.md yields bases
+# .../project/sub/dir, .../project/sub, .../project — covering both
+# same-directory references and references like "sub/dir/file.md" from the
+# project root.
+EVIDENCE_ANCESTOR_LEVELS = 3
+
+
+def extract_path_evidence(messages: Sequence[dict[str, Any]] | None) -> list[Path]:
+    """Return directories the agent touched, most recent first, deduplicated.
+
+    Evidence is collected from ``tool_calls`` entries of recent assistant
+    messages: the ``path`` argument of each file-like tool contributes its
+    parent directories as candidate reference bases.
+    """
+    if not messages:
+        return []
+    evidence: list[Path] = []
+    seen: set[Path] = set()
+
+    def add_candidate(path: Path) -> None:
+        if path in seen:
+            return
+        seen.add(path)
+        evidence.append(path)
+
+    for message in reversed(messages[-MAX_EVIDENCE_MESSAGES:]):
+        tool_calls = message.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        calls = cast(list[dict[str, Any]], tool_calls)
+        for call in calls:
+            function = call.get("function")
+            if not isinstance(function, dict):
+                continue
+            function_data = cast(dict[str, Any], function)
+            name = function_data.get("name")
+            if not isinstance(name, str) or name not in EVIDENCE_TOOLS:
+                continue
+            raw_args = function_data.get("arguments")
+            if not isinstance(raw_args, str):
+                continue
+            path = _extract_path_argument(name, raw_args)
+            if path is None:
+                continue
+            for base in _evidence_directories(name, path):
+                add_candidate(base)
+    return evidence
+
+
+def _extract_path_argument(tool_name: str, raw_args: str) -> str | None:
+    try:
+        parsed = json.loads(raw_args)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    args = cast(dict[str, Any], parsed)
+    value = args.get("path")
+    if not isinstance(value, str) or not value:
+        # find_files also accepts positional glob patterns, but only an
+        # explicit `path` establishes a directory base.
+        return None
+    return value
+
+
+def _evidence_directories(tool_name: str, raw_path: str) -> Iterable[Path]:
+    """Return candidate base directories for one tool call, nearest first."""
+    candidate = Path(raw_path).expanduser()
+    if not candidate.is_absolute():
+        # Relative tool paths resolve against the project root; they carry no
+        # cross-directory base information, so they are not evidence.
+        return ()
+    # list_dir/find_files take a directory as their path; file tools take a
+    # file, whose parent is the working directory.
+    start = candidate if tool_name in {"list_dir", "find_files"} else candidate.parent
+    return _ancestors(start)
+
+
+def _ancestors(start: Path) -> Iterable[Path]:
+    """Yield *start* and its ancestors up to EVIDENCE_ANCESTOR_LEVELS deep."""
+    current = start
+    for _ in range(EVIDENCE_ANCESTOR_LEVELS):
+        yield current
+        parent = current.parent
+        if parent == current:  # filesystem root
+            break
+        current = parent
+
+
+def resolve_with_evidence(
+    rel_path: str,
+    evidence_dirs: Iterable[Path],
+    *,
+    scope: WorkspaceScope,
+) -> Path | None:
+    """Resolve *rel_path* against evidence dirs, most recent base first.
+
+    Each candidate base is joined with the relative path, then the result must
+    pass the workspace boundary check (restricted mode: the resolved file must
+    stay inside the project root) and exist as a file.  The first hit wins;
+    ``None`` means no candidate resolved.
+    """
+    clean = rel_path.strip().strip("/")
+    if not clean:
+        return None
+    for base in evidence_dirs:
+        candidate = base / clean
+        try:
+            resolved = resolve_allowed_path(
+                candidate,
+                workspace=scope.project_path,
+                allowed_root=scope.project_path if scope.restrict_to_workspace else None,
+                strict=True,
+            )
+        except (FileNotFoundError, WorkspaceBoundaryError, OSError):
+            # Boundary violations are skipped rather than surfaced: an
+            # evidence dir that escapes the workspace is not a usable base.
+            continue
+        if resolved.is_file():
+            return resolved
+    return None

--- a/nanobot/webui/ws_http.py
+++ b/nanobot/webui/ws_http.py
@@ -90,6 +90,7 @@ from nanobot.webui.http_utils import (
 )
 from nanobot.webui.ingress_policy import WebUIIngressPolicy
 from nanobot.webui.media_gateway import WebUIMediaGateway
+from nanobot.webui.path_evidence import extract_path_evidence
 from nanobot.webui.native_folder_picker import (
     NativeFolderPickerError,
     native_folder_picker_available,
@@ -850,15 +851,37 @@ class GatewayHTTPHandler:
         query = _parse_query(request.path)
         path = _query_first(query, "path")
         is_probe = _query_first(query, "probe") == "1"
+
+        def evidence_provider() -> list[Path]:
+            """Lazily read session tool activity for cross-directory resolution."""
+            if self.session_manager is None:
+                return []
+            session_data = self.session_manager.read_session_file(decoded_key)
+            raw_messages = session_data.get("messages") if isinstance(session_data, dict) else None
+            if not isinstance(raw_messages, list):
+                return []
+            return extract_path_evidence(cast(list[Any], raw_messages))
+
+        scope = self.workspaces.scope_for_session_key(decoded_key)
         try:
-            scope = self.workspaces.scope_for_session_key(decoded_key)
             if is_probe:
-                payload = file_preview_availability_payload(path, scope=scope)
+                payload = file_preview_availability_payload(
+                    path, scope=scope, evidence_provider=evidence_provider
+                )
             else:
-                payload = file_preview_payload(path, scope=scope)
+                payload = file_preview_payload(
+                    path, scope=scope, evidence_provider=evidence_provider
+                )
         except WebUIFilePreviewError as e:
             if is_probe and e.status in {400, 403, 404, 415}:
-                return _http_json_response({"available": False})
+                hint: dict[str, Any] = {"available": False}
+                if e.status == 404:
+                    hint["reason"] = "not_found"
+                    hint["project_path"] = str(scope.project_path)
+                    hint["requested"] = path or ""
+                elif e.status == 403:
+                    hint["reason"] = "outside_workspace"
+                return _http_json_response(hint)
             return _http_error(e.status, e.message)
         return _http_json_response(payload)
 

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -1577,6 +1577,28 @@ async def test_request_context_uses_effective_key_for_spawn_tool(tmp_path: Path)
 
 
 @pytest.mark.asyncio
+async def test_spawn_tool_uses_webui_turn_id_for_subagent_events(tmp_path: Path) -> None:
+    loop = _make_full_loop(tmp_path)
+    spawn_tool = loop.tools.get("spawn")
+    assert spawn_tool is not None
+    spawn_tool._manager.spawn = AsyncMock(return_value="started")  # type: ignore[attr-defined]
+    runtime = loop.llm_runtime()
+
+    with request_context(RequestContext(
+        channel="websocket",
+        chat_id="web-chat",
+        session_key="websocket:web-chat",
+        runtime=runtime,
+        turn_id="websocket:web-chat:internal-turn",
+        metadata={"webui_turn_id": "client-turn-42"},
+    )):
+        await spawn_tool.execute(task="inspect context")
+
+    call = spawn_tool._manager.spawn.await_args.kwargs  # type: ignore[attr-defined]
+    assert call["origin_turn_id"] == "client-turn-42"
+
+
+@pytest.mark.asyncio
 async def test_next_turn_after_crash_closes_pending_user_turn_before_new_input(tmp_path: Path) -> None:
     loop = _make_full_loop(tmp_path)
     loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=False)  # type: ignore[method-assign]

--- a/tests/agent/test_subagent_state.py
+++ b/tests/agent/test_subagent_state.py
@@ -1,0 +1,68 @@
+"""Durable subagent detail replay tests."""
+
+from nanobot.session.manager import SessionManager
+from nanobot.session.subagent_state import (
+    SubagentDetailRecord,
+    SubagentDetailStore,
+    SubagentTaskRecord,
+    SubagentTaskStore,
+)
+
+
+def _record(status: str = "running") -> SubagentTaskRecord:
+    return SubagentTaskRecord(
+        task_id="task-1",
+        label="任务",
+        task_description="执行任务",
+        status=status,
+        channel="websocket",
+        chat_id="chat-1",
+        session_key="websocket:chat-1",
+        turn_id="turn-1",
+        created_at="2026-01-01T00:00:00+00:00",
+        updated_at="2026-01-01T00:00:00+00:00",
+    )
+
+
+def test_task_store_persists_and_reloads_records(tmp_path):
+    sessions = SessionManager(tmp_path)
+    store = SubagentTaskStore(sessions)
+    stored = store.upsert(_record("queued"))
+
+    assert stored.revision == 0
+    assert store.snapshot("websocket:chat-1")[0].status == "queued"
+
+
+def test_snapshot_marks_lost_active_task_interrupted(tmp_path):
+    sessions = SessionManager(tmp_path)
+    store = SubagentTaskStore(sessions)
+    store.upsert(_record("running"))
+
+    snapshot = store.snapshot("websocket:chat-1", active_task_ids=set())
+
+    assert snapshot[0].status == "interrupted"
+    assert snapshot[0].stop_reason == "gateway_restart_or_runtime_loss"
+
+
+def test_detail_store_keeps_replayable_snapshot(tmp_path):
+    sessions = SessionManager(tmp_path)
+    store = SubagentDetailStore(sessions)
+    store.upsert(
+        "websocket:chat-1",
+        SubagentDetailRecord(
+            task_id="task-1",
+            label="任务",
+            turn_id="turn-1",
+            status="completed",
+            revision=2,
+            seq=3,
+            input="执行任务",
+            steps=[{"kind": "tool_start", "name": "read_file"}],
+            output="完成",
+        ),
+    )
+
+    snapshot = store.snapshot("websocket:chat-1")
+
+    assert snapshot[0]["task_id"] == "task-1"
+    assert snapshot[0]["steps"][0]["name"] == "read_file"

--- a/tests/webui/test_file_preview.py
+++ b/tests/webui/test_file_preview.py
@@ -1,9 +1,16 @@
+import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from nanobot.security.workspace_access import default_workspace_scope
-from nanobot.webui.file_preview import WebUIFilePreviewError, file_preview_payload
+from nanobot.webui.file_preview import (
+    WebUIFilePreviewError,
+    file_preview_availability_payload,
+    file_preview_payload,
+)
+from nanobot.webui.ws_http import GatewayHTTPHandler
 
 
 def test_restricted_preview_allows_media_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -38,3 +45,292 @@ def test_restricted_preview_rejects_other_root(tmp_path: Path, monkeypatch: pyte
         file_preview_payload(str(outside), scope=scope)
 
     assert exc_info.value.status == 403
+
+
+def _prefixed_project(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a project directory whose name also appears in relative refs."""
+    project = tmp_path / "qizicheng-skill管理删除优化"
+    docs = project / "01_docs" / "03_方案"
+    docs.mkdir(parents=True)
+    doc = docs / "Skill删除优化-替换文件方案-v1.0.md"
+    doc.write_text("# 方案\n\n正文内容", encoding="utf-8")
+    return project, doc
+
+
+def test_prefixed_project_name_reference_is_available(tmp_path: Path) -> None:
+    project, _ = _prefixed_project(tmp_path)
+    scope = default_workspace_scope(project, restrict_to_workspace=True)
+
+    raw = f"{project.name}/01_docs/03_方案/Skill删除优化-替换文件方案-v1.0.md"
+
+    assert file_preview_availability_payload(raw, scope=scope) == {"available": True}
+
+
+def test_prefixed_project_name_reference_resolves_payload(tmp_path: Path) -> None:
+    project, doc = _prefixed_project(tmp_path)
+    scope = default_workspace_scope(project, restrict_to_workspace=True)
+
+    raw = f"{project.name}/01_docs/03_方案/Skill删除优化-替换文件方案-v1.0.md"
+    payload = file_preview_payload(raw, scope=scope)
+
+    assert Path(payload["path"]) == doc.resolve()
+    assert payload["display_path"] == "01_docs/03_方案/Skill删除优化-替换文件方案-v1.0.md"
+    assert payload["content"] == "# 方案\n\n正文内容"
+
+
+def test_relative_reference_without_prefix_resolves_directly(tmp_path: Path) -> None:
+    project, _ = _prefixed_project(tmp_path)
+    scope = default_workspace_scope(project, restrict_to_workspace=True)
+
+    assert file_preview_availability_payload(
+        "01_docs/03_方案/Skill删除优化-替换文件方案-v1.0.md",
+        scope=scope,
+    ) == {"available": True}
+
+
+def test_absolute_reference_resolves_directly(tmp_path: Path) -> None:
+    project, doc = _prefixed_project(tmp_path)
+    scope = default_workspace_scope(project, restrict_to_workspace=True)
+
+    assert file_preview_availability_payload(str(doc), scope=scope) == {"available": True}
+
+
+def test_missing_file_still_404(tmp_path: Path) -> None:
+    project, _ = _prefixed_project(tmp_path)
+    scope = default_workspace_scope(project, restrict_to_workspace=True)
+
+    with pytest.raises(WebUIFilePreviewError, match="file not found") as exc_info:
+        file_preview_availability_payload(
+            "01_docs/03_方案/不存在的文件.md",
+            scope=scope,
+        )
+
+    assert exc_info.value.status == 404
+
+
+def test_prefixed_missing_file_still_404_after_retry(tmp_path: Path) -> None:
+    project, _ = _prefixed_project(tmp_path)
+    scope = default_workspace_scope(project, restrict_to_workspace=True)
+
+    raw = f"{project.name}/01_docs/03_方案/不存在的文件.md"
+    with pytest.raises(WebUIFilePreviewError, match="file not found") as exc_info:
+        file_preview_availability_payload(raw, scope=scope)
+
+    assert exc_info.value.status == 404
+
+
+def test_unrelated_prefix_still_404(tmp_path: Path) -> None:
+    project, _ = _prefixed_project(tmp_path)
+    scope = default_workspace_scope(project, restrict_to_workspace=True)
+
+    raw = "other-project/01_docs/03_方案/Skill删除优化-替换文件方案-v1.0.md"
+    with pytest.raises(WebUIFilePreviewError, match="file not found") as exc_info:
+        file_preview_availability_payload(raw, scope=scope)
+
+    assert exc_info.value.status == 404
+
+
+def test_evidence_fallback_resolves_cross_repo_reference(tmp_path: Path) -> None:
+    """A relative path that misses the project root resolves via tool evidence."""
+    project = tmp_path / "13_nanobot"  # session project root (production repo)
+    project.mkdir()
+    dev_repo = tmp_path / "13_nanobot-dev"  # where the agent actually worked
+    docs = dev_repo / "分析报告"
+    docs.mkdir(parents=True)
+    doc = docs / "报告.md"
+    doc.write_text("跨库正文", encoding="utf-8")
+
+    scope = default_workspace_scope(project, restrict_to_workspace=False)
+    # Evidence mirrors extract_path_evidence output: the agent's read_file
+    # touched .../13_nanobot-dev/分析报告/报告.md, whose ancestor bases are
+    # [分析报告, 13_nanobot-dev, tmp_path] (newest first). The reference base
+    # is 13_nanobot-dev, so 分析报告/报告.md resolves via the ancestor entry.
+    evidence = [docs, dev_repo]
+
+    assert file_preview_availability_payload(
+        "分析报告/报告.md", scope=scope, evidence_provider=lambda: evidence
+    ) == {"available": True}
+
+    payload = file_preview_payload(
+        "分析报告/报告.md", scope=scope, evidence_provider=lambda: evidence
+    )
+    assert payload["content"] == "跨库正文"
+    assert Path(payload["path"]) == doc.resolve()
+
+
+def test_evidence_fallback_ignored_when_project_root_hits(tmp_path: Path) -> None:
+    """Baseline-aligned references keep resolving via project root (zero change)."""
+    project, doc = _prefixed_project(tmp_path)
+    scope = default_workspace_scope(project, restrict_to_workspace=True)
+
+    # Evidence points somewhere else entirely; it must not shadow the direct hit.
+    stray = tmp_path / "stray"
+    stray.mkdir()
+
+    assert file_preview_availability_payload(
+        "01_docs/03_方案/Skill删除优化-替换文件方案-v1.0.md",
+        scope=scope,
+        evidence_provider=lambda: [stray],
+    ) == {"available": True}
+
+    payload = file_preview_payload(
+        "01_docs/03_方案/Skill删除优化-替换文件方案-v1.0.md",
+        scope=scope,
+        evidence_provider=lambda: [stray],
+    )
+    assert Path(payload["path"]) == doc.resolve()
+
+
+def test_evidence_fallback_prefers_most_recent_dir_on_duplicate(tmp_path: Path) -> None:
+    """Same relative name in two evidence dirs: most-recent base wins, never guessed."""
+    project = tmp_path / "project"
+    project.mkdir()
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+    (dir_a / "dup.md").write_text("A", encoding="utf-8")
+    (dir_b / "dup.md").write_text("B", encoding="utf-8")
+
+    scope = default_workspace_scope(project, restrict_to_workspace=False)
+
+    # dir_a is the most recently touched base (evidence order is newest first).
+    payload = file_preview_payload(
+        "dup.md", scope=scope, evidence_provider=lambda: [dir_a, dir_b]
+    )
+    assert payload["content"] == "A"
+
+    payload = file_preview_payload(
+        "dup.md", scope=scope, evidence_provider=lambda: [dir_b, dir_a]
+    )
+    assert payload["content"] == "B"
+
+
+def test_evidence_fallback_respects_restricted_boundary(tmp_path: Path) -> None:
+    """Evidence pointing outside the workspace must not bypass restricted mode."""
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.md"
+    secret.write_text("secret", encoding="utf-8")
+
+    scope = default_workspace_scope(project, restrict_to_workspace=True)
+
+    with pytest.raises(WebUIFilePreviewError, match="file not found") as exc_info:
+        file_preview_availability_payload(
+            "secret.md", scope=scope, evidence_provider=lambda: [outside]
+        )
+    assert exc_info.value.status == 404
+
+
+# -- Handler-level integration: session evidence injected via ws_http --------
+
+
+def _preview_handler(
+    *,
+    session_data: dict | None,
+    scope,
+    authorized: bool = True,
+) -> GatewayHTTPHandler:
+    handler = object.__new__(GatewayHTTPHandler)
+    handler.tokens = SimpleNamespace(check_api_token=lambda _request: authorized)
+    handler.session_manager = SimpleNamespace(
+        read_session_file=lambda _key: session_data,
+    )
+    handler.workspaces = SimpleNamespace(scope_for_session_key=lambda _key: scope)
+    return handler
+
+
+def _preview_request(path: str) -> SimpleNamespace:
+    return SimpleNamespace(path=path, headers=SimpleNamespace())
+
+
+def _preview_response_json(response) -> dict:
+    body = getattr(response, "body", None)
+    if body is None:
+        return {}
+    return json.loads(body.decode("utf-8"))
+
+
+def test_handler_uses_session_evidence_for_cross_repo_probe(tmp_path: Path) -> None:
+    """End-to-end: session tool activity lets a cross-repo relative path probe true."""
+    project = tmp_path / "13_nanobot"  # session project root
+    project.mkdir()
+    dev_repo = tmp_path / "13_nanobot-dev"  # where the agent actually worked
+    docs = dev_repo / "分析报告"
+    docs.mkdir(parents=True)
+    doc = docs / "报告.md"
+    doc.write_text("跨库正文", encoding="utf-8")
+
+    # Session transcript: the agent read the file in the dev repo.
+    session_data = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": json.dumps({"path": str(doc)}),
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+    scope = default_workspace_scope(project, restrict_to_workspace=False)
+    handler = _preview_handler(session_data=session_data, scope=scope)
+
+    response = handler._handle_file_preview(
+        _preview_request("/api/sessions/k/file-preview?path=分析报告/报告.md&probe=1"),
+        "websocket:key",
+    )
+
+    assert _preview_response_json(response) == {"available": True}
+
+
+def test_handler_evidence_respects_restricted_scope(tmp_path: Path) -> None:
+    """Handler-level: evidence outside a restricted workspace stays unavailable."""
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.md"
+    secret.write_text("secret", encoding="utf-8")
+
+    session_data = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": json.dumps({"path": str(secret)}),
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+    scope = default_workspace_scope(project, restrict_to_workspace=True)
+    handler = _preview_handler(session_data=session_data, scope=scope)
+
+    response = handler._handle_file_preview(
+        _preview_request("/api/sessions/k/file-preview?path=secret.md&probe=1"),
+        "websocket:key",
+    )
+
+    payload = _preview_response_json(response)
+    assert payload["available"] is False
+    assert payload["reason"] == "not_found"
+    assert payload["requested"] == "secret.md"

--- a/tests/webui/test_path_evidence.py
+++ b/tests/webui/test_path_evidence.py
@@ -1,0 +1,120 @@
+from pathlib import Path
+
+from nanobot.security.workspace_access import default_workspace_scope
+from nanobot.webui.path_evidence import (
+    MAX_EVIDENCE_MESSAGES,
+    extract_path_evidence,
+    resolve_with_evidence,
+)
+
+
+def _tool_call(name: str, path: str) -> dict:
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": f"call_{name}_{len(path)}",
+                "type": "function",
+                "function": {"name": name, "arguments": f'{{"path": "{path}"}}'},
+            }
+        ],
+    }
+
+
+def test_extract_evidence_from_read_file_parent_dir(tmp_path: Path) -> None:
+    messages = [
+        _tool_call("read_file", f"{tmp_path}/a/b/file.md"),
+        _tool_call("list_dir", f"{tmp_path}/a"),
+    ]
+    evidence = extract_path_evidence(messages)
+
+    # list_dir contributes its own dir; read_file contributes its parent,
+    # grandparent, great-grandparent (3 levels). Most recent (last message)
+    # comes first.
+    assert evidence[0] == Path(f"{tmp_path}/a")
+    assert Path(f"{tmp_path}/a/b") in evidence
+    assert Path(f"{tmp_path}/a") in evidence
+    assert tmp_path in evidence
+
+
+def test_extract_evidence_ignores_exec_and_relative_paths(tmp_path: Path) -> None:
+    messages = [
+        _tool_call("exec", "cd /tmp && ls"),
+        _tool_call("read_file", "relative/path/file.md"),
+    ]
+    assert extract_path_evidence(messages) == []
+
+
+def test_extract_evidence_limits_recent_messages(tmp_path: Path) -> None:
+    messages = [_tool_call("read_file", f"{tmp_path}/recent/sub/recent.md")]
+    old = [
+        {"role": "assistant", "content": "", "tool_calls": []}
+        for _ in range(MAX_EVIDENCE_MESSAGES)
+    ]
+    old[0] = _tool_call("read_file", f"{tmp_path}/old/very-old.md")
+    evidence = extract_path_evidence(old + messages)
+
+    assert Path(f"{tmp_path}/recent/sub/recent.md").parent in evidence
+    assert Path(f"{tmp_path}/recent/sub") in evidence
+    assert Path(f"{tmp_path}/old/very-old.md").parent not in evidence
+    assert Path(f"{tmp_path}/old") not in evidence
+
+
+def test_resolve_with_evidence_hits_cross_directory_file(tmp_path: Path) -> None:
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    other = tmp_path / "other-repo"
+    docs = other / "分析报告"
+    docs.mkdir(parents=True)
+    target = docs / "报告.md"
+    target.write_text("正文", encoding="utf-8")
+
+    scope = default_workspace_scope(workspace, restrict_to_workspace=False)
+    evidence = [docs]
+
+    resolved = resolve_with_evidence("报告.md", evidence, scope=scope)
+    assert resolved == target.resolve()
+
+
+def test_resolve_with_evidence_skips_boundary_violations(tmp_path: Path) -> None:
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.md"
+    secret.write_text("secret", encoding="utf-8")
+
+    scope = default_workspace_scope(workspace, restrict_to_workspace=True)
+    # Evidence dir is outside the workspace: must not resolve in restricted mode.
+    assert resolve_with_evidence("secret.md", [outside], scope=scope) is None
+
+    # Full access may resolve it (restricted boundary is the only guard).
+    full_scope = default_workspace_scope(workspace, restrict_to_workspace=False)
+    assert resolve_with_evidence("secret.md", [outside], scope=full_scope) == secret.resolve()
+
+
+def test_resolve_with_evidence_returns_none_when_missing(tmp_path: Path) -> None:
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+
+    scope = default_workspace_scope(workspace, restrict_to_workspace=False)
+    assert resolve_with_evidence("nope.md", [docs], scope=scope) is None
+
+
+def test_resolve_with_evidence_prefers_most_recent_dir(tmp_path: Path) -> None:
+    """Same file name in two evidence dirs: most recent (first) wins."""
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+    (dir_a / "same.md").write_text("A", encoding="utf-8")
+    (dir_b / "same.md").write_text("B", encoding="utf-8")
+
+    scope = default_workspace_scope(workspace, restrict_to_workspace=False)
+    assert resolve_with_evidence("same.md", [dir_a, dir_b], scope=scope) == (dir_a / "same.md").resolve()
+    assert resolve_with_evidence("same.md", [dir_b, dir_a], scope=scope) == (dir_b / "same.md").resolve()

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -1172,6 +1172,24 @@ function Shell({
     }
   }, [client]);
 
+  // P5: 防拖放导航。Electron 桌面壳中，把文件拖到窗口内非表单区域（消息
+  // 列表/空白处）默认会导航到 file:// 路径，整个 WebUI 被文件内容替换。
+  // 这里在 document 冒泡阶段拦截拖放（仅当拖入的是文件），阻止默认导航；
+  // 输入区的附件拖拽由 composer 的局部处理先 preventDefault 完成，不受影响。
+  useEffect(() => {
+    const guard = (event: DragEvent) => {
+      const types = event.dataTransfer?.types;
+      if (!types || !Array.from(types).includes("Files")) return;
+      event.preventDefault();
+    };
+    document.addEventListener("dragover", guard);
+    document.addEventListener("drop", guard);
+    return () => {
+      document.removeEventListener("dragover", guard);
+      document.removeEventListener("drop", guard);
+    };
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     fetchSettings(getToken())
@@ -2567,8 +2585,23 @@ function Shell({
 
   useEffect(() => {
     document.documentElement.classList.toggle("native-host", showHostChrome);
+    if (!showHostChrome) return;
+    // Native host: reveal the (hidden-at-rest) custom scrollbar thumb while the
+    // user scrolls, fading it out shortly after scrolling stops. See the
+    // `native-scrolling` rules in globals.css.
+    let hideTimer: ReturnType<typeof setTimeout> | undefined;
+    const revealThumbs = () => {
+      document.documentElement.classList.add("native-scrolling");
+      if (hideTimer) clearTimeout(hideTimer);
+      hideTimer = setTimeout(() => {
+        document.documentElement.classList.remove("native-scrolling");
+      }, 400);
+    };
+    document.addEventListener("scroll", revealThumbs, true);
     return () => {
       document.documentElement.classList.remove("native-host");
+      document.removeEventListener("scroll", revealThumbs, true);
+      if (hideTimer) clearTimeout(hideTimer);
     };
   }, [showHostChrome]);
 

--- a/webui/src/components/FilePreviewPanel.tsx
+++ b/webui/src/components/FilePreviewPanel.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, PointerEvent as ReactPointerEvent } from "react";
-import { AlertCircle, ChevronRight, Loader2, X } from "lucide-react";
+import { AlertCircle, ChevronRight, ExternalLink, Loader2, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { CodeBlock } from "@/components/CodeBlock";
 import { splitFilePath } from "@/components/FileReferenceChip";
+import { MarkdownText } from "@/components/MarkdownText";
 import { ApiError, fetchFilePreview } from "@/lib/api";
+import { getRuntimeHost } from "@/lib/runtime";
 import type { FilePreviewPayload } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -15,6 +17,7 @@ interface FilePreviewPanelProps {
   token: string;
   desktopWidth?: number;
   isClosing?: boolean;
+  canOpenSystem?: boolean;
   onResizeStart?: (event: ReactPointerEvent<HTMLButtonElement>) => void;
   onClose: () => void;
 }
@@ -30,12 +33,14 @@ export function FilePreviewPanel({
   token,
   desktopWidth = 544,
   isClosing = false,
+  canOpenSystem = false,
   onResizeStart,
   onClose,
 }: FilePreviewPanelProps) {
   const { t } = useTranslation();
   const [state, setState] = useState<PreviewState>({ status: "loading" });
   const [entered, setEntered] = useState(false);
+  const [openError, setOpenError] = useState<string | null>(null);
   const tokenRef = useRef(token);
   tokenRef.current = token;
 
@@ -96,6 +101,27 @@ export function FilePreviewPanel({
       : t("filePreview.failed", { defaultValue: "Could not preview this file." }))
     : null;
 
+  const handleOpenSystem = async (): Promise<void> => {
+    if (state.status !== "ready") return;
+    setOpenError(null);
+    const host = getRuntimeHost();
+    try {
+      const result = await host.openFile?.(state.payload.path);
+      if (result && !result.ok) {
+        setOpenError(
+          result.error ??
+            t("filePreview.openSystemFailed", { defaultValue: "Could not open this file in the system." }),
+        );
+      }
+    } catch (error: unknown) {
+      setOpenError(
+        error instanceof Error
+          ? error.message
+          : t("filePreview.openSystemFailed", { defaultValue: "Could not open this file in the system." }),
+      );
+    }
+  };
+
   return (
     <aside
       aria-label={t("filePreview.aria", { defaultValue: "File preview" })}
@@ -128,6 +154,7 @@ export function FilePreviewPanel({
             className={cn(
               "group absolute inset-y-0 left-0 z-20 hidden w-3 -translate-x-1/2 cursor-col-resize touch-none md:flex",
               "items-stretch justify-center focus-visible:outline-none",
+              "host-no-drag",
             )}
             onPointerDown={onResizeStart}
           >
@@ -196,6 +223,24 @@ export function FilePreviewPanel({
                 );
               })}
             </nav>
+            {canOpenSystem && state.status === "ready" ? (
+              <button
+                type="button"
+                onClick={() => void handleOpenSystem()}
+                className={cn(
+                  "inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2 text-[12px] font-medium",
+                  "text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  "host-no-drag",
+                )}
+                title={t("filePreview.openSystem", { defaultValue: "在系统打开" })}
+                aria-label={t("filePreview.openSystem", { defaultValue: "在系统打开" })}
+                data-testid="file-preview-open-system"
+              >
+                <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+                {t("filePreview.openSystem", { defaultValue: "在系统打开" })}
+              </button>
+            ) : null}
             <button
               type="button"
               onClick={onClose}
@@ -203,6 +248,7 @@ export function FilePreviewPanel({
                 "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md",
                 "text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
                 "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                "host-no-drag",
               )}
               title={t("filePreview.close", { defaultValue: "Close file preview" })}
               aria-label={t("filePreview.close", { defaultValue: "Close file preview" })}
@@ -212,7 +258,17 @@ export function FilePreviewPanel({
             </button>
           </div>
 
-          <div className="min-h-0 flex-1 overflow-auto">
+          {openError ? (
+            <div
+              className="mx-4 mt-2 rounded-md border border-red-500/25 bg-red-500/10 px-3 py-2 text-xs text-red-600 dark:text-red-300"
+              role="alert"
+              data-testid="file-preview-open-error"
+            >
+              {openError}
+            </div>
+          ) : null}
+
+          <div className="min-h-0 flex-1 overflow-auto" data-file-preview-scroll>
             {state.status === "loading" ? (
               <div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
@@ -237,15 +293,21 @@ export function FilePreviewPanel({
                     })}
                   </div>
                 ) : null}
-                <CodeBlock
-                  language={state.payload.language}
-                  code={state.payload.content}
-                  chrome="none"
-                  highlight
-                  showLineNumbers
-                  wrapLongLines={false}
-                  className="min-h-full"
-                />
+                {state.payload.language === "markdown" ? (
+                  <div className="w-full min-w-0 px-4 py-3 [overflow-wrap:anywhere]">
+                    <MarkdownText>{state.payload.content}</MarkdownText>
+                  </div>
+                ) : (
+                  <CodeBlock
+                    language={state.payload.language}
+                    code={state.payload.content}
+                    chrome="none"
+                    highlight
+                    showLineNumbers
+                    wrapLongLines={false}
+                    className="min-h-full"
+                  />
+                )}
               </div>
             )}
           </div>

--- a/webui/src/components/FilePreviewPanel.tsx
+++ b/webui/src/components/FilePreviewPanel.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { CodeBlock } from "@/components/CodeBlock";
 import { splitFilePath } from "@/components/FileReferenceChip";
 import { MarkdownText } from "@/components/MarkdownText";
+import { ResizeDivider } from "@/components/ResizeDivider";
 import { ApiError, fetchFilePreview } from "@/lib/api";
 import { getRuntimeHost } from "@/lib/runtime";
 import type { FilePreviewPayload } from "@/lib/types";
@@ -148,24 +149,11 @@ export function FilePreviewPanel({
         )}
       >
         {onResizeStart ? (
-          <button
-            type="button"
-            aria-label={t("filePreview.resize", { defaultValue: "Resize file preview" })}
-            className={cn(
-              "group absolute inset-y-0 left-0 z-20 hidden w-3 -translate-x-1/2 cursor-col-resize touch-none md:flex",
-              "items-stretch justify-center focus-visible:outline-none",
-              "host-no-drag",
-            )}
+          <ResizeDivider
+            ariaLabel={t("filePreview.resize", { defaultValue: "Resize file preview" })}
+            className="absolute inset-y-0 left-0 hidden -translate-x-1/2 md:flex"
             onPointerDown={onResizeStart}
-          >
-            <span
-              aria-hidden
-              className={cn(
-                "h-full w-px bg-foreground/25 opacity-0 transition-opacity",
-                "group-hover:opacity-100 group-focus-visible:bg-ring group-focus-visible:opacity-100",
-              )}
-            />
-          </button>
+          />
         ) : null}
         <div className="flex min-h-0 flex-1 flex-col">
           <div

--- a/webui/src/components/MarkdownTextRenderer.tsx
+++ b/webui/src/components/MarkdownTextRenderer.tsx
@@ -688,6 +688,7 @@ export default function MarkdownTextRenderer({
             <table
               className={cn(
                 "w-full min-w-max border-collapse text-[13px] leading-5",
+                "[overflow-wrap:normal]",
                 "[&_thead]:bg-muted/45 [&_thead]:text-muted-foreground",
                 "[&_th]:border-b [&_th]:border-border/65 [&_th]:px-3 [&_th]:py-2",
                 "[&_th]:text-left [&_th]:font-medium",

--- a/webui/src/components/ResizeDivider.tsx
+++ b/webui/src/components/ResizeDivider.tsx
@@ -1,0 +1,57 @@
+import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent as ReactPointerEvent } from "react";
+import { GripVertical } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+interface ResizeDividerProps {
+  ariaLabel: string;
+  ariaControls?: string;
+  ariaValueMin?: number;
+  ariaValueMax?: number;
+  ariaValueNow?: number;
+  ariaValueText?: string;
+  className?: string;
+  onKeyDown?: (event: ReactKeyboardEvent<HTMLButtonElement>) => void;
+  onPointerDown: (event: ReactPointerEvent<HTMLButtonElement>) => void;
+  title?: string;
+  testId?: string;
+}
+
+export function ResizeDivider({
+  ariaLabel,
+  ariaControls,
+  ariaValueMin,
+  ariaValueMax,
+  ariaValueNow,
+  ariaValueText,
+  className,
+  onKeyDown,
+  onPointerDown,
+  title,
+  testId,
+}: ResizeDividerProps) {
+  return (
+    <button
+      type="button"
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={ariaLabel}
+      aria-controls={ariaControls}
+      aria-valuemin={ariaValueMin}
+      aria-valuemax={ariaValueMax}
+      aria-valuenow={ariaValueNow}
+      aria-valuetext={ariaValueText}
+      data-testid={testId}
+      onPointerDown={onPointerDown}
+      onKeyDown={onKeyDown}
+      title={title}
+      className={cn(
+        "group z-20 flex w-3 cursor-col-resize touch-none items-center justify-center border-x border-border bg-muted/25 text-muted-foreground/75 transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring host-no-drag",
+        className,
+      )}
+    >
+      <span className="absolute inset-y-0 w-px bg-border transition-colors group-hover:bg-primary/70" aria-hidden />
+      <GripVertical className="relative h-5 w-4 rounded-sm bg-background text-muted-foreground group-hover:text-foreground" aria-hidden />
+    </button>
+  );
+}

--- a/webui/src/components/thread/AgentActivityCluster.tsx
+++ b/webui/src/components/thread/AgentActivityCluster.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
   CheckCircle2,
   Clock3,
+  ChevronDown,
   Layers,
   Search,
   Server,
@@ -29,6 +30,7 @@ import {
 import { ReasoningRow } from "@/components/thread/activity/ReasoningRow";
 import { describeMcpActivity } from "@/components/thread/activity/mcp-activity-model";
 import { ThinkingReasoningShell } from "@/components/thread/activity/ThinkingReasoningShell";
+import { SubagentActivityGroup } from "@/components/thread/activity/SubagentActivityGroup";
 import { WebActivityRow } from "@/components/thread/activity/WebActivityRow";
 import {
   describeTraceLine,
@@ -46,7 +48,7 @@ import { logoFallbackUrls } from "@/lib/provider-brand";
 import { canonicalToolTrace, formatToolCallTrace } from "@/lib/tool-traces";
 import { cn } from "@/lib/utils";
 import { usePageVisibility } from "@/hooks/usePageVisibility";
-import type { CliAppInfo, McpPresetInfo, ToolProgressEvent, UIFileEdit, UIMessage } from "@/lib/types";
+import type { CliAppInfo, McpPresetInfo, SubagentActivityTask, ToolProgressEvent, UIFileEdit, UIMessage } from "@/lib/types";
 
 const ACTIVITY_SCROLL_NEAR_BOTTOM_PX = 24;
 
@@ -127,7 +129,9 @@ interface AgentActivityClusterProps {
   startedAtMs?: number;
   cliApps?: CliAppInfo[];
   mcpPresets?: McpPresetInfo[];
+  subagents?: SubagentActivityTask[];
   onOpenFilePreview?: (path: string) => void;
+  onOpenSubagent?: (taskId: string) => void;
 }
 
 /**
@@ -142,7 +146,9 @@ export function AgentActivityCluster({
   startedAtMs,
   cliApps = [],
   mcpPresets = [],
+  subagents = [],
   onOpenFilePreview,
+  onOpenSubagent,
 }: AgentActivityClusterProps) {
   const { t } = useTranslation();
   const fileEditDisplayMode = useFileEditDisplayMode();
@@ -180,13 +186,14 @@ export function AgentActivityCluster({
   const autoFollowActivityRef = useRef(true);
   const scrollFrameRef = useRef<number | null>(null);
   const wasTurnStreamingRef = useRef(isTurnStreaming);
+  const activityDetailsId = useId();
   const wasTurnStreaming = wasTurnStreamingRef.current;
   /** Live work stays open; completed work briefly shows the done state, then tucks away. */
   const outerExpanded = userToggledOuter
     ? outerOpenLocal
     : isTurnStreaming || completionHoldOpen || (wasTurnStreaming && !isTurnStreaming);
 
-  const hasVisibleActivity = reasoningSteps > 0 || toolCalls > 0 || cliCount > 0 || mcpCount > 0 || fileCount > 0;
+  const hasVisibleActivity = reasoningSteps > 0 || toolCalls > 0 || cliCount > 0 || mcpCount > 0 || fileCount > 0 || subagents.length > 0;
   const hasOnlyFileActivity = fileCount > 0 && activityMessages.every(messageHasOnlyFileActivity);
   const hasNonReasoningActivity = toolCalls > 0 || cliCount > 0 || mcpCount > 0 || fileCount > 0;
   const durationMs = activityDurationMs(
@@ -220,6 +227,72 @@ export function AgentActivityCluster({
           duration: activityDuration,
           defaultValue: "Thought for {{duration}}",
         });
+  const thoughtSummaryLabel = durationMs <= 0
+    ? t("message.activityThought", { defaultValue: "Thought" })
+    : t("message.activityThoughtFor", {
+        duration: activityDuration,
+        defaultValue: "Thought for {{duration}}",
+      });
+  const processedActivityCount = subagents.length > 0
+    ? subagents.length
+    : reasoningSteps + toolCalls + cliCount + mcpCount + fileCount;
+  const processedLabel = t("message.activityProcessed", {
+    count: processedActivityCount,
+    defaultValue: "Processed {{count}} tasks",
+  });
+  const completedSummary = !isTurnStreaming ? (
+    <div
+      className="flex flex-wrap items-center gap-2"
+      data-testid="completed-activity-summary"
+    >
+      <button
+        type="button"
+        data-thread-disclosure=""
+        onClick={toggleOuter}
+        aria-expanded={outerExpanded}
+        aria-controls={activityDetailsId}
+        aria-label={processedLabel}
+        className="group inline-flex min-h-7 items-center gap-1.5 rounded-full border border-border/60 bg-muted/35 px-2.5 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" aria-hidden />
+        <span>{processedLabel}</span>
+        <span
+          className={cn(
+            "inline-flex shrink-0 transition-transform [transition-duration:220ms] motion-reduce:transition-none",
+            outerExpanded && "rotate-180",
+          )}
+        >
+          <ChevronDown
+            className="h-3 w-3 text-muted-foreground/60 transition-colors duration-200 group-hover:text-muted-foreground motion-reduce:transition-none"
+            aria-hidden
+          />
+        </span>
+      </button>
+      <button
+        type="button"
+        data-thread-disclosure=""
+        onClick={toggleOuter}
+        aria-expanded={outerExpanded}
+        aria-controls={activityDetailsId}
+        aria-label={thoughtSummaryLabel}
+        className="group inline-flex min-h-7 items-center gap-1.5 rounded-full border border-border/60 bg-muted/35 px-2.5 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <Clock3 className="h-3.5 w-3.5 text-orange-500 dark:text-orange-400" aria-hidden />
+        <span>{thoughtSummaryLabel}</span>
+        <span
+          className={cn(
+            "inline-flex shrink-0 transition-transform [transition-duration:220ms] motion-reduce:transition-none",
+            outerExpanded && "rotate-180",
+          )}
+        >
+          <ChevronDown
+            className="h-3 w-3 text-muted-foreground/60 transition-colors duration-200 group-hover:text-muted-foreground motion-reduce:transition-none"
+            aria-hidden
+          />
+        </span>
+      </button>
+    </div>
+  ) : undefined;
 
   const cancelActivityScrollFrame = useCallback(() => {
     if (scrollFrameRef.current !== null) {
@@ -257,14 +330,14 @@ export function AgentActivityCluster({
     });
   }, [cancelActivityScrollFrame, scrollActivityToBottom]);
 
-  const toggleOuter = () => {
+  function toggleOuter() {
     const nextOpen = userToggledOuter ? !outerOpenLocal : !outerExpanded;
     if (nextOpen) {
       autoFollowActivityRef.current = true;
     }
     setUserToggledOuter(true);
     setOuterOpenLocal(nextOpen);
-  };
+  }
 
   useLayoutEffect(() => {
     if (!outerExpanded || !autoFollowActivityRef.current) return;
@@ -323,7 +396,11 @@ export function AgentActivityCluster({
 
   if (hasOnlyFileActivity) {
     return (
-      <div className={cn("w-full", hasBodyBelow && "mb-2")}>
+      <div className={cn(
+        "w-full",
+        hasBodyBelow && "mb-2",
+        !isTurnStreaming && hasBodyBelow && "border-b border-border/55 pb-3",
+      )}>
         <FileEditGroup
           edits={fileEdits}
           displayMode={fileEditDisplayMode}
@@ -334,11 +411,17 @@ export function AgentActivityCluster({
   }
 
   return (
-    <div className={cn("w-full", hasBodyBelow && "mb-2")}>
+    <div className={cn(
+      "w-full",
+      hasBodyBelow && "mb-2",
+      !isTurnStreaming && hasBodyBelow && "border-b border-border/55 pb-3",
+    )}>
       <ThinkingReasoningShell
         active={isTurnStreaming}
         expanded={outerExpanded}
         label={thoughtLabel}
+        summary={completedSummary}
+        detailsId={activityDetailsId}
         viewportRef={activityScrollRef}
         contentRef={activityContentRef}
         fadeTop={activityScrollFade.top}
@@ -360,6 +443,7 @@ export function AgentActivityCluster({
             onOpenFilePreview={onOpenFilePreview}
           />
         ) : null}
+        {subagents.length ? <SubagentActivityGroup tasks={subagents} onOpenTask={onOpenSubagent} /> : null}
       </ThinkingReasoningShell>
     </div>
   );

--- a/webui/src/components/thread/SubagentDetailPanel.tsx
+++ b/webui/src/components/thread/SubagentDetailPanel.tsx
@@ -1,0 +1,156 @@
+import { useMemo, useState } from "react";
+import { CheckCircle2, ChevronDown, ChevronRight, CircleAlert, Loader2, Terminal, X, XCircle } from "lucide-react";
+
+import { MarkdownText } from "@/components/MarkdownText";
+import { cn } from "@/lib/utils";
+import type { SubagentDetailSnapshot } from "@/lib/types";
+
+interface SubagentDetailPanelProps {
+  details: SubagentDetailSnapshot[];
+  selectedTaskId: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (taskId: string) => void;
+  onClose: (taskId: string) => void;
+}
+
+function statusIcon(status: string | undefined) {
+  if (status === "completed") return <CheckCircle2 className="h-4 w-4 text-emerald-600" />;
+  if (status === "failed" || status === "cancelled") return <XCircle className="h-4 w-4 text-red-600" />;
+  return <Loader2 className="h-4 w-4 animate-spin text-sky-600" />;
+}
+
+export function SubagentDetailPanel({
+  details,
+  selectedTaskId,
+  open,
+  onOpenChange,
+  onSelect,
+  onClose,
+}: SubagentDetailPanelProps) {
+  const [expandedExecution, setExpandedExecution] = useState<Record<string, boolean>>({});
+  const selected = useMemo(
+    () => details.find((item) => item.task_id === selectedTaskId) ?? details[0],
+    [details, selectedTaskId],
+  );
+  const executionExpanded = selected
+    ? expandedExecution[selected.task_id] ?? selected.status !== "completed"
+    : false;
+
+  if (!open) return null;
+
+  return (
+    <aside
+      className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background"
+      id="subagent-detail-panel"
+      data-testid="subagent-detail-panel"
+      aria-label="Subagent 运行详情"
+    >
+      <div className="flex shrink-0 items-start justify-between gap-3 border-b px-4 py-3">
+        <div className="min-w-0">
+          <h2 className="text-base font-semibold text-foreground">Subagent 运行详情</h2>
+          <p className="mt-1 text-xs text-muted-foreground">展示输入、阶段、工具调用摘要、流式输出和最终结果。</p>
+        </div>
+        <button
+          type="button"
+          aria-label="关闭 Subagent 详情"
+          title="关闭 Subagent 详情"
+          onClick={() => onOpenChange(false)}
+          className="shrink-0 rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <X className="h-4 w-4" aria-hidden />
+        </button>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col">
+        {details.length === 0 ? (
+          <div className="flex flex-1 items-center justify-center px-6 text-sm text-muted-foreground">
+            当前会话还没有 Subagent 详情。
+          </div>
+        ) : (
+          <div className="flex min-h-0 flex-1 flex-col">
+            <div className="flex shrink-0 gap-1 overflow-x-auto border-b px-3 py-2">
+              {details.map((item) => (
+                <div
+                  key={item.task_id}
+                  className={cn(
+                    "flex min-w-36 items-center gap-1 rounded-md text-left text-xs",
+                    selected?.task_id === item.task_id
+                      ? "bg-muted font-medium text-foreground"
+                      : "text-muted-foreground hover:bg-muted/60",
+                  )}
+                >
+                  <button
+                    type="button"
+                    onClick={() => onSelect(item.task_id)}
+                    className="flex min-w-0 flex-1 items-center gap-2 px-3 py-2 text-left"
+                  >
+                    {statusIcon(item.status)}
+                    <span className="truncate">{item.label}</span>
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`关闭 ${item.label}`}
+                    title={`关闭 ${item.label}`}
+                    onClick={() => onClose(item.task_id)}
+                    className="mr-1 rounded p-1 text-muted-foreground hover:bg-background hover:text-foreground"
+                  >
+                    <X className="h-3.5 w-3.5" aria-hidden />
+                  </button>
+                </div>
+              ))}
+            </div>
+            {selected ? (
+              <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-4 text-sm">
+                <section>
+                  <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">输入</h3>
+                  <div className="rounded-lg bg-muted/50 p-3 whitespace-pre-wrap break-words">{selected.input || "（暂无）"}</div>
+                </section>
+                <section className="overflow-hidden rounded-lg border border-border/70">
+                  <button
+                    type="button"
+                    data-thread-disclosure=""
+                    aria-expanded={executionExpanded}
+                    onClick={() => setExpandedExecution((current) => ({
+                      ...current,
+                      [selected.task_id]: !executionExpanded,
+                    }))}
+                    className="flex min-h-9 w-full items-center gap-2 px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground transition-colors hover:bg-muted/45 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                  >
+                    <Terminal className="h-3.5 w-3.5" aria-hidden />
+                    <span className="min-w-0 flex-1">执行过程</span>
+                    {executionExpanded
+                      ? <ChevronDown className="h-3.5 w-3.5" aria-hidden />
+                      : <ChevronRight className="h-3.5 w-3.5" aria-hidden />}
+                  </button>
+                  {executionExpanded ? (
+                    <div className="space-y-2 border-t border-border/60 bg-muted/15 p-3">
+                      {(selected.steps ?? []).map((step, index) => (
+                        <div key={`${String(step.kind)}-${index}`} className="rounded-md border border-border/70 bg-background px-3 py-2 text-xs">
+                          <span className="font-medium">{String(step.kind ?? "phase")}</span>
+                          {typeof step.name === "string" ? <span className="ml-2 text-muted-foreground">{step.name}</span> : null}
+                          {typeof step.iteration === "number" ? <span className="ml-2 text-muted-foreground">第 {step.iteration} 轮</span> : null}
+                        </div>
+                      ))}
+                      {(selected.steps ?? []).length === 0 ? <div className="text-muted-foreground">（暂无执行步骤）</div> : null}
+                    </div>
+                  ) : null}
+                </section>
+                <section>
+                  <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">流式输出 / 最终结果</h3>
+                  <MarkdownText streaming={selected.status !== "completed" && selected.status !== "failed"} className="max-w-none text-sm leading-relaxed">
+                    {selected.output || "（暂无输出）"}
+                  </MarkdownText>
+                </section>
+                {selected.error ? (
+                  <div className="flex gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-xs text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-300">
+                    <CircleAlert className="h-4 w-4 shrink-0" />{selected.error}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/webui/src/components/thread/ThreadMessages.tsx
+++ b/webui/src/components/thread/ThreadMessages.tsx
@@ -4,27 +4,36 @@ import { MessageBubble } from "@/components/MessageBubble";
 import { AgentActivityCluster } from "@/components/thread/AgentActivityCluster";
 import { AssistantSelectionAction } from "@/components/thread/AssistantSelectionAction";
 import { normalizeActivityTimeline, type TurnUnit } from "@/lib/activity-timeline";
-import type { CliAppInfo, McpPresetInfo, SlashCommand, UIMessage } from "@/lib/types";
+import type { CliAppInfo, McpPresetInfo, SlashCommand, SubagentActivityTask, UIMessage } from "@/lib/types";
 
 interface ThreadMessagesProps {
   messages: UIMessage[];
   temporary?: boolean;
   /** When true, agent turn still in flight — keeps activity timeline expanded. */
   isStreaming?: boolean;
+  turnEnded?: boolean;
   activeTurnId?: string | null;
   /** Optimistic or canonical active-turn start, in unix seconds. */
   runStartedAt?: number | null;
   hiddenUserMessageCount?: number;
   cliApps?: CliAppInfo[];
   mcpPresets?: McpPresetInfo[];
+  subagents?: SubagentActivityTask[];
+  subagentRounds?: SubagentRoundTasks[];
   slashCommands?: SlashCommand[];
   forkBoundaryMessageCount?: number | null;
   onOpenFilePreview?: (path: string) => void;
+  onOpenSubagent?: (taskId: string) => void;
   onForkFromMessage?: (beforeUserIndex: number) => void;
   onQuoteSelection?: (text: string) => void;
 }
 
 export type DisplayUnit = TurnUnit;
+
+export interface SubagentRoundTasks {
+  turnId: string;
+  tasks: SubagentActivityTask[];
+}
 
 export function buildDisplayUnits(
   messages: UIMessage[],
@@ -56,45 +65,59 @@ export function ThreadMessages({
   messages,
   temporary = false,
   isStreaming = false,
+  turnEnded = true,
   activeTurnId = null,
   runStartedAt = null,
   hiddenUserMessageCount = 0,
   cliApps = [],
   mcpPresets = [],
+  subagents = [],
+  subagentRounds = [],
   slashCommands = [],
   forkBoundaryMessageCount = null,
   onOpenFilePreview,
+  onOpenSubagent,
   onForkFromMessage,
   onQuoteSelection,
 }: ThreadMessagesProps) {
   const { t } = useTranslation();
   const messageListRef = useRef<HTMLDivElement>(null);
-  const units = useMemo(() => buildDisplayUnits(messages, isStreaming), [isStreaming, messages]);
+  const effectiveStreaming = isStreaming || !turnEnded;
+  const units = useMemo(() => buildDisplayUnits(messages, effectiveStreaming), [effectiveStreaming, messages]);
   const forkBoundaryAfterUnitIndex = useMemo(
     () => unitIndexAfterMessageCount(units, forkBoundaryMessageCount),
     [forkBoundaryMessageCount, units],
   );
   const forkFlags = useMemo(() => assistantForkFlags(units), [units]);
   const liveActivityClusterIndices = useMemo(
-    () => isStreaming
+    () => effectiveStreaming
       ? currentActivityClusterIndices(units, activeTurnId)
       : new Set<number>(),
-    [activeTurnId, isStreaming, units],
+    [activeTurnId, effectiveStreaming, units],
   );
   const pendingTurn = useMemo(
     () => pendingTurnProjection(messages, activeTurnId),
     [activeTurnId, messages],
   );
   const pendingActivity = (
-    isStreaming
+    effectiveStreaming
     && liveActivityClusterIndices.size === 0
     && pendingTurn !== null
     && !pendingTurn.hasVisibleOutput
   ) ? pendingTurn : null;
-  const currentTurnStartIndex = isStreaming
+  const currentTurnStartIndex = effectiveStreaming
     ? activeTurnStartIndex(units, activeTurnId)
     : units.length;
   const unitKeys = useMemo(() => unitKeysForDisplay(units), [units]);
+  const lastActivityIndex = useMemo(
+    () => units.reduce((last, unit, index) => unit.type === "activity" ? index : last, -1),
+    [units],
+  );
+  const hasActivityUnit = lastActivityIndex >= 0;
+  const subagentTasksByActivityIndex = useMemo(
+    () => subagentTasksForActivityUnits(units, subagentRounds),
+    [subagentRounds, units],
+  );
   let nextUserIndex = hiddenUserMessageCount;
 
   return (
@@ -146,7 +169,7 @@ export function ThreadMessages({
             isTurnStreaming={
               unit.type === "activity"
                 ? liveActivityClusterIndices.has(index)
-                : isStreaming && (
+                : effectiveStreaming && (
                     unit.message.turnId && activeTurnId !== null
                       ? unit.message.turnId === activeTurnId
                       : index > currentTurnStartIndex
@@ -158,12 +181,27 @@ export function ThreadMessages({
             temporary={temporary}
             cliApps={cliApps}
             mcpPresets={mcpPresets}
+            subagents={mergeSubagentTasks(
+              subagentTasksByActivityIndex.get(index) ?? [],
+              index === lastActivityIndex ? subagents : [],
+            )}
             slashCommands={slashCommands}
             onOpenFilePreview={onOpenFilePreview}
+            onOpenSubagent={onOpenSubagent}
             onForkFromMessage={onForkFromMessage}
           />
         );
       })}
+      {!hasActivityUnit && subagents.length > 0 ? (
+        <AgentActivityCluster
+          messages={[]}
+          subagents={subagents}
+          onOpenSubagent={onOpenSubagent}
+          isTurnStreaming={effectiveStreaming}
+          hasBodyBelow={false}
+          startedAtMs={runStartedAt != null ? runStartedAt * 1000 : undefined}
+        />
+      ) : null}
       {pendingActivity ? (
         <div className={units.length > 0 ? "mt-5" : undefined}>
           <AgentActivityCluster
@@ -239,8 +277,10 @@ interface ThreadDisplayUnitProps {
   temporary: boolean;
   cliApps: CliAppInfo[];
   mcpPresets: McpPresetInfo[];
+  subagents: SubagentActivityTask[];
   slashCommands: SlashCommand[];
   onOpenFilePreview?: (path: string) => void;
+  onOpenSubagent?: (taskId: string) => void;
   onForkFromMessage?: (beforeUserIndex: number) => void;
 }
 
@@ -257,8 +297,10 @@ const ThreadDisplayUnit = memo(function ThreadDisplayUnit({
   temporary,
   cliApps,
   mcpPresets,
+  subagents,
   slashCommands,
   onOpenFilePreview,
+  onOpenSubagent,
   onForkFromMessage,
 }: ThreadDisplayUnitProps) {
   // Introducing content-visibility after a unit has painted can move the
@@ -286,7 +328,9 @@ const ThreadDisplayUnit = memo(function ThreadDisplayUnit({
             startedAtMs={unit.startedAtMs}
             cliApps={cliApps}
             mcpPresets={mcpPresets}
+            subagents={subagents}
             onOpenFilePreview={onOpenFilePreview}
+            onOpenSubagent={onOpenSubagent}
           />
         ) : (
           <MessageBubble
@@ -323,8 +367,10 @@ function threadDisplayUnitPropsEqual(
     && previous.temporary === next.temporary
     && previous.cliApps === next.cliApps
     && previous.mcpPresets === next.mcpPresets
+    && previous.subagents === next.subagents
     && previous.slashCommands === next.slashCommands
     && previous.onOpenFilePreview === next.onOpenFilePreview
+    && previous.onOpenSubagent === next.onOpenSubagent
     && previous.onForkFromMessage === next.onForkFromMessage
   );
 }
@@ -429,6 +475,50 @@ function currentActivityClusterIndices(
     if (unit.message.role === "user") break;
   }
   return indices;
+}
+
+function subagentTasksForActivityUnits(
+  units: DisplayUnit[],
+  rounds: SubagentRoundTasks[],
+): Map<number, SubagentActivityTask[]> {
+  // ponytail: pair persisted rounds with spawn activity in chronological order;
+  // replace with a canonical parent-turn id when the protocol exposes one.
+  const activityIndices = units.flatMap((unit, index) => unit.type === "activity" ? [index] : []);
+  if (!activityIndices.length || !rounds.length) return new Map();
+
+  const delegationIndices = activityIndices.filter((index) => {
+    const unit = units[index];
+    return unit.type === "activity" && unit.messages.some((message) => (
+      message.toolEvents?.some((event) => event.name === "spawn")
+      || message.traces?.some((trace) => trace.includes("Delegated task") || trace.includes("spawn"))
+      || message.content.includes("Delegated task")
+      || message.content.includes("spawn(")
+    ));
+  });
+  const anchors = delegationIndices.length >= rounds.length ? delegationIndices : activityIndices;
+  const orderedRounds = [...rounds].sort((left, right) => subagentRoundSortKey(left.turnId) - subagentRoundSortKey(right.turnId));
+  const result = new Map<number, SubagentActivityTask[]>();
+  orderedRounds.forEach((round, index) => {
+    const activityIndex = anchors[index];
+    if (activityIndex !== undefined) result.set(activityIndex, round.tasks);
+  });
+  return result;
+}
+
+function subagentRoundSortKey(turnId: string): number {
+  const timestamp = Number(turnId.split(":").at(-1));
+  return Number.isFinite(timestamp) ? timestamp : Number.MAX_SAFE_INTEGER;
+}
+
+function mergeSubagentTasks(
+  ...groups: SubagentActivityTask[][]
+): SubagentActivityTask[] {
+  const seen = new Set<string>();
+  return groups.flat().filter((task) => {
+    if (seen.has(task.task_id)) return false;
+    seen.add(task.task_id);
+    return true;
+  });
 }
 
 export function unitKeysForDisplay(units: DisplayUnit[]): string[] {

--- a/webui/src/components/thread/ThreadShell.tsx
+++ b/webui/src/components/thread/ThreadShell.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 
 import { FilePreviewAvailabilityProvider } from "@/components/FilePreviewAvailabilityContext";
 import { FilePreviewPanel } from "@/components/FilePreviewPanel";
+import { ResizeDivider } from "@/components/ResizeDivider";
 import { SessionHandleLabel } from "@/components/SessionHandleLabel";
 import { PromptNavigator } from "@/components/thread/PromptNavigator";
 import { SessionInfoPopover } from "@/components/thread/SessionInfoPopover";
@@ -13,6 +14,7 @@ import type { ModelPresetOption } from "@/components/thread/ModelPresetBadge";
 import { ThreadHeader } from "@/components/thread/ThreadHeader";
 import { StreamErrorNotice } from "@/components/thread/StreamErrorNotice";
 import { ThreadViewport, type ThreadViewportHandle } from "@/components/thread/ThreadViewport";
+import { SubagentDetailPanel } from "@/components/thread/SubagentDetailPanel";
 import { useNanobotStream, type SendAttachment, type SendOptions } from "@/hooks/useNanobotStream";
 import { useSessionHistory } from "@/hooks/useSessions";
 import {
@@ -40,6 +42,8 @@ import type {
   SettingsPayload,
   SlashCommand,
   SkillSummary,
+  SubagentActivityTask,
+  SubagentDetailSnapshot,
   UIMessage,
   WorkspaceScopePayload,
   WorkspacesPayload,
@@ -276,6 +280,38 @@ const FILE_PREVIEW_MIN_WIDTH = 360;
 const FILE_PREVIEW_MAX_WIDTH = 860;
 const FILE_PREVIEW_MIN_MAIN_WIDTH = 420;
 const FILE_PREVIEW_CLOSE_ANIMATION_MS = 320;
+const SUBAGENT_PANEL_DEFAULT_RATIO = 0.42;
+const SUBAGENT_PANEL_MIN_RATIO = 0.28;
+const SUBAGENT_PANEL_MAX_RATIO = 0.6;
+const SUBAGENT_PANEL_MIN_WIDTH = 320;
+const SUBAGENT_PANEL_MIN_MAIN_WIDTH = 420;
+const SUBAGENT_PANEL_DIVIDER_WIDTH = 12;
+
+export function clampSubagentPanelRatio(
+  ratio: number,
+  shellWidth: number,
+  mainMinWidth = SUBAGENT_PANEL_MIN_MAIN_WIDTH,
+  subagentMinWidth = SUBAGENT_PANEL_MIN_WIDTH,
+): number {
+  const contentWidth = Math.max(shellWidth - SUBAGENT_PANEL_DIVIDER_WIDTH, 1);
+  const minRatio = Math.max(
+    SUBAGENT_PANEL_MIN_RATIO,
+    subagentMinWidth / contentWidth,
+  );
+  const maxRatio = Math.min(
+    SUBAGENT_PANEL_MAX_RATIO,
+    1 - mainMinWidth / contentWidth,
+  );
+  if (maxRatio < minRatio) {
+    // The grid below owns the hard minimum widths. When they cannot both fit,
+    // prefer preserving the main conversation instead of trusting the stale ratio.
+    return Math.min(
+      SUBAGENT_PANEL_MAX_RATIO,
+      Math.max(SUBAGENT_PANEL_MIN_RATIO, maxRatio),
+    );
+  }
+  return Math.min(maxRatio, Math.max(minRatio, ratio));
+}
 
 type FilePreviewAvailabilityCacheEntry = {
   available?: boolean;
@@ -287,10 +323,20 @@ function clampFilePreviewWidth(width: number, maxWidth: number): number {
   return Math.min(Math.max(width, FILE_PREVIEW_MIN_WIDTH), maxWidth);
 }
 
-function maxFilePreviewWidth(containerWidth: number): number {
+export function maxFilePreviewWidth(containerWidth: number, withSubagent = false): number {
+  const mainMinWidth = withSubagent ? 320 : FILE_PREVIEW_MIN_MAIN_WIDTH;
+  const subagentMinWidth = withSubagent ? 280 : 0;
+  const dividerCount = withSubagent ? 1 : 0;
+  const filePreviewMinWidth = withSubagent ? 320 : FILE_PREVIEW_MIN_WIDTH;
   return Math.max(
-    FILE_PREVIEW_MIN_WIDTH,
-    Math.min(FILE_PREVIEW_MAX_WIDTH, containerWidth - FILE_PREVIEW_MIN_MAIN_WIDTH),
+    filePreviewMinWidth,
+    Math.min(
+      FILE_PREVIEW_MAX_WIDTH,
+      containerWidth
+        - mainMinWidth
+        - subagentMinWidth
+        - dividerCount * SUBAGENT_PANEL_DIVIDER_WIDTH,
+    ),
   );
 }
 
@@ -693,9 +739,14 @@ export function ThreadShell({
   const [filePreviewWidth, setFilePreviewWidth] = useState(FILE_PREVIEW_DEFAULT_WIDTH);
   const [quotedContext, setQuotedContext] = useState<string | null>(null);
   const [composerFocusSignal, setComposerFocusSignal] = useState(0);
+  const [subagentPanelOpen, setSubagentPanelOpen] = useState(false);
+  const [subagentPanelRatio, setSubagentPanelRatio] = useState(SUBAGENT_PANEL_DEFAULT_RATIO);
+  const [selectedSubagentTaskId, setSelectedSubagentTaskId] = useState<string | null>(null);
+  const [openSubagentTaskIds, setOpenSubagentTaskIds] = useState<string[]>([]);
   const shellRef = useRef<HTMLElement | null>(null);
   const composerSurfaceRef = useRef<HTMLDivElement | null>(null);
   const filePreviewWidthRef = useRef(FILE_PREVIEW_DEFAULT_WIDTH);
+  const subagentPanelRatioRef = useRef(SUBAGENT_PANEL_DEFAULT_RATIO);
   const filePreviewCloseTimerRef = useRef<number | null>(null);
   const pendingFirstRef = useRef<PendingFirstMessage | null>(null);
   const [pendingFirstTargetChatId, setPendingFirstTargetChatId] = useState<string | null>(null);
@@ -736,6 +787,9 @@ export function ThreadShell({
     isStreaming,
     runStartedAt,
     goalState,
+    turnEnded,
+    subagents,
+    subagentDetails,
     send,
     transcribeAudio,
     stop,
@@ -767,6 +821,10 @@ export function ThreadShell({
   }, [filePreviewWidth]);
 
   useEffect(() => {
+    subagentPanelRatioRef.current = subagentPanelRatio;
+  }, [subagentPanelRatio]);
+
+  useEffect(() => {
     if (filePreviewCloseTimerRef.current !== null) {
       window.clearTimeout(filePreviewCloseTimerRef.current);
       filePreviewCloseTimerRef.current = null;
@@ -775,6 +833,9 @@ export function ThreadShell({
     setFilePreviewPath(null);
     setQuotedContext(null);
     setSubmittedViewportTurnId(null);
+    setSubagentPanelOpen(false);
+    setSelectedSubagentTaskId(null);
+    setOpenSubagentTaskIds([]);
   }, [historyKey]);
 
   useEffect(() => {
@@ -806,6 +867,92 @@ export function ThreadShell({
   const currentRunStartedAt = messagesReady ? runStartedAt : null;
   const currentGoalState = messagesReady ? goalState : undefined;
   const turnActive = messagesReady && (isStreaming || currentRunStartedAt !== null);
+  const currentSubagents = messagesReady ? subagents : [];
+  const currentSubagentActivity = useMemo<SubagentActivityTask[]>(
+    () => currentSubagents.map((item) => ({
+      task_id: item.subagent_id,
+      label: item.label,
+      status: item.status,
+      error: item.error ?? null,
+    })),
+    [currentSubagents],
+  );
+  const openSubagent = useCallback((taskId: string) => {
+    setOpenSubagentTaskIds((previous) => previous.includes(taskId) ? previous : [...previous, taskId]);
+    setSelectedSubagentTaskId(taskId);
+    setSubagentPanelOpen(true);
+  }, []);
+  const closeSubagent = useCallback((taskId: string) => {
+    setOpenSubagentTaskIds((previous) => {
+      const next = previous.filter((id) => id !== taskId);
+      if (next.length === 0) {
+        setSelectedSubagentTaskId(null);
+        setSubagentPanelOpen(false);
+      } else {
+        setSelectedSubagentTaskId((selected) => selected === taskId ? next[next.length - 1] : selected);
+      }
+      return next;
+    });
+  }, []);
+  const handleSubagentPanelChange = useCallback((open: boolean) => {
+    setSubagentPanelOpen(open);
+    if (!open) {
+      setOpenSubagentTaskIds([]);
+      setSelectedSubagentTaskId(null);
+    }
+  }, []);
+  const availableSubagentDetails = useMemo(() => {
+    const byId = new Map<string, SubagentDetailSnapshot>();
+    for (const item of subagentDetails) byId.set(item.task_id, item);
+    for (const item of currentSubagents) {
+      if (!byId.has(item.subagent_id)) {
+        byId.set(item.subagent_id, {
+          task_id: item.subagent_id,
+          label: item.label,
+          status: item.status,
+          turn_id: item.turn_id,
+          stop_reason: item.stop_reason,
+          error: item.error,
+        });
+      }
+    }
+    return [...byId.values()];
+  }, [currentSubagents, subagentDetails]);
+  const openedSubagentDetails = useMemo(
+    () => openSubagentTaskIds
+      .map((taskId) => availableSubagentDetails.find((item) => item.task_id === taskId))
+      .filter((item): item is SubagentDetailSnapshot => item !== undefined),
+    [availableSubagentDetails, openSubagentTaskIds],
+  );
+  const subagentPanelVisible = subagentPanelOpen && openedSubagentDetails.length > 0;
+  const filePreviewVisible = Boolean(filePreviewPath && historyKey);
+  const combinedPanelVisible = subagentPanelVisible && filePreviewVisible;
+  const subagentLayoutMainMinWidth = combinedPanelVisible ? 320 : SUBAGENT_PANEL_MIN_MAIN_WIDTH;
+  const subagentLayoutMinWidth = combinedPanelVisible ? 280 : SUBAGENT_PANEL_MIN_WIDTH;
+  const historicalSubagentRounds = useMemo(() => {
+    const rounds = new Map<string, SubagentDetailSnapshot[]>();
+    for (const item of subagentDetails) {
+      const key = item.turn_id || "unknown";
+      const items = rounds.get(key) ?? [];
+      items.push(item);
+      rounds.set(key, items);
+    }
+    const currentTaskIds = new Set(currentSubagents.map((item) => item.subagent_id));
+    return [...rounds.entries()]
+      .map(([turnId, items]) => {
+        const retainedItems = items.filter((item) => !currentTaskIds.has(item.task_id));
+        return {
+          turnId,
+          tasks: retainedItems.map((item) => ({
+            task_id: item.task_id,
+            label: item.label,
+            status: item.status ?? "completed",
+            error: item.error ?? null,
+          })),
+        };
+      })
+      .filter((round) => round.tasks.length > 0);
+  }, [currentSubagents, subagentDetails]);
   const restoredViewportTurnId = useMemo(
     () => turnActive ? latestActiveTurnId(displayMessages, currentRunStartedAt) : null,
     [currentRunStartedAt, displayMessages, turnActive],
@@ -1356,7 +1503,10 @@ export function ThreadShell({
     const panel = event.currentTarget.closest<HTMLElement>("[data-file-preview-panel]");
     const shellRect = shellRef.current?.getBoundingClientRect();
     const rightEdge = shellRect?.right ?? window.innerWidth;
-    const maxWidth = maxFilePreviewWidth(shellRect?.width ?? window.innerWidth);
+    const maxWidth = maxFilePreviewWidth(
+      shellRect?.width ?? window.innerWidth,
+      subagentPanelVisible,
+    );
     const originalBodyCursor = document.body.style.cursor;
     const originalBodyUserSelect = document.body.style.userSelect;
     const originalPanelTransition = panel?.style.transition ?? "";
@@ -1373,6 +1523,7 @@ export function ThreadShell({
       if (frame !== null) return;
       frame = window.requestAnimationFrame(() => {
         frame = null;
+        setFilePreviewWidth(nextWidth);
         panel?.style.setProperty("--file-preview-width", `${nextWidth}px`);
         panel?.style.setProperty("--file-preview-slot-width", `${nextWidth}px`);
       });
@@ -1401,13 +1552,98 @@ export function ThreadShell({
     window.addEventListener("pointermove", handlePointerMove);
     window.addEventListener("pointerup", handlePointerUp);
     window.addEventListener("pointercancel", handlePointerUp);
-  }, []);
+  }, [subagentPanelVisible]);
+
+  const handleSubagentPanelResizeStart = useCallback((event: ReactPointerEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const shellRect = shellRef.current?.getBoundingClientRect();
+    if (!shellRect || shellRect.width <= 0) return;
+
+    const originalBodyCursor = document.body.style.cursor;
+    const originalBodyUserSelect = document.body.style.userSelect;
+    let nextRatio = subagentPanelRatioRef.current;
+    const fileWidth = filePreviewVisible ? filePreviewWidthRef.current : 0;
+    const flexibleShellWidth = Math.max(shellRect.width - fileWidth, 1);
+    const flexibleContentWidth = Math.max(
+      flexibleShellWidth - SUBAGENT_PANEL_DIVIDER_WIDTH,
+      1,
+    );
+
+    const applyRatio = (clientX: number) => {
+      nextRatio = clampSubagentPanelRatio(
+        (shellRect.right - fileWidth - clientX) / flexibleContentWidth,
+        flexibleShellWidth,
+        subagentLayoutMainMinWidth,
+        subagentLayoutMinWidth,
+      );
+      subagentPanelRatioRef.current = nextRatio;
+      setSubagentPanelRatio(nextRatio);
+    };
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      moveEvent.preventDefault();
+      applyRatio(moveEvent.clientX);
+    };
+    const handlePointerUp = () => {
+      document.body.style.cursor = originalBodyCursor;
+      document.body.style.userSelect = originalBodyUserSelect;
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+      window.removeEventListener("pointercancel", handlePointerUp);
+    };
+
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    applyRatio(event.clientX);
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
+    window.addEventListener("pointercancel", handlePointerUp);
+  }, [filePreviewVisible, subagentLayoutMainMinWidth, subagentLayoutMinWidth]);
+
+  const handleSubagentPanelResizeKeyDown = useCallback((event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+    event.preventDefault();
+    const shellWidth = shellRef.current?.getBoundingClientRect().width ?? window.innerWidth;
+    const flexibleShellWidth = Math.max(
+      shellWidth - (filePreviewVisible ? filePreviewWidthRef.current : 0),
+      1,
+    );
+    const delta = event.key === "ArrowRight" ? 0.04 : -0.04;
+    const nextRatio = clampSubagentPanelRatio(
+      subagentPanelRatioRef.current + delta,
+      flexibleShellWidth,
+      subagentLayoutMainMinWidth,
+      subagentLayoutMinWidth,
+    );
+    subagentPanelRatioRef.current = nextRatio;
+    setSubagentPanelRatio(nextRatio);
+  }, [filePreviewVisible, subagentLayoutMainMinWidth, subagentLayoutMinWidth]);
+
+  useEffect(() => {
+    if (!subagentPanelVisible) return;
+    const clampToShell = () => {
+      const shellWidth = shellRef.current?.getBoundingClientRect().width ?? window.innerWidth;
+      const nextRatio = clampSubagentPanelRatio(subagentPanelRatioRef.current, shellWidth);
+      subagentPanelRatioRef.current = nextRatio;
+      setSubagentPanelRatio(nextRatio);
+    };
+    const observer = typeof ResizeObserver === "undefined"
+      ? null
+      : new ResizeObserver(clampToShell);
+    if (shellRef.current) observer?.observe(shellRef.current);
+    window.addEventListener("resize", clampToShell);
+    clampToShell();
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", clampToShell);
+    };
+  }, [subagentPanelVisible]);
 
   useEffect(() => {
     if (!filePreviewPath) return;
     const clampToShell = () => {
       const shellWidth = shellRef.current?.getBoundingClientRect().width ?? window.innerWidth;
-      const maxWidth = maxFilePreviewWidth(shellWidth);
+      const maxWidth = maxFilePreviewWidth(shellWidth, subagentPanelVisible);
       const nextWidth = clampFilePreviewWidth(filePreviewWidthRef.current, maxWidth);
       filePreviewWidthRef.current = nextWidth;
       setFilePreviewWidth(nextWidth);
@@ -1417,7 +1653,7 @@ export function ThreadShell({
     return () => {
       window.removeEventListener("resize", clampToShell);
     };
-  }, [filePreviewPath]);
+  }, [filePreviewPath, subagentPanelVisible]);
 
   const handleForkFromMessage = useCallback(
     async (beforeUserIndex: number) => {
@@ -1576,9 +1812,33 @@ export function ThreadShell({
     />
   ) : null;
 
+  const subagentPanelGridStyle = (() => {
+    const tracks = [
+      subagentPanelVisible
+        ? `minmax(${subagentLayoutMainMinWidth}px, ${1 - subagentPanelRatio}fr)`
+        : filePreviewVisible
+          ? `minmax(${FILE_PREVIEW_MIN_MAIN_WIDTH}px, 1fr)`
+          : "minmax(0, 1fr)",
+    ];
+    if (subagentPanelVisible) {
+      tracks.push(
+        `${SUBAGENT_PANEL_DIVIDER_WIDTH}px`,
+        `minmax(${subagentLayoutMinWidth}px, ${subagentPanelRatio}fr)`,
+      );
+    }
+    if (filePreviewVisible) tracks.push(`${filePreviewWidth}px`);
+    return { gridTemplateColumns: tracks.join(" ") };
+  })();
+
   return (
-    <section ref={shellRef} className="relative flex min-h-0 flex-1 overflow-hidden">
-      <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
+    <section
+      ref={shellRef}
+      className="relative grid min-h-0 min-w-0 flex-1 overflow-hidden"
+      style={subagentPanelGridStyle}
+    >
+      <div
+        className="relative flex min-w-0 flex-col overflow-hidden"
+      >
         {hideHeaderTitle && !temporary && session?.handle ? (
           <div
             aria-label={`Session @${session.handle.name}`}
@@ -1602,6 +1862,7 @@ export function ThreadShell({
             messages={displayMessages}
             temporary={temporary}
             isStreaming={turnActive}
+            turnEnded={turnEnded}
             runStartedAt={currentRunStartedAt}
             emptyState={emptyState}
             composer={composerPortalTarget === undefined ? composer : null}
@@ -1610,6 +1871,8 @@ export function ThreadShell({
             conversationKey={historyKey}
             conversationReady={messagesReady}
             showScrollToBottomButton={!!session}
+            subagents={currentSubagentActivity}
+            subagentRounds={historicalSubagentRounds}
             cliApps={cliApps}
             mcpPresets={mcpPresets}
             slashCommands={availableSlashCommands}
@@ -1619,11 +1882,41 @@ export function ThreadShell({
             userMessageOffset={userMessageOffset}
             onLoadOlder={loadOlder}
             onOpenFilePreview={historyKey ? handleOpenFilePreview : undefined}
+            onOpenSubagent={openSubagent}
             onForkFromMessage={onForkChat ? handleForkFromMessage : undefined}
             onQuoteSelection={session ? handleQuoteSelection : undefined}
           />
         </FilePreviewAvailabilityProvider>
       </div>
+      {subagentPanelVisible ? (
+        <>
+          <ResizeDivider
+            ariaLabel="调整主会话与 Subagent 详情比例"
+            ariaValueMin={Math.round(SUBAGENT_PANEL_MIN_RATIO * 100)}
+            ariaValueMax={Math.round(SUBAGENT_PANEL_MAX_RATIO * 100)}
+            ariaValueNow={Math.round(subagentPanelRatio * 100)}
+            ariaValueText={`${Math.round(subagentPanelRatio * 100)}% Subagent 详情`}
+            ariaControls="subagent-detail-panel"
+            className="relative z-10 h-full"
+            onPointerDown={handleSubagentPanelResizeStart}
+            onKeyDown={handleSubagentPanelResizeKeyDown}
+            title="拖动调整主会话与 Subagent 详情比例"
+            testId="subagent-panel-resizer"
+          />
+          <div
+            className="min-h-0 min-w-0 overflow-hidden"
+          >
+            <SubagentDetailPanel
+              details={messagesReady ? openedSubagentDetails : []}
+              selectedTaskId={selectedSubagentTaskId}
+              open
+              onOpenChange={handleSubagentPanelChange}
+              onSelect={setSelectedSubagentTaskId}
+              onClose={closeSubagent}
+            />
+          </div>
+        </>
+      ) : null}
       {headerPortalTarget && headerActive
         ? createPortal(threadHeader, headerPortalTarget)
         : null}

--- a/webui/src/components/thread/ThreadShell.tsx
+++ b/webui/src/components/thread/ThreadShell.tsx
@@ -1644,6 +1644,7 @@ export function ThreadShell({
           token={token}
           desktopWidth={filePreviewWidth}
           isClosing={filePreviewClosing}
+          canOpenSystem={workspaceScope?.access_mode !== "restricted"}
           onResizeStart={handleFilePreviewResizeStart}
           onClose={handleCloseFilePreview}
         />

--- a/webui/src/components/thread/ThreadViewport.tsx
+++ b/webui/src/components/thread/ThreadViewport.tsx
@@ -14,7 +14,7 @@ import { isNativeRuntime } from "@/lib/runtime";
 import { useTranslation } from "react-i18next";
 
 import { PromptRail } from "@/components/thread/PromptRail";
-import { ThreadMessages } from "@/components/thread/ThreadMessages";
+import { ThreadMessages, type SubagentRoundTasks } from "@/components/thread/ThreadMessages";
 import { isAgentActivityMember } from "@/components/thread/AgentActivityCluster";
 import { ThreadCameraController } from "@/components/thread/thread-camera";
 import {
@@ -27,7 +27,7 @@ import {
   promptTop,
 } from "@/components/thread/promptNavigation";
 import { cn } from "@/lib/utils";
-import type { CliAppInfo, McpPresetInfo, SlashCommand, UIMessage } from "@/lib/types";
+import type { CliAppInfo, McpPresetInfo, SlashCommand, SubagentActivityTask, UIMessage } from "@/lib/types";
 
 export interface ThreadViewportHandle {
   jumpToUserPrompt: (promptId: string) => void;
@@ -38,6 +38,7 @@ interface ThreadViewportProps {
   messages: UIMessage[];
   temporary?: boolean;
   isStreaming: boolean;
+  turnEnded?: boolean;
   /** Optimistic or canonical start time for the active turn, in unix seconds. */
   runStartedAt?: number | null;
   composer?: ReactNode;
@@ -50,6 +51,8 @@ interface ThreadViewportProps {
   showScrollToBottomButton?: boolean;
   cliApps?: CliAppInfo[];
   mcpPresets?: McpPresetInfo[];
+  subagents?: SubagentActivityTask[];
+  subagentRounds?: SubagentRoundTasks[];
   slashCommands?: SlashCommand[];
   forkBoundaryMessageCount?: number | null;
   hasMoreBefore?: boolean;
@@ -57,6 +60,7 @@ interface ThreadViewportProps {
   userMessageOffset?: number;
   onLoadOlder?: () => Promise<void> | void;
   onOpenFilePreview?: (path: string) => void;
+  onOpenSubagent?: (taskId: string) => void;
   onForkFromMessage?: (beforeUserIndex: number) => void;
   onQuoteSelection?: (text: string) => void;
 }
@@ -174,6 +178,7 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
   messages,
   temporary = false,
   isStreaming,
+  turnEnded = true,
   runStartedAt = null,
   composer,
   emptyState,
@@ -185,6 +190,8 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
   showScrollToBottomButton = true,
   cliApps = [],
   mcpPresets = [],
+  subagents = [],
+  subagentRounds = [],
   slashCommands = [],
   forkBoundaryMessageCount = null,
   hasMoreBefore = false,
@@ -192,6 +199,7 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
   userMessageOffset = 0,
   onLoadOlder,
   onOpenFilePreview,
+  onOpenSubagent,
   onForkFromMessage,
   onQuoteSelection,
 }, ref) {
@@ -757,14 +765,18 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
                   messages={visibleMessages}
                   temporary={temporary}
                   isStreaming={isStreaming}
+                  turnEnded={turnEnded}
                   activeTurnId={activeTurnId}
                   runStartedAt={runStartedAt}
                   hiddenUserMessageCount={hiddenUserMessageCount}
                   cliApps={cliApps}
                   mcpPresets={mcpPresets}
+                  subagents={subagents}
+                  subagentRounds={subagentRounds}
                   slashCommands={slashCommands}
                   forkBoundaryMessageCount={visibleForkBoundaryMessageCount}
                   onOpenFilePreview={onOpenFilePreview}
+                  onOpenSubagent={onOpenSubagent}
                   onForkFromMessage={onForkFromMessage}
                   onQuoteSelection={onQuoteSelection}
                 />

--- a/webui/src/components/thread/ThreadViewport.tsx
+++ b/webui/src/components/thread/ThreadViewport.tsx
@@ -10,6 +10,7 @@ import {
   useState,
 } from "react";
 import { ArrowDown } from "lucide-react";
+import { isNativeRuntime } from "@/lib/runtime";
 import { useTranslation } from "react-i18next";
 
 import { PromptRail } from "@/components/thread/PromptRail";
@@ -721,8 +722,8 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
             ? "overflow-hidden"
             : cn(
                 "thread-viewport-scrollbar scroll-auto",
-                "[overflow-anchor:none] [scrollbar-width:none]",
-                "[&::-webkit-scrollbar]:hidden",
+                "[overflow-anchor:none]",
+                !isNativeRuntime() && "[scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
                 hasVerticalOverflow ? "overflow-y-auto" : "overflow-hidden",
               ),
         )}
@@ -735,7 +736,7 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
           className={cn(
             "thread-layout mx-auto grid min-h-full w-full",
             hasMessages
-              ? "h-full max-w-[64rem]"
+              ? "h-full"
               : "max-w-[72rem] px-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] pt-6 sm:px-4 sm:py-12",
           )}
         >
@@ -746,8 +747,8 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
               className={cn(
                 "thread-viewport-scrollbar row-start-1 flex min-h-0 min-w-0 flex-col",
                 "scroll-auto justify-start overflow-x-hidden px-3 pb-4 pt-4 sm:px-4",
-                "[overflow-anchor:none] [scrollbar-width:none]",
-                "[&::-webkit-scrollbar]:hidden",
+                "[overflow-anchor:none]",
+                !isNativeRuntime() && "[scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
                 hasVerticalOverflow ? "overflow-y-auto" : "overflow-hidden",
               )}
             >

--- a/webui/src/components/thread/activity/SubagentActivityGroup.tsx
+++ b/webui/src/components/thread/activity/SubagentActivityGroup.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import { AlertCircle, CheckCircle2, ChevronDown, ChevronRight, Circle, Clock3 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { cn } from "@/lib/utils";
+import type { SubagentActivityTask } from "@/lib/types";
+
+interface SubagentActivityGroupProps {
+  tasks: SubagentActivityTask[];
+  onOpenTask?: (taskId: string) => void;
+}
+
+function elapsedLabel(value?: number): string {
+  if (!Number.isFinite(value) || value == null) return "—";
+  const seconds = Math.max(0, Math.round(value / 1000));
+  return seconds < 60 ? `${seconds}s` : `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+export function SubagentActivityGroup({ tasks, onOpenTask }: SubagentActivityGroupProps) {
+  const { t } = useTranslation();
+  const [expandedTaskId, setExpandedTaskId] = useState<string | null>(null);
+  const running = tasks.filter((task) => task.status === "running").length;
+  const statusLabel = running > 0
+    ? t("message.subagentsRunning", { count: running, defaultValue: `${running} 个运行中` })
+    : t("message.subagentsCompleted", { defaultValue: "已完成" });
+
+  return (
+    <section
+      className="mt-2 border-t border-border/55 pt-2"
+      data-testid="subagent-activity-group"
+      aria-label={t("message.subagents", { defaultValue: "Subagents" })}
+    >
+      <div className="mb-1 flex items-center justify-between gap-3 text-[12px] text-muted-foreground">
+        <span className="font-medium">
+          {t("message.subagents", { defaultValue: "Subagents" })} · {tasks.length}
+        </span>
+        <span>{statusLabel}</span>
+      </div>
+      <div className="flex flex-col gap-0.5">
+        {tasks.map((task) => {
+          const expanded = expandedTaskId === task.task_id;
+          const failed = task.status === "failed";
+          const completed = task.status === "completed";
+          const latest = task.latest_tool?.name;
+          return (
+            <div key={task.task_id} className="rounded-md">
+              <button
+                type="button"
+                data-thread-disclosure=""
+                className="group flex min-h-7 w-full items-center gap-2 rounded-md px-1.5 text-left text-[12px] text-muted-foreground hover:bg-muted/45 hover:text-foreground"
+                aria-expanded={expanded}
+                onClick={() => {
+                  onOpenTask?.(task.task_id);
+                  setExpandedTaskId(expanded ? null : task.task_id);
+                }}
+              >
+                {failed ? (
+                  <AlertCircle className="h-3.5 w-3.5 shrink-0 text-destructive" aria-hidden />
+                ) : completed ? (
+                  <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-emerald-600 dark:text-emerald-400" aria-hidden />
+                ) : (
+                  <Circle className="h-3.5 w-3.5 shrink-0 text-sky-600 dark:text-sky-400" aria-hidden />
+                )}
+                <span className="min-w-0 flex-1 truncate font-medium">{task.label}</span>
+                {task.iteration != null ? <span className="shrink-0 text-muted-foreground/65">第 {task.iteration} 轮</span> : null}
+                <span className="flex shrink-0 items-center gap-1 text-muted-foreground/65">
+                  <Clock3 className="h-3 w-3" aria-hidden />
+                  {elapsedLabel(task.elapsed_ms)}
+                </span>
+                {expanded ? <ChevronDown className="h-3 w-3" aria-hidden /> : <ChevronRight className="h-3 w-3" aria-hidden />}
+              </button>
+              {expanded ? (
+                <div className="ml-7 border-l border-border/50 pl-3 py-1 text-[11px] text-muted-foreground/75">
+                  <div>
+                    {t("message.subagentLatestActivity", { defaultValue: "最近活动" })}：{latest || t("message.subagentNoActivity", { defaultValue: "等待活动" })}
+                  </div>
+                  {task.recent_tools?.length ? (
+                    <div className="mt-1 flex flex-wrap gap-x-2 gap-y-0.5">
+                      {task.recent_tools.map((tool, index) => (
+                        <span key={`${tool.name}-${tool.phase}-${index}`} className={cn(tool.phase === "error" && "text-destructive")}>
+                          {tool.name}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
+                  {failed ? <div className="mt-1 text-destructive">{task.error || t("message.subagentFailed", { defaultValue: "执行失败" })}</div> : null}
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/webui/src/components/thread/activity/ThinkingReasoningShell.tsx
+++ b/webui/src/components/thread/activity/ThinkingReasoningShell.tsx
@@ -7,6 +7,8 @@ interface ThinkingReasoningShellProps {
   active: boolean;
   expanded: boolean;
   label: string;
+  summary?: ReactNode;
+  detailsId?: string;
   children: ReactNode;
   viewportRef: Ref<HTMLDivElement>;
   contentRef: Ref<HTMLDivElement>;
@@ -21,6 +23,8 @@ export function ThinkingReasoningShell({
   active,
   expanded,
   label,
+  summary,
+  detailsId,
   children,
   viewportRef,
   contentRef,
@@ -36,40 +40,43 @@ export function ThinkingReasoningShell({
       data-state={active ? "thinking" : "done"}
     >
       {hasDetails ? (
-        <button
-          type="button"
-          data-thread-disclosure=""
-          className="group inline-flex min-h-5 items-center self-start gap-1.5 bg-transparent p-0"
-          onClick={onToggle}
-          aria-expanded={expanded}
-          aria-label={label}
-          aria-live={active ? "polite" : undefined}
-        >
-          <span
-            className={cn(
-              "min-w-0 truncate text-[13px] font-medium leading-[18px] text-muted-foreground/70",
-              active && "animate-pulse motion-reduce:animate-none",
-            )}
+        summary ?? (
+          <button
+            type="button"
+            data-thread-disclosure=""
+            className="group inline-flex min-h-5 items-center self-start gap-1.5 bg-transparent p-0"
+            onClick={onToggle}
+            aria-expanded={expanded}
+            {...(detailsId ? { "aria-controls": detailsId } : {})}
+            aria-label={label}
+            aria-live={active ? "polite" : undefined}
           >
-            {label}
-          </span>
-          <span
-            className={cn(
-              "inline-flex shrink-0 transition-transform [transition-duration:220ms] ease-out",
-              "motion-reduce:transition-none",
-              expanded && "rotate-180",
-            )}
-          >
-            <ChevronDown
+            <span
               className={cn(
-                "h-3 w-3 text-muted-foreground/60 transition-colors duration-200",
-                "group-hover:text-muted-foreground motion-reduce:transition-none",
+                "min-w-0 truncate text-[13px] font-medium leading-[18px] text-muted-foreground/70",
+                active && "animate-pulse motion-reduce:animate-none",
               )}
-              strokeWidth={1.8}
-              aria-hidden
-            />
-          </span>
-        </button>
+            >
+              {label}
+            </span>
+            <span
+              className={cn(
+                "inline-flex shrink-0 transition-transform [transition-duration:220ms] ease-out",
+                "motion-reduce:transition-none",
+                expanded && "rotate-180",
+              )}
+            >
+              <ChevronDown
+                className={cn(
+                  "h-3 w-3 text-muted-foreground/60 transition-colors duration-200",
+                  "group-hover:text-muted-foreground motion-reduce:transition-none",
+                )}
+                strokeWidth={1.8}
+                aria-hidden
+              />
+            </span>
+          </button>
+        )
       ) : (
         <div
           className="inline-flex min-h-5 items-center self-start"
@@ -90,6 +97,7 @@ export function ThinkingReasoningShell({
 
       {hasDetails ? (
         <div
+          id={detailsId}
           {...(!expanded ? { inert: "" } : {})}
           aria-hidden={!expanded}
           className={cn(

--- a/webui/src/components/ui/sheet.tsx
+++ b/webui/src/components/ui/sheet.tsx
@@ -60,6 +60,7 @@ interface SheetContentProps
     VariantProps<typeof sheetVariants> {
   closeButtonClassName?: string;
   showCloseButton?: boolean;
+  showOverlay?: boolean;
 }
 
 const SheetContent = React.forwardRef<
@@ -70,16 +71,17 @@ const SheetContent = React.forwardRef<
     side = "right",
     className,
     children,
-    closeButtonClassName,
-    showCloseButton = true,
-    ...props
-  },
+  closeButtonClassName,
+  showCloseButton = true,
+  showOverlay = true,
+  ...props
+},
   ref,
 ) => {
   const { t } = useTranslation();
   return (
     <SheetPortal>
-      <SheetOverlay />
+      {showOverlay ? <SheetOverlay /> : null}
       <DialogPrimitive.Content
         ref={ref}
         className={cn(

--- a/webui/src/globals.css
+++ b/webui/src/globals.css
@@ -118,11 +118,11 @@
     overflow: hidden;
   }
 
-  * {
-    scrollbar-color: var(--scrollbar-thumb) transparent;
-    scrollbar-width: thin;
-  }
-
+  /* Custom scrollbars everywhere. Keep these as ::-webkit-scrollbar only: setting
+     the standard scrollbar-width/scrollbar-color properties makes Chromium ignore
+     ::-webkit-scrollbar entirely and fall back to the macOS overlay scrollbar,
+     which hides until the user actively scrolls (2026-08-13 实测：thin → delta=0
+     隐藏，仅 webkit 样式 → delta=10 常驻可见). */
   *::-webkit-scrollbar {
     width: 8px;
     height: 8px;
@@ -247,15 +247,55 @@
     }
   }
 
+  /* Desktop shell scrollbars: custom always-rendered scrollbars (overlay, so no
+     layout space is taken on macOS) whose thumb is hidden at rest and fades in
+     while the user scrolls — App.tsx toggles `native-scrolling` on <html> on any
+     scroll event (debounced ~400ms). Component-level `scrollbar-width:none` is
+     neutralised via scrollbar-width:auto (Chromium still honours the
+     ::-webkit-scrollbar rules below), and the message list's component-level
+     `::-webkit-scrollbar:hidden` is dropped for native hosts in ThreadViewport.
+     Wide tables and the file preview keep their always-visible thumb via the
+     more specific rules further down. */
   html.native-host * {
-    scrollbar-width: none;
+    scrollbar-width: auto;
     scrollbar-gutter: auto !important;
   }
-
   html.native-host *::-webkit-scrollbar {
-    display: none;
-    width: 0;
-    height: 0;
+    display: block;
+    width: 10px;
+    height: 10px;
+  }
+  html.native-host *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  html.native-host *::-webkit-scrollbar-thumb {
+    background: color-mix(in srgb, currentColor 22%, transparent);
+    border-radius: 6px;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+  }
+  html.native-host.native-scrolling *::-webkit-scrollbar-thumb {
+    opacity: 1;
+  }
+  html.native-host [data-testid="markdown-data-table"]::-webkit-scrollbar-thumb,
+  html.native-host [data-file-preview-scroll]::-webkit-scrollbar-thumb {
+    opacity: 1 !important;
+  }
+
+  /* In the desktop shell, the native-host rule above hides every scrollbar.
+     Restore always-visible scrollbars for wide markdown tables and the file
+     preview panel so overflow stays reachable. Specificity (0,2,1) beats
+     `html.native-host *` (0,1,1), regardless of source order. */
+  html.native-host [data-testid="markdown-data-table"],
+  html.native-host [data-file-preview-scroll] {
+    scrollbar-width: auto;
+    scrollbar-gutter: auto !important;
+  }
+  html.native-host [data-testid="markdown-data-table"]::-webkit-scrollbar,
+  html.native-host [data-file-preview-scroll]::-webkit-scrollbar {
+    display: block;
+    width: 10px;
+    height: 10px;
   }
 
   /* Keep the outer document rhythm clean at message boundaries. */

--- a/webui/src/hooks/useNanobotStream.ts
+++ b/webui/src/hooks/useNanobotStream.ts
@@ -35,11 +35,19 @@ import type {
   OutboundMedia,
   SessionMention,
   GoalStateWsPayload,
+  SubagentDetailSnapshot,
+  SubagentTraceEvent,
+  SubagentStatusItem,
   MessageDeliveryStatus,
   UIMediaAttachment,
   UIMessage,
   WorkspaceScopePayload,
 } from "@/lib/types";
+
+const NO_SUBAGENTS: SubagentStatusItem[] = [];
+const ACTIVE_SUBAGENT_STATUSES = new Set(["queued", "started", "running"]);
+const MAX_SUBAGENT_OUTPUT = 12000;
+const MAX_SUBAGENT_STEPS = 100;
 
 interface StreamBuffer {
   /** ID of the assistant message currently receiving deltas (cleared when its segment closes). */
@@ -255,6 +263,10 @@ export function useNanobotStream(
   runStartedAt: number | null;
   /** Latest sustained goal for this ``chatId`` (``goal_state`` WS events). */
   goalState: GoalStateWsPayload | undefined;
+  turnEnded: boolean;
+  subagents: SubagentStatusItem[];
+  backgroundSubagents: SubagentStatusItem[];
+  subagentDetails: SubagentDetailSnapshot[];
   send: (
     content: string,
     images?: SendAttachment[],
@@ -283,7 +295,10 @@ export function useNanobotStream(
   );
   /** Unix epoch seconds when the current user turn started; cleared on ``idle``. */
   const [runStartedAt, setRunStartedAt] = useState<number | null>(initialRunStartedAt);
+  const [subagentDetails, setSubagentDetails] = useState<SubagentDetailSnapshot[]>([]);
+  const [turnEnded, setTurnEnded] = useState(true);
   const [goalState, setGoalState] = useState<GoalStateWsPayload | undefined>(undefined);
+  const [subagents, setSubagents] = useState<SubagentStatusItem[]>(NO_SUBAGENTS);
   const [streamError, setStreamError] = useState<StreamError | null>(null);
   const buffer = useRef<StreamBuffer | null>(null);
   const activeAssistantRef = useRef<ActiveAssistantCursor | null>(null);
@@ -296,6 +311,7 @@ export function useNanobotStream(
   const streamTimerRef = useRef<number | null>(null);
   const suppressStreamUntilTurnEndRef = useRef(false);
   const sideChannelTurnIdsRef = useRef<Set<string>>(new Set());
+  const activeSubagentTurnIdRef = useRef<string | null>(null);
   /** Timer that defers ``isStreaming = false`` after ``stream_end``.
    *
    * When the model finishes a text segment and calls a tool, the server
@@ -531,6 +547,7 @@ export function useNanobotStream(
         if (event.kind === "delta") {
           next = appendAnswerChunk(next, event.text, event.turn, event.source);
         } else {
+          if (fileEditSegmentRef.current) clearActivitySegment();
           if (closeActiveAssistantStream()) clearActivitySegment();
           next = attachReasoningChunk(
             next,
@@ -683,6 +700,13 @@ export function useNanobotStream(
     setStreamError(null);
     setRunStartedAt(restoredRunStartedAt);
     setGoalState(chatId ? client.getGoalState(chatId) : undefined);
+    setSubagentDetails([]);
+    activeSubagentTurnIdRef.current = null;
+    setSubagents((previous) => {
+      const cached = chatId ? client.getSubagents?.(chatId) ?? NO_SUBAGENTS : NO_SUBAGENTS;
+      const next = cached.filter((item) => ACTIVE_SUBAGENT_STATUSES.has(item.status));
+      return previous === next ? previous : next;
+    });
     buffer.current = null;
     activeAssistantRef.current = null;
     closedAssistantStreamIdsRef.current.clear();
@@ -691,7 +715,6 @@ export function useNanobotStream(
     sideChannelTurnIdsRef.current.clear();
     suppressStreamUntilTurnEndRef.current = false;
     cancelStreamEndTimer();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chatId, client, cancelStreamEndTimer, clearActivitySegment, clearPendingStreamWork]);
 
   useEffect(() => {
@@ -725,6 +748,104 @@ export function useNanobotStream(
             turnId: ev.turn_id,
           });
         }
+        return;
+      }
+      if (ev.event === "subagent_status") {
+        if (ev.chat_id && ev.chat_id !== chatId) return;
+        const eventTurnId = ev.turn_id ?? activeSubagentTurnIdRef.current;
+        if (
+          eventTurnId
+          && activeSubagentTurnIdRef.current
+          && eventTurnId !== activeSubagentTurnIdRef.current
+        ) return;
+        if (
+          eventTurnId
+          && !activeSubagentTurnIdRef.current
+          && ACTIVE_SUBAGENT_STATUSES.has(ev.status)
+        ) activeSubagentTurnIdRef.current = eventTurnId;
+        const item: SubagentStatusItem = {
+          subagent_id: ev.subagent_id,
+          label: ev.label,
+          status: ev.status,
+          ...(eventTurnId ? { turn_id: eventTurnId } : {}),
+          ...(typeof ev.revision === "number" ? { revision: ev.revision } : {}),
+          ...(ev.stop_reason ? { stop_reason: ev.stop_reason } : {}),
+          ...(ev.error ? { error: ev.error } : {}),
+        };
+        setSubagents((previous) => {
+          const index = previous.findIndex((candidate) => candidate.subagent_id === item.subagent_id);
+          if (
+            index !== -1
+            && typeof item.revision === "number"
+            && typeof previous[index].revision === "number"
+            && item.revision < previous[index].revision
+          ) return previous;
+          const next = index === -1
+            ? [...previous, item]
+            : previous.map((candidate, candidateIndex) => candidateIndex === index ? item : candidate);
+          client.setSubagents?.(chatId, next);
+          return next;
+        });
+        return;
+      }
+      if (ev.event === "subagent_detail_snapshot") {
+        if (ev.chat_id && ev.chat_id !== chatId) return;
+        setSubagentDetails((previous) => {
+          const next = [...previous];
+          for (const item of ev.items) {
+            const index = next.findIndex((candidate) => candidate.task_id === item.task_id);
+            if (index === -1) next.push(item);
+            else if ((item.seq ?? 0) >= (next[index].seq ?? 0)) next[index] = { ...next[index], ...item };
+          }
+          return next;
+        });
+        return;
+      }
+      if (ev.event === "subagent_trace") {
+        if (ev.chat_id && ev.chat_id !== chatId) return;
+        const trace = ev as SubagentTraceEvent;
+        const traceTurnId = trace.turn_id ?? activeSubagentTurnIdRef.current;
+        if (
+          traceTurnId
+          && activeSubagentTurnIdRef.current
+          && traceTurnId !== activeSubagentTurnIdRef.current
+        ) return;
+        if (traceTurnId && !activeSubagentTurnIdRef.current) {
+          activeSubagentTurnIdRef.current = traceTurnId;
+        }
+        setSubagentDetails((previous) => {
+          const index = previous.findIndex((item) => item.task_id === trace.subagent_id);
+          const current: SubagentDetailSnapshot = index === -1
+            ? { task_id: trace.subagent_id, label: trace.label, ...(traceTurnId ? { turn_id: traceTurnId } : {}) }
+            : previous[index];
+          if (trace.seq <= (current.seq ?? 0)) return previous;
+          const payload = trace.payload;
+          const text = typeof payload.text === "string" ? payload.text : "";
+          const next: SubagentDetailSnapshot = {
+            ...current,
+            label: trace.label,
+            ...(traceTurnId ? { turn_id: traceTurnId } : {}),
+            seq: trace.seq,
+            revision: trace.revision,
+          };
+          if (trace.kind === "input") next.input = text;
+          if (trace.kind === "delta") next.output = `${current.output ?? ""}${text}`.slice(-MAX_SUBAGENT_OUTPUT);
+          if (["phase", "tool_start", "tool_end"].includes(trace.kind)) {
+            next.steps = [...(current.steps ?? []), { kind: trace.kind, ...payload }].slice(-MAX_SUBAGENT_STEPS);
+          }
+          if (["completed", "failed", "cancelled"].includes(trace.kind)) {
+            next.status = typeof payload.status === "string" ? payload.status : trace.kind;
+            next.output = text || current.output;
+            if (typeof payload.stop_reason === "string") next.stop_reason = payload.stop_reason;
+            if (typeof payload.error === "string") next.error = payload.error;
+          }
+          return index === -1
+            ? [...previous, next]
+            : previous.map((item, itemIndex) => itemIndex === index ? next : item);
+        });
+        return;
+      }
+      if (ev.event === "subagent_state" || ev.event === "subagent_state_sync") {
         return;
       }
       const turnId = eventTurnId(ev);
@@ -854,9 +975,12 @@ export function useNanobotStream(
 
       if (ev.event === "goal_status") {
         if (ev.status === "running" && typeof ev.started_at === "number") {
+          if (ev.turn_id) activeSubagentTurnIdRef.current = ev.turn_id;
           setRunStartedAt(ev.started_at);
           setIsStreaming(true);
+          setTurnEnded(false);
         } else {
+          activeSubagentTurnIdRef.current = null;
           setRunStartedAt(null);
           setIsStreaming(false);
         }
@@ -868,6 +992,17 @@ export function useNanobotStream(
           setGoalState(ev.goal_state);
         }
         setRunStartedAt(null);
+        setTurnEnded(true);
+        const scopedTurnId = activeSubagentTurnIdRef.current
+          ?? (typeof ev.turn_id === "string" ? ev.turn_id : null);
+        activeSubagentTurnIdRef.current = null;
+        setSubagents((previous) => {
+          const next = scopedTurnId
+            ? previous.filter((item) => item.turn_id !== scopedTurnId)
+            : [];
+          client.setSubagents?.(chatId, next);
+          return next;
+        });
         // Definitive signal that the turn is fully complete.  Cancel any
         // pending debounce timer and stop the loading indicator immediately.
         cancelStreamEndTimer();
@@ -1204,6 +1339,7 @@ export function useNanobotStream(
     });
     suppressStreamUntilTurnEndRef.current = false;
     setRunStartedAt(null);
+    setTurnEnded(true);
     client.finishRunLocally(chatId);
     client.sendMessage(chatId, "/stop");
   }, [chatId, clearActivitySegment, client, flushPendingStreamEvents]);
@@ -1217,6 +1353,7 @@ export function useNanobotStream(
     clearActivitySegment();
     suppressStreamUntilTurnEndRef.current = false;
     setRunStartedAt(null);
+    setTurnEnded(true);
     setIsStreaming(false);
   }, [cancelStreamEndTimer, clearActivitySegment, clearPendingStreamWork]);
 
@@ -1231,7 +1368,13 @@ export function useNanobotStream(
     messagesReady: messageOwnerChatId === chatId,
     isStreaming,
     runStartedAt,
+    turnEnded,
     goalState,
+    subagents: activeSubagentTurnIdRef.current
+      ? subagents.filter((item) => item.turn_id === activeSubagentTurnIdRef.current)
+      : subagents.filter((item) => !item.turn_id),
+    backgroundSubagents: [],
+    subagentDetails,
     send,
     transcribeAudio,
     stop,

--- a/webui/src/i18n/locales/en/common.json
+++ b/webui/src/i18n/locales/en/common.json
@@ -1389,6 +1389,7 @@
     "activityThinkingFor": "Thinking for {{duration}}",
     "activityThought": "Thought",
     "activityThoughtFor": "Thought for {{duration}}",
+    "activityProcessed": "Processed {{count}} tasks",
     "activityWorkingFor": "Working for {{duration}}",
     "activityWorked": "Worked",
     "activityWorkedFor": "Worked for {{duration}}",

--- a/webui/src/i18n/locales/es/common.json
+++ b/webui/src/i18n/locales/es/common.json
@@ -1398,6 +1398,7 @@
     "activityThinkingFor": "Pensando durante {{duration}}",
     "activityThought": "Pensamiento completado",
     "activityThoughtFor": "Pensó durante {{duration}}",
+    "activityProcessed": "{{count}} tareas procesadas",
     "activityWorkingFor": "Trabajando durante {{duration}}",
     "activityWorked": "Trabajo completado",
     "activityWorkedFor": "Trabajó durante {{duration}}",

--- a/webui/src/i18n/locales/fr/common.json
+++ b/webui/src/i18n/locales/fr/common.json
@@ -1397,6 +1397,7 @@
     "activityThinkingFor": "Réflexion pendant {{duration}}",
     "activityThought": "Réflexion terminée",
     "activityThoughtFor": "Réflexion terminée en {{duration}}",
+    "activityProcessed": "{{count}} tâches traitées",
     "activityWorkingFor": "Travail en cours depuis {{duration}}",
     "activityWorked": "Travail terminé",
     "activityWorkedFor": "Travail terminé en {{duration}}",

--- a/webui/src/i18n/locales/id/common.json
+++ b/webui/src/i18n/locales/id/common.json
@@ -1397,6 +1397,7 @@
     "activityThinkingFor": "Berpikir selama {{duration}}",
     "activityThought": "Selesai berpikir",
     "activityThoughtFor": "Selesai berpikir dalam {{duration}}",
+    "activityProcessed": "Memproses {{count}} tugas",
     "activityWorkingFor": "Memproses selama {{duration}}",
     "activityWorked": "Selesai memproses",
     "activityWorkedFor": "Diproses selama {{duration}}",

--- a/webui/src/i18n/locales/ja/common.json
+++ b/webui/src/i18n/locales/ja/common.json
@@ -1397,6 +1397,7 @@
     "activityThinkingFor": "{{duration}}考えています",
     "activityThought": "思考しました",
     "activityThoughtFor": "{{duration}}考えました",
+    "activityProcessed": "{{count}} 件のタスクを処理",
     "activityWorkingFor": "{{duration}}作業中",
     "activityWorked": "作業しました",
     "activityWorkedFor": "{{duration}}作業しました",

--- a/webui/src/i18n/locales/ko/common.json
+++ b/webui/src/i18n/locales/ko/common.json
@@ -1397,6 +1397,7 @@
     "activityThinkingFor": "{{duration}} 동안 생각 중",
     "activityThought": "생각함",
     "activityThoughtFor": "{{duration}} 동안 생각함",
+    "activityProcessed": "{{count}}개 작업 처리",
     "activityWorkingFor": "{{duration}} 동안 작업 중",
     "activityWorked": "작업함",
     "activityWorkedFor": "{{duration}} 동안 작업함",

--- a/webui/src/i18n/locales/pt-BR/common.json
+++ b/webui/src/i18n/locales/pt-BR/common.json
@@ -1389,6 +1389,7 @@
     "activityThinkingFor": "Pensando por {{duration}}",
     "activityThought": "Pensamento",
     "activityThoughtFor": "Pensou por {{duration}}",
+    "activityProcessed": "{{count}} tarefas processadas",
     "activityWorkingFor": "Trabalhando por {{duration}}",
     "activityWorked": "Trabalhou",
     "activityWorkedFor": "Trabalhou por {{duration}}",

--- a/webui/src/i18n/locales/vi/common.json
+++ b/webui/src/i18n/locales/vi/common.json
@@ -1397,6 +1397,7 @@
     "activityThinkingFor": "Đang suy nghĩ trong {{duration}}",
     "activityThought": "Đã suy nghĩ",
     "activityThoughtFor": "Đã suy nghĩ trong {{duration}}",
+    "activityProcessed": "Đã xử lý {{count}} tác vụ",
     "activityWorkingFor": "Đang xử lý trong {{duration}}",
     "activityWorked": "Đã xử lý",
     "activityWorkedFor": "Đã xử lý trong {{duration}}",

--- a/webui/src/i18n/locales/zh-CN/common.json
+++ b/webui/src/i18n/locales/zh-CN/common.json
@@ -1389,6 +1389,7 @@
     "activityThinkingFor": "思考中 {{duration}}",
     "activityThought": "已思考",
     "activityThoughtFor": "思考了 {{duration}}",
+    "activityProcessed": "已处理 {{count}} 个任务",
     "activityWorkingFor": "处理中 {{duration}}",
     "activityWorked": "已处理",
     "activityWorkedFor": "处理了 {{duration}}",

--- a/webui/src/i18n/locales/zh-TW/common.json
+++ b/webui/src/i18n/locales/zh-TW/common.json
@@ -1396,6 +1396,7 @@
     "activityThinkingFor": "思考中，已 {{duration}}",
     "activityThought": "已思考",
     "activityThoughtFor": "已思考 {{duration}}",
+    "activityProcessed": "已處理 {{count}} 個任務",
     "activityWorkingFor": "處理中，已 {{duration}}",
     "activityWorked": "已處理",
     "activityWorkedFor": "已處理 {{duration}}",

--- a/webui/src/lib/chat-groups.ts
+++ b/webui/src/lib/chat-groups.ts
@@ -311,6 +311,9 @@ function groupSessionsByProject(
   }
 
   groups.sort((a, b) => {
+    // 话题（workspace:chats）固定展示在所有项目分组之上，不受更新时间影响
+    if (a.id === "workspace:chats") return -1;
+    if (b.id === "workspace:chats") return 1;
     const timeOrder = dateToTime(b.updatedAt) - dateToTime(a.updatedAt);
     if (timeOrder !== 0) return timeOrder;
     return a.label.localeCompare(b.label, "en", {

--- a/webui/src/lib/nanobot-client.ts
+++ b/webui/src/lib/nanobot-client.ts
@@ -8,6 +8,8 @@ import type {
   SessionMention,
   SidebarStatePayload,
   GoalStateWsPayload,
+  SubagentActivityTask,
+  SubagentStatusItem,
   WorkspaceScopePayload,
 } from "./types";
 import { createHostWebSocket } from "./runtime";
@@ -216,6 +218,8 @@ export class NanobotClient {
   private static readonly COMPLETED_TURN_FENCE_MAX = 256;
   /** Latest ``goal_state`` snapshot per ``chat_id`` (multi-session isolation). */
   private goalStateByChatId = new Map<string, GoalStateWsPayload>();
+  private subagentStateByChatId = new Map<string, SubagentActivityTask[]>();
+  private subagentsByChatId = new Map<string, SubagentStatusItem[]>();
   private pendingNewChat: PendingChatRequest | null = null;
   private pendingTranscriptions = new Map<string, PendingRequest<string>>();
   private pendingSystemCommands = new Map<string, PendingRequest<void>>();
@@ -523,6 +527,18 @@ export class NanobotClient {
   /** Last ``goal_state`` payload for *chatId*, if any frame has arrived this connection. */
   getGoalState(chatId: string): GoalStateWsPayload | undefined {
     return this.goalStateByChatId.get(chatId);
+  }
+
+  getSubagentState(chatId: string): SubagentActivityTask[] {
+    return this.subagentStateByChatId.get(chatId) ?? [];
+  }
+
+  getSubagents(chatId: string): SubagentStatusItem[] | undefined {
+    return this.subagentsByChatId.get(chatId);
+  }
+
+  setSubagents(chatId: string, items: SubagentStatusItem[]): void {
+    this.subagentsByChatId.set(chatId, items);
   }
 
   private advanceRunGeneration(chatId: string, turnId?: string): void {
@@ -1243,6 +1259,20 @@ export class NanobotClient {
       this.recordGoalStatusForRunStrip(chatId, parsed);
       if (supersededRunCompletion) return;
       this.recordGoalStateSnapshot(chatId, parsed);
+      if (parsed.event === "subagent_state" || parsed.event === "subagent_state_sync") {
+        const previous = parsed.event === "subagent_state_sync"
+          ? []
+          : this.subagentStateByChatId.get(chatId) ?? [];
+        const byId = new Map(previous.map((task) => [task.task_id, task]));
+        for (const task of parsed.tasks) byId.set(task.task_id, task);
+        this.subagentStateByChatId.set(chatId, [...byId.values()]);
+      }
+      if (parsed.event === "subagent_status") {
+        const previous = this.subagentsByChatId.get(chatId) ?? [];
+        const byId = new Map(previous.map((item) => [item.subagent_id, item]));
+        byId.set(parsed.subagent_id, parsed);
+        this.subagentsByChatId.set(chatId, [...byId.values()]);
+      }
       this.dispatch(chatId, parsed);
     }
   }
@@ -1471,6 +1501,8 @@ export class NanobotClient {
     this.unsettledRunTurnIdsByChatId.delete(chatId);
     this.canonicalCompletedTurnIdsByChatId.delete(chatId);
     this.goalStateByChatId.delete(chatId);
+    this.subagentStateByChatId.delete(chatId);
+    this.subagentsByChatId.delete(chatId);
     for (const key of [...this.runStartedAtByTurnKey.keys()]) {
       if (key.startsWith(`${chatId}\u0000`)) this.runStartedAtByTurnKey.delete(key);
     }

--- a/webui/src/lib/runtime.ts
+++ b/webui/src/lib/runtime.ts
@@ -8,6 +8,7 @@ export interface RuntimeHost {
   restartEngine?: () => Promise<void>;
   openLogs?: () => Promise<void>;
   exportDiagnostics?: () => Promise<string>;
+  openFile?: (path: string) => Promise<{ ok: boolean; error?: string }>;
 }
 
 export interface HostRuntimeInfo {
@@ -29,6 +30,7 @@ export interface NanobotHostApi {
   pickFolder?(): Promise<string | null>;
   openLogs?(): Promise<void>;
   exportDiagnostics?(): Promise<string>;
+  openFile?(path: string): Promise<{ ok: boolean; error?: string }>;
   openSocket?(url: string): Promise<string>;
   sendSocket?(id: string, data: string): Promise<void>;
   closeSocket?(id: string): Promise<void>;
@@ -116,6 +118,7 @@ export function createRuntimeHost(
     restartEngine: api?.restartEngine?.bind(api),
     openLogs: api?.openLogs?.bind(api),
     exportDiagnostics: api?.exportDiagnostics?.bind(api),
+    openFile: api?.openFile?.bind(api),
   };
 }
 

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -300,6 +300,68 @@ export interface GoalStateWsPayload {
   recap?: string;
 }
 
+export interface SubagentActivityTask {
+  task_id: string;
+  label: string;
+  status: "running" | "completed" | "failed" | string;
+  phase?: string;
+  iteration?: number;
+  elapsed_ms?: number;
+  latest_tool?: { name: string; phase?: string } | null;
+  recent_tools?: Array<{ name: string; phase?: string }>;
+  error?: string | null;
+}
+
+export interface SubagentStatusItem {
+  subagent_id: string;
+  label: string;
+  status: "queued" | "started" | "running" | "completed" | "failed" | "cancelled" | "interrupted";
+  turn_id?: string;
+  revision?: number;
+  stop_reason?: string;
+  error?: string;
+}
+
+export type SubagentTraceKind =
+  | "input"
+  | "phase"
+  | "tool_start"
+  | "tool_end"
+  | "delta"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export interface SubagentTraceEvent {
+  event: "subagent_trace";
+  chat_id: string;
+  subagent_id: string;
+  label: string;
+  turn_id?: string;
+  seq: number;
+  revision: number;
+  kind: SubagentTraceKind | string;
+  payload: Record<string, unknown>;
+}
+
+export interface SubagentDetailSnapshot {
+  task_id: string;
+  label: string;
+  turn_id?: string;
+  status?: SubagentStatusItem["status"] | string;
+  revision?: number;
+  seq?: number;
+  input?: string;
+  steps?: Array<Record<string, unknown>>;
+  output?: string;
+  stop_reason?: string;
+  error?: string;
+}
+
+export interface SubagentStatePayload {
+  tasks: SubagentActivityTask[];
+}
+
 export interface ToolProgressEvent {
   version?: number;
   phase?: "start" | "end" | "error" | string;
@@ -1333,6 +1395,28 @@ export type InboundEvent =
       event: "goal_state";
       chat_id: string;
       goal_state: GoalStateWsPayload;
+    }
+  | {
+      event: "subagent_state" | "subagent_state_sync";
+      chat_id: string;
+      tasks: SubagentActivityTask[];
+    }
+  | {
+      event: "subagent_status";
+      chat_id: string;
+      subagent_id: string;
+      label: string;
+      status: SubagentStatusItem["status"];
+      turn_id?: string;
+      revision?: number;
+      stop_reason?: string;
+      error?: string;
+    }
+  | SubagentTraceEvent
+  | {
+      event: "subagent_detail_snapshot";
+      chat_id: string;
+      items: SubagentDetailSnapshot[];
     }
   | {
       event: "session_updated";

--- a/webui/src/tests/agent-activity-cluster.test.tsx
+++ b/webui/src/tests/agent-activity-cluster.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { AgentActivityCluster } from "@/components/thread/AgentActivityCluster";
 import { DEFAULT_LOCAL_PREFS, writeLocalPreferences } from "@/lib/local-preferences";
-import type { CliAppInfo, McpPresetInfo, UIMessage } from "@/lib/types";
+import type { CliAppInfo, McpPresetInfo, SubagentActivityTask, UIMessage } from "@/lib/types";
 
 const BLENDER_CLI_APP: CliAppInfo = {
   name: "blender",
@@ -139,6 +139,47 @@ function installReducedMotion() {
 }
 
 describe("AgentActivityCluster", () => {
+  it("renders isolated subagent activity without exposing arguments or results", () => {
+    const onOpenSubagent = vi.fn();
+    const tasks: SubagentActivityTask[] = [
+      {
+        task_id: "a1",
+        label: "检查 WebUI",
+        status: "running",
+        phase: "awaiting_tools",
+        iteration: 2,
+        elapsed_ms: 4_200,
+        latest_tool: { name: "read_file", phase: "start" },
+        recent_tools: [{ name: "read_file", phase: "start" }],
+      },
+      {
+        task_id: "a2",
+        label: "检查后端",
+        status: "completed",
+        iteration: 3,
+        elapsed_ms: 7_800,
+        recent_tools: [{ name: "rg", phase: "end" }],
+      },
+    ];
+    render(
+      <AgentActivityCluster
+        messages={[]}
+        subagents={tasks}
+        onOpenSubagent={onOpenSubagent}
+        isTurnStreaming
+        hasBodyBelow={false}
+      />,
+    );
+
+    expect(screen.getByTestId("subagent-activity-group")).toHaveTextContent("Subagents · 2");
+    expect(screen.getByText("检查 WebUI")).toBeInTheDocument();
+    expect(screen.getByText("检查后端")).toBeInTheDocument();
+    expect(screen.queryByText("arguments")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText("检查 WebUI"));
+    expect(onOpenSubagent).toHaveBeenCalledWith("a1");
+    expect(screen.getByText("read_file")).toBeInTheDocument();
+  });
+
   it("jumps to the latest activity when opened", () => {
     const raf = installAnimationFrameQueue();
     try {
@@ -424,7 +465,7 @@ describe("AgentActivityCluster", () => {
 
     const button = screen.getByRole("button", { name: "Thought" });
     expect(button).toHaveAttribute("data-thread-disclosure");
-    const chevron = button.querySelector("svg");
+    const chevron = button.querySelector(".lucide-chevron-down");
     expect(chevron).toBeInTheDocument();
     expect(chevron).toHaveClass("transition-colors", "duration-200");
     expect(chevron?.parentElement).toHaveClass(
@@ -452,7 +493,7 @@ describe("AgentActivityCluster", () => {
     expect(screen.getByText("Thought for 12s")).toBeInTheDocument();
   });
 
-  it("labels mixed tool activity as work instead of thought", () => {
+  it("shows processed and thought summaries for mixed activity", () => {
     render(
       <AgentActivityCluster
         messages={activityMessages()}
@@ -462,8 +503,9 @@ describe("AgentActivityCluster", () => {
       />,
     );
 
-    expect(screen.getByText("Worked for 12s")).toBeInTheDocument();
-    expect(screen.queryByText("Thought for 12s")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Processed 2 tasks" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Thought for 12s" })).toBeInTheDocument();
+    expect(screen.getByTestId("completed-activity-summary").closest("div.border-b")).not.toBeNull();
   });
 
   it("omits the duration when completed history has no reliable timing", () => {
@@ -1260,7 +1302,7 @@ describe("AgentActivityCluster", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Worked" }));
+    fireEvent.click(screen.getByRole("button", { name: "Processed 1 tasks" }));
 
     const row = screen.getByText("Could not use GitHub · --json repo view").closest(
       '[data-testid="activity-step"]',
@@ -1553,7 +1595,7 @@ describe("AgentActivityCluster", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Worked" }));
+    fireEvent.click(screen.getByRole("button", { name: "Processed 1 tasks" }));
 
     expect(screen.getByText("Ran command cat << 'EOF' | bash · script, 6 lines")).toBeInTheDocument();
     expect(screen.queryByText(/SECRET_TOKEN/)).not.toBeInTheDocument();

--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -447,6 +447,30 @@ describe("App layout", () => {
     expect(connectSpy).not.toHaveBeenCalled();
   });
 
+  it("prevents file drag-and-drop from navigating the page (P5 guard)", async () => {
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Simulate dragging a file over any non-composer region: the global guard
+    // must preventDefault so Electron does not navigate to the file:// path.
+    const fileEvent = new Event("dragover", { cancelable: true });
+    Object.defineProperty(fileEvent, "dataTransfer", {
+      value: { types: ["Files"], files: [new File(["x"], "x.txt")] },
+    });
+    const defaultPreventedFile = !document.dispatchEvent(fileEvent);
+    expect(defaultPreventedFile).toBe(true);
+
+    // Non-file drags (e.g. internal session-drag mentions) must not be blocked.
+    const textEvent = new Event("drop", { cancelable: true });
+    Object.defineProperty(textEvent, "dataTransfer", {
+      value: { types: ["text/plain"] },
+    });
+    const defaultPreventedText = !document.dispatchEvent(textEvent);
+    expect(defaultPreventedText).toBe(false);
+  });
+
   it("keeps sidebar layout out of the main thread width contract", async () => {
     const { container } = render(<App />);
 

--- a/webui/src/tests/chat-list.test.tsx
+++ b/webui/src/tests/chat-list.test.tsx
@@ -1402,7 +1402,7 @@ describe("ChatList", () => {
     expect(within(allRegions[chatsIdx]).getByText("Recent chat")).toBeInTheDocument();
   });
 
-  it("keeps one Projects heading when Topics sorts between project groups", () => {
+  it("keeps Topics fixed above all project groups", () => {
     const sessions = [
       session({
         chatId: "project-a",
@@ -1448,11 +1448,11 @@ describe("ChatList", () => {
       .getAllByRole("region")
       .map((r) => r.getAttribute("aria-label") ?? "");
 
-    expect(regionNames).toEqual(["project-a", "Topics", "project-b"]);
+    expect(regionNames).toEqual(["Topics", "project-a", "project-b"]);
     expect(screen.getAllByText("Projects")).toHaveLength(1);
   });
 
-  it("keeps Topics last when its latest conversation is older than all projects", () => {
+  it("keeps Topics fixed above projects even when older", () => {
     const sessions = [
       session({
         chatId: "project-a",
@@ -1498,7 +1498,7 @@ describe("ChatList", () => {
       .getAllByRole("region")
       .map((r) => r.getAttribute("aria-label") ?? "");
 
-    expect(regionNames).toEqual(["project-a", "project-b", "Topics"]);
+    expect(regionNames).toEqual(["Topics", "project-a", "project-b"]);
     expect(screen.getAllByText("Projects")).toHaveLength(1);
   });
 });

--- a/webui/src/tests/file-preview-panel.test.tsx
+++ b/webui/src/tests/file-preview-panel.test.tsx
@@ -1,10 +1,24 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FilePreviewPanel } from "@/components/FilePreviewPanel";
 import { setAppLanguage } from "@/i18n";
 import { fetchFilePreview } from "@/lib/api";
+
+const openFileMock = vi.fn(async (_path: string) => ({ ok: true }));
+
+vi.mock("@/lib/runtime", () => ({
+  getRuntimeHost: () => ({
+    openFile: openFileMock,
+  }),
+}));
+
+vi.mock("@/components/MarkdownText", () => ({
+  MarkdownText: ({ children }: { children: string }) => (
+    <div data-testid="mock-markdown-text">{children}</div>
+  ),
+}));
 
 vi.mock("@/components/CodeBlock", () => ({
   CodeBlock: ({
@@ -94,7 +108,7 @@ describe("FilePreviewPanel", () => {
       />,
     );
 
-    await screen.findByTestId("mock-code-block");
+    await screen.findByTestId("mock-markdown-text");
     expect(fetchFilePreview).toHaveBeenCalledTimes(1);
 
     await act(async () => {
@@ -102,5 +116,121 @@ describe("FilePreviewPanel", () => {
     });
 
     expect(fetchFilePreview).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the open-in-system button only when allowed", async () => {
+    vi.mocked(fetchFilePreview).mockResolvedValue({
+      path: "/workspace/notes.md",
+      display_path: "notes.md",
+      project_path: "",
+      language: "markdown",
+      content: "# Notes",
+      size: 0,
+      truncated: false,
+    });
+
+    const { unmount } = render(
+      <FilePreviewPanel
+        sessionKey="websocket:chat-1"
+        path="notes.md"
+        token="tok"
+        canOpenSystem
+        onClose={() => {}}
+      />,
+    );
+    await screen.findByTestId("mock-markdown-text");
+    expect(screen.getByTestId("file-preview-open-system")).toBeInTheDocument();
+    unmount();
+
+    render(
+      <FilePreviewPanel
+        sessionKey="websocket:chat-1"
+        path="notes.md"
+        token="tok"
+        onClose={() => {}}
+      />,
+    );
+    await screen.findByTestId("mock-markdown-text");
+    expect(screen.queryByTestId("file-preview-open-system")).not.toBeInTheDocument();
+  });
+
+  it("calls the host openFile with the resolved path", async () => {
+    vi.mocked(fetchFilePreview).mockResolvedValue({
+      path: "/workspace/notes.md",
+      display_path: "notes.md",
+      project_path: "",
+      language: "markdown",
+      content: "# Notes",
+      size: 0,
+      truncated: false,
+    });
+
+    render(
+      <FilePreviewPanel
+        sessionKey="websocket:chat-1"
+        path="notes.md"
+        token="tok"
+        canOpenSystem
+        onClose={() => {}}
+      />,
+    );
+    await screen.findByTestId("mock-markdown-text");
+    await userEvent.click(screen.getByTestId("file-preview-open-system"));
+
+    await waitFor(() => expect(openFileMock).toHaveBeenCalledWith("/workspace/notes.md"));
+  });
+
+  it("shows an error banner when the host cannot open the file", async () => {
+    vi.mocked(fetchFilePreview).mockResolvedValue({
+      path: "/workspace/notes.md",
+      display_path: "notes.md",
+      project_path: "",
+      language: "markdown",
+      content: "# Notes",
+      size: 0,
+      truncated: false,
+    });
+    openFileMock.mockResolvedValueOnce({ ok: false, error: "no handler" });
+
+    render(
+      <FilePreviewPanel
+        sessionKey="websocket:chat-1"
+        path="notes.md"
+        token="tok"
+        canOpenSystem
+        onClose={() => {}}
+      />,
+    );
+    await screen.findByTestId("mock-markdown-text");
+    await userEvent.click(screen.getByTestId("file-preview-open-system"));
+
+    expect(await screen.findByTestId("file-preview-open-error")).toHaveTextContent("no handler");
+  });
+
+  it("shows a fallback error banner when openFile throws", async () => {
+    vi.mocked(fetchFilePreview).mockResolvedValue({
+      path: "/workspace/notes.md",
+      display_path: "notes.md",
+      project_path: "",
+      language: "markdown",
+      content: "# Notes",
+      size: 0,
+      truncated: false,
+    });
+    openFileMock.mockRejectedValueOnce(new Error("boom"));
+
+    render(
+      <FilePreviewPanel
+        sessionKey="websocket:chat-1"
+        path="notes.md"
+        token="tok"
+        canOpenSystem
+        onClose={() => {}}
+      />,
+    );
+    await screen.findByTestId("mock-markdown-text");
+    await userEvent.click(screen.getByTestId("file-preview-open-system"));
+
+    expect(await screen.findByTestId("file-preview-open-error")).toHaveTextContent("boom");
   });
 });

--- a/webui/src/tests/markdown-text-renderer.test.tsx
+++ b/webui/src/tests/markdown-text-renderer.test.tsx
@@ -466,6 +466,10 @@ describe("MarkdownTextRenderer", () => {
     expect(surface).toHaveAttribute("tabindex", "0");
     expect(surface).toHaveAccessibleName("Data table");
     expect(screen.getByRole("table")).toHaveTextContent("nanobot");
+    // The table itself must opt out of the parent's overflow-wrap:anywhere so
+    // wide columns stretch the table and the surface scrolls horizontally
+    // instead of squeezing content (regression guard for table scrollbars).
+    expect(screen.getByRole("table")).toHaveClass("[overflow-wrap:normal]");
     expect(container.firstElementChild).toHaveClass("space-y-4");
     expect(container.firstElementChild).not.toHaveClass("space-y-0");
   });

--- a/webui/src/tests/subagent-detail-panel.test.tsx
+++ b/webui/src/tests/subagent-detail-panel.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SubagentDetailPanel } from "@/components/thread/SubagentDetailPanel";
+import type { SubagentDetailSnapshot } from "@/lib/types";
+
+const DETAILS: SubagentDetailSnapshot[] = [
+  {
+    task_id: "task-a",
+    label: "任务 A",
+    status: "completed",
+    input: "输入 A",
+    output: "结果 A",
+    steps: [{ kind: "tool_start", name: "读取文件", iteration: 1 }],
+  },
+  {
+    task_id: "task-b",
+    label: "任务 B",
+    status: "failed",
+    input: "输入 B",
+    output: "结果 B",
+  },
+];
+
+describe("SubagentDetailPanel", () => {
+  it("shows only the opened tabs and supports closing one tab", () => {
+    const onClose = vi.fn();
+    render(
+      <SubagentDetailPanel
+        details={DETAILS}
+        selectedTaskId="task-a"
+        open
+        onOpenChange={vi.fn()}
+        onSelect={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+
+    expect(screen.getByText("输入 A")).toBeInTheDocument();
+    expect(screen.queryByText("输入 B")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "关闭 任务 A" }));
+    expect(onClose).toHaveBeenCalledWith("task-a");
+  });
+
+  it("uses the activity disclosure pattern for the execution process", () => {
+    render(
+      <SubagentDetailPanel
+        details={DETAILS}
+        selectedTaskId="task-a"
+        open
+        onOpenChange={vi.fn()}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const execution = screen.getByRole("button", { name: "执行过程" });
+    expect(execution).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("读取文件")).not.toBeInTheDocument();
+
+    fireEvent.click(execution);
+    expect(execution).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("读取文件")).toBeInTheDocument();
+  });
+
+  it("renders as an embedded pane instead of a modal dialog", () => {
+    render(
+      <SubagentDetailPanel
+        details={DETAILS}
+        selectedTaskId="task-a"
+        open
+        onOpenChange={vi.fn()}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("subagent-detail-panel")).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/webui/src/tests/thread-messages.test.tsx
+++ b/webui/src/tests/thread-messages.test.tsx
@@ -659,7 +659,7 @@ describe("ThreadMessages", () => {
 
     render(<ThreadMessages messages={messages} isStreaming={false} />);
     expect(screen.queryByRole("button", { name: /^thinking$/i })).not.toBeInTheDocument();
-    expect(screen.getByText("Worked for 9s")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Thought for 9s" })).toBeInTheDocument();
     expect(screen.getByText("final answer")).toBeInTheDocument();
   });
 
@@ -696,8 +696,8 @@ describe("ThreadMessages", () => {
     expect(units[0].type === "activity" ? units[0].turnLatencyMs : undefined).toBe(20_000);
 
     render(<ThreadMessages messages={messages} isStreaming={false} />);
-    expect(screen.getByText("Worked for 20s")).toBeInTheDocument();
-    expect(screen.queryByText("Worked for 3s")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Thought for 20s" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Thought for 3s" })).not.toBeInTheDocument();
   });
 
   it("keeps late activity after the live assistant answer while streaming", () => {
@@ -1014,8 +1014,8 @@ describe("ThreadMessages", () => {
 
     render(<ThreadMessages messages={messages} isStreaming={false} />);
 
-    expect(screen.getByText("Worked for 15s")).toBeInTheDocument();
-    expect(screen.queryByText("Worked for 0s")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Thought for 15s" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Thought for 0s" })).not.toBeInTheDocument();
   });
 
   it("shows copy on every assistant slice while keeping fork on the last slice", () => {

--- a/webui/src/tests/thread-shell.test.tsx
+++ b/webui/src/tests/thread-shell.test.tsx
@@ -4,7 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { preloadMarkdownText } from "@/components/MarkdownText";
 import { ThreadCameraController } from "@/components/thread/thread-camera";
-import { ThreadShell } from "@/components/thread/ThreadShell";
+import {
+  clampSubagentPanelRatio,
+  maxFilePreviewWidth,
+  ThreadShell,
+} from "@/components/thread/ThreadShell";
 import { CLI_APPS_CHANGED_EVENT } from "@/lib/cli-app-events";
 import type { CanonicalRunSnapshot, StreamError } from "@/lib/nanobot-client";
 import { ClientProvider } from "@/providers/ClientProvider";
@@ -117,6 +121,7 @@ function makeClient() {
     canReconcileCanonicalCompletion,
     reconcileCanonicalCompletion,
     getGoalState: (chatId: string) => goalStateByChatId.get(chatId),
+    getSubagentState: () => [],
     onChat: (chatId: string, handler: (ev: import("@/lib/types").InboundEvent) => void) => {
       let handlers = chatHandlers.get(chatId);
       if (!handlers) {
@@ -406,6 +411,18 @@ function settingsWithFastPreset(): SettingsPayload {
 }
 
 describe("ThreadShell", () => {
+  it("clamps the Subagent ratio against the divider and main conversation width", () => {
+    expect(clampSubagentPanelRatio(0.42, 1000)).toBeCloseTo(0.42);
+    expect(clampSubagentPanelRatio(0.1, 760)).toBeGreaterThanOrEqual(0.42);
+    expect(clampSubagentPanelRatio(0.6, 760)).toBeLessThanOrEqual(0.44);
+    expect(clampSubagentPanelRatio(0.6, 600)).toBeLessThan(0.42);
+  });
+
+  it("reserves room for both right-side panels when preview and Subagent are open", () => {
+    expect(maxFilePreviewWidth(1000)).toBe(580);
+    expect(maxFilePreviewWidth(1000, true)).toBe(388);
+  });
+
   beforeEach(() => {
     vi.stubGlobal(
       "fetch",

--- a/webui/src/tests/useNanobotStream.test.tsx
+++ b/webui/src/tests/useNanobotStream.test.tsx
@@ -120,6 +120,9 @@ function fakeClient() {
       getGoalState(chatId: string) {
         return goalStateByChatId.get(chatId);
       },
+      getSubagentState() {
+        return [];
+      },
       hasUnsettledRun(chatId: string) {
         return unsettledRunByChatId.get(chatId) === true;
       },
@@ -2985,6 +2988,89 @@ describe("useNanobotStream", () => {
     expect(result.current.goalState).toEqual({ active: false });
   });
 
+});
+
+describe("subagent round scoping", () => {
+  it("keeps detail history but only exposes the active round statuses", () => {
+    const fake = fakeClient();
+    const { result } = renderHook(() => useNanobotStream("chat-rounds", EMPTY_MESSAGES), {
+      wrapper: wrap(fake.client),
+    });
+
+    act(() => {
+      fake.emit("chat-rounds", {
+        event: "goal_status",
+        chat_id: "chat-rounds",
+        status: "running",
+        started_at: 1000,
+        turn_id: "turn-1",
+      });
+      fake.emit("chat-rounds", {
+        event: "subagent_status",
+        chat_id: "chat-rounds",
+        subagent_id: "task-1",
+        label: "第一轮任务",
+        status: "running",
+        turn_id: "turn-1",
+      });
+      fake.emit("chat-rounds", {
+        event: "subagent_trace",
+        chat_id: "chat-rounds",
+        subagent_id: "task-1",
+        label: "第一轮任务",
+        turn_id: "turn-1",
+        seq: 1,
+        revision: 0,
+        kind: "input",
+        payload: { text: "第一轮输入" },
+      });
+      fake.emit("chat-rounds", {
+        event: "subagent_trace",
+        chat_id: "chat-rounds",
+        subagent_id: "task-1",
+        label: "第一轮任务",
+        turn_id: "turn-1",
+        seq: 2,
+        revision: 0,
+        kind: "completed",
+        payload: { status: "completed", text: "第一轮结果" },
+      });
+      fake.emit("chat-rounds", { event: "turn_end", chat_id: "chat-rounds", turn_id: "turn-1" });
+      fake.emit("chat-rounds", {
+        event: "goal_status",
+        chat_id: "chat-rounds",
+        status: "running",
+        started_at: 2000,
+        turn_id: "turn-2",
+      });
+      fake.emit("chat-rounds", {
+        event: "subagent_status",
+        chat_id: "chat-rounds",
+        subagent_id: "task-2",
+        label: "第二轮任务",
+        status: "running",
+        turn_id: "turn-2",
+      });
+      fake.emit("chat-rounds", {
+        event: "subagent_status",
+        chat_id: "chat-rounds",
+        subagent_id: "late-task-1",
+        label: "迟到的第一轮任务",
+        status: "running",
+        turn_id: "turn-1",
+      });
+    });
+
+    expect(result.current.subagents).toEqual([
+      expect.objectContaining({ subagent_id: "task-2", turn_id: "turn-2" }),
+    ]);
+    expect(result.current.subagentDetails.map((item) => item.task_id)).toEqual(["task-1"]);
+    expect(result.current.subagentDetails[0]).toMatchObject({
+      turn_id: "turn-1",
+      output: "第一轮结果",
+      status: "completed",
+    });
+  });
 });
 
 describe("live/replay projection before canonical-event revision migration", () => {


### PR DESCRIPTION
## Summary

Two batches of work on the web UI and agent lifecycle:

### 1. File preview panel fixes
- feat: add markdown rendering and open-in-system to the file preview panel
- fix: align file preview path base with session tool evidence — relative paths that don't resolve from the project root now fall back to directories the agent actually touched (read/write/edit/apply_patch/list/find evidence)
- fix: keep wide tables and preview panel scrollbars visible — drop standard scrollbar-width/color properties so custom scrollbars render; wide tables opt out of overflow-wrap for horizontal scrolling; desktop native hosts get an overlay scrollbar that fades in while scrolling

### 2. Subagent lifecycle & activity display
- feat(agent): persist subagent lifecycle and replay details so spawned subagents and their outcomes survive across turns
- feat(webui): show subagent activity grouped by turn, with resizable workspaces

## Commits
- f0c5aab8 feat(webui): add markdown rendering and open-in-system to file preview panel
- a4754b74 fix(webui): align file preview path base with session tool evidence
- d8a8f8fd fix(webui): keep wide tables and preview panel scrollbars visible
- 096d99ac feat(agent): persist subagent lifecycle and replay details
- 03298161 feat(webui): show subagent activity by turn and resize workspaces
