### PR TITLE
feat(api): stream tool progress events

### DIFF
--- a/nanobot/api/server.py
+++ b/nanobot/api/server.py
@@ -52,6 +52,11 @@ _REQUEST_TIMEOUT_KEY = web.AppKey[float]("request_timeout")
 _SESSION_LOCKS_KEY = web.AppKey[dict[str, asyncio.Lock]]("session_locks")
 _PREPARE_AGENT_KEY = web.AppKey[Callable[[], Awaitable[None]] | None]("prepare_agent")
 _MISSING = object()
+_TOOL_EVENT_STATUS = {
+    "start": "running",
+    "end": "completed",
+    "error": "failed",
+}
 
 
 class _UsageCaptureHook(AgentHook):
@@ -182,6 +187,43 @@ def _sse_chunk(delta: str, model: str, chunk_id: str, finish_reason: str | None 
     return f"data: {_json.dumps(payload)}\n\n".encode()
 
 
+def _include_tool_events(body: dict[str, Any]) -> bool:
+    """Return whether this request opted into nanobot tool progress events."""
+    options = body.get("stream_options")
+    if not isinstance(options, dict):
+        return False
+    typed_options = cast(dict[str, object], options)
+    include_tool_events = typed_options.get("include_tool_events")
+    return include_tool_events is True
+
+
+def _sse_tool_progress(event: dict[str, Any]) -> bytes | None:
+    """Format one structured agent tool event as a named SSE frame."""
+    phase = event.get("phase")
+    status = _TOOL_EVENT_STATUS.get(phase) if isinstance(phase, str) else None
+    name = event.get("name")
+    call_id = event.get("call_id")
+    if status is None or not isinstance(name, str) or not name or not call_id:
+        return None
+
+    arguments = event.get("arguments")
+    payload: dict[str, Any] = {
+        "version": 1,
+        "tool": name,
+        "toolCallId": str(call_id),
+        "status": status,
+        "arguments": arguments if isinstance(arguments, dict) else {},
+        "result": event.get("result"),
+        "error": event.get("error"),
+    }
+    try:
+        data = _json.dumps(payload, ensure_ascii=False, default=str)
+    except (TypeError, ValueError, OverflowError):
+        logger.warning("Skipping malformed tool progress event: {}", name)
+        return None
+    return f"event: nanobot.tool.progress\ndata: {data}\n\n".encode()
+
+
 _SSE_DONE = b"data: [DONE]\n\n"
 
 # ---------------------------------------------------------------------------
@@ -304,6 +346,7 @@ async def handle_chat_completions(request: web.Request) -> web.Response | web.St
     model_name: str = _app_value(request.app, _MODEL_NAME_KEY, "model_name", "nanobot")
 
     stream = False
+    include_tool_events = False
     try:
         if content_type.startswith("multipart/"):
             text, media_paths, session_id, requested_model = await _parse_multipart(request)
@@ -316,6 +359,7 @@ async def handle_chat_completions(request: web.Request) -> web.Response | web.St
                 return _error_json(400, "Invalid JSON body")
             body = cast(dict[str, Any], body)
             stream = body.get("stream", False)
+            include_tool_events = _include_tool_events(body)
             requested_model = body.get("model")
             text, media_paths = _parse_json_content(body)
             session_id = body.get("session_id")
@@ -351,7 +395,7 @@ async def handle_chat_completions(request: web.Request) -> web.Response | web.St
         await resp.prepare(request)
 
         chunk_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
-        queue: asyncio.Queue[str | None] = asyncio.Queue()
+        queue: asyncio.Queue[str | bytes | None] = asyncio.Queue()
         stream_failed = False
         emitted_content = False
 
@@ -360,6 +404,17 @@ async def handle_chat_completions(request: web.Request) -> web.Response | web.St
             if token:
                 emitted_content = True
             await queue.put(token)
+
+        async def _on_progress(
+            _text: str,
+            *,
+            tool_hint: bool = False,
+            tool_events: list[dict[str, Any]] | None = None,
+        ) -> None:
+            for event in tool_events or []:
+                frame = _sse_tool_progress(event)
+                if frame is not None:
+                    await queue.put(frame)
 
         async def _on_stream_end(*_a: Any, **_kw: Any) -> None:
             # Agent stream-end callbacks mark generation segment boundaries.
@@ -379,6 +434,7 @@ async def handle_chat_completions(request: web.Request) -> web.Response | web.St
                             session_key=session_key,
                             channel="api",
                             chat_id=API_CHAT_ID,
+                            on_progress=_on_progress if include_tool_events else None,
                             on_stream=_on_stream,
                             on_stream_end=_on_stream_end,
                         )
@@ -395,10 +451,13 @@ async def handle_chat_completions(request: web.Request) -> web.Response | web.St
         task = asyncio.create_task(_run())
         try:
             while True:
-                token = await queue.get()
-                if token is None:
+                item = await queue.get()
+                if item is None:
                     break
-                await resp.write(_sse_chunk(token, model_name, chunk_id))
+                if isinstance(item, bytes):
+                    await resp.write(item)
+                else:
+                    await resp.write(_sse_chunk(item, model_name, chunk_id))
         finally:
             if not task.done():
                 task.cancel()

--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -33,6 +33,18 @@ API_KEY = "secret"
 AUTH_HEADERS = {"Authorization": f"Bearer {API_KEY}"}
 
 
+def _named_sse_payloads(body: str, event_name: str) -> list[dict]:
+    payloads: list[dict] = []
+    for block in body.split("\n\n"):
+        lines = block.splitlines()
+        if not lines or lines[0] != f"event: {event_name}":
+            continue
+        data_line = next((line for line in lines[1:] if line.startswith("data: ")), None)
+        if data_line is not None:
+            payloads.append(json.loads(data_line.removeprefix("data: ")))
+    return payloads
+
+
 def _make_mock_agent(response_text: str = "mock response") -> MagicMock:
     agent = MagicMock()
     agent.process_direct = AsyncMock(return_value=response_text)
@@ -225,6 +237,138 @@ async def test_stream_true_returns_sse(aiohttp_client, app) -> None:
     )
     assert resp.status == 200
     assert resp.content_type == "text/event-stream"
+
+
+@pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")
+@pytest.mark.asyncio
+async def test_stream_does_not_emit_tool_events_without_opt_in(aiohttp_client) -> None:
+    async def process_direct(*, on_progress=None, on_stream=None, **_kwargs):
+        assert on_progress is None
+        await on_stream("done")
+        return "done"
+
+    agent = _make_mock_agent()
+    agent.process_direct = AsyncMock(side_effect=process_direct)
+    client = await aiohttp_client(create_app(agent, model_name="test-model", api_key=API_KEY))
+
+    resp = await client.post(
+        "/v1/chat/completions",
+        headers=AUTH_HEADERS,
+        json={
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+        },
+    )
+    body = await resp.text()
+
+    assert resp.status == 200
+    assert "event: nanobot.tool.progress" not in body
+    assert '"content": "done"' in body
+    assert body.endswith("data: [DONE]\n\n")
+
+
+@pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")
+@pytest.mark.asyncio
+async def test_stream_emits_opted_in_tool_events_in_order(aiohttp_client) -> None:
+    class NonJsonResult:
+        def __str__(self) -> str:
+            return "rendered-result"
+
+    async def process_direct(*, on_progress=None, on_stream=None, **_kwargs):
+        assert on_progress is not None
+        await on_progress(
+            "",
+            tool_events=[{
+                "version": 1,
+                "phase": "start",
+                "call_id": "call-1",
+                "name": "read_file",
+                "arguments": {"path": "README.md"},
+            }],
+        )
+        await on_progress(
+            "",
+            tool_events=[{
+                "version": 1,
+                "phase": "end",
+                "call_id": "call-1",
+                "name": "read_file",
+                "arguments": {"path": "README.md"},
+                "result": NonJsonResult(),
+            }],
+        )
+        await on_stream("finished")
+        return "finished"
+
+    agent = _make_mock_agent()
+    agent.process_direct = AsyncMock(side_effect=process_direct)
+    client = await aiohttp_client(create_app(agent, model_name="test-model", api_key=API_KEY))
+
+    resp = await client.post(
+        "/v1/chat/completions",
+        headers=AUTH_HEADERS,
+        json={
+            "messages": [{"role": "user", "content": "read the file"}],
+            "stream": True,
+            "stream_options": {"include_tool_events": True},
+        },
+    )
+    body = await resp.text()
+    payloads = _named_sse_payloads(body, "nanobot.tool.progress")
+
+    assert resp.status == 200
+    assert [payload["status"] for payload in payloads] == ["running", "completed"]
+    assert payloads[0]["tool"] == "read_file"
+    assert payloads[0]["toolCallId"] == "call-1"
+    assert payloads[0]["arguments"] == {"path": "README.md"}
+    assert payloads[1]["result"] == "rendered-result"
+    assert body.index('"status": "running"') < body.index('"status": "completed"')
+    assert body.index('"status": "completed"') < body.index('"content": "finished"')
+    assert body.endswith("data: [DONE]\n\n")
+
+
+@pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")
+@pytest.mark.asyncio
+async def test_stream_maps_tool_errors_to_failed_events(aiohttp_client) -> None:
+    async def process_direct(*, on_progress=None, on_stream=None, **_kwargs):
+        assert on_progress is not None
+        await on_progress(
+            "",
+            tool_events=[{
+                "version": 1,
+                "phase": "error",
+                "call_id": "call-2",
+                "name": "exec",
+                "arguments": {"command": "false"},
+                "error": "command failed",
+            }],
+        )
+        await on_stream("recovered")
+        return "recovered"
+
+    agent = _make_mock_agent()
+    agent.process_direct = AsyncMock(side_effect=process_direct)
+    client = await aiohttp_client(create_app(agent, model_name="test-model", api_key=API_KEY))
+
+    resp = await client.post(
+        "/v1/chat/completions",
+        headers=AUTH_HEADERS,
+        json={
+            "messages": [{"role": "user", "content": "run it"}],
+            "stream": True,
+            "stream_options": {"include_tool_events": True},
+        },
+    )
+    body = await resp.text()
+    payloads = _named_sse_payloads(body, "nanobot.tool.progress")
+
+    assert resp.status == 200
+    assert len(payloads) == 1
+    assert payloads[0]["status"] == "failed"
+    assert payloads[0]["error"] == "command failed"
+    assert payloads[0]["result"] is None
+    assert '"content": "recovered"' in body
+    assert body.endswith("data: [DONE]\n\n")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The OpenAI-compatible streaming endpoint currently emits assistant text chunks only. Clients therefore cannot observe tool execution lifecycle events while an agent is running.

Closes #3698.

## Solution

Expose the agent's existing structured tool progress events as an opt-in named SSE extension. Requests enable the extension with:

```json
{
  "stream": true,
  "stream_options": {
    "include_tool_events": true
  }
}
```

This keeps the default OpenAI-compatible stream unchanged while allowing interested clients to receive `nanobot.tool.progress` events.

## Changes

- Map agent tool phases to `running`, `completed`, and `failed`
- Emit versioned named SSE payloads with tool name, call ID, arguments, result, and error
- Safely serialize non-JSON-native tool results
- Route tool events and assistant text through the existing streaming queue
- Add coverage for default compatibility, ordered start/end events, and tool failures

## Testing

- `.venv/Scripts/python.exe -m pytest tests/test_openai_api.py -q` — 26 passed
- `.venv/Scripts/ruff.exe check nanobot/api/server.py tests/test_openai_api.py` — passed
- `.venv/Scripts/basedpyright.exe --pythonpath .venv/Scripts/python.exe nanobot/api/server.py` — 0 errors, 0 warnings

## Notes for reviewers

The custom event is deliberately opt-in because named SSE events are outside the standard OpenAI chat-completions stream contract. Existing clients receive the previous `data:` chunks and `[DONE]` terminator unless they request tool events. The agent loop and tool runner are unchanged.