### PR TITLE
fix(webui): roll back rejected message side effects

### DIFF
--- a/nanobot/channels/websocket/tests/test_websocket_channel.py
+++ b/nanobot/channels/websocket/tests/test_websocket_channel.py
@@ -1905,6 +1905,14 @@ async def test_remote_access_reduction_rejects_stale_in_flight_message_scope(
     monkeypatch,
 ) -> None:
     monkeypatch.setattr("nanobot.webui.workspaces.get_webui_dir", lambda: tmp_path / "webui")
+    media_root = tmp_path / "media"
+
+    def fake_media_dir(channel_name: str | None = None) -> Path:
+        path = media_root / channel_name if channel_name else media_root
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    monkeypatch.setattr("nanobot.webui.media_gateway.get_media_dir", fake_media_dir)
     default_workspace = tmp_path / "default"
     default_workspace.mkdir()
     sessions = SessionManager(tmp_path / "sessions")
@@ -1936,6 +1944,7 @@ async def test_remote_access_reduction_rejects_stale_in_flight_message_scope(
                 "chat_id": chat_id,
                 "content": "hello",
                 "webui": True,
+                "media": [{"data_url": "data:text/plain;base64,aGVsbG8="}],
                 "workspace_scope": {
                     "project_path": str(default_workspace),
                     "access_mode": "full",
@@ -1968,6 +1977,9 @@ async def test_remote_access_reduction_rejects_stale_in_flight_message_scope(
     assert payload["event"] == "error"
     assert payload["detail"] == "workspace_scope_rejected"
     bus.publish_inbound.assert_not_awaited()
+    assert message_conn not in channel._subs.get(chat_id, set())
+    assert chat_id not in channel._conn_chats.get(message_conn, set())
+    assert list((media_root / "websocket").iterdir()) == []
 
 
 @pytest.mark.asyncio
@@ -4578,7 +4590,17 @@ async def test_open_connection_rejects_revoked_webui_turn_without_acceptance_ack
 @pytest.mark.asyncio
 async def test_midflight_allowlist_revocation_rejects_turn_without_ack(
     bus: MagicMock,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    media_root = tmp_path / "media"
+
+    def fake_media_dir(channel_name: str | None = None) -> Path:
+        path = media_root / channel_name if channel_name else media_root
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    monkeypatch.setattr("nanobot.webui.media_gateway.get_media_dir", fake_media_dir)
     channel = _ch(bus)
     channel.is_allowed = MagicMock(side_effect=[True, False])
     conn = AsyncMock()
@@ -4591,6 +4613,7 @@ async def test_midflight_allowlist_revocation_rejects_turn_without_ack(
             "type": "message",
             "chat_id": "chat-midflight-revoked",
             "content": "must not be acknowledged",
+            "media": [{"data_url": "data:text/plain;base64,aGVsbG8="}],
             "webui": True,
             "turn_id": "turn-midflight-revoked",
         },
@@ -4605,6 +4628,145 @@ async def test_midflight_allowlist_revocation_rejects_turn_without_ack(
     }
     assert all(payload["event"] != "message_accepted" for payload in payloads)
     bus.publish_inbound.assert_not_awaited()
+    assert conn not in channel._subs.get("chat-midflight-revoked", set())
+    assert "chat-midflight-revoked" not in channel._conn_chats.get(conn, set())
+    assert list((media_root / "websocket").iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_rejected_message_rolls_back_side_effects_when_hydration_fails(
+    bus: MagicMock,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    media_root = tmp_path / "media"
+
+    def fake_media_dir(channel_name: str | None = None) -> Path:
+        path = media_root / channel_name if channel_name else media_root
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    monkeypatch.setattr("nanobot.webui.media_gateway.get_media_dir", fake_media_dir)
+    channel = _ch(bus)
+    conn = AsyncMock()
+    conn.remote_address = ("127.0.0.1", 50124)
+    monkeypatch.setattr(
+        channel,
+        "webui_hydrate",
+        AsyncMock(side_effect=RuntimeError("hydrate failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="hydrate failed"):
+        await channel._dispatch_envelope(
+            conn,
+            "webui-client",
+            {
+                "type": "message",
+                "chat_id": "chat-hydrate-rollback",
+                "content": "hello",
+                "media": [{"data_url": "data:text/plain;base64,aGVsbG8="}],
+                "webui": True,
+            },
+        )
+
+    bus.publish_inbound.assert_not_awaited()
+    assert conn not in channel._subs.get("chat-hydrate-rollback", set())
+    assert "chat-hydrate-rollback" not in channel._conn_chats.get(conn, set())
+    assert list((media_root / "websocket").iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_rejected_message_rolls_back_side_effects_when_dispatch_fails(
+    bus: MagicMock,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    media_root = tmp_path / "media"
+
+    def fake_media_dir(channel_name: str | None = None) -> Path:
+        path = media_root / channel_name if channel_name else media_root
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    monkeypatch.setattr("nanobot.webui.media_gateway.get_media_dir", fake_media_dir)
+    channel = _ch(bus)
+    conn = AsyncMock()
+    conn.remote_address = ("127.0.0.1", 50125)
+    monkeypatch.setattr(
+        channel,
+        "webui_dispatch_message",
+        AsyncMock(side_effect=RuntimeError("dispatch failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="dispatch failed"):
+        await channel._dispatch_envelope(
+            conn,
+            "webui-client",
+            {
+                "type": "message",
+                "chat_id": "chat-dispatch-rollback",
+                "content": "hello",
+                "media": [{"data_url": "data:text/plain;base64,aGVsbG8="}],
+                "webui": True,
+                "turn_id": "turn-dispatch-rollback",
+            },
+        )
+
+    bus.publish_inbound.assert_not_awaited()
+    assert conn not in channel._subs.get("chat-dispatch-rollback", set())
+    assert "chat-dispatch-rollback" not in channel._conn_chats.get(conn, set())
+    assert list((media_root / "websocket").iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_rejected_temporary_chat_message_discards_registered_media(
+    bus: MagicMock,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("nanobot.webui.workspaces.get_webui_dir", lambda: tmp_path / "webui")
+    media_root = tmp_path / "media"
+
+    def fake_media_dir(channel_name: str | None = None) -> Path:
+        path = media_root / channel_name if channel_name else media_root
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    monkeypatch.setattr("nanobot.webui.media_gateway.get_media_dir", fake_media_dir)
+    default_workspace = tmp_path / "default"
+    default_workspace.mkdir()
+    sessions = SessionManager(tmp_path / "sessions")
+    channel = WebSocketChannel(
+        {"enabled": True, "allowFrom": ["*"], "host": "127.0.0.1"},
+        bus,
+        gateway=_basic_handler(bus, session_manager=sessions, workspace_path=default_workspace),
+    )
+    conn = AsyncMock()
+    conn.remote_address = ("127.0.0.1", 50126)
+    chat_id = await _new_temporary_chat(channel, conn)
+    monkeypatch.setattr(
+        channel,
+        "webui_dispatch_message",
+        AsyncMock(side_effect=RuntimeError("dispatch failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="dispatch failed"):
+        await channel._dispatch_envelope(
+            conn,
+            "webui-client",
+            {
+                "type": "message",
+                "chat_id": chat_id,
+                "content": "hello",
+                "media": [{"data_url": "data:text/plain;base64,aGVsbG8="}],
+                "webui": True,
+            },
+        )
+
+    bus.publish_inbound.assert_not_awaited()
+    assert list((media_root / "websocket").iterdir()) == []
+    assert not channel.gateway.temporary_chats._media_paths.get(chat_id)
+    assert conn in channel._subs.get(chat_id, set())
 
 
 @pytest.mark.asyncio

--- a/nanobot/channels/websocket/tests/test_websocket_channel.py
+++ b/nanobot/channels/websocket/tests/test_websocket_channel.py
@@ -4676,6 +4676,65 @@ async def test_rejected_message_rolls_back_side_effects_when_hydration_fails(
 
 
 @pytest.mark.asyncio
+async def test_cancelled_session_mention_normalization_rolls_back_side_effects(
+    bus: MagicMock,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    media_root = tmp_path / "media"
+
+    def fake_media_dir(channel_name: str | None = None) -> Path:
+        path = media_root / channel_name if channel_name else media_root
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    monkeypatch.setattr("nanobot.webui.media_gateway.get_media_dir", fake_media_dir)
+    channel = WebSocketChannel(
+        {"enabled": True, "allowFrom": ["*"]},
+        bus,
+        gateway=_basic_handler(
+            bus,
+            session_manager=SessionManager(tmp_path / "sessions"),
+            workspace_path=tmp_path,
+        ),
+    )
+    conn = AsyncMock()
+    conn.remote_address = ("127.0.0.1", 50127)
+    channel._webui_connections.add(conn)
+    session_access = channel._commands._session_access
+    assert session_access is not None
+
+    def cancel_normalization(
+        _raw: object,
+        *,
+        exclude_session_key: str | None = None,
+    ) -> list[dict[str, str]]:
+        _ = exclude_session_key
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(session_access, "normalize_mentions", cancel_normalization)
+
+    with pytest.raises(asyncio.CancelledError):
+        await channel._dispatch_envelope(
+            conn,
+            "webui-client",
+            {
+                "type": "message",
+                "chat_id": "chat-mention-cancel",
+                "content": "hello",
+                "media": [{"data_url": "data:text/plain;base64,aGVsbG8="}],
+                "session_mentions": [{"session_key": "telegram:other"}],
+                "webui": True,
+            },
+        )
+
+    bus.publish_inbound.assert_not_awaited()
+    assert conn not in channel._subs.get("chat-mention-cancel", set())
+    assert "chat-mention-cancel" not in channel._conn_chats.get(conn, set())
+    assert list((media_root / "websocket").iterdir()) == []
+
+
+@pytest.mark.asyncio
 async def test_rejected_message_rolls_back_side_effects_when_dispatch_fails(
     bus: MagicMock,
     tmp_path,

--- a/nanobot/channels/websocket/tests/test_websocket_channel.py
+++ b/nanobot/channels/websocket/tests/test_websocket_channel.py
@@ -4744,6 +4744,10 @@ async def test_rejected_temporary_chat_message_discards_registered_media(
     conn = AsyncMock()
     conn.remote_address = ("127.0.0.1", 50126)
     chat_id = await _new_temporary_chat(channel, conn)
+    retained_path = media_root / "websocket" / "retained.txt"
+    retained_path.parent.mkdir(parents=True, exist_ok=True)
+    retained_path.write_text("keep", encoding="utf-8")
+    channel.gateway.temporary_chats.register_media(conn, chat_id, [str(retained_path)])
     monkeypatch.setattr(
         channel,
         "webui_dispatch_message",
@@ -4764,8 +4768,8 @@ async def test_rejected_temporary_chat_message_discards_registered_media(
         )
 
     bus.publish_inbound.assert_not_awaited()
-    assert list((media_root / "websocket").iterdir()) == []
-    assert not channel.gateway.temporary_chats._media_paths.get(chat_id)
+    assert list((media_root / "websocket").iterdir()) == [retained_path]
+    assert channel.gateway.temporary_chats._media_paths.get(chat_id) == {str(retained_path)}
     assert conn in channel._subs.get(chat_id, set())
 
 

--- a/nanobot/webui/attachment_ingress.py
+++ b/nanobot/webui/attachment_ingress.py
@@ -76,6 +76,15 @@ def extract_data_url_mime(url: Any) -> str | None:
     return match.group(1).strip().lower() or None
 
 
+def discard_inbound_attachments(paths: list[str], *, logger: Any) -> None:
+    """Remove attachment files that will not be associated with a message."""
+    for path in paths:
+        try:
+            Path(path).unlink(missing_ok=True)
+        except OSError as exc:
+            logger.warning("failed to unlink rejected media {}: {}", path, exc)
+
+
 def store_inbound_attachments(
     media: list[Any],
     *,
@@ -116,11 +125,7 @@ def store_inbound_attachments(
     total_attachment_bytes = 0
 
     def abort(reason: AttachmentRejection) -> AttachmentIngressResult:
-        for path in paths:
-            try:
-                Path(path).unlink(missing_ok=True)
-            except OSError as exc:
-                logger.warning("failed to unlink partial media {}: {}", path, exc)
+        discard_inbound_attachments(paths, logger=logger)
         return [], reason
 
     for item in media:

--- a/nanobot/webui/inbound_commands.py
+++ b/nanobot/webui/inbound_commands.py
@@ -47,7 +47,7 @@ from nanobot.webui.session_access import (
 )
 from nanobot.webui.session_identity import is_valid_webui_chat_id, webui_session_key
 from nanobot.webui.sidebar_state import write_webui_sidebar_state
-from nanobot.webui.temporary_chats import TemporaryChatError
+from nanobot.webui.temporary_chats import TemporaryChatError, TemporaryChatMessagePolicy
 from nanobot.webui.transcription_ws import webui_transcription_event
 
 _WEBUI_REQUEST_CACHE_TTL_S = 5 * 60.0
@@ -277,6 +277,22 @@ class WebUICommandRouter:
                 **({"turn_id": turn_id} if turn_id else {}),
             )
             return None
+
+    def _rollback_message_side_effects(
+        self,
+        connection: ServerConnection,
+        chat_id: str,
+        media_paths: list[str],
+        *,
+        detach_connection: bool,
+        temporary_policy: TemporaryChatMessagePolicy | None = None,
+    ) -> None:
+        """Undo resources created before a message was rejected."""
+        self._media.discard_inbound_attachments(media_paths)
+        if temporary_policy is not None:
+            self._temporary_chats.discard_registered_media(chat_id, media_paths)
+        if detach_connection:
+            self._transport.webui_detach(connection, chat_id)
 
     async def dispatch(
         self,
@@ -555,8 +571,6 @@ class WebUICommandRouter:
                 attachment = cast(dict[str, Any], item) if isinstance(item, dict) else {}
                 name = attachment.get("name")
                 media_names.append((safe_filename(name) or None) if isinstance(name, str) else None)
-            if temporary_policy is not None:
-                self._temporary_chats.register_media(connection, chat_id, media_paths)
 
         if not content.strip() and not media_paths:
             await self._transport.webui_send_event(
@@ -566,29 +580,54 @@ class WebUICommandRouter:
                 **rejection_fields,
             )
             return
-        self._transport.webui_attach(connection, chat_id)
-        if temporary_policy is None or temporary_policy.hydrate_transcript:
-            await self._transport.webui_hydrate(chat_id)
+        # The same connection processes envelopes serially (the recv loop
+        # awaits dispatch inline), and attached_before is per connection, so
+        # the detach below only ever removes the subscription this message
+        # added.
+        attached_before = chat_id in self._transport.webui_connection_chats(connection)
 
-        scope = await self.workspace_scope_or_error(
-            connection,
-            lambda: (
-                temporary_policy.workspace_scope
-                if temporary_policy is not None
-                else self._workspaces.scope_for_message(
-                    envelope,
-                    chat_id=chat_id,
-                    chat_running=websocket_turn_wall_started_at(chat_id) is not None,
-                    controls_available=self.workspace_controls_available(connection),
-                )
-            ),
-            chat_id=chat_id,
-            turn_id=turn_id,
-        )
+        def rollback_side_effects() -> None:
+            self._rollback_message_side_effects(
+                connection,
+                chat_id,
+                media_paths,
+                detach_connection=not attached_before,
+                temporary_policy=temporary_policy,
+            )
+
+        self._transport.webui_attach(connection, chat_id)
+        try:
+            if temporary_policy is None or temporary_policy.hydrate_transcript:
+                await self._transport.webui_hydrate(chat_id)
+        except BaseException:
+            rollback_side_effects()
+            raise
+
+        try:
+            scope = await self.workspace_scope_or_error(
+                connection,
+                lambda: (
+                    temporary_policy.workspace_scope
+                    if temporary_policy is not None
+                    else self._workspaces.scope_for_message(
+                        envelope,
+                        chat_id=chat_id,
+                        chat_running=websocket_turn_wall_started_at(chat_id) is not None,
+                        controls_available=self.workspace_controls_available(connection),
+                    )
+                ),
+                chat_id=chat_id,
+                turn_id=turn_id,
+            )
+        except BaseException:
+            rollback_side_effects()
+            raise
         if scope is None:
+            rollback_side_effects()
             return
 
         if not self._transport.is_allowed(client_id):
+            rollback_side_effects()
             await self._transport.webui_send_event(
                 connection,
                 "error",
@@ -641,7 +680,10 @@ class WebUICommandRouter:
                 metadata[WEBSOCKET_TURN_OWNER_METADATA_KEY] = queued_owner
 
         accepted = False
+        dispatched = False
         try:
+            if temporary_policy is not None:
+                self._temporary_chats.register_media(connection, chat_id, media_paths)
             if is_webui and (
                 temporary_policy is None or temporary_policy.persist_transcript
             ):
@@ -682,9 +724,12 @@ class WebUICommandRouter:
                     else False
                 ),
             )
+            dispatched = True
             self._workspaces.persist_scope(chat_id, scope)
             accepted = True
         finally:
+            if not dispatched:
+                rollback_side_effects()
             if not accepted and queued_owner is not None:
                 clear_websocket_turn_if_current(chat_id, queued_owner)
 

--- a/nanobot/webui/inbound_commands.py
+++ b/nanobot/webui/inbound_commands.py
@@ -587,6 +587,10 @@ class WebUICommandRouter:
         attached_before = chat_id in self._transport.webui_connection_chats(connection)
 
         def rollback_side_effects() -> None:
+            nonlocal rolled_back
+            if rolled_back:
+                return
+            rolled_back = True
             self._rollback_message_side_effects(
                 connection,
                 chat_id,
@@ -595,15 +599,15 @@ class WebUICommandRouter:
                 temporary_policy=temporary_policy,
             )
 
-        self._transport.webui_attach(connection, chat_id)
+        queued_owner = None
+        accepted = False
+        dispatched = False
+        rolled_back = False
         try:
+            self._transport.webui_attach(connection, chat_id)
             if temporary_policy is None or temporary_policy.hydrate_transcript:
                 await self._transport.webui_hydrate(chat_id)
-        except BaseException:
-            rollback_side_effects()
-            raise
 
-        try:
             scope = await self.workspace_scope_or_error(
                 connection,
                 lambda: (
@@ -619,69 +623,62 @@ class WebUICommandRouter:
                 chat_id=chat_id,
                 turn_id=turn_id,
             )
-        except BaseException:
-            rollback_side_effects()
-            raise
-        if scope is None:
-            rollback_side_effects()
-            return
+            if scope is None:
+                rollback_side_effects()
+                return
 
-        if not self._transport.is_allowed(client_id):
-            rollback_side_effects()
-            await self._transport.webui_send_event(
-                connection,
-                "error",
-                detail="access_denied",
-                **rejection_fields,
+            if not self._transport.is_allowed(client_id):
+                rollback_side_effects()
+                await self._transport.webui_send_event(
+                    connection,
+                    "error",
+                    detail="access_denied",
+                    **rejection_fields,
+                )
+                return
+
+            metadata: dict[str, Any] = {
+                "remote": getattr(connection, "remote_address", None)
+            }
+            if envelope.get("webui") is True:
+                metadata["webui"] = True
+                metadata.update(self._transcripts.client_turn_metadata(envelope.get("turn_id")))
+            trusted_webui = metadata.get("webui") is True and connection in self._webui_connections
+            is_user_shell = (
+                trusted_webui
+                and envelope.get("user_shell") is True
+                and content.startswith("!")
             )
-            return
-
-        metadata: dict[str, Any] = {
-            "remote": getattr(connection, "remote_address", None)
-        }
-        if envelope.get("webui") is True:
-            metadata["webui"] = True
-            metadata.update(self._transcripts.client_turn_metadata(envelope.get("turn_id")))
-        trusted_webui = metadata.get("webui") is True and connection in self._webui_connections
-        is_user_shell = (
-            trusted_webui
-            and envelope.get("user_shell") is True
-            and content.startswith("!")
-        )
-        if is_user_shell:
-            metadata[INBOUND_META_USER_SHELL] = True
-        dispatch_content = (
-            f"{USER_SHELL_COMMAND} {content[1:].lstrip()}" if is_user_shell else content
-        )
-        cli_apps = normalize_cli_app_mentions(envelope.get("cli_apps"))
-        if cli_apps:
-            metadata["cli_apps"] = cli_apps
-        mcp_presets = normalize_mcp_preset_mentions(
-            envelope.get("mcp_presets"),
-            config_path=self.gateway.settings.config.path,
-        )
-        if mcp_presets:
-            metadata["mcp_presets"] = mcp_presets
-        session_mentions: list[SessionMention] = []
-        if trusted_webui and self._session_access is not None:
-            session_mentions = await asyncio.to_thread(
-                self._session_access.normalize_mentions,
-                envelope.get("session_mentions"),
-                exclude_session_key=webui_session_key(chat_id),
+            if is_user_shell:
+                metadata[INBOUND_META_USER_SHELL] = True
+            dispatch_content = (
+                f"{USER_SHELL_COMMAND} {content[1:].lstrip()}" if is_user_shell else content
             )
-            if session_mentions:
-                metadata["session_mentions"] = session_mentions
-        metadata[WORKSPACE_SCOPE_METADATA_KEY] = scope.metadata()
-        is_webui = metadata.get("webui") is True
-        queued_owner = None
-        if is_webui and not is_user_shell and builtin_command_starts_agent_turn(content):
-            queued_owner = register_queued_websocket_turn_if_idle(chat_id, turn_id)
-            if queued_owner is not None:
-                metadata[WEBSOCKET_TURN_OWNER_METADATA_KEY] = queued_owner
+            cli_apps = normalize_cli_app_mentions(envelope.get("cli_apps"))
+            if cli_apps:
+                metadata["cli_apps"] = cli_apps
+            mcp_presets = normalize_mcp_preset_mentions(
+                envelope.get("mcp_presets"),
+                config_path=self.gateway.settings.config.path,
+            )
+            if mcp_presets:
+                metadata["mcp_presets"] = mcp_presets
+            session_mentions: list[SessionMention] = []
+            if trusted_webui and self._session_access is not None:
+                session_mentions = await asyncio.to_thread(
+                    self._session_access.normalize_mentions,
+                    envelope.get("session_mentions"),
+                    exclude_session_key=webui_session_key(chat_id),
+                )
+                if session_mentions:
+                    metadata["session_mentions"] = session_mentions
+            metadata[WORKSPACE_SCOPE_METADATA_KEY] = scope.metadata()
+            is_webui = metadata.get("webui") is True
+            if is_webui and not is_user_shell and builtin_command_starts_agent_turn(content):
+                queued_owner = register_queued_websocket_turn_if_idle(chat_id, turn_id)
+                if queued_owner is not None:
+                    metadata[WEBSOCKET_TURN_OWNER_METADATA_KEY] = queued_owner
 
-        accepted = False
-        dispatched = False
-        try:
             if temporary_policy is not None:
                 self._temporary_chats.register_media(connection, chat_id, media_paths)
             if is_webui and (

--- a/nanobot/webui/media_gateway.py
+++ b/nanobot/webui/media_gateway.py
@@ -13,6 +13,7 @@ from websockets.http11 import Response
 from nanobot.config.paths import get_media_dir
 from nanobot.webui.attachment_ingress import (
     AttachmentIngressResult,
+    discard_inbound_attachments,
     store_inbound_attachments,
 )
 from nanobot.webui.ingress_policy import AttachmentIngressLimits
@@ -54,6 +55,10 @@ class WebUIMediaGateway:
             logger=self.logger,
             limits=self.attachment_limits,
         )
+
+    def discard_inbound_attachments(self, paths: list[str]) -> None:
+        """Remove stored attachments that were rejected by later message checks."""
+        discard_inbound_attachments(paths, logger=self.logger)
 
     def serve_signed_media(
         self,

--- a/nanobot/webui/temporary_chats.py
+++ b/nanobot/webui/temporary_chats.py
@@ -150,6 +150,17 @@ class WebUITemporaryChats:
             raise TemporaryChatError("temporary_chat_unavailable")
         self._media_paths.setdefault(chat_id, set()).update(paths)
 
+    def discard_registered_media(self, chat_id: str, paths: list[str]) -> None:
+        """Drop media registrations for paths that will not be dispatched."""
+        if not paths:
+            return
+        registered = self._media_paths.get(chat_id)
+        if registered is None:
+            return
+        registered.difference_update(paths)
+        if not registered:
+            del self._media_paths[chat_id]
+
     def chat_ids_for_owner(self, owner: object) -> tuple[str, ...]:
         return tuple(self._owner_chat_ids.get(owner, ()))
 


### PR DESCRIPTION
## Summary

Rejected WebUI messages could leave saved attachments or WebSocket subscriptions behind. This change rolls back those side effects when message admission or dispatch fails, including cancellation during `session_mentions` normalization.

## Changes

- Roll back saved attachments, temporary-chat media registrations, and subscriptions added by the current message on hydration failure, scope rejection, allowlist revocation, dispatch failure, or cancellation during admission.
- Preserve subscriptions and media registrations that existed before the message.
- Keep media after a successful publish because the published message references it.
- Reuse the attachment cleanup helper for storage and rollback.

## Tests

- Added regression tests for hydration failure, dispatch failure, temporary-chat registry cleanup, and cancellation during `session_mentions` normalization.
- Extended scope-rejection and allowlist-revocation tests to verify attachment cleanup and subscription removal.
- `uv run --no-sync pytest nanobot/channels/websocket/tests/test_websocket_channel.py -q`: 199 passed.
- Ruff passed.
- BasedPyright passed with 0 errors, 0 warnings, and 0 notes.
