### PR TITLE
Detect a turn that claims an action it never performed (#1697)

### DIFF
--- a/nanobot/agent/action_claims.py
+++ b/nanobot/agent/action_claims.py
@@ -1,0 +1,105 @@
+"""Detect a turn that announces an action it never performed.
+
+Reported as #1697: the agent replied "I am querying now", "locating and
+executing", "results coming shortly" -- and issued no tool call at all. The user
+had to answer "there are no results" before the agent conceded that the query had
+never started.
+
+Nothing in the loop catches this. The turn returns a fluent, on-topic reply and
+raises nothing, so every existing check passes. The 353 test files in this
+repository cover many failure modes; none covers a turn that claims work it did
+not do.
+
+The check needs no model and makes no judgement about the text. If an assistant
+message asserts that it is performing or has performed an action, and the turn
+carried zero tool calls, the assertion cannot be true. That is a property of the
+transcript, which is why it can run on every turn without producing noise.
+
+It is deliberately narrow. It fires only on first-person claims of action in
+progress or already done. Offers, questions, plans and conditionals -- "shall I
+run it?", "I could write a script" -- claim nothing and are ignored.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+# First-person assertions that an action is under way or finished. The reported
+# case is Chinese and the framework is used in both languages, so both are
+# covered; the Chinese patterns are taken from the transcript in #1697.
+_CLAIM_PATTERNS: tuple[str, ...] = (
+    r"\b(?:i am|i'm) (?:now )?(?:querying|running|executing|fetching|searching|checking|calling)\b",
+    r"\b(?:i|we) (?:have )?(?:just )?(?:ran|executed|fetched|retrieved|queried|called|completed)\b",
+    r"\b(?:running|executing|fetching|querying) (?:it |this |that )?now\b",
+    r"\blet me (?:run|execute|fetch|query|check) (?:it|this|that)\b[^.]*\b(?:now|immediately)\b",
+    r"\b(?:results?|output) (?:will be|are) (?:back|returned|ready) (?:shortly|soon|in a moment)\b",
+    r"正在(?:执行|查询|定位|运行)",
+    r"我(?:立即|马上|现在就)(?:为您|给你)?(?:查询|执行|运行|开始)",
+    r"稍等[—\-, ]*结果(?:即将|马上)?返回",
+    r"已(?:执行|完成|查询)",
+)
+
+# Phrases that explicitly claim nothing. A message built only from these is an
+# offer, not a report, and must not be flagged.
+_OFFER_PATTERNS: tuple[str, ...] = (
+    r"\b(?:shall|should) i\b",
+    r"\bwould you like me to\b",
+    r"\bdo you want me to\b",
+    r"\bi (?:can|could|will be able to)\b",
+    r"\bif you (?:want|confirm|approve)\b",
+    r"需要我",
+    r"是否需要",
+    r"只需你回复",
+    r"我可以",
+)
+
+_CLAIM_RE = tuple(re.compile(p, re.IGNORECASE) for p in _CLAIM_PATTERNS)
+_OFFER_RE = tuple(re.compile(p, re.IGNORECASE) for p in _OFFER_PATTERNS)
+
+_OFFER_WINDOW = 40  # characters either side of a claim to look for a hedge
+
+
+def _text_of(content: Any) -> str:
+    """Flatten assistant content, which may be a string or a list of blocks."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, Iterable):
+        parts: list[str] = []
+        for block in content:  # type: ignore[union-attr]
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict):
+                value = block.get("text")
+                if isinstance(value, str):
+                    parts.append(value)
+        return "\n".join(parts)
+    return ""
+
+
+def unsupported_action_claims(
+    content: Any,
+    tool_calls: Sequence[Any] | None,
+) -> list[str]:
+    """Return the action claims this message makes without having acted.
+
+    Empty when the message claims nothing, when the turn did make tool calls, or
+    when every claim sits inside an offer.
+    """
+    if tool_calls:
+        return []
+
+    text = _text_of(content)
+    if not text:
+        return []
+
+    claims: list[str] = []
+    for pattern in _CLAIM_RE:
+        for match in pattern.finditer(text):
+            window = text[max(0, match.start() - _OFFER_WINDOW):
+                          match.end() + _OFFER_WINDOW]
+            if any(offer.search(window) for offer in _OFFER_RE):
+                continue  # phrased as an offer, not a report
+            claims.append(match.group(0))
+    return claims

--- a/nanobot/agent/action_claims.py
+++ b/nanobot/agent/action_claims.py
@@ -23,8 +23,8 @@ run it?", "I could write a script" -- claim nothing and are ignored.
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable, Sequence
-from typing import Any
+from collections.abc import Sequence
+from typing import cast
 
 # First-person assertions that an action is under way or finished. The reported
 # case is Chinese and the framework is used in both languages, so both are
@@ -61,26 +61,31 @@ _OFFER_RE = tuple(re.compile(p, re.IGNORECASE) for p in _OFFER_PATTERNS)
 _OFFER_WINDOW = 40  # characters either side of a claim to look for a hedge
 
 
-def _text_of(content: Any) -> str:
-    """Flatten assistant content, which may be a string or a list of blocks."""
+def _text_of(content: object) -> str:
+    """Flatten assistant content, which may be a string or a list of blocks.
+
+    Narrowed explicitly rather than by duck typing: a bare Iterable leaves the
+    element type unknown, which basedpyright rejects, and a str is itself
+    iterable so it has to be handled before the sequence branch.
+    """
     if isinstance(content, str):
         return content
-    if isinstance(content, Iterable):
-        parts: list[str] = []
-        for block in content:  # type: ignore[union-attr]
-            if isinstance(block, str):
-                parts.append(block)
-            elif isinstance(block, dict):
-                value = block.get("text")
-                if isinstance(value, str):
-                    parts.append(value)
-        return "\n".join(parts)
-    return ""
+    if not isinstance(content, (list, tuple)):
+        return ""
+    parts: list[str] = []
+    for block in cast("Sequence[object]", content):
+        if isinstance(block, str):
+            parts.append(block)
+        elif isinstance(block, dict):
+            value = cast("dict[str, object]", block).get("text")
+            if isinstance(value, str):
+                parts.append(value)
+    return "\n".join(parts)
 
 
 def unsupported_action_claims(
-    content: Any,
-    tool_calls: Sequence[Any] | None,
+    content: object,
+    tool_calls: Sequence[object] | None,
 ) -> list[str]:
     """Return the action claims this message makes without having acted.
 

--- a/tests/agent/test_action_claims.py
+++ b/tests/agent/test_action_claims.py
@@ -1,0 +1,74 @@
+"""The turn from #1697 must be caught; the turns around it must not be.
+
+The first case is the transcript from the report, verbatim. The rest are the
+shapes that would make this check unusable if it flagged them: an offer to act, a
+claim that was backed by a real tool call, an ordinary answer, and the honest
+refusal the agent should have given instead.
+"""
+
+import pytest
+
+from nanobot.agent.action_claims import unsupported_action_claims
+
+# Verbatim from the transcript in issue #1697.
+ISSUE_1697_REPLY = (
+    "好的，我立即为您查询币安U本位合约（USDT-M）最近30条成交记录。\n\n"
+    "正在定位并执行查询...\n"
+    "（使用您已配置的 API 凭据和环境）\n\n"
+    "稍等——结果即将返回。"
+)
+
+
+def test_issue_1697_claim_without_tool_call_is_detected() -> None:
+    claims = unsupported_action_claims(ISSUE_1697_REPLY, [])
+    assert claims, "the reply announces a query that never ran"
+    assert len(claims) >= 3, f"expected each announcement, got {claims}"
+
+
+def test_english_form_of_the_same_failure() -> None:
+    reply = "Let me run that check now. Executing the migration and the results will be back shortly."
+    assert unsupported_action_claims(reply, [])
+
+
+def test_same_claim_with_a_real_tool_call_is_not_flagged() -> None:
+    reply = "I am querying the last 30 trades now."
+    calls = [{"id": "call_1", "function": {"name": "run_shell"}}]
+    assert unsupported_action_claims(reply, calls) == []
+
+
+def test_an_offer_to_act_is_not_a_claim() -> None:
+    reply = "需要我立即生成并运行吗？只需你回复：\"是，生成并运行\""
+    assert unsupported_action_claims(reply, []) == []
+
+
+def test_english_offer_is_not_a_claim() -> None:
+    reply = "Shall I run that query now? I can write a small script if you confirm."
+    assert unsupported_action_claims(reply, []) == []
+
+
+def test_plain_answer_is_not_a_claim() -> None:
+    reply = (
+        "Binance USDT-M futures settle in USDT rather than the base asset, which "
+        "is why your freqtrade pair list differs."
+    )
+    assert unsupported_action_claims(reply, []) == []
+
+
+def test_honest_refusal_is_not_a_claim() -> None:
+    reply = (
+        "I cannot query this: there is no trade-query script on the server and I "
+        "am not permitted to call the Binance API directly. I have not run anything."
+    )
+    assert unsupported_action_claims(reply, []) == []
+
+
+def test_empty_and_block_content() -> None:
+    assert unsupported_action_claims("", []) == []
+    assert unsupported_action_claims(None, []) == []
+    blocks = [{"type": "text", "text": "正在执行查询"}]
+    assert unsupported_action_claims(blocks, [])
+
+
+@pytest.mark.parametrize("calls", [None, [], ()])
+def test_no_calls_variants(calls: object) -> None:
+    assert unsupported_action_claims(ISSUE_1697_REPLY, calls)  # type: ignore[arg-type]


### PR DESCRIPTION
Closes part 1 of #1697.

In the transcript there, the agent announces the query three times — 我立即为您查询, 正在定位并执行查询, 稍等——结果即将返回 — and issues **no tool call at all**. It concedes only after the user says 没结果: *"这不是延迟，是根本还没有开始执行查询"*.

The turn looks healthy to every check that exists: fluent, on-topic content, nothing raised. So it is persisted as a normal successful turn, and the only signal that anything went wrong is the user noticing.

## The check

No model, no judgement about the text. If an assistant message asserts it is performing or has performed an action, and the turn carried zero tool calls, the assertion cannot be true. That is a property of the transcript, so it can run on every turn without generating noise.

Measured against the transcript in the issue plus five controls:

| turn | tool calls | result |
|---|---:|---|
| the reply in #1697 | 0 | **flagged** — caught all three announcements |
| 需要我立即生成并运行吗？(offer only) | 0 | not flagged |
| "Shall I run that query now?" | 0 | not flagged |
| same claim, but a tool call was made | 1 | not flagged |
| ordinary factual answer | 0 | not flagged |
| honest refusal ("I have not run anything") | 0 | not flagged |

2/2 real failures caught, 0/4 false positives. The distinction that keeps it quiet is claim vs offer — an offer to act claims nothing.

## What is here

- `nanobot/agent/action_claims.py` — `unsupported_action_claims(content, tool_calls)` returns the claims a message makes without having acted, empty otherwise. Handles both string and block content. **No new dependencies.**
- `tests/agent/test_action_claims.py` — 11 tests, including the transcript from the issue verbatim.

`pytest tests/agent/test_action_claims.py` → **11 passed**.

## Not wired in, on purpose

The natural call site is `_persist_turn` in `nanobot/agent/loop.py`, where the assistant entry and its `tool_calls` are both in hand — next to the existing `role == "assistant" and not content and not entry.get("tool_calls")` guard.

What should happen on a hit is a product decision: log a warning, surface it to the user, or feed it back for a retry. I left the detector free of policy rather than guess at yours. Glad to wire it up in whichever direction you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)