### PR TITLE
feat(agent): bound reasoning replay to the latest assistant turn

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,7 +47,7 @@ the focused guides first and come back here for exact fields and defaults.
 | Add MCP servers | [MCP](#mcp-model-context-protocol) |
 | Review shell, workspace, and SSRF controls | [Security](#security) |
 | Control access and pairing | [Pairing](#pairing) |
-| Tune gateway jobs, sessions, and tools | [Gateway Heartbeat](#gateway-heartbeat), [Auto Compact](#auto-compact), [Unified Session](#unified-session), [Tool Hint Max Length](#tool-hint-max-length) |
+| Tune gateway jobs, sessions, and tools | [Gateway Heartbeat](#gateway-heartbeat), [Auto Compact](#auto-compact), [Unified Session](#unified-session), [Tool Hint Max Length](#tool-hint-max-length), [Reasoning Replay](#reasoning-replay) |
 
 ## Where a Setting Lives
 
@@ -2376,3 +2376,25 @@ Set `agents.defaults.toolHintMaxLength` to control the truncation threshold:
 | Option | Default | Description |
 |--------|---------|-------------|
 | `agents.defaults.toolHintMaxLength` | `40` | Maximum characters for tool hint display. Range: 20–500. Higher values show more of the command or path; lower values keep hints compact. |
+
+## Reasoning Replay
+
+When a provider returns reasoning (`reasoning_content` / `thinking_blocks`), nanobot persists it in the session so the current tool loop can replay it and the transcript stays auditable. By default, only the **latest** assistant turn's reasoning is replayed to the provider — past-turn reasoning is token-heavy, is not needed once its turn completes, and on small context windows it would otherwise evict genuine dialogue turns earlier than necessary.
+
+Set `agents.defaults.replayReasoning` to control this:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "replayReasoning": "all"
+    }
+  }
+}
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `agents.defaults.replayReasoning` | `recent` | How much past-turn reasoning reaches the provider at replay time. `recent` replays reasoning only for the turn after the last user message (an unfinished tool loop stays intact, as providers that require thinking blocks expect). `all` replays reasoning for every turn — the behavior before this option existed. `none` never replays reasoning; only use it with providers that tolerate a missing thinking trail. |
+
+Replay-time stripping never modifies the persisted session file, so display, consolidation, and turn recovery still see the full record.

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -277,6 +277,7 @@ class AgentLoop:
         max_tool_result_chars: int | None = None,
         provider_retry_mode: str = "standard",
         tool_hint_max_length: int | None = None,
+        replay_reasoning: str | None = None,
         cron_service: CronService | None = None,
         restrict_to_workspace: bool = False,
         session_manager: SessionManager | None = None,
@@ -355,6 +356,10 @@ class AgentLoop:
         self.tool_hint_max_length = (
             tool_hint_max_length if tool_hint_max_length is not None
             else defaults.tool_hint_max_length
+        )
+        self.replay_reasoning = (
+            replay_reasoning if replay_reasoning is not None
+            else defaults.replay_reasoning
         )
         self.tools_config = _tc
         self.web_config = _tc.web
@@ -509,6 +514,7 @@ class AgentLoop:
             max_tool_result_chars=defaults.max_tool_result_chars,
             provider_retry_mode=defaults.provider_retry_mode,
             tool_hint_max_length=defaults.tool_hint_max_length,
+            replay_reasoning=defaults.replay_reasoning,
             restrict_to_workspace=config.tools.restrict_to_workspace,
             channels_config=config.channels,
             timezone=defaults.timezone,
@@ -1898,7 +1904,10 @@ class AgentLoop:
             session = ctx.require_session()
         is_subagent = ctx.kind is TurnKind.SYSTEM and ctx.msg.sender_id == "subagent"
 
-        ctx.history = session.get_history(extend_to_user=is_subagent)
+        ctx.history = session.get_history(
+            extend_to_user=is_subagent,
+            replay_reasoning=self.replay_reasoning,
+        )
         stored_state = session.provider_state
         subagent_followup_persisted = False
         if is_subagent:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -154,6 +154,9 @@ class AgentDefaults(Base):
         default=60,
         ge=0,
     )  # Minimum interval in seconds between scans for idle sessions
+    replay_reasoning: Literal["recent", "all", "none"] = Field(
+        default="recent",
+    )  # How much past-turn reasoning is replayed to the provider: "recent" = only the latest assistant turn, "all" = every turn, "none" = never
     dream: DreamConfig = Field(default_factory=DreamConfig)
 
     @model_validator(mode="before")

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -15,7 +15,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Collection, Generator, Protocol, TypedDict, cast
+from typing import Any, Callable, Collection, Generator, Literal, Protocol, TypedDict, cast
 from weakref import WeakValueDictionary
 
 from filelock import FileLock
@@ -328,12 +328,20 @@ class Session:
         max_tokens: int = 0,
         extend_to_user: bool = False,
         include_runtime_context: bool = True,
+        replay_reasoning: Literal["recent", "all", "none"] = "all",
     ) -> list[dict[str, Any]]:
         """Return recent replayable messages for LLM input.
 
         A committed in-turn checkpoint replaces its old prefix with the stored
         summary and resumes replay at a hidden continuation marker. A positive
         ``max_messages`` applies an additional caller-owned count limit.
+
+        ``replay_reasoning`` bounds how far back ``reasoning_content`` and
+        ``thinking_blocks`` are replayed: ``"all"`` keeps them on every row,
+        ``"recent"`` keeps them only for the turn after the last user row
+        (an unfinished tool loop stays intact), and ``"none"`` drops them
+        everywhere. Stripping happens at replay time only — the persisted
+        session record is never modified.
         """
         replay_start = self.last_archived
         resumes_from_checkpoint = (
@@ -440,6 +448,28 @@ class Session:
                 if key in message:
                     entry[key] = message[key]
             out.append(entry)
+
+        if replay_reasoning != "all" and out:
+            # Past-turn reasoning is only useful to the provider inside the
+            # current tool loop. Drop it from older rows at replay time so it
+            # no longer competes with the conversation for the replay budget.
+            boundary = len(out)  # "none": no row replays reasoning
+            if replay_reasoning == "recent":
+                boundary = 0  # No user row in the replay: keep reasoning rather than guess a turn boundary.
+                for index in range(len(out) - 1, -1, -1):
+                    if out[index].get("role") == "user":
+                        boundary = index
+                        break
+            out = [
+                message
+                if index >= boundary
+                else {
+                    key: value
+                    for key, value in message.items()
+                    if key not in ("reasoning_content", "thinking_blocks")
+                }
+                for index, message in enumerate(out)
+            ]
 
         if max_tokens > 0 and out:
             kept: list[dict[str, Any]] = []

--- a/tests/agent/test_auto_compact.py
+++ b/tests/agent/test_auto_compact.py
@@ -236,6 +236,7 @@ class TestAgentLoopTTLParam:
         loop = _make_loop(tmp_path, session_ttl_minutes=0)
         assert loop.auto_compact._ttl == 0
 
+
 class TestAutoCompact:
     """Test the _archive method."""
 

--- a/tests/agent/test_history_replay.py
+++ b/tests/agent/test_history_replay.py
@@ -10,12 +10,17 @@ import pytest
 from nanobot.agent.loop import AgentLoop
 from nanobot.bus.events import InboundMessage
 from nanobot.bus.queue import MessageBus
+from nanobot.config.schema import AgentDefaults
 from nanobot.providers.base import LLMResponse
 from nanobot.session.manager import Session
 from nanobot.session.summary import SUMMARY_CONTINUATION_TEXT
 
 
-def _make_loop(tmp_path: Path, context_window_tokens: int = 200_000) -> AgentLoop:
+def _make_loop(
+    tmp_path: Path,
+    context_window_tokens: int = 200_000,
+    replay_reasoning: str | None = None,
+) -> AgentLoop:
     provider = MagicMock()
     provider.get_default_model.return_value = "test-model"
     provider.generation.max_tokens = 4096
@@ -25,6 +30,7 @@ def _make_loop(tmp_path: Path, context_window_tokens: int = 200_000) -> AgentLoo
         workspace=tmp_path,
         model="test-model",
         context_window_tokens=context_window_tokens,
+        replay_reasoning=replay_reasoning,
     )
 
 
@@ -81,7 +87,10 @@ async def test_process_message_hands_complete_replay_to_runner(tmp_path: Path) -
         )
 
     assert result is not None
-    assert get_history.call_args.kwargs == {"extend_to_user": False}
+    assert get_history.call_args.kwargs == {
+        "extend_to_user": False,
+        "replay_reasoning": "recent",
+    }
 
 
 @pytest.mark.asyncio
@@ -116,3 +125,113 @@ async def test_runner_checkpoint_keeps_current_user_as_replay_boundary(tmp_path:
     assert [message["role"] for message in sent_messages] == ["system", "user", "user"]
     assert sent_messages[1]["content"] == SUMMARY_CONTINUATION_TEXT
     assert any(message.get("content") == "long older turn" for message in session.messages)
+
+
+def _reasoning_session() -> Session:
+    session = Session(key="test:reasoning")
+    session.add_message("user", "first question")
+    session.add_message(
+        "assistant",
+        "first answer",
+        reasoning_content="first thought",
+        thinking_blocks=[{"type": "thinking", "thinking": "first thought", "signature": "sig-1"}],
+    )
+    session.add_message("user", "second question")
+    session.add_message(
+        "assistant",
+        "second answer",
+        reasoning_content="second thought",
+        thinking_blocks=[{"type": "thinking", "thinking": "second thought", "signature": "sig-2"}],
+    )
+    return session
+
+
+def test_replay_reasoning_all_is_the_default_replay_behavior() -> None:
+    session = _reasoning_session()
+
+    assert session.get_history() == session.get_history(replay_reasoning="all")
+    assert session.get_history()[1]["reasoning_content"] == "first thought"
+
+
+def test_replay_reasoning_recent_keeps_only_latest_turn_reasoning() -> None:
+    history = _reasoning_session().get_history(replay_reasoning="recent")
+
+    assert history[1] == {"role": "assistant", "content": "first answer"}
+    assert history[3]["reasoning_content"] == "second thought"
+    assert history[3]["thinking_blocks"][0]["signature"] == "sig-2"
+
+
+def test_replay_reasoning_recent_keeps_unfinished_tool_loop() -> None:
+    session = Session(key="test:tool-loop")
+    session.add_message("user", "first question")
+    session.add_message(
+        "assistant",
+        "first answer",
+        reasoning_content="old reasoning",
+        thinking_blocks=[{"type": "thinking", "thinking": "old reasoning", "signature": "sig-old"}],
+    )
+    session.add_message("user", "run it")
+    session.messages.extend(_tool_round("call-1"))
+    session.messages[-2]["thinking_blocks"] = [
+        {"type": "thinking", "thinking": "current thought", "signature": "sig-current"}
+    ]
+
+    history = session.get_history(replay_reasoning="recent")
+
+    assert history[1] == {"role": "assistant", "content": "first answer"}
+    current_assistant = next(message for message in history if message.get("tool_calls"))
+    assert current_assistant["thinking_blocks"][0]["signature"] == "sig-current"
+
+
+def test_replay_reasoning_none_strips_all_reasoning() -> None:
+    history = _reasoning_session().get_history(replay_reasoning="none")
+
+    assert all("reasoning_content" not in message for message in history)
+    assert all("thinking_blocks" not in message for message in history)
+
+
+def test_replay_reasoning_recent_without_user_row_keeps_reasoning() -> None:
+    session = Session(key="test:no-user")
+    session.add_message(
+        "assistant",
+        "proactive note",
+        reasoning_content="proactive reasoning",
+        thinking_blocks=[{"type": "thinking", "thinking": "proactive reasoning", "signature": "sig"}],
+    )
+
+    history = session.get_history(replay_reasoning="recent")
+
+    assert history[0]["reasoning_content"] == "proactive reasoning"
+
+
+def test_replay_reasoning_leaves_persisted_record_intact() -> None:
+    session = _reasoning_session()
+
+    session.get_history(replay_reasoning="recent")
+
+    assert session.messages[1]["reasoning_content"] == "first thought"
+    assert session.messages[3]["thinking_blocks"][0]["signature"] == "sig-2"
+
+
+def test_replay_reasoning_config_default_and_alias() -> None:
+    assert AgentDefaults().replay_reasoning == "recent"
+    assert AgentDefaults.model_validate({"replayReasoning": "all"}).replay_reasoning == "all"
+    assert AgentDefaults.model_validate({"replay_reasoning": "none"}).replay_reasoning == "none"
+
+
+@pytest.mark.asyncio
+async def test_replay_reasoning_setting_reaches_history_replay(tmp_path: Path) -> None:
+    loop = _make_loop(tmp_path, context_window_tokens=32_768, replay_reasoning="all")
+    loop.provider.chat_with_retry = AsyncMock(
+        return_value=LLMResponse(content="ok", tool_calls=[], usage=None)
+    )
+    loop.tools.get_definitions = MagicMock(return_value=[])
+
+    session = loop.sessions.get_or_create("cli:test")
+    with patch.object(session, "get_history", wraps=session.get_history) as get_history:
+        result = await loop._process_message(
+            InboundMessage(channel="cli", sender_id="user", chat_id="test", content="hello")
+        )
+
+    assert result is not None
+    assert get_history.call_args.kwargs["replay_reasoning"] == "all"


### PR DESCRIPTION
Closes #5584

## What

Persisted `reasoning_content` / `thinking_blocks` rows were replayed to the provider indefinitely — past-turn reasoning competed with the conversation for the replay token budget, and every deployment paid prefill for it on every turn.

This PR bounds reasoning replay at **replay time only**:

- `recent` (new default): reasoning fields are replayed only for the turn after the last user row, so an unfinished tool loop keeps its thinking blocks intact — providers that require thinking blocks across a tool loop keep working.
- `all`: identical to today's behavior, for anyone who depends on it.
- `none`: reasoning is never replayed.

The persisted session record is never modified, so display, consolidation, and turn recovery (`session/recovery.py` reads the persisted field) are unaffected. Stripping runs before the replay token-budget trim, so the budget is spent on the conversation instead.

## Config

`agents.defaults.replayReasoning`: `recent | all | none` (default `recent`). Documented in `docs/configuration.md` under a new **Reasoning Replay** section.

## Testing

- `tests/agent/test_history_replay.py`: 8 new tests covering `recent`/`all`/`none` semantics, the unfinished-tool-loop boundary, the no-user-row conservative fallback, persisted-record integrity, config defaults + camelCase alias, and loop→replay wiring. Two existing kwargs assertions updated for the new `replay_reasoning` kwarg.
- Full `tests/agent` suite: **1557 passed** on Windows / Python 3.13.
- `ruff check nanobot tests conftest.py`: clean (same invocation as CI).
- `basedpyright` (strict) on the three changed source files: 0 errors.