### PR TITLE
fix(telegram): upgrade streaming preview to rich in place at stream end

### DIFF
--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -897,6 +897,47 @@ class TelegramChannel(BaseChannel):
             self.logger.debug("sendRichMessage failed: {}", exc)
             return False
 
+    async def _try_edit_rich(self, chat_id: int, message_id: int, content: str) -> bool:
+        """Upgrade an existing message to rich in place via editMessageText (Bot API 10.1).
+
+        Editing in place keeps the message identity, so the streaming preview is
+        upgraded without the delete-and-resend pattern that caused flickering and
+        dropped line breaks (issue #4470). Returns True on success; on capability
+        errors (server older than Bot API 10.1) the rich latch is tripped so the
+        legacy HTML path is used from then on.
+        """
+        if not self._app:
+            return False
+
+        payload: dict[str, Any] = {
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "rich_message": {
+                "markdown": content,
+            },
+        }
+        try:
+            await self._call_with_retry(
+                self._app.bot.do_api_request,
+                "editMessageText",
+                api_kwargs=payload,
+            )
+            return True
+        except BadRequest as exc:
+            if self._is_rich_capability_error(exc):
+                self.logger.debug("editMessageText rich_message not available, disabling")
+                self._rich_send_disabled = True
+            else:
+                self.logger.debug("editMessageText rich_message rejected: {}", exc)
+            return False
+        except Exception as exc:
+            err_str = str(exc).lower()
+            if "timed out" in err_str or isinstance(exc, TimedOut):
+                self.logger.debug("editMessageText rich_message timeout, falling back to legacy path")
+                return False
+            self.logger.debug("editMessageText rich_message failed: {}", exc)
+            return False
+
     async def send(self, msg: OutboundMessage) -> None:
         """Send a message through Telegram."""
         app = await self._wait_for_app()
@@ -1136,26 +1177,16 @@ class TelegramChannel(BaseChannel):
                 thread_kwargs["message_thread_id"] = message_thread_id
             raw_text = buf.text
 
-            # Try sendRichMessage for final output (Bot API 10.1).
-            # Skip when a streaming preview already exists to avoid the
-            # delete-and-resend pattern that causes flickering and drops
-            # line breaks (issue #4470).
-            if not buf.message_id and self.config.rich_messages and not getattr(self, "_rich_send_disabled", False):
-                reply_params = None
-                if reply_to_message_id := meta.get("message_id"):
-                    reply_params = {"message_id": int(reply_to_message_id), "allow_sending_without_reply": True}
-                rich_ok = await self._try_send_rich(
-                    int_chat_id, raw_text, reply_params, thread_kwargs, None,
-                )
+            # Try upgrading the streaming preview to rich in place (Bot API 10.1:
+            # editMessageText gained a rich_message parameter). Editing in place
+            # keeps the message identity, so there is no delete-and-resend and
+            # none of the flickering / dropped line breaks from issue #4470.
+            # The previous branch here was unreachable: it was guarded by
+            # ``not buf.message_id`` after an early return had already ensured
+            # ``buf.message_id`` is set (issue #5516).
+            if self.config.rich_messages and not getattr(self, "_rich_send_disabled", False):
+                rich_ok = await self._try_edit_rich(int_chat_id, buf.message_id, raw_text)
                 if rich_ok:
-                    # Delete the streaming preview message
-                    try:
-                        await self._call_with_retry(
-                            app.bot.delete_message,
-                            chat_id=int_chat_id, message_id=buf.message_id,
-                        )
-                    except Exception:
-                        pass  # Preview stays if delete fails
                     self._stream_bufs.pop(chat_id, None)
                     return
 

--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -902,9 +902,16 @@ class TelegramChannel(BaseChannel):
 
         Editing in place keeps the message identity, so the streaming preview is
         upgraded without the delete-and-resend pattern that caused flickering and
-        dropped line breaks (issue #4470). Returns True on success; on capability
-        errors (server older than Bot API 10.1) the rich latch is tripped so the
-        legacy HTML path is used from then on.
+        dropped line breaks (issue #4470).
+
+        Returns True when the rich edit is in place (including the ambiguous
+        "message is not modified" retry outcome after a response timeout).
+        Returns False only when the legacy HTML path should take over:
+        capability errors (server older than Bot API 10.1, which also trip the
+        rich latch) and content-shaped BadRequest rejections. Transport,
+        rate-limit, and unexpected errors propagate so the final-edit retry
+        contract is preserved — ChannelManager retries the buffered send
+        instead of an immediate legacy edit doubling connection demand.
         """
         if not self._app:
             return False
@@ -924,19 +931,27 @@ class TelegramChannel(BaseChannel):
             )
             return True
         except BadRequest as exc:
+            if self._is_not_modified_error(exc):
+                # Ambiguous success: the rich edit was applied server-side but
+                # its response timed out, so the retry hit "message is not
+                # modified". Treat it as done rather than letting the legacy
+                # edit overwrite the already-successful rich result.
+                self.logger.debug("Rich stream edit already applied for {}", chat_id)
+                return True
             if self._is_rich_capability_error(exc):
                 self.logger.debug("editMessageText rich_message not available, disabling")
                 self._rich_send_disabled = True
-            else:
-                self.logger.debug("editMessageText rich_message rejected: {}", exc)
-            return False
-        except Exception as exc:
-            err_str = str(exc).lower()
-            if "timed out" in err_str or isinstance(exc, TimedOut):
-                self.logger.debug("editMessageText rich_message timeout, falling back to legacy path")
                 return False
-            self.logger.debug("editMessageText rich_message failed: {}", exc)
+            # Content-shaped rejections (invalid markdown, unsupported media in
+            # the rich payload, …) fall back to the legacy HTML edit.
+            self.logger.debug("editMessageText rich_message rejected: {}", exc)
             return False
+        except Exception:
+            # Transport, rate-limit, and unexpected errors propagate so the
+            # final-edit retry contract stays intact: ChannelManager retries
+            # the buffered send instead of this handler doubling connection
+            # demand with an immediate legacy edit.
+            raise
 
     async def send(self, msg: OutboundMessage) -> None:
         """Send a message through Telegram."""

--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -938,7 +938,13 @@ class TelegramChannel(BaseChannel):
                 # edit overwrite the already-successful rich result.
                 self.logger.debug("Rich stream edit already applied for {}", chat_id)
                 return True
-            if self._is_rich_capability_error(exc):
+            # Before Bot API 10.1, editMessageText ignores rich_message and
+            # reports the absent text argument instead.
+            pre_rich_edit_server = (
+                bool(content)
+                and str(exc).strip().lower() == "message text is empty"
+            )
+            if self._is_rich_capability_error(exc) or pre_rich_edit_server:
                 self.logger.debug("editMessageText rich_message not available, disabling")
                 self._rich_send_disabled = True
                 return False

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -2808,3 +2808,54 @@ async def test_send_delta_stream_end_rich_disabled_uses_legacy_html() -> None:
     channel._app.bot.do_api_request.assert_not_called()
     channel._app.bot.edit_message_text.assert_awaited_once()
     assert "123" not in channel._stream_bufs
+
+
+@pytest.mark.asyncio
+async def test_send_delta_stream_end_rich_network_error_propagates_for_retry() -> None:
+    """A transport failure on the rich edit must propagate so ChannelManager
+    retries the buffered send — not fall through to an immediate legacy edit
+    that doubles connection demand during pool exhaustion."""
+    from telegram.error import NetworkError
+
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_messages=True),
+        MessageBus(),
+    )
+    _install_ready_app(channel)
+    channel._app.bot.do_api_request = AsyncMock(side_effect=NetworkError("pool exhausted"))
+    channel._app.bot.edit_message_text = AsyncMock()
+    channel._stream_bufs["123"] = _StreamBuf(text="hello", message_id=7, last_edit=0.0)
+
+    with pytest.raises(NetworkError):
+        await channel.send_delta("123", "", stream_end=True)
+
+    # No legacy fallback edit: the buffered state stays for the manager retry.
+    channel._app.bot.edit_message_text.assert_not_awaited()
+    assert "123" in channel._stream_bufs
+
+
+@pytest.mark.asyncio
+async def test_send_delta_stream_end_rich_not_modified_after_timeout_is_success() -> None:
+    """Ambiguous success: the rich edit applied server-side but its response
+    timed out, so the retry hit "message is not modified". That is a completed
+    rich upgrade — the legacy edit must not overwrite it."""
+    from telegram.error import BadRequest, TimedOut
+
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_messages=True),
+        MessageBus(),
+    )
+    _install_ready_app(channel)
+    # First attempt (inside _call_with_retry) times out, retry reports the
+    # edit as already applied.
+    channel._app.bot.do_api_request = AsyncMock(
+        side_effect=[TimedOut(), BadRequest("Message is not modified")]
+    )
+    channel._app.bot.edit_message_text = AsyncMock(side_effect=AssertionError("must not overwrite rich result"))
+    channel._stream_bufs["123"] = _StreamBuf(text="hello", message_id=7, last_edit=0.0)
+
+    await channel.send_delta("123", "", stream_end=True)
+
+    assert channel._app.bot.do_api_request.await_count == 2
+    channel._app.bot.edit_message_text.assert_not_awaited()
+    assert "123" not in channel._stream_bufs

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -2777,7 +2777,10 @@ async def test_send_delta_stream_end_rich_capability_error_latches_and_falls_bac
         MessageBus(),
     )
     _install_ready_app(channel)
-    channel._app.bot.do_api_request = AsyncMock(side_effect=BadRequest("Method not found"))
+    # Before Bot API 10.1, editMessageText ignores rich_message and requires text.
+    channel._app.bot.do_api_request = AsyncMock(
+        side_effect=BadRequest("Message text is empty")
+    )
     channel._app.bot.edit_message_text = AsyncMock()
     channel._stream_bufs["123"] = _StreamBuf(text="hello", message_id=7, last_edit=0.0)
 

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -2735,3 +2735,76 @@ def test_markdown_to_html_code_block_same_line_no_newline() -> None:
 
     stripped = _strip_md_block(text)
     assert stripped == "Use <tag> here"
+
+
+@pytest.mark.asyncio
+async def test_send_delta_stream_end_upgrades_preview_to_rich_in_place() -> None:
+    """Rich messages finally work with streaming: the preview is upgraded via
+    editMessageText rich_message (in place), not delete-and-resend (issue #5516)."""
+    from telegram.error import BadRequest
+
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_messages=True),
+        MessageBus(),
+    )
+    _install_ready_app(channel)
+    channel._app.bot.do_api_request = AsyncMock()
+    channel._app.bot.edit_message_text = AsyncMock(side_effect=BadRequest("should not be reached"))
+    channel._stream_bufs["123"] = _StreamBuf(text="**hello**", message_id=7, last_edit=0.0)
+
+    await channel.send_delta("123", "", stream_end=True)
+
+    # editMessageText with rich_message payload, in place (same message_id)
+    channel._app.bot.do_api_request.assert_awaited_once()
+    args, kwargs = channel._app.bot.do_api_request.await_args
+    assert args[0] == "editMessageText"
+    assert kwargs["api_kwargs"]["chat_id"] == 123
+    assert kwargs["api_kwargs"]["message_id"] == 7
+    assert kwargs["api_kwargs"]["rich_message"] == {"markdown": "**hello**"}
+    # No delete-and-resend, no legacy HTML edit
+    channel._app.bot.edit_message_text.assert_not_awaited()
+    assert "123" not in channel._stream_bufs
+
+
+@pytest.mark.asyncio
+async def test_send_delta_stream_end_rich_capability_error_latches_and_falls_back() -> None:
+    """On a pre-10.1 Bot API server the rich edit fails, the latch trips, and the
+    legacy HTML edit handles the final output."""
+    from telegram.error import BadRequest
+
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_messages=True),
+        MessageBus(),
+    )
+    _install_ready_app(channel)
+    channel._app.bot.do_api_request = AsyncMock(side_effect=BadRequest("Method not found"))
+    channel._app.bot.edit_message_text = AsyncMock()
+    channel._stream_bufs["123"] = _StreamBuf(text="hello", message_id=7, last_edit=0.0)
+
+    await channel.send_delta("123", "", stream_end=True)
+
+    channel._app.bot.do_api_request.assert_awaited_once()
+    # Latch tripped: subsequent sends skip the rich path entirely
+    assert channel._rich_send_disabled is True
+    # Legacy HTML edit handled the final message
+    channel._app.bot.edit_message_text.assert_awaited_once()
+    assert "123" not in channel._stream_bufs
+
+
+@pytest.mark.asyncio
+async def test_send_delta_stream_end_rich_disabled_uses_legacy_html() -> None:
+    """rich_messages=False (the default) keeps the legacy HTML path untouched."""
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
+        MessageBus(),
+    )
+    _install_ready_app(channel)
+    channel._app.bot.do_api_request = AsyncMock()
+    channel._app.bot.edit_message_text = AsyncMock()
+    channel._stream_bufs["123"] = _StreamBuf(text="hello", message_id=7, last_edit=0.0)
+
+    await channel.send_delta("123", "", stream_end=True)
+
+    channel._app.bot.do_api_request.assert_not_called()
+    channel._app.bot.edit_message_text.assert_awaited_once()
+    assert "123" not in channel._stream_bufs


### PR DESCRIPTION
## Description

With `rich_messages: true` and `streaming: true` (the default), rich output never rendered: the final message always went through the legacy HTML `editMessageText` path. The rich branch in `send_delta(stream_end=True)` was unreachable — guarded by `if not buf.message_id` after an earlier return had already ensured `buf.message_id` is set (dead code, detailed in #5516).

The original rich-at-stream-end design (PR #4423) failed because it deleted and resent the final message, causing flicker and dropped line breaks (#4470) — so rich was skipped whenever a streaming preview exists, i.e. always with streaming on.

Bot API 10.1 (June 2026) added a `rich_message` parameter to `editMessageText`, which upgrades an existing message to rich **in place**. This PR uses it at stream end: the streaming preview keeps its message identity, so there is no delete-and-resend and none of the #4470 artifacts.

## Changes

- `runtime.py`: replace the unreachable delete-and-resend branch with an in-place upgrade via `editMessageText` + `rich_message={"markdown": ...}`, called through `do_api_request` (same raw-API pattern as `_try_send_rich`, so no python-telegram-bot version dependency).
- New `_try_edit_rich()`:
  - capability errors trip the existing `_rich_send_disabled` latch; this includes the real pre-10.1 `editMessageText` response, `Message text is empty`, returned when the server ignores `rich_message` and requires `text`;
  - content-shaped `BadRequest` rejections fall back to the legacy HTML edit without latching;
  - `Message is not modified` is treated as success after an ambiguous timeout/retry outcome;
  - transport, rate-limit, and unexpected errors propagate so `ChannelManager` retries the buffered final send instead of immediately doubling connection demand with a legacy edit.
- The legacy HTML path and the non-streaming `send_message` rich fast-path are otherwise unchanged.

## Test plan

- [x] `test_send_delta_stream_end_upgrades_preview_to_rich_in_place` — asserts the raw `editMessageText` call carries `rich_message={"markdown": ...}` with the preview's `message_id`, and that neither the legacy HTML edit nor delete-and-resend runs
- [x] `test_send_delta_stream_end_rich_capability_error_latches_and_falls_back` — uses the real pre-10.1 `Message text is empty` response, trips the latch, and completes through the legacy HTML edit
- [x] `test_send_delta_stream_end_rich_disabled_uses_legacy_html` — `rich_messages=False` (default) behavior unchanged
- [x] `test_send_delta_stream_end_rich_network_error_propagates_for_retry` — transport failure propagates and preserves the stream buffer
- [x] `test_send_delta_stream_end_rich_not_modified_after_timeout_is_success` — ambiguous success does not get overwritten by the legacy edit
- [x] Full Telegram suite: 115 passed; `ruff check` clean; `basedpyright` 0 errors

This is the "minimal fix" level from #5516. The full `sendRichMessageDraft` streaming path (Bot API 10.1/10.3 drafts with `can_stop` / `MessageGenerationStopped`) is the natural follow-up but replaces the whole edit-preview loop.

Fixes #5516