### PR TITLE
fix(session): move persistence off event loop

### DIFF
--- a/nanobot/agent/autocompact.py
+++ b/nanobot/agent/autocompact.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Collection
+from collections.abc import Awaitable, Collection
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Coroutine
 
 from loguru import logger
 
+from nanobot.session.async_compat import call_session_manager
 from nanobot.session.manager import MIN_COMPACTED_REPLAY_MESSAGES, Session, SessionManager
 from nanobot.session.summary import SessionSummary, session_summary_from_metadata
 
@@ -47,8 +48,26 @@ class AutoCompact:
         return idle_seconds >= self._ttl * 60
 
     def _has_unarchived_messages(self, key: str) -> bool:
-        session = self.sessions.get_or_create(key)
+        return self._session_has_unarchived_messages(self.sessions.get_or_create(key))
+
+    @staticmethod
+    def _session_has_unarchived_messages(session: Session) -> bool:
         return session.last_archived < len(session.messages)
+
+    async def _get_or_create_nonblocking(self, key: str) -> Session:
+        return await call_session_manager(
+            self.sessions,
+            "get_or_create_async",
+            self.sessions.get_or_create,
+            key,
+        )
+
+    async def _list_sessions_nonblocking(self) -> list[dict[str, Any]]:
+        return await call_session_manager(
+            self.sessions,
+            "list_sessions_async",
+            self.sessions.list_sessions,
+        )
 
     @classmethod
     def _is_internal_session(cls, key: str) -> bool:
@@ -79,6 +98,31 @@ class AutoCompact:
                 self._archiving.add(key)
                 schedule_background(self._archive(key, runtime=runtime))
 
+    async def check_expired_async(
+        self,
+        schedule_background: Callable[[Coroutine[Any, Any, None]], None],
+        resolve_runtime: Callable[[Session], Awaitable[LLMRuntime]],
+        active_session_keys: Collection[str] = (),
+    ) -> None:
+        """Schedule idle archival without blocking the event loop."""
+        now = datetime.now()
+        active_keys = set(active_session_keys)
+        for info in await self._list_sessions_nonblocking():
+            key = info.get("key", "")
+            if not key or self._is_internal_session(key) or key in self._archiving:
+                continue
+            if key in active_keys or not self._is_expired(info.get("updated_at"), now):
+                continue
+            session = await self._get_or_create_nonblocking(key)
+            if not self._session_has_unarchived_messages(session):
+                continue
+            try:
+                runtime = await resolve_runtime(session)
+            except (KeyError, ValueError):
+                continue
+            self._archiving.add(key)
+            schedule_background(self._archive_async(key, runtime=runtime))
+
     async def _archive(self, key: str, *, runtime: LLMRuntime) -> None:
         if self._is_internal_session(key):
             self._archiving.discard(key)
@@ -90,17 +134,37 @@ class AutoCompact:
                 max_suffix=self._RECENT_SUFFIX_MESSAGES,
             )
             if summary and summary != "(nothing)":
-                session = self.sessions.get_or_create(key)
-                stored = session_summary_from_metadata(
-                    session.metadata,
-                    fallback_last_active=session.updated_at,
-                )
-                if stored is not None:
-                    self._summaries[key] = stored
+                self._record_stored_summary(key, self.sessions.get_or_create(key))
         except Exception:
             logger.exception("Auto-compact: failed for {}", key)
         finally:
             self._archiving.discard(key)
+
+    async def _archive_async(self, key: str, *, runtime: LLMRuntime) -> None:
+        if self._is_internal_session(key):
+            self._archiving.discard(key)
+            return
+        try:
+            summary = await self.consolidator.compact_idle_session(
+                key,
+                runtime=runtime,
+                max_suffix=self._RECENT_SUFFIX_MESSAGES,
+            )
+            if summary and summary != "(nothing)":
+                session = await self._get_or_create_nonblocking(key)
+                self._record_stored_summary(key, session)
+        except Exception:
+            logger.exception("Auto-compact: failed for {}", key)
+        finally:
+            self._archiving.discard(key)
+
+    def _record_stored_summary(self, key: str, session: Session) -> None:
+        stored = session_summary_from_metadata(
+            session.metadata,
+            fallback_last_active=session.updated_at,
+        )
+        if stored is not None:
+            self._summaries[key] = stored
 
     def prepare_session(self, session: Session, key: str) -> tuple[Session, SessionSummary | None]:
         if self._is_internal_session(key):
@@ -110,6 +174,28 @@ class AutoCompact:
         if key in self._archiving or self._is_expired(session.updated_at):
             logger.info("Auto-compact: reloading session {} (archiving={})", key, key in self._archiving)
             session = self.sessions.get_or_create(key)
+        return self._prepared_summary(session, key)
+
+    async def prepare_session_async(
+        self,
+        session: Session,
+        key: str,
+    ) -> tuple[Session, SessionSummary | None]:
+        """Prepare a session without blocking on a reload."""
+        if self._is_internal_session(key):
+            self._archiving.discard(key)
+            self._summaries.pop(key, None)
+            return session, None
+        if key in self._archiving or self._is_expired(session.updated_at):
+            logger.info("Auto-compact: reloading session {} (archiving={})", key, key in self._archiving)
+            session = await self._get_or_create_nonblocking(key)
+        return self._prepared_summary(session, key)
+
+    def _prepared_summary(
+        self,
+        session: Session,
+        key: str,
+    ) -> tuple[Session, SessionSummary | None]:
         # Hot path: summary from in-memory dict (process hasn't restarted).
         entry = self._summaries.pop(key, None)
         if entry:

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -71,6 +71,7 @@ from nanobot.security.workspace_access import (
     reset_workspace_scope,
 )
 from nanobot.session import turn_continuation
+from nanobot.session.async_compat import call_session_manager
 from nanobot.session.automation_turns import automation_history_overrides
 from nanobot.session.goal_state import (
     goal_state_runtime_lines,
@@ -526,6 +527,33 @@ class AgentLoop:
             **extra,
         )
 
+    async def _get_or_create_session(self, key: str) -> Session:
+        """Use native async session loading, with a compatibility fallback."""
+        return await call_session_manager(
+            self.sessions,
+            "get_or_create_async",
+            self.sessions.get_or_create,
+            key,
+        )
+
+    async def _save_session(self, session: Session) -> None:
+        """Use native async session saving, with a compatibility fallback."""
+        await call_session_manager(
+            self.sessions,
+            "save_async",
+            self.sessions.save,
+            session,
+        )
+
+    async def _save_runtime_checkpoint(self, session: Session) -> None:
+        """Use native async checkpoint saving, with a compatibility fallback."""
+        await call_session_manager(
+            self.sessions,
+            "save_runtime_checkpoint_async",
+            self.sessions.save_runtime_checkpoint,
+            session,
+        )
+
     def _sync_subagent_runtime_limits(self) -> None:
         """Keep subagent runtime limits aligned with mutable loop settings."""
         self.subagents.max_iterations = self.max_iterations
@@ -565,6 +593,30 @@ class AgentLoop:
             self.sessions.save(session)
             return self.llm_runtime()
 
+    async def runtime_for_session_async(
+        self,
+        session: Session,
+        *,
+        recover_removed: bool = True,
+    ) -> LLMRuntime:
+        """Resolve a session runtime without blocking on recovery persistence."""
+        name = model_preset_from_metadata(session.metadata)
+        if name is None:
+            return self.llm_runtime()
+        try:
+            return self.runtime_resolver.resolve_preset(name)
+        except KeyError:
+            if not recover_removed or name in self.runtime_resolver.model_presets:
+                raise
+            logger.warning(
+                "Session '{}' references removed model preset '{}'; falling back to default",
+                session.key,
+                name,
+            )
+            session.metadata.pop(SESSION_MODEL_PRESET_METADATA_KEY, None)
+            await self._save_session(session)
+            return self.llm_runtime()
+
     def set_session_model_preset(
         self,
         session_key: str,
@@ -575,6 +627,18 @@ class AgentLoop:
         session = self.sessions.get_or_create(session_key)
         session.metadata[SESSION_MODEL_PRESET_METADATA_KEY] = runtime.model_preset
         self.sessions.save(session)
+        return runtime
+
+    async def set_session_model_preset_async(
+        self,
+        session_key: str,
+        name: str,
+    ) -> LLMRuntime:
+        """Validate and persist one session's preset selection without blocking."""
+        runtime = self.runtime_resolver.resolve_preset(name)
+        session = await self._get_or_create_session(session_key)
+        session.metadata[SESSION_MODEL_PRESET_METADATA_KEY] = runtime.model_preset
+        await self._save_session(session)
         return runtime
 
     def _publish_runtime_selection(
@@ -680,17 +744,14 @@ class AgentLoop:
             session_key=session_key,
         )
 
-    def _persist_user_message_early(
+    def _stage_user_message_early(
         self,
         msg: InboundMessage,
         session: Session,
         runtime_context_blocks: list[RuntimeContextBlock] | None = None,
         **kwargs: Any,
     ) -> bool:
-        """Persist the triggering user message before the turn starts.
-
-        Returns True if the message was persisted.
-        """
+        """Add the triggering user message and recovery markers in memory."""
         if not turn_continuation.should_persist_user_message(msg.metadata):
             return False
         media_paths = [
@@ -719,9 +780,44 @@ class AgentLoop:
             followup_id = msg.metadata.get(PENDING_FOLLOWUP_ID_KEY)
             if isinstance(followup_id, str) and followup_id:
                 acknowledge_pending_followups(session, [followup_id])
-            self.sessions.save(session)
             return True
         return False
+
+    def _persist_user_message_early(
+        self,
+        msg: InboundMessage,
+        session: Session,
+        runtime_context_blocks: list[RuntimeContextBlock] | None = None,
+        **kwargs: Any,
+    ) -> bool:
+        """Synchronously persist the user message for compatibility callers."""
+        persisted = self._stage_user_message_early(
+            msg,
+            session,
+            runtime_context_blocks,
+            **kwargs,
+        )
+        if persisted:
+            self.sessions.save(session)
+        return persisted
+
+    async def _persist_user_message_early_async(
+        self,
+        msg: InboundMessage,
+        session: Session,
+        runtime_context_blocks: list[RuntimeContextBlock] | None = None,
+        **kwargs: Any,
+    ) -> bool:
+        """Persist the user message without blocking the event loop."""
+        persisted = self._stage_user_message_early(
+            msg,
+            session,
+            runtime_context_blocks,
+            **kwargs,
+        )
+        if persisted:
+            await self._save_session(session)
+        return persisted
 
     def _build_initial_messages(self, ctx: TurnContext) -> list[dict[str, Any]]:
         """Build the initial message list for the LLM turn."""
@@ -820,7 +916,7 @@ class AgentLoop:
         if tool is None:
             content = "Shell execution is disabled in this nanobot configuration."
         else:
-            session = ctx.session or self.sessions.get_or_create(ctx.key)
+            session = ctx.session or await AgentLoop._get_or_create_session(self, ctx.key)
             scope = self.workspace_scopes.for_turn(
                 channel=ctx.msg.channel,
                 message_metadata=metadata,
@@ -972,7 +1068,7 @@ class AgentLoop:
                 public_payload[self._PROVIDER_STATE_CHECKPOINT_VERSION_KEY] = (
                     self._PROVIDER_STATE_CHECKPOINT_VERSION
                 )
-            self._set_runtime_checkpoint(session, public_payload)
+            await self._set_runtime_checkpoint_async(session, public_payload)
 
         async def _drain_pending(
             *,
@@ -1221,15 +1317,30 @@ class AgentLoop:
             logger.error("LLM returned error: {}", (result.final_content or "")[:200])
         return result
 
-    def _check_expired_sessions_if_due(self) -> None:
-        """Scan idle sessions no more often than the configured interval."""
+    def _idle_compact_scan_due(self) -> bool:
         now = time.monotonic()
         if now < self._next_idle_compact_check_at:
-            return
+            return False
         self._next_idle_compact_check_at = now + self._idle_compact_check_interval_s
+        return True
+
+    def _check_expired_sessions_if_due(self) -> None:
+        """Synchronously scan idle sessions for compatibility with direct callers."""
+        if not self._idle_compact_scan_due():
+            return
         self.auto_compact.check_expired(
             self.schedule_background,
             self.runtime_for_session,
+            active_session_keys=self._pending_queues.keys(),
+        )
+
+    async def _check_expired_sessions_if_due_async(self) -> None:
+        """Scan idle sessions without blocking the event loop."""
+        if not self._idle_compact_scan_due():
+            return
+        await self.auto_compact.check_expired_async(
+            self.schedule_background,
+            self.runtime_for_session_async,
             active_session_keys=self._pending_queues.keys(),
         )
 
@@ -1243,7 +1354,7 @@ class AgentLoop:
                 try:
                     msg = await asyncio.wait_for(self.bus.consume_inbound(), timeout=1.0)
                 except asyncio.TimeoutError:
-                    self._check_expired_sessions_if_due()
+                    await self._check_expired_sessions_if_due_async()
                     continue
                 except asyncio.CancelledError:
                     # Preserve real task cancellation so shutdown can complete cleanly.
@@ -1321,7 +1432,7 @@ class AgentLoop:
                         )
                         continue
                     pending_msg = routed_msg
-                    session = self.sessions.get_or_create(effective_key)
+                    session = await self._get_or_create_session(effective_key)
                     followup_id = record_pending_followup(session, pending_msg)
                     if followup_id is not None:
                         pending_msg = dataclasses.replace(
@@ -1331,7 +1442,7 @@ class AgentLoop:
                                 PENDING_FOLLOWUP_ID_KEY: followup_id,
                             },
                         )
-                        self.sessions.save(session)
+                        await self._save_session(session)
                     try:
                         self._pending_queues[effective_key].put_nowait(pending_msg)
                     except asyncio.QueueFull:
@@ -1442,10 +1553,10 @@ class AgentLoop:
                         raise
                     try:
                         key = self._effective_session_key(msg)
-                        session = self.sessions.get_or_create(key)
+                        session = await self._get_or_create_session(key)
                         if restore_runtime_checkpoint(session):
                             self._clear_pending_user_turn(session)
-                            self.sessions.save(session)
+                            await self._save_session(session)
                             logger.info(
                                 "Restored partial context for cancelled session {}",
                                 key,
@@ -1764,7 +1875,7 @@ class AgentLoop:
                 if ctx.session is None:
                     raise RuntimeError("required session is not active")
             else:
-                ctx.session = self.sessions.get_or_create(ctx.session_key)
+                ctx.session = await self._get_or_create_session(ctx.session_key)
         session = ctx.session
         ctx.ephemeral = ctx.ephemeral or not session.policy.persist
         tools = ctx.tools or self.tools
@@ -1795,16 +1906,16 @@ class AgentLoop:
             self.workspace_scopes.persist_message_scope(session, msg)
 
         if restore_runtime_checkpoint(session):
-            self.sessions.save(session)
+            await self._save_session(session)
         if (
             RECOVERY_INBOUND_METADATA_KEY not in msg.metadata
             and restore_pending_interruption(session)
         ):
-            self.sessions.save(session)
+            await self._save_session(session)
 
     async def _compact_session(self, ctx: TurnContext) -> None:
         session = ctx.require_session()
-        ctx.session, pending = self.auto_compact.prepare_session(
+        ctx.session, pending = await self.auto_compact.prepare_session_async(
             session,
             ctx.session_key,
         )
@@ -1841,14 +1952,14 @@ class AgentLoop:
             # them out of LLM context.  /new is excluded because it
             # intentionally clears the session.
             if cmd_ctx.raw.lower() != "/new":
-                ctx.input_persisted_early = self._persist_user_message_early(
+                ctx.input_persisted_early = await self._persist_user_message_early_async(
                     ctx.msg, session, _command=True
                 )
                 session.add_message(
                     "assistant", result.content, _command=True
                 )
                 self._clear_pending_user_turn(session)
-                self.sessions.save(session)
+                await self._save_session(session)
                 if not ctx.ephemeral:
                     await self.runtime_event_publisher.session_turn_persisted(
                         ctx.msg,
@@ -1863,7 +1974,7 @@ class AgentLoop:
         session = ctx.require_session()
         runtime = ctx.runtime
         if runtime is None:
-            runtime = self.runtime_for_session(session)
+            runtime = await self.runtime_for_session_async(session)
             ctx.runtime = runtime
         if ctx.session_key.startswith("dream:"):
             logger.info(
@@ -1903,7 +2014,7 @@ class AgentLoop:
                 # provider compatibility or prompt assembly work. A compatible
                 # staged state replaces this in a second atomic save below.
                 session.provider_state = None
-                self.sessions.save(session)
+                await self._save_session(session)
             ctx.input_persisted_early = True
         await ctx.delivery.runtime_admitted(runtime)
 
@@ -1957,7 +2068,7 @@ class AgentLoop:
         elif stored_state is not None:
             session.provider_state = None
         if ctx.kind is TurnKind.USER:
-            ctx.input_persisted_early = self._persist_user_message_early(
+            ctx.input_persisted_early = await self._persist_user_message_early_async(
                 ctx.msg,
                 session,
                 runtime_context_blocks=ctx.runtime_context_blocks,
@@ -1967,7 +2078,7 @@ class AgentLoop:
         elif subagent_followup_persisted and staged_provider_state:
             # Upgrade the replay-safe baseline to the resumable state before
             # prompt assembly and the first model checkpoint.
-            self.sessions.save(session)
+            await self._save_session(session)
         ctx.initial_messages = self._build_initial_messages(ctx)
 
         if ctx.on_progress is None:
@@ -2042,6 +2153,9 @@ class AgentLoop:
             turn_latency_ms=ctx.turn_latency_ms,
         )
         ctx.delivery.record_latency(ctx.turn_latency_ms)
+        self._clear_pending_user_turn(session)
+        self._clear_runtime_checkpoint(session)
+        await self._save_session(session)
         if not ctx.ephemeral:
             self.schedule_background(
                 self.consolidator.maybe_consolidate_by_tokens(
@@ -2049,10 +2163,6 @@ class AgentLoop:
                     runtime=runtime,
                 )
             )
-        self._clear_pending_user_turn(session)
-        self._clear_runtime_checkpoint(session)
-        self.sessions.save(session)
-        if not ctx.ephemeral:
             await self.runtime_event_publisher.session_turn_persisted(
                 ctx.msg,
                 ctx.session_key,
@@ -2265,9 +2375,18 @@ class AgentLoop:
         return True
 
     def _set_runtime_checkpoint(self, session: Session, payload: dict[str, Any]) -> None:
-        """Persist the latest in-flight turn state into session metadata."""
+        """Synchronously persist a checkpoint for compatibility callers."""
         session.metadata[self._RUNTIME_CHECKPOINT_KEY] = payload
         self.sessions.save_runtime_checkpoint(session)
+
+    async def _set_runtime_checkpoint_async(
+        self,
+        session: Session,
+        payload: dict[str, Any],
+    ) -> None:
+        """Persist the latest in-flight turn state without blocking the event loop."""
+        session.metadata[self._RUNTIME_CHECKPOINT_KEY] = payload
+        await self._save_runtime_checkpoint(session)
 
     def _mark_pending_user_turn(self, session: Session) -> None:
         session.metadata[self._PENDING_USER_TURN_KEY] = True

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -22,6 +22,7 @@ from loguru import logger
 
 from nanobot.llm_usage.context import llm_usage_source
 from nanobot.runtime_context import public_history_messages
+from nanobot.session.async_compat import call_session_manager
 from nanobot.session.manager import (
     MIN_COMPACTED_REPLAY_MESSAGES,
     Session,
@@ -983,6 +984,22 @@ class Consolidator:
             weakref.WeakValueDictionary()
         )
 
+    async def _get_or_create_session(self, key: str) -> Session:
+        return await call_session_manager(
+            self.sessions,
+            "get_or_create_async",
+            self.sessions.get_or_create,
+            key,
+        )
+
+    async def _save_session(self, session: Session) -> None:
+        await call_session_manager(
+            self.sessions,
+            "save_async",
+            self.sessions.save,
+            session,
+        )
+
     def get_lock(self, session_key: str) -> asyncio.Lock:
         """Return the shared consolidation lock for one session."""
         return self._locks.setdefault(session_key, asyncio.Lock())
@@ -1013,13 +1030,13 @@ class Consolidator:
             return []
         return session.get_history()
 
-    def _persist_last_summary(self, session: Session, summary: str | None) -> None:
+    async def _persist_last_summary(self, session: Session, summary: str | None) -> None:
         if summary and summary != "(nothing)":
             session.metadata["_last_summary"] = {
                 "text": summary,
                 "last_active": session.updated_at.isoformat(),
             }
-            self.sessions.save(session)
+            await self._save_session(session)
 
     def estimate_session_prompt_tokens(
         self,
@@ -1107,7 +1124,7 @@ class Consolidator:
         lock = self.get_lock(session.key)
         async with lock:
             # Refresh session reference: AutoCompact may have replaced it.
-            fresh = self.sessions.get_or_create(session.key)
+            fresh = await self._get_or_create_session(session.key)
             if fresh is not session:
                 session = fresh
             if not session.messages:
@@ -1120,7 +1137,7 @@ class Consolidator:
                 runtime=runtime,
             )
             if estimated <= 0:
-                self._persist_last_summary(session, last_summary)
+                await self._persist_last_summary(session, last_summary)
                 return
             if estimated < budget:
                 unarchived_count = len(session.messages) - session.last_archived
@@ -1132,7 +1149,7 @@ class Consolidator:
                     source,
                     unarchived_count,
                 )
-                self._persist_last_summary(session, last_summary)
+                await self._persist_last_summary(session, last_summary)
                 return
 
             end_idx = self.pick_consolidation_boundary(session)
@@ -1165,12 +1182,12 @@ class Consolidator:
             if summary:
                 last_summary = summary
             session.last_archived = end_idx
-            self.sessions.save(session)
+            await self._save_session(session)
 
             # Persist the last summary to session metadata so it can be injected
             # into the runtime context on the next prepare_session() call, aligning
             # the summary injection strategy with AutoCompact._archive().
-            self._persist_last_summary(session, last_summary)
+            await self._persist_last_summary(session, last_summary)
 
     async def compact_idle_session(
         self,
@@ -1195,7 +1212,7 @@ class Consolidator:
         lock = self.get_lock(session_key)
         async with lock:
             self.sessions.invalidate(session_key)
-            session = self.sessions.get_or_create(session_key)
+            session = await self._get_or_create_session(session_key)
 
             archive_start = session.last_archived
             messages_to_archive = list(session.messages[archive_start:])
@@ -1219,7 +1236,7 @@ class Consolidator:
             # A turn can append while the provider call is in flight. Advance only
             # through the captured batch so new messages remain eligible next time.
             session.last_archived = archive_end
-            self.sessions.save(session)
+            await self._save_session(session)
 
             visible = session.get_history(
                 max_messages=MIN_COMPACTED_REPLAY_MESSAGES,

--- a/nanobot/agent/tools/long_task.py
+++ b/nanobot/agent/tools/long_task.py
@@ -17,6 +17,7 @@ from nanobot.agent.tools.context import RequestContext, ToolContext, current_req
 from nanobot.agent.tools.schema import StringSchema, tool_parameters_schema
 from nanobot.bus.runtime_events import GoalStateChanged, RuntimeEventBus, RuntimeEventContext
 from nanobot.runtime_context import RuntimeContextBlock, wrap_runtime_context_lines
+from nanobot.session.async_compat import call_session_manager
 from nanobot.session.goal_state import (
     GOAL_STATE_KEY,
     MAX_GOAL_OBJECTIVE_CHARS,
@@ -28,6 +29,7 @@ from nanobot.session.goal_state import (
     sustained_goal_active,
 )
 from nanobot.session.turn_continuation import reset_goal_continuation_rounds
+from nanobot.utils.cancellation import shield_and_drain
 from nanobot.utils.prompt_templates import render_template
 
 if TYPE_CHECKING:
@@ -60,36 +62,67 @@ class _GoalToolsMixin:
         self._sessions = sessions
         self._runtime_events = runtime_events
 
-    def _session(self):
+    async def _get_or_create_session(self, key: str):
+        return await call_session_manager(
+            self._sessions,
+            "get_or_create_async",
+            self._sessions.get_or_create,
+            key,
+        )
+
+    async def _save_session(self, session: Any) -> None:
+        await call_session_manager(
+            self._sessions,
+            "save_async",
+            self._sessions.save,
+            session,
+        )
+
+    async def _session(self):
         request_ctx = current_request_context()
         if request_ctx is None:
             return None
         key = request_ctx.session_key
         if not key:
             return None
-        return self._sessions.get_or_create(key)
+        return await self._get_or_create_session(key)
 
     def _goal_mutation_allowed(self) -> bool:
         return current_request_context() is not None and goal_mutation_allowed()
 
-    def _save_goal_state(
+    async def _save_goal_state(
         self,
         sess: Any,
         blob: dict[str, Any],
         *,
         reset_continuation: bool = False,
+        revoke_permission: bool = False,
     ) -> None:
         previous_metadata = deepcopy(sess.metadata)
-        sess.metadata[GOAL_STATE_KEY] = blob
-        discard_legacy_goal_state_key(sess.metadata)
-        if reset_continuation:
-            reset_goal_continuation_rounds(sess.metadata)
+
+        saved = False
+
+        async def save_and_publish() -> None:
+            nonlocal saved
+            sess.metadata[GOAL_STATE_KEY] = blob
+            discard_legacy_goal_state_key(sess.metadata)
+            if reset_continuation:
+                reset_goal_continuation_rounds(sess.metadata)
+            try:
+                await self._save_session(sess)
+            except BaseException:
+                sess.metadata.clear()
+                sess.metadata.update(previous_metadata)
+                raise
+            saved = True
+            await self._publish_goal_state_changed(sess.metadata)
+
         try:
-            self._sessions.save(sess)
-        except BaseException:
-            sess.metadata.clear()
-            sess.metadata.update(previous_metadata)
-            raise
+            await shield_and_drain(save_and_publish())
+        finally:
+            # This ContextVar belongs to the caller task, not the settlement task.
+            if revoke_permission and saved:
+                revoke_goal_mutation_permission()
 
     async def _publish_goal_state_changed(self, metadata: dict[str, Any]) -> None:
         runtime_events = self._runtime_events
@@ -175,7 +208,7 @@ class CreateGoalTool(Tool, _GoalToolsMixin):
     ) -> RuntimeContextBlock | None:
         if not request.session_key:
             return None
-        session = self._sessions.get_or_create(request.session_key)
+        session = await self._get_or_create_session(request.session_key)
         goal_start_requested = explicit_goal_requested(request.metadata)
         goal_active = sustained_goal_active(session.metadata)
         if not goal_start_requested and not goal_active:
@@ -197,7 +230,7 @@ class CreateGoalTool(Tool, _GoalToolsMixin):
         ui_summary: str | None = None,
         **kwargs: Any,
     ) -> str:
-        sess = self._session()
+        sess = await self._session()
         if sess is None:
             return ToolResult.error(
                 "Error: create_goal requires an active chat session (missing routing context)."
@@ -225,8 +258,7 @@ class CreateGoalTool(Tool, _GoalToolsMixin):
             "ui_summary": summary,
             "started_at": _iso_now(),
         }
-        self._save_goal_state(sess, blob, reset_continuation=True)
-        await self._publish_goal_state_changed(sess.metadata)
+        await self._save_goal_state(sess, blob, reset_continuation=True)
         extra = f"\nSummary line: {summary}" if summary else ""
         return (
             "Goal recorded. Keep working toward the objective using ordinary tools. "
@@ -305,7 +337,7 @@ class UpdateGoalTool(Tool, _GoalToolsMixin):
         ui_summary: str | None = None,
         **kwargs: Any,
     ) -> str:
-        sess = self._session()
+        sess = await self._session()
         if sess is None:
             return ToolResult.error("Error: update_goal requires an active chat session.")
         prior = parse_goal_state(goal_state_raw(sess.metadata))
@@ -340,8 +372,7 @@ class UpdateGoalTool(Tool, _GoalToolsMixin):
                 "previous_objective": str(prior.get("objective") or ""),
                 "recap": (recap or "").strip(),
             }
-            self._save_goal_state(sess, blob, reset_continuation=True)
-            await self._publish_goal_state_changed(sess.metadata)
+            await self._save_goal_state(sess, blob, reset_continuation=True)
             extra = f"\nSummary line: {summary}" if summary else ""
             return "Goal replaced. Continue toward the new objective using ordinary tools." + extra
 
@@ -359,9 +390,7 @@ class UpdateGoalTool(Tool, _GoalToolsMixin):
         }
         if normalized == "complete":
             blob["completed_at"] = ended
-        self._save_goal_state(sess, blob)
-        revoke_goal_mutation_permission()
-        await self._publish_goal_state_changed(sess.metadata)
+        await self._save_goal_state(sess, blob, revoke_permission=True)
 
         tail = (recap or "").strip()
         label = {

--- a/nanobot/agent/tools/runtime_control.py
+++ b/nanobot/agent/tools/runtime_control.py
@@ -98,6 +98,13 @@ class RuntimeControl(Protocol):
         session_key: str | None,
     ) -> LLMRuntime: ...
 
+    async def set_model_preset_async(
+        self,
+        name: str,
+        *,
+        session_key: str | None,
+    ) -> LLMRuntime: ...
+
     def set_max_iterations(self, value: int) -> None: ...
 
     def set_context_window_tokens(self, value: int) -> LLMRuntime: ...
@@ -147,6 +154,12 @@ class _RuntimeControlTarget(Protocol):
 
     def set_session_model_preset(self, session_key: str, name: str) -> LLMRuntime: ...
 
+    async def set_session_model_preset_async(
+        self,
+        session_key: str,
+        name: str,
+    ) -> LLMRuntime: ...
+
 
 class AgentRuntimeControl:
     """Allowlisted adapter from agent-loop state to ``RuntimeControl``."""
@@ -189,6 +202,16 @@ class AgentRuntimeControl:
     ) -> LLMRuntime:
         if session_key is not None:
             return self.__target.set_session_model_preset(session_key, name)
+        return self.__target.set_model_preset(name)
+
+    async def set_model_preset_async(
+        self,
+        name: str,
+        *,
+        session_key: str | None,
+    ) -> LLMRuntime:
+        if session_key is not None:
+            return await self.__target.set_session_model_preset_async(session_key, name)
         return self.__target.set_model_preset(name)
 
     def set_max_iterations(self, value: int) -> None:

--- a/nanobot/agent/tools/self.py
+++ b/nanobot/agent/tools/self.py
@@ -373,7 +373,7 @@ class MyTool(Tool):
         if not self._modify_allowed:
             return ToolResult.error("Error: set is disabled (tools.my.allow_set is false)")
         if action in ("modify", "set"):
-            return self._modify(key, value)
+            return await self._modify_async(key, value)
         return f"Unknown action: {action}"
 
     # -- inspect --
@@ -492,6 +492,11 @@ class MyTool(Tool):
             return ToolResult.error(f"Error: '{key}' is read-only and cannot be modified")
         return self._modify_scratchpad(key, value)
 
+    async def _modify_async(self, key: str | None, value: Any) -> str:
+        if key == "model_preset":
+            return await self._modify_model_preset_async(value)
+        return self._modify(key, value)
+
     def _modify_model_preset(self, value: Any) -> str:
         if not isinstance(value, str) or not value.strip():
             return ToolResult.error("Error: 'model_preset' must be a non-empty string")
@@ -500,6 +505,34 @@ class MyTool(Tool):
         old = self._runtime_control.snapshot().model_preset
         try:
             runtime = self._runtime_control.set_model_preset(
+                name,
+                session_key=session_key,
+            )
+        except (KeyError, ValueError) as exc:
+            message = str(exc.args[0]) if exc.args else str(exc)
+            punctuation = "" if message.endswith((".", "!", "?")) else "."
+            return ToolResult.error(f"Error: {message}{punctuation}")
+        if session_key:
+            self._audit("modify", f"model_preset = {name!r}")
+            return (
+                f"Set model_preset = {name!r} for the next turn; "
+                f"model will be {runtime.model!r}; "
+                f"context_window_tokens will be {runtime.context_window_tokens!r}"
+            )
+        self._audit("modify", f"model_preset: {old!r} -> {name!r}")
+        return (
+            f"Set model_preset = {name!r} (was {old!r}); model is now {runtime.model!r}; "
+            f"context_window_tokens is now {runtime.context_window_tokens!r}"
+        )
+
+    async def _modify_model_preset_async(self, value: Any) -> str:
+        if not isinstance(value, str) or not value.strip():
+            return ToolResult.error("Error: 'model_preset' must be a non-empty string")
+        name = value.strip()
+        session_key = current_request_session_key()
+        old = self._runtime_control.snapshot().model_preset
+        try:
+            runtime = await self._runtime_control.set_model_preset_async(
                 name,
                 session_key=session_key,
             )

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import os
 import subprocess
 import sys
@@ -15,6 +16,8 @@ from nanobot import __version__
 from nanobot.bus.events import INBOUND_META_USER_SHELL, OutboundMessage
 from nanobot.command.router import CommandContext, CommandRouter, normalize_command_text
 from nanobot.providers.base import LLMUsage
+from nanobot.session.async_compat import call_session_manager
+from nanobot.utils.cancellation import shield_and_drain
 from nanobot.utils.helpers import build_status_content
 from nanobot.utils.restart import set_restart_notice_to_env
 from nanobot.utils.workspace_prompts import initialize_workspace_prompt
@@ -23,6 +26,7 @@ if TYPE_CHECKING:
     from nanobot.agent.loop import AgentLoop
     from nanobot.session.manager import Session
     from nanobot.utils.gitstore import CommitInfo
+    from nanobot.utils.llm_runtime import LLMRuntime
 
 # WebUI protocol contract for how a slash command participates in turn state:
 # - side_channel: returns control text without starting or ending an agent turn.
@@ -202,6 +206,50 @@ def builtin_command_starts_agent_turn(text: str) -> bool:
     return spec.lifecycle == "agent_turn_with_args" and bool(args.strip())
 
 
+def _has_native_coroutine_method(target: object, name: str) -> bool:
+    """Check the real target class without trusting dynamic mock attributes."""
+    method = inspect.getattr_static(type(target), name, None)
+    return inspect.iscoroutinefunction(method)
+
+
+async def _get_or_create_session(loop: AgentLoop, key: str) -> Session:
+    sessions = loop.sessions
+    return await call_session_manager(
+        sessions,
+        "get_or_create_async",
+        sessions.get_or_create,
+        key,
+    )
+
+
+async def _save_session(loop: AgentLoop, session: Session) -> None:
+    sessions = loop.sessions
+    await call_session_manager(
+        sessions,
+        "save_async",
+        sessions.save,
+        session,
+    )
+
+
+async def _runtime_for_session(loop: AgentLoop, session: Session) -> LLMRuntime:
+    if _has_native_coroutine_method(loop, "runtime_for_session_async"):
+        return await loop.runtime_for_session_async(session)
+    return await shield_and_drain(asyncio.to_thread(loop.runtime_for_session, session))
+
+
+async def _set_session_model_preset(
+    loop: AgentLoop,
+    session_key: str,
+    name: str,
+) -> LLMRuntime:
+    if _has_native_coroutine_method(loop, "set_session_model_preset_async"):
+        return await loop.set_session_model_preset_async(session_key, name)
+    return await shield_and_drain(
+        asyncio.to_thread(loop.set_session_model_preset, session_key, name)
+    )
+
+
 async def cmd_stop(ctx: CommandContext) -> OutboundMessage:
     """Cancel all active tasks and subagents for the session."""
     loop = ctx.loop
@@ -258,8 +306,8 @@ async def cmd_restart(ctx: CommandContext) -> OutboundMessage:
 async def cmd_status(ctx: CommandContext) -> OutboundMessage:
     """Build an outbound status message for a session."""
     loop = ctx.loop
-    session = ctx.session or loop.sessions.get_or_create(ctx.key)
-    runtime = ctx.runtime or loop.runtime_for_session(session)
+    session = ctx.session or await _get_or_create_session(loop, ctx.key)
+    runtime = ctx.runtime or await _runtime_for_session(loop, session)
     ctx_est = 0
     with suppress(Exception):
         ctx_est, _ = loop.consolidator.estimate_session_prompt_tokens(
@@ -307,29 +355,32 @@ async def cmd_new(ctx: CommandContext) -> OutboundMessage:
     loop = ctx.loop
     await loop._cancel_active_tasks(ctx.key)  # pyright: ignore[reportPrivateUsage]
     loop.discard_session_file_state(ctx.key)
-    session = ctx.session or loop.sessions.get_or_create(ctx.key)
+    session = ctx.session or await _get_or_create_session(loop, ctx.key)
     snapshot = list(session.messages)
     archive_snapshot = None
     runtime = None
     if session.last_archived < len(snapshot):
-        runtime = ctx.runtime or loop.runtime_for_session(session)
+        runtime = ctx.runtime or await _runtime_for_session(loop, session)
         archive_snapshot = replace(
             session,
             messages=snapshot,
             metadata=dict(session.metadata),
             provider_state=None,
         )
-    session.clear()
-    loop.sessions.save(session)
-    loop.sessions.invalidate(session.key)
-    if archive_snapshot is not None and runtime is not None:
-        loop.schedule_background(
-            loop.consolidator.archive_session(  # pyright: ignore[reportUnknownMemberType]
-                archive_snapshot,
-                archive_end=len(snapshot),
-                runtime=runtime,
+    async def reset_and_schedule_archive() -> None:
+        session.clear()
+        await _save_session(loop, session)
+        loop.sessions.invalidate(session.key)
+        if archive_snapshot is not None and runtime is not None:
+            loop.schedule_background(
+                loop.consolidator.archive_session(  # pyright: ignore[reportUnknownMemberType]
+                    archive_snapshot,
+                    archive_end=len(snapshot),
+                    runtime=runtime,
+                )
             )
-        )
+
+    await shield_and_drain(reset_and_schedule_archive())
     return OutboundMessage(
         channel=ctx.msg.channel, chat_id=ctx.msg.chat_id,
         content="New session started.",
@@ -378,7 +429,7 @@ async def cmd_model(ctx: CommandContext) -> OutboundMessage:
     metadata = {**dict(ctx.msg.metadata or {}), "render_as": "text"}
 
     if not args:
-        session = ctx.session or loop.sessions.get_or_create(ctx.key)
+        session = ctx.session or await _get_or_create_session(loop, ctx.key)
         return OutboundMessage(
             channel=ctx.msg.channel,
             chat_id=ctx.msg.chat_id,
@@ -388,7 +439,7 @@ async def cmd_model(ctx: CommandContext) -> OutboundMessage:
 
     name = args
     try:
-        runtime = loop.set_session_model_preset(ctx.key, name)
+        runtime = await _set_session_model_preset(loop, ctx.key, name)
     except (KeyError, ValueError) as exc:
         names = _model_preset_names(loop)
         return OutboundMessage(
@@ -849,7 +900,7 @@ async def cmd_history(ctx: CommandContext) -> OutboundMessage:
                 metadata=dict(ctx.msg.metadata or {}),
             )
 
-    session = ctx.session or ctx.loop.sessions.get_or_create(ctx.key)
+    session = ctx.session or await _get_or_create_session(ctx.loop, ctx.key)
     history = session.get_history(max_messages=0, include_runtime_context=False)
     visible = [_format_history_message(m) for m in history]
     visible = [m for m in visible if m is not None]

--- a/nanobot/sdk/clients.py
+++ b/nanobot/sdk/clients.py
@@ -39,7 +39,7 @@ class SessionClient:
         save: bool = True,
     ) -> SessionSnapshot:
         """Import an existing transcript without running the model."""
-        session = self._loop.sessions.get_or_create(session_key)
+        session = await self._loop.sessions.get_or_create_async(session_key)
         if metadata:
             session.metadata.update(deepcopy(dict(metadata)))
 
@@ -61,7 +61,7 @@ class SessionClient:
             session.add_message(role, deepcopy(raw["content"]), **extra)
 
         if save:
-            self._loop.sessions.save(session)
+            await self._loop.sessions.save_async(session)
         return snapshot_from_session(session)
 
     def get(self, session_key: str) -> SessionSnapshot | None:
@@ -109,7 +109,7 @@ class SessionClient:
         key = session_key or snapshot.key
         if not key:
             raise ValueError("restored snapshots must include a session key")
-        session = self._loop.sessions.get_or_create(key)
+        session = await self._loop.sessions.get_or_create_async(key)
         if session.messages:
             raise ValueError(f"restore target session is not empty: {key}")
 
@@ -132,7 +132,7 @@ class SessionClient:
             session.add_message(role, content, **extra)
 
         if save:
-            self._loop.sessions.save(session)
+            await self._loop.sessions.save_async(session)
         return snapshot_from_session(session)
 
     def clear(self, session_key: str) -> SessionSnapshot:
@@ -210,18 +210,20 @@ class RuntimeClient:
 
     async def compact_session(self, session_key: str) -> SessionSnapshot:
         """Run token consolidation for one session."""
-        session = self._loop.sessions.get_or_create(session_key)
-        runtime = self._loop.runtime_for_session(session)
+        session = await self._loop.sessions.get_or_create_async(session_key)
+        runtime = await self._loop.runtime_for_session_async(session)
         await self._loop.consolidator.maybe_consolidate_by_tokens(
             session,
             runtime=runtime,
         )
-        return snapshot_from_session(self._loop.sessions.get_or_create(session_key))
+        return snapshot_from_session(
+            await self._loop.sessions.get_or_create_async(session_key)
+        )
 
     async def compact_idle_session(self, session_key: str, *, max_suffix: int = 8) -> str | None:
         """Run idle-session compaction for one session and return the summary."""
-        session = self._loop.sessions.get_or_create(session_key)
-        runtime = self._loop.runtime_for_session(session)
+        session = await self._loop.sessions.get_or_create_async(session_key)
+        runtime = await self._loop.runtime_for_session_async(session)
         return await self._loop.consolidator.compact_idle_session(
             session_key,
             runtime=runtime,

--- a/nanobot/session/async_compat.py
+++ b/nanobot/session/async_compat.py
@@ -1,0 +1,44 @@
+"""Compatibility bridge for asynchronous SessionManager operations."""
+
+import asyncio
+import inspect
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar, cast
+
+from nanobot.utils.cancellation import shield_and_drain
+
+_SessionResult = TypeVar("_SessionResult")
+
+
+async def call_session_manager(
+    manager: object,
+    async_method_name: str,
+    sync_method: Callable[..., _SessionResult],
+    /,
+    *args: Any,
+    **kwargs: Any,
+) -> _SessionResult:
+    """Prefer a class-declared coroutine, or offload the established sync contract."""
+    sync_method_name = async_method_name.removesuffix("_async")
+    instance_methods = getattr(manager, "__dict__", {})
+    instance_override = (
+        isinstance(instance_methods, dict)
+        and sync_method_name in instance_methods
+    )
+    class_methods = vars(type(manager))
+    subclass_sync_override = (
+        sync_method_name in class_methods
+        and async_method_name not in class_methods
+    )
+    class_async_method = inspect.getattr_static(type(manager), async_method_name, None)
+    if (
+        not instance_override
+        and not subclass_sync_override
+        and inspect.iscoroutinefunction(class_async_method)
+    ):
+        async_method = cast(
+            Callable[..., Awaitable[_SessionResult]],
+            getattr(manager, async_method_name),
+        )
+        return await async_method(*args, **kwargs)
+    return await shield_and_drain(asyncio.to_thread(sync_method, *args, **kwargs))

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -1,5 +1,6 @@
 """Session management for conversation history."""
 
+import asyncio
 import base64
 import errno
 import hashlib
@@ -28,6 +29,7 @@ from nanobot.runtime_context import (
     public_history_message,
 )
 from nanobot.session.model_selection import SESSION_MODEL_PRESET_METADATA_KEY
+from nanobot.utils.cancellation import shield_and_drain
 from nanobot.utils.helpers import (
     content_with_media_breadcrumbs,
     ensure_dir,
@@ -71,6 +73,7 @@ _WORKSPACE_STATE_DIR = ".nanobot"
 _WORKSPACE_ID_FILE = "workspace-id"
 _WORKSPACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 _SESSION_MIGRATION_LOCK_TIMEOUT_SECONDS = 30
+_SESSION_FILES_LOCK_TIMEOUT_SECONDS = 5
 _SESSION_FILES_LOCK_FILENAME = ".session-files.lock"
 _COPY_CHUNK_SIZE = 1024 * 1024
 
@@ -686,7 +689,8 @@ class JsonlSessionStore:
             self.sessions_dir = ensure_dir(root / workspace_id)
             self.legacy_sessions_dir = get_legacy_sessions_dir()
             self._session_files_lock = FileLock(
-                str(self.sessions_dir / _SESSION_FILES_LOCK_FILENAME)
+                str(self.sessions_dir / _SESSION_FILES_LOCK_FILENAME),
+                timeout=_SESSION_FILES_LOCK_TIMEOUT_SECONDS,
             )
             with self._session_files_lock:
                 self._migrate_from_workspace(canonical_workspace)
@@ -1766,6 +1770,7 @@ class SessionManager:
         self._cache: OrderedDict[str, Session] = OrderedDict()
         # Preserve identity for sessions held by active callers without retaining idle ones.
         self._overflow_cache: WeakValueDictionary[str, Session] = WeakValueDictionary()
+        self._async_session_locks: WeakValueDictionary[str, asyncio.Lock] = WeakValueDictionary()
         self._max_cached_sessions = SESSION_CACHE_MAX_SIZE
         self._delete_observer: Callable[[str], None] | None = None
 
@@ -1865,6 +1870,28 @@ class SessionManager:
         self._remember(session)
         return session
 
+    def _async_session_lock(self, key: str) -> asyncio.Lock:
+        lock = self._async_session_locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._async_session_locks[key] = lock
+        return lock
+
+    async def get_or_create_async(self, key: str) -> Session:
+        """Load a session without running file I/O or lock waits on the event loop."""
+        cached = self.get_cached(key)
+        if cached is not None:
+            return cached
+        async with self._async_session_lock(key):
+            cached = self.get_cached(key)
+            if cached is not None:
+                return cached
+            session = await asyncio.to_thread(self._load, key)
+            if session is None:
+                session = Session(key=key)
+            self._remember(session)
+            return session
+
     def get_or_create_transient(
         self,
         key: str,
@@ -1898,6 +1925,17 @@ class SessionManager:
         self._store.save(session, fsync=fsync)
         self._remember(session)
 
+    async def save_async(self, session: Session, *, fsync: bool = False) -> None:
+        """Persist a session without blocking the caller's event loop."""
+        if not session.policy.persist:
+            return
+
+        async def save_and_remember() -> None:
+            await asyncio.to_thread(self._store.save, session, fsync=fsync)
+            self._remember(session)
+
+        await shield_and_drain(save_and_remember())
+
     def save_runtime_checkpoint(self, session: Session) -> None:
         """Persist volatile recovery state without rewriting long history."""
         if not session.policy.persist:
@@ -1909,6 +1947,23 @@ class SessionManager:
         # Third-party stores keep their existing all-or-nothing semantics until
         # they opt into a dedicated checkpoint primitive.
         self.save(session)
+
+    async def save_runtime_checkpoint_async(self, session: Session) -> None:
+        """Persist an in-flight checkpoint without blocking the event loop."""
+        if not session.policy.persist:
+            return
+
+        async def save_and_remember() -> None:
+            if self._store is self._jsonl_store:
+                await asyncio.to_thread(
+                    self._jsonl_store.save_runtime_checkpoint,
+                    session,
+                )
+            else:
+                await asyncio.to_thread(self._store.save, session, fsync=False)
+            self._remember(session)
+
+        await shield_and_drain(save_and_remember())
 
     def rename_model_preset(self, old_name: str, new_name: str) -> int:
         """Rename a session-scoped model preset across durable and live sessions."""
@@ -2054,6 +2109,10 @@ class SessionManager:
         """Read session metadata without loading the transcript."""
         return cast(dict[str, Any] | None, self._store.read_metadata(key))
 
+    async def read_session_metadata_async(self, key: str) -> dict[str, Any] | None:
+        """Read session metadata without blocking the event loop."""
+        return await asyncio.to_thread(self.read_session_metadata, key)
+
     def update_session_metadata(
         self,
         key: str,
@@ -2069,3 +2128,7 @@ class SessionManager:
 
     def list_sessions(self) -> list[dict[str, Any]]:
         return cast(list[dict[str, Any]], self._store.list_sessions())
+
+    async def list_sessions_async(self) -> list[dict[str, Any]]:
+        """List persisted sessions without blocking the event loop."""
+        return await asyncio.to_thread(self.list_sessions)

--- a/nanobot/session/recovery.py
+++ b/nanobot/session/recovery.py
@@ -25,6 +25,7 @@ from nanobot.bus.outbound_events import (
 )
 from nanobot.bus.queue import MessageBus
 from nanobot.session import turn_continuation
+from nanobot.session.async_compat import call_session_manager
 from nanobot.session.keys import UNIFIED_SESSION_KEY, last_channel_from_metadata
 from nanobot.session.manager import Session, SessionManager
 from nanobot.webui.metadata import WEBUI_TURN_METADATA_KEY
@@ -461,6 +462,37 @@ class RecoveryCoordinator:
         repr=False,
     )
 
+    async def _get_or_create_session(self, key: str) -> Session:
+        return await call_session_manager(
+            self.sessions,
+            "get_or_create_async",
+            self.sessions.get_or_create,
+            key,
+        )
+
+    async def _save_session(self, session: Session) -> None:
+        await call_session_manager(
+            self.sessions,
+            "save_async",
+            self.sessions.save,
+            session,
+        )
+
+    async def _read_session_metadata(self, key: str) -> dict[str, Any] | None:
+        return await call_session_manager(
+            self.sessions,
+            "read_session_metadata_async",
+            self.sessions.read_session_metadata,
+            key,
+        )
+
+    async def _list_sessions(self) -> list[dict[str, Any]]:
+        return await call_session_manager(
+            self.sessions,
+            "list_sessions_async",
+            self.sessions.list_sessions,
+        )
+
     def register_recovery_task(self, session_key: str, task: asyncio.Task[Any]) -> None:
         """Track the task that owns an explicit recovery continuation."""
         self._active_recovery_tasks[session_key] = task
@@ -483,8 +515,8 @@ class RecoveryCoordinator:
 
     async def scan(self) -> None:
         """Recover every interrupted WebUI session once at gateway startup."""
-        for key in self._recovery_candidates():
-            metadata_payload = self.sessions.read_session_metadata(key)
+        for key in await self._recovery_candidates():
+            metadata_payload = await self._read_session_metadata(key)
             raw_metadata = metadata_payload.get("metadata") if metadata_payload else None
             metadata = cast(dict[str, Any], raw_metadata) if isinstance(raw_metadata, dict) else {}
             route = self._websocket_route_for(key, metadata)
@@ -493,7 +525,7 @@ class RecoveryCoordinator:
             unfinished = self._has_unfinished_webui_transcript(key)
             if not self._needs_recovery(metadata) and not unfinished:
                 continue
-            session = self.sessions.get_or_create(key)
+            session = await self._get_or_create_session(key)
             try:
                 await self._recover_session(session, route[1])
                 await self._requeue_pending_followups(session)
@@ -508,14 +540,14 @@ class RecoveryCoordinator:
                     reason="recovery_failed",
                     can_continue=False,
                 )
-                self.sessions.save(session)
+                await self._save_session(session)
                 await self._publish(route[1], failed)
 
-    def _recovery_candidates(self) -> list[str]:
+    async def _recovery_candidates(self) -> list[str]:
         """Discover canonical and transcript-only WebUI sessions cheaply."""
         candidates = dict.fromkeys(
             key
-            for item in self.sessions.list_sessions()
+            for item in await self._list_sessions()
             if isinstance((key := item.get("key")), str)
         )
         try:
@@ -524,7 +556,7 @@ class RecoveryCoordinator:
             # duplicating its filename and migration rules here would drift.
             from nanobot.webui.session_list_index import list_webui_sessions
 
-            for item in list_webui_sessions(self.sessions):
+            for item in await asyncio.to_thread(list_webui_sessions, self.sessions):
                 key = item.get("key")
                 if isinstance(key, str):
                     candidates.setdefault(key, None)
@@ -550,7 +582,7 @@ class RecoveryCoordinator:
         """Reject stale queued recoveries and let new user input supersede them."""
         recovery_id = message.metadata.get(RECOVERY_INBOUND_METADATA_KEY)
         if isinstance(recovery_id, str):
-            session = self.sessions.get_or_create(message.session_key)
+            session = await self._get_or_create_session(message.session_key)
             state = recovery_state_from_metadata(session.metadata)
             return bool(
                 state
@@ -559,7 +591,7 @@ class RecoveryCoordinator:
             )
         if message.channel != "websocket":
             return True
-        session = self.sessions.get_or_create(message.session_key)
+        session = await self._get_or_create_session(message.session_key)
         state = recovery_state_from_metadata(session.metadata)
         if state and state["status"] in {"resuming", "awaiting_user", "failed"}:
             await self._cancel_active_recovery(message.session_key)
@@ -573,13 +605,13 @@ class RecoveryCoordinator:
                 attempts=cast(int, state.get("attempts", 0)),
                 reason="superseded",
             )
-            self.sessions.save(session)
+            await self._save_session(session)
             await self._publish(message.chat_id, recovered)
         return True
 
     async def turn_completed(self, session_key: str) -> None:
         """Resolve a resuming state after the recovered turn commits."""
-        session = self.sessions.get_or_create(session_key)
+        session = await self._get_or_create_session(session_key)
         state = recovery_state_from_metadata(session.metadata)
         if not state or state["status"] != "resuming":
             return
@@ -593,7 +625,7 @@ class RecoveryCoordinator:
             attempts=cast(int, state.get("attempts", 0)),
             reason="continued",
         )
-        self.sessions.save(session)
+        await self._save_session(session)
         await self._publish(route[1], recovered)
 
     async def handle_action(self, action: str, payload: dict[str, Any]) -> dict[str, Any]:
@@ -604,7 +636,7 @@ class RecoveryCoordinator:
             raise RecoveryActionError("missing chat_id")
         if not isinstance(recovery_id, str) or not recovery_id:
             raise RecoveryActionError("missing recovery_id")
-        session = self.sessions.get_or_create(self._session_key(chat_id))
+        session = await self._get_or_create_session(self._session_key(chat_id))
         state = recovery_state_from_metadata(session.metadata)
         if not state or state["recovery_id"] != recovery_id:
             raise RecoveryActionError("recovery state is stale", status=409)
@@ -619,7 +651,7 @@ class RecoveryCoordinator:
                 attempts=cast(int, state.get("attempts", 0)),
                 reason="dismissed",
             )
-            self.sessions.save(session)
+            await self._save_session(session)
             await self._publish(chat_id, next_state)
             return next_state
         if action != "continue":
@@ -636,7 +668,7 @@ class RecoveryCoordinator:
             reason="user_confirmed",
             resume_message_count=len(session.messages),
         )
-        self.sessions.save(session)
+        await self._save_session(session)
         await self._publish(chat_id, next_state)
         await self._queue_continuation(session, chat_id, next_state)
         return next_state
@@ -669,7 +701,7 @@ class RecoveryCoordinator:
                         attempts=cast(int, state.get("attempts", 1)),
                         reason="loop_guard",
                     )
-                self.sessions.save(session)
+                await self._save_session(session)
                 await self._publish(chat_id, next_state)
             elif self._has_unfinished_webui_transcript(session.key):
                 # A normal last-client shutdown can materialize the checkpoint
@@ -691,7 +723,7 @@ class RecoveryCoordinator:
                     ),
                     can_continue=can_continue,
                 )
-                self.sessions.save(session)
+                await self._save_session(session)
                 await self._publish(chat_id, waiting)
             return
         if state and state["status"] in {"awaiting_user", "failed"}:
@@ -707,7 +739,7 @@ class RecoveryCoordinator:
                 attempts=cast(int, state.get("attempts", 1)),
                 reason="loop_guard",
             )
-            self.sessions.save(session)
+            await self._save_session(session)
             await self._publish(chat_id, waiting)
             return
 
@@ -725,7 +757,7 @@ class RecoveryCoordinator:
                 reason="checkpoint_unknown",
                 can_continue=False,
             )
-            self.sessions.save(session)
+            await self._save_session(session)
             await self._publish(chat_id, waiting)
             return
         if checkpoint is not None and not _runtime_checkpoint_is_well_formed(checkpoint):
@@ -739,7 +771,7 @@ class RecoveryCoordinator:
                 reason="checkpoint_invalid",
                 can_continue=False,
             )
-            self.sessions.save(session)
+            await self._save_session(session)
             await self._publish(chat_id, waiting)
             return
         if phase == "final_response":
@@ -751,7 +783,7 @@ class RecoveryCoordinator:
                 attempts=0,
                 reason="answer_restored",
             )
-            self.sessions.save(session)
+            await self._save_session(session)
             await self._publish(chat_id, recovered)
             return
         if phase in _UNCERTAIN_TOOL_PHASES or pending_calls:
@@ -763,7 +795,7 @@ class RecoveryCoordinator:
                 attempts=0,
                 reason="tool_state_unknown",
             )
-            self.sessions.save(session)
+            await self._save_session(session)
             await self._publish(chat_id, waiting)
             return
         # A gateway restart is a lifecycle boundary.  Never enqueue model work
@@ -778,7 +810,7 @@ class RecoveryCoordinator:
             attempts=0,
             reason="restart_requires_confirmation",
         )
-        self.sessions.save(session)
+        await self._save_session(session)
         await self._publish(chat_id, waiting)
 
     async def _queue_continuation(

--- a/nanobot/session/webui_turns.py
+++ b/nanobot/session/webui_turns.py
@@ -210,12 +210,12 @@ async def maybe_generate_webui_title(
     so pass ``target_session_key`` to project the title onto that per-chat
     session instead of storing it on the shared one.
     """
-    routed_session = sessions.get_or_create(session_key)
+    routed_session = await sessions.get_or_create_async(session_key)
     target_is_routed = target_session_key is None or target_session_key == session_key
     if target_is_routed or target_session_key is None:
         target_session = routed_session
     else:
-        target_session = sessions.get_or_create(target_session_key)
+        target_session = await sessions.get_or_create_async(target_session_key)
     if (
         routed_session.metadata.get(WEBUI_SESSION_METADATA_KEY) is not True
         and target_session.metadata.get(WEBUI_SESSION_METADATA_KEY) is not True
@@ -229,7 +229,7 @@ async def maybe_generate_webui_title(
         if cleaned_current_title:
             if cleaned_current_title != current_title:
                 target_session.metadata[WEBUI_TITLE_METADATA_KEY] = cleaned_current_title
-                sessions.save(target_session)
+                await sessions.save_async(target_session)
             return False
         target_session.metadata.pop(WEBUI_TITLE_METADATA_KEY, None)
 
@@ -288,7 +288,7 @@ async def maybe_generate_webui_title(
         )
         return False
     target_session.metadata[WEBUI_TITLE_METADATA_KEY] = title
-    sessions.save(target_session)
+    await sessions.save_async(target_session)
     return True
 
 
@@ -489,8 +489,8 @@ class WebuiTurnRoutePolicy:
             )
             and route.channel == "websocket"
         ):
-            session = self.sessions.get_or_create(session_key)
-            if session.metadata.get(WEBUI_SESSION_METADATA_KEY) is True:
+            session = self.sessions.get_cached(session_key)
+            if session is not None and session.metadata.get(WEBUI_SESSION_METADATA_KEY) is True:
                 metadata = dict(route.metadata)
                 turn_prefix = "session-input" if internal_user_input else "subagent"
                 metadata.update({
@@ -632,7 +632,7 @@ class WebuiTurnCoordinator:
             or not is_webui_session_key(session_key)
         ):
             return
-        persisted = self.sessions.read_session_metadata(session_key)
+        persisted = await self.sessions.read_session_metadata_async(session_key)
         metadata_value: object = persisted.get("metadata") if persisted is not None else None
         metadata = (
             cast(dict[str, Any], metadata_value)
@@ -668,8 +668,9 @@ class WebuiTurnCoordinator:
     def _handle_session_turn_started(self, event: SessionTurnStarted) -> None:
         if not self._is_websocket_event(event.context):
             return
-        session = self.sessions.get_or_create(event.context.session_key)
-        mark_webui_session(session, event.context.metadata)
+        session = self.sessions.get_cached(event.context.session_key)
+        if session is not None:
+            mark_webui_session(session, event.context.metadata)
 
     async def _handle_run_status_changed(self, event: TurnRunStatusChanged) -> None:
         if not self._is_websocket_event(event.context):
@@ -755,7 +756,7 @@ class WebuiTurnCoordinator:
         if msg.channel != "websocket":
             return
 
-        session = self.sessions.get_or_create(session_key)
+        session = await self.sessions.get_or_create_async(session_key)
         await self.bus.publish_outbound(
             outbound_message_for_event(
                 channel=msg.channel,

--- a/nanobot/utils/cancellation.py
+++ b/nanobot/utils/cancellation.py
@@ -3,8 +3,48 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable
+from typing import TypeVar
+
+_T = TypeVar("_T")
 
 
 def task_is_cancelling() -> bool:
     task = asyncio.current_task()
     return task is not None and task.cancelling() > 0
+
+
+async def shield_and_drain(awaitable: Awaitable[_T]) -> _T:
+    """Delay caller cancellation until an accepted operation has fully settled.
+
+    ``asyncio.to_thread`` cannot stop a worker that has already started. Shielding
+    keeps cancellation from detaching that worker, and draining also lets any
+    post-write in-memory settlement in ``awaitable`` finish. Cancellation is still
+    re-raised as soon as the accepted operation is done.
+    """
+    settlement = asyncio.ensure_future(awaitable)
+    cancellation: asyncio.CancelledError | None = None
+
+    while not settlement.done():
+        try:
+            result = await asyncio.shield(settlement)
+        except asyncio.CancelledError as exc:
+            if cancellation is None:
+                cancellation = exc
+        except BaseException:
+            if cancellation is None:
+                raise
+            break
+        else:
+            if cancellation is not None:
+                raise cancellation
+            return result
+
+    if cancellation is not None:
+        try:
+            settlement.result()
+        except BaseException:
+            # The caller's cancellation wins once settlement has been observed.
+            pass
+        raise cancellation
+    return settlement.result()

--- a/tests/session/test_session_async.py
+++ b/tests/session/test_session_async.py
@@ -1,0 +1,191 @@
+"""Async SessionManager persistence and cancellation guarantees."""
+
+import asyncio
+import threading
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from filelock import FileLock
+
+from nanobot.session.manager import Session, SessionManager, SessionStore
+
+
+async def _cancel_blocked_mutation(
+    task: asyncio.Task[Any],
+    *,
+    started: threading.Event,
+    release: threading.Event,
+) -> None:
+    assert await asyncio.to_thread(started.wait, 1)
+    try:
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done(), "cancellation escaped before the persistence worker settled"
+    finally:
+        release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=1)
+
+
+async def test_concurrent_first_async_gets_share_cached_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager(tmp_path)
+    key = "test:concurrent-first-load"
+    load_started = threading.Event()
+    release_load = threading.Event()
+    load_calls = 0
+
+    def delayed_load(loaded_key: str) -> None:
+        nonlocal load_calls
+        assert loaded_key == key
+        load_calls += 1
+        load_started.set()
+        assert release_load.wait(timeout=1)
+
+    monkeypatch.setattr(manager, "_load", delayed_load)
+    first_task = asyncio.create_task(manager.get_or_create_async(key))
+    try:
+        assert await asyncio.to_thread(load_started.wait, 1)
+        second_task = asyncio.create_task(manager.get_or_create_async(key))
+        await asyncio.sleep(0)
+        assert not second_task.done()
+    finally:
+        release_load.set()
+
+    first, second = await asyncio.gather(first_task, second_task)
+
+    assert load_calls == 1
+    assert first is second
+    assert manager.get_cached(key) is first
+    assert await manager.get_or_create_async(key) is first
+
+
+async def test_async_methods_offload_third_party_store_and_keep_contract(
+    tmp_path: Path,
+) -> None:
+    session = Session(key="test:third-party")
+    store = MagicMock(spec=SessionStore)
+    store.load.return_value = session
+    manager = SessionManager(tmp_path, store=store)
+    event_loop_thread = threading.get_ident()
+    worker_threads: list[int] = []
+
+    def load(key: str) -> Session:
+        worker_threads.append(threading.get_ident())
+        assert key == session.key
+        return session
+
+    def save(target: Session, *, fsync: bool = False) -> None:
+        worker_threads.append(threading.get_ident())
+        assert target is session
+
+    store.load.side_effect = load
+    store.save.side_effect = save
+
+    assert await manager.get_or_create_async(session.key) is session
+    await manager.save_async(session, fsync=True)
+    await manager.save_runtime_checkpoint_async(session)
+
+    store.load.assert_called_once_with(session.key)
+    assert store.save.call_args_list[0].kwargs == {"fsync": True}
+    assert store.save.call_args_list[1].kwargs == {"fsync": False}
+    assert worker_threads
+    assert all(thread_id != event_loop_thread for thread_id in worker_threads)
+
+
+async def test_save_async_cancellation_settles_disk_and_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager(tmp_path)
+    session = Session(key="test:cancel-save")
+    session.add_message("user", "persist exactly once")
+    started = threading.Event()
+    release = threading.Event()
+    save_calls = 0
+    original_save = manager._store.save
+
+    def blocked_save(target: Session, *, fsync: bool = False) -> None:
+        nonlocal save_calls
+        save_calls += 1
+        started.set()
+        assert release.wait(timeout=1)
+        original_save(target, fsync=fsync)
+
+    monkeypatch.setattr(manager._store, "save", blocked_save)
+    task = asyncio.create_task(manager.save_async(session))
+
+    await _cancel_blocked_mutation(task, started=started, release=release)
+
+    assert save_calls == 1
+    assert manager.get_cached(session.key) is session
+    durable = manager.read_session_file(session.key)
+    assert durable is not None
+    assert durable["messages"][0]["content"] == "persist exactly once"
+
+
+async def test_checkpoint_async_cancellation_settles_disk_and_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager(tmp_path)
+    session = manager.get_or_create("test:cancel-checkpoint")
+    session.add_message("user", "question")
+    manager.save(session)
+    session.metadata["runtime_checkpoint"] = {"phase": "awaiting_tools"}
+    started = threading.Event()
+    release = threading.Event()
+    checkpoint_calls = 0
+    original_checkpoint = manager._jsonl_store.save_runtime_checkpoint
+
+    def blocked_checkpoint(target: Session) -> None:
+        nonlocal checkpoint_calls
+        checkpoint_calls += 1
+        started.set()
+        assert release.wait(timeout=1)
+        original_checkpoint(target)
+
+    monkeypatch.setattr(
+        manager._jsonl_store,
+        "save_runtime_checkpoint",
+        blocked_checkpoint,
+    )
+    task = asyncio.create_task(manager.save_runtime_checkpoint_async(session))
+
+    await _cancel_blocked_mutation(task, started=started, release=release)
+
+    assert checkpoint_calls == 1
+    assert manager.get_cached(session.key) is session
+    restored = SessionManager(tmp_path).get_or_create(session.key)
+    assert restored.metadata["runtime_checkpoint"] == {"phase": "awaiting_tools"}
+
+
+async def test_session_lock_contention_keeps_event_loop_responsive(
+    tmp_path: Path,
+) -> None:
+    manager = SessionManager(tmp_path)
+    first = manager.get_or_create("test:blocked-save")
+    second = manager.get_or_create("test:cached-session")
+    first.add_message("user", "hello")
+    lock = manager._jsonl_store._session_files_lock
+    assert lock.timeout == 5
+    blocker = FileLock(lock.lock_file, timeout=1)
+    blocker.acquire()
+    save_task = asyncio.create_task(manager.save_async(first))
+    ticks = 0
+    try:
+        for _ in range(3):
+            await asyncio.sleep(0.01)
+            ticks += 1
+        assert not save_task.done()
+        assert await manager.get_or_create_async(second.key) is second
+    finally:
+        blocker.release()
+
+    await asyncio.wait_for(save_task, timeout=1)
+    assert ticks == 3


### PR DESCRIPTION
## Summary

- add cancellation-safe async SessionManager load, save, checkpoint, metadata-read, and list APIs while preserving synchronous callers and third-party SessionStore contracts
- move active AgentLoop, compaction, recovery, slash-command, goal/model tool, SDK, and WebUI session persistence across the async compatibility boundary
- bound canonical session file-lock waits to 5 seconds without changing atomic replace or fsync behavior
- add regressions for lock contention responsiveness, concurrent cache identity, third-party stores, and save/checkpoint cancellation settlement

## Verification

- `uv run --no-sync ruff check nanobot/ tests/session/test_session_async.py`
- `uv run --no-sync basedpyright` (0 errors)
- high-signal verify suite: 18 passed
- full suite: 6716 passed, 50 skipped; the only failure was the existing Windows symlink test, which could not create a symlink without SeCreateSymbolicLinkPrivilege (WinError 1314)

Linear: NAN-52