### PR TITLE
feat(tg): add support for streaming rich messages

### DIFF
--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -46,6 +46,10 @@ TELEGRAM_MAX_MESSAGE_LEN = 4000  # Telegram message character limit
 # raw markdown into chunks whose rendered HTML fits Telegram's true 4096-char
 # boundary so the final rendered message never overflows.
 TELEGRAM_HTML_MAX_LEN = 4096
+# Bot API rich messages accept up to 32,768 UTF-8 characters. Raw Markdown is
+# counted conservatively here; Python's str length counts Unicode code points,
+# so multibyte text must not be split at an encoded-byte boundary.
+TELEGRAM_RICH_MAX_LEN = 32768
 TELEGRAM_REPLY_CONTEXT_MAX_LEN = TELEGRAM_MAX_MESSAGE_LEN  # Max length for reply context in user message
 
 # python-telegram-bot exposes a six-parameter Application generic. Nanobot
@@ -830,13 +834,48 @@ class TelegramChannel(BaseChannel):
 
     @staticmethod
     def _is_rich_capability_error(exc: Exception) -> bool:
-        """True when the error indicates sendRichMessage is unavailable."""
+        """True when the Bot API does not support rich-message endpoints."""
         err = str(exc).lower()
         return (
             "method not found" in err
             or "unknown method" in err
+            or ("endpoint" in err and "not found" in err)
             or "bad request: invalid parameter" in err
+            or "unsupported" in err
+            or "not implemented" in err
         )
+
+    def _rich_streaming_enabled(self) -> bool:
+        return self.config.rich_messages and not self._rich_send_disabled
+
+    @staticmethod
+    def _rich_message_payload(content: str) -> dict[str, str]:
+        return {"markdown": content}
+
+    @staticmethod
+    def _rich_result_message_id(result: Any) -> int | None:
+        """Extract a message id from PTB's raw ``do_api_request`` result."""
+        value: Any = None
+        if isinstance(result, dict):
+            value = cast(dict[str, Any], result).get("message_id")
+            if value is None:
+                nested = cast(dict[str, Any], result).get("result")
+                if isinstance(nested, dict):
+                    value = cast(dict[str, Any], nested).get("message_id")
+        else:
+            value = getattr(result, "message_id", None)
+        if isinstance(value, bool) or value is None:
+            return None
+        with suppress(TypeError, ValueError):
+            return int(value)
+        return None
+
+    def _mark_rich_unavailable(self, exc: Exception, operation: str) -> bool:
+        if not self._is_rich_capability_error(exc):
+            return False
+        self._rich_send_disabled = True
+        self.logger.debug("{} unavailable, disabling rich messages: {}", operation, exc)
+        return True
 
     async def _try_send_rich(
         self,
@@ -852,9 +891,7 @@ class TelegramChannel(BaseChannel):
 
         payload: dict[str, Any] = {
             "chat_id": chat_id,
-            "rich_message": {
-                "markdown": content,
-            },
+            "rich_message": self._rich_message_payload(content),
         }
         if reply_params is not None:
             # sendRichMessage uses reply_parameters (object), not reply_to_message_id.
@@ -882,13 +919,12 @@ class TelegramChannel(BaseChannel):
             )
             return True
         except BadRequest as exc:
-            if self._is_rich_capability_error(exc):
-                self.logger.debug("sendRichMessage not available, disabling")
-                self._rich_send_disabled = True
-            else:
+            if not self._mark_rich_unavailable(exc, "sendRichMessage"):
                 self.logger.debug("sendRichMessage rejected: {}", exc)
             return False
         except Exception as exc:
+            if self._mark_rich_unavailable(exc, "sendRichMessage"):
+                return False
             err_str = str(exc).lower()
             is_timeout = "timed out" in err_str or isinstance(exc, TimedOut)
             if is_timeout:
@@ -897,66 +933,84 @@ class TelegramChannel(BaseChannel):
             self.logger.debug("sendRichMessage failed: {}", exc)
             return False
 
-    async def _try_edit_rich(self, chat_id: int, message_id: int, content: str) -> bool:
-        """Upgrade an existing message to rich in place via editMessageText (Bot API 10.1).
+    async def _try_send_stream_rich(
+        self,
+        chat_id: int,
+        content: str,
+        thread_kwargs: dict[str, int],
+    ) -> int | None:
+        """Send a persistent rich stream message and return its message id.
 
-        Editing in place keeps the message identity, so the streaming preview is
-        upgraded without the delete-and-resend pattern that caused flickering and
-        dropped line breaks (issue #4470).
-
-        Returns True when the rich edit is in place (including the ambiguous
-        "message is not modified" retry outcome after a response timeout).
-        Returns False only when the legacy HTML path should take over:
-        capability errors (server older than Bot API 10.1, which also trip the
-        rich latch) and content-shaped BadRequest rejections. Transport,
-        rate-limit, and unexpected errors propagate so the final-edit retry
-        contract is preserved — ChannelManager retries the buffered send
-        instead of an immediate legacy edit doubling connection demand.
+        ``None`` means Telegram rejected rich formatting before delivery and the
+        caller may use the legacy path. Transport failures propagate because an
+        ambiguous resend could duplicate a message that Telegram already stored.
         """
-        if not self._app:
-            return False
+        app = self._require_app()
+        payload: dict[str, Any] = {
+            "chat_id": chat_id,
+            "rich_message": self._rich_message_payload(content),
+            **thread_kwargs,
+        }
+        try:
+            result = await self._call_with_retry(
+                app.bot.do_api_request,
+                "sendRichMessage",
+                api_kwargs=payload,
+            )
+        except BadRequest as exc:
+            if not self._mark_rich_unavailable(exc, "sendRichMessage"):
+                self.logger.debug("Stream rich send rejected: {}", exc)
+            return None
+        except Exception as exc:
+            if self._mark_rich_unavailable(exc, "sendRichMessage"):
+                return None
+            raise
 
+        message_id = self._rich_result_message_id(result)
+        if message_id is None:
+            raise RuntimeError("sendRichMessage returned no message_id")
+        return message_id
+
+    async def _try_edit_stream_rich(
+        self,
+        chat_id: int,
+        message_id: int,
+        content: str,
+    ) -> bool:
+        """Edit a stream message in place through ``rich_message``.
+
+        Rich edits are valid for both text and rich messages. A parser or
+        capability rejection returns False so the caller can retain the legacy
+        HTML/plain fallback. Transport failures propagate for normal retry.
+        """
+        app = self._require_app()
         payload: dict[str, Any] = {
             "chat_id": chat_id,
             "message_id": message_id,
-            "rich_message": {
-                "markdown": content,
-            },
+            "rich_message": self._rich_message_payload(content),
         }
         try:
             await self._call_with_retry(
-                self._app.bot.do_api_request,
+                app.bot.do_api_request,
                 "editMessageText",
                 api_kwargs=payload,
             )
             return True
         except BadRequest as exc:
             if self._is_not_modified_error(exc):
-                # Ambiguous success: the rich edit was applied server-side but
-                # its response timed out, so the retry hit "message is not
-                # modified". Treat it as done rather than letting the legacy
-                # edit overwrite the already-successful rich result.
-                self.logger.debug("Rich stream edit already applied for {}", chat_id)
                 return True
             # Before Bot API 10.1, editMessageText ignores rich_message and
             # reports the absent text argument instead.
-            pre_rich_edit_server = (
-                bool(content)
-                and str(exc).strip().lower() == "message text is empty"
-            )
-            if self._is_rich_capability_error(exc) or pre_rich_edit_server:
-                self.logger.debug("editMessageText rich_message not available, disabling")
+            if content and str(exc).strip().lower() == "message text is empty":
                 self._rich_send_disabled = True
+                self.logger.debug("rich editMessageText unavailable, disabling rich messages")
                 return False
-            # Content-shaped rejections (invalid markdown, unsupported media in
-            # the rich payload, …) fall back to the legacy HTML edit.
-            self.logger.debug("editMessageText rich_message rejected: {}", exc)
+            if not self._mark_rich_unavailable(exc, "rich editMessageText"):
+                self.logger.debug("Stream rich edit rejected: {}", exc)
             return False
-        except Exception:
-            # Transport, rate-limit, and unexpected errors propagate so the
-            # final-edit retry contract stays intact: ChannelManager retries
-            # the buffered send instead of this handler doubling connection
-            # demand with an immediate legacy edit.
+        except Exception as exc:
+            if self._mark_rich_unavailable(exc, "rich editMessageText"):
+                return False
             raise
 
     async def send(self, msg: OutboundMessage) -> None:
@@ -1172,7 +1226,7 @@ class TelegramChannel(BaseChannel):
         resuming: bool = False,
         merge_next: bool = False,
     ) -> None:
-        """Progressive message editing: send on first delta, edit on subsequent ones."""
+        """Stream one persistent message, using rich edits when configured."""
         app = await self._wait_for_app()
         if app is None:
             return
@@ -1198,20 +1252,16 @@ class TelegramChannel(BaseChannel):
                 thread_kwargs["message_thread_id"] = message_thread_id
             raw_text = buf.text
 
-            # Try upgrading the streaming preview to rich in place (Bot API 10.1:
-            # editMessageText gained a rich_message parameter). Editing in place
-            # keeps the message identity, so there is no delete-and-resend and
-            # none of the flickering / dropped line breaks from issue #4470.
-            # The previous branch here was unreachable: it was guarded by
-            # ``not buf.message_id`` after an early return had already ensured
-            # ``buf.message_id`` is set (issue #5516).
-            if self.config.rich_messages and not getattr(self, "_rich_send_disabled", False):
-                rich_ok = await self._try_edit_rich(int_chat_id, buf.message_id, raw_text)
-                if rich_ok:
+            # A streamed message can be converted to rich content in place.
+            # This avoids the duplicate/flicker caused by send + delete.
+            if self._rich_streaming_enabled() and len(raw_text) <= TELEGRAM_RICH_MAX_LEN:
+                if await self._try_edit_stream_rich(
+                    int_chat_id, buf.message_id, raw_text,
+                ):
                     self._stream_bufs.pop(chat_id, None)
                     return
 
-            # Legacy path: edit existing streaming message with HTML
+            # Legacy finalization after rich is disabled, rejected, or oversized.
             html_chunks = _split_telegram_markdown_html(raw_text, TELEGRAM_HTML_MAX_LEN)
             primary_html = html_chunks[0]
             extra_html_chunks = html_chunks[1:]
@@ -1222,16 +1272,16 @@ class TelegramChannel(BaseChannel):
                     text=primary_html, parse_mode="HTML",
                 )
             except BadRequest as e:
-                # Only fall back to plain text on actual HTML parse/format errors.
-                # Network errors (TimedOut, NetworkError) should propagate immediately
-                # to avoid doubling connection demand during pool exhaustion.
                 if self._is_not_modified_error(e):
                     self.logger.debug("Final stream edit already applied for {}", chat_id)
                     self._stream_bufs.pop(chat_id, None)
                     return
                 self.logger.debug("Final stream edit failed (HTML), trying plain: {}", e)
-                # Fall back to raw markdown (not HTML) so users don't see raw tags.
-                primary_plain = split_message(raw_text, TELEGRAM_MAX_MESSAGE_LEN)[0] if len(raw_text) > TELEGRAM_MAX_MESSAGE_LEN else raw_text
+                primary_plain = (
+                    split_message(raw_text, TELEGRAM_MAX_MESSAGE_LEN)[0]
+                    if len(raw_text) > TELEGRAM_MAX_MESSAGE_LEN
+                    else raw_text
+                )
                 try:
                     await self._call_with_retry(
                         app.bot.edit_message_text,
@@ -1243,7 +1293,7 @@ class TelegramChannel(BaseChannel):
                         self.logger.debug("Final stream plain edit already applied for {}", chat_id)
                     else:
                         self.logger.warning("Final stream edit failed: {}", e2)
-                        raise  # Let ChannelManager handle retry
+                        raise
             for extra_html_chunk in extra_html_chunks:
                 try:
                     await self._call_with_retry(
@@ -1253,13 +1303,20 @@ class TelegramChannel(BaseChannel):
                         **thread_kwargs,
                     )
                 except Exception:
-                    # Fall back to _send_text which handles HTML→plain gracefully.
-                    await self._send_text(int_chat_id, extra_html_chunk)
+                    await self._send_text(
+                        int_chat_id,
+                        extra_html_chunk,
+                        thread_kwargs=thread_kwargs,
+                    )
             self._stream_bufs.pop(chat_id, None)
             return
 
         buf = self._stream_bufs.get(chat_id)
-        if buf is None or (stream_id is not None and buf.stream_id is not None and buf.stream_id != stream_id):
+        if buf is None or (
+            stream_id is not None
+            and buf.stream_id is not None
+            and buf.stream_id != stream_id
+        ):
             buf = _StreamBuf(stream_id=stream_id)
             self._stream_bufs[chat_id] = buf
         elif buf.stream_id is None:
@@ -1274,25 +1331,43 @@ class TelegramChannel(BaseChannel):
         if message_thread_id := meta.get("message_thread_id"):
             stream_thread_kwargs["message_thread_id"] = message_thread_id
         if buf.message_id is None:
-            preview = _strip_md_block(buf.text)
             try:
-                sent = await self._call_with_retry(
-                    app.bot.send_message,
-                    chat_id=int_chat_id, text=preview,
-                    **stream_thread_kwargs,
-                )
-                buf.message_id = sent.message_id
+                if self._rich_streaming_enabled() and len(buf.text) <= TELEGRAM_RICH_MAX_LEN:
+                    buf.message_id = await self._try_send_stream_rich(
+                        int_chat_id, buf.text, stream_thread_kwargs,
+                    )
+                if buf.message_id is None:
+                    preview = _strip_md_block(buf.text)
+                    sent = await self._call_with_retry(
+                        app.bot.send_message,
+                        chat_id=int_chat_id, text=preview,
+                        **stream_thread_kwargs,
+                    )
+                    buf.message_id = sent.message_id
                 buf.last_edit = now
             except Exception as e:
                 self.logger.warning("Stream initial send failed: {}", e)
-                raise  # Let ChannelManager handle retry
+                raise
         elif (now - buf.last_edit) >= self.config.stream_edit_interval:
-            if len(buf.text) > TELEGRAM_MAX_MESSAGE_LEN:
-                await self._flush_stream_overflow(int_chat_id, buf, stream_thread_kwargs)
+            overflow_limit = (
+                TELEGRAM_RICH_MAX_LEN
+                if self._rich_streaming_enabled()
+                else TELEGRAM_MAX_MESSAGE_LEN
+            )
+            if len(buf.text) > overflow_limit:
+                await self._flush_stream_overflow(
+                    int_chat_id, buf, stream_thread_kwargs,
+                )
                 buf.last_edit = now
                 return
-            preview = _strip_md_block(buf.text)
             try:
+                if self._rich_streaming_enabled():
+                    if await self._try_edit_stream_rich(
+                        int_chat_id, buf.message_id, buf.text,
+                    ):
+                        buf.last_edit = now
+                        return
+                preview = _strip_md_block(buf.text)
                 await self._call_with_retry(
                     app.bot.edit_message_text,
                     chat_id=int_chat_id, message_id=buf.message_id,
@@ -1304,7 +1379,7 @@ class TelegramChannel(BaseChannel):
                     buf.last_edit = now
                     return
                 self.logger.warning("Stream edit failed: {}", e)
-                raise  # Let ChannelManager handle retry
+                raise
 
     async def _flush_stream_overflow(
         self,
@@ -1312,12 +1387,52 @@ class TelegramChannel(BaseChannel):
         buf: "_StreamBuf",
         thread_kwargs: dict[str, int],
     ) -> None:
-        """Split an oversized stream buffer mid-flight.
+        """Commit full rich chunks and continue streaming into a rich tail.
 
-        Edits the current stream message with the first chunk, sends any
-        intermediate chunks as standalone messages, then opens a new message
-        for the tail so subsequent deltas continue streaming into it.
+        Rich chunks use the 32,768-character limit and preserve raw Markdown.
+        If Telegram rejects rich formatting, the same buffer is flushed through
+        the established HTML/plain path without losing stream state.
         """
+        if self._rich_streaming_enabled():
+            chunks = _split_telegram_markdown(buf.text, TELEGRAM_RICH_MAX_LEN)
+            if len(chunks) <= 1:
+                return
+
+            first_markdown = chunks[0]
+            if await self._try_edit_stream_rich(
+                chat_id,
+                cast(int, buf.message_id),
+                first_markdown,
+            ):
+                for markdown in chunks[1:-1]:
+                    message_id = await self._try_send_stream_rich(
+                        chat_id, markdown, thread_kwargs,
+                    )
+                    if message_id is None:
+                        raise RuntimeError(
+                            "Rich messages became unavailable while flushing stream overflow"
+                        )
+                markdown_tail = chunks[-1]
+                tail_message_id = await self._try_send_stream_rich(
+                    chat_id, markdown_tail, thread_kwargs,
+                )
+                if tail_message_id is None:
+                    raise RuntimeError(
+                        "Rich messages became unavailable while opening overflow tail"
+                    )
+                buf.message_id = tail_message_id
+                buf.text = markdown_tail
+                return
+
+        await self._flush_stream_overflow_legacy(chat_id, buf, thread_kwargs)
+
+    async def _flush_stream_overflow_legacy(
+        self,
+        chat_id: int,
+        buf: "_StreamBuf",
+        thread_kwargs: dict[str, int],
+    ) -> None:
+        """Legacy HTML/plain overflow path used when rich messaging is absent."""
         chunks = _split_telegram_markdown_html_chunks(buf.text, TELEGRAM_HTML_MAX_LEN)
         if len(chunks) <= 1:
             return

--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -51,6 +51,7 @@ TELEGRAM_HTML_MAX_LEN = 4096
 # so multibyte text must not be split at an encoded-byte boundary.
 TELEGRAM_RICH_MAX_LEN = 32768
 TELEGRAM_REPLY_CONTEXT_MAX_LEN = TELEGRAM_MAX_MESSAGE_LEN  # Max length for reply context in user message
+TELEGRAM_RICH_DRAFT_MIN_INTERVAL = 0.75  # 40 draft updates per 30 seconds per chat
 
 # python-telegram-bot exposes a six-parameter Application generic. Nanobot
 # doesn't customize its context/data/job-queue types, so keep that SDK boundary
@@ -391,6 +392,7 @@ class _StreamBuf:
     """Per-chat streaming accumulator for progressive message editing."""
     text: str = ""
     message_id: int | None = None
+    draft_id: int | None = None
     last_edit: float = 0.0
     stream_id: str | None = None
 
@@ -852,24 +854,6 @@ class TelegramChannel(BaseChannel):
     def _rich_message_payload(content: str) -> dict[str, str]:
         return {"markdown": content}
 
-    @staticmethod
-    def _rich_result_message_id(result: Any) -> int | None:
-        """Extract a message id from PTB's raw ``do_api_request`` result."""
-        value: Any = None
-        if isinstance(result, dict):
-            value = cast(dict[str, Any], result).get("message_id")
-            if value is None:
-                nested = cast(dict[str, Any], result).get("result")
-                if isinstance(nested, dict):
-                    value = cast(dict[str, Any], nested).get("message_id")
-        else:
-            value = getattr(result, "message_id", None)
-        if isinstance(value, bool) or value is None:
-            return None
-        with suppress(TypeError, ValueError):
-            return int(value)
-        return None
-
     def _mark_rich_unavailable(self, exc: Exception, operation: str) -> bool:
         if not self._is_rich_capability_error(exc):
             return False
@@ -933,15 +917,51 @@ class TelegramChannel(BaseChannel):
             self.logger.debug("sendRichMessage failed: {}", exc)
             return False
 
+    @staticmethod
+    def _new_rich_draft_id() -> int:
+        """Return a non-zero Bot API Integer suitable for one live draft."""
+        return time.time_ns() % 2_147_483_647 or 1
+
+    async def _try_send_rich_draft(
+        self,
+        chat_id: int,
+        draft_id: int,
+        content: str,
+        thread_kwargs: dict[str, int],
+    ) -> bool:
+        """Create or update the ephemeral rich preview for a private chat."""
+        app = self._require_app()
+        payload: dict[str, Any] = {
+            "chat_id": chat_id,
+            "draft_id": draft_id,
+            "rich_message": self._rich_message_payload(content),
+            **thread_kwargs,
+        }
+        try:
+            await self._call_with_retry(
+                app.bot.do_api_request,
+                "sendRichMessageDraft",
+                api_kwargs=payload,
+            )
+            return True
+        except BadRequest as exc:
+            if not self._mark_rich_unavailable(exc, "sendRichMessageDraft"):
+                self.logger.debug("Rich draft rejected: {}", exc)
+            return False
+        except Exception as exc:
+            if self._mark_rich_unavailable(exc, "sendRichMessageDraft"):
+                return False
+            raise
+
     async def _try_send_stream_rich(
         self,
         chat_id: int,
         content: str,
         thread_kwargs: dict[str, int],
-    ) -> int | None:
-        """Send a persistent rich stream message and return its message id.
+    ) -> bool:
+        """Persist one completed rich stream chunk.
 
-        ``None`` means Telegram rejected rich formatting before delivery and the
+        ``False`` means Telegram rejected rich formatting before delivery and the
         caller may use the legacy path. Transport failures propagate because an
         ambiguous resend could duplicate a message that Telegram already stored.
         """
@@ -952,7 +972,7 @@ class TelegramChannel(BaseChannel):
             **thread_kwargs,
         }
         try:
-            result = await self._call_with_retry(
+            await self._call_with_retry(
                 app.bot.do_api_request,
                 "sendRichMessage",
                 api_kwargs=payload,
@@ -960,16 +980,34 @@ class TelegramChannel(BaseChannel):
         except BadRequest as exc:
             if not self._mark_rich_unavailable(exc, "sendRichMessage"):
                 self.logger.debug("Stream rich send rejected: {}", exc)
-            return None
+            return False
         except Exception as exc:
             if self._mark_rich_unavailable(exc, "sendRichMessage"):
-                return None
+                return False
             raise
+        return True
 
-        message_id = self._rich_result_message_id(result)
-        if message_id is None:
-            raise RuntimeError("sendRichMessage returned no message_id")
-        return message_id
+    async def _start_legacy_stream(
+        self,
+        chat_id: int,
+        buf: "_StreamBuf",
+        thread_kwargs: dict[str, int],
+    ) -> None:
+        """Replace a rejected rich draft with an editable plain-text tail."""
+        app = self._require_app()
+        chunks = _split_telegram_markdown_html_chunks(buf.text, TELEGRAM_HTML_MAX_LEN)
+        for markdown, _ in chunks[:-1]:
+            await self._send_text(chat_id, markdown, thread_kwargs=thread_kwargs)
+        tail = chunks[-1][0]
+        sent = await self._call_with_retry(
+            app.bot.send_message,
+            chat_id=chat_id,
+            text=_strip_md_block(tail),
+            **thread_kwargs,
+        )
+        buf.text = tail
+        buf.message_id = sent.message_id
+        buf.draft_id = None
 
     async def _try_edit_stream_rich(
         self,
@@ -1226,7 +1264,7 @@ class TelegramChannel(BaseChannel):
         resuming: bool = False,
         merge_next: bool = False,
     ) -> None:
-        """Stream one persistent message, using rich edits when configured."""
+        """Stream a rich draft in private chats, then persist the final message."""
         app = await self._wait_for_app()
         if app is None:
             return
@@ -1239,7 +1277,7 @@ class TelegramChannel(BaseChannel):
             stream_end = False
         if stream_end:
             buf = self._stream_bufs.get(chat_id)
-            if not buf or not buf.message_id or not buf.text:
+            if not buf or not buf.text or (buf.message_id is None and buf.draft_id is None):
                 return
             if stream_id is not None and buf.stream_id is not None and buf.stream_id != stream_id:
                 return
@@ -1252,11 +1290,31 @@ class TelegramChannel(BaseChannel):
                 thread_kwargs["message_thread_id"] = message_thread_id
             raw_text = buf.text
 
-            # A streamed message can be converted to rich content in place.
-            # This avoids the duplicate/flicker caused by send + delete.
+            if buf.draft_id is not None:
+                rich_chunks = _split_telegram_markdown(raw_text, TELEGRAM_RICH_MAX_LEN)
+                for index, rich_chunk in enumerate(rich_chunks):
+                    if await self._try_send_stream_rich(
+                        int_chat_id, rich_chunk, thread_kwargs,
+                    ):
+                        continue
+                    for remaining in rich_chunks[index:]:
+                        for legacy_chunk in _split_telegram_markdown(
+                            remaining, TELEGRAM_MAX_MESSAGE_LEN,
+                        ):
+                            await self._send_text(
+                                int_chat_id,
+                                legacy_chunk,
+                                thread_kwargs=thread_kwargs,
+                            )
+                    break
+                self._stream_bufs.pop(chat_id, None)
+                return
+
+            # Group chats and streams that rejected drafts use an editable
+            # persistent preview, which can still be upgraded on finalization.
             if self._rich_streaming_enabled() and len(raw_text) <= TELEGRAM_RICH_MAX_LEN:
                 if await self._try_edit_stream_rich(
-                    int_chat_id, buf.message_id, raw_text,
+                    int_chat_id, cast(int, buf.message_id), raw_text,
                 ):
                     self._stream_bufs.pop(chat_id, None)
                     return
@@ -1330,30 +1388,37 @@ class TelegramChannel(BaseChannel):
         stream_thread_kwargs: dict[str, int] = {}
         if message_thread_id := meta.get("message_thread_id"):
             stream_thread_kwargs["message_thread_id"] = message_thread_id
-        if buf.message_id is None:
+        rich_draft_allowed = (
+            self._rich_streaming_enabled() and meta.get("is_group") is False
+        )
+        if buf.message_id is None and buf.draft_id is None:
             try:
-                if self._rich_streaming_enabled() and len(buf.text) <= TELEGRAM_RICH_MAX_LEN:
-                    buf.message_id = await self._try_send_stream_rich(
-                        int_chat_id, buf.text, stream_thread_kwargs,
+                if rich_draft_allowed and len(buf.text) <= TELEGRAM_RICH_MAX_LEN:
+                    buf.draft_id = self._new_rich_draft_id()
+                    if not await self._try_send_rich_draft(
+                        int_chat_id,
+                        buf.draft_id,
+                        buf.text,
+                        stream_thread_kwargs,
+                    ):
+                        buf.draft_id = None
+                if buf.draft_id is None:
+                    await self._start_legacy_stream(
+                        int_chat_id, buf, stream_thread_kwargs,
                     )
-                if buf.message_id is None:
-                    preview = _strip_md_block(buf.text)
-                    sent = await self._call_with_retry(
-                        app.bot.send_message,
-                        chat_id=int_chat_id, text=preview,
-                        **stream_thread_kwargs,
-                    )
-                    buf.message_id = sent.message_id
                 buf.last_edit = now
             except Exception as e:
                 self.logger.warning("Stream initial send failed: {}", e)
                 raise
-        elif (now - buf.last_edit) >= self.config.stream_edit_interval:
-            overflow_limit = (
-                TELEGRAM_RICH_MAX_LEN
-                if self._rich_streaming_enabled()
-                else TELEGRAM_MAX_MESSAGE_LEN
+        else:
+            edit_interval = (
+                max(self.config.stream_edit_interval, TELEGRAM_RICH_DRAFT_MIN_INTERVAL)
+                if buf.draft_id is not None
+                else self.config.stream_edit_interval
             )
+            if (now - buf.last_edit) < edit_interval:
+                return
+            overflow_limit = TELEGRAM_RICH_MAX_LEN if buf.draft_id is not None else TELEGRAM_MAX_MESSAGE_LEN
             if len(buf.text) > overflow_limit:
                 await self._flush_stream_overflow(
                     int_chat_id, buf, stream_thread_kwargs,
@@ -1361,12 +1426,20 @@ class TelegramChannel(BaseChannel):
                 buf.last_edit = now
                 return
             try:
-                if self._rich_streaming_enabled():
-                    if await self._try_edit_stream_rich(
-                        int_chat_id, buf.message_id, buf.text,
+                if buf.draft_id is not None:
+                    if await self._try_send_rich_draft(
+                        int_chat_id,
+                        buf.draft_id,
+                        buf.text,
+                        stream_thread_kwargs,
                     ):
                         buf.last_edit = now
                         return
+                    await self._start_legacy_stream(
+                        int_chat_id, buf, stream_thread_kwargs,
+                    )
+                    buf.last_edit = now
+                    return
                 preview = _strip_md_block(buf.text)
                 await self._call_with_retry(
                     app.bot.edit_message_text,
@@ -1387,42 +1460,32 @@ class TelegramChannel(BaseChannel):
         buf: "_StreamBuf",
         thread_kwargs: dict[str, int],
     ) -> None:
-        """Commit full rich chunks and continue streaming into a rich tail.
+        """Persist full chunks and continue streaming into a new draft tail.
 
         Rich chunks use the 32,768-character limit and preserve raw Markdown.
         If Telegram rejects rich formatting, the same buffer is flushed through
         the established HTML/plain path without losing stream state.
         """
-        if self._rich_streaming_enabled():
+        if buf.draft_id is not None and self._rich_streaming_enabled():
             chunks = _split_telegram_markdown(buf.text, TELEGRAM_RICH_MAX_LEN)
             if len(chunks) <= 1:
                 return
 
-            first_markdown = chunks[0]
-            if await self._try_edit_stream_rich(
-                chat_id,
-                cast(int, buf.message_id),
-                first_markdown,
-            ):
-                for markdown in chunks[1:-1]:
-                    message_id = await self._try_send_stream_rich(
-                        chat_id, markdown, thread_kwargs,
-                    )
-                    if message_id is None:
-                        raise RuntimeError(
-                            "Rich messages became unavailable while flushing stream overflow"
-                        )
-                markdown_tail = chunks[-1]
-                tail_message_id = await self._try_send_stream_rich(
-                    chat_id, markdown_tail, thread_kwargs,
-                )
-                if tail_message_id is None:
-                    raise RuntimeError(
-                        "Rich messages became unavailable while opening overflow tail"
-                    )
-                buf.message_id = tail_message_id
-                buf.text = markdown_tail
+            for index, markdown in enumerate(chunks[:-1]):
+                if await self._try_send_stream_rich(chat_id, markdown, thread_kwargs):
+                    continue
+                buf.text = "\n".join(chunks[index:])
+                await self._start_legacy_stream(chat_id, buf, thread_kwargs)
                 return
+
+            buf.text = chunks[-1]
+            buf.draft_id = self._new_rich_draft_id()
+            if await self._try_send_rich_draft(
+                chat_id, buf.draft_id, buf.text, thread_kwargs,
+            ):
+                return
+            await self._start_legacy_stream(chat_id, buf, thread_kwargs)
+            return
 
         await self._flush_stream_overflow_legacy(chat_id, buf, thread_kwargs)
 

--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -25,7 +25,7 @@ from telegram import (
     Update,
     User,
 )
-from telegram.error import BadRequest, InvalidToken, NetworkError, TimedOut
+from telegram.error import BadRequest, InvalidToken, NetworkError, RetryAfter, TimedOut
 from telegram.ext import Application, CallbackQueryHandler, ContextTypes, MessageHandler, filters
 from telegram.request import BaseRequest, HTTPXRequest
 
@@ -962,8 +962,9 @@ class TelegramChannel(BaseChannel):
         """Persist one completed rich stream chunk.
 
         ``False`` means Telegram rejected rich formatting before delivery and the
-        caller may use the legacy path. Transport failures propagate because an
-        ambiguous resend could duplicate a message that Telegram already stored.
+        caller may use the legacy path. A timeout is treated as an ambiguous
+        success: retrying this non-idempotent method could duplicate a message
+        that Telegram already stored.
         """
         app = self._require_app()
         payload: dict[str, Any] = {
@@ -972,8 +973,7 @@ class TelegramChannel(BaseChannel):
             **thread_kwargs,
         }
         try:
-            await self._call_with_retry(
-                app.bot.do_api_request,
+            await app.bot.do_api_request(
                 "sendRichMessage",
                 api_kwargs=payload,
             )
@@ -981,6 +981,11 @@ class TelegramChannel(BaseChannel):
             if not self._mark_rich_unavailable(exc, "sendRichMessage"):
                 self.logger.debug("Stream rich send rejected: {}", exc)
             return False
+        except TimedOut as exc:
+            self.logger.warning(
+                "Stream rich send timed out; delivery is ambiguous, not retrying: {}", exc
+            )
+            return True
         except Exception as exc:
             if self._mark_rich_unavailable(exc, "sendRichMessage"):
                 return False
@@ -996,8 +1001,9 @@ class TelegramChannel(BaseChannel):
         """Replace a rejected rich draft with an editable plain-text tail."""
         app = self._require_app()
         chunks = _split_telegram_markdown_html_chunks(buf.text, TELEGRAM_HTML_MAX_LEN)
-        for markdown, _ in chunks[:-1]:
+        for index, (markdown, _) in enumerate(chunks[:-1]):
             await self._send_text(chat_id, markdown, thread_kwargs=thread_kwargs)
+            buf.text = "\n".join(markdown for markdown, _ in chunks[index + 1:])
         tail = chunks[-1][0]
         sent = await self._call_with_retry(
             app.bot.send_message,
@@ -1008,48 +1014,6 @@ class TelegramChannel(BaseChannel):
         buf.text = tail
         buf.message_id = sent.message_id
         buf.draft_id = None
-
-    async def _try_edit_stream_rich(
-        self,
-        chat_id: int,
-        message_id: int,
-        content: str,
-    ) -> bool:
-        """Edit a stream message in place through ``rich_message``.
-
-        Rich edits are valid for both text and rich messages. A parser or
-        capability rejection returns False so the caller can retain the legacy
-        HTML/plain fallback. Transport failures propagate for normal retry.
-        """
-        app = self._require_app()
-        payload: dict[str, Any] = {
-            "chat_id": chat_id,
-            "message_id": message_id,
-            "rich_message": self._rich_message_payload(content),
-        }
-        try:
-            await self._call_with_retry(
-                app.bot.do_api_request,
-                "editMessageText",
-                api_kwargs=payload,
-            )
-            return True
-        except BadRequest as exc:
-            if self._is_not_modified_error(exc):
-                return True
-            # Before Bot API 10.1, editMessageText ignores rich_message and
-            # reports the absent text argument instead.
-            if content and str(exc).strip().lower() == "message text is empty":
-                self._rich_send_disabled = True
-                self.logger.debug("rich editMessageText unavailable, disabling rich messages")
-                return False
-            if not self._mark_rich_unavailable(exc, "rich editMessageText"):
-                self.logger.debug("Stream rich edit rejected: {}", exc)
-            return False
-        except Exception as exc:
-            if self._mark_rich_unavailable(exc, "rich editMessageText"):
-                return False
-            raise
 
     async def send(self, msg: OutboundMessage) -> None:
         """Send a message through Telegram."""
@@ -1184,8 +1148,6 @@ class TelegramChannel(BaseChannel):
         **kwargs: Any,
     ) -> _T:
         """Call an async Telegram API function with retry on pool/network timeout and RetryAfter."""
-        from telegram.error import RetryAfter
-
         for attempt in range(1, _SEND_MAX_RETRIES + 1):
             try:
                 return await fn(*args, **kwargs)
@@ -1293,33 +1255,27 @@ class TelegramChannel(BaseChannel):
             if buf.draft_id is not None:
                 rich_chunks = _split_telegram_markdown(raw_text, TELEGRAM_RICH_MAX_LEN)
                 for index, rich_chunk in enumerate(rich_chunks):
-                    if await self._try_send_stream_rich(
+                    if self._rich_streaming_enabled() and await self._try_send_stream_rich(
                         int_chat_id, rich_chunk, thread_kwargs,
                     ):
+                        buf.text = "\n".join(rich_chunks[index + 1:])
                         continue
-                    for remaining in rich_chunks[index:]:
-                        for legacy_chunk in _split_telegram_markdown(
-                            remaining, TELEGRAM_MAX_MESSAGE_LEN,
-                        ):
-                            await self._send_text(
-                                int_chat_id,
-                                legacy_chunk,
-                                thread_kwargs=thread_kwargs,
-                            )
+                    legacy_chunks = [
+                        chunk
+                        for remaining in rich_chunks[index:]
+                        for chunk in _split_telegram_markdown(remaining, TELEGRAM_MAX_MESSAGE_LEN)
+                    ]
+                    for legacy_index, legacy_chunk in enumerate(legacy_chunks):
+                        await self._send_text(
+                            int_chat_id, legacy_chunk, thread_kwargs=thread_kwargs,
+                        )
+                        buf.text = "\n".join(legacy_chunks[legacy_index + 1:])
                     break
                 self._stream_bufs.pop(chat_id, None)
                 return
 
-            # Group chats and streams that rejected drafts use an editable
-            # persistent preview, which can still be upgraded on finalization.
-            if self._rich_streaming_enabled() and len(raw_text) <= TELEGRAM_RICH_MAX_LEN:
-                if await self._try_edit_stream_rich(
-                    int_chat_id, cast(int, buf.message_id), raw_text,
-                ):
-                    self._stream_bufs.pop(chat_id, None)
-                    return
-
-            # Legacy finalization after rich is disabled, rejected, or oversized.
+            # Group chats and streams that rejected drafts keep the established
+            # HTML/plain finalization path. Native rich drafts are private-only.
             html_chunks = _split_telegram_markdown_html(raw_text, TELEGRAM_HTML_MAX_LEN)
             primary_html = html_chunks[0]
             extra_html_chunks = html_chunks[1:]
@@ -1420,9 +1376,18 @@ class TelegramChannel(BaseChannel):
                 return
             overflow_limit = TELEGRAM_RICH_MAX_LEN if buf.draft_id is not None else TELEGRAM_MAX_MESSAGE_LEN
             if len(buf.text) > overflow_limit:
-                await self._flush_stream_overflow(
-                    int_chat_id, buf, stream_thread_kwargs,
-                )
+                try:
+                    await self._flush_stream_overflow(
+                        int_chat_id, buf, stream_thread_kwargs,
+                    )
+                except (NetworkError, RetryAfter) as exc:
+                    self.logger.warning(
+                        "Stream overflow flush paused with unsent content: {}", exc
+                    )
+                    # Persisted chunks have already been removed from ``buf``.
+                    # Let the next delta or stream_end resume that tail; manager
+                    # retry would append this same delta a second time.
+                    return
                 buf.last_edit = now
                 return
             try:
@@ -1466,19 +1431,22 @@ class TelegramChannel(BaseChannel):
         If Telegram rejects rich formatting, the same buffer is flushed through
         the established HTML/plain path without losing stream state.
         """
-        if buf.draft_id is not None and self._rich_streaming_enabled():
+        if buf.draft_id is not None:
+            if not self._rich_streaming_enabled():
+                await self._start_legacy_stream(chat_id, buf, thread_kwargs)
+                return
             chunks = _split_telegram_markdown(buf.text, TELEGRAM_RICH_MAX_LEN)
             if len(chunks) <= 1:
                 return
 
             for index, markdown in enumerate(chunks[:-1]):
                 if await self._try_send_stream_rich(chat_id, markdown, thread_kwargs):
+                    buf.text = "\n".join(chunks[index + 1:])
                     continue
                 buf.text = "\n".join(chunks[index:])
                 await self._start_legacy_stream(chat_id, buf, thread_kwargs)
                 return
 
-            buf.text = chunks[-1]
             buf.draft_id = self._new_rich_draft_id()
             if await self._try_send_rich_draft(
                 chat_id, buf.draft_id, buf.text, thread_kwargs,

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -18,6 +18,7 @@ from nanobot.bus.queue import MessageBus
 from nanobot.channels.telegram.runtime import (
     TELEGRAM_MAX_MESSAGE_LEN,
     TELEGRAM_REPLY_CONTEXT_MAX_LEN,
+    TELEGRAM_RICH_MAX_LEN,
     TelegramChannel,
     TelegramConfig,
     _markdown_to_telegram_html,
@@ -904,6 +905,217 @@ async def test_rich_messages_default_skips_send_rich_message() -> None:
     channel._app.bot.do_api_request.assert_not_called()
     assert len(channel._app.bot.sent_messages) == 1
     assert channel._app.bot.sent_messages[0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_send_delta_rich_stream_sends_and_edits_one_persistent_message() -> None:
+    channel = TelegramChannel(
+        TelegramConfig(
+            enabled=True,
+            token="123:abc",
+            allow_from=["*"],
+            rich_messages=True,
+            stream_edit_interval=0.1,
+        ),
+        MessageBus(),
+    )
+    _install_ready_app(channel)
+    channel._app.bot.do_api_request = AsyncMock(
+        side_effect=[{"message_id": 71}, {"message_id": 71}, {"message_id": 71}]
+    )
+
+    await channel.send_delta(
+        "123", "# head", {"message_thread_id": 42}, stream_id="s:0",
+    )
+    channel._stream_bufs["123"].last_edit = 0.0
+    await channel.send_delta("123", "\n\n**body**", stream_id="s:0")
+    await channel.send_delta("123", "", stream_id="s:0", stream_end=True)
+
+    calls = channel._app.bot.do_api_request.call_args_list
+    assert [call.args[0] for call in calls] == [
+        "sendRichMessage",
+        "editMessageText",
+        "editMessageText",
+    ]
+    assert calls[0].kwargs["api_kwargs"] == {
+        "chat_id": 123,
+        "message_thread_id": 42,
+        "rich_message": {"markdown": "# head"},
+    }
+    assert calls[1].kwargs["api_kwargs"]["message_id"] == 71
+    assert calls[1].kwargs["api_kwargs"]["rich_message"] == {
+        "markdown": "# head\n\n**body**",
+    }
+    assert calls[2].kwargs["api_kwargs"]["message_id"] == 71
+    assert channel._app.bot.sent_messages == []
+    assert "123" not in channel._stream_bufs
+
+
+@pytest.mark.asyncio
+async def test_send_delta_rich_initial_rejection_falls_back_to_legacy_preview() -> None:
+    from telegram.error import BadRequest
+
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_messages=True),
+        MessageBus(),
+    )
+    _install_ready_app(channel)
+    channel._app.bot.do_api_request = AsyncMock(side_effect=BadRequest("can't parse rich message"))
+
+    await channel.send_delta("123", "# head", stream_id="s:0")
+
+    channel._app.bot.do_api_request.assert_awaited_once()
+    assert channel._rich_send_disabled is False
+    assert channel._app.bot.sent_messages[0]["text"] == "head"
+    assert channel._stream_bufs["123"].message_id == 1
+
+
+@pytest.mark.asyncio
+async def test_send_delta_rich_edit_rejection_falls_back_to_legacy_edit() -> None:
+    from telegram.error import BadRequest
+
+    channel = TelegramChannel(
+        TelegramConfig(
+            enabled=True,
+            token="123:abc",
+            allow_from=["*"],
+            rich_messages=True,
+            stream_edit_interval=0.1,
+        ),
+        MessageBus(),
+    )
+    _install_ready_app(channel)
+    channel._stream_bufs["123"] = _StreamBuf(
+        text="# head", message_id=7, last_edit=0.0, stream_id="s:0",
+    )
+    channel._app.bot.do_api_request = AsyncMock(side_effect=BadRequest("can't parse rich message"))
+    channel._app.bot.edit_message_text = AsyncMock()
+
+    await channel.send_delta("123", "\nbody", stream_id="s:0")
+
+    rich_kwargs = channel._app.bot.do_api_request.call_args.kwargs["api_kwargs"]
+    assert rich_kwargs["rich_message"] == {"markdown": "# head\nbody"}
+    channel._app.bot.edit_message_text.assert_awaited_once_with(
+        chat_id=123,
+        message_id=7,
+        text="head\nbody",
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_delta_rich_stream_end_edits_in_place_without_resend() -> None:
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_messages=True),
+        MessageBus(),
+    )
+    _install_ready_app(channel)
+    channel._stream_bufs["123"] = _StreamBuf(
+        text="# heading\n\n| a | b |\n|---|---|\n| 1 | 2 |",
+        message_id=7,
+        last_edit=0.0,
+        stream_id="s:0",
+    )
+    channel._app.bot.do_api_request = AsyncMock(return_value={"message_id": 7})
+    channel._app.bot.delete_message = AsyncMock()
+
+    await channel.send_delta("123", "", stream_id="s:0", stream_end=True)
+
+    call = channel._app.bot.do_api_request.call_args
+    assert call.args[0] == "editMessageText"
+    assert call.kwargs["api_kwargs"]["message_id"] == 7
+    assert call.kwargs["api_kwargs"]["rich_message"]["markdown"].startswith("# heading")
+    channel._app.bot.delete_message.assert_not_awaited()
+    assert channel._app.bot.sent_messages == []
+    assert "123" not in channel._stream_bufs
+
+
+@pytest.mark.asyncio
+async def test_send_delta_rich_does_not_flush_at_legacy_limit() -> None:
+    channel = TelegramChannel(
+        TelegramConfig(
+            enabled=True,
+            token="123:abc",
+            allow_from=["*"],
+            rich_messages=True,
+            stream_edit_interval=0.1,
+        ),
+        MessageBus(),
+    )
+    _install_ready_app(channel)
+    channel._stream_bufs["123"] = _StreamBuf(
+        text="x" * TELEGRAM_MAX_MESSAGE_LEN,
+        message_id=7,
+        last_edit=0.0,
+        stream_id="s:0",
+    )
+    channel._app.bot.do_api_request = AsyncMock(return_value={"message_id": 7})
+
+    await channel.send_delta("123", "y", stream_id="s:0")
+
+    channel._app.bot.do_api_request.assert_awaited_once()
+    call = channel._app.bot.do_api_request.call_args
+    assert call.args[0] == "editMessageText"
+    assert len(call.kwargs["api_kwargs"]["rich_message"]["markdown"]) == (
+        TELEGRAM_MAX_MESSAGE_LEN + 1
+    )
+    assert channel._app.bot.sent_messages == []
+    assert channel._stream_bufs["123"].text.endswith("y")
+
+
+@pytest.mark.asyncio
+async def test_flush_stream_overflow_uses_rich_limit_and_reanchors_tail() -> None:
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_messages=True),
+        MessageBus(),
+    )
+    _install_ready_app(channel)
+    text = "x" * TELEGRAM_RICH_MAX_LEN + "\n" + "**tail**"
+    channel._stream_bufs["123"] = _StreamBuf(
+        text=text,
+        message_id=7,
+        last_edit=0.0,
+        stream_id="s:0",
+    )
+    channel._app.bot.do_api_request = AsyncMock(
+        side_effect=[{"message_id": 7}, {"message_id": 99}]
+    )
+
+    await channel._flush_stream_overflow(
+        123, channel._stream_bufs["123"], {"message_thread_id": 42},
+    )
+
+    calls = channel._app.bot.do_api_request.call_args_list
+    assert [call.args[0] for call in calls] == ["editMessageText", "sendRichMessage"]
+    first = calls[0].kwargs["api_kwargs"]["rich_message"]["markdown"]
+    tail = calls[1].kwargs["api_kwargs"]["rich_message"]["markdown"]
+    assert len(first) <= TELEGRAM_RICH_MAX_LEN
+    assert len(tail) <= TELEGRAM_RICH_MAX_LEN
+    assert calls[1].kwargs["api_kwargs"]["message_thread_id"] == 42
+    assert channel._stream_bufs["123"].message_id == 99
+    assert channel._stream_bufs["123"].text == tail
+    assert channel._app.bot.sent_messages == []
+
+
+@pytest.mark.asyncio
+async def test_flush_stream_overflow_rich_limit_counts_unicode_characters() -> None:
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_messages=True),
+        MessageBus(),
+    )
+    _install_ready_app(channel)
+    text = "测" * TELEGRAM_RICH_MAX_LEN + "\n尾"
+    buf = _StreamBuf(text=text, message_id=7, last_edit=0.0, stream_id="s:0")
+    channel._app.bot.do_api_request = AsyncMock(
+        side_effect=[{"message_id": 7}, {"message_id": 99}]
+    )
+
+    await channel._flush_stream_overflow(123, buf, {})
+
+    calls = channel._app.bot.do_api_request.call_args_list
+    first = calls[0].kwargs["api_kwargs"]["rich_message"]["markdown"]
+    assert len(first) == TELEGRAM_RICH_MAX_LEN
+    assert len(first.encode("utf-8")) > TELEGRAM_RICH_MAX_LEN
+    assert buf.text == "尾"
 
 
 @pytest.mark.asyncio

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -18,6 +18,7 @@ from nanobot.bus.queue import MessageBus
 from nanobot.channels.telegram.runtime import (
     TELEGRAM_MAX_MESSAGE_LEN,
     TELEGRAM_REPLY_CONTEXT_MAX_LEN,
+    TELEGRAM_RICH_DRAFT_MIN_INTERVAL,
     TELEGRAM_RICH_MAX_LEN,
     TelegramChannel,
     TelegramConfig,
@@ -908,7 +909,7 @@ async def test_rich_messages_default_skips_send_rich_message() -> None:
 
 
 @pytest.mark.asyncio
-async def test_send_delta_rich_stream_sends_and_edits_one_persistent_message() -> None:
+async def test_send_delta_rich_stream_updates_one_draft_then_persists_final() -> None:
     channel = TelegramChannel(
         TelegramConfig(
             enabled=True,
@@ -920,33 +921,42 @@ async def test_send_delta_rich_stream_sends_and_edits_one_persistent_message() -
         MessageBus(),
     )
     _install_ready_app(channel)
-    channel._app.bot.do_api_request = AsyncMock(
-        side_effect=[{"message_id": 71}, {"message_id": 71}, {"message_id": 71}]
-    )
+    channel._app.bot.do_api_request = AsyncMock(return_value=True)
 
     await channel.send_delta(
-        "123", "# head", {"message_thread_id": 42}, stream_id="s:0",
+        "123",
+        "# head",
+        {"is_group": False, "message_thread_id": 42},
+        stream_id="s:0",
     )
+    draft_id = channel._stream_bufs["123"].draft_id
+    assert draft_id is not None and draft_id != 0
     channel._stream_bufs["123"].last_edit = 0.0
-    await channel.send_delta("123", "\n\n**body**", stream_id="s:0")
-    await channel.send_delta("123", "", stream_id="s:0", stream_end=True)
+    metadata = {"is_group": False, "message_thread_id": 42}
+    await channel.send_delta("123", "\n\n**body**", metadata, stream_id="s:0")
+    await channel.send_delta("123", "", metadata, stream_id="s:0", stream_end=True)
 
     calls = channel._app.bot.do_api_request.call_args_list
     assert [call.args[0] for call in calls] == [
+        "sendRichMessageDraft",
+        "sendRichMessageDraft",
         "sendRichMessage",
-        "editMessageText",
-        "editMessageText",
     ]
     assert calls[0].kwargs["api_kwargs"] == {
         "chat_id": 123,
+        "draft_id": draft_id,
         "message_thread_id": 42,
         "rich_message": {"markdown": "# head"},
     }
-    assert calls[1].kwargs["api_kwargs"]["message_id"] == 71
+    assert calls[1].kwargs["api_kwargs"]["draft_id"] == draft_id
     assert calls[1].kwargs["api_kwargs"]["rich_message"] == {
         "markdown": "# head\n\n**body**",
     }
-    assert calls[2].kwargs["api_kwargs"]["message_id"] == 71
+    assert "draft_id" not in calls[2].kwargs["api_kwargs"]
+    assert calls[2].kwargs["api_kwargs"]["message_thread_id"] == 42
+    assert calls[2].kwargs["api_kwargs"]["rich_message"] == {
+        "markdown": "# head\n\n**body**",
+    }
     assert channel._app.bot.sent_messages == []
     assert "123" not in channel._stream_bufs
 
@@ -962,16 +972,20 @@ async def test_send_delta_rich_initial_rejection_falls_back_to_legacy_preview() 
     _install_ready_app(channel)
     channel._app.bot.do_api_request = AsyncMock(side_effect=BadRequest("can't parse rich message"))
 
-    await channel.send_delta("123", "# head", stream_id="s:0")
+    await channel.send_delta(
+        "123", "# head", {"is_group": False}, stream_id="s:0",
+    )
 
     channel._app.bot.do_api_request.assert_awaited_once()
+    assert channel._app.bot.do_api_request.call_args.args[0] == "sendRichMessageDraft"
     assert channel._rich_send_disabled is False
     assert channel._app.bot.sent_messages[0]["text"] == "head"
     assert channel._stream_bufs["123"].message_id == 1
+    assert channel._stream_bufs["123"].draft_id is None
 
 
 @pytest.mark.asyncio
-async def test_send_delta_rich_edit_rejection_falls_back_to_legacy_edit() -> None:
+async def test_send_delta_rich_draft_rejection_falls_back_to_legacy_preview() -> None:
     from telegram.error import BadRequest
 
     channel = TelegramChannel(
@@ -986,24 +1000,23 @@ async def test_send_delta_rich_edit_rejection_falls_back_to_legacy_edit() -> Non
     )
     _install_ready_app(channel)
     channel._stream_bufs["123"] = _StreamBuf(
-        text="# head", message_id=7, last_edit=0.0, stream_id="s:0",
+        text="# head", draft_id=17, last_edit=0.0, stream_id="s:0",
     )
     channel._app.bot.do_api_request = AsyncMock(side_effect=BadRequest("can't parse rich message"))
-    channel._app.bot.edit_message_text = AsyncMock()
 
     await channel.send_delta("123", "\nbody", stream_id="s:0")
 
+    assert channel._app.bot.do_api_request.call_args.args[0] == "sendRichMessageDraft"
     rich_kwargs = channel._app.bot.do_api_request.call_args.kwargs["api_kwargs"]
+    assert rich_kwargs["draft_id"] == 17
     assert rich_kwargs["rich_message"] == {"markdown": "# head\nbody"}
-    channel._app.bot.edit_message_text.assert_awaited_once_with(
-        chat_id=123,
-        message_id=7,
-        text="head\nbody",
-    )
+    assert channel._app.bot.sent_messages[0]["text"] == "head\nbody"
+    assert channel._stream_bufs["123"].message_id == 1
+    assert channel._stream_bufs["123"].draft_id is None
 
 
 @pytest.mark.asyncio
-async def test_send_delta_rich_stream_end_edits_in_place_without_resend() -> None:
+async def test_send_delta_rich_stream_end_persists_draft_with_send_rich_message() -> None:
     channel = TelegramChannel(
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_messages=True),
         MessageBus(),
@@ -1011,18 +1024,18 @@ async def test_send_delta_rich_stream_end_edits_in_place_without_resend() -> Non
     _install_ready_app(channel)
     channel._stream_bufs["123"] = _StreamBuf(
         text="# heading\n\n| a | b |\n|---|---|\n| 1 | 2 |",
-        message_id=7,
+        draft_id=17,
         last_edit=0.0,
         stream_id="s:0",
     )
-    channel._app.bot.do_api_request = AsyncMock(return_value={"message_id": 7})
+    channel._app.bot.do_api_request = AsyncMock(return_value=True)
     channel._app.bot.delete_message = AsyncMock()
 
     await channel.send_delta("123", "", stream_id="s:0", stream_end=True)
 
     call = channel._app.bot.do_api_request.call_args
-    assert call.args[0] == "editMessageText"
-    assert call.kwargs["api_kwargs"]["message_id"] == 7
+    assert call.args[0] == "sendRichMessage"
+    assert "draft_id" not in call.kwargs["api_kwargs"]
     assert call.kwargs["api_kwargs"]["rich_message"]["markdown"].startswith("# heading")
     channel._app.bot.delete_message.assert_not_awaited()
     assert channel._app.bot.sent_messages == []
@@ -1044,17 +1057,18 @@ async def test_send_delta_rich_does_not_flush_at_legacy_limit() -> None:
     _install_ready_app(channel)
     channel._stream_bufs["123"] = _StreamBuf(
         text="x" * TELEGRAM_MAX_MESSAGE_LEN,
-        message_id=7,
+        draft_id=17,
         last_edit=0.0,
         stream_id="s:0",
     )
-    channel._app.bot.do_api_request = AsyncMock(return_value={"message_id": 7})
+    channel._app.bot.do_api_request = AsyncMock(return_value=True)
 
     await channel.send_delta("123", "y", stream_id="s:0")
 
     channel._app.bot.do_api_request.assert_awaited_once()
     call = channel._app.bot.do_api_request.call_args
-    assert call.args[0] == "editMessageText"
+    assert call.args[0] == "sendRichMessageDraft"
+    assert call.kwargs["api_kwargs"]["draft_id"] == 17
     assert len(call.kwargs["api_kwargs"]["rich_message"]["markdown"]) == (
         TELEGRAM_MAX_MESSAGE_LEN + 1
     )
@@ -1072,26 +1086,28 @@ async def test_flush_stream_overflow_uses_rich_limit_and_reanchors_tail() -> Non
     text = "x" * TELEGRAM_RICH_MAX_LEN + "\n" + "**tail**"
     channel._stream_bufs["123"] = _StreamBuf(
         text=text,
-        message_id=7,
+        draft_id=17,
         last_edit=0.0,
         stream_id="s:0",
     )
-    channel._app.bot.do_api_request = AsyncMock(
-        side_effect=[{"message_id": 7}, {"message_id": 99}]
-    )
+    channel._app.bot.do_api_request = AsyncMock(return_value=True)
 
     await channel._flush_stream_overflow(
         123, channel._stream_bufs["123"], {"message_thread_id": 42},
     )
 
     calls = channel._app.bot.do_api_request.call_args_list
-    assert [call.args[0] for call in calls] == ["editMessageText", "sendRichMessage"]
+    assert [call.args[0] for call in calls] == [
+        "sendRichMessage",
+        "sendRichMessageDraft",
+    ]
     first = calls[0].kwargs["api_kwargs"]["rich_message"]["markdown"]
     tail = calls[1].kwargs["api_kwargs"]["rich_message"]["markdown"]
     assert len(first) <= TELEGRAM_RICH_MAX_LEN
     assert len(tail) <= TELEGRAM_RICH_MAX_LEN
     assert calls[1].kwargs["api_kwargs"]["message_thread_id"] == 42
-    assert channel._stream_bufs["123"].message_id == 99
+    assert channel._stream_bufs["123"].message_id is None
+    assert channel._stream_bufs["123"].draft_id not in (None, 0, 17)
     assert channel._stream_bufs["123"].text == tail
     assert channel._app.bot.sent_messages == []
 
@@ -1104,10 +1120,8 @@ async def test_flush_stream_overflow_rich_limit_counts_unicode_characters() -> N
     )
     _install_ready_app(channel)
     text = "测" * TELEGRAM_RICH_MAX_LEN + "\n尾"
-    buf = _StreamBuf(text=text, message_id=7, last_edit=0.0, stream_id="s:0")
-    channel._app.bot.do_api_request = AsyncMock(
-        side_effect=[{"message_id": 7}, {"message_id": 99}]
-    )
+    buf = _StreamBuf(text=text, draft_id=17, last_edit=0.0, stream_id="s:0")
+    channel._app.bot.do_api_request = AsyncMock(return_value=True)
 
     await channel._flush_stream_overflow(123, buf, {})
 
@@ -1116,6 +1130,51 @@ async def test_flush_stream_overflow_rich_limit_counts_unicode_characters() -> N
     assert len(first) == TELEGRAM_RICH_MAX_LEN
     assert len(first.encode("utf-8")) > TELEGRAM_RICH_MAX_LEN
     assert buf.text == "尾"
+
+
+@pytest.mark.asyncio
+async def test_send_delta_rich_draft_rate_is_limited_to_40_per_30_seconds() -> None:
+    channel = TelegramChannel(
+        TelegramConfig(
+            enabled=True,
+            token="123:abc",
+            allow_from=["*"],
+            rich_messages=True,
+            stream_edit_interval=0.1,
+        ),
+        MessageBus(),
+    )
+    _install_ready_app(channel)
+    channel._app.bot.do_api_request = AsyncMock(return_value=True)
+
+    await channel.send_delta(
+        "123", "first", {"is_group": False}, stream_id="s:0",
+    )
+    first_edit = channel._stream_bufs["123"].last_edit
+    await channel.send_delta("123", " second", stream_id="s:0")
+
+    assert TELEGRAM_RICH_DRAFT_MIN_INTERVAL == 30 / 40
+    channel._app.bot.do_api_request.assert_awaited_once()
+    assert channel._stream_bufs["123"].last_edit == first_edit
+
+
+@pytest.mark.asyncio
+async def test_send_delta_rich_group_uses_persistent_legacy_preview() -> None:
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_messages=True),
+        MessageBus(),
+    )
+    _install_ready_app(channel)
+    channel._app.bot.do_api_request = AsyncMock(return_value=True)
+
+    await channel.send_delta(
+        "-100123", "hello", {"is_group": True}, stream_id="s:0",
+    )
+
+    channel._app.bot.do_api_request.assert_not_awaited()
+    assert channel._app.bot.sent_messages[0]["text"] == "hello"
+    assert channel._stream_bufs["-100123"].draft_id is None
+    assert channel._stream_bufs["-100123"].message_id == 1
 
 
 @pytest.mark.asyncio

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -1043,6 +1043,135 @@ async def test_send_delta_rich_stream_end_persists_draft_with_send_rich_message(
 
 
 @pytest.mark.asyncio
+async def test_send_delta_rich_stream_end_timeout_is_not_retried() -> None:
+    from telegram.error import TimedOut
+
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_messages=True),
+        MessageBus(),
+    )
+    _install_ready_app(channel)
+    channel._stream_bufs["123"] = _StreamBuf(
+        text="final answer",
+        draft_id=17,
+        last_edit=0.0,
+        stream_id="s:0",
+    )
+    channel._app.bot.do_api_request = AsyncMock(side_effect=TimedOut("ambiguous timeout"))
+
+    await channel.send_delta("123", "", stream_id="s:0", stream_end=True)
+
+    channel._app.bot.do_api_request.assert_awaited_once()
+    assert channel._app.bot.do_api_request.call_args.args[0] == "sendRichMessage"
+    assert channel._app.bot.sent_messages == []
+    assert "123" not in channel._stream_bufs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("rich_error", [None, "can't parse rich message", "method not found"])
+async def test_rich_stream_final_retry_keeps_only_unsent_chunks(
+    rich_error: str | None,
+) -> None:
+    from telegram.error import BadRequest, NetworkError
+
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_messages=True),
+        MessageBus(),
+    )
+    _install_ready_app(channel)
+    delivered: list[str] = []
+    failed = False
+
+    async def deliver(text):
+        nonlocal failed
+        if text.startswith("B") and not failed:
+            failed = True
+            raise NetworkError("second chunk connection failed")
+        delivered.append(text)
+        return SimpleNamespace(message_id=len(delivered))
+
+    async def api(method, *, api_kwargs):
+        if method == "sendRichMessage":
+            if rich_error:
+                raise BadRequest(rich_error)
+            return await deliver(api_kwargs["rich_message"]["markdown"])
+        return True
+
+    async def send_message(**kwargs):
+        return await deliver(kwargs["text"])
+
+    channel._app.bot.do_api_request = AsyncMock(side_effect=api)
+    channel._app.bot.send_message = AsyncMock(side_effect=send_message)
+    metadata = {"is_group": False}
+    await channel.send_delta("123", "A", metadata, stream_id="s:0")
+    delta = "A" * (TELEGRAM_RICH_MAX_LEN - 1) + "\n" + "B" * TELEGRAM_RICH_MAX_LEN + "\nC"
+    await channel.send_delta("123", delta, metadata, stream_id="s:0")
+
+    with pytest.raises(NetworkError, match="second chunk"):
+        await channel.send_delta(
+            "123", "", metadata, stream_id="s:0", stream_end=True,
+        )
+    assert "".join(delivered) == "A" * TELEGRAM_RICH_MAX_LEN
+    assert channel._stream_bufs["123"].text.replace("\n", "") == (
+        "B" * TELEGRAM_RICH_MAX_LEN + "C"
+    )
+
+    await channel.send_delta(
+        "123", "", metadata, stream_id="s:0", stream_end=True,
+    )
+
+    assert "".join(delivered).replace("\n", "") == (
+        "A" * TELEGRAM_RICH_MAX_LEN + "B" * TELEGRAM_RICH_MAX_LEN + "C"
+    )
+    assert "123" not in channel._stream_bufs
+
+
+@pytest.mark.asyncio
+async def test_rich_stream_overflow_failure_does_not_drop_same_text_next_delta(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from telegram.error import NetworkError
+
+    monkeypatch.setattr("nanobot.channels.telegram.runtime.TELEGRAM_RICH_MAX_LEN", 4)
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_messages=True),
+        MessageBus(),
+    )
+    _install_ready_app(channel)
+    delivered: list[str] = []
+    failed = False
+
+    async def api(method, *, api_kwargs):
+        nonlocal failed
+        if method == "sendRichMessage":
+            text = api_kwargs["rich_message"]["markdown"]
+            if text == "BBBB" and not failed:
+                failed = True
+                raise NetworkError("second chunk connection failed")
+            delivered.append(text)
+        return True
+
+    channel._app.bot.do_api_request = AsyncMock(side_effect=api)
+    metadata = {"is_group": False}
+    await channel.send_delta("123", "A", metadata, stream_id="s:0")
+    channel._stream_bufs["123"].last_edit = 0.0
+    repeated_delta = "AAA\nBBBB\nC"
+
+    await channel.send_delta("123", repeated_delta, metadata, stream_id="s:0")
+
+    assert delivered == ["AAAA"]
+    assert channel._stream_bufs["123"].text == "BBBB\nC"
+
+    await channel.send_delta("123", repeated_delta, metadata, stream_id="s:0")
+    await channel.send_delta("123", "", metadata, stream_id="s:0", stream_end=True)
+
+    assert "".join(delivered).replace("\n", "") == (
+        "A" + repeated_delta + repeated_delta
+    ).replace("\n", "")
+    assert "123" not in channel._stream_bufs
+
+
+@pytest.mark.asyncio
 async def test_send_delta_rich_does_not_flush_at_legacy_limit() -> None:
     channel = TelegramChannel(
         TelegramConfig(
@@ -1159,22 +1288,30 @@ async def test_send_delta_rich_draft_rate_is_limited_to_40_per_30_seconds() -> N
 
 
 @pytest.mark.asyncio
-async def test_send_delta_rich_group_uses_persistent_legacy_preview() -> None:
+async def test_send_delta_rich_group_uses_legacy_preview_and_finalization() -> None:
     channel = TelegramChannel(
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_messages=True),
         MessageBus(),
     )
     _install_ready_app(channel)
     channel._app.bot.do_api_request = AsyncMock(return_value=True)
+    channel._app.bot.edit_message_text = AsyncMock()
+    metadata = {"is_group": True}
 
     await channel.send_delta(
-        "-100123", "hello", {"is_group": True}, stream_id="s:0",
+        "-100123", "**hello**", metadata, stream_id="s:0",
     )
+    await channel.send_delta("-100123", "", metadata, stream_id="s:0", stream_end=True)
 
     channel._app.bot.do_api_request.assert_not_awaited()
     assert channel._app.bot.sent_messages[0]["text"] == "hello"
-    assert channel._stream_bufs["-100123"].draft_id is None
-    assert channel._stream_bufs["-100123"].message_id == 1
+    channel._app.bot.edit_message_text.assert_awaited_once_with(
+        chat_id=-100123,
+        message_id=1,
+        text="<b>hello</b>",
+        parse_mode="HTML",
+    )
+    assert "-100123" not in channel._stream_bufs
 
 
 @pytest.mark.asyncio
@@ -3009,63 +3146,6 @@ def test_markdown_to_html_code_block_same_line_no_newline() -> None:
 
 
 @pytest.mark.asyncio
-async def test_send_delta_stream_end_upgrades_preview_to_rich_in_place() -> None:
-    """Rich messages finally work with streaming: the preview is upgraded via
-    editMessageText rich_message (in place), not delete-and-resend (issue #5516)."""
-    from telegram.error import BadRequest
-
-    channel = TelegramChannel(
-        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_messages=True),
-        MessageBus(),
-    )
-    _install_ready_app(channel)
-    channel._app.bot.do_api_request = AsyncMock()
-    channel._app.bot.edit_message_text = AsyncMock(side_effect=BadRequest("should not be reached"))
-    channel._stream_bufs["123"] = _StreamBuf(text="**hello**", message_id=7, last_edit=0.0)
-
-    await channel.send_delta("123", "", stream_end=True)
-
-    # editMessageText with rich_message payload, in place (same message_id)
-    channel._app.bot.do_api_request.assert_awaited_once()
-    args, kwargs = channel._app.bot.do_api_request.await_args
-    assert args[0] == "editMessageText"
-    assert kwargs["api_kwargs"]["chat_id"] == 123
-    assert kwargs["api_kwargs"]["message_id"] == 7
-    assert kwargs["api_kwargs"]["rich_message"] == {"markdown": "**hello**"}
-    # No delete-and-resend, no legacy HTML edit
-    channel._app.bot.edit_message_text.assert_not_awaited()
-    assert "123" not in channel._stream_bufs
-
-
-@pytest.mark.asyncio
-async def test_send_delta_stream_end_rich_capability_error_latches_and_falls_back() -> None:
-    """On a pre-10.1 Bot API server the rich edit fails, the latch trips, and the
-    legacy HTML edit handles the final output."""
-    from telegram.error import BadRequest
-
-    channel = TelegramChannel(
-        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_messages=True),
-        MessageBus(),
-    )
-    _install_ready_app(channel)
-    # Before Bot API 10.1, editMessageText ignores rich_message and requires text.
-    channel._app.bot.do_api_request = AsyncMock(
-        side_effect=BadRequest("Message text is empty")
-    )
-    channel._app.bot.edit_message_text = AsyncMock()
-    channel._stream_bufs["123"] = _StreamBuf(text="hello", message_id=7, last_edit=0.0)
-
-    await channel.send_delta("123", "", stream_end=True)
-
-    channel._app.bot.do_api_request.assert_awaited_once()
-    # Latch tripped: subsequent sends skip the rich path entirely
-    assert channel._rich_send_disabled is True
-    # Legacy HTML edit handled the final message
-    channel._app.bot.edit_message_text.assert_awaited_once()
-    assert "123" not in channel._stream_bufs
-
-
-@pytest.mark.asyncio
 async def test_send_delta_stream_end_rich_disabled_uses_legacy_html() -> None:
     """rich_messages=False (the default) keeps the legacy HTML path untouched."""
     channel = TelegramChannel(
@@ -3081,55 +3161,4 @@ async def test_send_delta_stream_end_rich_disabled_uses_legacy_html() -> None:
 
     channel._app.bot.do_api_request.assert_not_called()
     channel._app.bot.edit_message_text.assert_awaited_once()
-    assert "123" not in channel._stream_bufs
-
-
-@pytest.mark.asyncio
-async def test_send_delta_stream_end_rich_network_error_propagates_for_retry() -> None:
-    """A transport failure on the rich edit must propagate so ChannelManager
-    retries the buffered send — not fall through to an immediate legacy edit
-    that doubles connection demand during pool exhaustion."""
-    from telegram.error import NetworkError
-
-    channel = TelegramChannel(
-        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_messages=True),
-        MessageBus(),
-    )
-    _install_ready_app(channel)
-    channel._app.bot.do_api_request = AsyncMock(side_effect=NetworkError("pool exhausted"))
-    channel._app.bot.edit_message_text = AsyncMock()
-    channel._stream_bufs["123"] = _StreamBuf(text="hello", message_id=7, last_edit=0.0)
-
-    with pytest.raises(NetworkError):
-        await channel.send_delta("123", "", stream_end=True)
-
-    # No legacy fallback edit: the buffered state stays for the manager retry.
-    channel._app.bot.edit_message_text.assert_not_awaited()
-    assert "123" in channel._stream_bufs
-
-
-@pytest.mark.asyncio
-async def test_send_delta_stream_end_rich_not_modified_after_timeout_is_success() -> None:
-    """Ambiguous success: the rich edit applied server-side but its response
-    timed out, so the retry hit "message is not modified". That is a completed
-    rich upgrade — the legacy edit must not overwrite it."""
-    from telegram.error import BadRequest, TimedOut
-
-    channel = TelegramChannel(
-        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], rich_messages=True),
-        MessageBus(),
-    )
-    _install_ready_app(channel)
-    # First attempt (inside _call_with_retry) times out, retry reports the
-    # edit as already applied.
-    channel._app.bot.do_api_request = AsyncMock(
-        side_effect=[TimedOut(), BadRequest("Message is not modified")]
-    )
-    channel._app.bot.edit_message_text = AsyncMock(side_effect=AssertionError("must not overwrite rich result"))
-    channel._stream_bufs["123"] = _StreamBuf(text="hello", message_id=7, last_edit=0.0)
-
-    await channel.send_delta("123", "", stream_end=True)
-
-    assert channel._app.bot.do_api_request.await_count == 2
-    channel._app.bot.edit_message_text.assert_not_awaited()
     assert "123" not in channel._stream_bufs


### PR DESCRIPTION
Implement Telegram rich-message streaming with `sendRichMessageDraft` in private chats and persist the final response with `sendRichMessage`.

- Keep group chats and rejected or unsupported rich drafts on the existing HTML/plain streaming path.
- Remove the old end-of-stream `editMessageText(rich_message=...)` upgrade.
- Preserve unsent chunks across partial delivery failures without duplicating or dropping repeated deltas.
- Avoid retrying ambiguous final rich-message timeouts, which could duplicate a persisted message.

Tests:
- `pytest nanobot/channels/telegram/tests/test_telegram_channel.py -q`
- `ruff check nanobot/channels/telegram/runtime.py nanobot/channels/telegram/tests/test_telegram_channel.py`

Addresses #5516 as an alternative to #5531.