### PR TITLE
fix(webui): hide SkillHub install counts

### DIFF
--- a/webui/src/components/settings/SkillsMarketplace.tsx
+++ b/webui/src/components/settings/SkillsMarketplace.tsx
@@ -527,18 +527,22 @@ function MarketplaceSkillRow({
         <div className="mt-1 flex min-w-0 items-center gap-1.5 truncate text-[12px] text-muted-foreground">
           {skill.source}
           {skill.version ? <span>· v{skill.version}</span> : null}
-          <span>·</span>
-          {skill.metric === "installs_24h"
-            ? t("settings.skills.marketplaceInstalls24h", {
-                count: skill.installs,
-                formattedCount: skill.installs.toLocaleString(),
-                defaultValue: "{{formattedCount}} installs / 24h",
-              })
-            : t("settings.skills.marketplaceInstalls", {
-                count: skill.installs,
-                formattedCount: skill.installs.toLocaleString(),
-                defaultValue: "{{formattedCount}} installs",
-              })}
+          {skill.provider === "skills_sh" ? (
+            <>
+              <span>·</span>
+              {skill.metric === "installs_24h"
+                ? t("settings.skills.marketplaceInstalls24h", {
+                    count: skill.installs,
+                    formattedCount: skill.installs.toLocaleString(),
+                    defaultValue: "{{formattedCount}} installs / 24h",
+                  })
+                : t("settings.skills.marketplaceInstalls", {
+                    count: skill.installs,
+                    formattedCount: skill.installs.toLocaleString(),
+                    defaultValue: "{{formattedCount}} installs",
+                  })}
+            </>
+          ) : null}
         </div>
       </div>
       {skill.provider === "skills_sh" ? <TrendSparkline values={trend} /> : null}

--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -1201,6 +1201,7 @@ describe("App layout", () => {
     expect(screen.getAllByText("SkillHub")).toHaveLength(2);
     expect(screen.getAllByText("skills.sh")).toHaveLength(2);
     expect(screen.getByText(/14,481 installs \/ 24h/)).toBeInTheDocument();
+    expect(screen.queryByText(/11,831 installs/)).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("tab", { name: "SkillHub" }));
     expect(screen.getByText("ima-skills")).toBeInTheDocument();
     expect(screen.queryByText("find-skills")).not.toBeInTheDocument();


### PR DESCRIPTION
## Problem

SkillHub returns an `installs` field, but its marketplace data is sparse and many trending entries report zero even when they have substantial download activity. Rendering that value on every row produces repetitive `0 installs` metadata that looks broken and adds little value.

## Change

- Hide install counts for SkillHub marketplace rows.
- Keep the existing source and version metadata.
- Preserve install metrics for skills.sh, including its 24-hour label.
- Keep the backend payload unchanged so the upstream data remains available.

## Testing

- `cd webui && bun run test -- src/tests/app-layout.test.tsx` — 60 tests passed
- `cd webui && bun run lint`
- `cd webui && bun run build`

The regression assertion verifies that a SkillHub install count is not rendered while the skills.sh metric remains visible.