### PR TITLE
fix(provider): clean up replayed items before sending them to providers

### DIFF
--- a/nanobot/providers/openai_responses/converters.py
+++ b/nanobot/providers/openai_responses/converters.py
@@ -16,6 +16,7 @@ def convert_messages(
     messages: list[dict[str, Any]],
     *,
     preserve_reasoning: bool = False,
+    include_item_ids: bool = True,
 ) -> tuple[str, list[dict[str, Any]]]:
     """Convert Chat Completions messages to Responses API input items.
 
@@ -48,26 +49,32 @@ def convert_messages(
                         "content": [{"type": "output_text", "text": reasoning}],
                     })
             if isinstance(content, str) and content:
-                message_id = _unique_item_id(f"msg_{idx}", used_item_ids)
-                input_items.append({
+                message_item: dict[str, Any] = {
                     "type": "message", "role": "assistant",
                     "content": [{"type": "output_text", "text": content}],
-                    "status": "completed", "id": message_id,
-                })
+                    "status": "completed",
+                }
+                if include_item_ids:
+                    message_item["id"] = _unique_item_id(f"msg_{idx}", used_item_ids)
+                input_items.append(message_item)
             for raw_tool_call in cast(list[object], msg.get("tool_calls", []) or []):
                 tool_call = _as_json_object(raw_tool_call)
                 if tool_call is None:
                     continue
                 fn = _as_json_object(tool_call.get("function")) or {}
                 call_id, item_id = split_tool_call_id(tool_call.get("id"))
-                response_item_id = _unique_item_id(item_id or f"fc_{idx}", used_item_ids)
-                input_items.append({
+                function_call_item: dict[str, Any] = {
                     "type": "function_call",
-                    "id": response_item_id,
                     "call_id": call_id or f"call_{idx}",
                     "name": fn.get("name"),
                     "arguments": tool_arguments_json_for_replay(fn.get("arguments")),
-                })
+                }
+                if include_item_ids:
+                    function_call_item["id"] = _unique_item_id(
+                        item_id or f"fc_{idx}",
+                        used_item_ids,
+                    )
+                input_items.append(function_call_item)
             continue
 
         if role == "tool":

--- a/nanobot/providers/openai_responses/converters.py
+++ b/nanobot/providers/openai_responses/converters.py
@@ -16,18 +16,16 @@ def convert_messages(
     messages: list[dict[str, Any]],
     *,
     preserve_reasoning: bool = False,
-    include_item_ids: bool = True,
 ) -> tuple[str, list[dict[str, Any]]]:
     """Convert Chat Completions messages to Responses API input items.
 
     Returns ``(system_prompt, input_items)`` where *system_prompt* is extracted
     from any ``system`` role message and *input_items* is the Responses API
-    ``input`` array.
+    ``input`` array. Provider-generated item IDs are deliberately omitted:
+    Chat history may be replayed through a different provider connection.
     """
     system_prompt = ""
     input_items: list[dict[str, Any]] = []
-    used_item_ids: set[str] = set()
-
     for idx, msg in enumerate(messages):
         role = msg.get("role")
         content = msg.get("content")
@@ -49,32 +47,23 @@ def convert_messages(
                         "content": [{"type": "output_text", "text": reasoning}],
                     })
             if isinstance(content, str) and content:
-                message_item: dict[str, Any] = {
+                input_items.append({
                     "type": "message", "role": "assistant",
                     "content": [{"type": "output_text", "text": content}],
                     "status": "completed",
-                }
-                if include_item_ids:
-                    message_item["id"] = _unique_item_id(f"msg_{idx}", used_item_ids)
-                input_items.append(message_item)
+                })
             for raw_tool_call in cast(list[object], msg.get("tool_calls", []) or []):
                 tool_call = _as_json_object(raw_tool_call)
                 if tool_call is None:
                     continue
                 fn = _as_json_object(tool_call.get("function")) or {}
-                call_id, item_id = split_tool_call_id(tool_call.get("id"))
-                function_call_item: dict[str, Any] = {
+                call_id, _ = split_tool_call_id(tool_call.get("id"))
+                input_items.append({
                     "type": "function_call",
                     "call_id": call_id or f"call_{idx}",
                     "name": fn.get("name"),
                     "arguments": tool_arguments_json_for_replay(fn.get("arguments")),
-                }
-                if include_item_ids:
-                    function_call_item["id"] = _unique_item_id(
-                        item_id or f"fc_{idx}",
-                        used_item_ids,
-                    )
-                input_items.append(function_call_item)
+                })
             continue
 
         if role == "tool":
@@ -201,20 +190,6 @@ def convert_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
             "parameters": params if isinstance(params, dict) else {},
         })
     return converted
-
-
-def _unique_item_id(item_id: str, used: set[str]) -> str:
-    """Return a Responses input item id that is unique within one request."""
-    if item_id not in used:
-        used.add(item_id)
-        return item_id
-
-    suffix = 2
-    while f"{item_id}_{suffix}" in used:
-        suffix += 1
-    unique = f"{item_id}_{suffix}"
-    used.add(unique)
-    return unique
 
 
 def split_tool_call_id(tool_call_id: Any) -> tuple[str, str | None]:

--- a/nanobot/providers/openai_responses/state.py
+++ b/nanobot/providers/openai_responses/state.py
@@ -54,6 +54,7 @@ def prepare_responses_input(
     instructions, fallback_items = convert_messages(
         messages,
         preserve_reasoning=preserve_reasoning,
+        include_item_ids=False,
     )
     if state is None or not responses_state_matches(
         state,
@@ -69,13 +70,18 @@ def prepare_responses_input(
     _, delta_items = convert_messages(
         state.pending_messages,
         preserve_reasoning=preserve_reasoning,
+        include_item_ids=False,
     )
     logger.debug(
         "Replaying Responses state: prior_items={} pending_messages={}",
         len(prior_items),
         len(state.pending_messages),
     )
-    return instructions, [*deepcopy(prior_items), *delta_items], True
+    replayed_items = deepcopy(prior_items)
+    for item in replayed_items:
+        if item.get("type") == "reasoning":
+            item.pop("status", None)
+    return instructions, [*replayed_items, *delta_items], True
 
 
 def build_responses_state(

--- a/nanobot/providers/openai_responses/state.py
+++ b/nanobot/providers/openai_responses/state.py
@@ -54,7 +54,6 @@ def prepare_responses_input(
     instructions, fallback_items = convert_messages(
         messages,
         preserve_reasoning=preserve_reasoning,
-        include_item_ids=False,
     )
     if state is None or not responses_state_matches(
         state,
@@ -70,17 +69,13 @@ def prepare_responses_input(
     _, delta_items = convert_messages(
         state.pending_messages,
         preserve_reasoning=preserve_reasoning,
-        include_item_ids=False,
     )
     logger.debug(
         "Replaying Responses state: prior_items={} pending_messages={}",
         len(prior_items),
         len(state.pending_messages),
     )
-    replayed_items = deepcopy(prior_items)
-    for item in replayed_items:
-        if item.get("type") == "reasoning":
-            item.pop("status", None)
+    replayed_items = _prepare_replayed_items(prior_items)
     return instructions, [*replayed_items, *delta_items], True
 
 
@@ -200,3 +195,14 @@ def _state_items(
             return None
         items.append(cast(dict[str, Any], raw))
     return items
+
+
+def _prepare_replayed_items(
+    items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Copy provider state and remove output-only fields rejected on replay."""
+    replayed_items = deepcopy(items)
+    for item in replayed_items:
+        if item.get("type") == "reasoning":
+            item.pop("status", None)
+    return replayed_items

--- a/nanobot/providers/xai_grok_provider.py
+++ b/nanobot/providers/xai_grok_provider.py
@@ -111,7 +111,7 @@ class XAIGrokProvider(LLMProvider):
         on_stream_recover: Callable[[], Awaitable[None]] | None = None,
     ) -> LLMResponse:
         wire_model = _strip_model_prefix(model or self.default_model)
-        system_prompt, input_items = convert_messages(messages)
+        system_prompt, input_items = convert_messages(messages, include_item_ids=False)
 
         stage = "oauth_token"
         try:

--- a/nanobot/providers/xai_grok_provider.py
+++ b/nanobot/providers/xai_grok_provider.py
@@ -111,7 +111,7 @@ class XAIGrokProvider(LLMProvider):
         on_stream_recover: Callable[[], Awaitable[None]] | None = None,
     ) -> LLMResponse:
         wire_model = _strip_model_prefix(model or self.default_model)
-        system_prompt, input_items = convert_messages(messages, include_item_ids=False)
+        system_prompt, input_items = convert_messages(messages)
 
         stage = "oauth_token"
         try:

--- a/tests/providers/test_openai_responses.py
+++ b/tests/providers/test_openai_responses.py
@@ -216,6 +216,23 @@ class TestConvertMessages:
         assert items[0]["name"] == "get_weather"
         assert items[0]["arguments"] == '{"city": "SF"}'
 
+    def test_can_omit_item_ids_without_changing_call_ids(self):
+        _, items = convert_messages([
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": "call_1|fc_1",
+                    "function": {"name": "get_weather", "arguments": "{}"},
+                }],
+            },
+            {"role": "tool", "tool_call_id": "call_1|fc_1", "content": "ok"},
+        ], include_item_ids=False)
+
+        assert all("id" not in item for item in items)
+        assert items[0]["call_id"] == "call_1"
+        assert items[1]["call_id"] == "call_1"
+
     def test_assistant_tool_call_history_repairs_malformed_arguments(self):
         _, items = convert_messages([{
             "role": "assistant",
@@ -714,6 +731,36 @@ class TestParseResponseOutput:
 
 
 class TestResponsesConversationState:
+    def test_replayed_reasoning_items_omit_unsupported_status(self):
+        state = build_responses_state(
+            provider="openai:test",
+            model="gpt-5.6",
+            input_items=[{"role": "user", "content": "previous"}],
+            output_items=[{
+                "type": "reasoning",
+                "id": "rs_1",
+                "status": None,
+                "encrypted_content": "opaque",
+            }],
+        ).with_pending_messages([
+            {"role": "user", "content": "continue"},
+        ])
+
+        _, items, replayed = prepare_responses_input(
+            [{"role": "user", "content": "current"}],
+            state=state,
+            provider="openai:test",
+            model="gpt-5.6",
+        )
+
+        assert replayed is True
+        reasoning_item = next(
+            item for item in items
+            if item.get("type") == "reasoning"
+        )
+        assert "status" not in reasoning_item
+        assert reasoning_item["encrypted_content"] == "opaque"
+
     def test_server_compaction_prunes_superseded_prefix(self):
         state = build_responses_state(
             provider="openai:test",
@@ -812,6 +859,46 @@ class TestResponsesConversationState:
         assert "pending_messages=1" in log_text
         assert "dropped_items=2" in log_text
         assert secret not in log_text
+
+    def test_fresh_and_pending_conversions_omit_item_ids(self):
+        pending_messages = [{
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": "call_1|fc_1",
+                "function": {"name": "read_file", "arguments": "{}"},
+            }],
+        }]
+
+        _, fresh_items, replayed = prepare_responses_input(
+            pending_messages,
+            state=None,
+            provider="openai:test",
+            model="gpt-5.6",
+        )
+
+        assert replayed is False
+        assert fresh_items[0]["call_id"] == "call_1"
+        assert "id" not in fresh_items[0]
+
+        state = build_responses_state(
+            provider="openai:test",
+            model="gpt-5.6",
+            input_items=[{"role": "user", "content": "previous"}],
+            output_items=[{"type": "message", "id": "msg_previous"}],
+        ).with_pending_messages(pending_messages)
+
+        _, items, replayed = prepare_responses_input(
+            [{"role": "user", "content": "current"}],
+            state=state,
+            provider="openai:test",
+            model="gpt-5.6",
+        )
+
+        assert replayed is True
+        assert items[1]["id"] == "msg_previous"
+        assert items[2]["call_id"] == "call_1"
+        assert "id" not in items[2]
 
     def test_replays_exact_items_then_only_pending_and_new_messages(self):
         prior_items = [

--- a/tests/providers/test_openai_responses.py
+++ b/tests/providers/test_openai_responses.py
@@ -151,6 +151,7 @@ class TestConvertMessages:
         assert items[0]["role"] == "assistant"
         assert items[0]["content"][0]["type"] == "output_text"
         assert items[0]["content"][0]["text"] == "I'll help"
+        assert "id" not in items[0]
 
     def test_preserves_deepseek_reasoning_content(self):
         _, items = convert_messages([
@@ -167,7 +168,6 @@ class TestConvertMessages:
                 "role": "assistant",
                 "content": [{"type": "output_text", "text": "answer"}],
                 "status": "completed",
-                "id": "msg_0",
             },
         ]
 
@@ -212,26 +212,9 @@ class TestConvertMessages:
         }])
         assert items[0]["type"] == "function_call"
         assert items[0]["call_id"] == "call_abc"
-        assert items[0]["id"] == "fc_1"
+        assert "id" not in items[0]
         assert items[0]["name"] == "get_weather"
         assert items[0]["arguments"] == '{"city": "SF"}'
-
-    def test_can_omit_item_ids_without_changing_call_ids(self):
-        _, items = convert_messages([
-            {
-                "role": "assistant",
-                "content": None,
-                "tool_calls": [{
-                    "id": "call_1|fc_1",
-                    "function": {"name": "get_weather", "arguments": "{}"},
-                }],
-            },
-            {"role": "tool", "tool_call_id": "call_1|fc_1", "content": "ok"},
-        ], include_item_ids=False)
-
-        assert all("id" not in item for item in items)
-        assert items[0]["call_id"] == "call_1"
-        assert items[1]["call_id"] == "call_1"
 
     def test_assistant_tool_call_history_repairs_malformed_arguments(self):
         _, items = convert_messages([{
@@ -245,58 +228,32 @@ class TestConvertMessages:
 
         assert json.loads(items[0]["arguments"]) == {"path": "foo.txt"}
 
-    def test_duplicate_response_item_ids_are_made_unique(self):
-        """Codex rejects replayed Responses input items with duplicate ids."""
+    def test_discards_provider_item_ids_without_changing_call_ids(self):
         _, items = convert_messages([
             {
                 "role": "assistant",
                 "content": None,
                 "tool_calls": [{
-                    "id": "call_a|rs_same",
-                    "function": {"name": "first", "arguments": "{}"},
+                    "id": "call_1|fc_1",
+                    "function": {"name": "get_weather", "arguments": "{}"},
                 }],
             },
-            {"role": "tool", "tool_call_id": "call_a|rs_same", "content": "ok"},
-            {
-                "role": "assistant",
-                "content": None,
-                "tool_calls": [{
-                    "id": "call_b|rs_same",
-                    "function": {"name": "second", "arguments": "{}"},
-                }],
-            },
-            {"role": "tool", "tool_call_id": "call_b|rs_same", "content": "ok"},
+            {"role": "tool", "tool_call_id": "call_1|fc_1", "content": "ok"},
         ])
-        function_call_ids = [
-            item["id"] for item in items if item.get("type") == "function_call"
-        ]
-        assert function_call_ids == ["rs_same", "rs_same_2"]
-        assert len(function_call_ids) == len(set(function_call_ids))
 
-    def test_fallback_response_item_ids_are_unique_with_multiple_tool_calls(self):
-        _, items = convert_messages([{
-            "role": "assistant",
-            "content": None,
-            "tool_calls": [
-                {"id": "call_a", "function": {"name": "first", "arguments": "{}"}},
-                {"id": "call_b", "function": {"name": "second", "arguments": "{}"}},
-            ],
-        }])
-        function_call_ids = [
-            item["id"] for item in items if item.get("type") == "function_call"
-        ]
-        assert function_call_ids == ["fc_0", "fc_0_2"]
-        assert len(function_call_ids) == len(set(function_call_ids))
+        assert all("id" not in item for item in items)
+        assert items[0]["call_id"] == "call_1"
+        assert items[1]["call_id"] == "call_1"
 
     def test_assistant_with_tool_calls_no_id(self):
-        """Fallback IDs when tool_call.id is missing."""
+        """Fallback call IDs still work when tool_call.id is missing."""
         _, items = convert_messages([{
             "role": "assistant",
             "content": None,
             "tool_calls": [{"function": {"name": "f1", "arguments": "{}"}}],
         }])
         assert items[0]["call_id"] == "call_0"
-        assert items[0]["id"].startswith("fc_")
+        assert "id" not in items[0]
 
     def test_tool_message(self):
         _, items = convert_messages([{


### PR DESCRIPTION
## Summary

Prevent Responses API failures caused by replaying provider-generated item IDs from Chat history and unsupported provider fields from conversation state.

## Root Cause

There are two related but distinct replay problems.

### 1. Provider-generated item IDs in fresh history conversion

Responses tool-call IDs can be persisted as `call_id|item_id`. Chat-style history may outlive the provider connection that created `item_id`, so copying that value into a fresh Responses input can fail with:

`input item ID does not belong to this connection`

### 2. Unsupported `status` fields in opaque state replay

Some GitHub Copilot Responses reasoning items contain `status: null`. Replaying that output field as input can fail with:

`Unknown parameter: 'input[7].status'`

## Changes

- Make Chat-to-Responses conversion connection-independent: converted messages never emit provider item IDs.
- Preserve `call_id` so function-call outputs remain linked to their calls.
- Keep exact same-provider/model opaque state replay separate from Chat history conversion.
- Copy opaque state before replay and remove only `status` from reasoning items.
- Preserve encrypted reasoning content and other provider fields.
- Add regression coverage for fresh history, pending deltas, tool-call linkage, and reasoning replay.

## Verification

- Responses, Codex, Azure OpenAI, and xAI provider tests: 200 passed.
- Ruff: passed.
- Focused BasedPyright: 0 errors.
- Real `luna` preset (`openai_codex/gpt-5.6-luna`): tool call and same-session continuation passed.
- GitHub Copilot provider reproduction: pending author verification.

## Evidence

A production idle-session compaction encountered:

`input item ID does not belong to this connection`

A separate production request encountered:

`Unknown parameter: 'input[7].status'`