### PR TITLE
feat(gateway): add ConditionalTriggerRuntime for token-free event pre-filtering

### DIFF
--- a/nanobot/cli/gateway_runtime.py
+++ b/nanobot/cli/gateway_runtime.py
@@ -218,6 +218,44 @@ _GATEWAY_HEALTH_MAX_CONNECTIONS = 64
 _GATEWAY_HEALTH_READ_TIMEOUT_SECONDS = 2.0
 
 
+def _build_conditional_trigger_runtime(config: Any, trigger_store: Any) -> Any | None:
+    """Build the ConditionalTriggerRuntime.
+
+    Registers built-in monitors (script_signal).
+    Returns None when no monitor is active (no empty loop).
+    """
+    try:
+        from nanobot.triggers.conditional import (
+            ConditionalTriggerRuntime,
+            build_all_monitors,
+        )
+        from nanobot.triggers.conditional.monitors.script_signal import ScriptSignalMonitor
+
+        monitors = build_all_monitors()
+        # script_signal needs a workspace path; build one if the registry lacks it
+        if "script_signal" not in monitors:
+            monitors["script_signal"] = ScriptSignalMonitor(config.workspace_path)
+
+        # Do not start an idle loop when every monitor is disabled
+        active = {k: v for k, v in monitors.items() if getattr(v.config, "enabled", True)}
+        if not active:
+            return None
+
+        runtime = ConditionalTriggerRuntime(
+            workspace_path=config.workspace_path,
+            trigger_store=trigger_store,
+            monitors=active,
+        )
+        logger.info(
+            "Conditional triggers enabled: {}",
+            ", ".join(sorted(active.keys())),
+        )
+        return runtime
+    except Exception:
+        logger.exception("Failed to build conditional trigger runtime; continuing without it")
+        return None
+
+
 def _print_gateway_health_endpoint(host: str, port: int) -> None:
     """Print a usable health URL and make non-loopback binds explicit."""
     console.print(
@@ -413,6 +451,7 @@ def _run_gateway(
     cron_store_path = config.workspace_path / "cron" / "jobs.json"
     cron = CronService(cron_store_path)
     trigger_store = LocalTriggerStore(config.workspace_path)
+    conditional_runtime = _build_conditional_trigger_runtime(config, trigger_store)
 
     turn_delivery_factory = TurnDeliveryFactory(
         bus,
@@ -908,6 +947,16 @@ def _run_gateway(
                         is_channel_enabled=lambda name: channels.get_channel(name) is not None,
                     ),
                     name="nanobot-local-triggers",
+                ),
+                *(
+                    [
+                        asyncio.create_task(
+                            conditional_runtime.run(),
+                            name="nanobot-conditional-triggers",
+                        )
+                    ]
+                    if conditional_runtime is not None
+                    else []
                 ),
                 asyncio.create_task(
                     _monitor_local_clients(),

--- a/nanobot/triggers/conditional/__init__.py
+++ b/nanobot/triggers/conditional/__init__.py
@@ -1,0 +1,38 @@
+"""Gateway conditional-trigger runtime.
+
+A single asyncio-managed runtime that hosts N pure-Python condition
+monitors.  Monitors run on their own schedule, never touch the LLM
+unless they decide to wake it, and de-duplicated/cooldown-gated hits are
+enqueued into the workspace-local trigger store for agent delivery.
+"""
+
+from nanobot.triggers.conditional.registry import (
+    build_all_monitors,
+    clear_registry,
+    list_registered_ids,
+    register_factory,
+    register_monitor,
+)
+from nanobot.triggers.conditional.runtime import ConditionalTriggerRuntime
+from nanobot.triggers.conditional.state import ConditionalStateStore, MonitorStateRecord
+from nanobot.triggers.conditional.types import (
+    ConditionMonitor,
+    MonitorAuditEvent,
+    MonitorConfig,
+    TriggerDecision,
+)
+
+__all__ = [
+    "ConditionMonitor",
+    "ConditionalStateStore",
+    "ConditionalTriggerRuntime",
+    "MonitorAuditEvent",
+    "MonitorConfig",
+    "MonitorStateRecord",
+    "TriggerDecision",
+    "build_all_monitors",
+    "clear_registry",
+    "list_registered_ids",
+    "register_factory",
+    "register_monitor",
+]

--- a/nanobot/triggers/conditional/monitors/__init__.py
+++ b/nanobot/triggers/conditional/monitors/__init__.py
@@ -1,0 +1,5 @@
+"""Built-in conditional monitors."""
+
+from nanobot.triggers.conditional.monitors.script_signal import ScriptSignalMonitor
+
+__all__ = ["ScriptSignalMonitor"]

--- a/nanobot/triggers/conditional/monitors/script_signal.py
+++ b/nanobot/triggers/conditional/monitors/script_signal.py
@@ -1,0 +1,220 @@
+"""ScriptSignalMonitor — generic signal-file watcher.
+
+External detection scripts (market data, health checks, digests, etc., pure
+Python, 0 token) run on their own schedule and write a JSON signal file to
+{workspace}/signals/pending/ when their condition matches.  This monitor
+scans the pending directory on each tick, validates the payload, and wakes
+the LLM via LocalTriggerStore → run_local_trigger_queue → agent turn.
+
+Signal file schema (JSON, UTF-8):
+    {
+      "id": "unique-signal-id",        # required, unique
+      "trigger_id": "trg_XXXXXXXX",    # required, must exist and be enabled
+      "content": "full message for the LLM",  # required, non-empty
+      "dedupe_key": "optional",        # optional, prevents duplicates
+      "cooldown_s": 3600,              # optional, cooldown seconds after hit
+      "source": "market-monitor",     # optional, for auditing
+      "created_at": 1787316222         # optional, epoch seconds (defaults to file mtime)
+    }
+
+Directory semantics:
+    pending/    to be processed (external scripts only write here)
+    processed/  successfully enqueued into the trigger inbox
+    failed/     validation failures (bad JSON / missing fields / trigger missing)
+    expired/    older than max_age_s (prevent stale signals from triggering)
+
+Design constraints (aligned with the ConditionMonitor protocol):
+- evaluate() is pure Python with no network I/O; zero LLM cost when not waking.
+- At most one signal is consumed per tick (oldest first); interval_s controls throughput.
+- Bad files are moved to failed/ immediately and never retried; transient
+errors stay in pending for the next tick.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from nanobot.triggers.conditional.types import MonitorConfig, TriggerDecision
+
+
+class ScriptSignalMonitor:
+    """Scan {workspace}/signals/pending/*.json and wake on match."""
+
+    id = "script_signal"
+    name = "Script signal watcher"
+
+    def __init__(
+        self,
+        workspace_path: Path,
+        *,
+        interval_s: float = 60.0,
+        timeout_s: float = 10.0,
+        max_age_s: float = 21600.0,
+        enabled: bool = True,
+    ):
+        self.workspace_path = Path(workspace_path)
+        self.config = MonitorConfig(
+            interval_s=interval_s,
+            timeout_s=timeout_s,
+            enabled=enabled,
+        )
+        self.max_age_s = float(max_age_s)
+
+    # ---------- paths ----------
+
+    @property
+    def _dir_pending(self) -> Path:
+        return self.workspace_path / "signals" / "pending"
+
+    @property
+    def _dir_processed(self) -> Path:
+        return self.workspace_path / "signals" / "processed"
+
+    @property
+    def _dir_failed(self) -> Path:
+        return self.workspace_path / "signals" / "failed"
+
+    @property
+    def _dir_expired(self) -> Path:
+        return self.workspace_path / "signals" / "expired"
+
+    def _ensure_dirs(self) -> None:
+        for d in (self._dir_pending, self._dir_processed, self._dir_failed, self._dir_expired):
+            d.mkdir(parents=True, exist_ok=True)
+
+    # ---------- helpers ----------
+
+    def _move(self, src: Path, dest_dir: Path, tag: str) -> Path:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / f"{int(time.time())}-{tag}-{src.name}"
+        try:
+            os.replace(src, dest)
+        except OSError:
+            dest = dest_dir / f"{int(time.time()*1000)}-{src.name}"
+            os.replace(src, dest)
+        return dest
+
+    def _load_trigger(self, trigger_id: str) -> dict[str, Any] | None:
+        """Read-only check that the trigger exists and is enabled (camelCase store)."""
+        path = self.workspace_path / "triggers" / "triggers.json"
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return None
+        items = data if isinstance(data, list) else data.get("triggers") or []
+        for t in items:
+            if isinstance(t, dict) and t.get("id") == trigger_id:
+                return t
+        return None
+
+    # ---------- evaluate ----------
+
+    async def evaluate(self, now: datetime) -> TriggerDecision | None:
+        try:
+            self._ensure_dirs()
+            files = sorted(self._dir_pending.glob("*.json"), key=lambda p: p.stat().st_mtime)
+        except Exception as e:
+            return TriggerDecision(should_wake=False, reason=f"scan_failed: {e}")
+
+        now_ts = time.time()
+        for f in files:
+            # ---- stale signal → expired ----
+            try:
+                age = now_ts - f.stat().st_mtime
+            except OSError:
+                continue
+            if age > self.max_age_s:
+                try:
+                    self._move(f, self._dir_expired, "expired")
+                except OSError:
+                    pass
+                continue
+
+            # ---- parse ----
+            try:
+                raw = json.loads(f.read_text(encoding="utf-8"))
+                if not isinstance(raw, dict):
+                    raise ValueError("signal root must be a JSON object")
+            except Exception as e:
+                try:
+                    self._move(f, self._dir_failed, "badjson")
+                except OSError:
+                    pass
+                return TriggerDecision(should_wake=False, reason=f"bad signal moved to failed: {e}")
+
+            sig_id = str(raw.get("id") or "").strip()
+            trigger_id = str(raw.get("trigger_id") or "").strip()
+            content = str(raw.get("content") or "").strip()
+
+            # ---- field validation (fail → failed/, no retry) ----
+            problems: list[str] = []
+            if not sig_id:
+                problems.append("missing id")
+            if not trigger_id.startswith("trg_"):
+                problems.append("invalid trigger_id")
+            if not content:
+                problems.append("missing content")
+            if problems:
+                try:
+                    self._move(f, self._dir_failed, "schema")
+                except OSError:
+                    pass
+                return TriggerDecision(
+                    should_wake=False,
+                    reason=f"signal {sig_id or f.name} invalid ({'; '.join(problems)}) — moved to failed",
+                )
+
+            # ---- trigger existence check (missing/disabled → failed/, no retry) ----
+            trig = self._load_trigger(trigger_id)
+            if trig is None:
+                try:
+                    self._move(f, self._dir_failed, "no-trigger")
+                except OSError:
+                    pass
+                return TriggerDecision(
+                    should_wake=False,
+                    reason=f"signal {sig_id}: trigger {trigger_id} not found — moved to failed",
+                )
+            if not trig.get("enabled", True):
+                try:
+                    self._move(f, self._dir_failed, "disabled-trigger")
+                except OSError:
+                    pass
+                return TriggerDecision(
+                    should_wake=False,
+                    reason=f"signal {sig_id}: trigger {trigger_id} disabled — moved to failed",
+                )
+
+            # ---- valid signal: move to processed, then wake ----
+            try:
+                self._move(f, self._dir_processed, "ok")
+            except OSError:
+                return TriggerDecision(should_wake=False, reason=f"signal {sig_id}: move failed, retry next tick")
+
+            cooldown_until_ms = None
+            cooldown_s = raw.get("cooldown_s")
+            if isinstance(cooldown_s, (int, float)) and cooldown_s > 0:
+                cooldown_until_ms = int(now.timestamp() * 1000 + cooldown_s * 1000)
+
+            return TriggerDecision(
+                should_wake=True,
+                trigger_id=trigger_id,
+                content=content,
+                dedupe_key=str(raw["dedupe_key"]) if raw.get("dedupe_key") else None,
+                cooldown_until_ms=cooldown_until_ms,
+                evidence={
+                    "signal_id": sig_id,
+                    "source": str(raw.get("source") or "unknown"),
+                    "file": f.name,
+                },
+                reason=f"signal hit: {sig_id}",
+            )
+
+        return None

--- a/nanobot/triggers/conditional/registry.py
+++ b/nanobot/triggers/conditional/registry.py
@@ -1,0 +1,56 @@
+"""Monitor registry — construction-time registration.
+
+Each monitor registers via @register_monitor(monitor) or via a factory
+registered with register_factory().  The runtime receives the resulting
+dict and never imports monitors itself, decoupling the registry from
+gateway wiring.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from nanobot.triggers.conditional.types import ConditionMonitor
+
+
+_REGISTRY: dict[str, ConditionMonitor] = {}
+_FACTORIES: dict[str, Callable[[], ConditionMonitor]] = {}
+
+
+def register_monitor(monitor: ConditionMonitor) -> ConditionMonitor:
+    if not getattr(monitor, "id", None):
+        raise ValueError("monitor.id is required")
+    _REGISTRY[monitor.id] = monitor
+    return monitor
+
+
+def register_factory(monitor_id: str, factory: Callable[[], ConditionMonitor]) -> None:
+    if not monitor_id.strip():
+        raise ValueError("monitor_id is required")
+    _FACTORIES[monitor_id] = factory
+
+
+def build_all_monitors() -> dict[str, ConditionMonitor]:
+    """Return a snapshot combining eager + factory-built monitors."""
+    out: dict[str, ConditionMonitor] = dict(_REGISTRY)
+    for mid, fac in _FACTORIES.items():
+        if mid in out:
+            continue
+        try:
+            m = fac()
+            if getattr(m, "id", "") != mid:
+                # factory mismatch — keep factory's id but log via caller
+                pass
+            out[m.id] = m
+        except Exception:
+            continue
+    return out
+
+
+def clear_registry() -> None:
+    _REGISTRY.clear()
+    _FACTORIES.clear()
+
+
+def list_registered_ids() -> list[str]:
+    return sorted(set(list(_REGISTRY.keys()) + list(_FACTORIES.keys())))

--- a/nanobot/triggers/conditional/runtime.py
+++ b/nanobot/triggers/conditional/runtime.py
@@ -1,0 +1,278 @@
+"""ConditionalTriggerRuntime — single asyncio manager for all monitors.
+
+Sits alongside CronService / Heartbeat / LocalTriggerQueue in gateway_runtime.py.
+
+Key invariants:
+- One task per monitor, bounded by monitor timeout.
+- monitor.evaluate() is pure Python; never wakes LLM unless should_wake.
+- Hit path: dedupe + cooldown check → LocalTriggerStore.enqueue() only.
+- All I/O isolation: one monitor failure never kills siblings.
+- Restart recovery: ConditionalStateStore keeps last_check/trigger/dedupe/cooldown.
+- Backoff on consecutive failures, no spam.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+from loguru import logger
+
+from nanobot.triggers.conditional.state import ConditionalStateStore, MonitorStateRecord
+from nanobot.triggers.conditional.types import ConditionMonitor, MonitorAuditEvent, TriggerDecision
+from nanobot.triggers.local_store import LocalTriggerStore
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _now_dt() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class ConditionalTriggerRuntime:
+    def __init__(
+        self,
+        *,
+        workspace_path,
+        trigger_store: LocalTriggerStore,
+        state_store: ConditionalStateStore | None = None,
+        monitors: dict[str, ConditionMonitor] | None = None,
+    ):
+        from pathlib import Path
+
+        self.workspace_path = Path(workspace_path)
+        self.trigger_store = trigger_store
+        self.state_store = state_store or ConditionalStateStore(self.workspace_path)
+        self.monitors: dict[str, ConditionMonitor] = dict(monitors or {})
+        self._tasks: dict[str, asyncio.Task[None]] = {}
+        self._stop = asyncio.Event()
+        self._audit_log: list[MonitorAuditEvent] = []
+        self._audit_cap = 200
+
+    def set_monitors(self, monitors: dict[str, ConditionMonitor]) -> None:
+        self.monitors = dict(monitors)
+
+    def audit_tail(self, limit: int = 50) -> list[MonitorAuditEvent]:
+        return list(self._audit_log[-limit:])
+
+    async def run(self) -> None:
+        """Entrypoint — mirrors run_local_trigger_queue: never returns until cancelled."""
+        logger.info("ConditionalTriggerRuntime started ({} monitors)", len(self.monitors))
+        self.state_store.ensure()
+        # Recover next_due from durable state so restart does not burst
+        # (monitors with no prior state start at now + interval).
+        self._stop.clear()
+        loop = asyncio.get_running_loop()
+        for mid, mon in list(self.monitors.items()):
+            if not getattr(mon.config, "enabled", True):
+                continue
+            self._tasks[mid] = loop.create_task(self._run_monitor(mid, mon), name=f"conditional:{mid}")
+
+        try:
+            await self._stop.wait()
+        except asyncio.CancelledError:
+            pass
+        finally:
+            for t in list(self._tasks.values()):
+                if not t.done():
+                    t.cancel()
+            if self._tasks:
+                await asyncio.gather(*self._tasks.values(), return_exceptions=True)
+            logger.info("ConditionalTriggerRuntime stopped")
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    async def _run_monitor(self, monitor_id: str, monitor: ConditionMonitor) -> None:
+        interval = float(getattr(monitor.config, "interval_s", 2700))
+        timeout = float(getattr(monitor.config, "timeout_s", 15))
+        max_backoff = float(getattr(monitor.config, "max_backoff_s", 1800))
+        initial_backoff = float(getattr(monitor.config, "initial_backoff_s", 30))
+        factor = float(getattr(monitor.config, "backoff_factor", 2.0))
+
+        # Stagger start so N monitors don't align on gateway boot
+        await asyncio.sleep(min(interval * 0.05, 5.0) * (hash(monitor_id) % 7) / 7.0)
+
+        # Seed next_due from state if present
+        state = self.state_store.get(monitor_id)
+        if state and state.next_due_at_ms and state.next_due_at_ms > _now_ms():
+            delay = max(0, (state.next_due_at_ms - _now_ms()) / 1000.0)
+            if delay > 0:
+                try:
+                    await asyncio.wait_for(self._stop.wait(), timeout=delay)
+                    return
+                except asyncio.TimeoutError:
+                    pass
+
+        consecutive_failures = int(state.consecutive_failures) if state else 0
+
+        while not self._stop.is_set():
+            tick_start = _now_ms()
+            try:
+                await self._tick_once(monitor, timeout_s=timeout)
+                consecutive_failures = 0
+                # persist next_due for restart recovery
+                self.state_store.touch_check(
+                    monitor_id,
+                    now_ms=tick_start,
+                    next_due_at_ms=int(tick_start + interval * 1000),
+                    reset_failures=True,
+                )
+                sleep_s = interval
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                consecutive_failures += 1
+                err = f"{exc.__class__.__name__}: {exc}"[:1500]
+                logger.exception("Conditional monitor {} failed", monitor_id)
+                self._emit_audit(MonitorAuditEvent(
+                    monitor_id=monitor_id,
+                    at_ms=tick_start,
+                    should_wake=False,
+                    error=err,
+                    duration_ms=_now_ms() - tick_start,
+                ))
+                self.state_store.touch_check(
+                    monitor_id,
+                    now_ms=tick_start,
+                    next_due_at_ms=int(tick_start + min(max_backoff, initial_backoff * (factor ** (consecutive_failures - 1))) * 1000),
+                    error=err,
+                    increment_failure=True,
+                )
+                # exponential backoff, capped
+                backoff = min(max_backoff, initial_backoff * (factor ** (consecutive_failures - 1)))
+                sleep_s = backoff
+                if consecutive_failures >= 5:
+                    logger.warning("Conditional monitor {} backing off {}s (failures={})", monitor_id, backoff, consecutive_failures)
+
+            try:
+                await asyncio.wait_for(self._stop.wait(), timeout=sleep_s)
+                return
+            except asyncio.TimeoutError:
+                continue
+
+    async def _tick_once(self, monitor: ConditionMonitor, *, timeout_s: float) -> None:
+        mid = monitor.id
+        start = _now_ms()
+        now = _now_dt()
+
+        # 1) evaluate under timeout isolation
+        try:
+            decision = await asyncio.wait_for(monitor.evaluate(now), timeout=timeout_s)
+        except asyncio.TimeoutError as e:
+            raise TimeoutError(f"monitor {mid} evaluate timed out after {timeout_s}s") from e
+
+        elapsed = _now_ms() - start
+        if decision is None or not decision.should_wake:
+            reason = (decision.reason if decision else "") or "should_wake=false"
+            self._emit_audit(MonitorAuditEvent(
+                monitor_id=mid,
+                at_ms=start,
+                should_wake=False,
+                reason=reason,
+                evidence=dict(decision.evidence or {}) if decision and decision.evidence else None,
+                duration_ms=elapsed,
+                skipped_reason="not_triggered",
+            ))
+            logger.debug("Conditional {} not triggered: {} ({}ms)", mid, reason, elapsed)
+            return
+
+        # 2) cooldown / dedupe gate from durable state
+        state = self.state_store.get(mid)
+        if state and state.cooldown_until_ms and _now_ms() < state.cooldown_until_ms:
+            self._emit_audit(MonitorAuditEvent(
+                monitor_id=mid,
+                at_ms=start,
+                should_wake=False,
+                trigger_id=decision.trigger_id,
+                dedupe_key=decision.dedupe_key,
+                reason="cooldown",
+                duration_ms=elapsed,
+                skipped_reason="cooldown",
+            ))
+            logger.info("Conditional {} hit but in cooldown until {}", mid, state.cooldown_until_ms)
+            return
+        if decision.dedupe_key and state and state.last_dedupe_key == decision.dedupe_key:
+            self._emit_audit(MonitorAuditEvent(
+                monitor_id=mid,
+                at_ms=start,
+                should_wake=False,
+                trigger_id=decision.trigger_id,
+                dedupe_key=decision.dedupe_key,
+                reason="dedupe",
+                duration_ms=elapsed,
+                skipped_reason="dedupe",
+            ))
+            logger.info("Conditional {} hit but deduped key={}", mid, decision.dedupe_key)
+            return
+        if decision.cooldown_until_ms and decision.cooldown_until_ms <= _now_ms():
+            # stale cooldown — ignore
+            pass
+
+        # 3) enqueue into local trigger inbox (retryable errors bubble to _run_monitor)
+        try:
+            delivery = self.trigger_store.enqueue(decision.trigger_id, decision.content)
+        except Exception as e:
+            # invalid trigger id / disabled — record audit and don't retry enqueue loop
+            self._emit_audit(MonitorAuditEvent(
+                monitor_id=mid,
+                at_ms=start,
+                should_wake=True,
+                trigger_id=decision.trigger_id,
+                dedupe_key=decision.dedupe_key,
+                reason=decision.reason,
+                evidence=dict(decision.evidence or {}) if decision.evidence else None,
+                error=f"enqueue failed: {e}",
+                duration_ms=_now_ms() - start,
+            ))
+            logger.warning("Conditional {} enqueue failed for {}: {}", mid, decision.trigger_id, e)
+            return
+
+        # 4) durably record trigger + audit
+        self.state_store.record_trigger(
+            mid,
+            now_ms=_now_ms(),
+            dedupe_key=decision.dedupe_key,
+            cooldown_until_ms=decision.cooldown_until_ms,
+            next_due_at_ms=int(_now_ms() + float(monitor.config.interval_s) * 1000),
+        )
+        self._emit_audit(MonitorAuditEvent(
+            monitor_id=mid,
+            at_ms=start,
+            should_wake=True,
+            trigger_id=decision.trigger_id,
+            dedupe_key=decision.dedupe_key,
+            reason=decision.reason,
+            evidence=dict(decision.evidence or {}) if decision.evidence else None,
+            duration_ms=_now_ms() - start,
+            enqueued=True,
+        ))
+        logger.info("Conditional {} → enqueued {} (delivery {})", mid, decision.trigger_id, delivery.id)
+
+    def _emit_audit(self, event: MonitorAuditEvent) -> None:
+        self._audit_log.append(event)
+        if len(self._audit_log) > self._audit_cap:
+            self._audit_log = self._audit_log[-self._audit_cap:]
+
+    # Incremental hot-reload (config change) — caller diffs ids
+    def sync_monitors(self, desired: dict[str, ConditionMonitor]) -> None:
+        """Incrementally start/stop monitors without restarting runtime."""
+        loop = asyncio.get_running_loop()
+        to_remove = set(self.monitors.keys()) - set(desired.keys())
+        to_add = set(desired.keys()) - set(self.monitors.keys())
+        for mid in to_remove:
+            t = self._tasks.pop(mid, None)
+            if t and not t.done():
+                t.cancel()
+            self.monitors.pop(mid, None)
+            logger.info("Conditional runtime removed monitor {}", mid)
+        for mid in to_add:
+            mon = desired[mid]
+            self.monitors[mid] = mon
+            if getattr(mon.config, "enabled", True):
+                self._tasks[mid] = loop.create_task(self._run_monitor(mid, mon), name=f"conditional:{mid}")
+                logger.info("Conditional runtime added monitor {}", mid)

--- a/nanobot/triggers/conditional/state.py
+++ b/nanobot/triggers/conditional/state.py
@@ -1,0 +1,211 @@
+"""Durable per-monitor state for ConditionalTriggerRuntime.
+
+- Survives gateway restarts (atomic JSON on disk).
+- Holds last_check / last_trigger / dedupe / cooldown / backoff counters.
+- One file per workspace: <workspace>/triggers/conditional/state.json
+
+Design: single file with dict[monitor_id -> Record].  FileLock mirrors
+CronService / LocalTriggerStore conventions (same lock style).
+Ownership: only the gateway process writes; external collectors never touch it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from filelock import FileLock
+from loguru import logger
+
+
+@dataclass(slots=True)
+class MonitorStateRecord:
+    monitor_id: str
+    last_check_at_ms: int | None = None
+    last_trigger_at_ms: int | None = None
+    last_dedupe_key: str | None = None
+    cooldown_until_ms: int | None = None
+    consecutive_failures: int = 0
+    next_due_at_ms: int | None = None
+    last_error: str | None = None
+    updated_at_ms: int = 0
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "MonitorStateRecord":
+        return cls(
+            monitor_id=str(data.get("monitor_id") or data.get("id") or ""),
+            last_check_at_ms=data.get("last_check_at_ms"),
+            last_trigger_at_ms=data.get("last_trigger_at_ms"),
+            last_dedupe_key=data.get("last_dedupe_key"),
+            cooldown_until_ms=data.get("cooldown_until_ms"),
+            consecutive_failures=int(data.get("consecutive_failures") or 0),
+            next_due_at_ms=data.get("next_due_at_ms"),
+            last_error=data.get("last_error"),
+            updated_at_ms=int(data.get("updated_at_ms") or 0),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "monitor_id": self.monitor_id,
+            "last_check_at_ms": self.last_check_at_ms,
+            "last_trigger_at_ms": self.last_trigger_at_ms,
+            "last_dedupe_key": self.last_dedupe_key,
+            "cooldown_until_ms": self.cooldown_until_ms,
+            "consecutive_failures": self.consecutive_failures,
+            "next_due_at_ms": self.next_due_at_ms,
+            "last_error": self.last_error,
+            "updated_at_ms": self.updated_at_ms,
+        }
+
+
+class ConditionalStateStore:
+    """Atomic JSON store for monitor states — mirrors CronService._atomic_write."""
+
+    def __init__(self, workspace_path: Path):
+        self.workspace_path = Path(workspace_path)
+        self.root = self.workspace_path / "triggers" / "conditional"
+        self.path = self.root / "state.json"
+        self._lock = FileLock(str(self.root / ".lock"))
+
+    def ensure(self) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def load_all(self) -> dict[str, MonitorStateRecord]:
+        self.ensure()
+        if not self.path.exists():
+            return {}
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except Exception:
+            logger.exception("ConditionalState: failed to parse {}", self.path)
+            return {}
+        out: dict[str, MonitorStateRecord] = {}
+        # Support both {"records": [...]} and {"monitors": {...}} shapes
+        items: list[dict[str, Any]] = []
+        if isinstance(raw, dict) and isinstance(raw.get("records"), list):
+            items = [x for x in raw["records"] if isinstance(x, dict)]
+        elif isinstance(raw, dict) and isinstance(raw.get("monitors"), dict):
+            items = [v for v in raw["monitors"].values() if isinstance(v, dict)]
+        elif isinstance(raw, dict) and isinstance(raw.get("version"), int):
+            # tolerate legacy single-record file
+            pass
+        for d in items:
+            try:
+                rec = MonitorStateRecord.from_dict(d)
+                if rec.monitor_id:
+                    out[rec.monitor_id] = rec
+            except Exception:
+                continue
+        return out
+
+    def get(self, monitor_id: str) -> MonitorStateRecord | None:
+        return self.load_all().get(monitor_id)
+
+    def upsert(self, record: MonitorStateRecord) -> None:
+        self.ensure()
+        with self._lock:
+            all_records = self.load_all()
+            record.updated_at_ms = int(time.time() * 1000)
+            all_records[record.monitor_id] = record
+            self._save_unlocked(all_records)
+
+    def touch_check(
+        self,
+        monitor_id: str,
+        *,
+        now_ms: int,
+        next_due_at_ms: int | None = None,
+        error: str | None = None,
+        increment_failure: bool = False,
+        reset_failures: bool = False,
+    ) -> MonitorStateRecord:
+        """Update last_check / failure counters atomically."""
+        self.ensure()
+        with self._lock:
+            all_records = self.load_all()
+            rec = all_records.get(monitor_id) or MonitorStateRecord(monitor_id=monitor_id)
+            rec.last_check_at_ms = now_ms
+            if next_due_at_ms is not None:
+                rec.next_due_at_ms = next_due_at_ms
+            if error is not None:
+                rec.last_error = error[:2000]
+            elif reset_failures:
+                rec.last_error = None
+            if increment_failure:
+                rec.consecutive_failures += 1
+            elif reset_failures:
+                rec.consecutive_failures = 0
+            rec.updated_at_ms = int(time.time() * 1000)
+            all_records[monitor_id] = rec
+            self._save_unlocked(all_records)
+            return rec
+
+    def record_trigger(
+        self,
+        monitor_id: str,
+        *,
+        now_ms: int,
+        dedupe_key: str | None,
+        cooldown_until_ms: int | None,
+        next_due_at_ms: int | None = None,
+    ) -> MonitorStateRecord:
+        self.ensure()
+        with self._lock:
+            all_records = self.load_all()
+            rec = all_records.get(monitor_id) or MonitorStateRecord(monitor_id=monitor_id)
+            rec.last_check_at_ms = now_ms
+            rec.last_trigger_at_ms = now_ms
+            if dedupe_key is not None:
+                rec.last_dedupe_key = dedupe_key
+            if cooldown_until_ms is not None:
+                rec.cooldown_until_ms = cooldown_until_ms
+            rec.consecutive_failures = 0
+            rec.last_error = None
+            if next_due_at_ms is not None:
+                rec.next_due_at_ms = next_due_at_ms
+            rec.updated_at_ms = int(time.time() * 1000)
+            all_records[monitor_id] = rec
+            self._save_unlocked(all_records)
+            return rec
+
+    def _save_unlocked(self, records: dict[str, MonitorStateRecord]) -> None:
+        payload = {
+            "version": 1,
+            "updated_at_ms": int(time.time() * 1000),
+            "records": [r.to_dict() for r in sorted(records.values(), key=lambda x: x.monitor_id)],
+        }
+        self._atomic_write(self.path, json.dumps(payload, ensure_ascii=False, indent=2))
+
+    @staticmethod
+    def _atomic_write(path: Path, content: str) -> None:
+        import errno, uuid
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+        try:
+            with open(tmp, "w", encoding="utf-8") as f:
+                f.write(content)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, path)
+            try:
+                fd = os.open(str(path.parent), os.O_RDONLY)
+                try:
+                    try:
+                        os.fsync(fd)
+                    except OSError as e:
+                        if e.errno != errno.EINVAL:
+                            raise
+                finally:
+                    os.close(fd)
+            except PermissionError:
+                pass
+        finally:
+            try:
+                tmp.unlink(missing_ok=True)
+            except Exception:
+                pass

--- a/nanobot/triggers/conditional/types.py
+++ b/nanobot/triggers/conditional/types.py
@@ -1,0 +1,77 @@
+"""Types for gateway conditional-trigger runtime.
+
+ConditionMonitor / TriggerDecision / MonitorConfig contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True, slots=True)
+class TriggerDecision:
+    """Result of one ConditionMonitor.evaluate()."""
+
+    should_wake: bool
+    trigger_id: str = ""
+    content: str = ""
+    dedupe_key: str | None = None
+    cooldown_until_ms: int | None = None
+    evidence: dict[str, Any] | None = None
+    reason: str = ""
+
+    def __post_init__(self) -> None:
+        if self.should_wake:
+            if not self.trigger_id.strip():
+                raise ValueError("TriggerDecision.should_wake=True requires trigger_id")
+            if not self.content.strip():
+                raise ValueError("TriggerDecision.should_wake=True requires content")
+
+
+@dataclass(frozen=True, slots=True)
+class MonitorConfig:
+    """Static scheduling knobs per monitor — runtime owns the clock."""
+
+    interval_s: float = 2700.0
+    timeout_s: float = 15.0
+    max_backoff_s: float = 1800.0
+    initial_backoff_s: float = 30.0
+    backoff_factor: float = 2.0
+    enabled: bool = True
+
+    def __post_init__(self) -> None:
+        if self.interval_s <= 0:
+            raise ValueError("interval_s must be > 0")
+        if self.timeout_s <= 0:
+            raise ValueError("timeout_s must be > 0")
+
+
+@runtime_checkable
+class ConditionMonitor(Protocol):
+    """Lightweight pure-Python checker. Never touches LLM."""
+
+    id: str  # unique monitor identifier, e.g. "script_signal"
+    name: str  # human-readable label
+    config: MonitorConfig
+
+    async def evaluate(self, now: datetime) -> TriggerDecision | None:
+        """Return None or TriggerDecision(should_wake=False) to stay silent."""
+        ...
+
+
+# Audit event emitted per evaluation (for file log / metrics).
+@dataclass(slots=True)
+class MonitorAuditEvent:
+    monitor_id: str
+    at_ms: int
+    should_wake: bool
+    trigger_id: str | None = None
+    dedupe_key: str | None = None
+    reason: str = ""
+    evidence: dict[str, Any] | None = None
+    error: str | None = None
+    duration_ms: int = 0
+    enqueued: bool = False
+    skipped_reason: str | None = None  # cooldown/dedupe/disabled/not_due


### PR DESCRIPTION
## Summary

Adds a `ConditionalTriggerRuntime` to the gateway — a single asyncio manager that runs lightweight, pure-Python condition monitors and only wakes the LLM when a monitor's condition actually matches. This makes event-driven automation **token-free**: scripts/external systems write small JSON signal files, the runtime evaluates cheap local conditions (dedupe + cooldown + state), and the model is only invoked on a real hit.

## Motivation

Today, recurring automation relies on heartbeat polling, which burns a full LLM turn on every tick even when there is nothing to do. With conditional triggers, an external script can signal "condition met" and the gateway wakes the LLM once, with a pre-formatted `content` payload — no wasted tokens, no polling cost.

## What's included

- `nanobot/triggers/conditional/types.py` — `ConditionMonitor` protocol + `TriggerDecision` dataclass (single source of truth for the monitor contract)
- `nanobot/triggers/conditional/registry.py` — monitor registry by name
- `nanobot/triggers/conditional/state.py` — durable `ConditionalStateStore` for last-check / dedupe / cooldown, with restart recovery
- `nanobot/triggers/conditional/runtime.py` — asyncio runtime: one task per monitor, bounded timeouts, I/O isolation (one monitor failure never kills siblings), backoff on consecutive failures
- `nanobot/triggers/conditional/monitors/script_signal.py` — file-based signal monitor (`signals/pending/*.json` → `processed|failed|expired` folders) with dedupe/cooldown
- `nanobot/cli/gateway_runtime.py` — wires the runtime alongside CronService / Heartbeat / LocalTriggerQueue

## Design invariants

- `monitor.evaluate()` is pure Python; never wakes the LLM unless `should_wake` is returned
- Hit path is only `LocalTriggerStore.enqueue()` — the existing trigger queue handles the LLM step
- Restart-safe: state store keeps checkpoints so a reboot resumes without re-firing

## Testing

Manual verification across two gateway instances (companion + script_signal monitors) — monitors all active, conditions firing as expected.