### PR TITLE
feat(cli): expose nanobot process identities

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -56,6 +56,7 @@ from nanobot.cli.agent import agent  # noqa: E402
 from nanobot.cli.gateway import create_gateway_app  # noqa: E402
 from nanobot.cli.gateway_runtime import _run_gateway  # noqa: E402
 from nanobot.cli.log_control import _set_nanobot_logs  # noqa: E402
+from nanobot.cli.process_identity import set_cli_process_identity  # noqa: E402
 from nanobot.cli.provider import provider_app  # noqa: E402
 from nanobot.cli.runtime_config import (  # noqa: E402
     _load_inspection_config,
@@ -99,12 +100,17 @@ def version_callback(value: bool):
 
 @app.callback()
 def main(
+    ctx: typer.Context,
     version: bool = typer.Option(
         None, "--version", "-v", callback=version_callback, is_eager=True
     ),
 ):
     """nanobot - Personal AI Assistant."""
-    pass
+    # Editable/source installs can retain an older generated console script that
+    # imports this Typer app directly instead of ``nanobot.cli.entry``. Keep the
+    # role identity correct until that launcher is regenerated.
+    command = ctx.invoked_subcommand
+    set_cli_process_identity([command] if command else sys.argv[1:])
 
 
 # ============================================================================

--- a/nanobot/cli/entry.py
+++ b/nanobot/cli/entry.py
@@ -6,6 +6,8 @@ import os
 import sys
 from contextlib import suppress
 
+from nanobot.cli.process_identity import set_cli_process_identity
+
 
 def _native_tui_candidate(args: list[str]) -> bool:
     """Return whether ``agent`` can start without the classic agent stack."""
@@ -34,6 +36,7 @@ def _configure_windows_console() -> None:
 
 def main() -> None:
     """Dispatch native TUI startup without importing the complete CLI graph."""
+    set_cli_process_identity(sys.argv[1:])
     _configure_windows_console()
     if _native_tui_candidate(sys.argv[1:]):
         import typer

--- a/nanobot/cli/process_identity.py
+++ b/nanobot/cli/process_identity.py
@@ -1,0 +1,45 @@
+"""Give nanobot processes recognizable operating-system names."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+from typing import Final
+
+from setproctitle import setproctitle
+
+_ROLES: Final = {"agent", "gateway", "webui"}
+
+
+def set_cli_process_identity(args: list[str]) -> None:
+    """Name this CLI process after the nanobot role it is running."""
+    if os.name == "nt":
+        # Windows process managers use the console launcher's executable name,
+        # which packaging already generates as ``nanobot.exe``.
+        return
+    role = args[0] if args and args[0] in _ROLES else None
+    setproctitle(f"nanobot-{role}" if role else "nanobot")
+
+
+def named_executable(executable: str, *, name: str, directory: Path) -> str:
+    """Return a stable POSIX symlink whose basename identifies a child process."""
+    if os.name == "nt":
+        return executable
+    try:
+        target = Path(executable).resolve(strict=True)
+        digest = hashlib.sha256(os.fsencode(target)).hexdigest()[:12]
+        link_dir = directory / digest
+        link = link_dir / name
+        link_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if link.is_symlink() and link.resolve(strict=False) == target:
+            return str(link)
+        if link.exists():
+            return executable
+        pending = link.with_name(f".{name}.{os.getpid()}")
+        pending.unlink(missing_ok=True)
+        pending.symlink_to(target)
+        os.replace(pending, link)
+    except OSError:
+        return executable
+    return str(link)

--- a/nanobot/cli/process_identity.py
+++ b/nanobot/cli/process_identity.py
@@ -7,9 +7,16 @@ import os
 from pathlib import Path
 from typing import Final
 
-from setproctitle import setproctitle
-
 _ROLES: Final = {"agent", "gateway", "webui"}
+
+
+def _set_process_title(title: str) -> None:
+    # Process titles are short; do not trade Linux /proc environment visibility for
+    # extra title storage. setproctitle reads this switch when it is imported.
+    os.environ.setdefault("SPT_NOENV", "1")
+    from setproctitle import setproctitle
+
+    setproctitle(title)
 
 
 def set_cli_process_identity(args: list[str]) -> None:
@@ -19,7 +26,7 @@ def set_cli_process_identity(args: list[str]) -> None:
         # which packaging already generates as ``nanobot.exe``.
         return
     role = args[0] if args and args[0] in _ROLES else None
-    setproctitle(f"nanobot-{role}" if role else "nanobot")
+    _set_process_title(f"nanobot-{role}" if role else "nanobot")
 
 
 def named_executable(executable: str, *, name: str, directory: Path) -> str:

--- a/nanobot/cli/tui_launcher.py
+++ b/nanobot/cli/tui_launcher.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from nanobot import __version__
+from nanobot.cli.process_identity import named_executable
 from nanobot.cli.runtime_config import _model_display
 from nanobot.cli.webui_support import (
     _gateway_health_ready,
@@ -229,7 +230,12 @@ def _resolve_source_tui_command(source_dir: Path, bun: str) -> list[str]:
         detail = (install.stderr or install.stdout).strip().splitlines()
         suffix = f": {detail[-1]}" if detail else ""
         raise TuiUnavailableError(f"could not install TUI dependencies{suffix}")
-    return [bun, str(source_dir / "src" / "index.ts")]
+    executable = named_executable(
+        bun,
+        name="nanobot-tui",
+        directory=get_data_dir() / "run" / "executables",
+    )
+    return [executable, str(source_dir / "src" / "index.ts")]
 
 
 def _download_release_tui(asset: str) -> Path | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "qrcode[pil]>=8.0",
     "croniter>=6.0.0,<7.0.0",
     "prompt-toolkit>=3.0.50,<4.0.0",
+    "setproctitle>=1.3.7,<2.0.0",
     "questionary>=2.0.0,<3.0.0",
     "mcp>=1.26.0,<2.0.0",
     "json-repair>=0.57.0,<1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "qrcode[pil]>=8.0",
     "croniter>=6.0.0,<7.0.0",
     "prompt-toolkit>=3.0.50,<4.0.0",
-    "setproctitle>=1.3.7,<2.0.0",
+    "setproctitle>=1.3.7,<2.0.0; sys_platform != 'win32'",
     "questionary>=2.0.0,<3.0.0",
     "mcp>=1.26.0,<2.0.0",
     "json-repair>=0.57.0,<1.0.0",

--- a/tests/cli/test_process_identity.py
+++ b/tests/cli/test_process_identity.py
@@ -4,7 +4,9 @@ import os
 from pathlib import Path
 
 import pytest
+from typer.testing import CliRunner
 
+from nanobot.cli.commands import app
 from nanobot.cli.process_identity import named_executable, set_cli_process_identity
 
 
@@ -42,6 +44,18 @@ def test_cli_process_identity_keeps_windows_launcher_name(
     set_cli_process_identity(["agent"])
 
     assert titles == []
+
+
+def test_legacy_console_entrypoint_still_sets_subcommand_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    commands: list[list[str]] = []
+    monkeypatch.setattr("nanobot.cli.commands.set_cli_process_identity", commands.append)
+
+    result = CliRunner().invoke(app, ["webui", "--help"])
+
+    assert result.exit_code == 0
+    assert commands == [["webui"]]
 
 
 def test_named_executable_creates_stable_role_symlink(

--- a/tests/cli/test_process_identity.py
+++ b/tests/cli/test_process_identity.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nanobot.cli.process_identity import named_executable, set_cli_process_identity
+
+
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        (["agent"], "nanobot-agent"),
+        (["gateway", "--background"], "nanobot-gateway"),
+        (["webui"], "nanobot-webui"),
+        (["status"], "nanobot"),
+        ([], "nanobot"),
+    ],
+)
+def test_cli_process_identity_uses_product_and_role(
+    monkeypatch: pytest.MonkeyPatch,
+    args: list[str],
+    expected: str,
+) -> None:
+    titles: list[str] = []
+    monkeypatch.setattr("nanobot.cli.process_identity.os.name", "posix")
+    monkeypatch.setattr("nanobot.cli.process_identity.setproctitle", titles.append)
+
+    set_cli_process_identity(args)
+
+    assert titles == [expected]
+
+
+def test_cli_process_identity_keeps_windows_launcher_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    titles: list[str] = []
+    monkeypatch.setattr("nanobot.cli.process_identity.os.name", "nt")
+    monkeypatch.setattr("nanobot.cli.process_identity.setproctitle", titles.append)
+
+    set_cli_process_identity(["agent"])
+
+    assert titles == []
+
+
+def test_named_executable_creates_stable_role_symlink(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    executable = tmp_path / "bun"
+    executable.write_text("runtime", encoding="utf-8")
+    monkeypatch.setattr("nanobot.cli.process_identity.os.name", "posix")
+
+    first = Path(
+        named_executable(executable.as_posix(), name="nanobot-tui", directory=tmp_path / "run")
+    )
+    second = Path(
+        named_executable(executable.as_posix(), name="nanobot-tui", directory=tmp_path / "run")
+    )
+
+    assert first == second
+    assert first.name == "nanobot-tui"
+    assert first.is_symlink()
+    assert first.resolve() == executable
+
+
+def test_named_executable_uses_original_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr("nanobot.cli.process_identity.os.name", "nt")
+
+    assert (
+        named_executable("bun.exe", name="nanobot-tui", directory=tmp_path / "run")
+        == "bun.exe"
+    )

--- a/tests/cli/test_process_identity.py
+++ b/tests/cli/test_process_identity.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -24,7 +25,7 @@ def test_cli_process_identity_uses_product_and_role(
 ) -> None:
     titles: list[str] = []
     monkeypatch.setattr("nanobot.cli.process_identity.os.name", "posix")
-    monkeypatch.setattr("nanobot.cli.process_identity.setproctitle", titles.append)
+    monkeypatch.setattr("nanobot.cli.process_identity._set_process_title", titles.append)
 
     set_cli_process_identity(args)
 
@@ -36,7 +37,7 @@ def test_cli_process_identity_keeps_windows_launcher_name(
 ) -> None:
     titles: list[str] = []
     monkeypatch.setattr("nanobot.cli.process_identity.os.name", "nt")
-    monkeypatch.setattr("nanobot.cli.process_identity.setproctitle", titles.append)
+    monkeypatch.setattr("nanobot.cli.process_identity._set_process_title", titles.append)
 
     set_cli_process_identity(["agent"])
 
@@ -44,12 +45,12 @@ def test_cli_process_identity_keeps_windows_launcher_name(
 
 
 def test_named_executable_creates_stable_role_symlink(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    if os.name == "nt":
+        pytest.skip("POSIX symlink naming is not used on Windows")
     executable = tmp_path / "bun"
     executable.write_text("runtime", encoding="utf-8")
-    monkeypatch.setattr("nanobot.cli.process_identity.os.name", "posix")
 
     first = Path(
         named_executable(executable.as_posix(), name="nanobot-tui", directory=tmp_path / "run")

--- a/tests/cli/test_tui_launcher.py
+++ b/tests/cli/test_tui_launcher.py
@@ -467,9 +467,13 @@ def test_source_checkout_refreshes_locked_tui_dependencies(
         return subprocess.CompletedProcess(command, 0, "", "")
 
     monkeypatch.setattr("nanobot.cli.tui_launcher.subprocess.run", install)
+    monkeypatch.setattr(
+        "nanobot.cli.tui_launcher.named_executable",
+        lambda executable, **_kwargs: f"{executable}-named",
+    )
 
     assert _resolve_source_tui_command(source_dir, bun) == [
-        bun,
+        f"{bun}-named",
         str(source_dir / "src" / "index.ts"),
     ]
 


### PR DESCRIPTION
## Summary

- name Python CLI processes by their active role: `nanobot-agent`, `nanobot-webui`, and `nanobot-gateway`
- expose the source-checkout Bun child as `nanobot-tui` instead of the generic `bun`
- retain the installed `nanobot.exe` identity on Windows and the existing packaged TUI executable names

## Platform behavior

- **macOS/Linux:** set the process title at the earliest CLI entry point
- **Linux:** preserve `/proc/PID/environ` while setting the short role title
- **Windows:** rely on the generated `nanobot.exe`; Windows Task Manager does not expose runtime title changes reliably
- **source TUI:** launch Bun through a stable private symlink so the child has a nanobot-specific executable basename

The naming is intentionally role-aware: searching for `nanobot` finds the whole local process tree, while a user can still distinguish the gateway from attached clients.

## Multi-instance boundary

Process titles identify a product role, not a gateway instance. Multiple configs and workspaces remain isolated by the existing canonical `GatewayInstance` selectors and per-instance runtime state. Exact config, workspace, port, PID, lifetime, and client ownership belong in nanobot's control plane rather than in a public process title.

This PR deliberately does not create a synthetic supervisor merely to imitate desktop-app grouping. Activity Monitor's hierarchical grouping reflects real parent/child ownership; independent CLI clients may attach to an already-running gateway and therefore do not have that ownership relationship. A future native desktop host can provide genuine app-level grouping by owning its gateway and UI children.

## Verification

- `uv run --no-sync ruff check nanobot tests`
- `uv run --no-sync basedpyright` — 0 errors
- `uv run --no-sync pytest -q tests/cli tests/gateway` — 367 passed, 1 skipped
- focused portability regression suite — 38 passed
- `uv build`
- macOS hands-on process-name checks for gateway, WebUI, agent, and source TUI; all test processes exited cleanly

## References

- Apple Activity Monitor's parent/child hierarchical view
- Electron's main/renderer process and lifecycle model
- `setproctitle` platform behavior, including `SPT_NOENV`, macOS Activity Monitor, and Windows limitations
- PostgreSQL's explicit cluster label convention for opt-in multi-instance identification
- Bun standalone executable naming
