### PR TITLE
refactor(providers): make fallback attempts explicit

### DIFF
--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -30,6 +30,7 @@ from nanobot.providers.base import (
     LLMProvider,
     LLMResponse,
     LLMUsage,
+    ProviderAttempt,
     ProviderCallContext,
     ProviderConversationState,
     ToolCallRequest,
@@ -928,6 +929,73 @@ class AgentRunner:
         kwargs["reasoning_effort"] = generation.reasoning_effort
         return kwargs
 
+    async def _execute_provider_route(
+        self,
+        spec: AgentRunSpec,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None,
+        provider_context: ProviderCallContext | None,
+        on_content_delta: Callable[[str], Awaitable[None]] | None = None,
+        on_thinking_delta: Callable[[str], Awaitable[None]] | None = None,
+        on_tool_call_delta: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+        on_stream_recover: Callable[[], Awaitable[None]] | None = None,
+    ) -> LLMResponse:
+        """Drive one-way provider routing from immutable source messages."""
+        generation = spec.runtime.generation
+        route = spec.runtime.provider.create_attempt_route(
+            model=spec.runtime.model,
+            generation=generation,
+            context_window_tokens=spec.runtime.context_window_tokens,
+            provider_context=provider_context,
+            retry_mode=spec.provider_retry_mode,
+            on_retry_wait=spec.retry_wait_callback,
+            on_retry_exhausted=spec.retry_wait_callback,
+            on_stream_recover=on_stream_recover,
+        )
+        step = await route.start()
+        while isinstance(step, ProviderAttempt):
+            attempt = step
+            attempt_streamed = False
+
+            async def _tracking_content_delta(delta: str) -> None:
+                nonlocal attempt_streamed
+                if delta:
+                    attempt_streamed = True
+                if on_content_delta is not None:
+                    await on_content_delta(delta)
+
+            async def _recover_stream() -> None:
+                nonlocal attempt_streamed
+                if on_stream_recover is not None:
+                    await on_stream_recover()
+                attempt_streamed = False
+
+            kwargs = self._build_request_kwargs(spec, messages, tools=tools)
+            kwargs.update({
+                "model": attempt.model,
+                "temperature": attempt.generation.temperature,
+                "max_tokens": attempt.generation.max_tokens,
+                "reasoning_effort": attempt.generation.reasoning_effort,
+                "retry_mode": attempt.retry_mode,
+                "on_retry_wait": attempt.on_retry_wait,
+                "on_retry_exhausted": attempt.on_retry_exhausted,
+                "provider_context": attempt.provider_context,
+                "_provider_attempt": attempt,
+            })
+            if on_content_delta is not None:
+                response = await attempt.provider.chat_stream_with_retry(
+                    **kwargs,
+                    on_content_delta=_tracking_content_delta,
+                    on_thinking_delta=on_thinking_delta,
+                    on_tool_call_delta=on_tool_call_delta,
+                    on_stream_recover=_recover_stream,
+                )
+            else:
+                response = await attempt.provider.chat_with_retry(**kwargs)
+            step = await route.advance(response, streamed=attempt_streamed)
+        return step
+
     async def _request_model(
         self,
         spec: AgentRunSpec,
@@ -941,11 +1009,6 @@ class AgentRunner:
     ) -> LLMResponse:
         timeout_s = self._resolve_llm_timeout_s(spec)
 
-        kwargs = self._build_request_kwargs(
-            spec,
-            messages,
-            tools=spec.tools.get_definitions(),
-        )
         wants_streaming = hook.wants_streaming()
 
         active_hosted_tools: dict[str, dict[str, Any]] = {}
@@ -1022,8 +1085,10 @@ class AgentRunner:
                 await _close_native_reasoning()
                 await hook.on_stream_end(context, resuming=True)
 
-            coro = spec.runtime.provider.chat_stream_with_retry(
-                **kwargs,
+            coro = self._execute_provider_route(
+                spec,
+                messages,
+                tools=spec.tools.get_definitions(),
                 provider_context=provider_context,
                 on_content_delta=_stream,
                 on_thinking_delta=_thinking,
@@ -1031,8 +1096,10 @@ class AgentRunner:
                 on_stream_recover=_stream_recover,
             )
         else:
-            coro = spec.runtime.provider.chat_with_retry(
-                **kwargs,
+            coro = self._execute_provider_route(
+                spec,
+                messages,
+                tools=spec.tools.get_definitions(),
                 provider_context=provider_context,
             )
 
@@ -1271,13 +1338,10 @@ class AgentRunner:
         *,
         provider_context: ProviderCallContext | None = None,
     ) -> LLMResponse:
-        kwargs = self._build_request_kwargs(
+        coro = self._execute_provider_route(
             spec,
             messages,
             tools=None,
-        )
-        coro = spec.runtime.provider.chat_with_retry(
-            **kwargs,
             provider_context=provider_context,
         )
         timeout_s = self._resolve_llm_timeout_s(spec)

--- a/nanobot/providers/azure_openai_provider.py
+++ b/nanobot/providers/azure_openai_provider.py
@@ -27,8 +27,10 @@ from loguru import logger
 from openai import AsyncOpenAI
 
 from nanobot.providers.base import (
+    NATIVE_COMPACTION_FALLBACK_ERROR_KIND,
     LLMProvider,
     LLMResponse,
+    ProviderAttempt,
     ProviderCallContext,
     ProviderConversationState,
 )
@@ -176,6 +178,17 @@ class AzureOpenAIProvider(LLMProvider):
         _ = model
         return self._native_compaction_available
 
+    def mark_native_compaction_unsupported(
+        self,
+        status_code: int | None = None,
+    ) -> None:
+        self._native_compaction_available = False
+        logger.warning(
+            "Azure Responses server compaction unsupported; disabled for this provider "
+            "instance (status={})",
+            status_code,
+        )
+
     def _build_body(
         self,
         messages: list[dict[str, Any]],
@@ -247,23 +260,23 @@ class AzureOpenAIProvider(LLMProvider):
     async def _create_response_with_compaction_fallback(
         self,
         body: dict[str, Any],
+        *,
+        allow_fallback: bool = True,
     ) -> Any:
         """Retry once without server compaction when Azure rejects the option."""
         try:
             return cast(Any, await self._client.responses.create(**body))
         except Exception as exc:
             if (
-                "context_management" not in body
+                not allow_fallback
+                or "context_management" not in body
                 or not is_compaction_compatibility_error(exc)
             ):
                 raise
-            self._native_compaction_available = False
-            body.pop("context_management", None)
-            logger.warning(
-                "Azure Responses server compaction unsupported; disabled for this provider "
-                "instance (status={})",
-                getattr(exc, "status_code", None),
+            self.mark_native_compaction_unsupported(
+                getattr(exc, "status_code", None)
             )
+            body.pop("context_management", None)
             return cast(Any, await self._client.responses.create(**body))
 
     @staticmethod
@@ -345,6 +358,7 @@ class AzureOpenAIProvider(LLMProvider):
         reasoning_effort: str | None = None,
         tool_choice: str | dict[str, Any] | None = None,
         provider_context: ProviderCallContext | None = None,
+        _allow_compaction_fallback: bool = True,
     ) -> LLMResponse:
         body = self._build_body(
             messages, tools, model, max_tokens, temperature,
@@ -352,7 +366,10 @@ class AzureOpenAIProvider(LLMProvider):
             provider_context,
         )
         try:
-            response = await self._create_response_with_compaction_fallback(body)
+            response = await self._create_response_with_compaction_fallback(
+                body,
+                allow_fallback=_allow_compaction_fallback,
+            )
             return parse_response_output(
                 response,
                 state_provider=self._responses_state_provider(),
@@ -360,7 +377,27 @@ class AzureOpenAIProvider(LLMProvider):
                 state_input_items=cast(list[dict[str, Any]], body["input"]),
             )
         except Exception as e:
-            return self._handle_error(e)
+            response = self._handle_error(e)
+            if (
+                not _allow_compaction_fallback
+                and "context_management" in body
+                and is_compaction_compatibility_error(e)
+            ):
+                response.error_kind = NATIVE_COMPACTION_FALLBACK_ERROR_KIND
+            return response
+
+    async def chat_attempt(
+        self,
+        *,
+        attempt: ProviderAttempt,
+        provider_context: ProviderCallContext | None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        return await self.chat(
+            **kwargs,
+            provider_context=provider_context,
+            _allow_compaction_fallback=False,
+        )
 
     async def chat_stream(
         self,
@@ -375,6 +412,7 @@ class AzureOpenAIProvider(LLMProvider):
         on_thinking_delta: Callable[[str], Awaitable[None]] | None = None,
         on_tool_call_delta: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
         provider_context: ProviderCallContext | None = None,
+        _allow_compaction_fallback: bool = True,
     ) -> LLMResponse:
         _ = on_thinking_delta
         body = self._build_body(
@@ -385,7 +423,10 @@ class AzureOpenAIProvider(LLMProvider):
         body["stream"] = True
 
         try:
-            stream = await self._create_response_with_compaction_fallback(body)
+            stream = await self._create_response_with_compaction_fallback(
+                body,
+                allow_fallback=_allow_compaction_fallback,
+            )
             capture = ResponsesStreamCapture()
             content, tool_calls, finish_reason, usage, reasoning_content = (
                 await consume_sdk_stream(
@@ -412,7 +453,27 @@ class AzureOpenAIProvider(LLMProvider):
                 )
             return result
         except Exception as e:
-            return self._handle_error(e)
+            response = self._handle_error(e)
+            if (
+                not _allow_compaction_fallback
+                and "context_management" in body
+                and is_compaction_compatibility_error(e)
+            ):
+                response.error_kind = NATIVE_COMPACTION_FALLBACK_ERROR_KIND
+            return response
+
+    async def chat_stream_attempt(
+        self,
+        *,
+        attempt: ProviderAttempt,
+        provider_context: ProviderCallContext | None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        return await self.chat_stream(
+            **kwargs,
+            provider_context=provider_context,
+            _allow_compaction_fallback=False,
+        )
 
     def get_default_model(self) -> str:
         return self.default_model

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -14,7 +14,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
 
 import json_repair
 from loguru import logger
@@ -28,6 +28,12 @@ STREAM_IDLE_TIMEOUT_ENV = "NANOBOT_STREAM_IDLE_TIMEOUT_S"
 DEFAULT_STREAM_IDLE_TIMEOUT_S = 90.0
 MAX_STREAM_IDLE_TIMEOUT_S = 3600.0
 RETRY_AFTER_BUFFER = 1
+ROUTE_FALLBACK_ERROR_KIND = "route_fallback"
+NATIVE_COMPACTION_FALLBACK_ERROR_KIND = "native_compaction_fallback"
+_ATTEMPT_ROUTE_ERROR_KINDS = frozenset({
+    ROUTE_FALLBACK_ERROR_KIND,
+    NATIVE_COMPACTION_FALLBACK_ERROR_KIND,
+})
 
 RetryEventCallback = Callable[[str], Awaitable[None]]
 LLMCallObserver = Callable[["LLMCallRecord"], None]
@@ -597,6 +603,78 @@ class GenerationSettings:
     reasoning_effort: str | None = None
 
 
+ProviderContinuation = Literal["resume", "rebuild"]
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderAttempt:
+    """One fully resolved provider call.
+
+    Routing wrappers may choose another provider, model, or transport after an
+    attempt fails.  Those choices are represented by a new value instead of
+    mutating the request that was already prepared for this attempt.
+    """
+
+    provider: LLMProvider
+    model: str
+    transport: str
+    generation: GenerationSettings
+    context_window_tokens: int | None
+    provider_context: ProviderCallContext | None = field(default=None, repr=False)
+    continuation: ProviderContinuation = "rebuild"
+    native_compaction: bool = False
+    retry_mode: str = "standard"
+    on_retry_wait: RetryEventCallback | None = field(default=None, repr=False)
+    on_retry_exhausted: RetryEventCallback | None = field(default=None, repr=False)
+
+
+class ProviderAttemptRoute(Protocol):
+    """Advance one request through concrete provider attempts."""
+
+    async def start(self) -> ProviderAttempt | LLMResponse: ...
+
+    async def advance(
+        self,
+        response: LLMResponse,
+        *,
+        streamed: bool,
+    ) -> ProviderAttempt | LLMResponse: ...
+
+
+class _DefaultProviderAttemptRoute:
+    def __init__(
+        self,
+        attempt: ProviderAttempt,
+        native_compaction_fallback: ProviderAttempt | None,
+    ) -> None:
+        self._attempt = attempt
+        self._native_compaction_fallback = native_compaction_fallback
+
+    async def start(self) -> ProviderAttempt | LLMResponse:
+        return self._attempt
+
+    async def advance(
+        self,
+        response: LLMResponse,
+        *,
+        streamed: bool,
+    ) -> ProviderAttempt | LLMResponse:
+        if (
+            not streamed
+            and self._attempt.native_compaction
+            and self._native_compaction_fallback is not None
+            and response.finish_reason == "error"
+            and response.error_kind == NATIVE_COMPACTION_FALLBACK_ERROR_KIND
+        ):
+            self._attempt.provider.mark_native_compaction_unsupported(
+                response.error_status_code
+            )
+            self._attempt = self._native_compaction_fallback
+            self._native_compaction_fallback = None
+            return self._attempt
+        return response
+
+
 _SYNTHETIC_USER_CONTENT = "(conversation continued)"
 
 
@@ -789,6 +867,112 @@ class LLMProvider(ABC):
     def supports_native_compaction(self, model: str | None = None) -> bool:
         """Whether requests may include provider-native context compaction."""
         return False
+
+    def mark_native_compaction_unsupported(
+        self,
+        status_code: int | None = None,
+    ) -> None:
+        """Remember that native compaction failed for future attempt routes."""
+        _ = status_code
+
+    def _build_provider_attempt(
+        self,
+        *,
+        model: str | None,
+        generation: GenerationSettings,
+        context_window_tokens: int | None,
+        provider_context: ProviderCallContext | None,
+        transport: str = "default",
+        native_compaction: bool | None = None,
+        allow_continuation: bool = True,
+        retry_mode: str = "standard",
+        on_retry_wait: RetryEventCallback | None = None,
+        on_retry_exhausted: RetryEventCallback | None = None,
+    ) -> ProviderAttempt:
+        """Resolve immutable execution values for one concrete call."""
+        resolved_model = model or self.get_default_model()
+        supports_native = (
+            self.supports_native_compaction(resolved_model)
+            if native_compaction is None
+            else native_compaction
+        )
+        source_context = provider_context
+        state = source_context.conversation_state if source_context is not None else None
+        if (
+            not allow_continuation
+            or state is None
+            or not self.can_resume_conversation_state(state, resolved_model)
+        ):
+            state = None
+        attempt_context_window = context_window_tokens if supports_native else None
+        session_id = source_context.session_id if source_context is not None else None
+        attempt_context = (
+            ProviderCallContext(
+                conversation_state=state,
+                context_window_tokens=attempt_context_window,
+                session_id=session_id,
+            )
+            if source_context is not None
+            else None
+        )
+        return ProviderAttempt(
+            provider=self,
+            model=resolved_model,
+            transport=transport,
+            generation=generation,
+            context_window_tokens=context_window_tokens,
+            provider_context=attempt_context,
+            continuation="resume" if state is not None else "rebuild",
+            native_compaction=supports_native,
+            retry_mode=retry_mode,
+            on_retry_wait=on_retry_wait,
+            on_retry_exhausted=on_retry_exhausted,
+        )
+
+    def create_attempt_route(
+        self,
+        *,
+        model: str | None,
+        generation: GenerationSettings,
+        context_window_tokens: int | None,
+        provider_context: ProviderCallContext | None,
+        retry_mode: str,
+        on_retry_wait: RetryEventCallback | None = None,
+        on_retry_exhausted: RetryEventCallback | None = None,
+        on_stream_recover: Callable[[], Awaitable[None]] | None = None,
+    ) -> ProviderAttemptRoute:
+        """Return the explicit route for one provider request.
+
+        Ordinary providers have one attempt. Routing providers override this
+        method to yield a new immutable attempt when a real fallback occurs.
+        """
+        _ = on_stream_recover
+        supports_native = self.supports_native_compaction(model)
+        attempt = self._build_provider_attempt(
+            model=model,
+            generation=generation,
+            context_window_tokens=context_window_tokens,
+            provider_context=provider_context,
+            native_compaction=supports_native,
+            retry_mode=retry_mode,
+            on_retry_wait=on_retry_wait,
+            on_retry_exhausted=on_retry_exhausted,
+        )
+        native_compaction_fallback = (
+            self._build_provider_attempt(
+                model=model,
+                generation=generation,
+                context_window_tokens=context_window_tokens,
+                provider_context=provider_context,
+                native_compaction=False,
+                retry_mode=retry_mode,
+                on_retry_wait=on_retry_wait,
+                on_retry_exhausted=on_retry_exhausted,
+            )
+            if supports_native
+            else None
+        )
+        return _DefaultProviderAttemptRoute(attempt, native_compaction_fallback)
 
     @staticmethod
     def _sanitize_empty_content(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -1166,8 +1350,21 @@ class LLMProvider(ABC):
         started_at_ms = time.time_ns() // 1_000_000
         started_at_ns = time.monotonic_ns()
         try:
+            provider_attempt = kwargs.pop("_provider_attempt", None)
             provider_context = kwargs.pop("provider_context", None)
-            if isinstance(provider_context, ProviderCallContext):
+            if isinstance(provider_attempt, ProviderAttempt):
+                if provider_attempt.provider is not self:
+                    raise ValueError("provider attempt does not belong to this provider")
+                response = await self.chat_attempt(
+                    attempt=provider_attempt,
+                    provider_context=(
+                        provider_context
+                        if isinstance(provider_context, ProviderCallContext)
+                        else None
+                    ),
+                    **kwargs,
+                )
+            elif isinstance(provider_context, ProviderCallContext):
                 response = await self.chat_with_context(
                     provider_context=provider_context,
                     **kwargs,
@@ -1246,6 +1443,26 @@ class LLMProvider(ABC):
         _ = provider_context
         return await self.chat(**kwargs)
 
+    async def chat_attempt(
+        self,
+        *,
+        attempt: ProviderAttempt,
+        provider_context: ProviderCallContext | None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        """Execute one resolved non-streaming attempt.
+
+        Providers with more than one wire transport override this hook. Ordinary
+        providers retain the existing chat/context behavior.
+        """
+        _ = attempt
+        if provider_context is not None:
+            return await self.chat_with_context(
+                provider_context=provider_context,
+                **kwargs,
+            )
+        return await self.chat(**kwargs)
+
     async def chat_stream_with_context(
         self,
         *,
@@ -1254,6 +1471,22 @@ class LLMProvider(ABC):
     ) -> LLMResponse:
         """Streaming continuation hook with a context-free default."""
         _ = provider_context
+        return await self.chat_stream(**kwargs)
+
+    async def chat_stream_attempt(
+        self,
+        *,
+        attempt: ProviderAttempt,
+        provider_context: ProviderCallContext | None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        """Execute one resolved streaming attempt."""
+        _ = attempt
+        if provider_context is not None:
+            return await self.chat_stream_with_context(
+                provider_context=provider_context,
+                **kwargs,
+            )
         return await self.chat_stream(**kwargs)
 
     async def _safe_chat_stream(self, **kwargs: Any) -> LLMResponse:
@@ -1308,8 +1541,21 @@ class LLMProvider(ABC):
             return response
 
         try:
+            provider_attempt = kwargs.pop("_provider_attempt", None)
             provider_context = kwargs.pop("provider_context", None)
-            if isinstance(provider_context, ProviderCallContext):
+            if isinstance(provider_attempt, ProviderAttempt):
+                if provider_attempt.provider is not self:
+                    raise ValueError("provider attempt does not belong to this provider")
+                response = await self.chat_stream_attempt(
+                    attempt=provider_attempt,
+                    provider_context=(
+                        provider_context
+                        if isinstance(provider_context, ProviderCallContext)
+                        else None
+                    ),
+                    **kwargs,
+                )
+            elif isinstance(provider_context, ProviderCallContext):
                 response = await self.chat_stream_with_context(
                     provider_context=provider_context,
                     **kwargs,
@@ -1356,6 +1602,7 @@ class LLMProvider(ABC):
         on_retry_wait: RetryEventCallback | None = None,
         provider_context: ProviderCallContext | None = None,
         on_retry_exhausted: RetryEventCallback | None = None,
+        _provider_attempt: ProviderAttempt | None = None,
     ) -> LLMResponse:
         """Call chat_stream() with retry on transient provider failures."""
         if max_tokens is self._SENTINEL or max_tokens is None:
@@ -1390,6 +1637,8 @@ class LLMProvider(ABC):
         )
         if provider_context is not None:
             kw["provider_context"] = provider_context
+        if _provider_attempt is not None:
+            kw["_provider_attempt"] = _provider_attempt
         if on_stream_recover and getattr(self, "supports_stream_recover_callback", False):
             kw["on_stream_recover"] = _recover_stream
         return await self._run_chat_with_retry(
@@ -1416,6 +1665,7 @@ class LLMProvider(ABC):
         on_retry_wait: RetryEventCallback | None = None,
         provider_context: ProviderCallContext | None = None,
         on_retry_exhausted: RetryEventCallback | None = None,
+        _provider_attempt: ProviderAttempt | None = None,
     ) -> LLMResponse:
         """Call chat() with retry on transient provider failures.
 
@@ -1440,6 +1690,8 @@ class LLMProvider(ABC):
         )
         if provider_context is not None:
             kw["provider_context"] = provider_context
+        if _provider_attempt is not None:
+            kw["_provider_attempt"] = _provider_attempt
         return await self._run_chat_with_retry(
             kw,
             messages,
@@ -1591,6 +1843,8 @@ class LLMProvider(ABC):
             attempt += 1
             response = await call(**kw)
             if response.finish_reason != "error":
+                return response
+            if response.error_kind in _ATTEMPT_ROUTE_ERROR_KINDS:
                 return response
             last_response = response
             if should_retry_guard is not None and not should_retry_guard():

--- a/nanobot/providers/fallback_provider.py
+++ b/nanobot/providers/fallback_provider.py
@@ -1,21 +1,24 @@
 """Provider wrapper that transparently fails over to fallback models on error."""
 
-# pyright: reportIncompatibleMethodOverride=false, reportIncompatibleVariableOverride=false
+# pyright: reportIncompatibleMethodOverride=false, reportIncompatibleVariableOverride=false, reportPrivateUsage=false
 
 from __future__ import annotations
 
 import time
 from collections.abc import Awaitable, Callable
-from dataclasses import replace
-from typing import Any
+from dataclasses import dataclass, replace
+from typing import Any, cast
 
 from loguru import logger
 
 from nanobot.providers.base import (
+    RETRY_AFTER_BUFFER,
     GenerationSettings,
     LLMCallObserver,
     LLMProvider,
     LLMResponse,
+    ProviderAttempt,
+    ProviderAttemptRoute,
     ProviderCallContext,
     ProviderConversationState,
     RetryEventCallback,
@@ -95,6 +98,367 @@ _FALLBACK_ERROR_TOKENS = (
 FallbackModelObserver = Callable[[str], Awaitable[None]]
 
 
+@dataclass(frozen=True, slots=True)
+class _FallbackCandidate:
+    provider: LLMProvider
+    model: str
+    generation: GenerationSettings
+    context_window_tokens: int | None
+    fallback_index: int | None
+
+
+class _FallbackAttemptRoute:
+    def __init__(
+        self,
+        owner: FallbackProvider,
+        *,
+        model: str | None,
+        generation: GenerationSettings,
+        context_window_tokens: int | None,
+        provider_context: ProviderCallContext | None,
+        on_retry_wait: RetryEventCallback | None,
+        on_retry_exhausted: RetryEventCallback | None,
+        on_stream_recover: Callable[[], Awaitable[None]] | None,
+        fallback_stream_recovery: bool,
+    ) -> None:
+        self._owner = owner
+        self._primary_model = model or owner._primary.get_default_model()
+        self._primary_generation = generation
+        self._request_context_window_tokens = context_window_tokens
+        self._provider_context = provider_context
+        self._on_retry_wait = on_retry_wait
+        self._on_retry_exhausted = on_retry_exhausted
+        self._on_stream_recover = on_stream_recover
+        self._fallback_stream_recovery = fallback_stream_recovery
+        self._position = -1 if owner._primary_available() else 0
+        self._primary_was_attempted = self._position == -1
+        self._primary_error = "unknown error"
+        self._last_response: LLMResponse | None = None
+        self._last_exhausted_message: str | None = None
+        self._candidate: _FallbackCandidate | None = None
+        self._child_route: ProviderAttemptRoute | None = None
+        self._recover_before_next_attempt = False
+
+    async def start(self) -> ProviderAttempt | LLMResponse:
+        if not self._primary_was_attempted:
+            logger.debug(
+                "Primary model '{}' circuit open; skipping",
+                self._primary_model,
+            )
+        return await self._start_candidate()
+
+    async def advance(
+        self,
+        response: LLMResponse,
+        *,
+        streamed: bool,
+    ) -> ProviderAttempt | LLMResponse:
+        if self._child_route is None:
+            return response
+        step = await self._child_route.advance(response, streamed=streamed)
+        if isinstance(step, ProviderAttempt):
+            return step
+        return await self._finish_candidate(step, streamed=streamed)
+
+    async def _capture_exhaustion(self, message: str) -> None:
+        self._last_exhausted_message = message
+
+    def _candidate_for_position(self) -> _FallbackCandidate | None:
+        if self._position == -1:
+            return _FallbackCandidate(
+                provider=self._owner._primary,
+                model=self._primary_model,
+                generation=self._primary_generation,
+                context_window_tokens=(
+                    self._owner._primary_context_window_tokens
+                    if self._owner._primary_context_window_tokens is not None
+                    else self._request_context_window_tokens
+                ),
+                fallback_index=None,
+            )
+        if self._position >= len(self._owner._fallback_presets):
+            return None
+
+        preset = self._owner._fallback_presets[self._position]
+        model = preset.model
+        try:
+            provider = self._owner._provider_factory(preset)
+            provider.set_llm_call_observer(self._owner._llm_call_observer)
+        except Exception as exc:
+            logger.warning(
+                "Failed to create provider for fallback '{}': {}",
+                model,
+                exc,
+            )
+            return None
+        return _FallbackCandidate(
+            provider=provider,
+            model=model,
+            generation=GenerationSettings(
+                max_tokens=preset.max_tokens,
+                temperature=preset.temperature,
+                reasoning_effort=preset.reasoning_effort,
+            ),
+            context_window_tokens=preset.context_window_tokens,
+            fallback_index=self._position,
+        )
+
+    async def _start_candidate(self) -> ProviderAttempt | LLMResponse:
+        while self._position < len(self._owner._fallback_presets):
+            candidate = self._candidate_for_position()
+            if candidate is None:
+                self._position += 1
+                continue
+            self._candidate = candidate
+            self._last_exhausted_message = None
+            if candidate.fallback_index is not None:
+                self._log_fallback_start(candidate)
+            self._child_route = candidate.provider.create_attempt_route(
+                model=candidate.model,
+                generation=candidate.generation,
+                context_window_tokens=candidate.context_window_tokens,
+                provider_context=self._provider_context,
+                retry_mode="standard",
+                on_retry_wait=self._on_retry_wait,
+                on_retry_exhausted=self._capture_exhaustion,
+                on_stream_recover=self._on_stream_recover,
+            )
+            step = await self._child_route.start()
+            if isinstance(step, ProviderAttempt):
+                if self._recover_before_next_attempt:
+                    self._recover_before_next_attempt = False
+                    if self._on_stream_recover is not None:
+                        await self._on_stream_recover()
+                return step
+            return await self._finish_candidate(step, streamed=False)
+        return await self._finish_route()
+
+    def _log_fallback_start(self, candidate: _FallbackCandidate) -> None:
+        index = candidate.fallback_index
+        if index is None:
+            return
+        if index == 0 and not self._primary_was_attempted:
+            logger.info(
+                "Primary model '{}' circuit open, trying fallback '{}'",
+                self._primary_model,
+                candidate.model,
+            )
+        elif index == 0:
+            logger.info(
+                "Primary model '{}' failed: {}; trying fallback '{}'",
+                self._primary_model,
+                self._primary_error,
+                candidate.model,
+            )
+        else:
+            logger.info(
+                "Fallback '{}' also failed, trying next fallback '{}'",
+                self._owner._fallback_presets[index - 1].model,
+                candidate.model,
+            )
+
+    async def _finish_candidate(
+        self,
+        response: LLMResponse,
+        *,
+        streamed: bool,
+    ) -> ProviderAttempt | LLMResponse:
+        candidate = self._candidate
+        if candidate is None:
+            return response
+        if response.finish_reason != "error":
+            if candidate.fallback_index is None:
+                self._owner._primary_failures = 0
+                self._owner._primary_tripped_at = None
+            else:
+                await self._owner._notify_fallback_model(candidate.model)
+                logger.info(
+                    "Fallback '{}' succeeded after primary '{}' failed",
+                    candidate.model,
+                    self._primary_model,
+                )
+            return response
+
+        self._last_response = response
+        if streamed:
+            if (response.error_kind or "").lower() != "timeout":
+                logger.warning(
+                    "Model error but content already streamed; skipping failover"
+                )
+                return response
+            if (
+                candidate.fallback_index is not None
+                and not self._fallback_stream_recovery
+            ):
+                return response
+            logger.warning(
+                "Model '{}' stream stalled after content was emitted; "
+                "starting a new stream segment and trying next fallback",
+                candidate.model,
+            )
+            self._recover_before_next_attempt = True
+
+        if candidate.fallback_index is None:
+            self._primary_error = (response.content or self._primary_error)[:120]
+            if not self._owner._should_fallback(response):
+                logger.warning(
+                    "Primary model '{}' returned non-fallbackable error: {}",
+                    self._primary_model,
+                    (response.content or "")[:120],
+                )
+                return response
+            self._owner._primary_failures += 1
+            if self._owner._primary_failures >= _PRIMARY_FAILURE_THRESHOLD:
+                self._owner._primary_tripped_at = time.monotonic()
+                logger.warning(
+                    "Primary model '{}' circuit open after {} consecutive failures",
+                    self._primary_model,
+                    self._owner._primary_failures,
+                )
+        else:
+            logger.warning(
+                "Fallback '{}' also failed: {}",
+                candidate.model,
+                (response.content or "")[:120],
+            )
+
+        self._position = 0 if candidate.fallback_index is None else candidate.fallback_index + 1
+        return await self._start_candidate()
+
+    async def _finish_route(self) -> LLMResponse:
+        logger.warning(
+            "All {} fallback model(s) failed",
+            len(self._owner._fallback_presets),
+        )
+        if self._last_response is not None:
+            if self._last_exhausted_message and self._on_retry_exhausted:
+                await self._on_retry_exhausted(self._last_exhausted_message)
+            return replace(
+                self._last_response,
+                preserve_provider_state_on_error=True,
+            )
+        retry_after_s = (
+            max(
+                0.1,
+                _PRIMARY_COOLDOWN_S
+                - (time.monotonic() - self._owner._primary_tripped_at),
+            )
+            if self._owner._primary_tripped_at is not None
+            else None
+        )
+        return LLMResponse(
+            content=(
+                f"Primary model '{self._primary_model}' circuit open "
+                "and no fallbacks available"
+            ),
+            finish_reason="error",
+            preserve_provider_state_on_error=True,
+            error_retry_after_s=retry_after_s,
+            error_should_retry=True,
+        )
+
+
+class _PersistentFallbackRoute:
+    """Repeat the full fallback chain without mutating an emitted attempt."""
+
+    def __init__(
+        self,
+        *,
+        owner: FallbackProvider,
+        route_factory: Callable[[], ProviderAttemptRoute],
+        on_retry_wait: RetryEventCallback | None,
+        on_retry_exhausted: RetryEventCallback | None,
+        on_stream_recover: Callable[[], Awaitable[None]] | None,
+    ) -> None:
+        self._owner = owner
+        self._route_factory = route_factory
+        self._on_retry_wait = on_retry_wait
+        self._on_retry_exhausted = on_retry_exhausted
+        self._on_stream_recover = on_stream_recover
+        self._route = route_factory()
+        self._attempt = 0
+        self._last_error_key: str | None = None
+        self._identical_error_count = 0
+
+    async def start(self) -> ProviderAttempt | LLMResponse:
+        step = await self._route.start()
+        if isinstance(step, ProviderAttempt):
+            return step
+        return await self._retry_or_finish(step, streamed=False)
+
+    async def advance(
+        self,
+        response: LLMResponse,
+        *,
+        streamed: bool,
+    ) -> ProviderAttempt | LLMResponse:
+        step = await self._route.advance(response, streamed=streamed)
+        if isinstance(step, ProviderAttempt):
+            return step
+        return await self._retry_or_finish(step, streamed=streamed)
+
+    async def _retry_or_finish(
+        self,
+        response: LLMResponse,
+        *,
+        streamed: bool,
+    ) -> ProviderAttempt | LLMResponse:
+        if response.finish_reason != "error":
+            return response
+        if streamed:
+            if (response.error_kind or "").lower() != "timeout":
+                return response
+            if self._on_stream_recover is not None:
+                await self._on_stream_recover()
+
+        self._attempt += 1
+        error_key = ((response.content or "").strip().lower() or None)
+        if error_key and error_key == self._last_error_key:
+            self._identical_error_count += 1
+        else:
+            self._last_error_key = error_key
+            self._identical_error_count = 1 if error_key else 0
+
+        if not self._owner.is_transient_response(response):
+            return response
+        if self._identical_error_count >= self._owner._PERSISTENT_IDENTICAL_ERROR_LIMIT:
+            logger.warning(
+                "Stopping persistent retry after {} identical transient errors: {}",
+                self._identical_error_count,
+                (response.content or "")[:120].lower(),
+            )
+            if self._on_retry_exhausted is not None:
+                await self._on_retry_exhausted(
+                    "Persistent retry stopped after "
+                    f"{self._identical_error_count} identical errors."
+                )
+            return response
+
+        delays = list(self._owner._CHAT_RETRY_DELAYS)
+        retry_after = self._owner._extract_retry_after_from_response(response)
+        base_delay = delays[min(self._attempt - 1, len(delays) - 1)]
+        delay = retry_after + RETRY_AFTER_BUFFER if retry_after else base_delay
+        delay = min(delay, self._owner._PERSISTENT_MAX_DELAY)
+        logger.warning(
+            "LLM transient error (attempt {}{}), retrying in {}s: {}",
+            self._attempt,
+            "+" if self._attempt > len(delays) else f"/{len(delays)}",
+            int(round(delay)),
+            (response.content or "")[:120].lower(),
+        )
+        await self._owner._sleep_with_heartbeat(
+            delay,
+            attempt=self._attempt,
+            persistent=True,
+            on_retry_wait=self._on_retry_wait,
+        )
+        self._route = self._route_factory()
+        next_step = await self._route.start()
+        if isinstance(next_step, ProviderAttempt):
+            return next_step
+        return await self._retry_or_finish(next_step, streamed=False)
+
+
 class FallbackProvider(LLMProvider):
     """Wrap a primary provider and transparently failover to fallback models.
 
@@ -167,22 +531,62 @@ class FallbackProvider(LLMProvider):
     def supports_native_compaction(self, model: str | None = None) -> bool:
         return self._primary.supports_native_compaction(model)
 
-    def _primary_call_context(
+    def create_attempt_route(
         self,
-        provider_context: ProviderCallContext,
+        *,
         model: str | None,
-    ) -> ProviderCallContext:
-        context_window_tokens = (
-            self._primary_context_window_tokens
-            if self._primary_context_window_tokens is not None
-            else provider_context.context_window_tokens
-        )
-        if not self._primary.supports_native_compaction(model):
-            context_window_tokens = None
-        return ProviderCallContext(
-            conversation_state=provider_context.conversation_state,
-            context_window_tokens=context_window_tokens,
-            session_id=provider_context.session_id,
+        generation: GenerationSettings,
+        context_window_tokens: int | None,
+        provider_context: ProviderCallContext | None,
+        retry_mode: str,
+        on_retry_wait: RetryEventCallback | None = None,
+        on_retry_exhausted: RetryEventCallback | None = None,
+        on_stream_recover: Callable[[], Awaitable[None]] | None = None,
+        _fallback_stream_recovery: bool | None = None,
+    ) -> ProviderAttemptRoute:
+        if not self._has_fallbacks:
+            return self._primary.create_attempt_route(
+                model=model,
+                generation=generation,
+                context_window_tokens=(
+                    self._primary_context_window_tokens
+                    if self._primary_context_window_tokens is not None
+                    else context_window_tokens
+                ),
+                provider_context=provider_context,
+                retry_mode=retry_mode,
+                on_retry_wait=on_retry_wait,
+                on_retry_exhausted=on_retry_exhausted,
+                on_stream_recover=on_stream_recover,
+            )
+
+        def _route(
+            terminal_callback: RetryEventCallback | None,
+        ) -> ProviderAttemptRoute:
+            return _FallbackAttemptRoute(
+                self,
+                model=model,
+                generation=generation,
+                context_window_tokens=context_window_tokens,
+                provider_context=provider_context,
+                on_retry_wait=on_retry_wait,
+                on_retry_exhausted=terminal_callback,
+                on_stream_recover=on_stream_recover,
+                fallback_stream_recovery=(
+                    on_stream_recover is not None
+                    if _fallback_stream_recovery is None
+                    else _fallback_stream_recovery
+                ),
+            )
+
+        if retry_mode != "persistent":
+            return _route(on_retry_exhausted)
+        return _PersistentFallbackRoute(
+            owner=self,
+            route_factory=lambda: _route(None),
+            on_retry_wait=on_retry_wait,
+            on_retry_exhausted=on_retry_exhausted,
+            on_stream_recover=on_stream_recover,
         )
 
     def _primary_available(self) -> bool:
@@ -194,11 +598,138 @@ class FallbackProvider(LLMProvider):
             return True
         return False
 
+    def _generation_for_route(self, kwargs: dict[str, Any]) -> GenerationSettings:
+        defaults = self.generation
+        max_tokens = kwargs.get("max_tokens")
+        temperature = kwargs.get("temperature")
+        reasoning_effort = kwargs.get("reasoning_effort", defaults.reasoning_effort)
+        return GenerationSettings(
+            max_tokens=max_tokens if isinstance(max_tokens, int) else defaults.max_tokens,
+            temperature=(
+                temperature
+                if isinstance(temperature, (int, float))
+                else defaults.temperature
+            ),
+            reasoning_effort=(
+                reasoning_effort if isinstance(reasoning_effort, str) else None
+            ),
+        )
+
+    async def _execute_attempt_route(
+        self,
+        kwargs: dict[str, Any],
+        *,
+        stream: bool,
+        retry: bool,
+        retry_mode: str = "standard",
+        on_retry_wait: RetryEventCallback | None = None,
+        on_retry_exhausted: RetryEventCallback | None = None,
+        on_stream_recover: Callable[[], Awaitable[None]] | None = None,
+    ) -> LLMResponse:
+        """Execute direct and retrying entry points through one fallback policy."""
+        source_kwargs = dict(kwargs)
+        provider_context = source_kwargs.pop("provider_context", None)
+        source_kwargs.pop("_provider_attempt", None)
+        source_kwargs.pop("on_stream_recover", None)
+        typed_context = (
+            provider_context
+            if isinstance(provider_context, ProviderCallContext)
+            else None
+        )
+        attempt_streamed = False
+        suppress_deltas = False
+
+        async def _recover_stream() -> None:
+            nonlocal attempt_streamed, suppress_deltas
+            attempt_streamed = False
+            if on_stream_recover is not None:
+                await on_stream_recover()
+            else:
+                suppress_deltas = True
+
+        route = self.create_attempt_route(
+            model=source_kwargs.get("model"),
+            generation=self._generation_for_route(source_kwargs),
+            context_window_tokens=(
+                typed_context.context_window_tokens
+                if typed_context is not None
+                else None
+            ),
+            provider_context=typed_context,
+            retry_mode=retry_mode,
+            on_retry_wait=on_retry_wait,
+            on_retry_exhausted=on_retry_exhausted,
+            on_stream_recover=_recover_stream if stream else None,
+            _fallback_stream_recovery=on_stream_recover is not None,
+        )
+        step = await route.start()
+        while isinstance(step, ProviderAttempt):
+            attempt = step
+            attempt_streamed = False
+            original_delta = (
+                None if suppress_deltas else source_kwargs.get("on_content_delta")
+            )
+            delta_callback = cast(
+                Callable[[str], Awaitable[None]] | None,
+                original_delta if callable(original_delta) else None,
+            )
+
+            async def _tracking_delta(text: str) -> None:
+                nonlocal attempt_streamed
+                if text:
+                    attempt_streamed = True
+                if delta_callback is not None:
+                    await delta_callback(text)
+
+            call_kwargs: dict[str, Any] = {
+                **source_kwargs,
+                "model": attempt.model,
+                "max_tokens": attempt.generation.max_tokens,
+                "temperature": attempt.generation.temperature,
+            }
+            if attempt.generation.reasoning_effort is None:
+                call_kwargs.pop("reasoning_effort", None)
+            else:
+                call_kwargs["reasoning_effort"] = attempt.generation.reasoning_effort
+            if stream:
+                call_kwargs["on_content_delta"] = (
+                    _tracking_delta if original_delta is not None else None
+                )
+
+            if retry:
+                call_kwargs.update({
+                    "retry_mode": attempt.retry_mode,
+                    "on_retry_wait": attempt.on_retry_wait,
+                    "on_retry_exhausted": attempt.on_retry_exhausted,
+                    "provider_context": attempt.provider_context,
+                    "_provider_attempt": attempt,
+                })
+                if stream:
+                    if on_stream_recover is not None:
+                        call_kwargs["on_stream_recover"] = _recover_stream
+                    response = await attempt.provider.chat_stream_with_retry(**call_kwargs)
+                else:
+                    response = await attempt.provider.chat_with_retry(**call_kwargs)
+            elif stream:
+                response = await attempt.provider.chat_stream_attempt(
+                    attempt=attempt,
+                    provider_context=attempt.provider_context,
+                    **call_kwargs,
+                )
+            else:
+                response = await attempt.provider.chat_attempt(
+                    attempt=attempt,
+                    provider_context=attempt.provider_context,
+                    **call_kwargs,
+                )
+            step = await route.advance(response, streamed=attempt_streamed)
+        return step
+
     async def chat(self, **kwargs: Any) -> LLMResponse:
-        if not self._has_fallbacks:
-            return await self._primary.chat(**kwargs)
-        return await self._try_with_fallback(
-            lambda p, kw: p.chat(**kw), kwargs, has_streamed=None
+        return await self._execute_attempt_route(
+            kwargs,
+            stream=False,
+            retry=False,
         )
 
     async def _run_chat_with_retry(
@@ -213,66 +744,15 @@ class FallbackProvider(LLMProvider):
         should_retry_guard: Callable[[], bool] | None = None,
         on_stream_recover: Callable[[], Awaitable[None]] | None = None,
     ) -> LLMResponse:
-        """Retry each provider before advancing through the fallback chain."""
-        call_kwargs = dict(kw)
-        provider_context = call_kwargs.get("provider_context")
-        if isinstance(provider_context, ProviderCallContext):
-            call_kwargs["provider_context"] = self._primary_call_context(
-                provider_context,
-                call_kwargs.get("model"),
-            )
-        if not self._has_fallbacks:
-            call_kwargs.update({
-                "retry_mode": retry_mode,
-                "on_retry_wait": on_retry_wait,
-                "on_retry_exhausted": on_retry_exhausted,
-            })
-            if stream:
-                return await self._primary.chat_stream_with_retry(**call_kwargs)
-            return await self._primary.chat_with_retry(**call_kwargs)
-
-        has_streamed: list[bool] | None = None
-        recover_stream = on_stream_recover
-        if stream:
-            streamed = [False]
-            has_streamed = streamed
-            original_delta = call_kwargs.get("on_content_delta")
-
-            async def _tracking_delta(text: str) -> None:
-                if text:
-                    streamed[0] = True
-                if original_delta:
-                    await original_delta(text)
-
-            async def _recover_stream() -> None:
-                streamed[0] = False
-                if on_stream_recover:
-                    await on_stream_recover()
-
-            if original_delta is not None:
-                call_kwargs["on_content_delta"] = _tracking_delta
-            if on_stream_recover is not None:
-                call_kwargs["on_stream_recover"] = _recover_stream
-                recover_stream = _recover_stream
-
-        async def _call_provider(
-            provider: LLMProvider,
-            provider_kwargs: dict[str, Any],
-        ) -> LLMResponse:
-            if stream:
-                return await provider.chat_stream_with_retry(**provider_kwargs)
-            return await provider.chat_with_retry(**provider_kwargs)
-
-        return await self._retry_with_fallback(
-            _call_provider,
-            call_kwargs,
-            original_messages,
+        _ = original_messages, should_retry_guard
+        return await self._execute_attempt_route(
+            kw,
+            stream=stream,
+            retry=True,
             retry_mode=retry_mode,
             on_retry_wait=on_retry_wait,
             on_retry_exhausted=on_retry_exhausted,
-            has_streamed=has_streamed,
-            on_stream_recover=recover_stream,
-            persistent_retry_guard=should_retry_guard,
+            on_stream_recover=on_stream_recover,
         )
 
     async def chat_with_context(
@@ -281,101 +761,14 @@ class FallbackProvider(LLMProvider):
         provider_context: ProviderCallContext,
         **kwargs: Any,
     ) -> LLMResponse:
-        call_kwargs: dict[str, Any] = dict(kwargs)
-        call_kwargs["provider_context"] = self._primary_call_context(
-            provider_context,
-            kwargs.get("model"),
-        )
-        if not self._has_fallbacks:
-            return await self._primary.chat_with_context(**call_kwargs)
-        return await self._try_with_fallback(
-            lambda p, kw: p.chat_with_context(**kw),
-            call_kwargs,
-            has_streamed=None,
-        )
+        return await self.chat(**kwargs, provider_context=provider_context)
 
     async def chat_stream(self, **kwargs: Any) -> LLMResponse:
         on_stream_recover = kwargs.pop("on_stream_recover", None)
-        if not self._has_fallbacks:
-            return await self._primary.chat_stream(**kwargs)
-
-        has_streamed: list[bool] = [False]
-        original_delta = kwargs.get("on_content_delta")
-
-        async def _tracking_delta(text: str) -> None:
-            if text:
-                has_streamed[0] = True
-            if original_delta:
-                await original_delta(text)
-
-        kwargs["on_content_delta"] = _tracking_delta
-        return await self._try_with_fallback(
-            lambda p, kw: p.chat_stream(**kw),
+        return await self._execute_attempt_route(
             kwargs,
-            has_streamed=has_streamed,
-            on_stream_recover=on_stream_recover,
-        )
-
-    async def _retry_with_fallback(
-        self,
-        call: Callable[[LLMProvider, dict[str, Any]], Awaitable[LLMResponse]],
-        kwargs: dict[str, Any],
-        original_messages: list[dict[str, Any]],
-        *,
-        retry_mode: str,
-        on_retry_wait: RetryEventCallback | None,
-        on_retry_exhausted: RetryEventCallback | None,
-        has_streamed: list[bool] | None,
-        on_stream_recover: Callable[[], Awaitable[None]] | None,
-        persistent_retry_guard: Callable[[], bool] | None,
-    ) -> LLMResponse:
-        """Retry each candidate, deferring terminal events until the chain fails."""
-
-        async def _call_chain(**chain_kwargs: Any) -> LLMResponse:
-            last_exhausted_message: str | None = None
-
-            async def _capture_exhaustion(message: str) -> None:
-                nonlocal last_exhausted_message
-                last_exhausted_message = message
-
-            async def _call_candidate(
-                provider: LLMProvider,
-                candidate_kwargs: dict[str, Any],
-            ) -> LLMResponse:
-                nonlocal last_exhausted_message
-                last_exhausted_message = None
-                return await call(provider, {
-                    **candidate_kwargs,
-                    "retry_mode": "standard",
-                    "on_retry_wait": on_retry_wait,
-                    "on_retry_exhausted": _capture_exhaustion,
-                })
-
-            response = await self._try_with_fallback(
-                _call_candidate,
-                chain_kwargs,
-                has_streamed=has_streamed,
-                on_stream_recover=on_stream_recover,
-            )
-            if (
-                retry_mode != "persistent"
-                and response.finish_reason == "error"
-                and last_exhausted_message
-                and on_retry_exhausted
-            ):
-                await on_retry_exhausted(last_exhausted_message)
-            return response
-
-        if retry_mode != "persistent":
-            return await _call_chain(**kwargs)
-        return await self._run_with_retry(
-            _call_chain,
-            dict(kwargs),
-            original_messages,
-            retry_mode="persistent",
-            on_retry_wait=on_retry_wait,
-            on_retry_exhausted=on_retry_exhausted,
-            should_retry_guard=persistent_retry_guard,
+            stream=True,
+            retry=False,
             on_stream_recover=on_stream_recover,
         )
 
@@ -386,211 +779,10 @@ class FallbackProvider(LLMProvider):
         **kwargs: Any,
     ) -> LLMResponse:
         on_stream_recover = kwargs.pop("on_stream_recover", None)
-        call_kwargs: dict[str, Any] = dict(kwargs)
-        call_kwargs["provider_context"] = self._primary_call_context(
-            provider_context,
-            kwargs.get("model"),
-        )
-        if not self._has_fallbacks:
-            return await self._primary.chat_stream_with_context(**call_kwargs)
-
-        has_streamed: list[bool] = [False]
-        original_delta = call_kwargs.get("on_content_delta")
-
-        async def _tracking_delta(text: str) -> None:
-            if text:
-                has_streamed[0] = True
-            if original_delta:
-                await original_delta(text)
-
-        call_kwargs["on_content_delta"] = _tracking_delta
-        return await self._try_with_fallback(
-            lambda p, kw: p.chat_stream_with_context(**kw),
-            call_kwargs,
-            has_streamed=has_streamed,
+        return await self.chat_stream(
+            **kwargs,
+            provider_context=provider_context,
             on_stream_recover=on_stream_recover,
-        )
-
-    async def _try_with_fallback(
-        self,
-        call: Callable[[LLMProvider, dict[str, Any]], Awaitable[LLMResponse]],
-        kwargs: dict[str, Any],
-        has_streamed: list[bool] | None,
-        on_stream_recover: Callable[[], Awaitable[None]] | None = None,
-    ) -> LLMResponse:
-        primary_model = kwargs.get("model") or self._primary.get_default_model()
-        primary_was_attempted = False
-        primary_response: LLMResponse | None = None
-        primary_error = "unknown error"
-        # A primary error eligible for failover did not return a replacement
-        # continuation, so the incoming primary state remains reusable.
-        preserve_primary_state = True
-
-        if self._primary_available():
-            primary_was_attempted = True
-            response = await call(self._primary, kwargs)
-            if response.finish_reason != "error":
-                self._primary_failures = 0
-                self._primary_tripped_at = None
-                return response
-            primary_response = response
-            primary_error = (response.content or primary_error)[:120]
-
-            if has_streamed is not None and has_streamed[0]:
-                is_timeout = (response.error_kind or "").lower() == "timeout"
-                if is_timeout:
-                    logger.warning(
-                        "Primary model '{}' stream stalled after content was emitted; "
-                        "attempting failover anyway",
-                        primary_model,
-                    )
-                    has_streamed[0] = False
-                    if on_stream_recover:
-                        await on_stream_recover()
-                    else:
-                        kwargs["on_content_delta"] = None
-                else:
-                    logger.warning(
-                        "Primary model error but content already streamed; skipping failover"
-                    )
-                    return response
-
-            if not self._should_fallback(response):
-                logger.warning(
-                    "Primary model '{}' returned non-fallbackable error: {}",
-                    primary_model,
-                    (response.content or "")[:120],
-                )
-                return response
-
-            self._primary_failures += 1
-            if self._primary_failures >= _PRIMARY_FAILURE_THRESHOLD:
-                self._primary_tripped_at = time.monotonic()
-                logger.warning(
-                    "Primary model '{}' circuit open after {} consecutive failures",
-                    primary_model, self._primary_failures,
-                )
-        else:
-            logger.debug("Primary model '{}' circuit open; skipping", primary_model)
-
-        last_response = primary_response
-        primary_skipped = not primary_was_attempted
-        for idx, fallback in enumerate(self._fallback_presets):
-            fallback_model = fallback.model
-            if has_streamed is not None and has_streamed[0]:
-                is_timeout = (
-                    last_response is not None
-                    and (last_response.error_kind or "").lower() == "timeout"
-                )
-                if is_timeout and on_stream_recover:
-                    logger.warning(
-                        "Fallback model '{}' stream stalled after content was emitted; "
-                        "starting a new stream segment and trying next fallback",
-                        self._fallback_presets[idx - 1].model if idx > 0 else primary_model,
-                    )
-                    has_streamed[0] = False
-                    await on_stream_recover()
-                else:
-                    break
-            if idx == 0 and primary_skipped:
-                logger.info(
-                    "Primary model '{}' circuit open, trying fallback '{}'",
-                    primary_model, fallback_model,
-                )
-            elif idx == 0:
-                logger.info(
-                    "Primary model '{}' failed: {}; trying fallback '{}'",
-                    primary_model, primary_error, fallback_model,
-                )
-            else:
-                logger.info(
-                    "Fallback '{}' also failed, trying next fallback '{}'",
-                    self._fallback_presets[idx - 1].model, fallback_model,
-                )
-            try:
-                fallback_provider = self._provider_factory(fallback)
-                fallback_provider.set_llm_call_observer(self._llm_call_observer)
-            except Exception as exc:
-                logger.warning(
-                    "Failed to create provider for fallback '{}': {}", fallback_model, exc
-                )
-                continue
-
-            fallback_kwargs = {
-                **kwargs,
-                "model": fallback_model,
-                "max_tokens": fallback.max_tokens,
-                "temperature": fallback.temperature,
-            }
-            provider_context = fallback_kwargs.get("provider_context")
-            if isinstance(provider_context, ProviderCallContext):
-                state = provider_context.conversation_state
-                if state is not None and not fallback_provider.can_resume_conversation_state(
-                    state,
-                    fallback_model,
-                ):
-                    state = None
-                context_window_tokens = (
-                    fallback.context_window_tokens
-                    if fallback_provider.supports_native_compaction(fallback_model)
-                    else None
-                )
-                fallback_kwargs["provider_context"] = ProviderCallContext(
-                    conversation_state=state,
-                    context_window_tokens=context_window_tokens,
-                    session_id=provider_context.session_id,
-                )
-            if fallback.reasoning_effort is None:
-                fallback_kwargs.pop("reasoning_effort", None)
-            else:
-                fallback_kwargs["reasoning_effort"] = fallback.reasoning_effort
-            fallback_response = await call(fallback_provider, fallback_kwargs)
-
-            if fallback_response.finish_reason != "error":
-                # Do not publish a model switch merely because a fallback was
-                # attempted.  A fallback can fail just like the primary, and
-                # the WebUI would otherwise show a misleading success signal.
-                # Publish only after this response is known to be usable.
-                await self._notify_fallback_model(fallback_model)
-                logger.info(
-                    "Fallback '{}' succeeded after primary '{}' failed",
-                    fallback_model, primary_model,
-                )
-                return fallback_response
-
-            last_response = fallback_response
-            logger.warning(
-                "Fallback '{}' also failed: {}",
-                fallback_model,
-                (fallback_response.content or "")[:120],
-            )
-
-        logger.warning(
-            "All {} fallback model(s) failed",
-            len(self._fallback_presets),
-        )
-        # Return the last error response we saw (primary or last fallback).
-        if last_response is not None:
-            return replace(
-                last_response,
-                preserve_provider_state_on_error=preserve_primary_state,
-            )
-        # Primary was skipped and no fallback returned a response. Keep the result
-        # transient until the primary circuit is eligible for another probe.
-        retry_after_s = (
-            max(
-                0.1,
-                _PRIMARY_COOLDOWN_S - (time.monotonic() - self._primary_tripped_at),
-            )
-            if self._primary_tripped_at is not None
-            else None
-        )
-        return LLMResponse(
-            content=f"Primary model '{primary_model}' circuit open and no fallbacks available",
-            finish_reason="error",
-            preserve_provider_state_on_error=preserve_primary_state,
-            error_retry_after_s=retry_after_s,
-            error_should_retry=True,
         )
 
     async def _notify_fallback_model(self, model: str) -> None:

--- a/nanobot/providers/github_copilot_provider.py
+++ b/nanobot/providers/github_copilot_provider.py
@@ -255,6 +255,7 @@ class GitHubCopilotProvider(OpenAICompatProvider):
         reasoning_effort: str | None = None,
         tool_choice: str | dict[str, Any] | None = None,
         provider_context: ProviderCallContext | None = None,
+        _attempt_transport: str | None = None,
     ) -> LLMResponse:
         await self._refresh_client_api_key()
         return await super().chat(
@@ -266,6 +267,7 @@ class GitHubCopilotProvider(OpenAICompatProvider):
             reasoning_effort=reasoning_effort,
             tool_choice=tool_choice,
             provider_context=provider_context,
+            _attempt_transport=_attempt_transport,
         )
 
     async def chat_stream(
@@ -281,6 +283,7 @@ class GitHubCopilotProvider(OpenAICompatProvider):
         on_thinking_delta: Callable[[str], Awaitable[None]] | None = None,
         on_tool_call_delta: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
         provider_context: ProviderCallContext | None = None,
+        _attempt_transport: str | None = None,
     ) -> LLMResponse:
         await self._refresh_client_api_key()
         return await super().chat_stream(
@@ -295,4 +298,5 @@ class GitHubCopilotProvider(OpenAICompatProvider):
             on_thinking_delta=on_thinking_delta,
             on_tool_call_delta=on_tool_call_delta,
             provider_context=provider_context,
+            _attempt_transport=_attempt_transport,
         )

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -16,8 +16,10 @@ from loguru import logger
 from oauth_cli_kit import get_token as get_codex_token
 
 from nanobot.providers.base import (
+    NATIVE_COMPACTION_FALLBACK_ERROR_KIND,
     LLMProvider,
     LLMResponse,
+    ProviderAttempt,
     ProviderCallContext,
     ProviderConversationState,
     resolve_stream_idle_timeout_s,
@@ -82,6 +84,7 @@ class OpenAICodexProvider(LLMProvider):
         on_thinking_delta: Callable[[str], Awaitable[None]] | None = None,
         on_tool_call_delta: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
         provider_context: ProviderCallContext | None = None,
+        allow_compaction_fallback: bool = True,
     ) -> LLMResponse:
         """Shared request logic for both chat() and chat_stream()."""
         model = model or self.default_model
@@ -206,7 +209,13 @@ class OpenAICodexProvider(LLMProvider):
                     ]
                 except Exception as compact_error:
                     if is_compaction_compatibility_error(compact_error):
-                        self._native_compaction_available = False
+                        if not allow_compaction_fallback:
+                            response = _codex_error_response(compact_error)
+                            response.error_kind = NATIVE_COMPACTION_FALLBACK_ERROR_KIND
+                            return response
+                        self.mark_native_compaction_unsupported(
+                            getattr(compact_error, "status_code", None)
+                        )
                     logger.warning(
                         "Codex native compaction unavailable; continuing without it "
                         "(type={} status={} disabled={})",
@@ -241,6 +250,7 @@ class OpenAICodexProvider(LLMProvider):
         reasoning_effort: str | None = None,
         tool_choice: str | dict[str, Any] | None = None,
         provider_context: ProviderCallContext | None = None,
+        _allow_compaction_fallback: bool = True,
     ) -> LLMResponse:
         return await self._call_codex(
             messages,
@@ -250,6 +260,20 @@ class OpenAICodexProvider(LLMProvider):
             reasoning_effort,
             tool_choice,
             provider_context=provider_context,
+            allow_compaction_fallback=_allow_compaction_fallback,
+        )
+
+    async def chat_attempt(
+        self,
+        *,
+        attempt: ProviderAttempt,
+        provider_context: ProviderCallContext | None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        return await self.chat(
+            **kwargs,
+            provider_context=provider_context,
+            _allow_compaction_fallback=False,
         )
 
     async def chat_with_context(
@@ -272,6 +296,7 @@ class OpenAICodexProvider(LLMProvider):
         on_thinking_delta: Callable[[str], Awaitable[None]] | None = None,
         on_tool_call_delta: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
         provider_context: ProviderCallContext | None = None,
+        _allow_compaction_fallback: bool = True,
     ) -> LLMResponse:
         return await self._call_codex(
             messages=messages,
@@ -284,6 +309,20 @@ class OpenAICodexProvider(LLMProvider):
             on_thinking_delta=on_thinking_delta,
             on_tool_call_delta=on_tool_call_delta,
             provider_context=provider_context,
+            allow_compaction_fallback=_allow_compaction_fallback,
+        )
+
+    async def chat_stream_attempt(
+        self,
+        *,
+        attempt: ProviderAttempt,
+        provider_context: ProviderCallContext | None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        return await self.chat_stream(
+            **kwargs,
+            provider_context=provider_context,
+            _allow_compaction_fallback=False,
         )
 
     async def chat_stream_with_context(
@@ -319,6 +358,13 @@ class OpenAICodexProvider(LLMProvider):
         """Use the Codex backend's inline compaction trigger when needed."""
         _ = model
         return self._native_compaction_available
+
+    def mark_native_compaction_unsupported(
+        self,
+        status_code: int | None = None,
+    ) -> None:
+        _ = status_code
+        self._native_compaction_available = False
 
 
 def _strip_model_prefix(model: str) -> str:

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -1,6 +1,6 @@
 """OpenAI-compatible provider for all non-Anthropic LLM APIs."""
 
-# pyright: reportPrivateImportUsage=false
+# pyright: reportPrivateImportUsage=false, reportPrivateUsage=false
 
 from __future__ import annotations
 
@@ -24,11 +24,17 @@ from loguru import logger
 from pydantic.alias_generators import to_snake
 
 from nanobot.providers.base import (
+    NATIVE_COMPACTION_FALLBACK_ERROR_KIND,
+    ROUTE_FALLBACK_ERROR_KIND,
+    GenerationSettings,
     LLMProvider,
     LLMResponse,
     LLMUsage,
+    ProviderAttempt,
+    ProviderAttemptRoute,
     ProviderCallContext,
     ProviderConversationState,
+    RetryEventCallback,
     ToolCallRequest,
     parse_tool_arguments,
     resolve_stream_idle_timeout_s,
@@ -58,6 +64,19 @@ if TYPE_CHECKING:
 AsyncOpenAI: Any = None
 
 _GEMINI_SKIP_THOUGHT_SIGNATURE = "skip_thought_signature_validator"
+_RESPONSES_TRANSPORT = "responses"
+_CHAT_COMPLETIONS_TRANSPORT = "chat_completions"
+_RESPONSES_COMPATIBILITY_MARKERS = (
+    "responses",
+    "response api",
+    "max_output_tokens",
+    "instructions",
+    "previous_response",
+    "unsupported",
+    "not supported",
+    "unknown parameter",
+    "unrecognized request argument",
+)
 
 
 def _is_hosted_web_search_type(value: object) -> bool:
@@ -496,6 +515,58 @@ def _merge_responses_extra_body(
             merged["tools"] = configured_tools
 
     return merged
+
+
+class _OpenAICompatAttemptRoute:
+    def __init__(
+        self,
+        provider: OpenAICompatProvider,
+        first_attempt: ProviderAttempt,
+        native_compaction_fallback: ProviderAttempt | None,
+        chat_fallback: ProviderAttempt | None,
+    ) -> None:
+        self._provider = provider
+        self._current = first_attempt
+        self._native_compaction_fallback = native_compaction_fallback
+        self._chat_fallback = chat_fallback
+
+    async def start(self) -> ProviderAttempt | LLMResponse:
+        return self._current
+
+    async def advance(
+        self,
+        response: LLMResponse,
+        *,
+        streamed: bool,
+    ) -> ProviderAttempt | LLMResponse:
+        if streamed:
+            return response
+        if (
+            self._current.native_compaction
+            and self._native_compaction_fallback is not None
+            and response.finish_reason == "error"
+            and response.error_kind == NATIVE_COMPACTION_FALLBACK_ERROR_KIND
+        ):
+            self._provider.mark_native_compaction_unsupported(
+                response.error_status_code
+            )
+            self._current = self._native_compaction_fallback
+            self._native_compaction_fallback = None
+            return self._current
+        if (
+            self._current.transport == _RESPONSES_TRANSPORT
+            and self._chat_fallback is not None
+            and response.finish_reason == "error"
+            and self._provider._should_fallback_from_responses_response(response)
+        ):
+            self._provider._record_responses_failure(
+                self._current.model,
+                self._current.generation.reasoning_effort,
+            )
+            self._current = self._chat_fallback
+            self._chat_fallback = None
+            return self._current
+        return response
 
 
 class OpenAICompatProvider(LLMProvider):
@@ -1167,6 +1238,89 @@ class OpenAICompatProvider(LLMProvider):
             return False
         return _is_direct_openai_base(self._effective_base)
 
+    def create_attempt_route(
+        self,
+        *,
+        model: str | None,
+        generation: GenerationSettings,
+        context_window_tokens: int | None,
+        provider_context: ProviderCallContext | None,
+        retry_mode: str,
+        on_retry_wait: RetryEventCallback | None = None,
+        on_retry_exhausted: RetryEventCallback | None = None,
+        on_stream_recover: Callable[[], Awaitable[None]] | None = None,
+    ) -> ProviderAttemptRoute:
+        _ = on_stream_recover
+        if self._should_use_responses_api(model, generation.reasoning_effort):
+            supports_native = self.supports_native_compaction(model)
+            responses_attempt = self._build_provider_attempt(
+                model=model,
+                generation=generation,
+                context_window_tokens=context_window_tokens,
+                provider_context=provider_context,
+                transport=_RESPONSES_TRANSPORT,
+                native_compaction=supports_native,
+                allow_continuation=True,
+                retry_mode=retry_mode,
+                on_retry_wait=on_retry_wait,
+                on_retry_exhausted=on_retry_exhausted,
+            )
+            native_compaction_fallback = (
+                self._build_provider_attempt(
+                    model=model,
+                    generation=generation,
+                    context_window_tokens=context_window_tokens,
+                    provider_context=provider_context,
+                    transport=_RESPONSES_TRANSPORT,
+                    native_compaction=False,
+                    allow_continuation=True,
+                    retry_mode=retry_mode,
+                    on_retry_wait=on_retry_wait,
+                    on_retry_exhausted=on_retry_exhausted,
+                )
+                if supports_native
+                else None
+            )
+            can_fallback_to_chat = not self._responses_is_required() and not (
+                self._spec is not None and self._spec.name == "github_copilot"
+            )
+            chat_fallback = (
+                self._build_provider_attempt(
+                    model=model,
+                    generation=generation,
+                    context_window_tokens=context_window_tokens,
+                    provider_context=provider_context,
+                    transport=_CHAT_COMPLETIONS_TRANSPORT,
+                    native_compaction=False,
+                    allow_continuation=False,
+                    retry_mode=retry_mode,
+                    on_retry_wait=on_retry_wait,
+                    on_retry_exhausted=on_retry_exhausted,
+                )
+                if can_fallback_to_chat
+                else None
+            )
+            return _OpenAICompatAttemptRoute(
+                self,
+                responses_attempt,
+                native_compaction_fallback,
+                chat_fallback,
+            )
+
+        chat_attempt = self._build_provider_attempt(
+            model=model,
+            generation=generation,
+            context_window_tokens=context_window_tokens,
+            provider_context=provider_context,
+            transport=_CHAT_COMPLETIONS_TRANSPORT,
+            native_compaction=False,
+            allow_continuation=False,
+            retry_mode=retry_mode,
+            on_retry_wait=on_retry_wait,
+            on_retry_exhausted=on_retry_exhausted,
+        )
+        return _OpenAICompatAttemptRoute(self, chat_attempt, None, None)
+
     def _responses_circuit_allows_probe(
         self,
         model: str | None,
@@ -1214,18 +1368,16 @@ class OpenAICompatProvider(LLMProvider):
             or getattr(response, "text", None)
         )
         body_text = str(body).lower() if body is not None else ""
-        compatibility_markers = (
-            "responses",
-            "response api",
-            "max_output_tokens",
-            "instructions",
-            "previous_response",
-            "unsupported",
-            "not supported",
-            "unknown parameter",
-            "unrecognized request argument",
-        )
-        return any(marker in body_text for marker in compatibility_markers)
+        return any(marker in body_text for marker in _RESPONSES_COMPATIBILITY_MARKERS)
+
+    @staticmethod
+    def _should_fallback_from_responses_response(response: LLMResponse) -> bool:
+        if response.error_kind == ROUTE_FALLBACK_ERROR_KIND:
+            return True
+        if response.error_status_code not in {400, 404, 422}:
+            return False
+        text = (response.content or "").lower()
+        return any(marker in text for marker in _RESPONSES_COMPATIBILITY_MARKERS)
 
     def _build_responses_body(
         self,
@@ -1342,24 +1494,55 @@ class OpenAICompatProvider(LLMProvider):
         self,
         client: Any,
         body: dict[str, Any],
+        *,
+        allow_fallback: bool = True,
     ) -> Any:
         """Retry Responses once without server compaction on compatibility errors."""
         try:
             return await client.responses.create(**body)
         except Exception as exc:
             if (
-                "context_management" not in body
+                not allow_fallback
+                or "context_management" not in body
                 or not is_compaction_compatibility_error(exc)
             ):
                 raise
-            self._native_compaction_available = False
-            body.pop("context_management", None)
-            logger.warning(
-                "Responses server compaction unsupported; disabled for this provider instance "
-                "(status={})",
-                getattr(exc, "status_code", None),
+            self.mark_native_compaction_unsupported(
+                getattr(exc, "status_code", None)
             )
+            body.pop("context_management", None)
             return await client.responses.create(**body)
+
+    def mark_native_compaction_unsupported(
+        self,
+        status_code: int | None = None,
+    ) -> None:
+        self._native_compaction_available = False
+        logger.warning(
+            "Responses server compaction unsupported; disabled for this provider instance "
+            "(status={})",
+            status_code,
+        )
+
+    def _handle_attempt_responses_error(
+        self,
+        error: Exception,
+        body: dict[str, Any] | None,
+    ) -> LLMResponse:
+        response = self._handle_error(
+            error,
+            spec=self._spec,
+            api_base=self.api_base,
+        )
+        if (
+            body is not None
+            and "context_management" in body
+            and is_compaction_compatibility_error(error)
+        ):
+            response.error_kind = NATIVE_COMPACTION_FALLBACK_ERROR_KIND
+        elif self._should_fallback_from_responses_error(error):
+            response.error_kind = ROUTE_FALLBACK_ERROR_KIND
+        return response
 
     # ------------------------------------------------------------------
     # Response parsing
@@ -1922,6 +2105,42 @@ class OpenAICompatProvider(LLMProvider):
             provider_context=provider_context,
         )
 
+    async def chat_attempt(
+        self,
+        *,
+        attempt: ProviderAttempt,
+        provider_context: ProviderCallContext | None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        if attempt.transport not in {
+            _RESPONSES_TRANSPORT,
+            _CHAT_COMPLETIONS_TRANSPORT,
+        }:
+            raise ValueError(f"unsupported OpenAI transport: {attempt.transport}")
+        return await self.chat(
+            **kwargs,
+            provider_context=provider_context,
+            _attempt_transport=attempt.transport,
+        )
+
+    async def chat_stream_attempt(
+        self,
+        *,
+        attempt: ProviderAttempt,
+        provider_context: ProviderCallContext | None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        if attempt.transport not in {
+            _RESPONSES_TRANSPORT,
+            _CHAT_COMPLETIONS_TRANSPORT,
+        }:
+            raise ValueError(f"unsupported OpenAI transport: {attempt.transport}")
+        return await self.chat_stream(
+            **kwargs,
+            provider_context=provider_context,
+            _attempt_transport=attempt.transport,
+        )
+
     async def chat(
         self,
         messages: list[dict[str, Any]],
@@ -1932,10 +2151,16 @@ class OpenAICompatProvider(LLMProvider):
         reasoning_effort: str | None = None,
         tool_choice: str | dict[str, Any] | None = None,
         provider_context: ProviderCallContext | None = None,
+        _attempt_transport: str | None = None,
     ) -> LLMResponse:
         client = await self._ensure_client()
         try:
-            if self._should_use_responses_api(model, reasoning_effort):
+            use_responses = _attempt_transport == _RESPONSES_TRANSPORT or (
+                _attempt_transport is None
+                and self._should_use_responses_api(model, reasoning_effort)
+            )
+            if use_responses:
+                body: dict[str, Any] | None = None
                 try:
                     body = self._build_responses_body(
                         messages, tools, model, max_tokens, temperature,
@@ -1945,6 +2170,7 @@ class OpenAICompatProvider(LLMProvider):
                     responses_raw = await self._create_response_with_compaction_fallback(
                         client,
                         body,
+                        allow_fallback=_attempt_transport is None,
                     )
                     result = parse_response_output(
                         responses_raw,
@@ -1955,6 +2181,11 @@ class OpenAICompatProvider(LLMProvider):
                     self._record_responses_success(model, reasoning_effort)
                     return result
                 except Exception as responses_error:
+                    if _attempt_transport == _RESPONSES_TRANSPORT:
+                        return self._handle_attempt_responses_error(
+                            responses_error,
+                            body,
+                        )
                     if self._spec and self._spec.name == "github_copilot":
                         # Copilot gateway exposes GPT-5/o-series only via /responses;
                         # falling back to /chat/completions cannot succeed and would
@@ -1991,11 +2222,17 @@ class OpenAICompatProvider(LLMProvider):
         on_thinking_delta: Callable[[str], Awaitable[None]] | None = None,
         on_tool_call_delta: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
         provider_context: ProviderCallContext | None = None,
+        _attempt_transport: str | None = None,
     ) -> LLMResponse:
         client = await self._ensure_client()
         idle_timeout_s = resolve_stream_idle_timeout_s()
         try:
-            if self._should_use_responses_api(model, reasoning_effort):
+            use_responses = _attempt_transport == _RESPONSES_TRANSPORT or (
+                _attempt_transport is None
+                and self._should_use_responses_api(model, reasoning_effort)
+            )
+            if use_responses:
+                body: dict[str, Any] | None = None
                 try:
                     body = self._build_responses_body(
                         messages, tools, model, max_tokens, temperature,
@@ -2006,6 +2243,7 @@ class OpenAICompatProvider(LLMProvider):
                     responses_stream = await self._create_response_with_compaction_fallback(
                         client,
                         body,
+                        allow_fallback=_attempt_transport is None,
                     )
 
                     async def _timed_stream() -> AsyncIterator[Any]:
@@ -2051,6 +2289,11 @@ class OpenAICompatProvider(LLMProvider):
                         )
                     return result
                 except Exception as responses_error:
+                    if _attempt_transport == _RESPONSES_TRANSPORT:
+                        return self._handle_attempt_responses_error(
+                            responses_error,
+                            body,
+                        )
                     if self._spec and self._spec.name == "github_copilot":
                         # Copilot gateway exposes GPT-5/o-series only via /responses;
                         # falling back to /chat/completions cannot succeed and would

--- a/tests/agent/runner_helpers.py
+++ b/tests/agent/runner_helpers.py
@@ -3,11 +3,41 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import DEFAULT, Mock
 
 from nanobot.agent.runner import AgentRunSpec
 from nanobot.config.schema import AgentDefaults
 from nanobot.providers.base import GenerationSettings, LLMProvider
 from nanobot.utils.llm_runtime import LLMRuntime
+
+
+def bind_default_attempt_route(provider: LLMProvider) -> None:
+    """Teach spec-limited provider mocks the real single-attempt contract."""
+    if not isinstance(provider, Mock):
+        return
+
+    supports_native = provider.supports_native_compaction
+    if supports_native._mock_return_value is DEFAULT:
+        supports_native.return_value = False
+    can_resume = provider.can_resume_conversation_state
+    if can_resume._mock_return_value is DEFAULT:
+        can_resume.return_value = False
+    build_attempt = provider._build_provider_attempt
+    if build_attempt.side_effect is None and build_attempt._mock_return_value is DEFAULT:
+        build_attempt.side_effect = (
+            lambda **route_kwargs: LLMProvider._build_provider_attempt(
+                provider,
+                **route_kwargs,
+            )
+        )
+    create_route = provider.create_attempt_route
+    if create_route.side_effect is None and create_route._mock_return_value is DEFAULT:
+        create_route.side_effect = (
+            lambda **route_kwargs: LLMProvider.create_attempt_route(
+                provider,
+                **route_kwargs,
+            )
+        )
 
 
 def make_run_spec(provider: LLMProvider, **kwargs: Any) -> AgentRunSpec:
@@ -18,6 +48,7 @@ def make_run_spec(provider: LLMProvider, **kwargs: Any) -> AgentRunSpec:
     tests.  New tests should pass ``runtime`` to ``AgentRunSpec`` directly when
     runtime identity is itself under test.
     """
+    bind_default_attempt_route(provider)
     model = kwargs.pop("model")
     context_window_tokens = kwargs.pop(
         "context_window_tokens",

--- a/tests/agent/test_runner_fallback.py
+++ b/tests/agent/test_runner_fallback.py
@@ -732,6 +732,33 @@ class TestFallbackOnStreamStalledAfterContent:
         assert streamed == ["stream stalled", "fallback ok"]
         assert recoveries == ["recover"]
 
+    @pytest.mark.asyncio
+    async def test_timeout_in_fallback_without_recovery_stops_chain(self) -> None:
+        primary = _FakeProvider("primary", _error_response(""))
+        fallback_a = _FakeProvider(
+            "fallback-a",
+            _make_response(
+                "fallback stream stalled",
+                finish_reason="error",
+                error_kind="timeout",
+            ),
+        )
+        fallback_b = _FakeProvider("fallback-b", _make_response("unexpected"))
+        factory = MagicMock(side_effect=[fallback_a, fallback_b])
+        fb = FallbackProvider(
+            primary=primary,
+            fallback_presets=[_fallback("fallback-a"), _fallback("fallback-b")],
+            provider_factory=factory,
+        )
+
+        result = await fb.chat_stream(
+            messages=[{"role": "user", "content": "hi"}],
+            on_content_delta=AsyncMock(),
+        )
+
+        assert result.content == "fallback stream stalled"
+        factory.assert_called_once_with(_fallback("fallback-a"))
+
 
 class TestFailoverOnEmptyChoices:
     """Fallback should trigger when API returns empty choices (no error metadata)."""

--- a/tests/agent/test_runner_provider_attempts.py
+++ b/tests/agent/test_runner_provider_attempts.py
@@ -1,0 +1,262 @@
+"""Tests for explicit provider attempts at the AgentRunner boundary."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.runner_helpers import make_run_spec
+from nanobot.agent.runner import AgentRunner
+from nanobot.config.schema import AgentDefaults, ModelPresetConfig
+from nanobot.providers.base import (
+    LLMProvider,
+    LLMResponse,
+    ProviderAttempt,
+    ProviderCallContext,
+    ProviderConversationState,
+)
+from nanobot.providers.fallback_provider import FallbackProvider
+
+
+def _error(content: str) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        finish_reason="error",
+        error_status_code=503,
+        error_kind="server_error",
+        error_should_retry=True,
+    )
+
+
+class _AttemptProvider(LLMProvider):
+    def __init__(
+        self,
+        name: str,
+        responses: list[LLMResponse],
+        *,
+        resumable: bool = False,
+        native_compaction: bool = False,
+    ) -> None:
+        super().__init__(provider_name=name)
+        self._name = name
+        self._responses = iter(responses)
+        self._resumable = resumable
+        self._native_compaction = native_compaction
+        self.attempts: list[ProviderAttempt] = []
+        self.message_ids: list[int] = []
+
+    def get_default_model(self) -> str:
+        return f"{self._name}-model"
+
+    def can_resume_conversation_state(
+        self,
+        state: ProviderConversationState,
+        model: str | None = None,
+    ) -> bool:
+        _ = state, model
+        return self._resumable
+
+    def supports_native_compaction(self, model: str | None = None) -> bool:
+        _ = model
+        return self._native_compaction
+
+    async def chat_attempt(
+        self,
+        *,
+        attempt: ProviderAttempt,
+        provider_context: ProviderCallContext | None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        _ = provider_context
+        self.attempts.append(attempt)
+        self.message_ids.append(id(kwargs["messages"]))
+        return next(self._responses)
+
+    async def chat(self, **kwargs: Any) -> LLMResponse:
+        raise AssertionError("attempt-aware runner must call chat_attempt")
+
+
+@pytest.mark.asyncio
+async def test_retry_stays_within_attempt_and_fallback_rebuilds_from_source() -> None:
+    primary = _AttemptProvider(
+        "primary",
+        [_error(f"primary failure {index}") for index in range(4)],
+        resumable=True,
+        native_compaction=True,
+    )
+    fallback = _AttemptProvider("fallback", [LLMResponse(content="fallback ok")])
+    fallback_preset = ModelPresetConfig(
+        provider="custom",
+        model="fallback-model",
+        context_window_tokens=65_536,
+        max_tokens=1234,
+        temperature=0.4,
+    )
+    provider = FallbackProvider(
+        primary,
+        [fallback_preset],
+        MagicMock(return_value=fallback),
+        primary_context_window_tokens=150_000,
+    )
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    spec = make_run_spec(
+        provider,
+        initial_messages=[],
+        tools=tools,
+        model="primary-model",
+        context_window_tokens=200_000,
+        max_iterations=1,
+        max_tool_result_chars=AgentDefaults().max_tool_result_chars,
+    )
+    messages = [{"role": "user", "content": "keep this source unchanged"}]
+    source_snapshot = [dict(message) for message in messages]
+    state = ProviderConversationState(
+        kind="test",
+        provider="primary",
+        model="primary-model",
+        version=1,
+    )
+    provider_context = ProviderCallContext(
+        conversation_state=state,
+        context_window_tokens=200_000,
+        session_id="webui:test",
+    )
+
+    with patch("nanobot.providers.base.asyncio.sleep", new_callable=AsyncMock):
+        response = await AgentRunner()._execute_provider_route(
+            spec,
+            messages,
+            tools=None,
+            provider_context=provider_context,
+        )
+
+    assert response.content == "fallback ok"
+    assert messages == source_snapshot
+    assert primary.message_ids == [id(messages)] * 4
+    assert fallback.message_ids == [id(messages)]
+    assert len({id(attempt) for attempt in primary.attempts}) == 1
+    assert primary.attempts[0].model == "primary-model"
+    assert primary.attempts[0].context_window_tokens == 150_000
+    assert primary.attempts[0].continuation == "resume"
+    assert primary.attempts[0].native_compaction is True
+    assert primary.attempts[0].provider_context == ProviderCallContext(
+        conversation_state=state,
+        context_window_tokens=150_000,
+        session_id="webui:test",
+    )
+    assert fallback.attempts[0].model == "fallback-model"
+    assert fallback.attempts[0].generation.max_tokens == 1234
+    assert fallback.attempts[0].generation.temperature == 0.4
+    assert fallback.attempts[0].context_window_tokens == 65_536
+    assert fallback.attempts[0].continuation == "rebuild"
+    assert fallback.attempts[0].native_compaction is False
+    assert fallback.attempts[0].provider_context == ProviderCallContext(
+        session_id="webui:test",
+    )
+
+
+@pytest.mark.asyncio
+async def test_fallback_wrapper_without_candidates_keeps_one_leaf_attempt() -> None:
+    primary = _AttemptProvider("primary", [LLMResponse(content="ok")])
+    provider = FallbackProvider(primary, [], MagicMock())
+    route = provider.create_attempt_route(
+        model="primary-model",
+        generation=provider.generation,
+        context_window_tokens=128_000,
+        provider_context=None,
+        retry_mode="persistent",
+    )
+
+    attempt = await route.start()
+
+    assert isinstance(attempt, ProviderAttempt)
+    assert attempt.provider is primary
+    assert attempt.retry_mode == "persistent"
+
+
+@pytest.mark.asyncio
+async def test_native_compaction_fallback_is_refit_from_the_same_source() -> None:
+    provider = _AttemptProvider(
+        "native",
+        [
+            LLMResponse(
+                content="unsupported compaction",
+                finish_reason="error",
+                error_kind="native_compaction_fallback",
+                error_status_code=400,
+            ),
+            LLMResponse(content="local fit ok"),
+        ],
+        native_compaction=True,
+    )
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    spec = make_run_spec(
+        provider,
+        initial_messages=[],
+        tools=tools,
+        model="native-model",
+        context_window_tokens=128_000,
+        max_iterations=1,
+        max_tool_result_chars=AgentDefaults().max_tool_result_chars,
+    )
+    messages = [{"role": "user", "content": "same source"}]
+
+    response = await AgentRunner()._execute_provider_route(
+        spec,
+        messages,
+        tools=None,
+        provider_context=ProviderCallContext(context_window_tokens=128_000),
+    )
+
+    assert response.content == "local fit ok"
+    assert provider.message_ids == [id(messages), id(messages)]
+    assert [attempt.native_compaction for attempt in provider.attempts] == [True, False]
+    assert provider.attempts[0] is not provider.attempts[1]
+
+
+@pytest.mark.asyncio
+async def test_runner_defers_terminal_retry_event_until_fallbacks_exhaust() -> None:
+    primary = _AttemptProvider(
+        "primary",
+        [_error("primary unavailable") for _ in range(4)],
+    )
+    fallback = _AttemptProvider(
+        "fallback",
+        [_error("fallback unavailable") for _ in range(4)],
+    )
+    provider = FallbackProvider(
+        primary,
+        [ModelPresetConfig(provider="custom", model="fallback-model")],
+        MagicMock(return_value=fallback),
+    )
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    events: list[str] = []
+
+    async def on_retry(message: str) -> None:
+        events.append(message)
+
+    spec = make_run_spec(
+        provider,
+        initial_messages=[],
+        tools=tools,
+        model="primary-model",
+        max_iterations=1,
+        max_tool_result_chars=AgentDefaults().max_tool_result_chars,
+        retry_wait_callback=on_retry,
+    )
+
+    with patch("nanobot.providers.base.asyncio.sleep", new_callable=AsyncMock):
+        response = await AgentRunner()._execute_provider_route(
+            spec,
+            [{"role": "user", "content": "hello"}],
+            tools=None,
+            provider_context=None,
+        )
+
+    assert response.finish_reason == "error"
+    assert sum("giving up" in event for event in events) == 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Shared fixtures for the full test suite."""
+
+from __future__ import annotations
+
+import pytest
+from agent.runner_helpers import bind_default_attempt_route
+
+from nanobot.agent.runner import AgentRunner
+
+
+@pytest.fixture(autouse=True)
+def provider_mocks_use_default_attempt_route(monkeypatch):
+    """Keep legacy AgentRunner tests focused on behavior, not mock plumbing."""
+    execute_provider_route = AgentRunner._execute_provider_route
+
+    async def _execute(self, spec, *args, **kwargs):
+        bind_default_attempt_route(spec.runtime.provider)
+        return await execute_provider_route(self, spec, *args, **kwargs)
+
+    monkeypatch.setattr(AgentRunner, "_execute_provider_route", _execute)

--- a/tests/providers/test_azure_openai_provider.py
+++ b/tests/providers/test_azure_openai_provider.py
@@ -11,7 +11,12 @@ from nanobot.providers.azure_openai_provider import (
     AzureOpenAIProvider,
     _AzureTokenProvider,
 )
-from nanobot.providers.base import LLMResponse, ProviderCallContext
+from nanobot.providers.base import (
+    GenerationSettings,
+    LLMResponse,
+    ProviderAttempt,
+    ProviderCallContext,
+)
 
 # ---------------------------------------------------------------------------
 # Init & validation
@@ -413,6 +418,48 @@ async def test_chat_retries_without_unsupported_server_compaction():
     assert create.await_count == 2
     assert "context_management" in create.call_args_list[0].kwargs
     assert "context_management" not in create.call_args_list[1].kwargs
+    assert provider.supports_native_compaction() is False
+
+
+@pytest.mark.asyncio
+async def test_attempt_route_exposes_unsupported_server_compaction():
+    provider = AzureOpenAIProvider(
+        api_key="test-key",
+        api_base="https://test.openai.azure.com",
+        default_model="gpt-5.6",
+    )
+
+    class UnsupportedCompactionError(Exception):
+        status_code = 400
+        body = {"error": {"message": "Unknown parameter: context_management"}}
+
+    provider._client.responses = MagicMock()
+    provider._client.responses.create = AsyncMock(
+        side_effect=UnsupportedCompactionError()
+    )
+    provider_context = ProviderCallContext(context_window_tokens=200_000)
+    route = provider.create_attempt_route(
+        model="gpt-5.6",
+        generation=GenerationSettings(),
+        context_window_tokens=200_000,
+        provider_context=provider_context,
+        retry_mode="standard",
+    )
+    native_attempt = await route.start()
+    assert isinstance(native_attempt, ProviderAttempt)
+
+    response = await provider.chat_with_retry(
+        [{"role": "user", "content": "Hi"}],
+        provider_context=native_attempt.provider_context,
+        _provider_attempt=native_attempt,
+    )
+    local_fit_attempt = await route.advance(response, streamed=False)
+
+    assert response.error_kind == "native_compaction_fallback"
+    assert provider._client.responses.create.await_count == 1
+    assert isinstance(local_fit_attempt, ProviderAttempt)
+    assert local_fit_attempt.native_compaction is False
+    assert local_fit_attempt.provider_context == ProviderCallContext()
     assert provider.supports_native_compaction() is False
 
 

--- a/tests/providers/test_openai_attempt_route.py
+++ b/tests/providers/test_openai_attempt_route.py
@@ -1,0 +1,206 @@
+"""Tests for explicit OpenAI Responses and Chat Completions attempts."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nanobot.providers.base import (
+    GenerationSettings,
+    LLMResponse,
+    ProviderAttempt,
+    ProviderCallContext,
+)
+from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+from nanobot.providers.registry import find_by_name
+
+
+@pytest.mark.asyncio
+async def test_responses_compatibility_fallback_becomes_a_new_chat_attempt() -> None:
+    provider = OpenAICompatProvider(
+        api_key="test",
+        default_model="gpt-5",
+        spec=find_by_name("openai"),
+    )
+    source_context = ProviderCallContext(
+        context_window_tokens=128_000,
+        session_id="webui:test",
+    )
+    route = provider.create_attempt_route(
+        model="gpt-5",
+        generation=GenerationSettings(reasoning_effort="medium"),
+        context_window_tokens=128_000,
+        provider_context=source_context,
+        retry_mode="standard",
+    )
+
+    responses_attempt = await route.start()
+    assert isinstance(responses_attempt, ProviderAttempt)
+    assert responses_attempt.transport == "responses"
+    assert responses_attempt.native_compaction is True
+    assert responses_attempt.provider_context == source_context
+
+    compatibility_error = LLMResponse(
+        content="Error: unsupported Responses API parameter",
+        finish_reason="error",
+        error_status_code=400,
+        error_kind="invalid_request",
+    )
+    chat_attempt = await route.advance(compatibility_error, streamed=False)
+
+    assert isinstance(chat_attempt, ProviderAttempt)
+    assert chat_attempt is not responses_attempt
+    assert chat_attempt.transport == "chat_completions"
+    assert chat_attempt.native_compaction is False
+    assert chat_attempt.continuation == "rebuild"
+    assert chat_attempt.provider_context == ProviderCallContext(session_id="webui:test")
+
+
+@pytest.mark.asyncio
+async def test_attempt_transport_is_forced_at_execution() -> None:
+    provider = OpenAICompatProvider(
+        api_key="test",
+        default_model="gpt-5",
+        spec=find_by_name("openai"),
+    )
+    route = provider.create_attempt_route(
+        model="gpt-5",
+        generation=GenerationSettings(reasoning_effort="medium"),
+        context_window_tokens=128_000,
+        provider_context=None,
+        retry_mode="standard",
+    )
+    attempt = await route.start()
+    assert isinstance(attempt, ProviderAttempt)
+
+    with patch.object(
+        provider,
+        "chat",
+        new_callable=AsyncMock,
+        return_value=LLMResponse(content="ok"),
+    ) as chat:
+        response = await provider.chat_attempt(
+            attempt=attempt,
+            provider_context=attempt.provider_context,
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+    assert response.content == "ok"
+    assert chat.await_args.kwargs["_attempt_transport"] == "responses"
+
+
+@pytest.mark.asyncio
+async def test_native_compaction_fallback_becomes_a_new_responses_attempt() -> None:
+    provider = OpenAICompatProvider(
+        api_key="test",
+        default_model="gpt-5",
+        spec=find_by_name("openai"),
+    )
+    route = provider.create_attempt_route(
+        model="gpt-5",
+        generation=GenerationSettings(reasoning_effort="medium"),
+        context_window_tokens=128_000,
+        provider_context=ProviderCallContext(context_window_tokens=128_000),
+        retry_mode="standard",
+    )
+    native_attempt = await route.start()
+    assert isinstance(native_attempt, ProviderAttempt)
+
+    local_fit_attempt = await route.advance(
+        LLMResponse(
+            content="Error: unknown parameter context_management",
+            finish_reason="error",
+            error_status_code=400,
+            error_kind="native_compaction_fallback",
+        ),
+        streamed=False,
+    )
+
+    assert isinstance(local_fit_attempt, ProviderAttempt)
+    assert local_fit_attempt is not native_attempt
+    assert local_fit_attempt.transport == "responses"
+    assert local_fit_attempt.native_compaction is False
+    assert local_fit_attempt.provider_context == ProviderCallContext()
+    assert provider.supports_native_compaction("gpt-5") is False
+
+
+@pytest.mark.asyncio
+async def test_transport_fallback_bypasses_leaf_image_retry() -> None:
+    class CompatibilityError(Exception):
+        status_code = 400
+        body = {"error": "unknown parameter previous_response_id"}
+
+    provider = OpenAICompatProvider(
+        api_key="test",
+        default_model="gpt-5",
+        spec=find_by_name("openai"),
+    )
+    create_response = AsyncMock(side_effect=CompatibilityError())
+    provider._client = SimpleNamespace(
+        responses=SimpleNamespace(create=create_response),
+    )
+    route = provider.create_attempt_route(
+        model="gpt-5",
+        generation=GenerationSettings(reasoning_effort="medium"),
+        context_window_tokens=None,
+        provider_context=None,
+        retry_mode="standard",
+    )
+    attempt = await route.start()
+    assert isinstance(attempt, ProviderAttempt)
+
+    response = await provider.chat_with_retry(
+        messages=[{
+            "role": "user",
+            "content": [{
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,AAAA"},
+            }],
+        }],
+        model="gpt-5",
+        reasoning_effort="medium",
+        _provider_attempt=attempt,
+    )
+
+    assert response.error_kind == "route_fallback"
+    assert create_response.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_native_compaction_error_bypasses_hidden_provider_retry() -> None:
+    class CompatibilityError(Exception):
+        status_code = 400
+        body = {"error": "unknown parameter context_management"}
+
+    provider = OpenAICompatProvider(
+        api_key="test",
+        default_model="gpt-5",
+        spec=find_by_name("openai"),
+    )
+    create_response = AsyncMock(side_effect=CompatibilityError())
+    provider._client = SimpleNamespace(
+        responses=SimpleNamespace(create=create_response),
+    )
+    provider_context = ProviderCallContext(context_window_tokens=128_000)
+    route = provider.create_attempt_route(
+        model="gpt-5",
+        generation=GenerationSettings(reasoning_effort="medium"),
+        context_window_tokens=128_000,
+        provider_context=provider_context,
+        retry_mode="standard",
+    )
+    attempt = await route.start()
+    assert isinstance(attempt, ProviderAttempt)
+
+    response = await provider.chat_with_retry(
+        messages=[{"role": "user", "content": "hello"}],
+        model="gpt-5",
+        reasoning_effort="medium",
+        provider_context=attempt.provider_context,
+        _provider_attempt=attempt,
+    )
+
+    assert response.error_kind == "native_compaction_fallback"
+    assert create_response.await_count == 1

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -896,6 +896,83 @@ async def test_codex_disables_unsupported_native_compaction_and_continues(
 
 
 @pytest.mark.asyncio
+async def test_codex_attempt_route_exposes_native_compaction_fallback(
+    monkeypatch,
+) -> None:
+    _mock_codex_token(monkeypatch)
+    provider = OpenAICodexProvider(default_model="openai-codex/gpt-5.6-sol")
+    state_provider = provider._responses_state_provider()
+    state = build_responses_state(
+        provider=state_provider,
+        model="gpt-5.6-sol",
+        input_items=[{"type": "message", "role": "user", "content": "old"}],
+        output_items=[{"type": "reasoning", "encrypted_content": "opaque"}],
+        usage=provider_base.LLMUsage.reported(input_tokens=90, output_tokens=5),
+    )
+    bodies: list[dict[str, Any]] = []
+
+    async def fake_request(
+        url,
+        headers,
+        body,
+        verify,
+        **kwargs,
+    ):
+        _ = url, headers, verify, kwargs
+        bodies.append(body)
+        if body["input"][-1].get("type") == "compaction_trigger":
+            raise _CodexHTTPError(
+                "HTTP 400: Codex API request failed",
+                status_code=400,
+                compaction_unsupported=True,
+            )
+        return provider_base.LLMResponse(content="done")
+
+    monkeypatch.setattr(
+        "nanobot.providers.openai_codex_provider._request_codex",
+        fake_request,
+    )
+    provider_context = provider_base.ProviderCallContext(
+        conversation_state=state.with_pending_messages([
+            {"role": "user", "content": "new"},
+        ]),
+        context_window_tokens=100,
+    )
+    route = provider.create_attempt_route(
+        model="openai-codex/gpt-5.6-sol",
+        generation=provider_base.GenerationSettings(max_tokens=5),
+        context_window_tokens=100,
+        provider_context=provider_context,
+        retry_mode="standard",
+    )
+    native_attempt = await route.start()
+    assert isinstance(native_attempt, provider_base.ProviderAttempt)
+
+    first_response = await provider.chat_with_retry(
+        [{"role": "user", "content": "new"}],
+        max_tokens=5,
+        provider_context=native_attempt.provider_context,
+        _provider_attempt=native_attempt,
+    )
+    local_fit_attempt = await route.advance(first_response, streamed=False)
+    assert isinstance(local_fit_attempt, provider_base.ProviderAttempt)
+    final_response = await provider.chat_with_retry(
+        [{"role": "user", "content": "new"}],
+        max_tokens=5,
+        provider_context=local_fit_attempt.provider_context,
+        _provider_attempt=local_fit_attempt,
+    )
+
+    assert first_response.error_kind == "native_compaction_fallback"
+    assert local_fit_attempt.native_compaction is False
+    assert final_response.content == "done"
+    assert len(bodies) == 2
+    assert bodies[0]["input"][-1] == {"type": "compaction_trigger"}
+    assert bodies[1]["input"][-1] != {"type": "compaction_trigger"}
+    assert provider.supports_native_compaction() is False
+
+
+@pytest.mark.asyncio
 async def test_codex_stream_surfaces_reasoning_summary(monkeypatch) -> None:
     def fake_token(**_kwargs):
         return SimpleNamespace(account_id="acct", access="token")


### PR DESCRIPTION
## Summary

- introduce an immutable `ProviderAttempt` and an explicit async route that resolves the concrete provider, model, transport, context window, continuation mode, native-compaction capability, and retry policy before execution
- make `AgentRunner` drive that route from one unchanged source transcript, so transient retries stay inside one attempt while provider/model/transport/capability fallbacks yield a new attempt
- express fallback-provider routing and OpenAI Responses -> native-disabled Responses -> Chat Completions routing through the same attempt contract, including Azure Responses and OpenAI Codex native-compaction compatibility fallback
- preserve direct provider calls, per-leaf retries, circuit breaking, streaming recovery, continuation checks, fallback notifications, and terminal retry events

## Why this is a prerequisite

NAN-67 needs Runner to fit a request for the provider call that will actually execute. Today, provider/model/transport fallback can change that identity below Runner. Injecting a request-fit callback into those lower layers creates bidirectional control flow and makes the final compaction strategy implicit.

This PR changes only routing: Runner first receives a concrete attempt, and NAN-67 can later fit the original transcript once for that attempt. If routing advances, the next attempt is fitted again from the same source rather than from a request copy mutated for the previous attempt.

## Behavioral contract

- transient retry: same `ProviderAttempt`
- provider, model, transport, or native-capability fallback: new `ProviderAttempt`
- Responses -> Chat: rebuild continuation, matching current behavior
- compatible Responses/native fallback: retain continuation when the leaf can resume it
- streamed non-timeout errors: do not fail over after emitted content
- streamed timeout recovery: preserve the existing segment/recovery rules

## Non-goals

- no native/local request-fit or context-compaction policy
- no Memory/Dream consolidation, archive cursor, or durable transcript change
- no config or persistence schema change

## Verification

- `ruff check` on all changed Python files
- `basedpyright`: 0 errors, 0 warnings, 0 notes
- 2632 relevant AgentRunner/provider/CLI/SDK/tool tests passed, 1 skipped
- a broader Windows run exposed localhost WebSocket and symlink-permission failures that reproduce unchanged on the exact base commit; required GitHub CI remains the configured-matrix proof

Linear: [NAN-74](https://linear.app/nanobot-ai/issue/NAN-74/显式建模-providerattempt解耦-fallback-routing-与-request-fit)

Dependency chain: NAN-66 -> NAN-74 -> NAN-67 -> NAN-68 -> NAN-69
