### PR TITLE
test(tui): avoid clipboard status race on Windows

### DIFF
--- a/tui/src/app.test.ts
+++ b/tui/src/app.test.ts
@@ -415,8 +415,7 @@ describe("NanobotTui layout", () => {
 
     await setup.mockInput.typeText("这是什么？ ")
     setup.mockInput.pressKey("v", { ctrl: true })
-    await waitUntil(() => ui.status.plainText.includes("Pasted Image #1"), 3_000)
-    expect(ui.composer.plainText).toBe("这是什么？ [Image #1] ")
+    await waitUntil(() => ui.composer.plainText === "这是什么？ [Image #1] ")
     setup.mockInput.pressTab()
     expect(ui.status.plainText).toContain("Images cannot be queued")
     expect(ui.composer.plainText).toBe("这是什么？ [Image #1] ")


### PR DESCRIPTION
## Summary
- stop the Windows clipboard-image test from waiting on a transient status-line message
- wait for the inserted composer placeholder, which is the stable observable result

## Context
The main-branch Windows TUI job failed at `app.test.ts:418` because the active-turn shimmer can replace `Pasted Image #1` before the test observes it. The same commit passed after rerunning, confirming a timing-dependent test failure.

Failing job: https://github.com/HKUDS/nanobot/actions/runs/33155995241/job/98798782648

## Tests
- `bun test src/app.test.ts --test-name-pattern "pastes clipboard images into removable placeholders" --rerun-each 20`
- `bun run check`
- `bun run test` (160 passed)