### PR TITLE
fix(webui): delete unpersisted pane sessions

### DIFF
--- a/nanobot/channels/websocket/tests/test_websocket_http_routes.py
+++ b/nanobot/channels/websocket/tests/test_websocket_http_routes.py
@@ -2334,6 +2334,48 @@ async def test_session_delete_removes_transcript_without_canonical_file(
 
 
 @pytest.mark.asyncio
+async def test_session_delete_removes_unpersisted_new_chat(
+    bus: MagicMock, tmp_path: Path
+) -> None:
+    sm = SessionManager(tmp_path / "sessions")
+    project = tmp_path / "project"
+    project.mkdir()
+    channel = _ch(bus, session_manager=sm, workspace_path=tmp_path, port=_free_port())
+    connection = AsyncMock()
+    connection.remote_address = ("127.0.0.1", 50123)
+
+    await channel._dispatch_envelope(
+        connection,
+        "webui-client",
+        {
+            "type": "new_chat",
+            "workspace_scope": {
+                "project_path": str(project),
+                "access_mode": "full",
+            },
+        },
+    )
+
+    attached = next(
+        payload
+        for payload in (
+            json.loads(call.args[0]) for call in connection.send.await_args_list
+        )
+        if payload.get("event") == "attached"
+    )
+    key = f"websocket:{attached['chat_id']}"
+
+    assert sm.list_sessions() == []
+    assert channel.gateway.workspaces.scope_for_session_key(key).project_path == project.resolve()
+
+    response = await _webui_mutate(channel, "session.delete", {"key": key})
+
+    assert response.status_code == 200
+    assert response.json()["deleted"] is True
+    assert channel.gateway.workspaces.scope_for_session_key(key).project_path == tmp_path.resolve()
+
+
+@pytest.mark.asyncio
 async def test_webui_automations_route_lists_all_jobs_and_allows_user_actions(
     bus: MagicMock, tmp_path: Path
 ) -> None:

--- a/nanobot/webui/workspaces.py
+++ b/nanobot/webui/workspaces.py
@@ -357,3 +357,7 @@ class WebUIWorkspaceController:
         self._draft_scopes.move_to_end(session_key)
         while len(self._draft_scopes) > _MAX_DRAFT_SCOPES:
             self._draft_scopes.popitem(last=False)
+
+    def discard_draft_scope(self, session_key: str) -> bool:
+        """Discard the staged scope for a chat that has not persisted yet."""
+        return self._draft_scopes.pop(session_key, None) is not None

--- a/nanobot/webui/ws_http.py
+++ b/nanobot/webui/ws_http.py
@@ -952,9 +952,12 @@ class GatewayHTTPHandler:
                         self.local_trigger_store.delete(job.id)
                 elif self.cron_service is not None:
                     self.cron_service.remove_job(job.id)
+        draft_deleted = self.workspaces.discard_draft_scope(decoded_key)
         session_deleted = self.session_manager.delete_session(decoded_key)
         transcript_deleted = delete_webui_thread(decoded_key)
-        return _http_json_response({"deleted": bool(session_deleted or transcript_deleted)})
+        return _http_json_response(
+            {"deleted": bool(draft_deleted or session_deleted or transcript_deleted)}
+        )
 
     # -- Automation routes --------------------------------------------------
 

--- a/webui/src/hooks/useSessions.ts
+++ b/webui/src/hooks/useSessions.ts
@@ -257,11 +257,14 @@ export function useSessions(): {
 
   const deleteChat = useCallback(
     async (key: string, options?: { deleteAutomations?: boolean }) => {
+      const optimistic = optimisticKeysRef.current.has(key);
       const result = await apiDeleteSession(client, key, options);
-      if (!result.deleted) return result;
+      if (result.blocked_by_automations || (!result.deleted && !optimistic)) return result;
       optimisticKeysRef.current.delete(key);
       setSessions((prev) => prev.filter((s) => s.key !== key));
-      return result;
+      // The gateway may have restarted and forgotten an unpersisted chat's
+      // draft scope, but removing that optimistic session is still a deletion.
+      return result.deleted ? result : { ...result, deleted: true };
     },
     [client],
   );

--- a/webui/src/tests/useSessions.test.tsx
+++ b/webui/src/tests/useSessions.test.tsx
@@ -124,6 +124,59 @@ describe("useSessions", () => {
     expect(result.current.sessions.map((s) => s.key)).toEqual(["websocket:chat-b"]);
   });
 
+  it("removes an optimistic chat when the gateway no longer has its draft", async () => {
+    vi.mocked(api.listSessions).mockResolvedValue([]);
+    vi.mocked(api.deleteSession).mockResolvedValue({ deleted: false });
+    const client = fakeClient();
+    client.newChat.mockResolvedValue("chat-empty");
+
+    const { result } = renderHook(() => useSessions(), {
+      wrapper: wrap(client),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(async () => {
+      await result.current.createChat();
+    });
+    expect(result.current.sessions.map((s) => s.key)).toEqual(["websocket:chat-empty"]);
+
+    let deleteResult: Awaited<ReturnType<typeof result.current.deleteChat>> | undefined;
+    await act(async () => {
+      deleteResult = await result.current.deleteChat("websocket:chat-empty");
+    });
+
+    expect(deleteResult?.deleted).toBe(true);
+    expect(result.current.sessions).toEqual([]);
+  });
+
+  it("keeps an optimistic chat when delete is blocked by bound automations", async () => {
+    vi.mocked(api.listSessions).mockResolvedValue([]);
+    vi.mocked(api.deleteSession).mockResolvedValue({
+      deleted: false,
+      blocked_by_automations: true,
+      automations: [],
+    });
+    const client = fakeClient();
+    client.newChat.mockResolvedValue("chat-empty");
+
+    const { result } = renderHook(() => useSessions(), {
+      wrapper: wrap(client),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(async () => {
+      await result.current.createChat();
+    });
+
+    let deleteResult: Awaited<ReturnType<typeof result.current.deleteChat>> | undefined;
+    await act(async () => {
+      deleteResult = await result.current.deleteChat("websocket:chat-empty");
+    });
+
+    expect(deleteResult?.blocked_by_automations).toBe(true);
+    expect(result.current.sessions.map((s) => s.key)).toEqual(["websocket:chat-empty"]);
+  });
+
   it("keeps a session when delete is blocked by bound automations", async () => {
     vi.mocked(api.listSessions).mockResolvedValue([
       {


### PR DESCRIPTION
## Summary

- allow newly created WebUI panes to be deleted before their first message is persisted
- clear the staged workspace scope when deleting an unpersisted chat
- keep optimistic empty panes deletable after a gateway restart loses the staged scope
- add regression coverage for server-side draft cleanup and client-side optimistic deletion

## Before and after

### Before

Confirming deletion does not remove an empty pane. The pane remains visible until it receives a message and becomes a persisted session.

[! cannot-delete-empty-pane-github.mp4 here ](https://github.com/user-attachments/assets/86cc7d79-b9a1-4249-a8b2-1c93afc36eb6)

### After

Confirming deletion immediately removes the empty pane and keeps the remaining pane group active.

[! delete-empty-pane-github.mp4 here ](https://github.com/user-attachments/assets/46938633-b7ec-4a25-9065-782c085e290e)



## Root cause

Clicking **Add pane** creates a new WebUI chat and displays it optimistically as “New topic”. By design, the server does not persist that session until its first message is accepted.

Deleting the empty pane called `session.delete`, but the endpoint only considered a persisted session file or WebUI transcript as deletable state. Since neither existed yet, it returned `deleted: false`. The frontend consequently kept the optimistic session in the sidebar and workbench. After sending a message, the session was persisted and deletion worked normally.

## Solution

New chats already have a staged workspace scope on the server. The delete route now discards that draft scope and includes it when determining whether the session was deleted.

If a gateway restart has already lost that transient scope, the frontend still removes a locally owned optimistic chat when the server has no persisted object to delete. A bound automation continues to block both server-side and optimistic deletion unless cascading deletion is explicitly requested.

This preserves the existing behavior of not persisting empty sessions while allowing explicitly deleted empty panes to be removed correctly.

## Testing

- `17 passed` — WebUI workspace-scope tests
- `1 passed` — unpersisted `new_chat` behavior
- `10 passed` — session deletion routes
- `30 passed` — `useSessions` tests, including lost-draft and automation-blocked optimistic deletion
- `88 passed` — WebUI session and layout tests
- WebUI production build passed
- ESLint and Ruff checks passed
- `git diff --check` passed