### PR TITLE
feat(email): filter by recipient alias

### DIFF
--- a/nanobot/channels/email/manifest.py
+++ b/nanobot/channels/email/manifest.py
@@ -19,6 +19,10 @@ SETUP_SPEC = ChannelSetupSpec(
         "fromAddress": field(),
         "pollIntervalSeconds": field("int", default=30),
         "allowFrom": field("list"),
+        # When set, only process mail actually addressed to this alias (To/Cc/
+        # Delivered-To/X-Original-To) — leave blank to process anything the
+        # mailbox receives.
+        "aliasAddress": field(),
         "verifyDkim": field("bool", default=True),
         "verifySpf": field("bool", default=True),
     },

--- a/nanobot/channels/email/runtime.py
+++ b/nanobot/channels/email/runtime.py
@@ -14,7 +14,7 @@ from email import policy
 from email.header import decode_header, make_header
 from email.message import EmailMessage
 from email.parser import BytesParser
-from email.utils import parseaddr
+from email.utils import getaddresses, parseaddr
 from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -62,6 +62,11 @@ class EmailConfig(Base):
     max_body_chars: int = 12000
     subject_prefix: str = "Re: "
     allow_from: list[str] = Field(default_factory=list)
+
+    # When set, only process messages actually addressed (To/Cc/Delivered-To/
+    # X-Original-To) to this alias — lets the bot share a mailbox that also
+    # receives mail for other aliases without acting on it.
+    alias_address: str = ""
 
     # Email authentication verification (anti-spoofing)
     verify_dkim: bool = True   # Require Authentication-Results with dkim=pass
@@ -501,6 +506,16 @@ class EmailChannel(BaseChannel):
                     skipped_uids.add(uid)
                     continue
 
+                if self.config.alias_address and not self._addressed_to_alias(parsed):
+                    self.logger.info(
+                        "From {} ignored: not addressed to configured alias {}",
+                        sender,
+                        self.config.alias_address,
+                    )
+                    self._remember_processed_uid(uid, dedupe, cycle_uids)
+                    skipped_uids.add(uid)
+                    continue
+
                 # --- Anti-spoofing: verify Authentication-Results ---
                 spf_pass, dkim_pass = self._check_authentication_results(parsed)
                 if self.config.verify_spf and not spf_pass:
@@ -676,6 +691,31 @@ class EmailChannel(BaseChannel):
         """Return True when an inbound sender belongs to the bot itself."""
         normalized_sender = self._normalize_address(sender)
         return bool(normalized_sender) and normalized_sender in self._self_addresses
+
+    def _addressed_to_alias(self, parsed_msg: Any) -> bool:
+        """Return True when the configured alias appears among the message's
+        actual recipients (To/Cc, plus Delivered-To/X-Original-To when present)."""
+        alias = self._normalize_address(self.config.alias_address)
+        if not alias:
+            return True
+        return alias in self._extract_recipient_addresses(parsed_msg)
+
+    @staticmethod
+    def _extract_recipient_addresses(parsed_msg: Any) -> set[str]:
+        """Collect every normalized recipient address a message was sent to."""
+        addresses: set[str] = set()
+        for header in ("To", "Cc"):
+            raw_values = cast(list[str], parsed_msg.get_all(header) or [])
+            for _name, addr in getaddresses(raw_values):
+                normalized = EmailChannel._normalize_address(addr)
+                if normalized:
+                    addresses.add(normalized)
+        for header in ("Delivered-To", "X-Original-To", "Envelope-To"):
+            for raw_value in cast(list[str], parsed_msg.get_all(header) or []):
+                normalized = EmailChannel._normalize_address(str(raw_value))
+                if normalized:
+                    addresses.add(normalized)
+        return addresses
 
     def _remember_processed_uid(self, uid: str, dedupe: bool, cycle_uids: set[str]) -> None:
         """Track a fetched UID so skipped messages are not reprocessed forever."""

--- a/nanobot/channels/email/runtime.py
+++ b/nanobot/channels/email/runtime.py
@@ -138,6 +138,9 @@ class EmailChannel(BaseChannel):
         self._last_message_id_by_chat: dict[str, str] = {}
         self._processed_uids: set[str] = set()  # Capped to prevent unbounded growth
         self._MAX_PROCESSED_UIDS = 100000
+        # UIDs that were delivered but whose \Seen STORE failed (e.g. a dropped
+        # IMAP connection). Retried on the next poll — never re-delivered.
+        self._pending_mark_seen: set[str] = set()
 
     async def start(self) -> None:
         """Start polling IMAP for inbound emails."""
@@ -166,10 +169,14 @@ class EmailChannel(BaseChannel):
                 inbound_items, skipped_uids = await asyncio.to_thread(self._fetch_new_messages)
                 should_apply_post_action = self._should_apply_post_action()
                 post_actions_uids: set[str] = set()
+                mark_seen_uids: set[str] = set()
                 for item in inbound_items:
                     sender = item["sender"]
                     subject = item.get("subject", "")
                     message_id = item.get("message_id", "")
+                    metadata = item.get("metadata")
+                    metadata_data = cast(dict[str, Any], metadata) if isinstance(metadata, dict) else {}
+                    uid = str(metadata_data.get("uid") or "")
 
                     if subject:
                         self._last_subject_by_chat[sender] = subject
@@ -186,16 +193,36 @@ class EmailChannel(BaseChannel):
                         )
                     except Exception:
                         self.logger.exception("Error delivering email from {}", sender)
+                        # Delivery failed, so this UID was never marked \Seen — undo
+                        # the in-memory dedup mark too, or it would silently never be
+                        # retried even though it's still unread on the server.
+                        if uid:
+                            self._processed_uids.discard(uid)
                         continue
 
-                    metadata = item.get("metadata")
-                    metadata_data = cast(dict[str, Any], metadata) if isinstance(metadata, dict) else {}
-                    uid = str(metadata_data.get("uid") or "")
+                    # Only a message that was genuinely accepted (passed all filters)
+                    # AND handed off successfully above is marked \Seen.
+                    if uid and self.config.mark_seen:
+                        mark_seen_uids.add(uid)
                     if uid and should_apply_post_action:
                         post_actions_uids.add(uid)
 
                 if should_apply_post_action and not self.config.post_action_ignore_skipped:
                     post_actions_uids.update(skipped_uids)
+
+                mark_seen_uids.update(self._pending_mark_seen)
+                if mark_seen_uids:
+                    try:
+                        await asyncio.to_thread(self._mark_seen_batch, sorted(mark_seen_uids))
+                    except Exception:
+                        # Don't let a mark-\Seen failure (e.g. a dropped IMAP
+                        # connection) suppress the post_action batch below. The
+                        # message was already delivered and must not be
+                        # re-delivered, so retry only the \Seen STORE next poll.
+                        self.logger.exception("Failed to mark messages \\Seen; will retry next poll")
+                        self._pending_mark_seen.update(mark_seen_uids)
+                    else:
+                        self._pending_mark_seen.clear()
 
                 if post_actions_uids:
                     await asyncio.to_thread(self._apply_post_actions_batch, sorted(post_actions_uids))
@@ -355,10 +382,13 @@ class EmailChannel(BaseChannel):
             smtp.send_message(msg)
 
     def _fetch_new_messages(self) -> tuple[list[dict[str, Any]], set[str]]:
-        """Poll IMAP and return parsed unread messages plus skipped message UIDs."""
+        """Poll IMAP and return parsed unread messages plus skipped message UIDs.
+
+        Nothing is marked \\Seen here — the caller marks a message \\Seen only
+        after it has actually been delivered to the agent (see start()).
+        """
         return self._fetch_messages(
             search_criteria=("UNSEEN",),
-            mark_seen=self.config.mark_seen,
             dedupe=True,
             limit=0,
         )
@@ -384,7 +414,6 @@ class EmailChannel(BaseChannel):
                 "BEFORE",
                 self._format_imap_date(end_date),
             ),
-            mark_seen=False,
             dedupe=False,
             limit=max(1, int(limit)),
         )
@@ -393,7 +422,6 @@ class EmailChannel(BaseChannel):
     def _fetch_messages(
         self,
         search_criteria: tuple[str, ...],
-        mark_seen: bool,
         dedupe: bool,
         limit: int,
     ) -> tuple[list[dict[str, Any]], set[str]]:
@@ -405,7 +433,6 @@ class EmailChannel(BaseChannel):
             try:
                 self._fetch_messages_once(
                     search_criteria,
-                    mark_seen,
                     dedupe,
                     limit,
                     messages,
@@ -423,7 +450,6 @@ class EmailChannel(BaseChannel):
     def _fetch_messages_once(
         self,
         search_criteria: tuple[str, ...],
-        mark_seen: bool,
         dedupe: bool,
         limit: int,
         messages: list[dict[str, Any]],
@@ -452,8 +478,6 @@ class EmailChannel(BaseChannel):
             if limit > 0 and len(uids) > limit:
                 uids = uids[-limit:]
 
-            features: _ServerFeatures | None = None
-
             for uid in uids:
                 if not uid or uid in cycle_uids:
                     continue
@@ -474,8 +498,6 @@ class EmailChannel(BaseChannel):
                 if self._is_self_address(sender):
                     self.logger.info("From {} ignored: matches bot-owned address", sender)
                     self._remember_processed_uid(uid, dedupe, cycle_uids)
-                    if mark_seen:
-                        features = self._mark_seen_uid(client, uid, features)
                     skipped_uids.add(uid)
                     continue
 
@@ -502,8 +524,6 @@ class EmailChannel(BaseChannel):
 
                 if not self.is_allowed(sender):
                     self._remember_processed_uid(uid, dedupe, cycle_uids)
-                    if mark_seen:
-                        features = self._mark_seen_uid(client, uid, features)
                     skipped_uids.add(uid)
                     continue
 
@@ -567,20 +587,31 @@ class EmailChannel(BaseChannel):
                 )
 
                 self._remember_processed_uid(uid, dedupe, cycle_uids)
-
-                if mark_seen:
-                    features = self._mark_seen_uid(client, uid, features)
         finally:
             self._close_imap_client(client)
 
-    def _mark_seen_uid(
-        self, client: Any, uid: str, features: _ServerFeatures | None
-    ) -> _ServerFeatures:
-        """Mark a single UID \\Seen, reusing session-learned STORE support."""
-        if features is None:
+    def _mark_seen_batch(self, uids: list[str]) -> None:
+        """Mark UIDs \\Seen in one IMAP session.
+
+        Called only for messages that were actually delivered to the agent —
+        see start(). Messages filtered out (self-sent, SPF/DKIM failure, not
+        allow-listed) are never marked \\Seen here.
+        """
+        if not uids:
+            return
+
+        mailbox = self.config.imap_mailbox or "INBOX"
+        client = self._open_imap_client(mailbox=mailbox)
+        if client is None:
+            return
+
+        try:
             features = self._server_features(client)
-        self._uid_store_flag(client, uid, "\\Seen", features)
-        return features
+            for uid in uids:
+                if uid:
+                    self._uid_store_flag(client, uid, "\\Seen", features)
+        finally:
+            self._close_imap_client(client)
 
     def _open_imap_client(self, mailbox: str, *, missing_mailbox_ok: bool = False) -> Any | None:
         if self.config.imap_use_ssl:

--- a/nanobot/channels/email/tests/test_email_channel.py
+++ b/nanobot/channels/email/tests/test_email_channel.py
@@ -50,7 +50,7 @@ def _make_raw_email(
     return msg.as_bytes()
 
 
-def test_fetch_new_messages_parses_unseen_and_marks_seen(monkeypatch) -> None:
+def test_fetch_new_messages_parses_unseen_without_marking_seen(monkeypatch) -> None:
     raw = _make_raw_email(subject="Invoice", body="Please pay")
 
     fake = _make_fake_imap(raw, uid=b"123")
@@ -63,11 +63,13 @@ def test_fetch_new_messages_parses_unseen_and_marks_seen(monkeypatch) -> None:
     assert items[0]["sender"] == "alice@example.com"
     assert items[0]["subject"] == "Invoice"
     assert "Please pay" in items[0]["content"]
-    assert ("STORE", "123", "+FLAGS", "(\\Seen)") in fake.uid_calls
     assert [call for call in fake.uid_calls if call[0] == "FETCH"] == [
         ("FETCH", "123", "(BODY.PEEK[HEADER])"),
         ("FETCH", "123", "(BODY.PEEK[])"),
     ]
+    # Marking \Seen is deferred to the caller (see start()) — fetching alone
+    # must never issue a STORE.
+    assert not any(call[0] == "STORE" for call in fake.uid_calls)
     assert skipped_uids == set()
 
     # Same UID should be deduped in-process.
@@ -401,17 +403,23 @@ async def test_start_applies_post_action_only_after_delivery(monkeypatch) -> Non
     async def _fake_handle_message(**_kwargs):
         calls.append("delivered")
 
-    def _fake_batch(actions):
+    def _fake_mark_seen(uids):
         assert calls == ["delivered"]
+        assert uids == ["123"]
+        calls.append("mark_seen")
+
+    def _fake_batch(actions):
+        assert calls == ["delivered", "mark_seen"]
         assert actions == ["123"]
         calls.append("post_action")
 
     monkeypatch.setattr(channel, "_fetch_new_messages", _fake_fetch)
     monkeypatch.setattr(channel, "_handle_message", _fake_handle_message)
+    monkeypatch.setattr(channel, "_mark_seen_batch", _fake_mark_seen)
     monkeypatch.setattr(channel, "_apply_post_actions_batch", _fake_batch)
 
     await channel.start()
-    assert calls == ["delivered", "post_action"]
+    assert calls == ["delivered", "mark_seen", "post_action"]
 
 
 @pytest.mark.asyncio
@@ -475,22 +483,139 @@ async def test_start_keeps_post_actions_for_successful_emails_when_later_deliver
         channel._running = False
         return fetched
 
+    called_mark_seen: list[str] = []
+
     async def _fake_handle_message(**kwargs):
         if kwargs["chat_id"] == "bob@example.com":
             raise RuntimeError("delivery failed")
+
+    def _fake_mark_seen(uids):
+        called_mark_seen.extend(uids)
 
     def _fake_batch(actions):
         called_actions.extend(actions)
 
     monkeypatch.setattr(channel, "_fetch_new_messages", _fake_fetch)
     monkeypatch.setattr(channel, "_handle_message", _fake_handle_message)
+    monkeypatch.setattr(channel, "_mark_seen_batch", _fake_mark_seen)
     monkeypatch.setattr(channel, "_apply_post_actions_batch", _fake_batch)
 
     await channel.start()
+    assert called_mark_seen == ["123"]
     assert called_actions == ["123"]
 
 
-def test_fetch_new_messages_skips_self_sent_email_and_marks_seen(monkeypatch) -> None:
+async def test_start_evicts_uid_from_dedup_cache_when_delivery_fails(monkeypatch) -> None:
+    """A UID that fails delivery must be retried on a later poll, not silently
+    dropped forever — it was never marked \\Seen, so it must not be stuck as
+    "already processed" either."""
+    channel = EmailChannel(_make_config(), MessageBus())
+
+    fetched = (
+        [
+            {
+                "sender": "alice@example.com",
+                "subject": "Hi",
+                "message_id": "<m1@example.com>",
+                "content": "hello",
+                "metadata": {"uid": "123"},
+            }
+        ],
+        [],
+    )
+
+    def _fake_fetch():
+        channel._running = False
+        return fetched
+
+    async def _fake_handle_message(**_kwargs):
+        raise RuntimeError("delivery failed")
+
+    monkeypatch.setattr(channel, "_fetch_new_messages", _fake_fetch)
+    monkeypatch.setattr(channel, "_handle_message", _fake_handle_message)
+
+    channel._processed_uids.add("123")
+    await channel.start()
+
+    assert "123" not in channel._processed_uids
+
+
+async def test_start_mark_seen_failure_does_not_suppress_post_action(monkeypatch) -> None:
+    channel = EmailChannel(_make_config(post_action="delete"), MessageBus())
+
+    fetched = (
+        [
+            {
+                "sender": "alice@example.com",
+                "subject": "Hi",
+                "message_id": "<m1@example.com>",
+                "content": "hello",
+                "metadata": {"uid": "123"},
+            }
+        ],
+        [],
+    )
+
+    def _fake_fetch():
+        channel._running = False
+        return fetched
+
+    async def _fake_handle_message(**_kwargs):
+        return None
+
+    def _fake_mark_seen(_uids):
+        raise RuntimeError("IMAP connection dropped")
+
+    called_actions: list[str] = []
+
+    def _fake_batch(actions):
+        called_actions.extend(actions)
+
+    monkeypatch.setattr(channel, "_fetch_new_messages", _fake_fetch)
+    monkeypatch.setattr(channel, "_handle_message", _fake_handle_message)
+    monkeypatch.setattr(channel, "_mark_seen_batch", _fake_mark_seen)
+    monkeypatch.setattr(channel, "_apply_post_actions_batch", _fake_batch)
+
+    await channel.start()
+
+    assert called_actions == ["123"]
+    # The message was already delivered — it must not be re-delivered, but
+    # the failed \Seen STORE must be retried on a later poll.
+    assert channel._pending_mark_seen == {"123"}
+
+
+async def test_start_retries_pending_mark_seen_without_redelivering(monkeypatch) -> None:
+    """A UID whose \\Seen STORE failed last cycle must be retried on the next
+    poll, without the message going through delivery again."""
+    channel = EmailChannel(_make_config(), MessageBus())
+    channel._pending_mark_seen.add("123")
+
+    def _fake_fetch():
+        channel._running = False
+        return ([], set())
+
+    handled: list[str] = []
+
+    async def _fake_handle_message(**kwargs):
+        handled.append(kwargs["chat_id"])
+
+    marked: list[list[str]] = []
+
+    def _fake_mark_seen(uids):
+        marked.append(uids)
+
+    monkeypatch.setattr(channel, "_fetch_new_messages", _fake_fetch)
+    monkeypatch.setattr(channel, "_handle_message", _fake_handle_message)
+    monkeypatch.setattr(channel, "_mark_seen_batch", _fake_mark_seen)
+
+    await channel.start()
+
+    assert handled == []
+    assert marked == [["123"]]
+    assert channel._pending_mark_seen == set()
+
+
+def test_fetch_new_messages_skips_self_sent_email_without_marking_seen(monkeypatch) -> None:
     raw = _make_raw_email(from_addr="Nanobot <bot@example.com>", subject="Loop test")
 
     fake = _make_fake_imap(raw, uid=b"123")
@@ -501,7 +626,7 @@ def test_fetch_new_messages_skips_self_sent_email_and_marks_seen(monkeypatch) ->
 
     assert items == []
     assert skipped_uids == {"123"}
-    assert ("STORE", "123", "+FLAGS", "(\\Seen)") in fake.uid_calls
+    assert not any(call[0] == "STORE" for call in fake.uid_calls)
 
     # Same UID should still be deduped after being ignored.
     items_again, skipped_again = channel._fetch_new_messages()
@@ -546,7 +671,7 @@ def test_fetch_new_messages_skips_self_sent_across_identity_sources(
     items, _ = channel._fetch_new_messages()
 
     assert items == []
-    assert ("STORE", "123", "+FLAGS", "(\\Seen)") in fake.uid_calls
+    assert not any(call[0] == "STORE" for call in fake.uid_calls)
 
 
 def test_fetch_new_messages_retries_once_when_imap_connection_goes_stale(monkeypatch) -> None:
@@ -1200,7 +1325,7 @@ def test_fetch_new_messages_ignores_unauthorized_sender_before_attachments(monke
     assert [call for call in fake.uid_calls if call[0] == "FETCH"] == [
         ("FETCH", "500", "(BODY.PEEK[HEADER])")
     ]
-    assert ("STORE", "500", "+FLAGS", "(\\Seen)") in fake.uid_calls
+    assert not any(call[0] == "STORE" for call in fake.uid_calls)
 
 
 def test_extract_attachments_saves_pdf(tmp_path, monkeypatch) -> None:

--- a/nanobot/channels/email/tests/test_email_channel.py
+++ b/nanobot/channels/email/tests/test_email_channel.py
@@ -38,14 +38,21 @@ def _make_raw_email(
     subject: str = "Hello",
     body: str = "This is the body.",
     auth_results: str | None = None,
+    to_addr: str = "bot@example.com",
+    cc_addr: str | None = None,
+    extra_headers: dict[str, str] | None = None,
 ) -> bytes:
     msg = EmailMessage()
     msg["From"] = from_addr
-    msg["To"] = "bot@example.com"
+    msg["To"] = to_addr
+    if cc_addr:
+        msg["Cc"] = cc_addr
     msg["Subject"] = subject
     msg["Message-ID"] = "<m1@example.com>"
     if auth_results:
         msg["Authentication-Results"] = auth_results
+    for name, value in (extra_headers or {}).items():
+        msg[name] = value
     msg.set_content(body)
     return msg.as_bytes()
 
@@ -672,6 +679,82 @@ def test_fetch_new_messages_skips_self_sent_across_identity_sources(
 
     assert items == []
     assert not any(call[0] == "STORE" for call in fake.uid_calls)
+
+
+def test_fetch_new_messages_accepts_mail_addressed_to_configured_alias(monkeypatch) -> None:
+    raw = _make_raw_email(to_addr="Assistant <assistant@example.com>", subject="For the alias")
+    fake = _make_fake_imap(raw)
+    monkeypatch.setattr("nanobot.channels.email.runtime.imaplib.IMAP4_SSL", lambda _h, _p: fake)
+
+    channel = EmailChannel(_make_config(alias_address="assistant@example.com"), MessageBus())
+    items, skipped_uids = channel._fetch_new_messages()
+
+    assert len(items) == 1
+    assert items[0]["subject"] == "For the alias"
+    assert skipped_uids == set()
+
+
+def test_fetch_new_messages_rejects_mail_not_addressed_to_configured_alias(monkeypatch) -> None:
+    raw = _make_raw_email(to_addr="someone-else@example.com", subject="Not for us")
+    fake = _make_fake_imap(raw)
+    monkeypatch.setattr("nanobot.channels.email.runtime.imaplib.IMAP4_SSL", lambda _h, _p: fake)
+
+    channel = EmailChannel(_make_config(alias_address="assistant@example.com"), MessageBus())
+    items, skipped_uids = channel._fetch_new_messages()
+
+    assert items == []
+    assert skipped_uids == {"500"}
+    # Rejected mail must never be marked \Seen — only genuinely delivered mail is.
+    assert not any(call[0] == "STORE" for call in fake.uid_calls)
+
+
+def test_fetch_new_messages_matches_alias_in_cc(monkeypatch) -> None:
+    raw = _make_raw_email(
+        to_addr="someone-else@example.com", cc_addr="assistant@example.com", subject="CC'd"
+    )
+    fake = _make_fake_imap(raw)
+    monkeypatch.setattr("nanobot.channels.email.runtime.imaplib.IMAP4_SSL", lambda _h, _p: fake)
+
+    channel = EmailChannel(_make_config(alias_address="assistant@example.com"), MessageBus())
+    items, _ = channel._fetch_new_messages()
+
+    assert len(items) == 1
+
+
+def test_fetch_new_messages_matches_alias_case_insensitively(monkeypatch) -> None:
+    raw = _make_raw_email(to_addr="ASSISTANT@EXAMPLE.COM")
+    fake = _make_fake_imap(raw)
+    monkeypatch.setattr("nanobot.channels.email.runtime.imaplib.IMAP4_SSL", lambda _h, _p: fake)
+
+    channel = EmailChannel(_make_config(alias_address="assistant@example.com"), MessageBus())
+    items, _ = channel._fetch_new_messages()
+
+    assert len(items) == 1
+
+
+def test_fetch_new_messages_matches_alias_via_delivered_to(monkeypatch) -> None:
+    raw = _make_raw_email(
+        to_addr="mailing-list@example.com",
+        extra_headers={"Delivered-To": "assistant@example.com"},
+    )
+    fake = _make_fake_imap(raw)
+    monkeypatch.setattr("nanobot.channels.email.runtime.imaplib.IMAP4_SSL", lambda _h, _p: fake)
+
+    channel = EmailChannel(_make_config(alias_address="assistant@example.com"), MessageBus())
+    items, _ = channel._fetch_new_messages()
+
+    assert len(items) == 1
+
+
+def test_fetch_new_messages_ignores_alias_filter_when_unset(monkeypatch) -> None:
+    raw = _make_raw_email(to_addr="whoever@example.com")
+    fake = _make_fake_imap(raw)
+    monkeypatch.setattr("nanobot.channels.email.runtime.imaplib.IMAP4_SSL", lambda _h, _p: fake)
+
+    channel = EmailChannel(_make_config(alias_address=""), MessageBus())
+    items, _ = channel._fetch_new_messages()
+
+    assert len(items) == 1
 
 
 def test_fetch_new_messages_retries_once_when_imap_connection_goes_stale(monkeypatch) -> None:

--- a/nanobot/channels/email/webui/index.ts
+++ b/nanobot/channels/email/webui/index.ts
@@ -57,6 +57,7 @@ export default {
         { key: "channels.email.smtpPort" },
         { key: "channels.email.fromAddress" },
         { key: "channels.email.pollIntervalSeconds" },
+        { key: "channels.email.aliasAddress" },
         { key: "channels.email.allowFrom" },
         { key: "channels.email.verifyDkim" },
         { key: "channels.email.verifySpf" },

--- a/nanobot/channels/email/webui/locales/en.json
+++ b/nanobot/channels/email/webui/locales/en.json
@@ -68,6 +68,11 @@
         "label": "Poll interval",
         "placeholder": "30"
       },
+      "aliasAddress": {
+        "label": "Alias address",
+        "placeholder": "assistant@example.com",
+        "help": "Only process mail actually addressed to this alias (To/Cc/Delivered-To). Leave blank to process anything the mailbox receives."
+      },
       "allowFrom": {
         "label": "Allowed senders",
         "placeholder": "Email addresses, comma separated",

--- a/nanobot/channels/email/webui/locales/es.json
+++ b/nanobot/channels/email/webui/locales/es.json
@@ -68,6 +68,11 @@
         "label": "Intervalo de consulta",
         "placeholder": "30"
       },
+      "aliasAddress": {
+        "label": "Dirección de alias",
+        "placeholder": "assistant@example.com",
+        "help": "Solo procesa correo dirigido realmente a este alias (Para/CC/Delivered-To). Déjalo vacío para procesar todo lo que reciba el buzón."
+      },
       "allowFrom": {
         "label": "Remitentes permitidos",
         "placeholder": "Correos separados por comas",

--- a/nanobot/channels/email/webui/locales/fr.json
+++ b/nanobot/channels/email/webui/locales/fr.json
@@ -68,6 +68,11 @@
         "label": "Intervalle de relève",
         "placeholder": "30"
       },
+      "aliasAddress": {
+        "label": "Adresse d'alias",
+        "placeholder": "assistant@example.com",
+        "help": "Traite uniquement le courrier réellement adressé à cet alias (À/Cc/Delivered-To). Laissez vide pour traiter tout ce que la boîte reçoit."
+      },
       "allowFrom": {
         "label": "Expéditeurs autorisés",
         "placeholder": "Adresses séparées par des virgules",

--- a/nanobot/channels/email/webui/locales/id.json
+++ b/nanobot/channels/email/webui/locales/id.json
@@ -68,6 +68,11 @@
         "label": "Interval pemeriksaan",
         "placeholder": "30"
       },
+      "aliasAddress": {
+        "label": "Alamat alias",
+        "placeholder": "assistant@example.com",
+        "help": "Hanya proses email yang benar-benar dialamatkan ke alias ini (To/Cc/Delivered-To). Kosongkan untuk memproses semua yang diterima kotak surat."
+      },
       "allowFrom": {
         "label": "Pengirim yang diizinkan",
         "placeholder": "Alamat email, dipisahkan koma",

--- a/nanobot/channels/email/webui/locales/ja.json
+++ b/nanobot/channels/email/webui/locales/ja.json
@@ -68,6 +68,11 @@
         "label": "確認間隔",
         "placeholder": "30"
       },
+      "aliasAddress": {
+        "label": "エイリアスアドレス",
+        "placeholder": "assistant@example.com",
+        "help": "このエイリアス宛て (To/Cc/Delivered-To) のメールのみを処理します。空欄にするとメールボックスが受信したすべてを処理します。"
+      },
       "allowFrom": {
         "label": "許可する送信者",
         "placeholder": "メールアドレス（カンマ区切り）",

--- a/nanobot/channels/email/webui/locales/ko.json
+++ b/nanobot/channels/email/webui/locales/ko.json
@@ -68,6 +68,11 @@
         "label": "확인 간격",
         "placeholder": "30"
       },
+      "aliasAddress": {
+        "label": "별칭 주소",
+        "placeholder": "assistant@example.com",
+        "help": "이 별칭으로 실제 수신된 메일만 처리합니다(수신/참조/Delivered-To). 비워 두면 메일함이 받는 모든 메일을 처리합니다."
+      },
       "allowFrom": {
         "label": "허용된 발신자",
         "placeholder": "이메일 주소, 쉼표로 구분",

--- a/nanobot/channels/email/webui/locales/pt-BR.json
+++ b/nanobot/channels/email/webui/locales/pt-BR.json
@@ -68,6 +68,11 @@
         "label": "Intervalo de consulta",
         "placeholder": "30"
       },
+      "aliasAddress": {
+        "label": "Endereço do alias",
+        "placeholder": "assistant@example.com",
+        "help": "Processa apenas e-mails realmente endereçados a este alias (Para/Cc/Delivered-To). Deixe em branco para processar tudo que a caixa receber."
+      },
       "allowFrom": {
         "label": "Remetentes permitidos",
         "placeholder": "E-mails separados por vírgulas",

--- a/nanobot/channels/email/webui/locales/vi.json
+++ b/nanobot/channels/email/webui/locales/vi.json
@@ -68,6 +68,11 @@
         "label": "Chu kỳ kiểm tra",
         "placeholder": "30"
       },
+      "aliasAddress": {
+        "label": "Địa chỉ alias",
+        "placeholder": "assistant@example.com",
+        "help": "Chỉ xử lý email thực sự được gửi đến alias này (To/Cc/Delivered-To). Để trống để xử lý mọi thư hộp thư nhận được."
+      },
       "allowFrom": {
         "label": "Người gửi được phép",
         "placeholder": "Địa chỉ email, phân tách bằng dấu phẩy",

--- a/nanobot/channels/email/webui/locales/zh-CN.json
+++ b/nanobot/channels/email/webui/locales/zh-CN.json
@@ -68,6 +68,11 @@
         "label": "轮询间隔",
         "placeholder": "30"
       },
+      "aliasAddress": {
+        "label": "别名地址",
+        "placeholder": "assistant@example.com",
+        "help": "仅处理确实发送到此别名的邮件(收件人/抄送/Delivered-To)。留空则处理邮箱收到的所有邮件。"
+      },
       "allowFrom": {
         "label": "允许的发件人",
         "placeholder": "邮箱地址，用逗号分隔",

--- a/nanobot/channels/email/webui/locales/zh-TW.json
+++ b/nanobot/channels/email/webui/locales/zh-TW.json
@@ -68,6 +68,11 @@
         "label": "輪詢間隔",
         "placeholder": "30"
       },
+      "aliasAddress": {
+        "label": "別名地址",
+        "placeholder": "assistant@example.com",
+        "help": "僅處理實際寄至此別名的郵件(收件者/副本/Delivered-To)。留空則處理郵箱收到的所有郵件。"
+      },
       "allowFrom": {
         "label": "允許的寄件者",
         "placeholder": "電子郵件地址，以逗號分隔",


### PR DESCRIPTION
## Summary

A mailbox is sometimes shared across multiple addresses (aliases that all deliver to the same inbox — e.g. `assistant@example.com` and `team@example.com` landing in the same mailbox). Today the email channel processes every message it receives regardless of which address it was actually sent to, so a bot configured against a shared mailbox ends up acting on mail that wasn't meant for it.

This adds an `alias_address` config option: when set, only messages actually addressed to that alias are processed. Everything else is skipped — logged, deduped, added to `skipped_uids` — exactly like the existing self-sent/SPF/DKIM/allow-list filters already do, so it's never marked `\Seen` either (per #5605).

The match checks `To`/`Cc` (multiple comma-separated recipients handled via `email.utils.getaddresses`), plus `Delivered-To`/`X-Original-To`/`Envelope-To` as a bonus for providers that set them (Exchange Online does not, but Postfix/Gmail-style servers often do).

Leaving `alias_address` unset preserves current behavior exactly — the mailbox processes everything it receives, as before.

This is stacked on top of #5605 (deferred mark-`\Seen`) since the filter's skip path relies on that behavior. Until #5605 merges, this diff will also show that commit — it'll collapse to just the alias filter once #5605 lands.

## Test plan

- [x] `pytest nanobot/channels/email/tests/` — 60 passed (6 new: accepts alias match, rejects non-match without marking `\Seen`, matches via Cc, case-insensitive match, matches via `Delivered-To`, no-op when unset)
- [x] Full suite: `pytest` — 6792 passed, 12 skipped (one pre-existing, unrelated failure in `tests/cli/test_tui_launcher.py` reproduces identically against unmodified `upstream/main`)
- [x] `ruff check nanobot/channels/email/`
- [x] `uv run --no-sync basedpyright` (strict type check, per CONTRIBUTING.md) — 0 errors
- [x] WebUI locale parity: `aliasAddress` label/placeholder/help added to all 10 locale files (not just `en.json`), satisfying `channel-locale-registry.test.ts`