### PR TITLE
feat(runtime-context): allow blocks to opt out of history persistence

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -63,6 +63,8 @@ from nanobot.runtime_context import (
     RuntimeContextBlock,
     RuntimeContextProvider,
     append_runtime_context,
+    persistent_runtime_context_blocks,
+    project_runtime_context_for_history,
     resolve_runtime_context,
     runtime_context_blocks_from_metadata,
 )
@@ -700,7 +702,10 @@ class AgentLoop:
         ]
         content_value = cast(object, msg.content)
         has_text = isinstance(content_value, str) and content_value.strip()
-        if has_text or media_paths or runtime_context_blocks:
+        persistent_blocks = persistent_runtime_context_blocks(
+            runtime_context_blocks or (),
+        )
+        if has_text or media_paths or persistent_blocks:
             extra: dict[str, Any] = ({"media": list(media_paths)} if media_paths else {}) | agent_context.session_extra(msg.metadata)
             extra.update(kwargs)
             text = content_value if isinstance(content_value, str) else ""
@@ -710,7 +715,7 @@ class AgentLoop:
             extra.update(automation_extra)
             text, runtime_context_meta = append_runtime_context(
                 text,
-                runtime_context_blocks or (),
+                persistent_blocks,
             )
             if runtime_context_meta is not None:
                 extra[RUNTIME_CONTEXT_HISTORY_META] = runtime_context_meta
@@ -2213,6 +2218,13 @@ class AgentLoop:
                         ]
                     entry["content"] = filtered
             elif role == "user":
+                history_runtime_meta: dict[str, Any] | None = None
+                if isinstance(runtime_context_meta, dict):
+                    content, history_runtime_meta = project_runtime_context_for_history(
+                        content,
+                        cast(dict[str, Any], runtime_context_meta),
+                    )
+                    entry["content"] = content
                 if isinstance(content, list):
                     filtered = self._sanitize_persisted_blocks(
                         cast(list[object], content),
@@ -2220,8 +2232,15 @@ class AgentLoop:
                     if not filtered:
                         continue
                     entry["content"] = filtered
-                if isinstance(runtime_context_meta, dict):
-                    entry[RUNTIME_CONTEXT_HISTORY_META] = runtime_context_meta
+                elif (
+                    isinstance(content, str)
+                    and not content
+                    and isinstance(runtime_context_meta, dict)
+                    and history_runtime_meta is None
+                ):
+                    continue
+                if history_runtime_meta is not None:
+                    entry[RUNTIME_CONTEXT_HISTORY_META] = history_runtime_meta
             entry.setdefault("timestamp", datetime.now().isoformat())
             session.messages.append(entry)
             if role == "user":

--- a/nanobot/runtime_context.py
+++ b/nanobot/runtime_context.py
@@ -6,7 +6,7 @@ import json
 from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, TypeAlias, TypedDict, cast
 
 if TYPE_CHECKING:
     from nanobot.agent.tools.context import RequestContext
@@ -19,6 +19,14 @@ RUNTIME_CONTEXT_END = "[/Runtime Context]"
 WEBUI_QUOTE_METADATA = "_webui_quote"
 WEBUI_QUOTE_SOURCE = "webui_quote"
 MAX_WEBUI_QUOTE_CHARS = 4_000
+_RUNTIME_CONTEXT_LIFECYCLE = "_lifecycle"
+_RUNTIME_CONTEXT_DETACHED = "_runtime_context_detached"
+
+
+class _RuntimeContextLifecycleEntry(TypedDict):
+    sources: list[str]
+    ephemeral: bool
+    length: int
 
 
 @dataclass(frozen=True)
@@ -26,10 +34,12 @@ class RuntimeContextBlock:
     """Provider-owned context appended verbatim to the current user content.
 
     Callers must bound and delimit content obtained from untrusted sources.
+    Ephemeral blocks are visible to the current request but excluded from history.
     """
 
     source: str
     content: str
+    ephemeral: bool = False
 
 
 def normalize_webui_quote(value: Any) -> str | None:
@@ -92,8 +102,19 @@ def normalize_runtime_context_blocks(result: RuntimeContextResult) -> list[Runti
         if not source:
             raise ValueError("runtime context block source must not be empty")
         if content:
-            blocks.append(RuntimeContextBlock(source=source, content=content))
+            blocks.append(RuntimeContextBlock(
+                source=source,
+                content=content,
+                ephemeral=block.ephemeral,
+            ))
     return blocks
+
+
+def persistent_runtime_context_blocks(
+    blocks: Sequence[RuntimeContextBlock],
+) -> list[RuntimeContextBlock]:
+    """Return blocks allowed to enter durable conversation history."""
+    return [block for block in blocks if not block.ephemeral]
 
 
 def runtime_context_blocks_from_metadata(
@@ -117,32 +138,120 @@ async def resolve_runtime_context(
     return blocks
 
 
+def _validated_sources(value: object) -> list[str] | None:
+    if not isinstance(value, list):
+        return None
+    sources: list[str] = []
+    for source in cast(list[object], value):
+        if not isinstance(source, str) or not source:
+            return None
+        sources.append(source)
+    return sources
+
+
+def _validated_lifecycle(value: object) -> list[_RuntimeContextLifecycleEntry] | None:
+    if not isinstance(value, list) or not value:
+        return None
+    lifecycle: list[_RuntimeContextLifecycleEntry] = []
+    for raw_item in cast(list[object], value):
+        if not isinstance(raw_item, Mapping):
+            return None
+        item = cast(Mapping[str, object], raw_item)
+        sources = _validated_sources(item.get("sources"))
+        ephemeral = item.get("ephemeral")
+        length = item.get("length")
+        if (
+            sources is None
+            or not isinstance(ephemeral, bool)
+            or isinstance(length, bool)
+            or not isinstance(length, int)
+            or length < 0
+        ):
+            return None
+        lifecycle.append({
+            "sources": sources,
+            "ephemeral": ephemeral,
+            "length": length,
+        })
+    return lifecycle
+
+
+def _split_runtime_suffix_by_lifecycle(
+    suffix: str,
+    lifecycle: Sequence[_RuntimeContextLifecycleEntry],
+) -> list[str] | None:
+    parts: list[str] = []
+    cursor = 0
+    for index, item in enumerate(lifecycle):
+        end = cursor + item["length"]
+        if end > len(suffix):
+            return None
+        parts.append(suffix[cursor:end])
+        cursor = end
+        if index != len(lifecycle) - 1:
+            if suffix[cursor:cursor + 2] != "\n\n":
+                return None
+            cursor += 2
+    return parts if cursor == len(suffix) else None
+
+
+def _detached_runtime_text_block(
+    text: str,
+    *,
+    sources: Sequence[str],
+    ephemeral: bool,
+) -> dict[str, Any]:
+    return {
+        "type": "text",
+        "text": text,
+        _RUNTIME_CONTEXT_DETACHED: {
+            "sources": list(sources),
+            "ephemeral": ephemeral,
+        },
+    }
+
+
 def append_runtime_context(
     content: Any,
     blocks: Sequence[RuntimeContextBlock],
 ) -> tuple[Any, dict[str, Any] | None]:
-    """Append blocks and return a durable marker for exact display-time removal."""
+    """Append blocks and return a marker for exact lifecycle handling."""
     if not blocks:
         return content, None
 
     rendered = [block.content for block in blocks]
     sources = [block.source for block in blocks]
+    lifecycle: list[_RuntimeContextLifecycleEntry] = [
+        {
+            "sources": [block.source],
+            "ephemeral": block.ephemeral,
+            "length": len(block.content),
+        }
+        for block in blocks
+    ]
+    has_ephemeral = any(block.ephemeral for block in blocks)
     if isinstance(content, list):
         context_blocks = [{"type": "text", "text": text} for text in rendered]
-        return [*content, *context_blocks], {
+        marker: dict[str, Any] = {
             "version": 1,
             "sources": sources,
             "blocks": context_blocks,
         }
+        if has_ephemeral:
+            marker[_RUNTIME_CONTEXT_LIFECYCLE] = lifecycle
+        return [*content, *context_blocks], marker
 
     text = "" if content is None else str(content)
     suffix = "\n\n".join(rendered)
     merged = f"{text}\n\n{suffix}" if text else suffix
-    return merged, {
+    marker = {
         "version": 1,
         "sources": sources,
         "suffix": suffix,
     }
+    if has_ephemeral:
+        marker[_RUNTIME_CONTEXT_LIFECYCLE] = lifecycle
+    return merged, marker
 
 
 def detach_runtime_context(
@@ -153,12 +262,12 @@ def detach_runtime_context(
     marker_data = marker
     if marker_data.get("version") != 1:
         return None
-    raw_sources = marker_data.get("sources")
-    sources: list[str] = [
-        source
-        for source in cast(list[Any], raw_sources)
-        if isinstance(source, str) and source
-    ] if isinstance(raw_sources, list) else []
+    sources = _validated_sources(marker_data.get("sources")) or []
+    lifecycle: list[_RuntimeContextLifecycleEntry] | None = None
+    if _RUNTIME_CONTEXT_LIFECYCLE in marker_data:
+        lifecycle = _validated_lifecycle(marker_data.get(_RUNTIME_CONTEXT_LIFECYCLE))
+        if lifecycle is None:
+            return None
 
     suffix = marker_data.get("suffix")
     if isinstance(content, str) and isinstance(suffix, str) and suffix:
@@ -168,16 +277,65 @@ def detach_runtime_context(
             clean_content = content[: -(len(suffix) + 2)]
         else:
             return None
-        return clean_content, sources, [{"type": "text", "text": suffix}]
+        if lifecycle is not None:
+            parts = _split_runtime_suffix_by_lifecycle(suffix, lifecycle)
+            if parts is None:
+                return None
+            return clean_content, sources, [
+                _detached_runtime_text_block(
+                    text,
+                    sources=item["sources"],
+                    ephemeral=item["ephemeral"],
+                )
+                for text, item in zip(parts, lifecycle, strict=True)
+            ]
+        return clean_content, sources, [
+            _detached_runtime_text_block(
+                suffix,
+                sources=sources,
+                ephemeral=False,
+            )
+        ]
 
     expected = marker_data.get("blocks")
     if isinstance(content, list) and isinstance(expected, list) and expected:
         content_blocks = cast(list[Any], content)
-        expected_blocks = cast(list[dict[str, Any]], expected)
+        expected_blocks: list[dict[str, Any]] = []
+        for raw_block in cast(list[object], expected):
+            if not isinstance(raw_block, Mapping):
+                return None
+            expected_blocks.append(deepcopy(dict(cast(Mapping[str, Any], raw_block))))
         count = len(expected_blocks)
         if content_blocks[-count:] != expected_blocks:
             return None
-        return content_blocks[:-count], sources, deepcopy(expected_blocks)
+        if lifecycle is not None:
+            if len(lifecycle) != count:
+                return None
+            detached_blocks: list[dict[str, Any]] = []
+            for block, item in zip(expected_blocks, lifecycle, strict=True):
+                text = block.get("text")
+                if not isinstance(text, str) or len(text) != item["length"]:
+                    return None
+                block[_RUNTIME_CONTEXT_DETACHED] = {
+                    "sources": list(item["sources"]),
+                    "ephemeral": item["ephemeral"],
+                }
+                detached_blocks.append(block)
+            return content_blocks[:-count], sources, detached_blocks
+
+        detached_blocks = []
+        for index, block in enumerate(expected_blocks):
+            item_sources = (
+                [sources[index]]
+                if len(sources) == count
+                else (sources if index == 0 else [])
+            )
+            block[_RUNTIME_CONTEXT_DETACHED] = {
+                "sources": item_sources,
+                "ephemeral": False,
+            }
+            detached_blocks.append(block)
+        return content_blocks[:-count], sources, detached_blocks
     return None
 
 
@@ -187,29 +345,101 @@ def reattach_runtime_context(
     blocks: Sequence[Mapping[str, Any]],
 ) -> tuple[Any, dict[str, Any]]:
     """Append detached runtime-context blocks after visible messages are merged."""
-    context_blocks = [deepcopy(dict(block)) for block in blocks]
+    context_blocks: list[dict[str, Any]] = []
+    lifecycle: list[_RuntimeContextLifecycleEntry] = []
+    has_internal_lifecycle = False
+    for block in blocks:
+        clean = deepcopy(dict(block))
+        raw_detached_meta = clean.pop(_RUNTIME_CONTEXT_DETACHED, None)
+        if isinstance(raw_detached_meta, Mapping):
+            has_internal_lifecycle = True
+            detached_meta = cast(Mapping[str, object], raw_detached_meta)
+            item_sources = _validated_sources(detached_meta.get("sources")) or []
+            item_ephemeral = detached_meta.get("ephemeral") is True
+        else:
+            item_sources = []
+            item_ephemeral = False
+        text = clean.get("text")
+        lifecycle.append({
+            "sources": item_sources,
+            "ephemeral": item_ephemeral,
+            "length": len(text) if isinstance(text, str) else 0,
+        })
+        context_blocks.append(clean)
+
+    effective_sources = (
+        [source for item in lifecycle for source in item["sources"]]
+        if has_internal_lifecycle
+        else list(sources)
+    )
+    has_ephemeral = has_internal_lifecycle and any(
+        item["ephemeral"] for item in lifecycle
+    )
     if isinstance(content, str) and all(
         block.get("type") == "text" and isinstance(block.get("text"), str)
         for block in context_blocks
     ):
         suffix = "\n\n".join(block["text"] for block in context_blocks)
         merged = f"{content}\n\n{suffix}" if content else suffix
-        return merged, {
+        marker: dict[str, Any] = {
             "version": 1,
-            "sources": list(sources),
+            "sources": effective_sources,
             "suffix": suffix,
         }
+        if has_ephemeral:
+            marker[_RUNTIME_CONTEXT_LIFECYCLE] = lifecycle
+        return merged, marker
 
     visible_blocks: list[Any] = (
         [*cast(list[Any], content)]
         if isinstance(content, list)
         else ([] if content is None else [{"type": "text", "text": str(content)}])
     )
-    return [*visible_blocks, *context_blocks], {
+    marker = {
         "version": 1,
-        "sources": list(sources),
+        "sources": effective_sources,
         "blocks": context_blocks,
     }
+    if has_ephemeral:
+        marker[_RUNTIME_CONTEXT_LIFECYCLE] = lifecycle
+    return [*visible_blocks, *context_blocks], marker
+
+
+def project_runtime_context_for_history(
+    content: Any,
+    marker: Mapping[str, Any],
+) -> tuple[Any, dict[str, Any] | None]:
+    """Remove ephemeral runtime-context segments before history persistence."""
+    if _RUNTIME_CONTEXT_LIFECYCLE not in marker:
+        return content, deepcopy(dict(marker))
+
+    detached = detach_runtime_context(content, marker)
+    if detached is None:
+        return content, deepcopy(dict(marker))
+
+    visible_content, _sources, detached_blocks = detached
+    persistent_blocks: list[dict[str, Any]] = []
+    persistent_sources: list[str] = []
+    for block in detached_blocks:
+        raw_detached_meta = block.get(_RUNTIME_CONTEXT_DETACHED)
+        if not isinstance(raw_detached_meta, Mapping):
+            return content, deepcopy(dict(marker))
+        detached_meta = cast(Mapping[str, object], raw_detached_meta)
+        item_sources = _validated_sources(detached_meta.get("sources"))
+        if item_sources is None:
+            return content, deepcopy(dict(marker))
+        if detached_meta.get("ephemeral") is True:
+            continue
+        persistent_sources.extend(item_sources)
+        persistent_blocks.append(block)
+
+    if not persistent_blocks:
+        return visible_content, None
+    return reattach_runtime_context(
+        visible_content,
+        persistent_sources,
+        persistent_blocks,
+    )
 
 
 def public_history_message(message: Mapping[str, Any]) -> dict[str, Any]:

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -195,6 +195,63 @@ def test_persist_cron_turn_uses_distinct_history_marker(tmp_path: Path) -> None:
     assert message["cron_prompt_ref"] == prompt_ref
 
 
+def test_persist_user_message_early_drops_ephemeral_runtime_context(
+    tmp_path: Path,
+) -> None:
+    loop = _make_full_loop(tmp_path)
+    session = loop.sessions.get_or_create("cli:ephemeral-early")
+
+    persisted = loop._persist_user_message_early(
+        InboundMessage(
+            channel="cli",
+            sender_id="user",
+            chat_id="ephemeral-early",
+            content="hello",
+        ),
+        session,
+        runtime_context_blocks=[
+            RuntimeContextBlock(source="goal", content="persistent context"),
+            RuntimeContextBlock(
+                source="voice",
+                content="ephemeral voice contract",
+                ephemeral=True,
+            ),
+        ],
+    )
+
+    assert persisted is True
+    assert len(session.messages) == 1
+    message = session.messages[0]
+    assert message["content"] == "hello\n\npersistent context"
+    assert "ephemeral voice contract" not in message["content"]
+    assert message[RUNTIME_CONTEXT_HISTORY_META]["sources"] == ["goal"]
+
+
+def test_persist_user_message_early_skips_ephemeral_only_context_without_payload(
+    tmp_path: Path,
+) -> None:
+    loop = _make_full_loop(tmp_path)
+    session = loop.sessions.get_or_create("cli:ephemeral-only")
+
+    persisted = loop._persist_user_message_early(
+        InboundMessage(
+            channel="cli",
+            sender_id="user",
+            chat_id="ephemeral-only",
+            content="",
+        ),
+        session,
+        runtime_context_blocks=[RuntimeContextBlock(
+            source="voice",
+            content="ephemeral voice contract",
+            ephemeral=True,
+        )],
+    )
+
+    assert persisted is False
+    assert session.messages == []
+
+
 def test_persist_user_message_acknowledges_durable_followup(tmp_path: Path) -> None:
     loop = _make_full_loop(tmp_path)
     session = loop.sessions.get_or_create("websocket:chat")
@@ -592,6 +649,115 @@ def test_save_turn_persists_runtime_context_and_public_view_hides_it() -> None:
     assert session.messages[0]["content"] == "hello world\n\ninternal goal guidance"
     assert session.messages[0][RUNTIME_CONTEXT_HISTORY_META]["sources"] == ["goal"]
     assert public_history_message(session.messages[0])["content"] == "hello world"
+
+
+def test_save_turn_persists_only_non_ephemeral_runtime_context() -> None:
+    loop = _mk_loop()
+    session = Session(key="test:ephemeral-injection")
+
+    loop._save_turn(
+        session,
+        [_runtime_message(
+            "follow up",
+            [
+                RuntimeContextBlock(
+                    source="goal",
+                    content="persistent injected context",
+                ),
+                RuntimeContextBlock(
+                    source="voice",
+                    content="ephemeral injected context",
+                    ephemeral=True,
+                ),
+            ],
+        )],
+        skip=0,
+    )
+
+    assert len(session.messages) == 1
+    message = session.messages[0]
+    assert message["content"] == "follow up\n\npersistent injected context"
+    assert "ephemeral injected context" not in message["content"]
+    assert message[RUNTIME_CONTEXT_HISTORY_META]["sources"] == ["goal"]
+    assert public_history_message(message)["content"] == "follow up"
+
+
+def test_save_turn_drops_all_ephemeral_context_but_keeps_visible_user_text() -> None:
+    loop = _mk_loop()
+    session = Session(key="test:all-ephemeral-injection")
+
+    loop._save_turn(
+        session,
+        [_runtime_message(
+            "follow up",
+            [RuntimeContextBlock(
+                source="voice",
+                content="ephemeral injected context",
+                ephemeral=True,
+            )],
+        )],
+        skip=0,
+    )
+
+    assert len(session.messages) == 1
+    assert session.messages[0]["content"] == "follow up"
+    assert RUNTIME_CONTEXT_HISTORY_META not in session.messages[0]
+
+
+def test_save_turn_skips_empty_user_row_with_only_ephemeral_context() -> None:
+    loop = _mk_loop()
+    session = Session(key="test:empty-ephemeral-injection")
+
+    loop._save_turn(
+        session,
+        [_runtime_message(
+            "",
+            [RuntimeContextBlock(
+                source="voice",
+                content="ephemeral injected context",
+                ephemeral=True,
+            )],
+        )],
+        skip=0,
+    )
+
+    assert session.messages == []
+
+
+def test_save_turn_drops_ephemeral_context_from_multimodal_user_message() -> None:
+    loop = _mk_loop()
+    session = Session(key="test:ephemeral-image")
+
+    loop._save_turn(
+        session,
+        [_runtime_message(
+            [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,abc"},
+                    "_meta": {"path": "/media/photo.jpg"},
+                },
+                {"type": "text", "text": "inspect this"},
+            ],
+            [
+                RuntimeContextBlock(source="goal", content="persistent context"),
+                RuntimeContextBlock(
+                    source="voice",
+                    content="ephemeral contract",
+                    ephemeral=True,
+                ),
+            ],
+        )],
+        skip=0,
+    )
+
+    assert session.messages[0]["content"] == [
+        {"type": "text", "text": "[image: /media/photo.jpg]"},
+        {"type": "text", "text": "inspect this"},
+        {"type": "text", "text": "persistent context"},
+    ]
+    assert session.messages[0][RUNTIME_CONTEXT_HISTORY_META]["sources"] == ["goal"]
+    assert "ephemeral contract" not in str(session.messages[0]["content"])
 
 
 def test_build_and_save_preserves_user_text_containing_goal_guidance_tag(tmp_path: Path) -> None:

--- a/tests/agent/test_runner_injections.py
+++ b/tests/agent/test_runner_injections.py
@@ -963,6 +963,64 @@ def test_runner_merge_preserves_runtime_markers_with_media() -> None:
     ]
 
 
+def test_runner_merge_preserves_ephemeral_runtime_lifecycle_with_media() -> None:
+    from nanobot.agent.runner import AgentRunner
+    from nanobot.runtime_context import (
+        RUNTIME_CONTEXT_MESSAGE_META,
+        RuntimeContextBlock,
+        append_runtime_context,
+        project_runtime_context_for_history,
+    )
+
+    first_visible = [
+        {"type": "text", "text": "first"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AA=="}},
+    ]
+    first_content, first_marker = append_runtime_context(
+        first_visible,
+        [RuntimeContextBlock(source="first", content="persistent first context")],
+    )
+    second_content, second_marker = append_runtime_context(
+        "second",
+        [RuntimeContextBlock(
+            source="voice",
+            content="ephemeral second context",
+            ephemeral=True,
+        )],
+    )
+    messages: list[dict] = []
+
+    AgentRunner._append_injected_messages(messages, [
+        {
+            "role": "user",
+            "content": first_content,
+            "_meta": {RUNTIME_CONTEXT_MESSAGE_META: first_marker},
+        },
+        {
+            "role": "user",
+            "content": second_content,
+            "_meta": {RUNTIME_CONTEXT_MESSAGE_META: second_marker},
+        },
+    ])
+
+    assert len(messages) == 1
+    merged = messages[0]
+    assert "persistent first context" in str(merged["content"])
+    assert "ephemeral second context" in str(merged["content"])
+
+    history_content, history_marker = project_runtime_context_for_history(
+        merged["content"],
+        merged["_meta"][RUNTIME_CONTEXT_MESSAGE_META],
+    )
+    assert history_content == [
+        *first_visible,
+        {"type": "text", "text": "second"},
+        {"type": "text", "text": "persistent first context"},
+    ]
+    assert history_marker is not None
+    assert history_marker["sources"] == ["first"]
+
+
 @pytest.mark.asyncio
 async def test_injection_cycles_capped_at_max():
     """Injection cycles should be capped at _MAX_INJECTION_CYCLES."""

--- a/tests/agent/test_runtime_context.py
+++ b/tests/agent/test_runtime_context.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from nanobot.agent.context import ContextBuilder
 from nanobot.agent.tools.context import RequestContext
 from nanobot.runtime_context import (
     MAX_WEBUI_QUOTE_CHARS,
@@ -13,7 +14,9 @@ from nanobot.runtime_context import (
     WEBUI_QUOTE_SOURCE,
     RuntimeContextBlock,
     append_runtime_context,
+    normalize_runtime_context_blocks,
     normalize_webui_quote,
+    project_runtime_context_for_history,
     public_history_message,
     resolve_runtime_context,
     runtime_context_blocks_from_metadata,
@@ -47,6 +50,151 @@ async def test_resolve_runtime_context_preserves_provider_order() -> None:
         ("first", "one"),
         ("second", "two"),
     ]
+
+
+def test_normalize_runtime_context_preserves_ephemeral_flag() -> None:
+    normalized = normalize_runtime_context_blocks(RuntimeContextBlock(
+        source=" voice ",
+        content=" keep replies short ",
+        ephemeral=True,
+    ))
+
+    assert normalized == [RuntimeContextBlock(
+        source="voice",
+        content="keep replies short",
+        ephemeral=True,
+    )]
+
+
+def test_ephemeral_runtime_context_is_request_visible_but_not_history_persistent() -> None:
+    request_content, request_marker = append_runtime_context(
+        "hello",
+        [
+            RuntimeContextBlock(source="goal", content="persistent goal context"),
+            RuntimeContextBlock(
+                source="voice",
+                content="speak briefly",
+                ephemeral=True,
+            ),
+        ],
+    )
+
+    assert request_marker is not None
+    assert request_content == "hello\n\npersistent goal context\n\nspeak briefly"
+
+    history_content, history_marker = project_runtime_context_for_history(
+        request_content,
+        request_marker,
+    )
+
+    assert history_content == "hello\n\npersistent goal context"
+    assert history_marker is not None
+    assert history_marker["sources"] == ["goal"]
+    assert "_lifecycle" not in history_marker
+
+
+def test_all_ephemeral_runtime_context_projects_to_visible_user_content_only() -> None:
+    request_content, request_marker = append_runtime_context(
+        "hello",
+        [RuntimeContextBlock(
+            source="voice",
+            content="speak briefly",
+            ephemeral=True,
+        )],
+    )
+
+    assert request_marker is not None
+    assert "speak briefly" in request_content
+    assert project_runtime_context_for_history(request_content, request_marker) == (
+        "hello",
+        None,
+    )
+
+
+def test_multimodal_ephemeral_runtime_context_is_removed_from_history() -> None:
+    visible = [
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,AA=="},
+        },
+        {"type": "text", "text": "what is this?"},
+    ]
+    request_content, request_marker = append_runtime_context(
+        visible,
+        [
+            RuntimeContextBlock(source="goal", content="persistent context"),
+            RuntimeContextBlock(
+                source="voice",
+                content="ephemeral voice contract",
+                ephemeral=True,
+            ),
+        ],
+    )
+
+    assert request_marker is not None
+    history_content, history_marker = project_runtime_context_for_history(
+        request_content,
+        request_marker,
+    )
+
+    assert history_content == [
+        *visible,
+        {"type": "text", "text": "persistent context"},
+    ]
+    assert history_marker is not None
+    assert history_marker["sources"] == ["goal"]
+
+
+def test_ephemeral_projection_handles_internal_blank_lines_and_mixed_order() -> None:
+    request_content, request_marker = append_runtime_context(
+        "hello",
+        [
+            RuntimeContextBlock(source="first", content="first persistent"),
+            RuntimeContextBlock(
+                source="voice",
+                content="line one\n\nline two",
+                ephemeral=True,
+            ),
+            RuntimeContextBlock(source="last", content="last persistent"),
+        ],
+    )
+
+    assert request_marker is not None
+    history_content, history_marker = project_runtime_context_for_history(
+        request_content,
+        request_marker,
+    )
+
+    assert history_content == "hello\n\nfirst persistent\n\nlast persistent"
+    assert history_marker is not None
+    assert history_marker["sources"] == ["first", "last"]
+
+
+def test_persistent_runtime_context_history_projection_is_unchanged() -> None:
+    request_content, request_marker = append_runtime_context(
+        "hello",
+        [RuntimeContextBlock(source="goal", content="persistent context")],
+    )
+
+    assert request_marker is not None
+    assert project_runtime_context_for_history(request_content, request_marker) == (
+        request_content,
+        request_marker,
+    )
+
+
+def test_context_builder_keeps_ephemeral_context_in_current_request(tmp_path) -> None:
+    current = ContextBuilder(tmp_path).build_current_message(
+        "hello",
+        runtime_context_blocks=[RuntimeContextBlock(
+            source="voice",
+            content="ephemeral voice contract",
+            ephemeral=True,
+        )],
+    )
+
+    assert "ephemeral voice contract" in str(current["content"])
+    assert current["_meta"]["runtime_context"]["_lifecycle"][0]["ephemeral"] is True
 
 
 def test_webui_quote_is_bounded_and_projected_as_model_only_context() -> None:


### PR DESCRIPTION
## Summary

Add an `ephemeral` lifecycle option to `RuntimeContextBlock`. Ephemeral runtime-context blocks remain visible to the current model request, but are projected out before user messages enter durable session history.

Closes #5586.

## Behavior

| block | current request | session history | later replay |
|---|---:|---:|---:|
| persistent (default) | yes | yes | yes |
| ephemeral | yes | no | no |

## Implementation

- preserve `ephemeral` through normalization while retaining the default `False` behavior
- add a length-based lifecycle sidecar only when a marker contains ephemeral blocks
- carry lifecycle metadata transparently through detach/reattach, including merged injected messages
- filter ephemeral blocks from early user-message persistence
- project injected user messages onto persistent context in `_save_turn`
- preserve public history stripping and existing persistent-only marker shapes

## Compatibility

Existing producers are unchanged because `ephemeral=False` remains the default. Persistent-only markers do not gain lifecycle metadata.

## Relation to existing work

This is an alternative implementation to #5615. This version avoids duplicating string runtime-context content in marker metadata and keeps `AgentRunner` unchanged by using an internal detach/reattach carrier.

## Out of scope

This controls nanobot transcript/history persistence. Provider-owned opaque conversation continuation state is not rewritten.

## Tests

- `uv run --no-sync pytest -q tests/agent`: 1567 passed
- focused runtime-context/loop/runner suite: 138 passed
- `ruff check`: passed
- `uv run --no-sync basedpyright`: 0 errors, 0 warnings
- full `pytest -q`: 6792 passed, 12 skipped; 12 local environment failures reproduced unchanged on clean `origin/main` (WebUI npm cache and proxy/network transport tests)

## AI Assistance Disclosure

OpenAI Codex assisted with issue analysis, implementation, verification, and PR preparation. The contributor explicitly approved submission.