### PR TITLE
feat(cron): support configurable delivery and batch archive

### DIFF
--- a/docs/automations.md
+++ b/docs/automations.md
@@ -57,8 +57,21 @@ scheduled tasks. Cron expressions can include an IANA timezone such as
 `America/Vancouver`; otherwise nanobot uses the runtime default timezone.
 
 Scheduled automations normally deliver the result back to the session where they
-were created. Use them for work that should run on a predictable schedule and
-report each run.
+were created. A scheduled automation can instead set both `delivery_channel`
+and `delivery_chat_id` to send visible results to another registered channel,
+such as a Slack channel or Feishu group. The original session still owns the
+automation's history, workspace, and execution context. Leave both delivery
+fields empty to keep the origin-session behavior; providing only one is rejected.
+
+You can set or clear the delivery target in the WebUI automation editor. The
+cron tool also accepts the two fields when creating a job. A destination is a
+registered nanobot channel plus its channel-specific chat ID, not an arbitrary
+webhook URL.
+
+Use scheduled automations for work that should run on a predictable schedule
+and report each run. New one-time jobs remain as completed, disabled jobs after
+they run so their history can be inspected and archived. Existing stored jobs
+with `deleteAfterRun=true` keep the legacy delete-after-run behavior.
 
 For background checks that should stay quiet unless there is something useful to
 report, use heartbeat instead of a user-created scheduled automation.
@@ -119,14 +132,21 @@ Heartbeat is enabled by default when `nanobot gateway` starts. Configure it in
 
 Use the WebUI Automations view to:
 
-- filter by all, active, paused, needs-attention, or system jobs;
+- filter by all, active, paused, needs-attention, system, or archived jobs;
 - search by task name, message, trigger command, linked topic, schedule, or
   status;
 - sort by next run, last run, updated time, or name;
 - run scheduled automations now;
 - pause or resume, rename, or delete user-created automations;
+- edit a scheduled automation's result delivery target;
+- select and archive multiple scheduled automations in one action;
 - copy the CLI command for local triggers;
 - inspect protected system automations without changing them.
+
+Archiving is a soft removal: it disables the job, removes its next run, and
+keeps its last result and run history. Archived jobs cannot be edited, resumed,
+or run, but they can still be inspected or permanently deleted. System jobs and
+local triggers cannot be archived.
 
 Local triggers do not have a WebUI "Run now" action because each run needs a
 message. Copy the `nanobot trigger ...` command from the WebUI and replace
@@ -189,7 +209,7 @@ config as the gateway.
 If a trigger message appears twice after a restart, treat it as expected
 at-least-once delivery and make the external message idempotent.
 
-If you need to edit, pause, resume, rename, delete, or inspect automations, use
+If you need to edit, pause, resume, archive, delete, or inspect automations, use
 the WebUI Automations view.
 
 ## Related Docs

--- a/docs/webui.md
+++ b/docs/webui.md
@@ -271,7 +271,8 @@ your agent.
 Automations are agent turns that run later in a linked topic. Create them from
 the topic or channel where they are supposed to run so nanobot keeps the
 correct target context. When an automation runs, it normally delivers the
-result back to that topic.
+result back to that topic. Scheduled automations can also keep that original
+session context while sending the visible result to another configured channel.
 
 For the full automation model, creation flow, trigger CLI usage, and delivery
 semantics, see [`automations.md`](./automations.md).
@@ -289,13 +290,19 @@ instead of creating a chat automation.
 
 Use the Automations view to:
 
-- Filter by all, active, paused, needs-attention, or system jobs.
+- Filter by all, active, paused, needs-attention, system, or archived jobs.
 - Search by task name, message, trigger command, linked topic, schedule, or status.
 - Sort by next run, last run, updated time, or name.
 - Run scheduled automations now.
 - Pause or resume, rename, or delete user-created automations.
+- Set or clear a scheduled automation's result delivery channel and chat ID.
+- Select and archive multiple scheduled automations while retaining run history.
 - Copy the CLI command for local triggers.
 - Inspect protected system automations without changing them.
+
+Archived scheduled automations are read-only in the first archive workflow:
+you can inspect or permanently delete them, but cannot run, resume, or edit
+them. Local triggers and protected system jobs are not selectable for archive.
 
 Search accepts plain text and field filters such as `name:backup`,
 `chat:WeChat`, `schedule:09:30`, `cron:"0 23 * * *"`, `trigger`, and

--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -20,7 +20,7 @@ from nanobot.cron.types import CronJob, CronJobState, CronSchedule
 from nanobot.session.keys import UNIFIED_SESSION_KEY
 
 _CRON_PARAMETERS = tool_parameters_schema(
-    action=StringSchema("Action to perform", enum=["add", "list", "remove"]),
+    action=StringSchema("Action to perform", enum=["add", "list", "remove", "archive"]),
     name=StringSchema(
         "Optional short human-readable label for the job "
         "(e.g., 'weather-monitor', 'daily-standup'). Defaults to first 30 chars of message."
@@ -41,10 +41,26 @@ _CRON_PARAMETERS = tool_parameters_schema(
         "Naive values use the tool's default timezone."
     ),
     job_id=StringSchema("REQUIRED when action='remove'. Job ID to remove (obtain via action='list')."),
+    job_ids=StringSchema(
+        "REQUIRED when action='archive'. Comma-separated job IDs to archive."
+    ),
+    delivery_channel=StringSchema(
+        "Optional result delivery channel for action='add'. "
+        "Must be provided with delivery_chat_id."
+    ),
+    delivery_chat_id=StringSchema(
+        "Optional destination chat/channel ID for action='add'. "
+        "Must be provided with delivery_channel."
+    ),
+    view=StringSchema(
+        "List view for action='list'.",
+        enum=["active", "archived", "all"],
+    ),
     required=["action"],
     description=(
         "Action-specific parameters: add requires a non-empty message plus one schedule "
-        "(every_seconds, cron_expr, or at); remove requires job_id; list only needs action. "
+        "(every_seconds, cron_expr, or at); remove requires job_id; archive requires job_ids; "
+        "list only needs action. "
         "Per-action requirements are enforced at runtime (see field descriptions) so the "
         "top-level schema stays compatible with providers (e.g. OpenAI Codex/Responses) that "
         "reject oneOf/anyOf/allOf/enum/not at the root of function parameters."
@@ -120,7 +136,7 @@ class CronTool(Tool):
     @property
     def description(self) -> str:
         return (
-            "Schedule reminders and recurring tasks. Actions: add, list, remove. "
+            "Schedule reminders and recurring tasks. Actions: add, list, remove, archive. "
             f"If tz is omitted, cron expressions and naive ISO times default to {self._default_timezone}."
         )
 
@@ -131,6 +147,15 @@ class CronTool(Tool):
             errors.append("message is required when action='add'")
         if action == "remove" and not str(params.get("job_id") or "").strip():
             errors.append("job_id is required when action='remove'")
+        if action == "archive" and not str(params.get("job_ids") or "").strip():
+            errors.append("job_ids is required when action='archive'")
+        if action == "add":
+            delivery_channel = str(params.get("delivery_channel") or "").strip()
+            delivery_chat_id = str(params.get("delivery_chat_id") or "").strip()
+            if bool(delivery_channel) != bool(delivery_chat_id):
+                errors.append(
+                    "delivery_channel and delivery_chat_id must be provided together"
+                )
         return errors
 
     async def execute(
@@ -143,15 +168,30 @@ class CronTool(Tool):
         tz: str | None = None,
         at: str | None = None,
         job_id: str | None = None,
+        job_ids: str | None = None,
+        delivery_channel: str | None = None,
+        delivery_chat_id: str | None = None,
+        view: str | None = None,
     ) -> str:
         if action == "add":
             if self._in_cron_context.get():
                 return ToolResult.error("Error: cannot schedule new jobs from within a cron job execution")
-            return self._add_job(name, message, every_seconds, cron_expr, tz, at)
+            return self._add_job(
+                name,
+                message,
+                every_seconds,
+                cron_expr,
+                tz,
+                at,
+                delivery_channel,
+                delivery_chat_id,
+            )
         elif action == "list":
-            return self._list_jobs()
+            return self._list_jobs(view=view or "active")
         elif action == "remove":
             return self._remove_job(job_id)
+        elif action == "archive":
+            return self._archive_jobs(job_ids)
         return f"Unknown action: {action}"
 
     def _add_job(
@@ -162,6 +202,8 @@ class CronTool(Tool):
         cron_expr: str | None,
         tz: str | None,
         at: str | None,
+        delivery_channel: str | None = None,
+        delivery_chat_id: str | None = None,
     ) -> str:
         if not message:
             return ToolResult.error(
@@ -174,6 +216,12 @@ class CronTool(Tool):
             return ToolResult.error("Error: scheduled cron jobs must be created from a chat session")
         if not origin_channel or not origin_chat_id:
             return ToolResult.error("Error: scheduled cron jobs must be created from a chat session")
+        delivery_channel = (delivery_channel or "").strip() or None
+        delivery_chat_id = (delivery_chat_id or "").strip() or None
+        if bool(delivery_channel) != bool(delivery_chat_id):
+            return ToolResult.error(
+                "Error: delivery_channel and delivery_chat_id must be provided together"
+            )
         if tz and not cron_expr:
             return ToolResult.error("Error: tz can only be used with cron_expr")
         if tz:
@@ -202,7 +250,6 @@ class CronTool(Tool):
                 dt = dt.replace(tzinfo=ZoneInfo(self._default_timezone))
             at_ms = int(dt.timestamp() * 1000)
             schedule = CronSchedule(kind="at", at_ms=at_ms)
-            delete_after = True
         else:
             return ToolResult.error("Error: either every_seconds, cron_expr, or at is required")
 
@@ -215,6 +262,8 @@ class CronTool(Tool):
             origin_channel=origin_channel,
             origin_chat_id=origin_chat_id,
             origin_metadata=origin_metadata,
+            delivery_channel=delivery_channel,
+            delivery_chat_id=delivery_chat_id,
         )
         return f"Created job '{job.name}' (id: {job.id})"
 
@@ -258,10 +307,20 @@ class CronTool(Tool):
             return "Dream memory consolidation for long-term memory."
         return "System-managed internal job."
 
-    def _list_jobs(self) -> str:
-        jobs = self._cron.list_jobs()
+    def _list_jobs(self, *, view: str = "active") -> str:
+        if view == "active":
+            jobs = self._cron.list_jobs()
+        elif view == "archived":
+            jobs = self._cron.list_archived_jobs()
+        elif view == "all":
+            jobs = self._cron.list_jobs(
+                include_disabled=True,
+                include_archived=True,
+            )
+        else:
+            return ToolResult.error(f"Error: unsupported list view '{view}'")
         if not jobs:
-            return "No scheduled jobs."
+            return "No scheduled jobs." if view == "active" else f"No {view} scheduled jobs."
         lines: list[str] = []
         for j in jobs:
             timing = self._format_timing(j.schedule)
@@ -269,9 +328,44 @@ class CronTool(Tool):
             if j.payload.kind == "system_event":
                 parts.append(f"  Purpose: {self._system_job_purpose(j)}")
                 parts.append("  Protected: visible for inspection, but cannot be removed.")
+            else:
+                if j.payload.delivery_channel and j.payload.delivery_chat_id:
+                    parts.append(
+                        "  Delivery: "
+                        f"{j.payload.delivery_channel}:{j.payload.delivery_chat_id}"
+                    )
+                else:
+                    parts.append("  Delivery: origin session")
+                if j.archived_at_ms is not None:
+                    parts.append(
+                        "  Archived: "
+                        + self._format_timestamp(
+                            j.archived_at_ms,
+                            self._display_timezone(j.schedule),
+                        )
+                    )
             parts.extend(self._format_state(j.state, j.schedule))
             lines.append("\n".join(parts))
         return "Scheduled jobs:\n" + "\n".join(lines)
+
+    def _archive_jobs(self, raw_job_ids: str | None) -> str:
+        if not raw_job_ids:
+            return ToolResult.error("Error: job_ids is required for archive")
+        job_ids = [part.strip() for part in raw_job_ids.split(",") if part.strip()]
+        if not job_ids:
+            return ToolResult.error("Error: job_ids is required for archive")
+
+        result = self._cron.archive_jobs(job_ids)
+        lines: list[str] = []
+        if result.archived:
+            lines.append("Archived: " + ", ".join(result.archived))
+        if result.already_archived:
+            lines.append("Already archived: " + ", ".join(result.already_archived))
+        if result.protected:
+            lines.append("Protected system jobs: " + ", ".join(result.protected))
+        if result.not_found:
+            lines.append("Not found: " + ", ".join(result.not_found))
+        return "\n".join(lines) or "No jobs changed."
 
     def _remove_job(self, job_id: str | None) -> str:
         if not job_id:

--- a/nanobot/channels/websocket/tests/test_websocket_http_routes.py
+++ b/nanobot/channels/websocket/tests/test_websocket_http_routes.py
@@ -2347,6 +2347,8 @@ async def test_webui_automations_route_lists_all_jobs_and_allows_user_actions(
         session_key="websocket:abc",
         origin_channel="websocket",
         origin_chat_id="abc",
+        delivery_channel="slack",
+        delivery_chat_id="C123",
     )
     incomplete_job = cron.add_job(
         name="english-quiz",
@@ -2411,6 +2413,9 @@ async def test_webui_automations_route_lists_all_jobs_and_allows_user_actions(
         assert by_id[user_job.id]["state"]["run_history"] == []
         assert by_id[user_job.id]["origin"]["session_key"] == "websocket:abc"
         assert by_id[user_job.id]["origin"]["preview"] == "hi"
+        assert by_id[user_job.id]["payload"]["delivery_channel"] == "slack"
+        assert by_id[user_job.id]["payload"]["delivery_chat_id"] == "C123"
+        assert by_id[user_job.id]["archived_at_ms"] is None
         assert "session_key" not in by_id[incomplete_job.id]["payload"]
         assert "origin_channel" not in by_id[incomplete_job.id]["payload"]
         assert "origin_chat_id" not in by_id[incomplete_job.id]["payload"]
@@ -2447,6 +2452,52 @@ async def test_webui_automations_route_lists_all_jobs_and_allows_user_actions(
         assert by_id[user_job.id]["schedule"]["kind"] == "cron"
         assert by_id[user_job.id]["schedule"]["expr"] == "0 9 * * *"
         assert by_id[user_job.id]["schedule"]["tz"] == "UTC"
+
+        delivery_update = await _webui_mutate(
+            channel,
+            "automation.update",
+            {
+                "id": user_job.id,
+                "values": {
+                    "delivery_channel": "feishu",
+                    "delivery_chat_id": "oc_ops",
+                },
+            },
+        )
+        assert delivery_update.status_code == 200
+        assert cron.get_job(user_job.id).payload.delivery_channel == "feishu"
+        assert cron.get_job(user_job.id).payload.delivery_chat_id == "oc_ops"
+
+        matching_schedule_delivery_update = await _webui_mutate(
+            channel,
+            "automation.update",
+            {
+                "id": user_job.id,
+                "values": {
+                    "schedule": {
+                        "kind": "cron",
+                        "expr": "0 9 * * *",
+                        "tz": "UTC",
+                    },
+                    "delivery_channel": "slack",
+                    "delivery_chat_id": "C456",
+                },
+            },
+        )
+        assert matching_schedule_delivery_update.status_code == 200
+        assert cron.get_job(user_job.id).payload.delivery_channel == "slack"
+        assert cron.get_job(user_job.id).payload.delivery_chat_id == "C456"
+
+        partial_delivery_update = await _webui_mutate(
+            channel,
+            "automation.update",
+            {
+                "id": user_job.id,
+                "values": {"delivery_channel": "slack"},
+            },
+        )
+        assert partial_delivery_update.status_code == 400
+        assert cron.get_job(user_job.id).payload.delivery_channel == "slack"
 
         unicode_update = await _webui_mutate(
             channel,
@@ -2562,6 +2613,39 @@ async def test_webui_automations_route_lists_all_jobs_and_allows_user_actions(
         assert enabled.status_code == 200
         by_id = {job["id"]: job for job in enabled.json()["jobs"]}
         assert by_id[user_job.id]["enabled"] is True
+
+        archived = await _webui_mutate(
+            channel,
+            "automation.archive",
+            {"job_ids": [user_job.id, user_job.id, "heartbeat", "missing"]},
+        )
+        assert archived.status_code == 200
+        assert archived.json() == {
+            "archived": [user_job.id],
+            "already_archived": [],
+            "protected": ["heartbeat"],
+            "not_found": ["missing"],
+        }
+        assert cron.get_job(user_job.id).archived_at_ms is not None
+
+        archived_list = await _http_get(
+            f"{base_url}/api/webui/automations",
+            headers=auth,
+        )
+        archived_by_id = {job["id"]: job for job in archived_list.json()["jobs"]}
+        assert archived_by_id[user_job.id]["archived_at_ms"] is not None
+        assert archived_by_id[user_job.id]["enabled"] is False
+
+        for archived_action in ("enable", "disable", "run", "update"):
+            payload: dict[str, Any] = {"id": user_job.id}
+            if archived_action == "update":
+                payload["values"] = {"name": "cannot change"}
+            response = await _webui_mutate(
+                channel,
+                f"automation.{archived_action}",
+                payload,
+            )
+            assert response.status_code == 409
 
         deleted = await _webui_mutate(
             channel,

--- a/nanobot/cron/bound_runner.py
+++ b/nanobot/cron/bound_runner.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 from nanobot.agent.tools.cron import CronTool
 from nanobot.bus.events import InboundMessage, OutboundMessage
-from nanobot.cron.session_delivery import origin_delivery_context
+from nanobot.cron.session_delivery import configured_delivery_context
 from nanobot.cron.session_turns import CRON_DEFER_UNTIL_IDLE_META, CRON_TRIGGER_META
 from nanobot.cron.types import CronJob
 from nanobot.cron.webui_metadata import cron_proactive_delivery_metadata
@@ -46,7 +46,7 @@ def _bound_session_delivery_context(
     turn_seed: str,
     source_label: str | None,
 ) -> tuple[str, str, dict[str, Any]]:
-    channel, chat_id, metadata = origin_delivery_context(job)
+    channel, chat_id, metadata = configured_delivery_context(job)
 
     if channel == "websocket":
         metadata["webui"] = True
@@ -102,6 +102,10 @@ async def run_bound_cron_job(
         "prompt_ref": prompt_ref,
         "prompt_vars": {"message": job.payload.message},
         "rendered_prompt": prompt,
+        "delivery": {
+            "channel": channel,
+            "chat_id": chat_id,
+        },
     }
 
     cron.write_run_record(

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -18,6 +18,7 @@ from loguru import logger
 
 from nanobot.cron.session_turns import is_bound_cron_job
 from nanobot.cron.types import (
+    CronArchiveResult,
     CronJob,
     CronJobState,
     CronPayload,
@@ -116,7 +117,34 @@ def _disable_malformed_legacy_job(job: CronJob) -> None:
     logger.warning("Cron: disabled malformed legacy job '{}' ({}): {}", job.name, job.id, reason)
 
 
-def _persistable_origin_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+def _validate_delivery_pair(channel: str | None, chat_id: str | None) -> None:
+    if channel is None and chat_id is None:
+        return
+    if (
+        not isinstance(channel, str)
+        or not channel.strip()
+        or not isinstance(chat_id, str)
+        or not chat_id.strip()
+    ):
+        raise ValueError(
+            "cron delivery target requires both 'delivery_channel' and 'delivery_chat_id'"
+        )
+
+
+def _validate_delivery_target(payload: CronPayload) -> None:
+    _validate_delivery_pair(payload.delivery_channel, payload.delivery_chat_id)
+
+
+def _disable_malformed_delivery_job(job: CronJob, reason: str) -> None:
+    job.enabled = False
+    job.state.next_run_at_ms = None
+    job.state.last_status = "error"
+    job.state.last_error = reason
+    job.updated_at_ms = max(job.updated_at_ms, _now_ms())
+    logger.warning("Cron: disabled malformed delivery for job '{}' ({}): {}", job.name, job.id, reason)
+
+
+def _persistable_route_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
     """Return a detached JSON-safe routing snapshot for a cron payload."""
     snapshot: dict[str, Any] = {}
     for key, value in metadata.items():
@@ -138,30 +166,65 @@ def _normalize_agent_turn_job(job: CronJob) -> bool:
     a runtime legacy execution path.
     """
     payload = job.payload
-    origin_metadata = _persistable_origin_metadata(payload.origin_metadata)
-    changed = origin_metadata != payload.origin_metadata
+    origin_metadata = _persistable_route_metadata(payload.origin_metadata)
+    delivery_metadata = _persistable_route_metadata(payload.delivery_metadata)
+    changed = (
+        origin_metadata != payload.origin_metadata
+        or delivery_metadata != payload.delivery_metadata
+    )
     payload.origin_metadata = origin_metadata
+    payload.delivery_metadata = delivery_metadata
 
-    if payload.kind != "agent_turn" or not _has_legacy_delivery_context(payload):
+    if job.archived_at_ms is not None:
+        if job.enabled or job.state.next_run_at_ms is not None:
+            changed = True
+        job.enabled = False
+        job.state.next_run_at_ms = None
+
+    if payload.kind != "agent_turn":
         return changed
 
-    if not payload.channel or not payload.to:
-        _disable_malformed_legacy_job(job)
-        return True
+    if _has_legacy_delivery_context(payload):
+        if not payload.channel or not payload.to:
+            _disable_malformed_legacy_job(job)
+            changed = True
+        else:
+            payload.session_key = _legacy_session_key(payload)
+            payload.origin_channel = payload.origin_channel or payload.channel
+            payload.origin_chat_id = payload.origin_chat_id or payload.to
+            if not payload.origin_metadata:
+                payload.origin_metadata = _persistable_route_metadata(payload.channel_meta or {})
 
-    payload.session_key = _legacy_session_key(payload)
-    payload.origin_channel = payload.origin_channel or payload.channel
-    payload.origin_chat_id = payload.origin_chat_id or payload.to
-    if not payload.origin_metadata:
-        payload.origin_metadata = _persistable_origin_metadata(payload.channel_meta or {})
+            payload.deliver = False
+            payload.channel = None
+            payload.to = None
+            payload.channel_meta = {}
+            job.updated_at_ms = max(job.updated_at_ms, _now_ms())
+            logger.info(
+                "Cron: migrated legacy job '{}' ({}) to session-bound payload",
+                job.name,
+                job.id,
+            )
+            changed = True
 
-    payload.deliver = False
-    payload.channel = None
-    payload.to = None
-    payload.channel_meta = {}
-    job.updated_at_ms = max(job.updated_at_ms, _now_ms())
-    logger.info("Cron: migrated legacy job '{}' ({}) to session-bound payload", job.name, job.id)
-    return True
+    try:
+        _validate_delivery_target(payload)
+    except ValueError as exc:
+        _disable_malformed_delivery_job(job, str(exc))
+        changed = True
+
+    return changed
+
+
+def _is_archived(job: CronJob) -> bool:
+    return job.archived_at_ms is not None
+
+
+def _archive_job_in_place(job: CronJob, *, now_ms: int) -> None:
+    job.archived_at_ms = now_ms
+    job.enabled = False
+    job.state.next_run_at_ms = None
+    job.updated_at_ms = now_ms
 
 
 class CronService:
@@ -200,6 +263,8 @@ class CronService:
 
     def _enforce_agent_binding(self, job: CronJob) -> bool:
         """Disable user cron jobs that cannot be routed to a concrete session."""
+        if _is_archived(job):
+            return False
         if not self._is_unbound_agent_job(job):
             return False
         if (
@@ -401,6 +466,9 @@ class CronService:
                         "originChannel": j.payload.origin_channel,
                         "originChatId": j.payload.origin_chat_id,
                         "originMetadata": j.payload.origin_metadata,
+                        "deliveryChannel": j.payload.delivery_channel,
+                        "deliveryChatId": j.payload.delivery_chat_id,
+                        "deliveryMetadata": j.payload.delivery_metadata,
                     },
                     "state": {
                         "nextRunAtMs": j.state.next_run_at_ms,
@@ -420,6 +488,7 @@ class CronService:
                     "createdAtMs": j.created_at_ms,
                     "updatedAtMs": j.updated_at_ms,
                     "deleteAfterRun": j.delete_after_run,
+                    "archivedAtMs": j.archived_at_ms,
                 }
                 for j in self._store.jobs
             ]
@@ -502,17 +571,26 @@ class CronService:
             return
         now = _now_ms()
         for job in self._store.jobs:
+            if _is_archived(job):
+                job.enabled = False
+                job.state.next_run_at_ms = None
+                continue
             if self._enforce_agent_binding(job):
                 continue
             if job.enabled:
                 job.state.next_run_at_ms = _compute_next_run(job.schedule, now)
+            else:
+                job.state.next_run_at_ms = None
 
     def _get_next_wake_ms(self) -> int | None:
         """Get the earliest next run time across all jobs."""
         if not self._store:
             return None
-        times = [j.state.next_run_at_ms for j in self._store.jobs
-                 if j.enabled and j.state.next_run_at_ms]
+        times = [
+            j.state.next_run_at_ms
+            for j in self._store.jobs
+            if j.enabled and not _is_archived(j) and j.state.next_run_at_ms
+        ]
         return min(times) if times else None
 
     def _arm_timer(self) -> None:
@@ -559,7 +637,12 @@ class CronService:
             now = _now_ms()
             due_jobs = [
                 j for j in store.jobs
-                if j.enabled and j.state.next_run_at_ms and now >= j.state.next_run_at_ms
+                if (
+                    j.enabled
+                    and not _is_archived(j)
+                    and j.state.next_run_at_ms
+                    and now >= j.state.next_run_at_ms
+                )
             ]
 
             for job in due_jobs:
@@ -635,35 +718,71 @@ class CronService:
             # Compute next run
             job.state.next_run_at_ms = _compute_next_run(job.schedule, _now_ms())
 
+    def _append_actions(
+        self,
+        actions: list[tuple[Literal["add", "del", "update"], dict[str, Any]]],
+    ) -> None:
+        if not actions:
+            return
+        self.store_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._lock:
+            with open(self._action_path, "a", encoding="utf-8") as f:
+                for action, params in actions:
+                    f.write(
+                        json.dumps(
+                            {"action": action, "params": params}, ensure_ascii=False
+                        )
+                        + "\n"
+                    )
+
     def _append_action(
         self,
         action: Literal["add", "del", "update"],
         params: dict[str, Any],
     ) -> None:
-        self.store_path.parent.mkdir(parents=True, exist_ok=True)
-        with self._lock:
-            with open(self._action_path, "a", encoding="utf-8") as f:
-                f.write(json.dumps({"action": action, "params": params}, ensure_ascii=False) + "\n")
+        self._append_actions([(action, params)])
 
 
     # ========== Public API ==========
 
-    def list_jobs(self, include_disabled: bool = False) -> list[CronJob]:
+    def list_jobs(
+        self,
+        include_disabled: bool = False,
+        *,
+        include_archived: bool = False,
+    ) -> list[CronJob]:
         """List all jobs."""
         store = self._require_store()
-        jobs = store.jobs if include_disabled else [j for j in store.jobs if j.enabled]
+        jobs = list(store.jobs)
+        if not include_archived:
+            jobs = [job for job in jobs if not _is_archived(job)]
+        if not include_disabled:
+            jobs = [job for job in jobs if job.enabled]
         return sorted(jobs, key=lambda j: j.state.next_run_at_ms or float('inf'))
+
+    def list_archived_jobs(self) -> list[CronJob]:
+        """List archived jobs with the most recently archived first."""
+        store = self._require_store()
+        return sorted(
+            [job for job in store.jobs if _is_archived(job)],
+            key=lambda job: job.archived_at_ms or 0,
+            reverse=True,
+        )
 
     def list_bound_cron_jobs_for_session(
         self,
         session_key: str,
         *,
         include_disabled: bool = True,
+        include_archived: bool = False,
     ) -> list[CronJob]:
         """Return user-created bound cron jobs owned by *session_key*."""
         return [
             job
-            for job in self.list_jobs(include_disabled=include_disabled)
+            for job in self.list_jobs(
+                include_disabled=include_disabled,
+                include_archived=include_archived,
+            )
             if is_bound_cron_job(job)
             and job.payload.session_key == session_key
         ]
@@ -682,6 +801,9 @@ class CronService:
         origin_channel: str | None = None,
         origin_chat_id: str | None = None,
         origin_metadata: dict[str, Any] | None = None,
+        delivery_channel: str | None = None,
+        delivery_chat_id: str | None = None,
+        delivery_metadata: dict[str, Any] | None = None,
     ) -> CronJob:
         """Add a new job."""
         _validate_schedule_for_add(schedule)
@@ -703,6 +825,9 @@ class CronService:
                 origin_channel=origin_channel,
                 origin_chat_id=origin_chat_id,
                 origin_metadata=origin_metadata or {},
+                delivery_channel=delivery_channel,
+                delivery_chat_id=delivery_chat_id,
+                delivery_metadata=delivery_metadata or {},
             ),
             state=CronJobState(next_run_at_ms=_compute_next_run(schedule, now)),
             created_at_ms=now,
@@ -710,6 +835,7 @@ class CronService:
             delete_after_run=delete_after_run,
         )
         _normalize_agent_turn_job(job)
+        _validate_delivery_target(job.payload)
         self._enforce_agent_binding(job)
         if self._should_persist_store():
             store = self._require_store()
@@ -729,6 +855,7 @@ class CronService:
         job.state = CronJobState(next_run_at_ms=_compute_next_run(job.schedule, now))
         job.created_at_ms = now
         job.updated_at_ms = now
+        job.archived_at_ms = None
         store.jobs = [j for j in store.jobs if j.id != job.id]
         store.jobs.append(job)
         self._save_store()
@@ -778,6 +905,17 @@ class CronService:
         store = self._require_store()
         for job in store.jobs:
             if job.id == job_id:
+                if _is_archived(job):
+                    changed = job.enabled or job.state.next_run_at_ms is not None
+                    job.enabled = False
+                    job.state.next_run_at_ms = None
+                    if changed:
+                        if self._should_persist_store():
+                            self._save_store()
+                            self._arm_timer()
+                        else:
+                            self._append_action("update", asdict(job))
+                    return job
                 job.enabled = enabled
                 job.updated_at_ms = _now_ms()
                 self._enforce_agent_binding(job)
@@ -804,7 +942,10 @@ class CronService:
         channel: str | None | EllipsisType = ...,
         to: str | None | EllipsisType = ...,
         delete_after_run: bool | None = None,
-    ) -> CronJob | Literal["not_found", "protected"]:
+        delivery_channel: str | None | EllipsisType = ...,
+        delivery_chat_id: str | None | EllipsisType = ...,
+        delivery_metadata: dict[str, Any] | None | EllipsisType = ...,
+    ) -> CronJob | Literal["not_found", "protected", "archived"]:
         """Update mutable fields of an existing job. System jobs cannot be updated.
 
         For ``channel`` and ``to``, pass an explicit value (including ``None``)
@@ -816,6 +957,23 @@ class CronService:
             return "not_found"
         if job.payload.kind == "system_event":
             return "protected"
+        if _is_archived(job):
+            return "archived"
+
+        candidate_delivery_channel = (
+            job.payload.delivery_channel
+            if delivery_channel is ...
+            else delivery_channel
+        )
+        candidate_delivery_chat_id = (
+            job.payload.delivery_chat_id
+            if delivery_chat_id is ...
+            else delivery_chat_id
+        )
+        _validate_delivery_pair(
+            candidate_delivery_channel,
+            candidate_delivery_chat_id,
+        )
 
         if schedule is not None:
             _validate_schedule_for_add(schedule)
@@ -832,7 +990,14 @@ class CronService:
             job.payload.to = to
         if delete_after_run is not None:
             job.delete_after_run = delete_after_run
+        if delivery_channel is not ...:
+            job.payload.delivery_channel = delivery_channel
+        if delivery_chat_id is not ...:
+            job.payload.delivery_chat_id = delivery_chat_id
+        if delivery_metadata is not ...:
+            job.payload.delivery_metadata = dict(delivery_metadata or {})
         _normalize_agent_turn_job(job)
+        _validate_delivery_target(job.payload)
         self._enforce_agent_binding(job)
 
         job.updated_at_ms = _now_ms()
@@ -863,6 +1028,8 @@ class CronService:
             store = self._require_store(reload_during_execution=reload_store)
             for job in store.jobs:
                 if job.id == job_id:
+                    if _is_archived(job):
+                        return False
                     if self._is_unbound_agent_job(job):
                         self._enforce_agent_binding(job)
                         self._save_store()
@@ -877,6 +1044,43 @@ class CronService:
             self._active_executions -= 1
             if self._running and self._active_executions == 0:
                 self._arm_timer()
+
+    def archive_jobs(self, job_ids: list[str]) -> CronArchiveResult:
+        """Archive user cron jobs in one mutation while retaining their history."""
+        store = self._require_store()
+        now = _now_ms()
+        result = CronArchiveResult()
+        jobs_by_id = {job.id: job for job in store.jobs}
+        updated_jobs: list[CronJob] = []
+
+        for job_id in dict.fromkeys(job_ids):
+            job = jobs_by_id.get(job_id)
+            if job is None:
+                result.not_found.append(job_id)
+                continue
+            if job.payload.kind == "system_event":
+                result.protected.append(job_id)
+                continue
+            if _is_archived(job):
+                result.already_archived.append(job_id)
+                continue
+
+            _archive_job_in_place(job, now_ms=now)
+            updated_jobs.append(job)
+            result.archived.append(job_id)
+
+        if not updated_jobs:
+            return result
+
+        if self._should_persist_store():
+            self._save_store()
+            self._arm_timer()
+        else:
+            self._append_actions(
+                [("update", asdict(job)) for job in updated_jobs]
+            )
+
+        return result
 
     def get_job(self, job_id: str) -> CronJob | None:
         """Get a job by ID."""

--- a/nanobot/cron/session_delivery.py
+++ b/nanobot/cron/session_delivery.py
@@ -13,3 +13,17 @@ def origin_delivery_context(job: CronJob) -> tuple[str, str, dict[str, Any]]:
     if not payload.origin_channel or not payload.origin_chat_id:
         raise ValueError(f"cron job {job.id} is missing origin delivery context")
     return payload.origin_channel, payload.origin_chat_id, dict(payload.origin_metadata or {})
+
+
+def configured_delivery_context(job: CronJob) -> tuple[str, str, dict[str, Any]]:
+    """Return the configured result route, falling back to the origin route."""
+    payload = job.payload
+    if payload.delivery_channel is None and payload.delivery_chat_id is None:
+        return origin_delivery_context(job)
+    if not payload.delivery_channel or not payload.delivery_chat_id:
+        raise ValueError(f"cron job {job.id} has incomplete delivery target")
+    return (
+        payload.delivery_channel,
+        payload.delivery_chat_id,
+        dict(payload.delivery_metadata or {}),
+    )

--- a/nanobot/cron/types.py
+++ b/nanobot/cron/types.py
@@ -61,6 +61,11 @@ class CronPayload:
     origin_channel: str | None = None
     origin_chat_id: str | None = None
     origin_metadata: dict[str, Any] = field(default_factory=dict)
+    # Visible result delivery. None/None falls back to the origin route while
+    # session_key continues to own execution history and workspace context.
+    delivery_channel: str | None = None
+    delivery_chat_id: str | None = None
+    delivery_metadata: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def from_store_dict(cls, data: dict[str, Any]) -> CronPayload:
@@ -78,6 +83,15 @@ class CronPayload:
             origin_chat_id=get_camel_snake(data, "originChatId", "origin_chat_id"),
             origin_metadata=dict(
                 get_camel_snake(data, "originMetadata", "origin_metadata", {}) or {}
+            ),
+            delivery_channel=get_camel_snake(
+                data, "deliveryChannel", "delivery_channel"
+            ),
+            delivery_chat_id=get_camel_snake(
+                data, "deliveryChatId", "delivery_chat_id"
+            ),
+            delivery_metadata=dict(
+                get_camel_snake(data, "deliveryMetadata", "delivery_metadata", {}) or {}
             ),
         )
 
@@ -146,6 +160,7 @@ class CronJob:
     created_at_ms: int = 0
     updated_at_ms: int = 0
     delete_after_run: bool = False
+    archived_at_ms: int | None = None
 
     @classmethod
     def from_dict(cls, kwargs: dict[str, Any]) -> CronJob:
@@ -178,7 +193,20 @@ class CronJob:
             delete_after_run=bool(
                 get_camel_snake(data, "deleteAfterRun", "delete_after_run", False)
             ),
+            archived_at_ms=_store_int(
+                get_camel_snake(data, "archivedAtMs", "archived_at_ms"), None
+            ),
         )
+
+
+@dataclass
+class CronArchiveResult:
+    """Grouped outcome for one idempotent batch archive request."""
+
+    archived: list[str] = field(default_factory=list)
+    already_archived: list[str] = field(default_factory=list)
+    protected: list[str] = field(default_factory=list)
+    not_found: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/nanobot/webui/session_automations.py
+++ b/nanobot/webui/session_automations.py
@@ -14,7 +14,12 @@ AutomationJob = CronJob | LocalTrigger
 
 
 class _CronServiceLike(Protocol):
-    def list_jobs(self, include_disabled: bool = False) -> list[CronJob]: ...
+    def list_jobs(
+        self,
+        include_disabled: bool = False,
+        *,
+        include_archived: bool = False,
+    ) -> list[CronJob]: ...
 
     def list_bound_cron_jobs_for_session(
         self,
@@ -94,7 +99,12 @@ def all_automations_payload(
     """Return all cron jobs visible to the WebUI automation manager."""
     jobs: list[AutomationJob] = []
     if cron_service is not None:
-        jobs.extend(cron_service.list_jobs(include_disabled=True))
+        jobs.extend(
+            cron_service.list_jobs(
+                include_disabled=True,
+                include_archived=True,
+            )
+        )
     if local_trigger_store is not None:
         jobs.extend(local_trigger_store.list_triggers(include_disabled=True))
     return {
@@ -144,6 +154,7 @@ def _serialize_job(
         "id": job.id,
         "name": job.name,
         "enabled": job.enabled,
+        "archived_at_ms": job.archived_at_ms,
         "schedule": {
             "kind": job.schedule.kind,
             "at_ms": job.schedule.at_ms,
@@ -153,6 +164,8 @@ def _serialize_job(
         },
         "payload": {
             "message": job.payload.message,
+            "delivery_channel": job.payload.delivery_channel,
+            "delivery_chat_id": job.payload.delivery_chat_id,
         },
         "state": {
             "next_run_at_ms": job.state.next_run_at_ms,

--- a/nanobot/webui/ws_http.py
+++ b/nanobot/webui/ws_http.py
@@ -142,6 +142,7 @@ _WEBUI_MUTATION_PATHS = {
     "automation.delete": "/api/webui/automations/delete",
     "automation.run": "/api/webui/automations/run",
     "automation.update": "/api/webui/automations/update",
+    "automation.archive": "/api/webui/automations/archive",
     "skill.install": "/api/webui/skills/install",
     "skill.update": "/api/webui/skills/update",
     "skill.delete": "/api/webui/skills/delete",
@@ -460,7 +461,10 @@ class GatewayHTTPHandler:
             return True
         if re.match(r"^/api/sessions/[^/]+/delete$", path):
             return True
-        if re.match(r"^/api/webui/automations/(enable|disable|delete|run|update)$", path):
+        if re.match(
+            r"^/api/webui/automations/(enable|disable|delete|run|update|archive)$",
+            path,
+        ):
             return True
         if path in {"/api/webui/recovery/continue", "/api/webui/recovery/dismiss"}:
             return True
@@ -965,7 +969,10 @@ class GatewayHTTPHandler:
     ) -> Response | None:
         if got == "/api/webui/automations":
             return self._handle_webui_automations(request)
-        m = re.match(r"^/api/webui/automations/(enable|disable|delete|run|update)$", got)
+        m = re.match(
+            r"^/api/webui/automations/(enable|disable|delete|run|update|archive)$",
+            got,
+        )
         if m:
             return await self._handle_webui_automation_action(request, m.group(1))
         return None
@@ -1026,6 +1033,31 @@ class GatewayHTTPHandler:
         if self.cron_service is None and self.local_trigger_store is None:
             return _http_error(503, "automation service unavailable")
 
+        if action == "archive":
+            if self.cron_service is None:
+                return _http_error(503, "cron service unavailable")
+            payload = _mutation_payload(request)
+            raw_job_ids = payload.get("job_ids") if payload is not None else None
+            if not isinstance(raw_job_ids, list):
+                return _http_error(400, "job_ids must be an array")
+            raw_items = cast(list[object], raw_job_ids)
+            job_ids = [
+                item.strip()
+                for item in raw_items
+                if isinstance(item, str) and item.strip()
+            ]
+            if len(job_ids) != len(raw_items) or not job_ids:
+                return _http_error(400, "job_ids must contain non-empty strings")
+            result = self.cron_service.archive_jobs(job_ids)
+            return _http_json_response(
+                {
+                    "archived": result.archived,
+                    "already_archived": result.already_archived,
+                    "protected": result.protected,
+                    "not_found": result.not_found,
+                }
+            )
+
         query = _request_query(request)
         job_id = (_query_first(query, "id") or _query_first(query, "job_id") or "").strip()
         if not job_id:
@@ -1041,6 +1073,8 @@ class GatewayHTTPHandler:
             return _http_error(404, "automation not found")
         if job.payload.kind == "system_event":
             return _http_error(403, "system automation is protected")
+        if job.archived_at_ms is not None and action in {"enable", "disable", "run", "update"}:
+            return _http_error(409, "archived automation is read-only")
         if action in {"enable", "run"} and not is_bound_cron_job(job):
             return _http_error(409, "automation has no linked chat")
 
@@ -1076,6 +1110,8 @@ class GatewayHTTPHandler:
                 return _http_error(404, "automation not found")
             if result == "protected":
                 return _http_error(403, "system automation is protected")
+            if result == "archived":
+                return _http_error(409, "archived automation is read-only")
         else:
             return _http_error(404, "unknown automation action")
 
@@ -1520,13 +1556,32 @@ def _parse_automation_update(
         parsed_schedule = _parse_automation_schedule(cast(dict[str, Any], raw_schedule))
         if isinstance(parsed_schedule, str):
             return parsed_schedule
-        if current_job is not None and _schedule_matches_job(parsed_schedule, current_job):
-            return update
-        schedule_error = _validate_automation_schedule(parsed_schedule)
-        if schedule_error:
-            return schedule_error
-        update["schedule"] = parsed_schedule
-        update["delete_after_run"] = parsed_schedule.kind == "at"
+        if current_job is None or not _schedule_matches_job(parsed_schedule, current_job):
+            schedule_error = _validate_automation_schedule(parsed_schedule)
+            if schedule_error:
+                return schedule_error
+            update["schedule"] = parsed_schedule
+            # New one-shot jobs are retained as completed/disabled so users can
+            # inspect and archive them. Existing deleteAfterRun jobs keep their
+            # legacy behavior until their schedule is explicitly changed.
+            update["delete_after_run"] = False
+    has_delivery_channel = "delivery_channel" in values
+    has_delivery_chat_id = "delivery_chat_id" in values
+    if has_delivery_channel != has_delivery_chat_id:
+        return "delivery_channel and delivery_chat_id must be provided together"
+    if has_delivery_channel:
+        raw_channel = values.get("delivery_channel")
+        raw_chat_id = values.get("delivery_chat_id")
+        if raw_channel is not None and not isinstance(raw_channel, str):
+            return "delivery_channel must be a string or null"
+        if raw_chat_id is not None and not isinstance(raw_chat_id, str):
+            return "delivery_chat_id must be a string or null"
+        channel = raw_channel.strip() if isinstance(raw_channel, str) else ""
+        chat_id = raw_chat_id.strip() if isinstance(raw_chat_id, str) else ""
+        if bool(channel) != bool(chat_id):
+            return "delivery_channel and delivery_chat_id must be provided together"
+        update["delivery_channel"] = channel or None
+        update["delivery_chat_id"] = chat_id or None
     return update
 
 

--- a/tests/cron/test_bound_runner_delivery.py
+++ b/tests/cron/test_bound_runner_delivery.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nanobot.agent.tools.registry import ToolRegistry
+from nanobot.bus.events import InboundMessage, OutboundMessage
+from nanobot.cron.bound_runner import run_bound_cron_job
+from nanobot.cron.types import CronJob, CronPayload
+
+
+class _FakeAgent:
+    def __init__(self) -> None:
+        self.tools = ToolRegistry()
+        self.messages: list[InboundMessage] = []
+
+    async def submit_cron_turn(self, msg: InboundMessage) -> OutboundMessage:
+        self.messages.append(msg)
+        return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id, content="done")
+
+
+class _FakeRecorder:
+    def __init__(self) -> None:
+        self.records: list[tuple[str, dict[str, Any]]] = []
+
+    def write_run_record(self, run_id: str, record: dict[str, Any]) -> None:
+        self.records.append((run_id, record))
+
+
+@pytest.mark.asyncio
+async def test_bound_cron_routes_target_but_keeps_origin_session() -> None:
+    agent = _FakeAgent()
+    recorder = _FakeRecorder()
+    job = CronJob(
+        id="job1",
+        name="health",
+        payload=CronPayload(
+            message="check health",
+            session_key="websocket:origin-topic",
+            origin_channel="websocket",
+            origin_chat_id="origin-topic",
+            delivery_channel="slack",
+            delivery_chat_id="C123",
+        ),
+    )
+
+    result = await run_bound_cron_job(job, agent=agent, cron=recorder)
+
+    assert result == "done"
+    message = agent.messages[0]
+    assert message.channel == "slack"
+    assert message.chat_id == "C123"
+    assert message.session_key_override == "websocket:origin-topic"
+    assert recorder.records[0][1]["delivery"] == {
+        "channel": "slack",
+        "chat_id": "C123",
+    }
+
+
+@pytest.mark.asyncio
+async def test_bound_cron_without_target_delivers_to_origin() -> None:
+    agent = _FakeAgent()
+    recorder = _FakeRecorder()
+    job = CronJob(
+        id="job1",
+        name="health",
+        payload=CronPayload(
+            message="check health",
+            session_key="websocket:origin-topic",
+            origin_channel="websocket",
+            origin_chat_id="origin-topic",
+        ),
+    )
+
+    await run_bound_cron_job(job, agent=agent, cron=recorder)
+
+    message = agent.messages[0]
+    assert message.channel == "websocket"
+    assert message.chat_id == "origin-topic"
+    assert message.session_key_override == "websocket:origin-topic"

--- a/tests/cron/test_cron_service.py
+++ b/tests/cron/test_cron_service.py
@@ -631,6 +631,37 @@ async def test_run_history_persisted_to_disk(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("delete_after_run", [True, False])
+async def test_one_shot_retention_respects_delete_after_run(
+    tmp_path,
+    delete_after_run: bool,
+) -> None:
+    service = CronService(
+        tmp_path / "cron" / "jobs.json",
+        on_job=lambda _: asyncio.sleep(0),
+    )
+    job = service.add_job(
+        name="one-shot",
+        schedule=CronSchedule(kind="at", at_ms=int(time.time() * 1000) + 60_000),
+        message="hello",
+        delete_after_run=delete_after_run,
+        **_bound_chat(),
+    )
+
+    assert await service.run_job(job.id) is True
+
+    completed = service.get_job(job.id)
+    if delete_after_run:
+        assert completed is None
+    else:
+        assert completed is not None
+        assert completed.enabled is False
+        assert completed.state.next_run_at_ms is None
+        assert completed.state.last_status == "ok"
+        assert len(completed.state.run_history) == 1
+
+
+@pytest.mark.asyncio
 async def test_run_job_disabled_does_not_flip_running_state(tmp_path) -> None:
     store_path = tmp_path / "cron" / "jobs.json"
     service = CronService(store_path, on_job=lambda _: asyncio.sleep(0))
@@ -1427,3 +1458,285 @@ def test_load_jobs_skips_null_run_history_elements(tmp_path) -> None:
     assert len(jobs[0].state.run_history) == 1
     assert jobs[0].state.run_history[0].run_at_ms == 1
     assert jobs[0].state.run_history[0].status == "ok"
+
+
+def _add_archivable_job(
+    service: CronService,
+    *,
+    name: str = "job",
+    delivery_channel: str | None = None,
+    delivery_chat_id: str | None = None,
+) -> CronJob:
+    return service.add_job(
+        name=name,
+        schedule=CronSchedule(kind="every", every_ms=60_000),
+        message="hello",
+        delivery_channel=delivery_channel,
+        delivery_chat_id=delivery_chat_id,
+        **_bound_chat(name),
+    )
+
+
+def test_delivery_target_round_trips_through_jobs_json(tmp_path) -> None:
+    store_path = tmp_path / "cron" / "jobs.json"
+    service = CronService(store_path)
+    service._active_executions = 1
+    job = service.add_job(
+        name="ops",
+        schedule=CronSchedule(kind="every", every_ms=60_000),
+        message="check",
+        delivery_channel="slack",
+        delivery_chat_id="C123",
+        delivery_metadata={"thread_ts": "1.2", RUNTIME_CONTEXT_INPUT_META: object()},
+        **_bound_chat("origin"),
+    )
+
+    loaded = CronService(store_path).get_job(job.id)
+
+    assert loaded is not None
+    assert loaded.payload.delivery_channel == "slack"
+    assert loaded.payload.delivery_chat_id == "C123"
+    assert loaded.payload.delivery_metadata == {"thread_ts": "1.2"}
+
+
+@pytest.mark.parametrize(
+    ("channel", "chat_id"),
+    [("slack", None), (None, "C123"), ("", "C123"), ("slack", "")],
+)
+def test_add_job_rejects_partial_delivery_target(
+    tmp_path,
+    channel: str | None,
+    chat_id: str | None,
+) -> None:
+    service = CronService(tmp_path / "cron" / "jobs.json")
+
+    with pytest.raises(ValueError, match="requires both"):
+        _add_archivable_job(
+            service,
+            delivery_channel=channel,
+            delivery_chat_id=chat_id,
+        )
+
+    assert service.list_jobs(include_disabled=True) == []
+
+
+def test_update_delivery_target_is_atomic_and_can_be_cleared(tmp_path) -> None:
+    service = CronService(tmp_path / "cron" / "jobs.json")
+    job = _add_archivable_job(
+        service,
+        delivery_channel="slack",
+        delivery_chat_id="C123",
+    )
+
+    with pytest.raises(ValueError, match="requires both"):
+        service.update_job(job.id, delivery_channel=None)
+
+    current = service.get_job(job.id)
+    assert current is not None
+    assert current.payload.delivery_channel == "slack"
+    assert current.payload.delivery_chat_id == "C123"
+
+    cleared = service.update_job(
+        job.id,
+        delivery_channel=None,
+        delivery_chat_id=None,
+    )
+    assert isinstance(cleared, CronJob)
+    assert cleared.payload.delivery_channel is None
+    assert cleared.payload.delivery_chat_id is None
+
+
+def test_malformed_delivery_in_store_is_disabled_without_corrupting_store(tmp_path) -> None:
+    store_path = tmp_path / "cron" / "jobs.json"
+    store_path.parent.mkdir(parents=True)
+    store_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "jobs": [
+                    {
+                        "id": "bad-route",
+                        "name": "bad-route",
+                        "enabled": True,
+                        "schedule": {"kind": "every", "everyMs": 60_000},
+                        "payload": {
+                            "message": "hello",
+                            "sessionKey": "websocket:origin",
+                            "originChannel": "websocket",
+                            "originChatId": "origin",
+                            "deliveryChannel": "slack",
+                        },
+                        "state": {"nextRunAtMs": 1},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = CronService(store_path).get_job("bad-route")
+
+    assert loaded is not None
+    assert loaded.enabled is False
+    assert loaded.state.next_run_at_ms is None
+    assert loaded.state.last_status == "error"
+    assert "requires both" in (loaded.state.last_error or "")
+    assert store_path.exists()
+    assert list(store_path.parent.glob("jobs.json.corrupt-*")) == []
+
+
+def test_non_string_delivery_in_store_is_disabled_without_corrupting_store(tmp_path) -> None:
+    store_path = tmp_path / "cron" / "jobs.json"
+    store_path.parent.mkdir(parents=True)
+    store_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "jobs": [
+                    {
+                        "id": "bad-route-type",
+                        "name": "bad-route-type",
+                        "enabled": True,
+                        "schedule": {"kind": "every", "everyMs": 60_000},
+                        "payload": {
+                            "message": "hello",
+                            "sessionKey": "websocket:origin",
+                            "originChannel": "websocket",
+                            "originChatId": "origin",
+                            "deliveryChannel": 7,
+                            "deliveryChatId": "C123",
+                        },
+                        "state": {"nextRunAtMs": 1},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = CronService(store_path).get_job("bad-route-type")
+
+    assert loaded is not None
+    assert loaded.enabled is False
+    assert loaded.state.last_status == "error"
+    assert "requires both" in (loaded.state.last_error or "")
+    assert list(store_path.parent.glob("jobs.json.corrupt-*")) == []
+
+
+def test_archive_jobs_is_idempotent_deduplicated_and_preserves_history(tmp_path) -> None:
+    service = CronService(tmp_path / "cron" / "jobs.json")
+    service._active_executions = 1
+    first = _add_archivable_job(service, name="first")
+    second = _add_archivable_job(service, name="second")
+    first.state.last_status = "ok"
+
+    result = service.archive_jobs([first.id, first.id, second.id, "missing"])
+    repeated = service.archive_jobs([first.id])
+
+    assert result.archived == [first.id, second.id]
+    assert result.already_archived == []
+    assert result.not_found == ["missing"]
+    assert repeated.archived == []
+    assert repeated.already_archived == [first.id]
+    assert service.list_jobs(include_disabled=True) == []
+    archived = service.list_archived_jobs()
+    assert {job.id for job in archived} == {first.id, second.id}
+    archived_first = next(job for job in archived if job.id == first.id)
+    assert archived_first.enabled is False
+    assert archived_first.state.next_run_at_ms is None
+    assert archived_first.state.last_status == "ok"
+    reloaded = CronService(service.store_path).get_job(first.id)
+    assert reloaded is not None
+    assert reloaded.archived_at_ms is not None
+    assert reloaded.state.last_status == "ok"
+    service._active_executions = 0
+
+
+def test_archive_jobs_protects_system_jobs_and_allows_hard_delete(tmp_path) -> None:
+    service = CronService(tmp_path / "cron" / "jobs.json")
+    user_job = _add_archivable_job(service)
+    system_job = CronJob(
+        id="dream",
+        name="dream",
+        schedule=CronSchedule(kind="every", every_ms=60_000),
+        payload=CronPayload(kind="system_event"),
+    )
+    service.register_system_job(system_job)
+
+    result = service.archive_jobs([system_job.id, user_job.id])
+
+    assert result.protected == [system_job.id]
+    assert result.archived == [user_job.id]
+    assert service.remove_job(user_job.id) == "removed"
+    assert service.get_job(user_job.id) is None
+
+
+@pytest.mark.asyncio
+async def test_archived_jobs_cannot_be_enabled_updated_or_force_run(tmp_path) -> None:
+    calls: list[str] = []
+
+    async def on_job(job: CronJob) -> None:
+        calls.append(job.id)
+
+    service = CronService(tmp_path / "cron" / "jobs.json", on_job=on_job)
+    service._running = True
+    job = _add_archivable_job(service)
+    service.archive_jobs([job.id])
+
+    enabled = service.enable_job(job.id, enabled=True)
+    updated = service.update_job(job.id, name="changed")
+    ran = await service.run_job(job.id, force=True)
+
+    assert enabled is not None
+    assert enabled.enabled is False
+    assert updated == "archived"
+    assert ran is False
+    assert calls == []
+    service.stop()
+
+
+@pytest.mark.asyncio
+async def test_timer_defensively_skips_archived_job(tmp_path) -> None:
+    calls: list[str] = []
+
+    async def on_job(job: CronJob) -> None:
+        calls.append(job.id)
+
+    service = CronService(tmp_path / "cron" / "jobs.json", on_job=on_job)
+    service._running = True
+    job = _add_archivable_job(service)
+    service.archive_jobs([job.id])
+    current = service.get_job(job.id)
+    assert current is not None
+    current.enabled = True
+    current.state.next_run_at_ms = 1
+
+    await service._on_timer()
+
+    assert calls == []
+    service.stop()
+
+
+def test_non_owner_batch_archive_writes_full_update_actions(tmp_path) -> None:
+    store_path = tmp_path / "cron" / "jobs.json"
+    owner = CronService(store_path)
+    owner._active_executions = 1
+    first = _add_archivable_job(owner, name="first")
+    second = _add_archivable_job(owner, name="second")
+    client = CronService(store_path)
+
+    result = client.archive_jobs([first.id, second.id])
+    lines = [
+        json.loads(line)
+        for line in client._action_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+    assert result.archived == [first.id, second.id]
+    assert [line["action"] for line in lines] == ["update", "update"]
+    assert {line["params"]["id"] for line in lines} == {first.id, second.id}
+    assert all(line["params"]["archived_at_ms"] is not None for line in lines)
+
+    owner._load_store(reload_during_execution=True)
+    assert {job.id for job in owner.list_archived_jobs()} == {first.id, second.id}
+    owner._active_executions = 0

--- a/tests/cron/test_cron_tool_list.py
+++ b/tests/cron/test_cron_tool_list.py
@@ -448,3 +448,87 @@ def test_list_excludes_disabled_jobs(tmp_path) -> None:
     result = tool._list_jobs()
     assert "Paused job" not in result
     assert result == "No scheduled jobs."
+
+
+def test_add_job_stores_and_lists_explicit_delivery_target(tmp_path) -> None:
+    tool = _make_tool(tmp_path)
+    with request_context(
+        RequestContext(channel="websocket", chat_id="origin", session_key="websocket:origin")
+    ):
+        result = tool._add_job(
+            "ops",
+            "check health",
+            60,
+            None,
+            None,
+            None,
+            "slack",
+            "C123",
+        )
+
+    assert result.startswith("Created job")
+    job = tool._cron.list_jobs()[0]
+    assert job.payload.delivery_channel == "slack"
+    assert job.payload.delivery_chat_id == "C123"
+    assert "Delivery: slack:C123" in tool._list_jobs()
+
+
+def test_new_one_shot_job_is_retained_for_archive(tmp_path) -> None:
+    tool = _make_tool(tmp_path)
+    with request_context(
+        RequestContext(channel="websocket", chat_id="origin", session_key="websocket:origin")
+    ):
+        result = tool._add_job(
+            "once",
+            "remind me",
+            None,
+            None,
+            None,
+            "2099-01-01T10:00:00",
+        )
+
+    assert result.startswith("Created job")
+    job = tool._cron.list_jobs()[0]
+    assert job.schedule.kind == "at"
+    assert job.delete_after_run is False
+
+
+def test_list_archived_view_and_batch_archive_output(tmp_path) -> None:
+    tool = _make_tool(tmp_path)
+    first = tool._cron.add_job(
+        name="first",
+        schedule=CronSchedule(kind="every", every_ms=60_000),
+        message="hello",
+        **_bound_chat("first"),
+    )
+    second = tool._cron.add_job(
+        name="second",
+        schedule=CronSchedule(kind="every", every_ms=60_000),
+        message="hello",
+        **_bound_chat("second"),
+    )
+
+    output = tool._archive_jobs(f"{first.id},{second.id},missing")
+    archived = tool._list_jobs(view="archived")
+
+    assert "Archived:" in output
+    assert first.id in output and second.id in output
+    assert "Not found: missing" in output
+    assert "first" in archived and "second" in archived
+    assert tool._list_jobs() == "No scheduled jobs."
+
+
+def test_validate_params_checks_archive_and_delivery_pair(tmp_path) -> None:
+    tool = _make_tool(tmp_path)
+
+    assert "job_ids is required when action='archive'" in tool.validate_params(
+        {"action": "archive"}
+    )
+    errors = tool.validate_params(
+        {
+            "action": "add",
+            "message": "check",
+            "delivery_channel": "slack",
+        }
+    )
+    assert any("delivery_channel and delivery_chat_id" in error for error in errors)

--- a/tests/cron/test_cron_tool_schema_contract.py
+++ b/tests/cron/test_cron_tool_schema_contract.py
@@ -102,3 +102,11 @@ class TestSchemaSelfDescribesRequirements:
         # accidentally introduced).
         tool = CronTool(_SvcStub())
         assert tool.parameters["required"] == ["action"]
+
+    def test_archive_and_delivery_fields_are_advertised(self) -> None:
+        tool = CronTool(_SvcStub())
+        properties = tool.parameters["properties"]
+        assert "archive" in properties["action"]["enum"]
+        assert "job_ids" in properties
+        assert "delivery_channel" in properties
+        assert "delivery_chat_id" in properties

--- a/tests/cron/test_session_delivery.py
+++ b/tests/cron/test_session_delivery.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nanobot.cron.session_delivery import origin_delivery_context
+from nanobot.cron.session_delivery import configured_delivery_context, origin_delivery_context
 from nanobot.cron.types import CronJob, CronPayload
 
 
@@ -42,3 +42,68 @@ def test_origin_delivery_context_rejects_missing_origin_fields() -> None:
 
     with pytest.raises(ValueError, match="missing origin delivery context"):
         origin_delivery_context(job)
+
+
+def test_configured_delivery_context_falls_back_to_origin() -> None:
+    job = CronJob(
+        id="job1",
+        name="health",
+        payload=CronPayload(
+            session_key="websocket:topic-1",
+            origin_channel="websocket",
+            origin_chat_id="topic-1",
+            origin_metadata={"webui": True},
+        ),
+    )
+
+    assert configured_delivery_context(job) == (
+        "websocket",
+        "topic-1",
+        {"webui": True},
+    )
+
+
+def test_configured_delivery_context_uses_explicit_target_without_origin_metadata() -> None:
+    job = CronJob(
+        id="job1",
+        name="health",
+        payload=CronPayload(
+            session_key="websocket:topic-1",
+            origin_channel="websocket",
+            origin_chat_id="topic-1",
+            origin_metadata={"webui": True},
+            delivery_channel="slack",
+            delivery_chat_id="C123",
+            delivery_metadata={"thread_ts": "123.456"},
+        ),
+    )
+
+    assert configured_delivery_context(job) == (
+        "slack",
+        "C123",
+        {"thread_ts": "123.456"},
+    )
+
+
+@pytest.mark.parametrize(
+    ("delivery_channel", "delivery_chat_id"),
+    [("slack", None), (None, "C123"), ("", "C123"), ("slack", "")],
+)
+def test_configured_delivery_context_rejects_partial_target(
+    delivery_channel: str | None,
+    delivery_chat_id: str | None,
+) -> None:
+    job = CronJob(
+        id="job1",
+        name="health",
+        payload=CronPayload(
+            session_key="websocket:topic-1",
+            origin_channel="websocket",
+            origin_chat_id="topic-1",
+            delivery_channel=delivery_channel,
+            delivery_chat_id=delivery_chat_id,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="incomplete delivery target"):
+        configured_delivery_context(job)

--- a/webui/src/components/settings/SettingsPage.tsx
+++ b/webui/src/components/settings/SettingsPage.tsx
@@ -94,6 +94,7 @@ export function SettingsPage({
     form,
     handleApiServiceAction,
     handleAutomationAction,
+    handleAutomationArchive,
     handleAutomationEdit,
     handleCliAppAction,
     handleDeleteModelConfiguration,
@@ -470,6 +471,7 @@ export function SettingsPage({
             onFilterChange={setAutomationsFilter}
             onSortChange={setAutomationsSort}
             onAction={handleAutomationAction}
+            onArchive={handleAutomationArchive}
             onRequestEdit={setAutomationPendingEdit}
             onRequestDelete={setAutomationPendingDelete}
             onBackToChat={onBackToChat}

--- a/webui/src/components/settings/system/AutomationsSettings.tsx
+++ b/webui/src/components/settings/system/AutomationsSettings.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { FormEvent, ReactNode } from "react";
 import {
+  Archive,
   ArrowUpDown,
   Check,
   ChevronDown,
@@ -44,7 +45,7 @@ import { fmtDateTime, relativeTime } from "@/lib/format";
 import type { AutomationsPayload, AutomationUpdatePayload, SessionAutomationJob } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
-export type AutomationFilter = "all" | "active" | "paused" | "failed" | "system";
+export type AutomationFilter = "all" | "active" | "paused" | "failed" | "system" | "archived";
 export type AutomationSort = "next" | "last" | "updated" | "name";
 export type AutomationAction = "enable" | "disable" | "delete" | "run";
 
@@ -60,6 +61,7 @@ export function AutomationsSettings({
   onFilterChange,
   onSortChange,
   onAction,
+  onArchive,
   onRequestEdit,
   onRequestDelete,
   onBackToChat,
@@ -75,6 +77,7 @@ export function AutomationsSettings({
   onFilterChange: (value: AutomationFilter) => void;
   onSortChange: (value: AutomationSort) => void;
   onAction: (action: AutomationAction, job: SessionAutomationJob) => void | Promise<void>;
+  onArchive: (jobIds: string[]) => Promise<boolean>;
   onRequestEdit: (job: SessionAutomationJob) => void;
   onRequestDelete: (job: SessionAutomationJob) => void;
   onBackToChat: () => void;
@@ -85,6 +88,7 @@ export function AutomationsSettings({
   const jobs = payload?.jobs ?? [];
   const locale = i18n.resolvedLanguage || i18n.language;
   const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
+  const [selectedArchiveIds, setSelectedArchiveIds] = useState<Set<string>>(new Set());
   const filtered = useMemo(() => {
     const searchTokens = parseAutomationSearchQuery(query);
     return sortAutomationJobs(jobs, sort)
@@ -98,12 +102,14 @@ export function AutomationsSettings({
   const pausedCount = jobs.filter((job) => automationStatusKey(job) === "paused").length;
   const failedCount = jobs.filter(automationNeedsAttention).length;
   const systemCount = jobs.filter((job) => job.protected).length;
+  const archivedCount = jobs.filter((job) => job.archived_at_ms != null).length;
   const summaryOptions: Array<{ value: AutomationFilter; label: string; count: number }> = [
     { value: "all", label: tx("settings.automations.filters.all", "All"), count: jobs.length },
     { value: "active", label: tx("settings.automations.filters.active", "Active"), count: activeCount },
     { value: "paused", label: tx("settings.automations.filters.paused", "Paused"), count: pausedCount },
     { value: "failed", label: tx("settings.automations.filters.failed", "Needs attention"), count: failedCount },
     { value: "system", label: tx("settings.automations.filters.system", "System"), count: systemCount },
+    { value: "archived", label: tx("settings.automations.filters.archived", "Archived"), count: archivedCount },
   ];
   const sortLabel = {
     next: tx("settings.automations.sort.next", "Next run"),
@@ -123,13 +129,21 @@ export function AutomationsSettings({
     }
   }, [filtered, selectedJobId]);
 
+  useEffect(() => {
+    const selectableIds = new Set(jobs.filter(automationCanArchive).map((job) => job.id));
+    setSelectedArchiveIds((current) => {
+      const next = new Set([...current].filter((id) => selectableIds.has(id)));
+      return next.size === current.size ? current : next;
+    });
+  }, [jobs]);
+
   return (
     <div className="space-y-5">
       {jobs.length ? (
         <section className="shrink-0">
           <div className="mx-auto flex w-full max-w-[56rem] flex-col gap-3">
             <div className="-mx-1 overflow-x-auto px-1 pb-0.5">
-              <div className="grid w-full min-w-[36rem] grid-cols-5 gap-1 rounded-floating bg-muted p-1">
+              <div className="grid w-full min-w-[42rem] grid-cols-6 gap-1 rounded-floating bg-muted p-1">
                 {summaryOptions.map((option) => (
                   <button
                     key={option.value}
@@ -171,26 +185,50 @@ export function AutomationsSettings({
                   )}
                 />
               </div>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <button
+              <div className="flex items-center justify-end gap-2">
+                {selectedArchiveIds.size ? (
+                  <Button
                     type="button"
-                    className="inline-flex h-9 min-w-[8.5rem] items-center justify-center gap-1.5 whitespace-nowrap rounded-control border border-border/45 bg-settings-surface px-3 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground sm:w-auto"
+                    variant="outline"
+                    className="h-9 rounded-control px-3 text-[12px]"
+                    disabled={actionKey === "archive"}
+                    onClick={() => {
+                      void onArchive([...selectedArchiveIds]).then((ok) => {
+                        if (ok) setSelectedArchiveIds(new Set());
+                      });
+                    }}
                   >
-                    <ArrowUpDown className="h-3.5 w-3.5" aria-hidden />
-                    <span>{sortLabel[sort]}</span>
-                    <ChevronDown className="h-3.5 w-3.5" aria-hidden />
-                  </button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="min-w-40">
-                  {(Object.keys(sortLabel) as AutomationSort[]).map((value) => (
-                    <DropdownMenuItem key={value} onClick={() => onSortChange(value)}>
-                      <span>{sortLabel[value]}</span>
-                      {sort === value ? <Check className="ml-auto h-3.5 w-3.5" aria-hidden /> : null}
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownMenuContent>
-              </DropdownMenu>
+                    {actionKey === "archive" ? (
+                      <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" aria-hidden />
+                    ) : (
+                      <Archive className="mr-1.5 h-3.5 w-3.5" aria-hidden />
+                    )}
+                    {tx("settings.automations.archiveSelected", "Archive selected ({{count}})", {
+                      count: selectedArchiveIds.size,
+                    })}
+                  </Button>
+                ) : null}
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      className="inline-flex h-9 min-w-[8.5rem] items-center justify-center gap-1.5 whitespace-nowrap rounded-control border border-border/45 bg-settings-surface px-3 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground sm:w-auto"
+                    >
+                      <ArrowUpDown className="h-3.5 w-3.5" aria-hidden />
+                      <span>{sortLabel[sort]}</span>
+                      <ChevronDown className="h-3.5 w-3.5" aria-hidden />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="min-w-40">
+                    {(Object.keys(sortLabel) as AutomationSort[]).map((value) => (
+                      <DropdownMenuItem key={value} onClick={() => onSortChange(value)}>
+                        <span>{sortLabel[value]}</span>
+                        {sort === value ? <Check className="ml-auto h-3.5 w-3.5" aria-hidden /> : null}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
             </div>
           </div>
         </section>
@@ -230,7 +268,16 @@ export function AutomationsSettings({
                   job={job}
                   locale={locale}
                   selected={job.id === selectedJob.id}
+                  archiveSelected={selectedArchiveIds.has(job.id)}
                   onSelect={() => setSelectedJobId(job.id)}
+                  onArchiveSelect={(selected) => {
+                    setSelectedArchiveIds((current) => {
+                      const next = new Set(current);
+                      if (selected) next.add(job.id);
+                      else next.delete(job.id);
+                      return next;
+                    });
+                  }}
                 />
               ))}
             </div>
@@ -291,12 +338,16 @@ function AutomationListItem({
   job,
   locale,
   selected,
+  archiveSelected,
   onSelect,
+  onArchiveSelect,
 }: {
   job: SessionAutomationJob;
   locale: string;
   selected: boolean;
+  archiveSelected: boolean;
   onSelect: () => void;
+  onArchiveSelect: (selected: boolean) => void;
 }) {
   const { t } = useTranslation();
   const tx = (key: string, fallback: string, values?: Record<string, unknown>) =>
@@ -306,8 +357,26 @@ function AutomationListItem({
   const nextRun = formatAutomationNext(job, tx);
   const summary = automationSummary(job, tx);
 
+  const canArchive = automationCanArchive(job);
+
   return (
-    <div role="listitem">
+    <div
+      role="listitem"
+      className="grid grid-cols-[1.75rem_minmax(0,1fr)] items-center"
+    >
+      {canArchive ? (
+        <input
+          type="checkbox"
+          checked={archiveSelected}
+          onChange={(event) => onArchiveSelect(event.target.checked)}
+          aria-label={tx("settings.automations.selectForArchive", "Select {{name}} for archive", {
+            name: job.name || job.id,
+          })}
+          className="h-3.5 w-3.5 justify-self-center rounded border-border accent-primary"
+        />
+      ) : (
+        <span aria-hidden />
+      )}
       <button
         type="button"
         aria-pressed={selected}
@@ -387,6 +456,7 @@ function AutomationDetailPanel({
     : null;
   const created = job.created_at_ms ? fmtDateTime(job.created_at_ms, locale) : null;
   const updated = job.updated_at_ms ? fmtDateTime(job.updated_at_ms, locale) : null;
+  const archived = job.archived_at_ms ? fmtDateTime(job.archived_at_ms, locale) : null;
   const localTrigger = isLocalTriggerAutomation(job);
   const triggerCommand = automationTriggerCommand(job);
   const message = automationDetailText(job, tx);
@@ -394,6 +464,7 @@ function AutomationDetailPanel({
     ? tx("settings.automations.fields.command", "Command")
     : tx("settings.automations.fields.message", "Message");
   const schedule = formatAutomationSchedule(job, locale, tx);
+  const delivery = automationDeliveryLabel(job, tx);
   const [messageExpanded, setMessageExpanded] = useState(false);
   const [commandCopied, setCommandCopied] = useState(false);
   const messageNeedsExpansion = automationMessageNeedsExpansion(message);
@@ -483,7 +554,7 @@ function AutomationDetailPanel({
             ) : null}
           </section>
 
-          <div className="grid gap-3 md:grid-cols-2">
+          <div className="grid gap-3 md:grid-cols-3">
             <AutomationDetail
               label={tx("settings.automations.labels.next", "Next")}
               title={formatAutomationNextTitle(job, locale, tx)}
@@ -502,6 +573,12 @@ function AutomationDetailPanel({
               ) : (
                 origin
               )}
+            </AutomationDetail>
+            <AutomationDetail
+              label={tx("settings.automations.labels.delivery", "Result delivery")}
+              title={delivery}
+            >
+              {delivery}
             </AutomationDetail>
           </div>
 
@@ -538,6 +615,14 @@ function AutomationDetailPanel({
                     <div className="mt-1.5 text-[12.5px] leading-5 text-foreground/80">{updated}</div>
                   </div>
                 ) : null}
+                {archived ? (
+                  <div>
+                    <div className="text-[11px] leading-none text-muted-foreground/75">
+                      {tx("settings.automations.labels.archived", "Archived")}
+                    </div>
+                    <div className="mt-1.5 text-[12.5px] leading-5 text-foreground/80">{archived}</div>
+                  </div>
+                ) : null}
                 <div>
                   <div className="text-[11px] leading-none text-muted-foreground/75">ID</div>
                   <div className="mt-1.5 break-all font-mono text-[11.5px] leading-5 text-foreground/70">
@@ -570,6 +655,7 @@ function AutomationActionGroup({
   const tx = (key: string, fallback: string, values?: Record<string, unknown>) =>
     t(key, { defaultValue: fallback, ...(values ?? {}) });
   const canManage = !job.protected;
+  const archived = job.archived_at_ms != null;
   const hasLinkedChat = Boolean(job.origin);
   const localTrigger = isLocalTriggerAutomation(job);
   const canRun = canManage && hasLinkedChat && job.enabled && !job.state.pending && !localTrigger;
@@ -582,6 +668,21 @@ function AutomationActionGroup({
       <span className="inline-flex h-9 items-center rounded-full bg-muted px-3 text-[12px] font-medium text-muted-foreground">
         {tx("settings.automations.protected", "Protected")}
       </span>
+    );
+  }
+
+  if (archived) {
+    return (
+      <div className="flex shrink-0 items-center gap-1 rounded-full bg-background/65 p-1">
+        <AppsActionButton
+          ariaLabel={tx("settings.automations.delete", "Delete")}
+          tone="danger"
+          disabled={Boolean(actionKey)}
+          onClick={() => onRequestDelete(job)}
+        >
+          <Trash2 className="h-4 w-4" aria-hidden />
+        </AppsActionButton>
+      </div>
     );
   }
 
@@ -701,6 +802,8 @@ type AutomationEditDraft = {
   cronExpr: string;
   tz: string;
   atLocal: string;
+  deliveryChannel: string;
+  deliveryChatId: string;
 };
 type AutomationScheduleUpdate = NonNullable<AutomationUpdatePayload["schedule"]>;
 
@@ -889,6 +992,50 @@ export function AutomationEditDialog({
                 </label>
               ) : null}
 
+              {!localTrigger ? (
+                <div className="space-y-2 rounded-floating bg-muted/45 p-3">
+                  <div>
+                    <div className="text-[12px] font-medium text-muted-foreground">
+                      {tx("settings.automations.fields.delivery", "Result delivery")}
+                    </div>
+                    <div className="mt-1 text-[11.5px] leading-5 text-muted-foreground">
+                      {tx(
+                        "settings.automations.deliveryHint",
+                        "Leave both fields empty to deliver back to the linked chat.",
+                      )}
+                    </div>
+                  </div>
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    <label className="block space-y-1.5">
+                      <span className="text-[12px] font-medium text-muted-foreground">
+                        {tx("settings.automations.fields.deliveryChannel", "Channel")}
+                      </span>
+                      <Input
+                        value={draft.deliveryChannel}
+                        onChange={(event) => setDraft((prev) => ({
+                          ...prev,
+                          deliveryChannel: event.target.value,
+                        }))}
+                        placeholder="slack"
+                      />
+                    </label>
+                    <label className="block space-y-1.5">
+                      <span className="text-[12px] font-medium text-muted-foreground">
+                        {tx("settings.automations.fields.deliveryChatId", "Chat/channel ID")}
+                      </span>
+                      <Input
+                        value={draft.deliveryChatId}
+                        onChange={(event) => setDraft((prev) => ({
+                          ...prev,
+                          deliveryChatId: event.target.value,
+                        }))}
+                        placeholder="C0123456789"
+                      />
+                    </label>
+                  </div>
+                </div>
+              ) : null}
+
               {validation ? (
                 <div className="rounded-control bg-destructive/8 px-3 py-2 text-[12px] text-destructive">
                   {validation}
@@ -997,12 +1144,13 @@ function automationDetailText(
 }
 
 function automationNeedsAttention(job: SessionAutomationJob): boolean {
-  return job.state.last_status === "error";
+  return job.archived_at_ms == null && job.state.last_status === "error";
 }
 
 function automationStatusKey(
   job: SessionAutomationJob,
-): "active" | "running" | "paused" | "failed" | "system" | "completed" | "idle" {
+): "active" | "running" | "paused" | "failed" | "system" | "completed" | "idle" | "archived" {
+  if (job.archived_at_ms != null) return "archived";
   if (job.protected) return "system";
   if (job.state.pending) return "running";
   if (!job.enabled) return "paused";
@@ -1046,6 +1194,8 @@ function automationDraftFromJob(job: SessionAutomationJob | null): AutomationEdi
     cronExpr: job?.schedule.expr ?? "0 9 * * *",
     tz: job?.schedule.tz ?? "",
     atLocal: formatLocalDateTimeInput(job?.schedule.at_ms ?? Date.now() + 3_600_000),
+    deliveryChannel: job?.payload.delivery_channel ?? "",
+    deliveryChatId: job?.payload.delivery_chat_id ?? "",
   };
 }
 
@@ -1074,6 +1224,12 @@ function automationEditDraftError(
   if (isLocalTriggerAutomation(job)) return null;
   if (!draft.message.trim()) {
     return tx("settings.automations.validation.messageRequired", "Message is required.");
+  }
+  if (Boolean(draft.deliveryChannel.trim()) !== Boolean(draft.deliveryChatId.trim())) {
+    return tx(
+      "settings.automations.validation.deliveryPair",
+      "Delivery channel and chat/channel ID must be provided together.",
+    );
   }
   if (draft.scheduleKind === "every") {
     const value = Number(draft.everyValue);
@@ -1108,6 +1264,18 @@ function automationUpdatePayloadFromDraft(
   const message = draft.message.trim();
   if (!name || !message) return "invalid";
   const payload: AutomationUpdatePayload = { name, message };
+  const deliveryChannel = draft.deliveryChannel.trim();
+  const deliveryChatId = draft.deliveryChatId.trim();
+  const currentDeliveryChannel = job?.payload.delivery_channel?.trim() ?? "";
+  const currentDeliveryChatId = job?.payload.delivery_chat_id?.trim() ?? "";
+  if (
+    !job
+    || deliveryChannel !== currentDeliveryChannel
+    || deliveryChatId !== currentDeliveryChatId
+  ) {
+    payload.delivery_channel = deliveryChannel || null;
+    payload.delivery_chat_id = deliveryChatId || null;
+  }
   const schedule = automationSchedulePayloadFromDraft(draft);
   if (typeof schedule === "string") return schedule;
   if (automationScheduleChanged(draft, job, schedule)) {
@@ -1210,7 +1378,13 @@ function automationSearchParts(
   if (field === "id") return [job.id];
   if (field === "name") return [job.name, job.id];
   if (field === "message") return [job.payload.message, job.payload.command, job.trigger?.command];
-  if (field === "chat") return originParts;
+  if (field === "chat") {
+    return [
+      ...originParts,
+      job.payload.delivery_channel,
+      job.payload.delivery_chat_id,
+    ];
+  }
   if (field === "cron" || field === "schedule") return scheduleParts;
   if (field === "status") return [automationStatusKey(job), job.enabled ? "enabled" : "disabled"];
   return [
@@ -1223,6 +1397,8 @@ function automationSearchParts(
     ...scheduleParts,
     automationStatusKey(job),
     ...originParts,
+    job.payload.delivery_channel,
+    job.payload.delivery_chat_id,
   ];
 }
 
@@ -1295,6 +1471,7 @@ function automationMatchesFilter(job: SessionAutomationJob, filter: AutomationFi
   if (filter === "paused") return status === "paused";
   if (filter === "failed") return automationNeedsAttention(job);
   if (filter === "system") return Boolean(job.protected);
+  if (filter === "archived") return job.archived_at_ms != null;
   return true;
 }
 
@@ -1321,6 +1498,11 @@ const AUTOMATION_FILTER_TONES: Partial<
     selectedText: "text-sky-700 dark:text-sky-300",
     count: "bg-sky-500/10 text-sky-700 dark:text-sky-300",
   },
+  archived: {
+    text: "text-violet-600 dark:text-violet-400",
+    selectedText: "text-violet-700 dark:text-violet-300",
+    count: "bg-violet-500/10 text-violet-700 dark:text-violet-300",
+  },
 };
 
 function automationFilterToneClass(value: AutomationFilter, count: number, selected: boolean): string {
@@ -1339,6 +1521,9 @@ function automationStatus(
   tx: (key: string, fallback: string, values?: Record<string, unknown>) => string,
 ): { label: string; tone: "neutral" | "success" | "warning" } {
   const status = automationStatusKey(job);
+  if (status === "archived") {
+    return { label: tx("settings.automations.status.archived", "Archived"), tone: "neutral" };
+  }
   if (status === "system") return { label: tx("settings.automations.status.system", "System"), tone: "neutral" };
   if (status === "running") {
     return { label: tx("settings.automations.status.running", "Running now"), tone: "warning" };
@@ -1365,6 +1550,22 @@ function automationOriginLabel(
   if (!origin) return tx("settings.automations.origin.unknown", "No linked chat");
   if (origin.channel !== "websocket") return automationChannelLabel(origin.channel, tx);
   return origin.title || origin.preview || origin.session_key || automationChannelLabel(origin.channel, tx);
+}
+
+function automationDeliveryLabel(
+  job: SessionAutomationJob,
+  tx: (key: string, fallback: string, values?: Record<string, unknown>) => string,
+): string {
+  const channel = job.payload.delivery_channel;
+  const chatId = job.payload.delivery_chat_id;
+  if (!channel || !chatId) {
+    return tx("settings.automations.delivery.origin", "Origin session");
+  }
+  return `${automationChannelLabel(channel, tx)} · ${chatId}`;
+}
+
+function automationCanArchive(job: SessionAutomationJob): boolean {
+  return !job.protected && !isLocalTriggerAutomation(job) && job.archived_at_ms == null;
 }
 
 function automationChannelLabel(
@@ -1470,6 +1671,7 @@ function formatAutomationNext(
   job: SessionAutomationJob,
   tx: (key: string, fallback: string, values?: Record<string, unknown>) => string,
 ): string {
+  if (job.archived_at_ms != null) return tx("settings.automations.next.archived", "Archived");
   if (!job.enabled) return tx("settings.automations.next.paused", "Paused");
   if (job.state.pending) return tx("settings.automations.next.pending", "Running now");
   if (isLocalTriggerAutomation(job)) {

--- a/webui/src/components/settings/system/createSystemSettingsActions.ts
+++ b/webui/src/components/settings/system/createSystemSettingsActions.ts
@@ -10,6 +10,7 @@ import type { AutomationAction } from "@/components/settings/system/AutomationsS
 import { DEFAULT_CUSTOM_MCP_FORM } from "@/components/settings/system/AppsSettings";
 import type { SystemSettingsState } from "@/components/settings/system/useSystemSettingsState";
 import {
+  archiveAutomations,
   cancelMcpOAuth,
   completeMcpOAuth,
   disableNanobotFeature,
@@ -266,6 +267,40 @@ export function createSystemSettingsActions({
       setAutomationPendingEdit(null);
     } catch (err) {
       setAutomationsError((err as Error).message);
+    } finally {
+      setAutomationAction(null);
+    }
+  };
+
+  const handleAutomationArchive = async (jobIds: string[]): Promise<boolean> => {
+    if (!jobIds.length) return false;
+    setAutomationAction("archive");
+    setAutomationsError(null);
+    try {
+      const result = await archiveAutomations(client, jobIds);
+      await refreshAutomations(false);
+      const warnings: string[] = [];
+      if (result.protected.length) {
+        warnings.push(
+          t("settings.automations.archiveProtected", {
+            defaultValue: "Protected jobs were not archived: {{ids}}",
+            ids: result.protected.join(", "),
+          }),
+        );
+      }
+      if (result.not_found.length) {
+        warnings.push(
+          t("settings.automations.archiveNotFound", {
+            defaultValue: "Jobs not found: {{ids}}",
+            ids: result.not_found.join(", "),
+          }),
+        );
+      }
+      if (warnings.length) setAutomationsError(warnings.join(" "));
+      return true;
+    } catch (err) {
+      setAutomationsError((err as Error).message);
+      return false;
     } finally {
       setAutomationAction(null);
     }
@@ -640,6 +675,7 @@ export function createSystemSettingsActions({
   return {
     handleApiServiceAction,
     handleAutomationAction,
+    handleAutomationArchive,
     handleAutomationEdit,
     handleCliAppAction,
     handleImportMcpConfig,

--- a/webui/src/components/settings/useSettingsController.ts
+++ b/webui/src/components/settings/useSettingsController.ts
@@ -444,6 +444,7 @@ export function useSettingsController({
   const {
     handleApiServiceAction,
     handleAutomationAction,
+    handleAutomationArchive,
     handleAutomationEdit,
     handleCliAppAction,
     handleImportMcpConfig,
@@ -495,6 +496,7 @@ export function useSettingsController({
     form,
     handleApiServiceAction,
     handleAutomationAction,
+    handleAutomationArchive,
     handleAutomationEdit,
     handleCliAppAction,
     handleDeleteModelConfiguration,

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -1,5 +1,6 @@
 import type {
   ApiServicePayload,
+  AutomationArchiveResult,
   AutomationsPayload,
   AutomationUpdatePayload,
   ChannelConfigurePayload,
@@ -320,6 +321,15 @@ export async function runAutomationAction(
   id: string,
 ): Promise<AutomationsPayload> {
   return mutation<AutomationsPayload>(transport, `automation.${action}`, { id });
+}
+
+export async function archiveAutomations(
+  transport: WebUIMutationTransport,
+  jobIds: string[],
+): Promise<AutomationArchiveResult> {
+  return mutation<AutomationArchiveResult>(transport, "automation.archive", {
+    job_ids: jobIds,
+  });
 }
 
 export async function updateAutomation(

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -164,6 +164,7 @@ export interface SessionAutomationJob {
   name: string;
   enabled: boolean;
   protected?: boolean;
+  archived_at_ms?: number | null;
   delete_after_run?: boolean;
   created_at_ms?: number | null;
   updated_at_ms?: number | null;
@@ -179,6 +180,8 @@ export interface SessionAutomationJob {
     message: string;
     kind?: "agent_turn" | "system_event" | "local_trigger" | string;
     command?: string;
+    delivery_channel?: string | null;
+    delivery_chat_id?: string | null;
   };
   state: {
     next_run_at_ms?: number | null;
@@ -211,6 +214,8 @@ export interface AutomationsPayload { jobs: SessionAutomationJob[]; }
 export interface AutomationUpdatePayload {
   name?: string;
   message?: string;
+  delivery_channel?: string | null;
+  delivery_chat_id?: string | null;
   schedule?: {
     kind: "at" | "every" | "cron";
     at_ms?: number;
@@ -218,6 +223,13 @@ export interface AutomationUpdatePayload {
     expr?: string;
     tz?: string;
   };
+}
+
+export interface AutomationArchiveResult {
+  archived: string[];
+  already_archived: string[];
+  protected: string[];
+  not_found: string[];
 }
 
 export interface SessionDeleteResult {

--- a/webui/src/tests/api.test.ts
+++ b/webui/src/tests/api.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  archiveAutomations,
   cancelMcpOAuth,
   configureChannel,
   completeMcpOAuth,
@@ -266,6 +267,16 @@ describe("webui API helpers", () => {
     expect(requestMutation).toHaveBeenCalledWith(
       "automation.disable",
       { id: "job 1/2" },
+      20_000,
+    );
+  });
+
+  it("serializes batch automation archive actions", async () => {
+    await archiveAutomations(mutationTransport, ["job-a", "job-b"]);
+
+    expect(requestMutation).toHaveBeenCalledWith(
+      "automation.archive",
+      { job_ids: ["job-a", "job-b"] },
       20_000,
     );
   });

--- a/webui/src/tests/settings-system.test.tsx
+++ b/webui/src/tests/settings-system.test.tsx
@@ -149,6 +149,129 @@ describe("Settings system domains", () => {
     expect(await screen.findByRole("heading", { name: "Daily summary" })).toBeInTheDocument();
   });
 
+  it("filters archived automations and archives selected cron jobs in one request", async () => {
+    const jobs = [
+      {
+        id: "job-a",
+        name: "Daily summary",
+        enabled: true,
+        archived_at_ms: null,
+        schedule: { kind: "cron", expr: "0 9 * * *" },
+        payload: { message: "Summarize the day" },
+        state: { next_run_at_ms: Date.now() + 60_000 },
+        origin: { channel: "websocket", session_key: "websocket:a", title: "Ops" },
+      },
+      {
+        id: "job-b",
+        name: "Weekly report",
+        enabled: false,
+        archived_at_ms: null,
+        schedule: { kind: "every", every_ms: 60_000 },
+        payload: { message: "Write report" },
+        state: {},
+        origin: { channel: "websocket", session_key: "websocket:b", title: "Reports" },
+      },
+      {
+        id: "job-old",
+        name: "Old reminder",
+        enabled: false,
+        archived_at_ms: 1_800_000_000_000,
+        schedule: { kind: "every", every_ms: 60_000 },
+        payload: { message: "Old work" },
+        state: { last_status: "ok" },
+        origin: { channel: "websocket", session_key: "websocket:old", title: "Old" },
+      },
+    ];
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/settings") return jsonResponse(settingsPayload());
+      if (url === "/api/webui/automations") return jsonResponse({ jobs });
+      return jsonResponse({});
+    }));
+    requestMutationMock.mockResolvedValue({
+      archived: ["job-a", "job-b"],
+      already_archived: [],
+      protected: [],
+      not_found: [],
+    });
+
+    renderSettingsView({
+      initialSection: "automations",
+      initialSettings: settingsPayload(),
+      showSidebar: false,
+    });
+
+    expect(await screen.findByRole("heading", { name: "Daily summary" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Archived 1" }));
+    expect(await screen.findByRole("heading", { name: "Old reminder" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Run now" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "All 3" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Daily summary for archive" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Weekly report for archive" }));
+    fireEvent.click(screen.getByRole("button", { name: "Archive selected (2)" }));
+
+    await waitFor(() => expect(requestMutationMock).toHaveBeenCalledWith(
+      "automation.archive",
+      { job_ids: ["job-a", "job-b"] },
+      20_000,
+    ));
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Archive selected (2)" })).not.toBeInTheDocument();
+    });
+  });
+
+  it("edits an automation delivery target as a complete pair", async () => {
+    const jobs = [{
+      id: "job-1",
+      name: "Daily summary",
+      enabled: true,
+      archived_at_ms: null,
+      schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+      payload: { message: "Summarize the day" },
+      state: { next_run_at_ms: Date.now() + 60_000 },
+      origin: { channel: "websocket", session_key: "websocket:a", title: "Ops" },
+    }];
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/settings") return jsonResponse(settingsPayload());
+      if (url === "/api/webui/automations") return jsonResponse({ jobs });
+      return jsonResponse({});
+    }));
+    requestMutationMock.mockResolvedValue({ jobs });
+
+    renderSettingsView({
+      initialSection: "automations",
+      initialSettings: settingsPayload(),
+      showSidebar: false,
+    });
+
+    expect(await screen.findByRole("heading", { name: "Daily summary" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    const channel = screen.getByLabelText("Channel");
+    const chatId = screen.getByLabelText("Chat/channel ID");
+    fireEvent.change(channel, { target: { value: "slack" } });
+    expect(screen.getByText(
+      "Delivery channel and chat/channel ID must be provided together.",
+    )).toBeInTheDocument();
+    fireEvent.change(chatId, { target: { value: "C123" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(requestMutationMock).toHaveBeenCalledWith(
+      "automation.update",
+      {
+        id: "job-1",
+        values: expect.objectContaining({
+          delivery_channel: "slack",
+          delivery_chat_id: "C123",
+        }),
+      },
+      20_000,
+    ));
+  });
+
   it("coalesces focus refreshes while automations are already loading", async () => {
     let resolveAutomations!: (response: Response) => void;
     const pendingAutomations = new Promise<Response>((resolve) => {


### PR DESCRIPTION
## Summary

- add explicit per-cron result delivery targets without changing session ownership
- preserve origin-session fallback for existing jobs
- add batch archive as a lifecycle state while retaining run history
- keep archived jobs out of scheduling and active views
- add tool and WebUI management for archived automations

## Compatibility

- existing session-bound jobs keep current delivery behavior
- legacy `channel/to` payload migration remains unchanged
- store schema remains additive and version 1
- existing `deleteAfterRun=true` jobs keep legacy behavior
- new one-shot tool jobs remain disabled after completion so they can be inspected and archived

## Testing

- `uv run --no-sync ruff check nanobot tests`
- `uv run --no-sync python -m scripts.install_channel_dependencies --all-channels`
- `uv run --no-sync basedpyright` (0 errors, 0 warnings)
- `uv run --no-sync pytest tests/cron nanobot/channels/websocket/tests/test_websocket_http_routes.py -q` (251 passed)
- `bun run test --run` (1122 passed)
- `bun run lint`
- `bun run build`

## Local full-suite note

`uv run --no-sync pytest -q` completed with 6815 passed and 12 skipped. Eight failures are in untouched proxy/TUI tests: this macOS host has a global system proxy enabled, and the Python 3.14 TUI process probe interacts with an existing upstream subprocess mock. The issue-specific suites above pass completely.

Closes #5513