### PR TITLE
feat(agent): support ephemeral runtime context

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -65,6 +65,7 @@ from nanobot.runtime_context import (
     append_runtime_context,
     resolve_runtime_context,
     runtime_context_blocks_from_metadata,
+    runtime_context_for_persistence,
 )
 from nanobot.security.workspace_access import (
     WorkspaceScopeResolver,
@@ -713,6 +714,13 @@ class AgentLoop:
                 text,
                 runtime_context_blocks or (),
             )
+            if runtime_context_meta is not None:
+                text, runtime_context_meta = runtime_context_for_persistence(
+                    text,
+                    runtime_context_meta,
+                )
+            if not text and not media_paths and runtime_context_meta is None:
+                return False
             if runtime_context_meta is not None:
                 extra[RUNTIME_CONTEXT_HISTORY_META] = runtime_context_meta
             session.add_message("user", text, **extra)
@@ -2178,6 +2186,14 @@ class AgentLoop:
                 else None
             )
             role, content = entry.get("role"), entry.get("content")
+            if role == "user" and isinstance(runtime_context_meta, dict):
+                content, runtime_context_meta = runtime_context_for_persistence(
+                    content,
+                    cast(dict[str, Any], runtime_context_meta),
+                )
+                entry["content"] = content
+                if content in ("", []) and runtime_context_meta is None:
+                    continue
             if role == "assistant" and not content and not entry.get("tool_calls"):
                 continue  # skip empty assistant messages — they poison session context
             if role == "tool":

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -43,6 +43,7 @@ from nanobot.runtime_context import (
     RUNTIME_CONTEXT_MESSAGE_META,
     detach_runtime_context,
     reattach_runtime_context,
+    runtime_context_ephemeral_flags,
 )
 from nanobot.session.history_visibility import is_hidden_history_message
 from nanobot.session.recovery import PENDING_FOLLOWUP_ID_KEY
@@ -218,6 +219,16 @@ class AgentRunner:
                 if detached_left is not None and detached_right is not None:
                     left_content, left_sources, left_blocks = detached_left
                     right_content, right_sources, right_blocks = detached_right
+                    left_ephemeral = (
+                        runtime_context_ephemeral_flags(left_marker_dict, len(left_blocks))
+                        if left_marker_dict is not None
+                        else []
+                    )
+                    right_ephemeral = (
+                        runtime_context_ephemeral_flags(right_marker_dict, len(right_blocks))
+                        if right_marker_dict is not None
+                        else []
+                    )
                     merged_content = cls._merge_message_content(left_content, right_content)
                     context_blocks = [*left_blocks, *right_blocks]
                     if context_blocks:
@@ -225,6 +236,7 @@ class AgentRunner:
                             merged_content,
                             [*left_sources, *right_sources],
                             context_blocks,
+                            ephemeral=[*left_ephemeral, *right_ephemeral],
                         )
                         internal_meta = dict(left_meta_dict) if left_meta_dict is not None else {}
                         if right_meta_dict is not None:

--- a/nanobot/runtime_context.py
+++ b/nanobot/runtime_context.py
@@ -1,4 +1,4 @@
-"""Optional, persistent context appended to the current user prompt."""
+"""Optional context appended to the current user prompt."""
 
 from __future__ import annotations
 
@@ -26,10 +26,13 @@ class RuntimeContextBlock:
     """Provider-owned context appended verbatim to the current user content.
 
     Callers must bound and delimit content obtained from untrusted sources.
+    Ephemeral blocks are sent to the model for the current turn but are not
+    persisted in session history.
     """
 
     source: str
     content: str
+    ephemeral: bool = False
 
 
 def normalize_webui_quote(value: Any) -> str | None:
@@ -92,7 +95,13 @@ def normalize_runtime_context_blocks(result: RuntimeContextResult) -> list[Runti
         if not source:
             raise ValueError("runtime context block source must not be empty")
         if content:
-            blocks.append(RuntimeContextBlock(source=source, content=content))
+            blocks.append(
+                RuntimeContextBlock(
+                    source=source,
+                    content=content,
+                    ephemeral=block.ephemeral,
+                )
+            )
     return blocks
 
 
@@ -127,21 +136,26 @@ def append_runtime_context(
 
     rendered = [block.content for block in blocks]
     sources = [block.source for block in blocks]
+    ephemeral = [block.ephemeral for block in blocks]
     if isinstance(content, list):
         context_blocks = [{"type": "text", "text": text} for text in rendered]
         return [*content, *context_blocks], {
             "version": 1,
             "sources": sources,
             "blocks": context_blocks,
+            "ephemeral": ephemeral,
         }
 
     text = "" if content is None else str(content)
     suffix = "\n\n".join(rendered)
     merged = f"{text}\n\n{suffix}" if text else suffix
+    context_blocks = [{"type": "text", "text": block} for block in rendered]
     return merged, {
         "version": 1,
         "sources": sources,
         "suffix": suffix,
+        "blocks": context_blocks,
+        "ephemeral": ephemeral,
     }
 
 
@@ -168,7 +182,18 @@ def detach_runtime_context(
             clean_content = content[: -(len(suffix) + 2)]
         else:
             return None
-        return clean_content, sources, [{"type": "text", "text": suffix}]
+        raw_blocks = marker_data.get("blocks")
+        marker_blocks = (
+            [
+                deepcopy(cast(dict[str, Any], block))
+                for block in cast(list[object], raw_blocks)
+                if isinstance(block, dict)
+            ]
+            if isinstance(raw_blocks, list)
+            else []
+        )
+        rendered_blocks = marker_blocks or [{"type": "text", "text": suffix}]
+        return clean_content, sources, rendered_blocks
 
     expected = marker_data.get("blocks")
     if isinstance(content, list) and isinstance(expected, list) and expected:
@@ -185,9 +210,12 @@ def reattach_runtime_context(
     content: Any,
     sources: Sequence[str],
     blocks: Sequence[Mapping[str, Any]],
+    *,
+    ephemeral: Sequence[bool] | None = None,
 ) -> tuple[Any, dict[str, Any]]:
     """Append detached runtime-context blocks after visible messages are merged."""
     context_blocks = [deepcopy(dict(block)) for block in blocks]
+    ephemeral_flags = list(ephemeral or (False for _ in context_blocks))
     if isinstance(content, str) and all(
         block.get("type") == "text" and isinstance(block.get("text"), str)
         for block in context_blocks
@@ -198,6 +226,8 @@ def reattach_runtime_context(
             "version": 1,
             "sources": list(sources),
             "suffix": suffix,
+            "blocks": context_blocks,
+            "ephemeral": ephemeral_flags,
         }
 
     visible_blocks: list[Any] = (
@@ -209,7 +239,55 @@ def reattach_runtime_context(
         "version": 1,
         "sources": list(sources),
         "blocks": context_blocks,
+        "ephemeral": ephemeral_flags,
     }
+
+
+def runtime_context_ephemeral_flags(
+    marker: Mapping[str, Any],
+    count: int,
+) -> list[bool]:
+    """Return marker flags aligned to its rendered context blocks."""
+    raw_flags = marker.get("ephemeral")
+    if not isinstance(raw_flags, list):
+        return [False] * count
+    flags = cast(list[object], raw_flags)
+    return [
+        flags[index] is True if index < len(flags) else False
+        for index in range(count)
+    ]
+
+
+def runtime_context_for_persistence(
+    content: Any,
+    marker: Mapping[str, Any],
+) -> tuple[Any, dict[str, Any] | None]:
+    """Remove ephemeral blocks while retaining durable runtime context."""
+    raw_flags = marker.get("ephemeral")
+    if not isinstance(raw_flags, list) or not any(
+        flag is True for flag in cast(list[object], raw_flags)
+    ):
+        return content, dict(marker)
+
+    detached = detach_runtime_context(content, marker)
+    if detached is None:
+        return content, dict(marker)
+
+    visible_content, sources, blocks = detached
+    flags = runtime_context_ephemeral_flags(marker, len(blocks))
+    persistent = [
+        (source, block)
+        for source, block, ephemeral in zip(sources, blocks, flags, strict=False)
+        if not ephemeral
+    ]
+    if not persistent:
+        return visible_content, None
+
+    return reattach_runtime_context(
+        visible_content,
+        [source for source, _block in persistent],
+        [block for _source, block in persistent],
+    )
 
 
 def public_history_message(message: Mapping[str, Any]) -> dict[str, Any]:

--- a/tests/agent/test_loop_runner_integration.py
+++ b/tests/agent/test_loop_runner_integration.py
@@ -14,6 +14,7 @@ from nanobot.bus.outbound_events import StreamedResponseEvent
 from nanobot.config.schema import AgentDefaults
 from nanobot.providers.base import GenerationSettings, LLMProvider, LLMResponse, ToolCallRequest
 from nanobot.runtime_context import (
+    RUNTIME_CONTEXT_HISTORY_META,
     RUNTIME_CONTEXT_INPUT_META,
     WEBUI_QUOTE_METADATA,
     RuntimeContextBlock,
@@ -207,6 +208,57 @@ async def test_runtime_context_is_persisted_as_next_turn_prompt_prefix(tmp_path)
     persisted_first_user = session.messages[0]
     assert persisted_first_user["content"] == first_wire[1]["content"]
     assert public_history_message(persisted_first_user)["content"] == "first turn $review"
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_runtime_context_is_not_replayed_on_later_turns(tmp_path):
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.events import InboundMessage
+    from nanobot.bus.queue import MessageBus
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.generation = GenerationSettings()
+    provider.chat_with_retry = AsyncMock(side_effect=[
+        LLMResponse(content="first answer", usage=None),
+        LLMResponse(content="second answer", usage=None),
+    ])
+    loop = AgentLoop(bus=MessageBus(), provider=provider, workspace=tmp_path, model="test-model")
+    loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=None)
+    session = loop.sessions.get_or_create("cli:direct")
+    provider_calls = 0
+
+    async def provide_context(_request):
+        nonlocal provider_calls
+        provider_calls += 1
+        return RuntimeContextBlock(
+            source="voice",
+            content=f"ephemeral voice contract {provider_calls}",
+            ephemeral=True,
+        )
+
+    loop.register_runtime_context_provider(provide_context)
+
+    await loop._process_message(InboundMessage(
+        channel="cli",
+        sender_id="user",
+        chat_id="direct",
+        content="first turn",
+    ))
+    await loop._process_message(InboundMessage(
+        channel="cli",
+        sender_id="user",
+        chat_id="direct",
+        content="second turn",
+    ))
+
+    first_request = provider.chat_with_retry.await_args_list[0].kwargs["messages"]
+    second_request = provider.chat_with_retry.await_args_list[1].kwargs["messages"]
+    assert "ephemeral voice contract 1" in str(first_request)
+    assert "ephemeral voice contract 1" not in str(second_request)
+    assert "ephemeral voice contract 2" in str(second_request)
+    assert session.messages[0]["content"] == "first turn"
+    assert RUNTIME_CONTEXT_HISTORY_META not in session.messages[0]
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -594,6 +594,47 @@ def test_save_turn_persists_runtime_context_and_public_view_hides_it() -> None:
     assert public_history_message(session.messages[0])["content"] == "hello world"
 
 
+def test_save_turn_drops_ephemeral_runtime_context() -> None:
+    loop = _mk_loop()
+    session = Session(key="test:ephemeral-context")
+    blocks = [
+        RuntimeContextBlock(source="goal", content="durable goal guidance"),
+        RuntimeContextBlock(
+            source="voice",
+            content="current-turn voice contract",
+            ephemeral=True,
+        ),
+    ]
+
+    loop._save_turn(
+        session,
+        [_runtime_message("hello world", blocks)],
+        skip=0,
+    )
+
+    assert session.messages[0]["content"] == "hello world\n\ndurable goal guidance"
+    assert session.messages[0][RUNTIME_CONTEXT_HISTORY_META]["sources"] == ["goal"]
+    assert "current-turn voice contract" not in str(session.messages[0])
+
+
+def test_save_turn_drops_ephemeral_only_user_row() -> None:
+    loop = _mk_loop()
+    session = Session(key="test:ephemeral-only-context")
+    block = RuntimeContextBlock(
+        source="voice",
+        content="current-turn voice contract",
+        ephemeral=True,
+    )
+
+    loop._save_turn(
+        session,
+        [_runtime_message("", [block])],
+        skip=0,
+    )
+
+    assert session.messages == []
+
+
 def test_build_and_save_preserves_user_text_containing_goal_guidance_tag(tmp_path: Path) -> None:
     loop = _mk_loop()
     session = Session(key="test:user-guidance-literal")

--- a/tests/agent/test_runner_injections.py
+++ b/tests/agent/test_runner_injections.py
@@ -931,7 +931,13 @@ def test_runner_merge_preserves_runtime_markers_with_media() -> None:
     )
     second_content, second_marker = append_runtime_context(
         "second",
-        [RuntimeContextBlock(source="second", content="private second")],
+        [
+            RuntimeContextBlock(
+                source="second",
+                content="private second",
+                ephemeral=True,
+            )
+        ],
     )
     messages: list[dict] = []
 
@@ -952,6 +958,7 @@ def test_runner_merge_preserves_runtime_markers_with_media() -> None:
     merged = messages[0]
     assert "private first" in str(merged["content"])
     assert "private second" in str(merged["content"])
+    assert merged["_meta"][RUNTIME_CONTEXT_MESSAGE_META]["ephemeral"] == [False, True]
     persisted = {
         "role": "user",
         "content": merged["content"],

--- a/tests/agent/test_runtime_context.py
+++ b/tests/agent/test_runtime_context.py
@@ -17,6 +17,7 @@ from nanobot.runtime_context import (
     public_history_message,
     resolve_runtime_context,
     runtime_context_blocks_from_metadata,
+    runtime_context_for_persistence,
     webui_quote_runtime_context,
 )
 from nanobot.sdk.types import snapshot_from_session
@@ -114,6 +115,29 @@ def test_public_history_removes_only_trusted_exact_suffix() -> None:
         "content": "visible user text\n\nprivate goal context",
     }
     assert public_history_message(user_authored) == user_authored
+
+
+def test_ephemeral_runtime_context_is_removed_before_persistence() -> None:
+    content, marker = append_runtime_context(
+        "visible user text",
+        [
+            RuntimeContextBlock(source="durable", content="durable context"),
+            RuntimeContextBlock(
+                source="voice",
+                content="current-turn voice contract",
+                ephemeral=True,
+            ),
+        ],
+    )
+    assert marker is not None
+    assert "current-turn voice contract" in content
+
+    persisted_content, persisted_marker = runtime_context_for_persistence(content, marker)
+
+    assert persisted_content == "visible user text\n\ndurable context"
+    assert persisted_marker is not None
+    assert persisted_marker["sources"] == ["durable"]
+    assert persisted_marker["ephemeral"] == [False]
 
 
 def test_public_history_keeps_content_when_marker_does_not_match() -> None:


### PR DESCRIPTION
## Summary

- add an opt-out `ephemeral` lifecycle to `RuntimeContextBlock`, defaulting to the existing persistent behavior
- keep ephemeral context available to the current model request and tool loop while projecting it out before session persistence
- preserve per-block lifecycle metadata when injected user messages merge, and avoid storing empty ephemeral-only user rows

## Testing

- `pytest tests/agent -q` (1556 passed)
- focused runtime-context suite (144 passed)
- `ruff check` on changed files
- `basedpyright` (0 errors, 0 warnings)
- full suite reached 1951 passed and 5 skipped before an unrelated WebUI CLI test attempted to access the internal npm registry and failed with `SELF_SIGNED_CERT_IN_CHAIN`

Closes #5586

## AI Assistance Disclosure

TRAE assisted with issue analysis, implementation, and test execution. The contributor reviewed the diff, behavior contract, and reported verification evidence.