### PR TITLE
feat(config): add shared complete editor contract

### DIFF
--- a/nanobot/config/editor.py
+++ b/nanobot/config/editor.py
@@ -152,10 +152,103 @@ def config_editor_snapshot(*, config_path: Path) -> dict[str, Any]:
         "version": CONFIG_EDITOR_VERSION,
         "revision": _revision(persisted),
         "config": redacted,
-        "schema": Config.model_json_schema(mode="validation", by_alias=True),
+        "schema": _config_editor_schema(),
         "secrets": secrets,
         "presentation": deepcopy(_PRESENTATION),
     }
+
+
+def _config_editor_schema() -> dict[str, Any]:
+    """Augment the typed config schema with dependency-free channel manifests."""
+    schema = Config.model_json_schema(mode="validation", by_alias=True)
+    raw_properties = schema.get("properties")
+    raw_definitions = schema.get("$defs")
+    if not isinstance(raw_properties, dict) or not isinstance(raw_definitions, dict):
+        return schema
+    properties = cast(dict[str, Any], raw_properties)
+    definitions = cast(dict[str, Any], raw_definitions)
+    channels_ref = properties.get("channels")
+    if not isinstance(channels_ref, dict):
+        return schema
+    typed_channels_ref = cast(dict[str, Any], channels_ref)
+    ref = typed_channels_ref.get("$ref")
+    if not isinstance(ref, str):
+        return schema
+    definition_name = ref.rsplit("/", maxsplit=1)[-1]
+    channels_schema = definitions.get(definition_name)
+    if not isinstance(channels_schema, dict):
+        return schema
+    typed_channels_schema = cast(dict[str, Any], channels_schema)
+    channel_properties = typed_channels_schema.setdefault("properties", {})
+    if not isinstance(channel_properties, dict):
+        return schema
+    typed_channel_properties = cast(dict[str, Any], channel_properties)
+
+    for name, plugin in discover_plugins().items():
+        if not plugin.settings_visible:
+            continue
+        setup = plugin.setup
+        plugin_properties: dict[str, Any] = {}
+        if "always_enabled" not in plugin.capabilities:
+            plugin_properties["enabled"] = {
+                "type": "boolean",
+                "default": plugin.default_enabled,
+                "title": "Enabled",
+            }
+        if setup is not None:
+            for field_name, field in setup.fields.items():
+                if not field.writable:
+                    continue
+                _insert_channel_field_schema(
+                    plugin_properties,
+                    field_name.split("."),
+                    _channel_field_schema(field.kind, field.choices, field.default),
+                )
+        typed_channel_properties[name] = {
+            "type": "object",
+            "title": plugin.display_name,
+            "description": f"{plugin.display_name} channel configuration.",
+            "properties": plugin_properties,
+            "additionalProperties": True,
+        }
+    return schema
+
+
+def _channel_field_schema(kind: str, choices: frozenset[str], default: Any) -> dict[str, Any]:
+    if kind == "bool":
+        schema: dict[str, Any] = {"type": "boolean"}
+    elif kind == "int":
+        schema = {"type": "integer"}
+    elif kind == "list":
+        schema = {"type": "array", "items": {"type": "string"}}
+    else:
+        schema = {"type": "string"}
+    if kind == "enum":
+        schema["enum"] = sorted(choices)
+    if default is not None:
+        schema["default"] = default
+    return schema
+
+
+def _insert_channel_field_schema(
+    properties: dict[str, Any],
+    parts: list[str],
+    field_schema: dict[str, Any],
+) -> None:
+    name = parts[0]
+    if len(parts) == 1:
+        properties[name] = field_schema
+        return
+    parent_value = properties.setdefault(
+        name,
+        {"type": "object", "properties": {}, "additionalProperties": True},
+    )
+    if not isinstance(parent_value, dict):
+        return
+    parent = cast(dict[str, Any], parent_value)
+    nested = parent.setdefault("properties", {})
+    if isinstance(nested, dict):
+        _insert_channel_field_schema(cast(dict[str, Any], nested), parts[1:], field_schema)
 
 
 def update_config_editor(

--- a/nanobot/config/editor.py
+++ b/nanobot/config/editor.py
@@ -1,0 +1,338 @@
+"""Transport-neutral, complete configuration editor contract.
+
+The contract intentionally exposes a redacted typed draft plus the Pydantic
+JSON schema. UI clients can present a small guided surface and still offer an
+advanced editor without duplicating nanobot's configuration model.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, cast
+
+from pydantic import ValidationError
+
+from nanobot.channels.registry import discover_plugins
+from nanobot.config.errors import validation_issues
+from nanobot.config.loader import config_to_persisted_data, load_config, save_config
+from nanobot.config.schema import Config
+
+CONFIG_EDITOR_VERSION = 1
+
+_SECRET_KEY_NAMES = frozenset(
+    {
+        "auth",
+        "authentication",
+        "authorization",
+        "bearer",
+        "cookie",
+        "credential",
+        "credentials",
+        "hmac",
+        "key",
+        "passphrase",
+        "passwd",
+        "proxyauthorization",
+        "setcookie",
+        "sig",
+        "signature",
+    }
+)
+_SECRET_KEY_SUFFIXES = (
+    "accesskey",
+    "apikey",
+    "encryptionkey",
+    "password",
+    "privatekey",
+    "secret",
+    "secretkey",
+    "signingkey",
+    "subscriptionkey",
+    "token",
+)
+_DEPRECATED_PATHS = (
+    "/channels/extractDocumentText",
+    "/channels/transcriptionProvider",
+    "/channels/transcriptionLanguage",
+)
+_PRESENTATION = {
+    "primary_paths": [
+        "/agents/defaults/workspace",
+        "/agents/defaults/modelPreset",
+        "/agents/defaults/model",
+        "/agents/defaults/provider",
+    ],
+    "provider_primary_fields": ["apiKey", "apiBase"],
+    "sections": [
+        {
+            "id": "models",
+            "label": "Models and providers",
+            "description": "Choose the models nanobot uses and connect their providers.",
+            "prefixes": [
+                "/agents/defaults/modelPreset",
+                "/agents/defaults/model",
+                "/agents/defaults/provider",
+                "/agents/defaults/maxTokens",
+                "/agents/defaults/contextWindowTokens",
+                "/agents/defaults/contextBlockLimit",
+                "/agents/defaults/temperature",
+                "/agents/defaults/fallbackModels",
+                "/agents/defaults/reasoningEffort",
+                "/modelPresets",
+                "/providers",
+            ],
+        },
+        {
+            "id": "agent",
+            "label": "Agent",
+            "description": "Workspace, identity, sessions, memory, and agent behavior.",
+            "prefixes": ["/agents"],
+        },
+        {
+            "id": "channels",
+            "label": "Channels",
+            "description": "Chat integrations and behavior shared across channels.",
+            "prefixes": ["/channels"],
+        },
+        {
+            "id": "tools",
+            "label": "Tools",
+            "description": "Filesystem, shell, web, image generation, MCP, and safety controls.",
+            "prefixes": ["/tools"],
+        },
+        {
+            "id": "transcription",
+            "label": "Transcription",
+            "description": "Audio transcription defaults shared by chat channels.",
+            "prefixes": ["/transcription"],
+        },
+        {
+            "id": "api",
+            "label": "API server",
+            "description": "OpenAI-compatible API endpoint and authentication.",
+            "prefixes": ["/api"],
+        },
+        {
+            "id": "gateway",
+            "label": "Gateway",
+            "description": "Gateway network, restart, and heartbeat behavior.",
+            "prefixes": ["/gateway"],
+        },
+    ],
+    "deprecated_paths": list(_DEPRECATED_PATHS),
+}
+
+
+class ConfigEditorError(ValueError):
+    """A safe user-facing configuration editor failure."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: int = 400,
+        issues: list[dict[str, Any]] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status = status
+        self.issues = issues or []
+
+
+def config_editor_snapshot(*, config_path: Path) -> dict[str, Any]:
+    """Return a complete redacted draft and its presentation contract."""
+    config = load_config(config_path)
+    persisted = config_to_persisted_data(config)
+    redacted, secrets = _redacted_config(persisted)
+    return {
+        "version": CONFIG_EDITOR_VERSION,
+        "revision": _revision(persisted),
+        "config": redacted,
+        "schema": Config.model_json_schema(mode="validation", by_alias=True),
+        "secrets": secrets,
+        "presentation": deepcopy(_PRESENTATION),
+    }
+
+
+def update_config_editor(
+    payload: dict[str, Any],
+    *,
+    config_path: Path,
+) -> dict[str, Any]:
+    """Validate and persist one optimistic full-document configuration draft."""
+    revision = payload.get("revision")
+    submitted = payload.get("config")
+    if not isinstance(revision, str) or not revision:
+        raise ConfigEditorError("Configuration revision is required.")
+    if not isinstance(submitted, dict):
+        raise ConfigEditorError("Configuration draft must be an object.")
+
+    current = config_to_persisted_data(load_config(config_path))
+    if revision != _revision(current):
+        raise ConfigEditorError(
+            "Configuration changed on disk. Reload it before saving your changes.",
+            status=409,
+        )
+
+    draft = deepcopy(cast(dict[str, Any], submitted))
+    _restore_redacted_secrets(draft, current)
+    try:
+        config = Config.model_validate(draft)
+    except ValidationError as exc:
+        issues = [
+            {
+                "path": "/" + "/".join(_pointer_escape(str(part)) for part in issue.path),
+                "message": issue.message,
+            }
+            for issue in validation_issues(exc)
+        ]
+        raise ConfigEditorError(
+            f"Found {len(issues)} invalid setting(s).",
+            issues=issues,
+        ) from exc
+
+    save_config(config, config_path)
+    return config_editor_snapshot(config_path=config_path)
+
+
+def _revision(value: dict[str, Any]) -> str:
+    serialized = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def _pointer_escape(value: str) -> str:
+    return value.replace("~", "~0").replace("/", "~1")
+
+
+def _pointer(parts: tuple[str, ...]) -> str:
+    return "/" + "/".join(_pointer_escape(part) for part in parts)
+
+
+def _compact_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", value.lower())
+
+
+def _secret_key(value: str) -> bool:
+    compact = _compact_key(value)
+    return compact in _SECRET_KEY_NAMES or compact.endswith(_SECRET_KEY_SUFFIXES)
+
+
+def _declared_secret_paths(config: dict[str, Any]) -> set[tuple[str, ...]]:
+    paths: set[tuple[str, ...]] = {("api", "apiKey"), ("tools", "web", "search", "apiKey")}
+    providers = config.get("providers")
+    if isinstance(providers, dict):
+        provider_map = cast(dict[str, Any], providers)
+        paths.update(("providers", name, "apiKey") for name in provider_map)
+    for name, plugin in discover_plugins().items():
+        setup = plugin.setup
+        if setup is None:
+            continue
+        for field in setup.secrets:
+            paths.add(("channels", name, *field.split(".")))
+    return paths
+
+
+def _sensitive_container(parts: tuple[str, ...]) -> bool:
+    return len(parts) >= 5 and parts[0] == "tools" and parts[1] == "mcpServers" and (
+        parts[3] in {"env", "headers"}
+    )
+
+
+def _redacted_config(
+    config: dict[str, Any],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    declared = _declared_secret_paths(config)
+    secrets: list[dict[str, Any]] = []
+
+    def redact(value: Any, parts: tuple[str, ...]) -> Any:
+        secret = parts in declared or (parts and _secret_key(parts[-1])) or _sensitive_container(parts)
+        if secret:
+            secrets.append({"path": _pointer(parts), "configured": value not in (None, "")})
+            return None
+        if isinstance(value, dict):
+            return {
+                str(key): redact(item, (*parts, str(key)))
+                for key, item in cast(dict[str, Any], value).items()
+            }
+        if isinstance(value, list):
+            items = cast(list[Any], value)
+            return [redact(item, (*parts, str(index))) for index, item in enumerate(items)]
+        return value
+
+    redacted = cast(dict[str, Any], redact(config, ()))
+    known = {_pointer(path) for path in declared}
+    existing = {item["path"] for item in secrets}
+    for path in sorted(known - existing):
+        secrets.append({"path": path, "configured": False})
+    secrets.sort(key=lambda item: cast(str, item["path"]))
+    return redacted, secrets
+
+
+def _restore_redacted_secrets(submitted: dict[str, Any], current: dict[str, Any]) -> None:
+    _redacted, secrets = _redacted_config(current)
+    for item in secrets:
+        raw_path = cast(str, item["path"])
+        parts = tuple(
+            part.replace("~1", "/").replace("~0", "~")
+            for part in raw_path.removeprefix("/").split("/")
+        )
+        submitted_parent = _parent_at(submitted, parts)
+        current_parent = _parent_at(current, parts)
+        if submitted_parent is None or current_parent is None:
+            continue
+        submitted_container, key = submitted_parent
+        current_container, current_key = current_parent
+        submitted_value = _item_at(submitted_container, key)
+        if submitted_value is not None:
+            continue
+        current_value = _item_at(current_container, current_key)
+        _assign_at(submitted_container, key, deepcopy(current_value))
+
+
+def _parent_at(
+    value: Any,
+    parts: tuple[str, ...],
+) -> tuple[dict[str, Any] | list[Any], str] | None:
+    if not parts:
+        return None
+    current = value
+    for part in parts[:-1]:
+        if isinstance(current, dict):
+            if part not in current:
+                return None
+            current = cast(dict[str, Any], current)[part]
+        elif isinstance(current, list) and part.isdigit():
+            items = cast(list[Any], current)
+            index = int(part)
+            if index >= len(items):
+                return None
+            current = items[index]
+        else:
+            return None
+    if not isinstance(current, (dict, list)):
+        return None
+    return cast(dict[str, Any] | list[Any], current), parts[-1]
+
+
+def _item_at(container: dict[str, Any] | list[Any], key: str) -> Any:
+    if isinstance(container, dict):
+        return container.get(key)
+    if not key.isdigit() or int(key) >= len(container):
+        return None
+    return container[int(key)]
+
+
+def _assign_at(container: dict[str, Any] | list[Any], key: str, value: Any) -> None:
+    if isinstance(container, dict):
+        container[key] = value
+    elif key.isdigit() and int(key) < len(container):
+        container[int(key)] = value

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -154,6 +154,19 @@ def save_config(config: Config, config_path: Path | None = None) -> None:
     path = config_path or get_config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
 
+    data = config_to_persisted_data(config)
+    # Temp + replace so a crash mid-write cannot leave a truncated config.json.
+    _write_text_atomic(path, json.dumps(data, indent=2, ensure_ascii=False))
+
+
+def config_to_persisted_data(config: Config) -> dict[str, Any]:
+    """Return the exact JSON object persisted by :func:`save_config`.
+
+    Configuration UIs use this projection so their drafts match the file on
+    disk, including the small non-credential subset retained for OAuth
+    providers. Keeping the projection here prevents each settings surface from
+    growing its own subtly different serializer.
+    """
     data = config.model_dump(mode="json", by_alias=True)
     # OAuth credentials live in dedicated token stores. Persist only the
     # non-credential request settings consumed by these provider backends.
@@ -169,9 +182,7 @@ def save_config(config: Config, config_path: Path | None = None) -> None:
         )
         if settings:
             data.setdefault("providers", {})[alias] = settings
-
-    # Temp + replace so a crash mid-write cannot leave a truncated config.json.
-    _write_text_atomic(path, json.dumps(data, indent=2, ensure_ascii=False))
+    return data
 
 
 def merge_missing_defaults(existing: object, defaults: object) -> object:

--- a/nanobot/config/store.py
+++ b/nanobot/config/store.py
@@ -1,0 +1,49 @@
+"""Path-scoped, serialized access to one nanobot configuration file."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from pathlib import Path
+from typing import TypeVar
+
+from filelock import FileLock
+
+from nanobot.config.loader import load_config, save_config
+from nanobot.config.schema import Config
+
+_T = TypeVar("_T")
+
+
+class ConfigStore:
+    """Read and atomically update one explicit configuration file.
+
+    The store is deliberately transport-agnostic. WebUI, OpenTUI, and future
+    local settings surfaces must share this lock and persistence boundary
+    instead of implementing independent read-modify-write paths.
+    """
+
+    def __init__(self, config_path: Path) -> None:
+        self.path = config_path.expanduser().resolve(strict=False)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        lock_path = self.path.with_suffix(f"{self.path.suffix}.lock")
+        self._file_lock = FileLock(str(lock_path))
+
+    def load(self) -> Config:
+        """Load this store's config without consulting process-global state."""
+        with self._lock:
+            return load_config(self.path)
+
+    def update(self, mutation: Callable[[Config], _T]) -> _T:
+        """Apply and atomically persist one typed config mutation."""
+        with self._lock, self._file_lock:
+            config = load_config(self.path)
+            result = mutation(config)
+            save_config(config, self.path)
+            return result
+
+    def run_serialized(self, operation: Callable[[Path], _T]) -> _T:
+        """Run a path-aware operation under the config-file lock."""
+        with self._lock, self._file_lock:
+            return operation(self.path)

--- a/nanobot/webui/settings_routes.py
+++ b/nanobot/webui/settings_routes.py
@@ -17,6 +17,11 @@ from nanobot.api.runtime import ApiRuntime, api_runtime_paths
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.registry import load_channel_plugin
 from nanobot.channels.validation import validate_channel_config
+from nanobot.config.editor import (
+    ConfigEditorError,
+    config_editor_snapshot,
+    update_config_editor,
+)
 from nanobot.pairing import approve_code, deny_code, list_pending
 from nanobot.webui import settings_capabilities as capability_domain
 from nanobot.webui import settings_contracts as contracts
@@ -148,6 +153,7 @@ _SYSTEM_ROUTES = {
 }
 
 _SETTINGS_MUTATION_PATHS = frozenset({
+    "/api/settings/config-editor/update",
     "/api/settings/update",
     "/api/settings/model-configurations/create",
     "/api/settings/model-configurations/update",
@@ -287,6 +293,10 @@ class WebUISettingsRouter:
             return self._handle_settings()
         if route == ("root", "usage"):
             return self._handle_settings_usage()
+        if route == ("root", "config-editor"):
+            return self._handle_config_editor()
+        if route == ("root", "config-editor-update"):
+            return self._handle_config_editor_update(request)
 
         domain, action = route
         domain_request = self._domain_request(
@@ -334,6 +344,10 @@ class WebUISettingsRouter:
             return "root", "settings"
         if path == "/api/settings/usage":
             return "root", "usage"
+        if path == "/api/settings/config-editor":
+            return "root", "config-editor"
+        if path == "/api/settings/config-editor/update":
+            return "root", "config-editor-update"
         if action := _MODEL_ROUTES.get(path):
             return "models", action
         if action := _CAPABILITY_ROUTES.get(path):
@@ -428,6 +442,32 @@ class WebUISettingsRouter:
 
     def _handle_settings_usage(self) -> Response:
         return self._json_response(self.settings.read(settings_usage_payload))
+
+    def _handle_config_editor(self) -> Response:
+        return self._json_response(
+            config_editor_snapshot(config_path=self.settings.config.path)
+        )
+
+    def _handle_config_editor_update(self, request: WsRequest) -> Response:
+        payload = _mutation_payload(request)
+        if payload is None:
+            return self._error_response(400, "Configuration draft is required.")
+        try:
+            updated = self.settings.config.run_serialized(
+                lambda config_path: update_config_editor(payload, config_path=config_path)
+            )
+        except ConfigEditorError as exc:
+            detail = exc.message
+            if exc.issues:
+                first = exc.issues[0]
+                detail = f"{detail} {first['path']}: {first['message']}"
+            return self._error_response(exc.status, detail)
+        if self.settings.refresh_runtime_config is not None:
+            self.settings.refresh_runtime_config()
+        updated["requires_restart"] = True
+        return self._json_response(
+            self._with_restart_state(updated, section="advanced")
+        )
 
     def _model_operations(self) -> model_domain.ModelSettingsOperations:
         return model_domain.ModelSettingsOperations(

--- a/nanobot/webui/settings_services.py
+++ b/nanobot/webui/settings_services.py
@@ -8,42 +8,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TypeVar
 
-from filelock import FileLock
-
-from nanobot.config.loader import load_config, save_config
-from nanobot.config.schema import Config
+from nanobot.config.store import ConfigStore
 
 _T = TypeVar("_T")
 _WEBUI_OAUTH_MAX_FLOWS = 8
 
 
-class WebUISettingsConfig:
-    """Path-scoped config access with process-safe read-modify-write operations."""
-
-    def __init__(self, config_path: Path) -> None:
-        self.path = config_path.expanduser().resolve(strict=False)
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self._lock = threading.RLock()
-        lock_path = self.path.with_suffix(f"{self.path.suffix}.lock")
-        self._file_lock = FileLock(str(lock_path))
-
-    def load(self) -> Config:
-        """Load this gateway's config without consulting the process-global path."""
-        with self._lock:
-            return load_config(self.path)
-
-    def update(self, mutation: Callable[[Config], _T]) -> _T:
-        """Apply and atomically persist one path-scoped read-modify-write operation."""
-        with self._lock, self._file_lock:
-            config = load_config(self.path)
-            result = mutation(config)
-            save_config(config, self.path)
-            return result
-
-    def run_serialized(self, operation: Callable[[Path], _T]) -> _T:
-        """Run a path-aware read-modify-write operation under the config-file lock."""
-        with self._lock, self._file_lock:
-            return operation(self.path)
+class WebUISettingsConfig(ConfigStore):
+    """Compatibility name for the shared configuration store."""
 
 
 class WebUIOAuthFlowRegistry:

--- a/nanobot/webui/ws_http.py
+++ b/nanobot/webui/ws_http.py
@@ -149,6 +149,7 @@ _WEBUI_MUTATION_PATHS = {
     "recovery.continue": "/api/webui/recovery/continue",
     "recovery.dismiss": "/api/webui/recovery/dismiss",
     "settings.agent.update": "/api/settings/update",
+    "settings.config_editor.update": "/api/settings/config-editor/update",
     "settings.model_configuration.create": "/api/settings/model-configurations/create",
     "settings.model_configuration.update": "/api/settings/model-configurations/update",
     "settings.model_configuration.delete": "/api/settings/model-configurations/delete",

--- a/tests/config/test_config_editor.py
+++ b/tests/config/test_config_editor.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from nanobot.config.editor import (
+    ConfigEditorError,
+    config_editor_snapshot,
+    update_config_editor,
+)
+from nanobot.config.loader import load_config, save_config
+from nanobot.config.schema import Config, MCPServerConfig, ModelPresetConfig
+
+
+def _secret(snapshot: dict[str, object], path: str) -> dict[str, object]:
+    secrets = snapshot["secrets"]
+    assert isinstance(secrets, list)
+    return next(item for item in secrets if isinstance(item, dict) and item.get("path") == path)
+
+
+def test_snapshot_is_complete_but_never_returns_stored_secrets(tmp_path: Path) -> None:
+    path = tmp_path / "config.json"
+    config = Config()
+    config.providers.openai.api_key = "sk-provider-secret"
+    config.api.api_key = "api-service-secret"
+    config.channels.telegram = {
+        "enabled": True,
+        "token": "telegram-secret",
+    }
+    config.tools.mcp_servers["docs"] = MCPServerConfig(
+        command="docs-mcp",
+        env={"INTERNAL_VALUE": "mcp-env-secret"},
+        headers={"X-Workspace": "mcp-header-secret"},
+    )
+    save_config(config, path)
+
+    snapshot = config_editor_snapshot(config_path=path)
+    serialized = json.dumps(snapshot, ensure_ascii=False)
+
+    assert snapshot["version"] == 1
+    assert len(str(snapshot["revision"])) == 64
+    assert set(snapshot) == {"version", "revision", "config", "schema", "secrets", "presentation"}
+    assert "sk-provider-secret" not in serialized
+    assert "api-service-secret" not in serialized
+    assert "telegram-secret" not in serialized
+    assert "mcp-env-secret" not in serialized
+    assert "mcp-header-secret" not in serialized
+    assert _secret(snapshot, "/providers/openai/apiKey")["configured"] is True
+    assert _secret(snapshot, "/api/apiKey")["configured"] is True
+    assert _secret(snapshot, "/channels/telegram/token")["configured"] is True
+    assert _secret(snapshot, "/tools/mcpServers/docs/env/INTERNAL_VALUE")["configured"] is True
+    assert _secret(snapshot, "/tools/mcpServers/docs/headers/X-Workspace")["configured"] is True
+
+
+def test_full_document_update_covers_every_top_level_config_domain(tmp_path: Path) -> None:
+    path = tmp_path / "config.json"
+    config = Config()
+    config.providers.openai.api_key = "keep-me"
+    save_config(config, path)
+    snapshot = config_editor_snapshot(config_path=path)
+    draft = deepcopy(snapshot["config"])
+    assert isinstance(draft, dict)
+
+    draft["agents"]["defaults"]["botName"] = "Mochi"
+    draft["channels"]["sendProgress"] = False
+    draft["channels"]["telegram"] = {"enabled": True, "token": "new-token"}
+    draft["transcription"]["maxUploadMb"] = 40
+    draft["providers"]["openai"]["apiBase"] = "https://api.example.test/v1"
+    draft["api"]["port"] = 8911
+    draft["gateway"]["heartbeat"]["keepRecentMessages"] = 12
+    draft["tools"]["exec"]["timeout"] = 75
+    draft["tools"]["mcpServers"] = {
+        "docs": {
+            "command": "docs-mcp",
+            "env": {"DOCS_TOKEN": "new-mcp-token"},
+        }
+    }
+    draft["modelPresets"] = {
+        "fast": {
+            "model": "openai/gpt-test",
+            "provider": "openai",
+            "maxTokens": 4096,
+            "contextWindowTokens": 128000,
+            "temperature": 0.2,
+        }
+    }
+
+    updated = update_config_editor(
+        {"revision": snapshot["revision"], "config": draft},
+        config_path=path,
+    )
+    saved = load_config(path)
+
+    assert saved.agents.defaults.bot_name == "Mochi"
+    assert saved.channels.send_progress is False
+    assert saved.channels.telegram["token"] == "new-token"
+    assert saved.transcription.max_upload_mb == 40
+    assert saved.providers.openai.api_key == "keep-me"
+    assert saved.providers.openai.api_base == "https://api.example.test/v1"
+    assert saved.api.port == 8911
+    assert saved.gateway.heartbeat.keep_recent_messages == 12
+    assert saved.tools.exec.timeout == 75
+    assert saved.tools.mcp_servers["docs"].env["DOCS_TOKEN"] == "new-mcp-token"
+    assert saved.model_presets["fast"] == ModelPresetConfig(
+        model="openai/gpt-test",
+        provider="openai",
+        max_tokens=4096,
+        context_window_tokens=128000,
+        temperature=0.2,
+    )
+    assert _secret(updated, "/providers/openai/apiKey")["configured"] is True
+    assert _secret(updated, "/channels/telegram/token")["configured"] is True
+
+
+def test_redacted_secret_is_preserved_replaced_and_cleared_explicitly(tmp_path: Path) -> None:
+    path = tmp_path / "config.json"
+    config = Config()
+    config.providers.openai.api_key = "original"
+    save_config(config, path)
+
+    first = config_editor_snapshot(config_path=path)
+    unchanged = update_config_editor(
+        {"revision": first["revision"], "config": first["config"]},
+        config_path=path,
+    )
+    assert load_config(path).providers.openai.api_key == "original"
+
+    replacement = deepcopy(unchanged["config"])
+    replacement["providers"]["openai"]["apiKey"] = "replacement"
+    cleared = update_config_editor(
+        {"revision": unchanged["revision"], "config": replacement},
+        config_path=path,
+    )
+    assert load_config(path).providers.openai.api_key == "replacement"
+
+    clear_draft = deepcopy(cleared["config"])
+    clear_draft["providers"]["openai"]["apiKey"] = ""
+    update_config_editor(
+        {"revision": cleared["revision"], "config": clear_draft},
+        config_path=path,
+    )
+    assert load_config(path).providers.openai.api_key == ""
+
+
+def test_update_rejects_stale_and_invalid_drafts(tmp_path: Path) -> None:
+    path = tmp_path / "config.json"
+    save_config(Config(), path)
+    snapshot = config_editor_snapshot(config_path=path)
+
+    changed = load_config(path)
+    changed.api.port = 8999
+    save_config(changed, path)
+    with pytest.raises(ConfigEditorError, match="changed on disk") as stale:
+        update_config_editor(
+            {"revision": snapshot["revision"], "config": snapshot["config"]},
+            config_path=path,
+        )
+    assert stale.value.status == 409
+
+    current = config_editor_snapshot(config_path=path)
+    invalid = deepcopy(current["config"])
+    invalid["api"]["port"] = "not-a-port"
+    with pytest.raises(ConfigEditorError, match="invalid setting") as validation:
+        update_config_editor(
+            {"revision": current["revision"], "config": invalid},
+            config_path=path,
+        )
+    assert validation.value.status == 400
+    assert validation.value.issues
+    assert validation.value.issues[0]["path"].endswith("/port")
+
+
+def test_presentation_assigns_every_root_schema_domain_to_a_section(tmp_path: Path) -> None:
+    path = tmp_path / "config.json"
+    snapshot = config_editor_snapshot(config_path=path)
+    schema = snapshot["schema"]
+    presentation = snapshot["presentation"]
+    assert isinstance(schema, dict)
+    assert isinstance(presentation, dict)
+    properties = schema["properties"]
+    sections = presentation["sections"]
+    assigned_roots = {
+        prefix.split("/")[1]
+        for section in sections
+        for prefix in section["prefixes"]
+        if prefix.count("/") == 1
+    }
+
+    assert set(properties) <= assigned_roots

--- a/tests/config/test_config_editor.py
+++ b/tests/config/test_config_editor.py
@@ -190,3 +190,18 @@ def test_presentation_assigns_every_root_schema_domain_to_a_section(tmp_path: Pa
     }
 
     assert set(properties) <= assigned_roots
+
+
+def test_snapshot_schema_includes_unconfigured_channel_manifest_fields(tmp_path: Path) -> None:
+    path = tmp_path / "config.json"
+    save_config(Config(), path)
+
+    snapshot = config_editor_snapshot(config_path=path)
+    channel_ref = snapshot["schema"]["properties"]["channels"]["$ref"]
+    channels = snapshot["schema"]["$defs"][channel_ref.rsplit("/", 1)[-1]]
+
+    telegram = channels["properties"]["telegram"]["properties"]
+    assert telegram["token"]["type"] == "string"
+    assert telegram["allowFrom"]["type"] == "array"
+    signal = channels["properties"]["signal"]["properties"]
+    assert signal["dm"]["properties"]["allowFrom"]["type"] == "array"

--- a/tests/webui/test_settings_routes.py
+++ b/tests/webui/test_settings_routes.py
@@ -11,7 +11,8 @@ from urllib.parse import parse_qs, urlsplit
 import pytest
 from websockets.datastructures import Headers
 
-from nanobot.config.loader import get_config_path
+from nanobot.config.loader import get_config_path, load_config, save_config
+from nanobot.config.schema import Config
 from nanobot.webui.http_utils import http_json_response
 from nanobot.webui.mcp_presets_api import custom_mcp_action
 from nanobot.webui.settings_routes import WebUISettingsRouter
@@ -56,6 +57,55 @@ def _mutation_request(path: str, payload: dict[str, object]) -> SimpleNamespace:
     request._nanobot_webui_mutation_payload = payload
     request._nanobot_trusted_proxy_authenticated = True
     return request
+
+
+@pytest.mark.asyncio
+async def test_config_editor_route_reads_and_updates_complete_config(tmp_path) -> None:
+    config_path = tmp_path / "config.json"
+    save_config(Config(), config_path)
+    refreshed: list[bool] = []
+    router = _router(
+        config_path=config_path,
+        refresh_runtime_config=lambda: refreshed.append(True),
+    )
+
+    read_request = SimpleNamespace(path="/api/settings/config-editor", headers=Headers())
+    read_request._nanobot_trusted_proxy_authenticated = True
+    response = await router.dispatch(None, read_request, "/api/settings/config-editor")
+
+    assert response is not None
+    snapshot = json.loads(response.body)
+    snapshot["config"]["agents"]["defaults"]["botName"] = "Mochi"
+    update_request = _mutation_request(
+        "/api/settings/config-editor/update",
+        {"revision": snapshot["revision"], "config": snapshot["config"]},
+    )
+    updated = await router.dispatch(
+        None,
+        update_request,
+        "/api/settings/config-editor/update",
+    )
+
+    assert updated is not None
+    assert updated.status_code == 200
+    assert json.loads(updated.body)["requires_restart"] is True
+    assert load_config(config_path).agents.defaults.bot_name == "Mochi"
+    assert refreshed == [True]
+
+
+@pytest.mark.asyncio
+async def test_config_editor_update_rejects_plain_http(tmp_path) -> None:
+    router = _router(config_path=tmp_path / "config.json")
+    request = SimpleNamespace(path="/api/settings/config-editor/update", headers=Headers())
+
+    response = await router.dispatch(
+        None,
+        request,
+        "/api/settings/config-editor/update",
+    )
+
+    assert response is not None
+    assert response.status_code == 405
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a transport-neutral, full-schema configuration editor contract
- redact and preserve secrets while supporting explicit replacement and clearing
- share serialized config storage with existing WebUI settings and expose authenticated read/write routes

## Verification
- 241 passed, 1 skipped across config and settings suites
- ruff check on changed files
- basedpyright on changed files