### PR TITLE
feat(spawn): per-spawn model presets behind a spawnPresets allowlist

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2230,6 +2230,27 @@ The deprecated `agents.defaults.failOnToolError` field is silently ignored when 
 | Option | Default | Description |
 |--------|---------|-------------|
 | `agents.defaults.maxConcurrentSubagents` | `4` | Maximum number of subagents that may run at the same time. Additional tasks wait for capacity. |
+| `agents.defaults.spawnPresets` | `[]` | Model presets that the `spawn` tool may select. Omit `preset` to inherit the parent runtime. |
+
+Allow a subagent to use selected entries from `modelPresets` by adding their names to
+`agents.defaults.spawnPresets`:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "spawnPresets": ["fast", "deep"]
+    }
+  },
+  "modelPresets": {
+    "fast": { "model": "openai/gpt-4.1-mini" },
+    "deep": { "model": "openai/gpt-5" }
+  }
+}
+```
+
+The `spawn` tool lists the allowed names and rejects any other `preset`. Gateway config
+reloads update the allowlist before the next tool call.
 
 
 ## Auto Compact

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -296,6 +296,7 @@ class AgentLoop:
         idle_compact_check_interval_seconds: int = 0,
         recovery_admission: RecoveryAdmission | None = None,
         spawn_presets: list[str] | None = None,
+        spawn_presets_loader: preset_helpers.SpawnPresetsLoader | None = None,
     ):
         from nanobot.config.schema import ToolsConfig
 
@@ -459,8 +460,8 @@ class AgentLoop:
             self.set_model_preset(model_preset, publish_update=False)
         self._register_default_tools(
             provider_snapshot_loader=provider_snapshot_loader,
-            preset_snapshot_loader=preset_snapshot_loader,
             spawn_presets=spawn_presets,
+            spawn_presets_loader=spawn_presets_loader,
         )
         self.commands = CommandRouter()
         register_builtin_commands(self.commands)
@@ -542,10 +543,11 @@ class AgentLoop:
     def invalidate_runtime_config(self) -> None:
         """Invalidate runtime config for lazy refresh at the next admission."""
         self.runtime_resolver.invalidate()
+        self.tools.invalidate_definitions()
 
     def refresh_runtime_config(self) -> LLMRuntime:
         """Refresh runtime config now and publish the canonical selection."""
-        self.runtime_resolver.invalidate()
+        self.invalidate_runtime_config()
         runtime = self.runtime_resolver.admit()
         self._publish_runtime_selection(runtime)
         return runtime
@@ -630,8 +632,8 @@ class AgentLoop:
         self,
         *,
         provider_snapshot_loader: Callable[..., ProviderSnapshot] | None,
-        preset_snapshot_loader: preset_helpers.PresetSnapshotLoader | None,
         spawn_presets: list[str] | None,
+        spawn_presets_loader: preset_helpers.SpawnPresetsLoader | None,
     ) -> None:
         """Register the default set of tools via plugin loader."""
         from nanobot.agent.tools.context import ToolContext
@@ -646,8 +648,8 @@ class AgentLoop:
             exec_session_manager=self._exec_session_manager,
             sessions=self.sessions,
             provider_snapshot_loader=provider_snapshot_loader,
-            preset_snapshot_loader=preset_snapshot_loader,
-            spawn_presets=spawn_presets or [],
+            preset_runtime_resolver=self.runtime_resolver.resolve_preset,
+            spawn_presets_loader=spawn_presets_loader or (lambda: list(spawn_presets or [])),
             image_generation_provider_configs=self._image_generation_provider_configs,
             timezone=self.context.timezone or "UTC",
             workspace_sandbox=self.workspace_scopes.sandbox_status,

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -295,6 +295,7 @@ class AgentLoop:
         local_trigger_store: LocalTriggerStore | None = None,
         idle_compact_check_interval_seconds: int = 0,
         recovery_admission: RecoveryAdmission | None = None,
+        spawn_presets: list[str] | None = None,
     ):
         from nanobot.config.schema import ToolsConfig
 
@@ -456,7 +457,11 @@ class AgentLoop:
         self._next_idle_compact_check_at = time.monotonic()
         if model_preset:
             self.set_model_preset(model_preset, publish_update=False)
-        self._register_default_tools(provider_snapshot_loader=provider_snapshot_loader)
+        self._register_default_tools(
+            provider_snapshot_loader=provider_snapshot_loader,
+            preset_snapshot_loader=preset_snapshot_loader,
+            spawn_presets=spawn_presets,
+        )
         self.commands = CommandRouter()
         register_builtin_commands(self.commands)
 
@@ -505,6 +510,7 @@ class AgentLoop:
             model=model,
             max_iterations=defaults.max_tool_iterations,
             max_concurrent_subagents=defaults.max_concurrent_subagents,
+            spawn_presets=defaults.spawn_presets,
             context_window_tokens=context_window_tokens,
             context_block_limit=defaults.context_block_limit,
             max_tool_result_chars=defaults.max_tool_result_chars,
@@ -624,6 +630,8 @@ class AgentLoop:
         self,
         *,
         provider_snapshot_loader: Callable[..., ProviderSnapshot] | None,
+        preset_snapshot_loader: preset_helpers.PresetSnapshotLoader | None,
+        spawn_presets: list[str] | None,
     ) -> None:
         """Register the default set of tools via plugin loader."""
         from nanobot.agent.tools.context import ToolContext
@@ -638,6 +646,8 @@ class AgentLoop:
             exec_session_manager=self._exec_session_manager,
             sessions=self.sessions,
             provider_snapshot_loader=provider_snapshot_loader,
+            preset_snapshot_loader=preset_snapshot_loader,
+            spawn_presets=spawn_presets or [],
             image_generation_provider_configs=self._image_generation_provider_configs,
             timezone=self.context.timezone or "UTC",
             workspace_sandbox=self.workspace_scopes.sandbox_status,

--- a/nanobot/agent/model_presets.py
+++ b/nanobot/agent/model_presets.py
@@ -12,6 +12,7 @@ from nanobot.providers.factory import ProviderSnapshot, build_provider_snapshot
 
 PresetSnapshotLoader = Callable[[str], ProviderSnapshot]
 PresetCatalogLoader = Callable[[], Mapping[str, ModelPresetConfig]]
+SpawnPresetsLoader = Callable[[], list[str]]
 
 
 def default_selection_signature(
@@ -37,6 +38,17 @@ def load_model_preset_catalog(
             config_path=config_path,
         ),
     )
+
+
+def load_spawn_presets(config_path: Path | None = None) -> list[str]:
+    """Load the current subagent preset allowlist from the configured file."""
+    from nanobot.config.loader import load_config, resolve_config_env_vars
+
+    config = resolve_config_env_vars(
+        load_config(config_path),
+        config_path=config_path,
+    )
+    return list(config.agents.defaults.spawn_presets)
 
 
 def make_preset_snapshot_loader(
@@ -78,6 +90,8 @@ def build_runtime_preset_snapshot(
 def normalize_preset_name(name: str | None, presets: dict[str, ModelPresetConfig]) -> str:
     if not isinstance(name, str) or not name.strip():
         raise ValueError("model_preset must be a non-empty string")
+    if name in presets:
+        return name
     name = name.strip()
     if name in presets:
         return name

--- a/nanobot/agent/tools/context.py
+++ b/nanobot/agent/tools/context.py
@@ -92,5 +92,5 @@ class ToolContext:
     workspace_sandbox: WorkspaceSandboxStatus | None = None
     runtime_events: RuntimeEventBus | None = None
     runtime_control: RuntimeControl | None = None
-    preset_snapshot_loader: Callable[[str], ProviderSnapshot] | None = None
-    spawn_presets: list[str] = field(default_factory=list)
+    preset_runtime_resolver: Callable[[str], LLMRuntime] | None = None
+    spawn_presets_loader: Callable[[], list[str]] | None = None

--- a/nanobot/agent/tools/context.py
+++ b/nanobot/agent/tools/context.py
@@ -92,3 +92,5 @@ class ToolContext:
     workspace_sandbox: WorkspaceSandboxStatus | None = None
     runtime_events: RuntimeEventBus | None = None
     runtime_control: RuntimeControl | None = None
+    preset_snapshot_loader: Callable[[str], ProviderSnapshot] | None = None
+    spawn_presets: list[str] = field(default_factory=list)

--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -37,6 +37,10 @@ class ToolRegistry:
         self._tools.pop(name, None)
         self._cached_definitions = None
 
+    def invalidate_definitions(self) -> None:
+        """Rebuild dynamic tool descriptions on the next request."""
+        self._cached_definitions = None
+
     def get(self, name: str) -> Tool | None:
         """Get a tool by name."""
         return self._tools.get(name)

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from nanobot.agent.tools.base import Tool, ToolResult, tool_parameters
@@ -15,12 +16,11 @@ from nanobot.agent.tools.schema import (
     tool_parameters_schema,
 )
 from nanobot.security.workspace_access import current_workspace_scope
-from nanobot.utils.llm_runtime import runtime_from_provider_snapshot
 
 if TYPE_CHECKING:
-    from nanobot.agent.model_presets import PresetSnapshotLoader
     from nanobot.agent.subagent import SubagentManager
     from nanobot.agent.tools.context import ToolContext
+    from nanobot.utils.llm_runtime import LLMRuntime
 
 
 @tool_parameters(
@@ -56,12 +56,14 @@ class SpawnTool(Tool):
     def __init__(
         self,
         manager: "SubagentManager",
-        spawn_presets: list[str] | None = None,
-        preset_snapshot_loader: "PresetSnapshotLoader | None" = None,
+        spawn_presets_loader: Callable[[], list[str]] | None = None,
+        preset_runtime_resolver: Callable[[str], LLMRuntime] | None = None,
     ):
         self._manager = manager
-        self._spawn_presets = frozenset(spawn_presets or ())
-        self._preset_snapshot_loader = preset_snapshot_loader
+        self._spawn_presets_loader: Callable[[], list[str]] = (
+            spawn_presets_loader or (lambda: [])
+        )
+        self._preset_runtime_resolver = preset_runtime_resolver
 
     @classmethod
     def create(cls, ctx: ToolContext) -> Tool:
@@ -70,8 +72,8 @@ class SpawnTool(Tool):
             raise RuntimeError("SpawnTool requires an initialized subagent manager")
         return cls(
             manager=manager,
-            spawn_presets=ctx.spawn_presets,
-            preset_snapshot_loader=ctx.preset_snapshot_loader,
+            spawn_presets_loader=ctx.spawn_presets_loader,
+            preset_runtime_resolver=ctx.preset_runtime_resolver,
         )
 
     @property
@@ -80,13 +82,15 @@ class SpawnTool(Tool):
 
     @property
     def description(self) -> str:
+        available = ", ".join(sorted(self._spawn_presets_loader())) or "(none)"
         return (
             "Spawn a subagent to handle a task in the background. "
             "Use this for complex or time-consuming tasks that can run independently. "
             "Set wait=true for a consultation whose result must inform the current turn. "
             "The subagent will complete the task and report back when done. "
             "For deliverables or existing projects, inspect the workspace first "
-            "and use a dedicated subdirectory when helpful."
+            "and use a dedicated subdirectory when helpful. "
+            f"Available model presets: {available}."
         )
 
     @property
@@ -109,18 +113,17 @@ class SpawnTool(Tool):
             return ToolResult.error("Error: spawn requires an active model runtime")
         runtime = request_ctx.runtime
         if preset is not None:
-            if preset not in self._spawn_presets:
-                available = ", ".join(sorted(self._spawn_presets)) or "(none)"
+            spawn_presets = self._spawn_presets_loader()
+            if preset not in spawn_presets:
+                available = ", ".join(sorted(spawn_presets)) or "(none)"
                 return ToolResult.error(
                     f"Error: spawn preset {preset!r} is not allowlisted. "
                     f"Available: {available}"
                 )
-            if self._preset_snapshot_loader is None:
+            if self._preset_runtime_resolver is None:
                 return ToolResult.error("Error: spawn preset resolution is unavailable")
             try:
-                runtime = runtime_from_provider_snapshot(
-                    self._preset_snapshot_loader(preset)
-                )
+                runtime = self._preset_runtime_resolver(preset)
             except (KeyError, ValueError) as exc:
                 return ToolResult.error(
                     f"Error: failed to resolve spawn preset {preset!r}: {exc}"

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -15,8 +15,10 @@ from nanobot.agent.tools.schema import (
     tool_parameters_schema,
 )
 from nanobot.security.workspace_access import current_workspace_scope
+from nanobot.utils.llm_runtime import runtime_from_provider_snapshot
 
 if TYPE_CHECKING:
+    from nanobot.agent.model_presets import PresetSnapshotLoader
     from nanobot.agent.subagent import SubagentManager
     from nanobot.agent.tools.context import ToolContext
 
@@ -25,6 +27,9 @@ if TYPE_CHECKING:
     tool_parameters_schema(
         task=StringSchema("The task for the subagent to complete"),
         label=StringSchema("Optional short label for the task (for display)"),
+        preset=StringSchema(
+            "Model preset for the subagent; only allowlisted presets are accepted"
+        ),
         temperature=NumberSchema(
             description=(
                 "Optional sampling temperature for the subagent "
@@ -48,15 +53,26 @@ if TYPE_CHECKING:
 class SpawnTool(Tool):
     """Tool to spawn a subagent for background task execution."""
 
-    def __init__(self, manager: "SubagentManager"):
+    def __init__(
+        self,
+        manager: "SubagentManager",
+        spawn_presets: list[str] | None = None,
+        preset_snapshot_loader: "PresetSnapshotLoader | None" = None,
+    ):
         self._manager = manager
+        self._spawn_presets = frozenset(spawn_presets or ())
+        self._preset_snapshot_loader = preset_snapshot_loader
 
     @classmethod
     def create(cls, ctx: ToolContext) -> Tool:
         manager = ctx.subagent_manager
         if manager is None:
             raise RuntimeError("SpawnTool requires an initialized subagent manager")
-        return cls(manager=manager)
+        return cls(
+            manager=manager,
+            spawn_presets=ctx.spawn_presets,
+            preset_snapshot_loader=ctx.preset_snapshot_loader,
+        )
 
     @property
     def name(self) -> str:
@@ -82,6 +98,7 @@ class SpawnTool(Tool):
         self,
         task: str,
         label: str | None = None,
+        preset: str | None = None,
         temperature: float | None = None,
         wait: bool = False,
         **kwargs: Any,
@@ -90,13 +107,29 @@ class SpawnTool(Tool):
         request_ctx = current_request_context()
         if request_ctx is None or request_ctx.runtime is None:
             return ToolResult.error("Error: spawn requires an active model runtime")
+        runtime = request_ctx.runtime
+        if preset is not None:
+            if preset not in self._spawn_presets:
+                return ToolResult.error(
+                    f"Error: spawn preset {preset!r} is not allowlisted"
+                )
+            if self._preset_snapshot_loader is None:
+                return ToolResult.error("Error: spawn preset resolution is unavailable")
+            try:
+                runtime = runtime_from_provider_snapshot(
+                    self._preset_snapshot_loader(preset)
+                )
+            except (KeyError, ValueError) as exc:
+                return ToolResult.error(
+                    f"Error: failed to resolve spawn preset {preset!r}: {exc}"
+                )
         origin_channel = request_ctx.channel
         origin_chat_id = request_ctx.chat_id
         session_key = request_ctx.session_key or f"{origin_channel}:{origin_chat_id}"
         method = self._manager.run_inline if wait else self._manager.spawn
         return await method(
             task=task,
-            runtime=request_ctx.runtime,
+            runtime=runtime,
             label=label,
             origin_channel=origin_channel,
             origin_chat_id=origin_chat_id,

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -110,8 +110,10 @@ class SpawnTool(Tool):
         runtime = request_ctx.runtime
         if preset is not None:
             if preset not in self._spawn_presets:
+                available = ", ".join(sorted(self._spawn_presets)) or "(none)"
                 return ToolResult.error(
-                    f"Error: spawn preset {preset!r} is not allowlisted"
+                    f"Error: spawn preset {preset!r} is not allowlisted. "
+                    f"Available: {available}"
                 )
             if self._preset_snapshot_loader is None:
                 return ToolResult.error("Error: spawn preset resolution is unavailable")

--- a/nanobot/cli/gateway_runtime.py
+++ b/nanobot/cli/gateway_runtime.py
@@ -353,7 +353,7 @@ def _run_gateway(
     gateway_instance: GatewayInstance | None = None,
 ) -> None:
     """Shared gateway runtime; ``open_browser_url`` opens a tab once channels are up."""
-    from nanobot.agent.model_presets import load_model_preset_catalog
+    from nanobot.agent.model_presets import load_model_preset_catalog, load_spawn_presets
     from nanobot.agent.tools.message import MessageTool
     from nanobot.agent.turn_delivery import TurnDeliveryFactory
     from nanobot.bus.queue import MessageBus
@@ -492,6 +492,7 @@ def _run_gateway(
         image_generation_provider_configs=image_gen_provider_configs(config),
         provider_snapshot_loader=_load_gateway_provider_snapshot,
         preset_catalog_loader=load_model_preset_catalog,
+        spawn_presets_loader=lambda: load_spawn_presets(Path(config_path)),
         runtime_events=runtime_events,
         turn_delivery_factory=turn_delivery_factory,
         provider_signature=provider_snapshot.signature,

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -129,6 +129,7 @@ class AgentDefaults(Base):
     fallback_models: list[FallbackCandidate] = Field(default_factory=list)
     max_tool_iterations: int = 200
     max_concurrent_subagents: int = Field(default=4, ge=1)
+    spawn_presets: list[str] = Field(default_factory=list)
     max_tool_result_chars: int = 16_000
     provider_retry_mode: Literal["standard", "persistent"] = "standard"
     tool_hint_max_length: int = Field(
@@ -476,6 +477,11 @@ class Config(BaseSettings):
         for fallback in self.agents.defaults.fallback_models:
             if isinstance(fallback, str) and fallback not in self.model_presets:
                 raise ValueError(f"fallback_models entry {fallback!r} not found in model_presets")
+        for spawn_preset in self.agents.defaults.spawn_presets:
+            if spawn_preset not in self.model_presets:
+                raise ValueError(
+                    f"spawn_presets entry {spawn_preset!r} not found in model_presets"
+                )
         return self
 
     def resolve_default_preset(self) -> ModelPresetConfig:

--- a/tests/agent/test_model_runtime_resolver.py
+++ b/tests/agent/test_model_runtime_resolver.py
@@ -95,6 +95,35 @@ def test_resolver_resolves_preset_without_mutating_selected_runtime() -> None:
     assert resolved.generation == GenerationSettings(0.5, 512, None)
 
 
+def test_resolver_preserves_exact_legacy_preset_name() -> None:
+    name = " fast "
+    preset = ModelPresetConfig(model="fast-model")
+    resolver = ModelRuntimeResolver(
+        _runtime(),
+        model_presets={name: preset},
+        preset_snapshot_loader=lambda loaded_name: ProviderSnapshot(
+            provider=_provider(),
+            model=preset.model,
+            context_window_tokens=preset.context_window_tokens,
+            signature=(loaded_name, preset.model),
+        ),
+    )
+
+    resolved = resolver.resolve_preset(name)
+
+    assert resolved.model_preset == name
+
+
+def test_resolver_rejects_whitespace_only_legacy_preset_name() -> None:
+    resolver = ModelRuntimeResolver(
+        _runtime(),
+        model_presets={"   ": ModelPresetConfig(model="fast-model")},
+    )
+
+    with pytest.raises(ValueError, match="non-empty"):
+        resolver.resolve_preset("   ")
+
+
 def test_resolver_reuses_preset_until_runtime_config_is_invalidated() -> None:
     initial = _runtime()
     preset = ModelPresetConfig(model="fast-model")

--- a/tests/agent/tools/test_subagent_tools.py
+++ b/tests/agent/tools/test_subagent_tools.py
@@ -240,8 +240,11 @@ async def test_spawn_tool_uses_allowlisted_preset_runtime(tmp_path):
     providers = {"preset-model": MagicMock(), "updated-model": MagicMock()}
     preset = config.model_presets["fast"]
     registry = ToolRegistry()
+    load_count = 0
 
     def load_preset(name):
+        nonlocal load_count
+        load_count += 1
         current = config.model_presets[name]
         return build_static_preset_snapshot(providers[current.model], name, current)
 
@@ -271,11 +274,13 @@ async def test_spawn_tool_uses_allowlisted_preset_runtime(tmp_path):
         runtime=parent_runtime,
     )):
         result = await tool.execute(task="do task", preset="fast", wait=True)
+        await tool.execute(task="reuse preset", preset="fast", wait=True)
         config.model_presets["fast"] = preset.model_copy(update={
             "model": "updated-model",
             "max_tokens": 5678,
             "context_window_tokens": 8192,
         })
+        loop.invalidate_runtime_config()
         await tool.execute(task="do another task", preset="fast", wait=True)
 
     runtime = seen[0]
@@ -292,11 +297,49 @@ async def test_spawn_tool_uses_allowlisted_preset_runtime(tmp_path):
         preset.model_dump_json(),
     )
     assert parent_runtime.model == "main-model"
-    assert seen[1].model == "updated-model"
-    assert seen[1].provider is providers["updated-model"]
-    assert seen[1].generation.max_tokens == 5678
-    assert seen[1].context_window_tokens == 8192
-    assert seen[0].snapshot_signature != seen[1].snapshot_signature
+    assert seen[1] is seen[0]
+    assert load_count == 2
+    assert seen[2].model == "updated-model"
+    assert seen[2].provider is providers["updated-model"]
+    assert seen[2].generation.max_tokens == 5678
+    assert seen[2].context_window_tokens == 8192
+    assert seen[0].snapshot_signature != seen[2].snapshot_signature
+
+
+@pytest.mark.asyncio
+async def test_spawn_tool_refreshes_allowlist_and_description(tmp_path):
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.agent.tools.context import request_context
+    from nanobot.agent.tools.registry import ToolRegistry
+    from nanobot.bus.queue import MessageBus
+
+    allowed = ["fast"]
+    registry = ToolRegistry()
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=MagicMock(),
+        workspace=tmp_path,
+        tool_registry=registry,
+        spawn_presets=["stale"],
+        spawn_presets_loader=lambda: allowed,
+    )
+    tool = registry.get("spawn")
+    assert tool is not None
+    first_definitions = registry.get_definitions()
+    assert "Available model presets: fast" in str(first_definitions)
+
+    allowed.clear()
+    loop.invalidate_runtime_config()
+    with request_context(RequestContext(
+        channel="test",
+        chat_id="c1",
+        runtime=_runtime(MagicMock()),
+    )):
+        result = await tool.execute(task="do task", preset="fast")
+
+    assert result.is_error
+    assert "Available: (none)" in result
+    assert "Available model presets: (none)" in str(registry.get_definitions())
 
 
 @pytest.mark.asyncio
@@ -322,8 +365,8 @@ async def test_spawn_tool_rejects_unavailable_preset_without_touching_main_runti
     parent_runtime = _runtime(MagicMock(), model="main-model")
     tool = SpawnTool(
         manager,
-        spawn_presets=allowlist,
-        preset_snapshot_loader=loader,
+        spawn_presets_loader=lambda: allowlist,
+        preset_runtime_resolver=loader,
     )
     with request_context(RequestContext(
         channel="test",

--- a/tests/agent/tools/test_subagent_tools.py
+++ b/tests/agent/tools/test_subagent_tools.py
@@ -211,6 +211,159 @@ async def test_spawn_forwards_temperature_to_run_spec(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_spawn_tool_uses_allowlisted_preset_runtime(tmp_path):
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.agent.model_presets import build_static_preset_snapshot
+    from nanobot.agent.tools.context import request_context
+    from nanobot.agent.tools.registry import ToolRegistry
+    from nanobot.bus.queue import MessageBus
+    from nanobot.config.schema import Config
+
+    config = Config.model_validate({
+        "agents": {
+            "defaults": {
+                "workspace": str(tmp_path),
+                "spawnPresets": ["fast"],
+            }
+        },
+        "modelPresets": {
+            "fast": {
+                "model": "preset-model",
+                "provider": "openai",
+                "maxTokens": 1234,
+                "contextWindowTokens": 4321,
+                "temperature": 0.6,
+                "reasoningEffort": "high",
+            }
+        },
+    })
+    providers = {"preset-model": MagicMock(), "updated-model": MagicMock()}
+    preset = config.model_presets["fast"]
+    registry = ToolRegistry()
+
+    def load_preset(name):
+        current = config.model_presets[name]
+        return build_static_preset_snapshot(providers[current.model], name, current)
+
+    loop = AgentLoop.from_config(
+        config,
+        bus=MessageBus(),
+        provider=MagicMock(),
+        preset_snapshot_loader=load_preset,
+        tool_registry=registry,
+    )
+    seen = []
+
+    async def fake_run(spec):
+        seen.append(spec.runtime)
+        return SimpleNamespace(
+            stop_reason="done", final_content="done", error=None, tool_events=[],
+        )
+
+    loop.subagents.runner.run = AsyncMock(side_effect=fake_run)
+    parent_runtime = _runtime(MagicMock(), model="main-model")
+    tool = registry.get("spawn")
+    assert tool is not None
+    with request_context(RequestContext(
+        channel="test",
+        chat_id="c1",
+        session_key="test:c1",
+        runtime=parent_runtime,
+    )):
+        result = await tool.execute(task="do task", preset="fast", wait=True)
+        config.model_presets["fast"] = preset.model_copy(update={
+            "model": "updated-model",
+            "max_tokens": 5678,
+            "context_window_tokens": 8192,
+        })
+        await tool.execute(task="do another task", preset="fast", wait=True)
+
+    runtime = seen[0]
+    assert result == "done"
+    assert runtime.provider is providers["preset-model"]
+    assert runtime.model == "preset-model"
+    assert runtime.generation.max_tokens == 1234
+    assert runtime.generation.temperature == 0.6
+    assert runtime.generation.reasoning_effort == "high"
+    assert runtime.context_window_tokens == 4321
+    assert runtime.snapshot_signature == (
+        "model_preset",
+        "fast",
+        preset.model_dump_json(),
+    )
+    assert parent_runtime.model == "main-model"
+    assert seen[1].model == "updated-model"
+    assert seen[1].provider is providers["updated-model"]
+    assert seen[1].generation.max_tokens == 5678
+    assert seen[1].context_window_tokens == 8192
+    assert seen[0].snapshot_signature != seen[1].snapshot_signature
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("allowlist", "preset", "loader"),
+    [
+        (["fast"], "unknown", lambda _name: None),
+        (["missing"], "missing", lambda name: (_ for _ in ()).throw(KeyError(name))),
+    ],
+)
+async def test_spawn_tool_rejects_unavailable_preset_without_touching_main_runtime(
+    allowlist,
+    preset,
+    loader,
+):
+    from nanobot.agent.tools.context import request_context
+    from nanobot.agent.tools.spawn import SpawnTool
+
+    manager = MagicMock()
+    manager.max_concurrent_subagents = 1
+    manager.get_running_count.return_value = 0
+    manager.spawn = AsyncMock(return_value="started")
+    parent_runtime = _runtime(MagicMock(), model="main-model")
+    tool = SpawnTool(
+        manager,
+        spawn_presets=allowlist,
+        preset_snapshot_loader=loader,
+    )
+    with request_context(RequestContext(
+        channel="test",
+        chat_id="c1",
+        runtime=parent_runtime,
+    )):
+        result = await tool.execute(task="do task", preset=preset)
+
+    assert result.is_error
+    assert "spawn preset" in result
+    manager.spawn.assert_not_awaited()
+    assert parent_runtime.model == "main-model"
+
+
+@pytest.mark.asyncio
+async def test_spawn_tool_empty_allowlist_rejects_preset_but_keeps_default_path():
+    from nanobot.agent.tools.context import request_context
+    from nanobot.agent.tools.spawn import SpawnTool
+
+    manager = MagicMock()
+    manager.max_concurrent_subagents = 1
+    manager.get_running_count.return_value = 0
+    manager.spawn = AsyncMock(return_value="started")
+    parent_runtime = _runtime(MagicMock(), model="main-model")
+    tool = SpawnTool(manager)
+    with request_context(RequestContext(
+        channel="test",
+        chat_id="c1",
+        runtime=parent_runtime,
+    )):
+        rejected = await tool.execute(task="preset", preset="fast")
+        result = await tool.execute(task="default")
+
+    assert rejected.is_error
+    assert result == "started"
+    manager.spawn.assert_awaited_once()
+    assert manager.spawn.await_args.kwargs["runtime"] is parent_runtime
+
+
+@pytest.mark.asyncio
 async def test_background_spawn_waits_for_concurrency_capacity(tmp_path):
     """Background tasks should be accepted and start when capacity becomes available."""
     from nanobot.agent.subagent import SubagentManager

--- a/tests/config/test_model_presets.py
+++ b/tests/config/test_model_presets.py
@@ -7,7 +7,7 @@ import warnings
 
 import pytest
 
-from nanobot.agent.model_presets import load_model_preset_catalog
+from nanobot.agent.model_presets import load_model_preset_catalog, load_spawn_presets
 from nanobot.config.errors import ConfigLoadError
 from nanobot.config.schema import Config
 
@@ -39,6 +39,19 @@ def test_model_preset_catalog_missing_env_reports_explicit_config_path(
         load_model_preset_catalog(config_path)
 
     assert exc_info.value.path == config_path
+
+
+def test_load_spawn_presets_reads_current_config(tmp_path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({
+            "agents": {"defaults": {"spawnPresets": ["fast"]}},
+            "modelPresets": {"fast": {"model": "openai/gpt-4.1-mini"}},
+        }),
+        encoding="utf-8",
+    )
+
+    assert load_spawn_presets(config_path) == ["fast"]
 
 
 def test_agent_timezone_rejects_unknown_iana_name() -> None:

--- a/tests/config/test_model_presets.py
+++ b/tests/config/test_model_presets.py
@@ -351,6 +351,16 @@ def test_validator_rejects_unknown_preset() -> None:
         })
 
 
+def test_validator_rejects_unknown_spawn_preset() -> None:
+    with pytest.raises(
+        ValueError,
+        match="spawn_presets entry 'unknown' not found in model_presets",
+    ):
+        Config.model_validate({
+            "agents": {"defaults": {"spawnPresets": ["unknown"]}},
+        })
+
+
 def test_validator_accepts_dream_model_preset() -> None:
     config = Config.model_validate({
         "modelPresets": {


### PR DESCRIPTION

Resolves #4231.

This is an alternative implementation of the feature pursued in #4291. It keeps the
`spawnPresets` allowlist interface that emerged from that PR's review discussion
(credit to @aiguozhi123456 for the design direction and to @chengyongru for the
review analysis), while addressing the two review-blocking issues structurally in
the implementation.

## What it does

```jsonc
{
  "modelPresets": {
    "fast-search": { "model": "...", "reasoningEffort": "low", "contextWindowTokens": 128000 }
  },
  "agents": { "defaults": { "spawnPresets": ["fast-search"] } }
}
```

The `spawn` tool gains an optional `preset` parameter. An allowlisted preset runs the
subagent using that preset's model and generation settings. Any other value is rejected
with a tool error listing the available presets (following the error-message shape from
#4291). When `spawnPresets` is empty or absent, as it is by default, spawn behavior is
unchanged: the subagent inherits the parent runtime exactly as it does today.

## Design notes (how this differs from #4291)

**1. Resolution happens per spawn through the existing snapshot infrastructure; there is
no preset-runner cache.** At call time, `SpawnTool` resolves the preset through the
loop's existing `preset_snapshot_loader` (`make_preset_snapshot_loader` →
`build_provider_snapshot`). This produces a `ProviderSnapshot` whose signature already
includes the preset's full content (`preset.model_dump_json()`). Because snapshots are
not cached by preset name, this avoids the stale-provider-after-reload failure mode
reproduced during the review of #4291. Cross-cutting concerns and state, including
provider construction and circuit-breaker state, continue to flow through the same
paths as the main runtime.

**2. The subagent layer stays policy-free.** `subagent.py` is untouched. The tool layer
owns the allowlist and passes `SubagentManager.spawn/run_inline` a fully resolved
`LLMRuntime` through the `runtime=` parameter they already accept. Because
`AgentRunSpec` consumes the runtime as a whole, the preset's `context_window_tokens`
and generation settings (`max_tokens`, `temperature`, `reasoning_effort`) reach the
subagent run without field-by-field copying. This structurally avoids the second review
gap identified in #4291.

**3. The freshness model is explicit and consistent.** The allowlist is captured when
the loop wires its tools, like other `agents.defaults` values, while preset *definitions*
are resolved through the loop's snapshot loader at spawn time. There is no ad hoc config
reload from disk, so the allowlist and definitions always come from the same config
lifecycle. If in-process config reload later becomes a first-class mechanism, this code
inherits it through the loader without requiring separate cache invalidation.

## Tests

- allowlisted preset → subagent runtime carries the preset's provider, model,
  generation settings, and `context_window_tokens` (asserted individually);
- freshness: preset definition changed between two spawns → second spawn resolves the
  new definition (distinct snapshot signatures);
- unknown / non-allowlisted preset → tool error, parent runtime untouched, nothing spawned;
- empty allowlist → `preset` rejected and the default path passes the parent runtime
  **by identity** (`runtime is parent_runtime`);
- config validation rejects `spawnPresets` entries missing from `modelPresets`.

## Verification

- `pytest`: 6,790 passed, 12 skipped (one pre-existing `tests/cli/test_tui_launcher.py`
  failure reproduces identically on a clean `origin/main` checkout in this environment
  and is unrelated);
- `ruff check` on changed files: clean;
- `basedpyright` on changed files: 0 errors, 0 warnings.

This is opened as a draft because #4291 and the broader multi-agent discussion in
#5000 remain open. Happy to adjust the scope or fold this implementation into whichever
direction the maintainers choose.
