### PR TITLE
fix(codex): reuse TLS contexts across requests

### DIFF
--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import ssl
 from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
@@ -56,6 +57,18 @@ class OpenAICodexProvider(LLMProvider):
         self.proxy = proxy or None
         self._extra_body = dict(extra_body or {})
         self._native_compaction_available = True
+        self._ssl_contexts: dict[bool, ssl.SSLContext] = {}
+
+    def _ssl_context(self, *, verify: bool) -> ssl.SSLContext:
+        """Reuse synchronous TLS setup across requests on the shared event loop."""
+        context = self._ssl_contexts.get(verify)
+        if context is None:
+            context = httpx.create_ssl_context(
+                verify=verify,
+                trust_env=self.proxy is None,
+            )
+            self._ssl_contexts[verify] = context
+        return context
 
     async def _call_codex(
         self,
@@ -129,7 +142,7 @@ class OpenAICodexProvider(LLMProvider):
                         DEFAULT_CODEX_URL,
                         headers,
                         wire_body,
-                        verify=True,
+                        verify=self._ssl_context(verify=True),
                         proxy=self.proxy,
                         on_content_delta=on_content_delta if emit_deltas else None,
                         on_thinking_delta=on_thinking_delta if emit_deltas else None,
@@ -145,7 +158,7 @@ class OpenAICodexProvider(LLMProvider):
                         DEFAULT_CODEX_URL,
                         headers,
                         wire_body,
-                        verify=False,
+                        verify=self._ssl_context(verify=False),
                         proxy=self.proxy,
                         on_content_delta=on_content_delta if emit_deltas else None,
                         on_thinking_delta=on_thinking_delta if emit_deltas else None,
@@ -411,7 +424,7 @@ async def _request_codex(
     url: str,
     headers: dict[str, str],
     body: dict[str, Any],
-    verify: bool,
+    verify: ssl.SSLContext | bool,
     proxy: str | None = None,
     on_content_delta: Callable[[str], Awaitable[None]] | None = None,
     on_thinking_delta: Callable[[str], Awaitable[None]] | None = None,

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import io
+import ssl
 from types import SimpleNamespace
 from typing import Any
 
@@ -40,6 +42,46 @@ def test_codex_default_model_matches_curated_flagship() -> None:
     assert spec is not None
     assert spec.builtin_models
     assert OpenAICodexProvider().get_default_model() == spec.builtin_models[0].id
+
+
+@pytest.mark.asyncio
+async def test_codex_provider_reuses_tls_context_for_concurrent_requests(monkeypatch) -> None:
+    _mock_codex_token(monkeypatch)
+    proxy = "http://127.0.0.1:23458"
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    context_calls: list[tuple[bool, bool]] = []
+    request_contexts: list[object] = []
+
+    def fake_create_ssl_context(
+        *,
+        verify: bool,
+        cert: object = None,
+        trust_env: bool = True,
+    ) -> ssl.SSLContext:
+        _ = cert
+        context_calls.append((verify, trust_env))
+        return context
+
+    async def fake_request(_url, _headers, _body, *, verify, **_kwargs):
+        request_contexts.append(verify)
+        await asyncio.sleep(0)
+        return provider_base.LLMResponse(content="ok")
+
+    monkeypatch.setattr(
+        "nanobot.providers.openai_codex_provider.httpx.create_ssl_context",
+        fake_create_ssl_context,
+    )
+    monkeypatch.setattr("nanobot.providers.openai_codex_provider._request_codex", fake_request)
+
+    provider = OpenAICodexProvider(proxy=proxy)
+    responses = await asyncio.gather(*(
+        provider.chat([{"role": "user", "content": f"request {index}"}])
+        for index in range(3)
+    ))
+
+    assert [response.content for response in responses] == ["ok", "ok", "ok"]
+    assert context_calls == [(True, False)]
+    assert request_contexts == [context, context, context]
 
 
 class _WarningCaptureLogger:


### PR DESCRIPTION
## Summary
- cache verified and fallback TLS contexts per OpenAI Codex provider instance
- preserve explicit proxy isolation with `trust_env=False`
- cover concurrent requests with a regression test that proves one TLS context construction

## Root cause
A 10-second py-spy capture of an unresponsive gateway attributed 67.6% of samples to synchronous `ssl.create_default_context()` calls under `httpx.AsyncClient` construction. Concurrent large-context Codex turns starved the shared asyncio event loop, delaying WebUI and health responses.

## Validation
- [x] `pytest tests/providers/test_openai_codex_provider.py -q` (28 passed)
- [x] `pytest tests/providers/test_openai_codex_provider.py tests/cli/test_commands.py -q -k "not test_webui_yes_creates_config_and_enables_local_websocket"` (168 passed, 1 skipped; one production-port conflict deselected)
- [x] `ruff check nanobot/providers/openai_codex_provider.py tests/providers/test_openai_codex_provider.py`
- [x] targeted BasedPyright (0 errors)
- [x] WebUI focused tests (109 passed) and production build
- [x] exact-HEAD isolated gateway/WebUI black-box verification on `dda59aac7`
  - browser showed Connected and WebSocket-backed `/model` completed
  - thread API returned the persisted user command and deterministic assistant response before and after a fresh browser load
  - fresh-load console: 0 errors, 0 warnings
  - WebUI/gateway health: HTTP 200 in ~2 ms/~1 ms
  - cleanup: runtime removed and both ports released

## Verification note
New-session optimistic routing briefly requests the thread before it exists (404), then automatically retries to 200. A fresh load is clean. Evidence is retained locally under `webui/.verify-evidence-pr5500-dda59aac/`.