### PR TITLE
feat(tools): add copy_file and move_file filesystem tools

### DIFF
--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -5,6 +5,7 @@
 import difflib
 import mimetypes
 import os
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -1186,3 +1187,140 @@ class ListDirTool(_FsTool):
             return ToolResult.error(f"Error: {e}")
         except Exception as e:
             return ToolResult.error(f"Error listing directory: {e}")
+
+
+# ---------------------------------------------------------------------------
+# copy_file / move_file
+# ---------------------------------------------------------------------------
+
+
+@tool_parameters(
+    tool_parameters_schema(
+        source=StringSchema("The existing file to copy from"),
+        destination=StringSchema("The path to copy the file to"),
+        overwrite=BooleanSchema(
+            description="Replace the destination if it already exists (default false)",
+            default=False,
+        ),
+        required=["source", "destination"],
+    )
+)
+class CopyFileTool(_FsTool):
+    """Copy a single file to a new path."""
+    _scopes = {"core", "subagent", "memory"}
+
+    @property
+    def name(self) -> str:
+        return "copy_file"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Copy a single file to a new path, preserving its contents (binary files "
+            "included). Creates parent directories as needed. The source is read-only; "
+            "the destination must be writable. Pass overwrite=true to replace an "
+            "existing destination. Prefer this over reading a file and writing it back "
+            "by hand."
+        )
+
+    async def execute(
+        self,
+        source: str | None = None,
+        destination: str | None = None,
+        overwrite: bool = False,
+        **kwargs: Any,
+    ) -> str:
+        try:
+            if not source:
+                raise ValueError("Unknown source")
+            if not destination:
+                raise ValueError("Unknown destination")
+            src = self._resolve_read(source)
+            dst = self._resolve_write(destination)
+            error = _check_transfer(src, dst, overwrite)
+            if error is not None:
+                return error
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+            self._file_states.record_write(dst)
+            return f"Successfully copied {src} to {dst}"
+        except PermissionError as e:
+            return ToolResult.error(f"Error: {e}")
+        except Exception as e:
+            return ToolResult.error(f"Error copying file: {e}")
+
+
+@tool_parameters(
+    tool_parameters_schema(
+        source=StringSchema("The existing file to move from"),
+        destination=StringSchema("The path to move the file to"),
+        overwrite=BooleanSchema(
+            description="Replace the destination if it already exists (default false)",
+            default=False,
+        ),
+        required=["source", "destination"],
+    )
+)
+class MoveFileTool(_FsTool):
+    """Move or rename a single file."""
+    _scopes = {"core", "subagent", "memory"}
+
+    @property
+    def name(self) -> str:
+        return "move_file"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Move or rename a single file. Because the original is removed, both the "
+            "source and the destination must be writable. Creates parent directories "
+            "as needed. Pass overwrite=true to replace an existing destination."
+        )
+
+    async def execute(
+        self,
+        source: str | None = None,
+        destination: str | None = None,
+        overwrite: bool = False,
+        **kwargs: Any,
+    ) -> str:
+        try:
+            if not source:
+                raise ValueError("Unknown source")
+            if not destination:
+                raise ValueError("Unknown destination")
+            # A move deletes the original, so the source needs write access too.
+            src = self._resolve_write(source)
+            dst = self._resolve_write(destination)
+            error = _check_transfer(src, dst, overwrite)
+            if error is not None:
+                return error
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            # shutil.move raises on Windows if the destination file exists; clear it
+            # first so overwrite behaves the same on every platform.
+            if dst.is_file():
+                dst.unlink()
+            shutil.move(str(src), str(dst))
+            self._file_states.record_write(dst)
+            return f"Successfully moved {src} to {dst}"
+        except PermissionError as e:
+            return ToolResult.error(f"Error: {e}")
+        except Exception as e:
+            return ToolResult.error(f"Error moving file: {e}")
+
+
+def _check_transfer(src: Path, dst: Path, overwrite: bool) -> str | None:
+    """Validate a copy/move; return an error message, or None when it may proceed."""
+    if not src.exists():
+        return ToolResult.error(f"Error: Source file not found: {src}")
+    if src.is_dir():
+        return ToolResult.error(f"Error: Source is a directory, not a file: {src}")
+    if src.resolve() == dst.resolve():
+        return ToolResult.error("Error: source and destination are the same file")
+    if dst.is_dir():
+        return ToolResult.error(f"Error: Destination is a directory: {dst}")
+    if dst.exists() and not overwrite:
+        return ToolResult.error(
+            f"Error: Destination already exists: {dst}. Pass overwrite=true to replace it."
+        )
+    return None

--- a/tests/tools/test_filesystem_tools.py
+++ b/tests/tools/test_filesystem_tools.py
@@ -3,8 +3,10 @@
 import pytest
 
 from nanobot.agent.tools.filesystem import (
+    CopyFileTool,
     EditFileTool,
     ListDirTool,
+    MoveFileTool,
     ReadFileTool,
     WriteFileTool,
 )
@@ -267,6 +269,206 @@ class TestListDirTool:
     async def test_missing_path_returns_clear_error(self, tool):
         result = await tool.execute()
         assert result == "Error listing directory: Unknown path"
+
+
+# ---------------------------------------------------------------------------
+# CopyFileTool
+# ---------------------------------------------------------------------------
+
+class TestCopyFileTool:
+
+    @pytest.fixture()
+    def tool(self, tmp_path):
+        return CopyFileTool(workspace=tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_basic_copy(self, tool, tmp_path):
+        src = tmp_path / "tmp" / "test.txt"
+        src.parent.mkdir()
+        src.write_text("hello", encoding="utf-8")
+
+        result = await tool.execute(source=str(src), destination=str(tmp_path / "test2.txt"))
+
+        assert "Successfully copied" in result
+        assert (tmp_path / "test2.txt").read_text(encoding="utf-8") == "hello"
+        # Source is left in place.
+        assert src.read_text(encoding="utf-8") == "hello"
+
+    @pytest.mark.asyncio
+    async def test_copy_preserves_binary(self, tool, tmp_path):
+        src = tmp_path / "pixel.png"
+        blob = b"\x89PNG\r\n\x1a\n\x00\xff\xfe\x01"
+        src.write_bytes(blob)
+
+        result = await tool.execute(source=str(src), destination=str(tmp_path / "copy.png"))
+
+        assert "Successfully copied" in result
+        assert (tmp_path / "copy.png").read_bytes() == blob
+
+    @pytest.mark.asyncio
+    async def test_creates_parent_dirs(self, tool, tmp_path):
+        src = tmp_path / "a.txt"
+        src.write_text("x", encoding="utf-8")
+
+        result = await tool.execute(
+            source=str(src), destination=str(tmp_path / "nested" / "deep" / "a.txt")
+        )
+
+        assert "Successfully copied" in result
+        assert (tmp_path / "nested" / "deep" / "a.txt").read_text(encoding="utf-8") == "x"
+
+    @pytest.mark.asyncio
+    async def test_source_not_found(self, tool, tmp_path):
+        result = await tool.execute(
+            source=str(tmp_path / "nope.txt"), destination=str(tmp_path / "out.txt")
+        )
+        assert "Error" in result
+        assert "not found" in result
+
+    @pytest.mark.asyncio
+    async def test_source_directory_rejected(self, tool, tmp_path):
+        d = tmp_path / "dir"
+        d.mkdir()
+        result = await tool.execute(source=str(d), destination=str(tmp_path / "out.txt"))
+        assert "Error" in result
+        assert "directory" in result.lower()
+        assert not (tmp_path / "out.txt").exists()
+
+    @pytest.mark.asyncio
+    async def test_existing_destination_needs_overwrite(self, tool, tmp_path):
+        src = tmp_path / "a.txt"
+        src.write_text("new", encoding="utf-8")
+        dst = tmp_path / "b.txt"
+        dst.write_text("old", encoding="utf-8")
+
+        result = await tool.execute(source=str(src), destination=str(dst))
+
+        assert "Error" in result
+        assert "already exists" in result
+        assert dst.read_text(encoding="utf-8") == "old"
+
+    @pytest.mark.asyncio
+    async def test_overwrite_replaces_destination(self, tool, tmp_path):
+        src = tmp_path / "a.txt"
+        src.write_text("new", encoding="utf-8")
+        dst = tmp_path / "b.txt"
+        dst.write_text("old", encoding="utf-8")
+
+        result = await tool.execute(source=str(src), destination=str(dst), overwrite=True)
+
+        assert "Successfully copied" in result
+        assert dst.read_text(encoding="utf-8") == "new"
+
+    @pytest.mark.asyncio
+    async def test_same_source_and_destination_rejected(self, tool, tmp_path):
+        src = tmp_path / "a.txt"
+        src.write_text("x", encoding="utf-8")
+        result = await tool.execute(source=str(src), destination=str(src), overwrite=True)
+        assert "Error" in result
+        assert "same file" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_args_return_clear_error(self, tool, tmp_path):
+        result = await tool.execute(source=str(tmp_path / "a.txt"))
+        assert result == "Error copying file: Unknown destination"
+
+    @pytest.mark.asyncio
+    async def test_copy_blocked_outside_workspace(self, tmp_path):
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        src = workspace / "a.txt"
+        src.write_text("secret", encoding="utf-8")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+
+        tool = CopyFileTool(workspace=workspace, allowed_dir=workspace)
+        result = await tool.execute(source=str(src), destination=str(outside / "leak.txt"))
+
+        assert "Error" in result
+        assert "outside" in result.lower()
+        assert not (outside / "leak.txt").exists()
+
+
+# ---------------------------------------------------------------------------
+# MoveFileTool
+# ---------------------------------------------------------------------------
+
+class TestMoveFileTool:
+
+    @pytest.fixture()
+    def tool(self, tmp_path):
+        return MoveFileTool(workspace=tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_basic_move(self, tool, tmp_path):
+        src = tmp_path / "tmp" / "test.txt"
+        src.parent.mkdir()
+        src.write_text("hello", encoding="utf-8")
+        dst = tmp_path / "test2.txt"
+
+        result = await tool.execute(source=str(src), destination=str(dst))
+
+        assert "Successfully moved" in result
+        assert dst.read_text(encoding="utf-8") == "hello"
+        # Original is gone.
+        assert not src.exists()
+
+    @pytest.mark.asyncio
+    async def test_source_not_found(self, tool, tmp_path):
+        result = await tool.execute(
+            source=str(tmp_path / "nope.txt"), destination=str(tmp_path / "out.txt")
+        )
+        assert "Error" in result
+        assert "not found" in result
+
+    @pytest.mark.asyncio
+    async def test_existing_destination_needs_overwrite(self, tool, tmp_path):
+        src = tmp_path / "a.txt"
+        src.write_text("new", encoding="utf-8")
+        dst = tmp_path / "b.txt"
+        dst.write_text("old", encoding="utf-8")
+
+        result = await tool.execute(source=str(src), destination=str(dst))
+
+        assert "Error" in result
+        assert "already exists" in result
+        assert src.exists()
+        assert dst.read_text(encoding="utf-8") == "old"
+
+    @pytest.mark.asyncio
+    async def test_overwrite_replaces_destination(self, tool, tmp_path):
+        src = tmp_path / "a.txt"
+        src.write_text("new", encoding="utf-8")
+        dst = tmp_path / "b.txt"
+        dst.write_text("old", encoding="utf-8")
+
+        result = await tool.execute(source=str(src), destination=str(dst), overwrite=True)
+
+        assert "Successfully moved" in result
+        assert dst.read_text(encoding="utf-8") == "new"
+        assert not src.exists()
+
+    @pytest.mark.asyncio
+    async def test_missing_args_return_clear_error(self, tool, tmp_path):
+        result = await tool.execute(source=str(tmp_path / "a.txt"))
+        assert result == "Error moving file: Unknown destination"
+
+    @pytest.mark.asyncio
+    async def test_move_blocked_when_source_outside_workspace(self, tmp_path):
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        src = outside / "secret.txt"
+        src.write_text("top secret", encoding="utf-8")
+
+        tool = MoveFileTool(workspace=workspace, allowed_dir=workspace)
+        result = await tool.execute(source=str(src), destination=str(workspace / "here.txt"))
+
+        assert "Error" in result
+        assert "outside" in result.lower()
+        # A move must not delete a file it is not allowed to touch.
+        assert src.exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds two first-class filesystem primitives — `copy_file` and `move_file` — to the agent's tool set.

Today the filesystem tools are only `read_file`, `write_file`, `edit_file`, and `list_dir`. There is no way to copy or move a file, so the model has to either:

1. chain `read_file` → `write_file` (breaks on binary/large files, and weaker models routinely fail to sequence it), or
2. shell out to `exec cp` / `mv` (no `cp` on Windows PowerShell, and subject to shell/sandbox reliability).

This is the friction behind #2061, where a small local model never emits the write step, and a commenter reports `exec cp` failing outright.

## What this does

Both tools are `_FsTool` subclasses, so they route through the **existing workspace path resolver** — no new path handling, no agent-loop changes, and they inherit the same read/write containment guarantees as the current tools (per `.agent/security.md`).

- **`copy_file(source, destination, overwrite=false)`** — source resolves **read-only**, destination resolves **write**. Uses `shutil.copy2` to preserve contents/metadata, including binary files.
- **`move_file(source, destination, overwrite=false)`** — **both** source and destination resolve **write**, because the move removes the original (a move must not be able to delete a file outside the write scope). Clears an existing destination first so `overwrite` behaves identically on Windows and POSIX.

Shared safety checks (`_check_transfer`): source must exist and be a regular file, destination must not be an existing directory, source ≠ destination, and an existing destination is refused unless `overwrite=true`. Parent directories are created as needed.

## Tests

Added `TestCopyFileTool` and `TestMoveFileTool` in `tests/tools/test_filesystem_tools.py` covering happy paths, binary preservation, parent-dir creation, missing/directory sources, the overwrite guard, no-op source==destination, and workspace-restriction enforcement (including that a blocked `move` does **not** delete its source).

- `ruff check` clean
- `basedpyright` clean (0 errors)
- `pytest tests/tools/ tests/test_file_tool_toggle.py` → 825 passed, 6 skipped

## Notes for reviewers

- Scope is intentionally kept to **regular files** (directories are rejected with a clear error); recursive directory copy/move could be a follow-up if wanted.
- Opened as a **draft** to check the direction before polishing — happy to adjust the tool names, descriptions, overwrite semantics, or add a config toggle if you'd prefer. Relates to #2061.