### PR TITLE
fix(agent): default request concurrency to unlimited

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -188,7 +188,7 @@ These variables are process-level switches. Set them in the same terminal, servi
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `NANOBOT_MAX_CONCURRENT_REQUESTS` | `3` | Maximum concurrently running inbound agent requests. Must be an integer; set `0` or a negative value for unlimited. |
+| `NANOBOT_MAX_CONCURRENT_REQUESTS` | Unlimited | Maximum concurrently running inbound agent requests. Set a positive integer to apply a cap; unset, `0`, or a negative value means unlimited. |
 | `NANOBOT_LLM_TIMEOUT_S` | `300` | Wall-clock timeout, in seconds. Ordinary requests use this value; streaming requests use the greater of 300 seconds or twice this value. Set `0` to disable. Sustained-goal turns bypass this wall-clock cap. |
 | `NANOBOT_STREAM_IDLE_TIMEOUT_S` | `90` | Streaming idle timeout, in seconds, used by streaming providers. Invalid or non-positive values are ignored; values above `3600` are clamped. |
 | `NANOBOT_OPENAI_COMPAT_TIMEOUT_S` | `120` | HTTP request timeout, in seconds, for OpenAI-compatible providers. Invalid or non-positive values are ignored. |

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -430,8 +430,8 @@ class AgentLoop:
             ("cron", self._cron_turns),
             ("local trigger", self._local_trigger_turns),
         )
-        # NANOBOT_MAX_CONCURRENT_REQUESTS: <=0 means unlimited; default 3.
-        _max = int(os.environ.get("NANOBOT_MAX_CONCURRENT_REQUESTS", "3"))
+        # NANOBOT_MAX_CONCURRENT_REQUESTS: unset or <=0 means unlimited.
+        _max = int(os.environ.get("NANOBOT_MAX_CONCURRENT_REQUESTS", "0"))
         self._concurrency_gate: asyncio.Semaphore | None = (
             asyncio.Semaphore(_max) if _max > 0 else None
         )

--- a/tests/agent/test_loop_concurrency.py
+++ b/tests/agent/test_loop_concurrency.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _provider() -> MagicMock:
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.generation = SimpleNamespace(
+        max_tokens=4096,
+        temperature=0.1,
+        reasoning_effort=None,
+    )
+    return provider
+
+
+def test_request_concurrency_is_unlimited_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    loop_factory,
+) -> None:
+    monkeypatch.delenv("NANOBOT_MAX_CONCURRENT_REQUESTS", raising=False)
+
+    loop = loop_factory(provider=_provider(), patch_deps=True)
+
+    assert loop._concurrency_gate is None
+
+
+@pytest.mark.asyncio
+async def test_positive_request_concurrency_keeps_explicit_cap(
+    monkeypatch: pytest.MonkeyPatch,
+    loop_factory,
+) -> None:
+    monkeypatch.setenv("NANOBOT_MAX_CONCURRENT_REQUESTS", "2")
+    loop = loop_factory(provider=_provider(), patch_deps=True)
+    gate = loop._concurrency_gate
+
+    assert gate is not None
+    for _ in range(2):
+        await gate.acquire()
+    try:
+        assert gate.locked()
+    finally:
+        for _ in range(2):
+            gate.release()

--- a/tests/agent/test_task_cancel.py
+++ b/tests/agent/test_task_cancel.py
@@ -254,7 +254,7 @@ class TestDispatch:
         assert isinstance(second.event, StreamEndEvent)
 
     @pytest.mark.asyncio
-    async def test_processing_lock_serializes(self):
+    async def test_same_session_dispatches_serialize(self):
         from nanobot.bus.events import InboundMessage, OutboundMessage
 
         loop, bus = _make_loop()


### PR DESCRIPTION
## Summary

- default inbound agent request concurrency to unlimited when `NANOBOT_MAX_CONCURRENT_REQUESTS` is unset
- preserve positive environment values as an explicit operator-configured cap
- document the new default and add regression coverage for default and capped modes

## Why

The WebUI makes dozens of simultaneous sessions a normal workload. The current default semaphore of 3 is held for an entire session turn, including provider streaming and retry waits. In a one-to-six session fan-out, the source and two targets can therefore occupy every slot while the remaining four targets wait, making the instance look frozen.

The cap was introduced as a conservative guard when dispatch moved from one global lock to per-session locks; its history does not identify a provider or resource constraint that requires a default of 3. Operators who need a cap can still set any positive value explicitly.

Linear: [NAN-71](https://linear.app/nanobot-ai/issue/NAN-71/remove-the-default-global-inbound-request-concurrency-cap)

## Verification

- `pytest tests/agent/test_loop_concurrency.py tests/agent/test_session_model_runtime.py tests/tools/test_session_messages_tool.py -q` — 17 passed
- `pytest tests/agent/test_session_inputs.py -q` — 2 passed
- `ruff check nanobot/agent/loop.py tests/agent/test_loop_concurrency.py`
- `basedpyright` — 0 errors
- focused WebUI session/stream tests — 190 passed
- WebUI production build
- deterministic one-to-six fan-out — source follow-up and all six targets entered before release with no global gate
- isolated gateway/WebUI smoke — connected and `/model` history persisted and replayed