### PR TITLE
fix(channels): deliver provider retry waits as progress

### DIFF
--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -737,7 +737,9 @@ class ChannelManager:
                     ):
                         continue
 
-                if isinstance(event, RetryWaitEvent):
+                if isinstance(event, RetryWaitEvent) and not self._should_send_progress(
+                    msg.channel, tool_hint=False,
+                ):
                     continue
 
                 if (

--- a/tests/channels/test_channel_manager_delta_coalescing.py
+++ b/tests/channels/test_channel_manager_delta_coalescing.py
@@ -454,10 +454,11 @@ class TestProgressFiltering:
 
 
 class TestRetryWaitFiltering:
-    """Internal provider retry heartbeats must never reach channels."""
+    """Provider retry waits should honor each channel's progress setting."""
 
     @pytest.mark.asyncio
-    async def test_retry_wait_message_dropped(self, manager, bus):
+    async def test_retry_wait_message_dropped_when_progress_disabled(self, manager, bus):
+        manager.channels["mock"].send_progress = False
         retry_msg = outbound_message_for_event(
             channel="mock",
             chat_id="chat1",
@@ -489,3 +490,34 @@ class TestRetryWaitFiltering:
         sent = send_mock.await_args_list[0].args[0]
         assert sent.content == "final answer"
         assert sent.event is None
+
+    @pytest.mark.asyncio
+    async def test_retry_wait_message_sent_when_progress_enabled(self, manager, bus):
+        manager.channels["mock"].send_progress = True
+        retry_event = RetryWaitEvent(
+            content="Model request failed, retry in 1s (attempt 1).",
+        )
+        await bus.publish_outbound(outbound_message_for_event(
+            channel="mock",
+            chat_id="chat1",
+            event=retry_event,
+        ))
+
+        task = asyncio.create_task(manager._dispatch_outbound())
+        try:
+            for _ in range(30):
+                if manager.channels["mock"]._send_mock.await_count >= 1:
+                    break
+                await asyncio.sleep(0.05)
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        send_mock = manager.channels["mock"]._send_mock
+        send_mock.assert_awaited_once()
+        sent = send_mock.await_args.args[0]
+        assert sent.content == retry_event.content
+        assert sent.event is retry_event


### PR DESCRIPTION
## Summary

- Route RetryWaitEvent through the existing sendProgress visibility gate.
- Preserve the channel opt-out path while delivering the existing event and content when progress is enabled.
- Cover both disabled and enabled channel dispatch behavior.

## Problem

ChannelManager discarded every RetryWaitEvent before channel dispatch, so external channel users could not see that a provider request was backing off.

## Solution

Reuse the established per-channel progress gate. This keeps retry waits aligned with other progress notices without adding configuration or changing channel interfaces.

## Validation

- pytest tests/channels/test_channel_manager_delta_coalescing.py tests/bus/test_outbound_events.py tests/cli/test_interactive_retry_wait.py -q (37 passed)
- ruff check nanobot/channels/manager.py tests/channels/test_channel_manager_delta_coalescing.py
- git diff --check

Fixes #5585.