### PR TITLE
docs(edit_file): state that match selectors are mutually exclusive

### DIFF
--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -904,9 +904,11 @@ class EditFileTool(_FsTool):
             "old_text and new_text must be different. Use this for narrow text substitutions "
             "with old_text copied from read_file. For multi-file, structural, "
             "or generated code edits, prefer apply_patch. If old_text matches "
-            "multiple times, provide more context or set occurrence, line_hint, "
-            "replace_all, and expected_replacements. When editing from numbered "
-            "read_file output, set line_hint to the exact target line. "
+            "multiple times, provide more context or choose exactly one of "
+            "occurrence, line_hint, or replace_all (these selectors are "
+            "mutually exclusive); expected_replacements may be combined with "
+            "the chosen selector. When editing from numbered read_file output, "
+            "set line_hint to the exact target line. "
             "Shows closest-match diagnostics on failure."
         )
 

--- a/nanobot/templates/agent/tool_contract.md
+++ b/nanobot/templates/agent/tool_contract.md
@@ -40,7 +40,7 @@
   result with its original consumer or checker when one is available.
 - Use `apply_patch` as the default code editing tool, especially for multi-file changes, structural edits, generated code, moves, adds, or deletes.
 - Use `apply_patch dry_run=true` when the patch is uncertain and you want validation plus a change summary before writing.
-- Use `edit_file` only for small exact replacements in one file, with `old_text` copied from `read_file`; when editing a specific numbered line, pass that exact line as `line_hint`; add `occurrence` or `expected_replacements` when ambiguity matters.
+- Use `edit_file` only for small exact replacements in one file, with `old_text` copied from `read_file`; `occurrence`, `line_hint`, and `replace_all=true` are mutually exclusive — choose exactly one; `expected_replacements` may be combined with the chosen selector.
 - Use `write_file` for new files or intentional full-file rewrites, not routine partial edits.
 - If `apply_patch` or `edit_file` fails, re-read with `force=true`, narrow the context, and try a smaller patch rather than switching to shell `sed` or `echo`.
 


### PR DESCRIPTION
The edit_file description and the agent tool contract implied that
occurrence, line_hint, and replace_all could be combined, but the
runtime rejects any combination of them. This change documents that the
three selectors are mutually exclusive and that expected_replacements may
be combined with whichever selector is chosen.

Closes #5592