### PR TITLE
fix(email): only mark \Seen on messages that are actually delivered

### DIFF
--- a/nanobot/channels/email/runtime.py
+++ b/nanobot/channels/email/runtime.py
@@ -138,6 +138,9 @@ class EmailChannel(BaseChannel):
         self._last_message_id_by_chat: dict[str, str] = {}
         self._processed_uids: set[str] = set()  # Capped to prevent unbounded growth
         self._MAX_PROCESSED_UIDS = 100000
+        # UIDs that were delivered but whose \Seen STORE failed (e.g. a dropped
+        # IMAP connection). Retried on the next poll — never re-delivered.
+        self._pending_mark_seen: set[str] = set()
 
     async def start(self) -> None:
         """Start polling IMAP for inbound emails."""
@@ -166,10 +169,14 @@ class EmailChannel(BaseChannel):
                 inbound_items, skipped_uids = await asyncio.to_thread(self._fetch_new_messages)
                 should_apply_post_action = self._should_apply_post_action()
                 post_actions_uids: set[str] = set()
+                mark_seen_uids: set[str] = set()
                 for item in inbound_items:
                     sender = item["sender"]
                     subject = item.get("subject", "")
                     message_id = item.get("message_id", "")
+                    metadata = item.get("metadata")
+                    metadata_data = cast(dict[str, Any], metadata) if isinstance(metadata, dict) else {}
+                    uid = str(metadata_data.get("uid") or "")
 
                     if subject:
                         self._last_subject_by_chat[sender] = subject
@@ -186,16 +193,36 @@ class EmailChannel(BaseChannel):
                         )
                     except Exception:
                         self.logger.exception("Error delivering email from {}", sender)
+                        # Delivery failed, so this UID was never marked \Seen — undo
+                        # the in-memory dedup mark too, or it would silently never be
+                        # retried even though it's still unread on the server.
+                        if uid:
+                            self._processed_uids.discard(uid)
                         continue
 
-                    metadata = item.get("metadata")
-                    metadata_data = cast(dict[str, Any], metadata) if isinstance(metadata, dict) else {}
-                    uid = str(metadata_data.get("uid") or "")
+                    # Only a message that was genuinely accepted (passed all filters)
+                    # AND handed off successfully above is marked \Seen.
+                    if uid and self.config.mark_seen:
+                        mark_seen_uids.add(uid)
                     if uid and should_apply_post_action:
                         post_actions_uids.add(uid)
 
                 if should_apply_post_action and not self.config.post_action_ignore_skipped:
                     post_actions_uids.update(skipped_uids)
+
+                mark_seen_uids.update(self._pending_mark_seen)
+                if mark_seen_uids:
+                    try:
+                        await asyncio.to_thread(self._mark_seen_batch, sorted(mark_seen_uids))
+                    except Exception:
+                        # Don't let a mark-\Seen failure (e.g. a dropped IMAP
+                        # connection) suppress the post_action batch below. The
+                        # message was already delivered and must not be
+                        # re-delivered, so retry only the \Seen STORE next poll.
+                        self.logger.exception("Failed to mark messages \\Seen; will retry next poll")
+                        self._pending_mark_seen.update(mark_seen_uids)
+                    else:
+                        self._pending_mark_seen.clear()
 
                 if post_actions_uids:
                     await asyncio.to_thread(self._apply_post_actions_batch, sorted(post_actions_uids))
@@ -355,10 +382,13 @@ class EmailChannel(BaseChannel):
             smtp.send_message(msg)
 
     def _fetch_new_messages(self) -> tuple[list[dict[str, Any]], set[str]]:
-        """Poll IMAP and return parsed unread messages plus skipped message UIDs."""
+        """Poll IMAP and return parsed unread messages plus skipped message UIDs.
+
+        Nothing is marked \\Seen here — the caller marks a message \\Seen only
+        after it has actually been delivered to the agent (see start()).
+        """
         return self._fetch_messages(
             search_criteria=("UNSEEN",),
-            mark_seen=self.config.mark_seen,
             dedupe=True,
             limit=0,
         )
@@ -384,7 +414,6 @@ class EmailChannel(BaseChannel):
                 "BEFORE",
                 self._format_imap_date(end_date),
             ),
-            mark_seen=False,
             dedupe=False,
             limit=max(1, int(limit)),
         )
@@ -393,7 +422,6 @@ class EmailChannel(BaseChannel):
     def _fetch_messages(
         self,
         search_criteria: tuple[str, ...],
-        mark_seen: bool,
         dedupe: bool,
         limit: int,
     ) -> tuple[list[dict[str, Any]], set[str]]:
@@ -405,7 +433,6 @@ class EmailChannel(BaseChannel):
             try:
                 self._fetch_messages_once(
                     search_criteria,
-                    mark_seen,
                     dedupe,
                     limit,
                     messages,
@@ -423,7 +450,6 @@ class EmailChannel(BaseChannel):
     def _fetch_messages_once(
         self,
         search_criteria: tuple[str, ...],
-        mark_seen: bool,
         dedupe: bool,
         limit: int,
         messages: list[dict[str, Any]],
@@ -452,8 +478,6 @@ class EmailChannel(BaseChannel):
             if limit > 0 and len(uids) > limit:
                 uids = uids[-limit:]
 
-            features: _ServerFeatures | None = None
-
             for uid in uids:
                 if not uid or uid in cycle_uids:
                     continue
@@ -474,8 +498,6 @@ class EmailChannel(BaseChannel):
                 if self._is_self_address(sender):
                     self.logger.info("From {} ignored: matches bot-owned address", sender)
                     self._remember_processed_uid(uid, dedupe, cycle_uids)
-                    if mark_seen:
-                        features = self._mark_seen_uid(client, uid, features)
                     skipped_uids.add(uid)
                     continue
 
@@ -502,8 +524,6 @@ class EmailChannel(BaseChannel):
 
                 if not self.is_allowed(sender):
                     self._remember_processed_uid(uid, dedupe, cycle_uids)
-                    if mark_seen:
-                        features = self._mark_seen_uid(client, uid, features)
                     skipped_uids.add(uid)
                     continue
 
@@ -567,20 +587,31 @@ class EmailChannel(BaseChannel):
                 )
 
                 self._remember_processed_uid(uid, dedupe, cycle_uids)
-
-                if mark_seen:
-                    features = self._mark_seen_uid(client, uid, features)
         finally:
             self._close_imap_client(client)
 
-    def _mark_seen_uid(
-        self, client: Any, uid: str, features: _ServerFeatures | None
-    ) -> _ServerFeatures:
-        """Mark a single UID \\Seen, reusing session-learned STORE support."""
-        if features is None:
+    def _mark_seen_batch(self, uids: list[str]) -> None:
+        """Mark UIDs \\Seen in one IMAP session.
+
+        Called only for messages that were actually delivered to the agent —
+        see start(). Messages filtered out (self-sent, SPF/DKIM failure, not
+        allow-listed) are never marked \\Seen here.
+        """
+        if not uids:
+            return
+
+        mailbox = self.config.imap_mailbox or "INBOX"
+        client = self._open_imap_client(mailbox=mailbox)
+        if client is None:
+            return
+
+        try:
             features = self._server_features(client)
-        self._uid_store_flag(client, uid, "\\Seen", features)
-        return features
+            for uid in uids:
+                if uid:
+                    self._uid_store_flag(client, uid, "\\Seen", features)
+        finally:
+            self._close_imap_client(client)
 
     def _open_imap_client(self, mailbox: str, *, missing_mailbox_ok: bool = False) -> Any | None:
         if self.config.imap_use_ssl:

--- a/nanobot/channels/email/tests/test_email_channel.py
+++ b/nanobot/channels/email/tests/test_email_channel.py
@@ -50,7 +50,7 @@ def _make_raw_email(
     return msg.as_bytes()
 
 
-def test_fetch_new_messages_parses_unseen_and_marks_seen(monkeypatch) -> None:
+def test_fetch_new_messages_parses_unseen_without_marking_seen(monkeypatch) -> None:
     raw = _make_raw_email(subject="Invoice", body="Please pay")
 
     fake = _make_fake_imap(raw, uid=b"123")
@@ -63,11 +63,13 @@ def test_fetch_new_messages_parses_unseen_and_marks_seen(monkeypatch) -> None:
     assert items[0]["sender"] == "alice@example.com"
     assert items[0]["subject"] == "Invoice"
     assert "Please pay" in items[0]["content"]
-    assert ("STORE", "123", "+FLAGS", "(\\Seen)") in fake.uid_calls
     assert [call for call in fake.uid_calls if call[0] == "FETCH"] == [
         ("FETCH", "123", "(BODY.PEEK[HEADER])"),
         ("FETCH", "123", "(BODY.PEEK[])"),
     ]
+    # Marking \Seen is deferred to the caller (see start()) — fetching alone
+    # must never issue a STORE.
+    assert not any(call[0] == "STORE" for call in fake.uid_calls)
     assert skipped_uids == set()
 
     # Same UID should be deduped in-process.
@@ -401,17 +403,23 @@ async def test_start_applies_post_action_only_after_delivery(monkeypatch) -> Non
     async def _fake_handle_message(**_kwargs):
         calls.append("delivered")
 
-    def _fake_batch(actions):
+    def _fake_mark_seen(uids):
         assert calls == ["delivered"]
+        assert uids == ["123"]
+        calls.append("mark_seen")
+
+    def _fake_batch(actions):
+        assert calls == ["delivered", "mark_seen"]
         assert actions == ["123"]
         calls.append("post_action")
 
     monkeypatch.setattr(channel, "_fetch_new_messages", _fake_fetch)
     monkeypatch.setattr(channel, "_handle_message", _fake_handle_message)
+    monkeypatch.setattr(channel, "_mark_seen_batch", _fake_mark_seen)
     monkeypatch.setattr(channel, "_apply_post_actions_batch", _fake_batch)
 
     await channel.start()
-    assert calls == ["delivered", "post_action"]
+    assert calls == ["delivered", "mark_seen", "post_action"]
 
 
 @pytest.mark.asyncio
@@ -475,22 +483,139 @@ async def test_start_keeps_post_actions_for_successful_emails_when_later_deliver
         channel._running = False
         return fetched
 
+    called_mark_seen: list[str] = []
+
     async def _fake_handle_message(**kwargs):
         if kwargs["chat_id"] == "bob@example.com":
             raise RuntimeError("delivery failed")
+
+    def _fake_mark_seen(uids):
+        called_mark_seen.extend(uids)
 
     def _fake_batch(actions):
         called_actions.extend(actions)
 
     monkeypatch.setattr(channel, "_fetch_new_messages", _fake_fetch)
     monkeypatch.setattr(channel, "_handle_message", _fake_handle_message)
+    monkeypatch.setattr(channel, "_mark_seen_batch", _fake_mark_seen)
     monkeypatch.setattr(channel, "_apply_post_actions_batch", _fake_batch)
 
     await channel.start()
+    assert called_mark_seen == ["123"]
     assert called_actions == ["123"]
 
 
-def test_fetch_new_messages_skips_self_sent_email_and_marks_seen(monkeypatch) -> None:
+async def test_start_evicts_uid_from_dedup_cache_when_delivery_fails(monkeypatch) -> None:
+    """A UID that fails delivery must be retried on a later poll, not silently
+    dropped forever — it was never marked \\Seen, so it must not be stuck as
+    "already processed" either."""
+    channel = EmailChannel(_make_config(), MessageBus())
+
+    fetched = (
+        [
+            {
+                "sender": "alice@example.com",
+                "subject": "Hi",
+                "message_id": "<m1@example.com>",
+                "content": "hello",
+                "metadata": {"uid": "123"},
+            }
+        ],
+        [],
+    )
+
+    def _fake_fetch():
+        channel._running = False
+        return fetched
+
+    async def _fake_handle_message(**_kwargs):
+        raise RuntimeError("delivery failed")
+
+    monkeypatch.setattr(channel, "_fetch_new_messages", _fake_fetch)
+    monkeypatch.setattr(channel, "_handle_message", _fake_handle_message)
+
+    channel._processed_uids.add("123")
+    await channel.start()
+
+    assert "123" not in channel._processed_uids
+
+
+async def test_start_mark_seen_failure_does_not_suppress_post_action(monkeypatch) -> None:
+    channel = EmailChannel(_make_config(post_action="delete"), MessageBus())
+
+    fetched = (
+        [
+            {
+                "sender": "alice@example.com",
+                "subject": "Hi",
+                "message_id": "<m1@example.com>",
+                "content": "hello",
+                "metadata": {"uid": "123"},
+            }
+        ],
+        [],
+    )
+
+    def _fake_fetch():
+        channel._running = False
+        return fetched
+
+    async def _fake_handle_message(**_kwargs):
+        return None
+
+    def _fake_mark_seen(_uids):
+        raise RuntimeError("IMAP connection dropped")
+
+    called_actions: list[str] = []
+
+    def _fake_batch(actions):
+        called_actions.extend(actions)
+
+    monkeypatch.setattr(channel, "_fetch_new_messages", _fake_fetch)
+    monkeypatch.setattr(channel, "_handle_message", _fake_handle_message)
+    monkeypatch.setattr(channel, "_mark_seen_batch", _fake_mark_seen)
+    monkeypatch.setattr(channel, "_apply_post_actions_batch", _fake_batch)
+
+    await channel.start()
+
+    assert called_actions == ["123"]
+    # The message was already delivered — it must not be re-delivered, but
+    # the failed \Seen STORE must be retried on a later poll.
+    assert channel._pending_mark_seen == {"123"}
+
+
+async def test_start_retries_pending_mark_seen_without_redelivering(monkeypatch) -> None:
+    """A UID whose \\Seen STORE failed last cycle must be retried on the next
+    poll, without the message going through delivery again."""
+    channel = EmailChannel(_make_config(), MessageBus())
+    channel._pending_mark_seen.add("123")
+
+    def _fake_fetch():
+        channel._running = False
+        return ([], set())
+
+    handled: list[str] = []
+
+    async def _fake_handle_message(**kwargs):
+        handled.append(kwargs["chat_id"])
+
+    marked: list[list[str]] = []
+
+    def _fake_mark_seen(uids):
+        marked.append(uids)
+
+    monkeypatch.setattr(channel, "_fetch_new_messages", _fake_fetch)
+    monkeypatch.setattr(channel, "_handle_message", _fake_handle_message)
+    monkeypatch.setattr(channel, "_mark_seen_batch", _fake_mark_seen)
+
+    await channel.start()
+
+    assert handled == []
+    assert marked == [["123"]]
+    assert channel._pending_mark_seen == set()
+
+
+def test_fetch_new_messages_skips_self_sent_email_without_marking_seen(monkeypatch) -> None:
     raw = _make_raw_email(from_addr="Nanobot <bot@example.com>", subject="Loop test")
 
     fake = _make_fake_imap(raw, uid=b"123")
@@ -501,7 +626,7 @@ def test_fetch_new_messages_skips_self_sent_email_and_marks_seen(monkeypatch) ->
 
     assert items == []
     assert skipped_uids == {"123"}
-    assert ("STORE", "123", "+FLAGS", "(\\Seen)") in fake.uid_calls
+    assert not any(call[0] == "STORE" for call in fake.uid_calls)
 
     # Same UID should still be deduped after being ignored.
     items_again, skipped_again = channel._fetch_new_messages()
@@ -546,7 +671,7 @@ def test_fetch_new_messages_skips_self_sent_across_identity_sources(
     items, _ = channel._fetch_new_messages()
 
     assert items == []
-    assert ("STORE", "123", "+FLAGS", "(\\Seen)") in fake.uid_calls
+    assert not any(call[0] == "STORE" for call in fake.uid_calls)
 
 
 def test_fetch_new_messages_retries_once_when_imap_connection_goes_stale(monkeypatch) -> None:
@@ -1200,7 +1325,7 @@ def test_fetch_new_messages_ignores_unauthorized_sender_before_attachments(monke
     assert [call for call in fake.uid_calls if call[0] == "FETCH"] == [
         ("FETCH", "500", "(BODY.PEEK[HEADER])")
     ]
-    assert ("STORE", "500", "+FLAGS", "(\\Seen)") in fake.uid_calls
+    assert not any(call[0] == "STORE" for call in fake.uid_calls)
 
 
 def test_extract_attachments_saves_pdf(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

A message polled from IMAP was marked `\Seen` as soon as it passed the channel's filters (self-sent, SPF/DKIM, allow-list), *before* it was actually delivered to the agent. This meant:

- A message rejected by a filter (self-sent, SPF/DKIM failure, not allow-listed) was still marked `\Seen`, even though the bot never acted on it — a human checking the mailbox couldn't tell what the bot actually handled from the unread state.
- A message could be marked `\Seen` and then fail delivery to the agent right afterward, silently dropping it.

This PR defers marking `\Seen` until a message has passed every filter **and** been successfully handed off to the agent — mirroring the existing `post_action` (delete/move) gate, which already only applies after successful delivery.

Three related bugs fixed along the way:
- A UID that failed delivery was left in the in-memory dedup cache (marked "already processed") even though it was never marked `\Seen`, so it silently never got retried on a later poll. It's now evicted from that cache on failure.
- A mark-`\Seen` batch failure (e.g. a dropped IMAP connection) could suppress a configured `post_action` for the same successfully-delivered messages. The two are now isolated from each other.
- A mark-`\Seen` batch failure otherwise left the affected UIDs unmarked with no retry, which would redeliver them as duplicates after a restart (the dedup cache is in-memory only). Failed UIDs are now retried on the next poll without re-delivering the message.

No behavior change to filter outcomes or message content — only when `\Seen` gets set.

## Test plan

- [x] `pytest nanobot/channels/email/tests/` — 54 passed
- [x] Full suite: `pytest` — 6792 passed, 12 skipped (one pre-existing, unrelated failure in `tests/cli/test_tui_launcher.py` reproduces identically against unmodified `upstream/main`)
- [x] `ruff check nanobot/channels/email/`
- [x] `uv run --no-sync basedpyright` (strict type check, per CONTRIBUTING.md) — 0 errors