### PR TITLE
fix(agent): drop empty active-task groups after tasks finish

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -866,6 +866,22 @@ class AgentLoop:
         exec_cancelled = await self._exec_session_manager.terminate_by_owner(key)
         return cancelled + sub_cancelled + exec_cancelled
 
+    def _release_active_task(self, task: asyncio.Task[Any], key: str) -> None:
+        """Drop *task* from its session group, deleting the group when empty.
+
+        A finished task is removed from the per-session set by the done
+        callback, but the empty set itself would otherwise stay in
+        ``_active_tasks`` for the lifetime of the loop. A gateway that sees
+        many short-lived sessions then accumulates one entry per session
+        (issue #5428).
+        """
+        tasks = self._active_tasks.get(key)
+        if tasks is None:
+            return
+        tasks.discard(task)
+        if not tasks:
+            self._active_tasks.pop(key, None)
+
     async def discard_session(self, key: str) -> None:
         """Stop active work for *key* and forget its cached session."""
         self._discarding_sessions.add(key)
@@ -1355,7 +1371,9 @@ class AgentLoop:
                     set(),
                 )
                 active_tasks.add(task)
-                task.add_done_callback(active_tasks.discard)
+                task.add_done_callback(
+                    lambda t, k=effective_key: self._release_active_task(t, k)
+                )
         finally:
             await self.aclose()
 

--- a/tests/agent/test_active_task_cleanup.py
+++ b/tests/agent/test_active_task_cleanup.py
@@ -1,0 +1,75 @@
+"""Tests for releasing active-task groups when their tasks finish (issue #5428)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_loop(*, tools_config=None):
+    """Create a minimal AgentLoop with mocked dependencies."""
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    workspace = MagicMock()
+    workspace.__truediv__ = MagicMock(return_value=MagicMock())
+
+    with (
+        patch("nanobot.agent.loop.ContextBuilder"),
+        patch("nanobot.agent.loop.SessionManager"),
+        patch("nanobot.agent.loop.SubagentManager") as mock_sub_mgr,
+    ):
+        mock_sub_mgr.return_value.cancel_by_session = AsyncMock(return_value=0)
+        loop = AgentLoop(
+            bus=bus,
+            provider=provider,
+            workspace=workspace,
+            tools_config=tools_config,
+        )
+    return loop
+
+
+async def _completed() -> None:
+    return None
+
+
+class TestActiveTaskCleanup:
+    @pytest.mark.asyncio
+    async def test_release_removes_group_when_last_task_finishes(self):
+        loop = _make_loop()
+        key = "session:abc"
+        task = asyncio.create_task(_completed())
+        await task
+        loop._active_tasks[key] = {task}
+
+        loop._release_active_task(task, key)
+
+        assert key not in loop._active_tasks
+
+    @pytest.mark.asyncio
+    async def test_release_keeps_group_while_other_tasks_remain(self):
+        loop = _make_loop()
+        key = "session:abc"
+        first = asyncio.create_task(_completed())
+        second = asyncio.create_task(_completed())
+        await asyncio.gather(first, second)
+        loop._active_tasks[key] = {first, second}
+
+        loop._release_active_task(first, key)
+
+        assert loop._active_tasks[key] == {second}
+
+    @pytest.mark.asyncio
+    async def test_release_ignores_unknown_group(self):
+        loop = _make_loop()
+        task = asyncio.create_task(_completed())
+        await task
+
+        loop._release_active_task(task, "session:missing")
+
+        assert loop._active_tasks == {}


### PR DESCRIPTION
## Summary

Fixes #5428.

`AgentLoop._active_tasks` maps a session key to the set of in-flight dispatch
tasks. The done callback bound `set.discard` directly, which removes the
finished task but leaves the now-empty set in the mapping. A long-running
gateway that routes many one-shot or temporary session keys therefore
accumulates one mapping entry per session for the lifetime of the loop.

## Change

- Added `AgentLoop._release_active_task(task, key)`: discards the finished task
  and pops the group from `_active_tasks` once it becomes empty.
- The dispatch callback now calls that helper instead of binding `set.discard`
  directly.

Cancellation and shutdown paths are unchanged - `_cancel_active_tasks()` and
`aclose()` still clear groups eagerly.

## Test

Added `tests/agent/test_active_task_cleanup.py` covering:

- the last task finishing removes the group entirely,
- a group that still has tasks is kept,
- an unknown key is a no-op.

Closes #5428