### PR TITLE
fix(agent): hold goal continuation after a failed completion attempt …“goal完成“ 失败后不再继续触发goal延续

### DIFF
--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -43,6 +43,7 @@ from nanobot.runtime_context import (
     detach_runtime_context,
     reattach_runtime_context,
 )
+from nanobot.session.goal_state import had_goal_completion_attempt
 from nanobot.session.history_visibility import is_hidden_history_message
 from nanobot.session.recovery import PENDING_FOLLOWUP_ID_KEY
 from nanobot.utils.helpers import (
@@ -291,7 +292,18 @@ class AgentRunner:
             real_injection = bool(injections)
         if not injections and allow_goal_continue and assistant_message is not None:
             predicate = spec.goal_active_predicate
-            if predicate is not None and predicate():
+            # A run that already attempted to complete the goal without the goal
+            # becoming inactive means the completion failed to take effect (its
+            # tool result was an error). Re-injecting the goal continuation
+            # would re-prompt the model to repeat the same failing call on every
+            # iteration, so hold the continuation instead and let the final
+            # response stand (HKUDS/nanobot#4864).
+            guard_messages = [*messages, assistant_message]
+            if (
+                predicate is not None
+                and predicate()
+                and not had_goal_completion_attempt(guard_messages)
+            ):
                 injections = [self._build_goal_continue_message(spec)]
         if (
             not injections

--- a/nanobot/session/goal_state.py
+++ b/nanobot/session/goal_state.py
@@ -62,6 +62,48 @@ def sustained_goal_turn(
     return sustained_goal_active(metadata) or explicit_goal_requested(message_metadata)
 
 
+def had_goal_completion_attempt(messages: list[dict[str, Any]] | None) -> bool:
+    """True when the conversation already attempted to complete the goal.
+
+    Detects an assistant tool call to the goal-completion tool (``update_goal``
+    with ``action="complete"``) or to the ``complete_goal`` alias that some
+    third-party models emit even though no such tool is registered. When such an
+    attempt is present while the goal is still active, the completion did not
+    take effect (its tool result was an error); re-prompting the model to
+    complete the goal would only reproduce the same failing call. Continuation
+    policy should therefore hold instead of amplifying a single malformed
+    completion into a disruptive loop (see HKUDS/nanobot#4864).
+    """
+    for message in messages or []:
+        if message.get("role") != "assistant":
+            continue
+        for call in message.get("tool_calls") or []:
+            function = call.get("function") if isinstance(call, dict) else None
+            name = str((function or {}).get("name") or "").strip()
+            if name == "complete_goal":
+                return True
+            if name != "update_goal":
+                continue
+            if _tool_call_action((function or {}).get("arguments")) == "complete":
+                return True
+    return False
+
+
+def _tool_call_action(arguments: Any) -> str:
+    """Return the lowercased ``action`` argument of a tool call, if any."""
+    payload = arguments
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError:
+            return ""
+    if isinstance(payload, dict):
+        action = payload.get("action")
+        if isinstance(action, str):
+            return action.strip().lower()
+    return ""
+
+
 def parse_goal_state(blob: Any) -> dict[str, Any] | None:
     if blob is None:
         return None

--- a/nanobot/session/goal_state.py
+++ b/nanobot/session/goal_state.py
@@ -77,14 +77,19 @@ def had_goal_completion_attempt(messages: list[dict[str, Any]] | None) -> bool:
     for message in messages or []:
         if message.get("role") != "assistant":
             continue
-        for call in message.get("tool_calls") or []:
-            function = call.get("function") if isinstance(call, dict) else None
-            name = str((function or {}).get("name") or "").strip()
+        for call in cast(list[Any], message.get("tool_calls") or []):
+            if not isinstance(call, dict):
+                continue
+            function = cast(dict[str, Any], call).get("function")
+            if not isinstance(function, dict):
+                continue
+            name = str(cast(dict[str, Any], function).get("name") or "").strip()
             if name == "complete_goal":
                 return True
             if name != "update_goal":
                 continue
-            if _tool_call_action((function or {}).get("arguments")) == "complete":
+            arguments = cast(dict[str, Any], function).get("arguments")
+            if _tool_call_action(arguments) == "complete":
                 return True
     return False
 
@@ -98,7 +103,7 @@ def _tool_call_action(arguments: Any) -> str:
         except json.JSONDecodeError:
             return ""
     if isinstance(payload, dict):
-        action = payload.get("action")
+        action = cast(dict[str, Any], payload).get("action")
         if isinstance(action, str):
             return action.strip().lower()
     return ""

--- a/nanobot/session/turn_continuation.py
+++ b/nanobot/session/turn_continuation.py
@@ -14,6 +14,7 @@ from loguru import logger
 
 from nanobot.session.goal_state import (
     goal_state_runtime_lines,
+    had_goal_completion_attempt,
     sustained_goal_active,
     sustained_goal_turn,
 )
@@ -114,6 +115,15 @@ async def maybe_continue_turn(ctx: TurnContext) -> bool:
         session_metadata=ctx.session.metadata,
         message_metadata=ctx.msg.metadata,
     ):
+        return False
+
+    # A run that already tried to complete the goal without the goal changing
+    # to inactive means that completion attempt failed to take effect (its tool
+    # result was an error). Re-prompting the model to "call update_goal with
+    # action='complete'" would only reproduce the exact same failure on every
+    # continuation round, amplifying a single message into a disruptive loop.
+    # Hold the continuation instead and let the current turn finalize normally.
+    if had_goal_completion_attempt(ctx.all_messages):
         return False
 
     metadata = _internal_continuation_metadata(

--- a/tests/agent/test_runner_goal_continue.py
+++ b/tests/agent/test_runner_goal_continue.py
@@ -245,3 +245,98 @@ async def test_runner_resolves_goal_continue_message_lazily():
     user_msgs = [m for m in result.messages if m.get("role") == "user"]
     assert calls["n"] == 1
     assert any("Write the article draft." in str(m.get("content", "")) for m in user_msgs)
+
+
+@pytest.mark.asyncio
+async def test_runner_does_not_continue_after_failed_goal_completion_attempt():
+    """A failed completion attempt must stop goal-continue re-injection.
+
+    Reproduces HKUDS/nanobot#4864: the goal stays active while the run already
+    contains a malformed update_goal(action='complete') call. Re-injecting the
+    goal continuation would re-prompt the model to repeat the same failing call
+    on every iteration, so the runner should exit normally with the final
+    message instead of looping until max_iterations.
+    """
+    from nanobot.agent.runner import AgentRunner
+
+    provider = MagicMock(spec=LLMProvider)
+    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(
+        content="all done", tool_calls=[], usage=None,
+    ))
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+
+    initial_messages = [
+        {"role": "user", "content": "do task"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "update_goal",
+                    "arguments": '{"action": "complete", "recap": "done"}',
+                },
+            }],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "name": "update_goal",
+         "content": "Error: action is required"},
+    ]
+
+    runner = AgentRunner()
+    result = await runner.run(make_run_spec(provider,
+        initial_messages=initial_messages,
+        tools=tools,
+        model="test-model",
+        max_iterations=3,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        goal_active_predicate=lambda: True,
+    ))
+
+    assert result.stop_reason == "completed"
+    assert result.final_content == "all done"
+    user_msgs = [m for m in result.messages if m.get("role") == "user"]
+    assert not any("active sustained goal" in str(m.get("content", "")) for m in user_msgs)
+
+
+@pytest.mark.asyncio
+async def test_runner_still_continues_for_goal_work_after_other_tool_call():
+    """A non-completion tool call in history must not suppress the continuation."""
+    from nanobot.agent.runner import AgentRunner
+
+    provider = MagicMock(spec=LLMProvider)
+    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(
+        content="still working", tool_calls=[], usage=None,
+    ))
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+
+    initial_messages = [
+        {"role": "user", "content": "do task"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": '{"path": "a.py"}'},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "name": "read_file",
+         "content": "def foo(): pass"},
+    ]
+
+    runner = AgentRunner()
+    result = await runner.run(make_run_spec(provider,
+        initial_messages=initial_messages,
+        tools=tools,
+        model="test-model",
+        max_iterations=3,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        goal_active_predicate=lambda: True,
+    ))
+
+    assert result.stop_reason == "max_iterations"
+    user_msgs = [m for m in result.messages if m.get("role") == "user"]
+    assert any("active sustained goal" in str(m.get("content", "")) for m in user_msgs)

--- a/tests/session/test_goal_state.py
+++ b/tests/session/test_goal_state.py
@@ -9,6 +9,7 @@ from nanobot.session.goal_state import (
     explicit_goal_requested,
     goal_state_runtime_lines,
     goal_state_ws_blob,
+    had_goal_completion_attempt,
     parse_goal_state,
     runner_wall_llm_timeout_s,
     sustained_goal_active,
@@ -138,6 +139,64 @@ def test_sustained_goal_active_true_when_active():
 def test_sustained_goal_active_respects_legacy_thread_goal_key():
     meta = {"thread_goal": {"status": "active", "objective": "Legacy."}}
     assert sustained_goal_active(meta) is True
+
+
+def _assistant_call(name: str, arguments: object) -> dict:
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {"id": "call_1", "type": "function", "function": {"name": name, "arguments": arguments}}
+        ],
+    }
+
+
+def test_goal_completion_attempt_detects_update_goal_complete():
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "start"},
+        _assistant_call("update_goal", '{"action": "complete", "recap": "done"}'),
+        {"role": "tool", "tool_call_id": "call_1", "name": "update_goal",
+         "content": "Error: action is required"},
+    ]
+    assert had_goal_completion_attempt(messages) is True
+
+
+def test_goal_completion_attempt_accepts_dict_arguments():
+    messages = [
+        _assistant_call("update_goal", {"action": "complete", "recap": "done"}),
+    ]
+    assert had_goal_completion_attempt(messages) is True
+
+
+def test_goal_completion_attempt_detects_complete_goal_alias():
+    # Third-party models emit complete_goal even though it is not registered.
+    messages = [_assistant_call("complete_goal", '{"recap": "done"}')]
+    assert had_goal_completion_attempt(messages) is True
+
+
+def test_goal_completion_attempt_ignores_non_complete_update_goal():
+    messages = [_assistant_call("update_goal", '{"action": "cancel", "recap": "stop"}')]
+    assert had_goal_completion_attempt(messages) is False
+
+
+def test_goal_completion_attempt_ignores_other_tools():
+    messages = [
+        _assistant_call("read_file", '{"path": "a.py"}'),
+        {"role": "assistant", "content": "working"},
+    ]
+    assert had_goal_completion_attempt(messages) is False
+
+
+def test_goal_completion_attempt_malformed_arguments_is_safe():
+    assert had_goal_completion_attempt([_assistant_call("update_goal", "{not json")]) is False
+    assert had_goal_completion_attempt([_assistant_call("update_goal", None)]) is False
+
+
+def test_goal_completion_attempt_empty_or_none_inputs():
+    assert had_goal_completion_attempt(None) is False
+    assert had_goal_completion_attempt([]) is False
+    assert had_goal_completion_attempt([{"role": "assistant", "content": "no tools"}]) is False
 
 
 def test_explicit_goal_requested_only_reads_command_metadata():

--- a/tests/session/test_turn_continuation.py
+++ b/tests/session/test_turn_continuation.py
@@ -91,6 +91,88 @@ async def test_maybe_continue_turn_queues_internal_message():
 
 
 @pytest.mark.asyncio
+async def test_maybe_continue_turn_stops_after_failed_goal_completion_attempt():
+    # Goal remains active while the run already contains a completion attempt
+    # (e.g. a malformed update_goal action=complete call from #4864). Continuing
+    # would only re-prompt the model to retry the same failing completion, so an
+    # internal continuation must NOT be scheduled.
+    meta = {
+        GOAL_STATE_KEY: {"status": "active", "objective": "Finish the migration."},
+    }
+    assistant_msg = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "update_goal",
+                    "arguments": '{"action": "complete", "recap": "done"}',
+                },
+            }
+        ],
+    }
+    tool_msg = {
+        "role": "tool",
+        "tool_call_id": "call_1",
+        "name": "update_goal",
+        "content": "Error: action is required",
+    }
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "start"},
+        assistant_msg,
+        tool_msg,
+        {"role": "assistant", "content": "paused"},
+    ]
+    pending: asyncio.Queue[InboundMessage] = asyncio.Queue()
+    ctx = SimpleNamespace(
+        session=SimpleNamespace(metadata=meta),
+        msg=InboundMessage(channel="feishu", sender_id="u1", chat_id="c1", content="start"),
+        session_key="feishu:c1",
+        pending_queue=pending,
+        stop_reason="max_iterations",
+        final_content="paused",
+        all_messages=messages,
+        suppress_response=False,
+        visible_run_started_at=100.0,
+    )
+
+    assert await maybe_continue_turn(ctx) is False
+    assert pending.empty()
+
+
+@pytest.mark.asyncio
+async def test_maybe_continue_turn_allows_other_goal_work_to_continue():
+    # A run whose tool work did not end on a failed completion attempt still
+    # qualifies for an internal continuation.
+    meta = {
+        GOAL_STATE_KEY: {"status": "active", "objective": "Finish the migration."},
+    }
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "start"},
+        {"role": "assistant", "content": "working, ran out of budget"},
+    ]
+    pending: asyncio.Queue[InboundMessage] = asyncio.Queue()
+    ctx = SimpleNamespace(
+        session=SimpleNamespace(metadata=meta),
+        msg=InboundMessage(channel="feishu", sender_id="u1", chat_id="c1", content="start"),
+        session_key="feishu:c1",
+        pending_queue=pending,
+        stop_reason="max_iterations",
+        final_content="working, ran out of budget",
+        all_messages=messages,
+        suppress_response=False,
+        visible_run_started_at=100.0,
+    )
+
+    assert await maybe_continue_turn(ctx) is True
+    assert not pending.empty()
+
+
+@pytest.mark.asyncio
 async def test_internal_continuation_respects_round_limit():
     meta = {
         GOAL_STATE_KEY: {"status": "active", "objective": "x"},


### PR DESCRIPTION
…(#4864)

A sustained goal that stays active after the model already attempted to complete it means the completion call failed to take effect (its tool result was an error). The runner re-injects a goal-continue message after every final response while the goal is active, so a malformed completion (truncated args, or a call to the unregistered complete_goal tool) is amplified into a disruptive loop that burns the full iteration budget.

Add a guard to both goal-continuation paths: AgentRunner skips the goal-continue injection in _try_drain_injections when the conversation already contains a completion attempt, and maybe_continue_turn holds the session-level continuation for the same reason. The failing run now finalizes normally with the model's closing message instead of looping.
持续目标在模型已经尝试完成之后仍处于激活状态 即完成调用并没有真正生效（其工具结果返回了错误）运行器会在每次最终回复后重新注入"目标继续"消息，只要目标还没结束，就会一直这样。这就导致，一旦出现格式错误的完成调用（比如参数被截断，或者调用了不存在的 complete_goal 工具），就会被不断放大，形成一个死循环，把迭代预算全部耗尽。 修改在两处目标继续的路径上都加了防护：_try_drain_injections 里，如果对话中已经有过完成尝试，AgentRunner 就不再注入"目标继续"；maybe_continue_turn 那边也因为同样的原因，把会话级别的继续逻辑拦住了。改完之后，失败的运行会正常收尾，以模型的结束消息结束，不再死循环。