### PR TITLE
fix: summarize persisted JSON tool results

### DIFF
--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -515,11 +515,12 @@ def _tool_result_json_summary(text: str) -> str | None:
     if isinstance(payload, dict):
         scalars: list[tuple[str, Any]] = []
         containers: list[tuple[str, str]] = []
-        for key, value in payload.items():
+        # JSON objects always have string keys; values remain dynamic here.
+        for key, value in cast(dict[str, Any], payload).items():
             if isinstance(value, dict):
-                containers.append((key, f"<object: {len(value)} fields>"))
+                containers.append((key, f"<object: {len(cast(dict[str, Any], value))} fields>"))
             elif isinstance(value, list):
-                containers.append((key, f"<array: {len(value)} items>"))
+                containers.append((key, f"<array: {len(cast(list[Any], value))} items>"))
             elif isinstance(value, str) and len(value) > _TOOL_RESULT_SUMMARY_SCALAR_CHARS:
                 scalars.append(
                     (
@@ -539,7 +540,7 @@ def _tool_result_json_summary(text: str) -> str | None:
         if omitted:
             summary["<omitted root fields>"] = omitted
     elif isinstance(payload, list):
-        summary = {"<root>": f"array with {len(payload)} items"}
+        summary = {"<root>": f"array with {len(cast(list[Any], payload))} items"}
     else:
         return None
 

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -358,6 +358,8 @@ def timestamp() -> str:
 
 _UNSAFE_CHARS = re.compile(r'[<>:"/\\|?*]')
 _TOOL_RESULT_PREVIEW_CHARS = 1200
+_TOOL_RESULT_SUMMARY_MAX_FIELDS = 64
+_TOOL_RESULT_SUMMARY_SCALAR_CHARS = 240
 _TOOL_RESULTS_DIR = ".nanobot/tool-results"
 _TOOL_RESULT_RETENTION_SECS = 7 * 24 * 60 * 60
 _TOOL_RESULT_MAX_BUCKETS = 32
@@ -502,6 +504,50 @@ def stringify_text_blocks(content: list[object]) -> str | None:
     return "\n".join(parts)
 
 
+def _tool_result_json_summary(text: str) -> str | None:
+    """Summarize oversized JSON without copying nested payloads into context."""
+
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+    if isinstance(payload, dict):
+        scalars: list[tuple[str, Any]] = []
+        containers: list[tuple[str, str]] = []
+        for key, value in payload.items():
+            if isinstance(value, dict):
+                containers.append((key, f"<object: {len(value)} fields>"))
+            elif isinstance(value, list):
+                containers.append((key, f"<array: {len(value)} items>"))
+            elif isinstance(value, str) and len(value) > _TOOL_RESULT_SUMMARY_SCALAR_CHARS:
+                scalars.append(
+                    (
+                        key,
+                        value[:_TOOL_RESULT_SUMMARY_SCALAR_CHARS]
+                        + f"... <{len(value)} chars>",
+                    )
+                )
+            else:
+                scalars.append((key, value))
+
+        # Keep mechanically useful root metadata visible even when a large
+        # nested payload appears first in the original document.
+        selected = (scalars + containers)[:_TOOL_RESULT_SUMMARY_MAX_FIELDS]
+        summary = dict(selected)
+        omitted = len(scalars) + len(containers) - len(selected)
+        if omitted:
+            summary["<omitted root fields>"] = omitted
+    elif isinstance(payload, list):
+        summary = {"<root>": f"array with {len(payload)} items"}
+    else:
+        return None
+
+    prefix = "[JSON structure summary]\n"
+    rendered = json.dumps(summary, ensure_ascii=False, indent=2)
+    return prefix + truncate_text(rendered, _TOOL_RESULT_PREVIEW_CHARS - len(prefix))
+
+
 def _render_tool_result_reference(
     filepath: Path,
     *,
@@ -606,7 +652,9 @@ def maybe_persist_tool_result(
         else:
             _write_text_atomic(path, text_payload)
 
-    preview = text_payload[:_TOOL_RESULT_PREVIEW_CHARS]
+    preview = _tool_result_json_summary(text_payload)
+    if preview is None:
+        preview = text_payload[:_TOOL_RESULT_PREVIEW_CHARS]
     return _render_tool_result_reference(
         path,
         original_size=len(text_payload),

--- a/tests/agent/test_runner_persistence.py
+++ b/tests/agent/test_runner_persistence.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -96,6 +97,65 @@ def test_persist_tool_result_leaves_no_temp_files(tmp_path):
 
     assert (root / "current_session" / "call_big.txt").exists()
     assert list((root / "current_session").glob("*.tmp")) == []
+
+
+def test_persist_json_result_summarizes_root_scalars_after_large_nested_data(tmp_path):
+    from nanobot.utils.helpers import maybe_persist_tool_result
+
+    nested_detail = "private transcript " * 1000
+    payload = {
+        "private": {"turns": [nested_detail], "notes": {"raw": nested_detail}},
+        "artifact": "artifact://run/complete.json",
+        "revision": 37,
+        "result_id": "result-at-tail",
+    }
+    raw = json.dumps(payload)
+
+    persisted = maybe_persist_tool_result(
+        tmp_path,
+        "current:session",
+        "call_json",
+        raw,
+        max_chars=64,
+    )
+
+    assert "[tool output persisted]" in persisted
+    assert "[JSON structure summary]" in persisted
+    assert '"artifact": "artifact://run/complete.json"' in persisted
+    assert '"revision": 37' in persisted
+    assert '"result_id": "result-at-tail"' in persisted
+    assert '"private": "<object: 2 fields>"' in persisted
+    assert nested_detail not in persisted
+    assert len(persisted) < 1800
+
+    saved = tmp_path / ".nanobot" / "tool-results" / "current_session" / "call_json.txt"
+    assert saved.read_text(encoding="utf-8") == raw
+
+
+def test_persist_json_result_keeps_root_failure_fields_visible(tmp_path):
+    from nanobot.utils.helpers import maybe_persist_tool_result
+
+    raw = json.dumps(
+        {
+            "diagnostics": {"requests": ["sensitive detail" * 2000]},
+            "ok": False,
+            "status": "failed",
+            "error": "revision conflict",
+        }
+    )
+
+    persisted = maybe_persist_tool_result(
+        tmp_path,
+        "current:session",
+        "call_error",
+        raw,
+        max_chars=64,
+    )
+
+    assert '"ok": false' in persisted
+    assert '"status": "failed"' in persisted
+    assert '"error": "revision conflict"' in persisted
+    assert "sensitive detail" not in persisted
 
 
 def test_persist_tool_result_logs_cleanup_failures(monkeypatch, tmp_path):


### PR DESCRIPTION
## Problem

When an oversized tool result is persisted, nanobot currently uses the first 1,200 characters as the model-facing preview. If a large nested object appears first, useful root-level outcome fields such as `ok`, `status`, `error`, `artifact`, or `revision` can disappear from the preview even though they are needed for the next reasoning step.

## Change

- Parse oversized JSON object and array results before rendering their preview.
- Put bounded root-level scalar fields first and represent nested containers by shape only.
- Bound long scalar values and the number of root fields.
- Keep the complete persisted artifact unchanged.
- Preserve the existing prefix preview for non-JSON results and scalar JSON values.

This changes only the compact preview after the existing persistence threshold is crossed; it does not change tool execution or the stored full output.

## Validation

- `pytest tests/agent/test_runner_persistence.py -q` — 8 passed
- `ruff check nanobot/utils/helpers.py tests/agent/test_runner_persistence.py`
- `git diff --check`

Regression coverage verifies that root success/failure metadata remains visible while large nested content stays out of the preview and remains intact in the persisted file.
