### PR TITLE
docs: add RepoCloud as a deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ nanobot agent
 This opens the native terminal client with the launch directory as its workspace. It shares saved conversations and the local gateway with the WebUI.
 
 - Type `/` to discover commands, `/sessions` to switch conversations, or `@` to mention an app, MCP server, or saved session.
-- Press `Enter` to send or steer, `Tab` to queue a follow-up, and `Shift+Enter` to add a newline (`Ctrl+J` works in terminals that cannot distinguish modified Enter keys).
+- Press `Enter` to send. While nanobot is working, `Enter` sends now and `Tab` sends after the current response. Press `Shift+Enter` to add a newline (`Ctrl+J` works in terminals that cannot distinguish modified Enter keys).
 - Use `/detach` to leave the current task running, or start with `nanobot gateway --background` when nanobot should stay online after all local clients exit.
 
 Each launch starts a new session by default. Use `--session` to resume one and `--workspace` to choose another workspace. See the [CLI reference](./docs/cli-reference.md#agent-cli) for session branching, diffs, history, shortcuts, gateway lifecycle, and compatibility options.
@@ -247,6 +247,12 @@ Deploy nanobot's gateway and bundled WebUI from the repository's ready-to-use Bl
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/HKUDS/nanobot)
 
 Render will ask for `ANTHROPIC_API_KEY` and a private `NANOBOT_WEB_TOKEN`, then provision persistent storage for sessions, memory, and WebUI history. Persistent disks require a paid Render service.
+
+**RepoCloud — one click**
+
+Deploy nanobot on RepoCloud with managed hosting for open-source applications:
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/nanobot/)
 
 **Self-host**
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ nanobot agent
 This opens the native terminal client with the launch directory as its workspace. It shares saved conversations and the local gateway with the WebUI.
 
 - Type `/` to discover commands, `/sessions` to switch conversations, or `@` to mention an app, MCP server, or saved session.
-- Press `Enter` to send. While nanobot is working, `Enter` sends now and `Tab` sends after the current response. Press `Shift+Enter` to add a newline (`Ctrl+J` works in terminals that cannot distinguish modified Enter keys).
+- Press `Enter` to send or steer, `Tab` to queue a follow-up, and `Shift+Enter` to add a newline (`Ctrl+J` works in terminals that cannot distinguish modified Enter keys).
 - Use `/detach` to leave the current task running, or start with `nanobot gateway --background` when nanobot should stay online after all local clients exit.
 
 Each launch starts a new session by default. Use `--session` to resume one and `--workspace` to choose another workspace. See the [CLI reference](./docs/cli-reference.md#agent-cli) for session branching, diffs, history, shortcuts, gateway lifecycle, and compatibility options.


### PR DESCRIPTION
Adds [RepoCloud](https://repocloud.io) as a one-click deployment option in the Deploy section
alongside the existing Render deploy button.

RepoCloud provides managed cloud hosting for open-source applications with one-click deployment.

- Adds "RepoCloud — one click" subsection to `README.md` Deploy section
- Follows existing bold-heading + description + SVG badge pattern
- Links to: https://repocloud.io/details/nanobot/