### PR TITLE
fix(telegram): attribute group messages to senders

### DIFF
--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -1352,6 +1352,12 @@ class TelegramChannel(BaseChannel):
         sid = str(user.id)
         return f"{sid}|{user.username}" if user.username else sid
 
+    @staticmethod
+    def _with_group_sender(content: str, user: User) -> str:
+        """Prefix group-chat content with the Telegram sender's display name."""
+        sender = user.first_name or user.username or str(user.id)
+        return f"[{sender}]: {content}"
+
     async def _send_pairing_code_if_private(
         self, sender_id: str, message: Message, user: User
     ) -> None:
@@ -1714,6 +1720,9 @@ class TelegramChannel(BaseChannel):
             if tag:
                 content_parts.insert(0, tag)
         content = "\n".join(content_parts) if content_parts else "[empty message]"
+
+        if message.chat.type != "private":
+            content = self._with_group_sender(content, user)
 
         self.logger.debug("message from {}: {}...", sender_id, content[:50])
 

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -1639,7 +1639,7 @@ async def test_group_policy_mention_accepts_caption_mention() -> None:
     )
 
     assert len(handled) == 1
-    assert handled[0]["content"] == "@nanobot_test photo"
+    assert handled[0]["content"] == "[Alice]: @nanobot_test photo"
 
 
 @pytest.mark.asyncio
@@ -1757,7 +1757,7 @@ async def test_on_message_includes_reply_context() -> None:
     await channel._on_message(update, None)
 
     assert len(handled) == 1
-    assert handled[0]["content"].startswith("[Reply to: Hello]")
+    assert handled[0]["content"].startswith("[Alice]: [Reply to: Hello]")
     assert "translate this" in handled[0]["content"]
 
 
@@ -1891,7 +1891,7 @@ async def test_on_message_attaches_reply_to_media_when_available(monkeypatch, tm
     await channel._on_message(update, None)
 
     assert len(handled) == 1
-    assert handled[0]["content"].startswith("[Reply to: [image:")
+    assert handled[0]["content"].startswith("[Alice]: [Reply to: [image:")
     assert "what is the image?" in handled[0]["content"]
     assert len(handled[0]["media"]) == 1
     assert "reply_photo_fid" in handled[0]["media"][0]
@@ -2199,7 +2199,69 @@ async def test_on_message_location_content() -> None:
     await channel._on_message(update, None)
 
     assert len(handled) == 1
-    assert handled[0]["content"] == "[location: 48.8566, 2.3522]"
+    assert handled[0]["content"] == "[Alice]: [location: 48.8566, 2.3522]"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("first_name", "username", "user_id", "expected_sender"),
+    [
+        ("Alice", "alice", 12345, "Alice"),
+        (None, "alice", 12345, "alice"),
+        (None, None, 12345, "12345"),
+    ],
+)
+async def test_group_message_includes_sender_attribution(
+    first_name: str | None,
+    username: str | None,
+    user_id: int,
+    expected_sender: str,
+) -> None:
+    """Group messages identify their author before reaching the agent."""
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], group_policy="open"),
+        MessageBus(),
+    )
+    _install_ready_app(channel)
+    handled: list[dict] = []
+
+    async def capture_handle(**kwargs) -> None:
+        handled.append(kwargs)
+
+    channel._handle_message = capture_handle
+    channel._start_typing = lambda _chat_id: None
+    update = _make_telegram_update(text="hello", chat_type="group")
+    update.effective_user.first_name = first_name
+    update.effective_user.username = username
+    update.effective_user.id = user_id
+
+    await channel._on_message(update, None)
+
+    assert len(handled) == 1
+    assert handled[0]["content"] == f"[{expected_sender}]: hello"
+
+
+@pytest.mark.asyncio
+async def test_private_message_does_not_include_sender_attribution() -> None:
+    """Private messages retain their existing content format."""
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], group_policy="open"),
+        MessageBus(),
+    )
+    _install_ready_app(channel)
+    handled: list[dict] = []
+
+    async def capture_handle(**kwargs) -> None:
+        handled.append(kwargs)
+
+    channel._handle_message = capture_handle
+    channel._start_typing = lambda _chat_id: None
+    update = _make_telegram_update(text="hello", chat_type="private")
+
+    await channel._on_message(update, None)
+
+    assert len(handled) == 1
+    assert handled[0]["content"] == "hello"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- prefix non-private Telegram messages with the sender display name
- fall back from first name to username to numeric Telegram user ID
- keep private-chat content unchanged
- add regression coverage for all sender fallbacks and private chats

Fixes #1091

## Validation

- `pytest nanobot/channels/telegram/tests -q` (128 passed)
- `ruff check nanobot/channels/telegram/runtime.py nanobot/channels/telegram/tests/test_telegram_channel.py`
- `basedpyright nanobot/channels/telegram/runtime.py`
- `git diff --check`