### PR TITLE
fix(tools): interpolate ToolLoader log context

### DIFF
--- a/nanobot/agent/tools/loader.py
+++ b/nanobot/agent/tools/loader.py
@@ -46,7 +46,7 @@ class ToolLoader:
             try:
                 module = importlib.import_module(f".{module_name}", self._package.__name__)
             except Exception:
-                logger.exception("Failed to import tool module: %s", module_name)
+                logger.exception("Failed to import tool module: {}", module_name)
                 continue
             for attr_name in dir(module):
                 attr = getattr(module, attr_name)
@@ -85,7 +85,7 @@ class ToolLoader:
                 ):
                     plugins[ep.name] = cls
             except Exception:
-                logger.exception("Failed to load tool plugin: %s", ep.name)
+                logger.exception("Failed to load tool plugin: {}", ep.name)
         self._plugins = plugins
         return plugins
 
@@ -107,12 +107,12 @@ class ToolLoader:
                     if registry.has(tool.name):
                         if is_plugin_source and tool.name in builtin_names:
                             logger.warning(
-                                "Plugin %s skipped: conflicts with built-in tool %s",
+                                "Plugin {} skipped: conflicts with built-in tool {}",
                                 cls_label, tool.name,
                             )
                             continue
                         logger.warning(
-                            "Tool name collision: %s from %s overwrites existing",
+                            "Tool name collision: {} from {} overwrites existing",
                             tool.name, cls_label,
                         )
                     registry.register(tool)
@@ -120,7 +120,7 @@ class ToolLoader:
                     if not is_plugin_source:
                         builtin_names.add(tool.name)
                 except Exception:
-                    logger.exception("Failed to register tool: %s", cls_label)
+                    logger.exception("Failed to register tool: {}", cls_label)
         return registered
 
 

--- a/tests/agent/test_tool_loader_entrypoints.py
+++ b/tests/agent/test_tool_loader_entrypoints.py
@@ -80,6 +80,23 @@ def test_loader_skips_abstract_entry_point_tools():
     assert "abstract_plugin" not in discovered
 
 
+def test_loader_logs_entry_point_load_error():
+    """Log the entry-point name when a plugin fails to load."""
+    mock_ep = MagicMock()
+    mock_ep.name = "broken_plugin"
+    mock_ep.load.side_effect = RuntimeError("boom")
+
+    with (
+        patch("nanobot.agent.tools.loader.entry_points", return_value=[mock_ep]),
+        patch("nanobot.agent.tools.loader.logger") as mock_logger,
+    ):
+        ToolLoader()._discover_plugins()
+
+    mock_logger.exception.assert_called_once_with(
+        "Failed to load tool plugin: {}", "broken_plugin"
+    )
+
+
 @pytest.mark.asyncio
 async def test_loader_entry_point_error_wrapper_preserves_tool_api(tmp_path):
     """Only adapt legacy plugin error strings; keep the wrapped tool API intact."""


### PR DESCRIPTION
## Summary

- replace the remaining printf-style `%s` placeholders in `ToolLoader` logs
- use Loguru-compatible `{}` placeholders
- add regression coverage for entry-point plugin load failures

## Problem

`ToolLoader` passed dynamic log arguments to Loguru while still using
printf-style `%s` placeholders. As a result, diagnostic context such as plugin
or tool names could remain uninterpolated when loading or registration failed.

This affects diagnostic logging only, not tool discovery, loading,
registration, or execution behavior.

## Changes

- fix tool module import failure logging
- fix entry-point plugin load failure logging
- fix built-in/plugin collision warnings
- fix tool name collision warnings
- fix tool registration failure logging
- add a regression test for failed entry-point plugin loading

## Testing

- targeted ToolLoader tests: 39 passed
- Ruff: passed
- BasedPyright: 0 errors, 0 warnings, 0 notes
- `git diff --check`: passed