### PR TITLE
fix(tui): preserve cursor position on Windows exit

### DIFF
--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -94,7 +94,7 @@ import {
   type FooterMode,
   type FooterHintTheme,
 } from "./footer-hints"
-import { createTuiHost, type TuiHost } from "./host"
+import { configureOpenTuiEnvironment, createTuiHost, type TuiHost } from "./host"
 
 interface AppOptions {
   wsUrl?: string
@@ -820,6 +820,7 @@ export class NanobotTui {
   }
 
   static async create(options: AppOptions): Promise<NanobotTui> {
+    configureOpenTuiEnvironment()
     const host = createTuiHost()
     const renderer = await createCliRenderer({
       targetFps: 30,

--- a/tui/src/host.test.ts
+++ b/tui/src/host.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test"
 
-import { createTuiHost } from "./host"
+import {
+  configureOpenTuiEnvironment,
+  createTuiHost,
+} from "./host"
 
 async function settle(): Promise<void> {
   await Bun.sleep(0)
@@ -8,6 +11,27 @@ async function settle(): Promise<void> {
 }
 
 describe("TUI host integration", () => {
+  test("disables the explicit-width probe on Windows", () => {
+    const environment: Record<string, string | undefined> = {}
+
+    configureOpenTuiEnvironment(environment, "win32")
+
+    expect(environment.OPENTUI_FORCE_EXPLICIT_WIDTH).toBe("false")
+  })
+
+  test("preserves explicit probe choices and leaves other platforms unchanged", () => {
+    const overridden = {
+      OPENTUI_FORCE_EXPLICIT_WIDTH: "true",
+    }
+    const nonWindows: Record<string, string | undefined> = {}
+
+    configureOpenTuiEnvironment(overridden, "win32")
+    configureOpenTuiEnvironment(nonWindows, "linux")
+
+    expect(overridden.OPENTUI_FORCE_EXPLICIT_WIDTH).toBe("true")
+    expect(nonWindows.OPENTUI_FORCE_EXPLICIT_WIDTH).toBeUndefined()
+  })
+
   test("standalone terminals remain a no-op", async () => {
     const commands: string[][] = []
     const host = createTuiHost({}, async (command) => { commands.push([...command]) })

--- a/tui/src/host.ts
+++ b/tui/src/host.ts
@@ -8,6 +8,19 @@ type CommandRunner = (command: readonly string[]) => Promise<void>
 
 const METADATA_SOURCE = "nanobot:tui:metadata"
 
+export function configureOpenTuiEnvironment(
+  environment: Environment = process.env,
+  platform = process.platform,
+): void {
+  if (platform !== "win32") return
+
+  // OpenTUI probes OSC 66 support on the main screen before its renderer is
+  // active. Some Windows terminal hosts do not restore the cursor around that
+  // probe, so shutdown resumes in terminal history instead of below the TUI.
+  // Keep an explicit user choice, but use the safe default on Windows.
+  environment.OPENTUI_FORCE_EXPLICIT_WIDTH ??= "false"
+}
+
 class StandaloneHost implements TuiHost {
   reportTitle(): void {}
   release(): void {}


### PR DESCRIPTION
## Summary

Prevent the TUI from returning the shell cursor to terminal history after `nanobot agent` exits in affected Windows terminals.

The fix disables OpenTUI's explicit-width capability probe by default on Windows while preserving explicit user overrides.

## Problem

In some embedded Windows terminals, exiting `nanobot agent` returns control to PowerShell with the cursor positioned inside the existing terminal history instead of below the TUI.

This can cause:

- the PowerShell prompt to remain invisible until Enter is pressed;
- the cursor to appear over previous commands;
- existing terminal output to look overwritten or rearranged.

The issue is caused by OpenTUI's OSC 66 explicit-width capability probe. The probe runs on the primary screen before the renderer becomes active and relies on cursor save/restore behavior that is not handled correctly by the affected terminal.

Upgrading from OpenTUI 0.5.3 to 0.5.4 did not resolve the issue. An A/B test confirmed that disabling this probe restores the expected cursor position.

## Changes

- Configure the OpenTUI environment before creating the renderer.
- Default `OPENTUI_FORCE_EXPLICIT_WIDTH` to `false` on Windows.
- Preserve an explicitly configured `OPENTUI_FORCE_EXPLICIT_WIDTH` value.
- Leave behavior on Linux and macOS unchanged.
- Add tests for the Windows default, explicit overrides, and non-Windows behavior.
- Keep OpenTUI pinned to version 0.5.3, and this PR does not change dependencies.

## Tests

- `bun run check`
- `bun run test` — 163 tests passed
- Windows ConPTY smoke test
- Manual A/B test in an embedded Windows PowerShell terminal
- Manual test with all related environment variables removed

## Visual comparison

Both recordings use the same Windows PowerShell terminal, terminal dimensions, command, and TUI exit method.

### Before

[<!-- The before-fix video -->](https://github.com/user-attachments/assets/ef5c7b18-25d9-424e-9757-6b676e678e37)

After the TUI exits, the cursor returns to a previous line in the terminal history. The PowerShell prompt only appears in the correct position after Enter is pressed.

### After

[<!-- The after-fix video -->](https://github.com/user-attachments/assets/ff6086d5-f446-4991-bd40-8ab0b5bdd5d4)

After the TUI exits, the PowerShell prompt immediately appears below the TUI without requiring any additional input.



