### PR TITLE
fix(agent): stop discarded sessions from reviving

### DIFF
--- a/nanobot/agent/automation_turns.py
+++ b/nanobot/agent/automation_turns.py
@@ -13,6 +13,10 @@ class AutomationTurnError(RuntimeError):
     """Raised when an automation turn reaches the agent and finishes with an error."""
 
 
+class AutomationTurnDiscardedError(AutomationTurnError):
+    """Raised when a session discard cancels an automation turn."""
+
+
 async def publish_next_deferred_turn(
     *,
     deferred_queues: dict[str, list[InboundMessage]],
@@ -140,3 +144,25 @@ class AutomationTurnCoordinator:
             if pending_id:
                 pending_ids.add(pending_id)
         return pending_ids
+
+    def discard_session(self, session_key: str) -> int:
+        """Cancel deferred and in-flight automation turns for a discarded session."""
+        dropped = self.deferred_queues.pop(session_key, [])
+        discarded = 0
+        seen: set[str] = set()
+        for msg in [*dropped, *self._pending_messages_by_turn_id.values()]:
+            if msg.session_key != session_key:
+                continue
+            turn_id = self._turn_id(msg)
+            if not turn_id or turn_id in seen:
+                continue
+            seen.add(turn_id)
+            future = self._waiters.get(turn_id)
+            if future is not None and not future.done():
+                future.set_exception(
+                    AutomationTurnDiscardedError(
+                        f"automation turn for discarded session {session_key!r}"
+                    )
+                )
+                discarded += 1
+        return discarded

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -898,6 +898,8 @@ class AgentLoop:
         """Stop active work for *key* and forget its cached session."""
         self._discarding_sessions.add(key)
         try:
+            for _, coordinator in self._automation_turn_coordinators:
+                coordinator.discard_session(key)
             self.sessions.invalidate(key)
             await self._cancel_active_tasks(key)
         finally:
@@ -1293,6 +1295,9 @@ class AgentLoop:
                 effective_key = self._effective_session_key(msg)
                 if await agent_context.handle_runtime_control(self, msg, self.tools):
                     continue
+                if effective_key in self._discarding_sessions:
+                    logger.info("Dropping inbound message for discarded session {}", effective_key)
+                    continue
                 if (
                     msg.require_existing_session
                     and self.sessions.get_cached(effective_key) is None
@@ -1508,6 +1513,7 @@ class AgentLoop:
                         queue = self._pending_queues.pop(session_key, None)
                     else:
                         queue = pending
+                    discarding = session_key in self._discarding_sessions
                     if queue is not None:
                         leftover = 0
                         while True:
@@ -1515,7 +1521,8 @@ class AgentLoop:
                                 item = queue.get_nowait()
                             except asyncio.QueueEmpty:
                                 break
-                            await self.bus.publish_inbound(item)
+                            if not discarding:
+                                await self.bus.publish_inbound(item)
                             leftover += 1
                         if leftover:
                             logger.info(
@@ -1524,7 +1531,8 @@ class AgentLoop:
                             )
                     if not turn_continuation.internal_continuation_pending(msg.metadata):
                         await delivery.idle()
-                    await self._publish_next_deferred_automation_turn(session_key)
+                    if not discarding:
+                        await self._publish_next_deferred_automation_turn(session_key)
         finally:
             if (
                 recovery_task_registered
@@ -1534,7 +1542,8 @@ class AgentLoop:
                 recovery_admission.unregister_recovery_task(session_key, current_task)
             if pending is None:
                 await delivery.idle()
-                await self._publish_next_deferred_automation_turn(session_key)
+                if session_key not in self._discarding_sessions:
+                    await self._publish_next_deferred_automation_turn(session_key)
 
     async def aclose(self) -> None:
         """Stop active work, then close resources owned by the agent loop.

--- a/nanobot/cron/bound_runner.py
+++ b/nanobot/cron/bound_runner.py
@@ -8,6 +8,7 @@ import time
 import uuid
 from typing import TYPE_CHECKING, Any, Protocol
 
+from nanobot.agent.automation_turns import AutomationTurnDiscardedError
 from nanobot.agent.tools.cron import CronTool
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.cron.session_delivery import origin_delivery_context
@@ -127,6 +128,16 @@ async def run_bound_cron_job(
                 session_key_override=session_key,
             )
         )
+    except AutomationTurnDiscardedError as exc:
+        cron.write_run_record(
+            run_id,
+            {
+                **run_record_base,
+                "status": "discarded",
+                "error": str(exc) or exc.__class__.__name__,
+            },
+        )
+        return None
     except (Exception, asyncio.CancelledError) as exc:
         error_text = str(exc) or exc.__class__.__name__
         cron.write_run_record(

--- a/nanobot/triggers/local_runner.py
+++ b/nanobot/triggers/local_runner.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from loguru import logger
 
-from nanobot.agent.automation_turns import AutomationTurnError
+from nanobot.agent.automation_turns import AutomationTurnDiscardedError, AutomationTurnError
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.triggers.local_session_turns import LOCAL_TRIGGER_META
 from nanobot.triggers.local_store import LocalTriggerStore
@@ -78,6 +78,27 @@ async def run_local_trigger_queue(
                     delivery.id,
                     delivery.trigger_id,
                     exc,
+                )
+            except AutomationTurnDiscardedError as exc:
+                error = str(exc) or exc.__class__.__name__
+                store.record_delivery(
+                    delivery.trigger_id,
+                    status="error",
+                    error="discarded: " + error,
+                    run_at_ms=delivery.created_at_ms,
+                )
+                _write_delivery_run_record(
+                    store,
+                    delivery,
+                    status="discarded",
+                    error=error,
+                )
+                store.complete_delivery(delivery)
+                logger.info(
+                    "Trigger: discarded delivery {} for {}: {}",
+                    delivery.id,
+                    delivery.trigger_id,
+                    error,
                 )
             except AutomationTurnError as exc:
                 error = str(exc) or exc.__class__.__name__

--- a/tests/agent/test_automation_turn_discard.py
+++ b/tests/agent/test_automation_turn_discard.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from nanobot.agent.automation_turns import (
+    AutomationTurnCoordinator,
+    AutomationTurnDiscardedError,
+)
+from nanobot.bus.events import InboundMessage
+from nanobot.bus.queue import MessageBus
+
+
+def _message(session_key: str, run_id: str) -> InboundMessage:
+    return InboundMessage(
+        channel="system",
+        sender_id="cron",
+        chat_id=session_key,
+        content=run_id,
+        session_key_override=session_key,
+        metadata={"run_id": run_id},
+    )
+
+
+def _coordinator(bus: MessageBus, deferred: dict[str, list[InboundMessage]]) -> AutomationTurnCoordinator:
+    return AutomationTurnCoordinator(
+        publish_inbound=bus.publish_inbound,
+        dispatch=lambda _msg: asyncio.sleep(0),
+        is_running=lambda: True,
+        turn_id=lambda msg: msg.metadata.get("run_id"),
+        pending_id=lambda msg: msg.metadata.get("run_id"),
+        should_defer_turn=lambda _msg, key, active: key in active,
+        missing_id_error="missing run id",
+        duplicate_id_error=lambda run_id: f"duplicate {run_id}",
+        deferred_queues=deferred,
+    )
+
+
+@pytest.mark.asyncio
+async def test_discard_session_drops_deferred_turn_and_unblocks_waiter() -> None:
+    bus = MessageBus()
+    deferred: dict[str, list[InboundMessage]] = {}
+    coordinator = _coordinator(bus, deferred)
+    msg = _message("websocket:chat", "run-1")
+
+    submit_task = asyncio.create_task(coordinator.submit(msg))
+    await asyncio.sleep(0)
+    assert await bus.consume_inbound() is msg
+    assert coordinator.defer_if_active(
+        msg, session_key=msg.session_key, active_session_keys={msg.session_key}
+    )
+
+    assert coordinator.discard_session(msg.session_key) == 1
+    with pytest.raises(AutomationTurnDiscardedError):
+        await submit_task
+    assert msg.session_key not in deferred
+    assert bus.inbound.empty()
+
+
+def test_discard_session_ignores_unrelated_session() -> None:
+    bus = MessageBus()
+    deferred = {"websocket:other": [_message("websocket:other", "run-2")]}
+    coordinator = _coordinator(bus, deferred)
+
+    assert coordinator.discard_session("websocket:chat") == 0
+    assert "websocket:other" in deferred


### PR DESCRIPTION
## Problem

  When a session is discarded, its active Agent task is cancelled and the session cache is invalidated. However, messages that were already waiting in the session's pending queue or deferred automation queue
  could still be published to the global message bus during task cleanup.

  Those messages were then processed as new inbound messages. Since `SessionManager.invalidate()` only removes the cached session and does not permanently mark the session key as discarded, the message routing
  path could recreate the session and start a new Agent task.

  As a result, a discarded session could be revived in the background and continue to:

  - consume LLM tokens;
  - execute tools or subprocesses;
  - run deferred cron/local-trigger tasks;
  - produce unexpected side effects.

  ## Root Cause

  The discard lifecycle and normal turn cleanup shared the same finalization logic.

  Normal turn cleanup is expected to republish messages:

  ```text
  normal turn finishes
    → republish pending messages
    → publish the next deferred automation turn

  But discard cleanup should have different semantics:

  session is discarded
    → cancel active work
    → drop pending messages
    → cancel deferred automation
    → do not publish anything for this session

  The existing implementation only checked _discarding_sessions to skip runtime checkpoint restoration after cancellation. It did not apply the same discard guard to the finally block, which still:

  - republished pending queue leftovers;
  - published the next deferred automation turn.

  In addition, deferred automation waiters had no explicit session-level termination path, so simply removing deferred messages could leave cron/local-trigger callers waiting indefinitely.
```

## Solution

  Implement a session-scoped discard fence while preserving the existing normal-turn behavior.

### Automation coordinator cleanup

  Add session-level discard handling to AutomationTurnCoordinator:

  - remove deferred automation messages for the discarded session;
  - complete in-flight automation waiters with AutomationTurnDiscardedError;
  - prevent discarded automation from being treated as a normal retryable failure.

### Agent loop cleanup

  Update AgentLoop so that:

  - automation coordinators are discarded before active tasks are cancelled;
  - pending messages are drained and dropped during discard cleanup;
  - deferred automation publication is skipped for discarded sessions;
  - new inbound messages are ignored while the discard fence is active.

  Normal session behavior remains unchanged:

  normal turn:
    pending messages → republished

  discarded session:
    pending messages → dropped

### Automation runner semantics

  - Cron runs terminated by session discard are recorded as discarded.
  - Local trigger deliveries terminated by session discard are completed as discarded and are not retried.
