### PR TITLE
style(tui): keep short transcripts and composer top-aligned

### DIFF
--- a/tui/src/app.test.ts
+++ b/tui/src/app.test.ts
@@ -14,6 +14,7 @@ import type {
   WorkspaceScopePayload,
 } from "./protocol"
 import type { HostAgentState, HostMetadata, TuiHost } from "./host"
+import type { Transcript } from "./transcript"
 
 const options: AppOptions = {
   wsUrl: "ws://localhost.invalid/ws",
@@ -122,6 +123,45 @@ describe("NanobotTui layout", () => {
   })
 
   const createRenderer = (options: Parameters<typeof createTestRenderer>[0]) => createTestRenderer(options)
+
+  test("keeps short transcripts and the composer anchored at the top", async () => {
+    setup = await createRenderer({
+      width: 100,
+      height: 18,
+      screenMode: "alternate-screen",
+      consoleMode: "disabled",
+    })
+    const app = mount(setup)
+    const ui = app as unknown as {
+      transcript: Transcript
+      title: BoxRenderable
+      status: TextRenderable
+    }
+    const positions = () => ({
+      transcriptHeight: ui.transcript.root.height,
+      titleY: ui.title.y,
+      statusY: ui.status.y,
+    })
+
+    let anchoredPositions: ReturnType<typeof positions> | undefined
+    for (const height of [18, 30, 36]) {
+      setup.resize(100, height)
+      await setup.renderOnce()
+      expect(ui.title.y).toBe(ui.transcript.root.y + ui.transcript.root.height)
+      expect(ui.status.y + ui.status.height).toBeLessThan(setup.renderer.height)
+      if (!anchoredPositions) anchoredPositions = positions()
+      else expect(positions()).toEqual(anchoredPositions)
+    }
+
+    ui.transcript.user("A short prompt")
+    await setup.renderOnce()
+    const promptPositions = positions()
+    expect(promptPositions.titleY).toBeGreaterThan(anchoredPositions?.titleY || 0)
+
+    setup.resize(100, 40)
+    await setup.renderOnce()
+    expect(positions()).toEqual(promptPositions)
+  })
 
   test("reflows a single retained layout across terminal resizes", async () => {
     setup = await createRenderer({

--- a/tui/src/transcript.ts
+++ b/tui/src/transcript.ts
@@ -91,7 +91,7 @@ export class Transcript {
       id: "nanobot-tui-transcript",
       width: "100%",
       minHeight: 0,
-      flexGrow: 1,
+      flexGrow: 0,
       scrollX: false,
       scrollY: true,
       stickyScroll: true,
@@ -99,6 +99,7 @@ export class Transcript {
       viewportCulling: true,
       contentOptions: {
         flexDirection: "column",
+        minHeight: 0,
         paddingTop: 1,
         paddingBottom: 1,
         paddingLeft: 1,


### PR DESCRIPTION
## Summary

- keep short transcripts, runtime controls, and the composer together at the top of tall terminal panes
- allow the transcript to expand into the available space while preserving sticky scrolling once its content overflows
- add regression coverage for vertical resizing and short transcript growth

## Problem

The transcript currently consumes all remaining vertical space, even when it only contains the startup card or a few short messages.

Because the transcript content stays at the top of that space while the controls and composer are placed after it, a tall terminal creates a large gap between the conversation and its input area. Resizing an IDE terminal pane makes this separation grow or shrink, causing closely related parts of the interface to feel visually disconnected.

## Change

Let the transcript use its content height while the conversation is short instead of forcing it to fill the available space.

This keeps the startup card, short conversations, runtime controls, composer, and status row grouped at the top of the terminal. Once the transcript exceeds the available height, the existing shell constraints and sticky scrolling behavior continue to apply, so long conversations remain scrollable and the composer stays visible.

## Visual verification

https://github.com/user-attachments/assets/aea43c12-9850-465c-9d97-d729a41cfaa0

The recording shows the terminal pane being resized vertically. The short transcript and composer remain anchored at the top, while additional unused rows appear below the interface rather than between the transcript and composer.

## Testing

- `bun run --cwd tui check`
- `bun run --cwd tui test` — 130 tests passed
- `bun run --cwd tui build`
- manually resized the TUI in a PyCharm terminal to verify the top-anchored short transcript layout


