### PR TITLE
feat: support ephemeral runtime context blocks(#5586)

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -63,6 +63,8 @@ from nanobot.runtime_context import (
     RuntimeContextBlock,
     RuntimeContextProvider,
     append_runtime_context,
+    persistent_runtime_context_blocks,
+    project_runtime_context_for_persistence,
     resolve_runtime_context,
     runtime_context_blocks_from_metadata,
 )
@@ -700,7 +702,10 @@ class AgentLoop:
         ]
         content_value = cast(object, msg.content)
         has_text = isinstance(content_value, str) and content_value.strip()
-        if has_text or media_paths or runtime_context_blocks:
+        persisted_runtime_context_blocks = persistent_runtime_context_blocks(
+            runtime_context_blocks or ()
+        )
+        if has_text or media_paths or persisted_runtime_context_blocks:
             extra: dict[str, Any] = ({"media": list(media_paths)} if media_paths else {}) | agent_context.session_extra(msg.metadata)
             extra.update(kwargs)
             text = content_value if isinstance(content_value, str) else ""
@@ -710,7 +715,7 @@ class AgentLoop:
             extra.update(automation_extra)
             text, runtime_context_meta = append_runtime_context(
                 text,
-                runtime_context_blocks or (),
+                persisted_runtime_context_blocks,
             )
             if runtime_context_meta is not None:
                 extra[RUNTIME_CONTEXT_HISTORY_META] = runtime_context_meta
@@ -2192,6 +2197,14 @@ class AgentLoop:
                 else None
             )
             role, content = entry.get("role"), entry.get("content")
+            if role == "user" and isinstance(runtime_context_meta, Mapping):
+                projected = project_runtime_context_for_persistence(
+                    content,
+                    runtime_context_meta,
+                )
+                if projected is not None:
+                    content, runtime_context_meta = projected
+                    entry["content"] = content
             if role == "assistant" and not content and not entry.get("tool_calls"):
                 continue  # skip empty assistant messages — they poison session context
             if role == "tool":

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -2200,7 +2200,7 @@ class AgentLoop:
             if role == "user" and isinstance(runtime_context_meta, Mapping):
                 projected = project_runtime_context_for_persistence(
                     content,
-                    runtime_context_meta,
+                    cast(Mapping[str, Any], runtime_context_meta),
                 )
                 if projected is not None:
                     content, runtime_context_meta = projected

--- a/nanobot/runtime_context.py
+++ b/nanobot/runtime_context.py
@@ -173,8 +173,11 @@ def append_runtime_context(
 
 def _ephemeral_flags(marker: Mapping[str, Any], count: int) -> list[bool]:
     """Read in-memory block lifecycle flags, defaulting old markers to durable."""
-    raw_flags = marker.get("ephemeral_blocks")
-    if not isinstance(raw_flags, list) or len(raw_flags) != count:
+    raw_flags_value = marker.get("ephemeral_blocks")
+    if not isinstance(raw_flags_value, list):
+        return [False] * count
+    raw_flags = cast(list[object], raw_flags_value)
+    if len(raw_flags) != count:
         return [False] * count
     return [value is True for value in raw_flags]
 

--- a/nanobot/runtime_context.py
+++ b/nanobot/runtime_context.py
@@ -1,4 +1,4 @@
-"""Optional, persistent context appended to the current user prompt."""
+"""Optional runtime context appended to the current user prompt."""
 
 from __future__ import annotations
 
@@ -19,6 +19,7 @@ RUNTIME_CONTEXT_END = "[/Runtime Context]"
 WEBUI_QUOTE_METADATA = "_webui_quote"
 WEBUI_QUOTE_SOURCE = "webui_quote"
 MAX_WEBUI_QUOTE_CHARS = 4_000
+_RUNTIME_CONTEXT_EPHEMERAL_KEY = "_runtime_context_ephemeral"
 
 
 @dataclass(frozen=True)
@@ -26,10 +27,12 @@ class RuntimeContextBlock:
     """Provider-owned context appended verbatim to the current user content.
 
     Callers must bound and delimit content obtained from untrusted sources.
+    Ephemeral blocks are available to the current model request only.
     """
 
     source: str
     content: str
+    ephemeral: bool = False
 
 
 def normalize_webui_quote(value: Any) -> str | None:
@@ -92,8 +95,21 @@ def normalize_runtime_context_blocks(result: RuntimeContextResult) -> list[Runti
         if not source:
             raise ValueError("runtime context block source must not be empty")
         if content:
-            blocks.append(RuntimeContextBlock(source=source, content=content))
+            blocks.append(
+                RuntimeContextBlock(
+                    source=source,
+                    content=content,
+                    ephemeral=block.ephemeral,
+                )
+            )
     return blocks
+
+
+def persistent_runtime_context_blocks(
+    blocks: Sequence[RuntimeContextBlock],
+) -> list[RuntimeContextBlock]:
+    """Return only blocks that are allowed to enter durable session history."""
+    return [block for block in blocks if not block.ephemeral]
 
 
 def runtime_context_blocks_from_metadata(
@@ -121,28 +137,52 @@ def append_runtime_context(
     content: Any,
     blocks: Sequence[RuntimeContextBlock],
 ) -> tuple[Any, dict[str, Any] | None]:
-    """Append blocks and return a durable marker for exact display-time removal."""
+    """Append blocks and return a marker for removal and persistence projection."""
     if not blocks:
         return content, None
 
     rendered = [block.content for block in blocks]
     sources = [block.source for block in blocks]
-    if isinstance(content, list):
-        context_blocks = [{"type": "text", "text": text} for text in rendered]
-        return [*content, *context_blocks], {
+    ephemeral_flags = [block.ephemeral for block in blocks]
+
+    def marker_base() -> dict[str, Any]:
+        marker: dict[str, Any] = {
             "version": 1,
             "sources": sources,
-            "blocks": context_blocks,
         }
+        if any(ephemeral_flags):
+            # These fields are used only while the model transcript is in
+            # memory. The persistence projection removes them before saving.
+            marker["parts"] = rendered
+            marker["ephemeral_blocks"] = ephemeral_flags
+        return marker
+
+    if isinstance(content, list):
+        context_blocks = [{"type": "text", "text": text} for text in rendered]
+        marker = marker_base()
+        marker["blocks"] = context_blocks
+        return [*content, *context_blocks], marker
 
     text = "" if content is None else str(content)
     suffix = "\n\n".join(rendered)
     merged = f"{text}\n\n{suffix}" if text else suffix
-    return merged, {
-        "version": 1,
-        "sources": sources,
-        "suffix": suffix,
-    }
+    marker = marker_base()
+    marker["suffix"] = suffix
+    return merged, marker
+
+
+def _ephemeral_flags(marker: Mapping[str, Any], count: int) -> list[bool]:
+    """Read in-memory block lifecycle flags, defaulting old markers to durable."""
+    raw_flags = marker.get("ephemeral_blocks")
+    if not isinstance(raw_flags, list) or len(raw_flags) != count:
+        return [False] * count
+    return [value is True for value in raw_flags]
+
+
+def _with_ephemeral_flag(block: dict[str, Any], ephemeral: bool) -> dict[str, Any]:
+    if ephemeral:
+        block[_RUNTIME_CONTEXT_EPHEMERAL_KEY] = True
+    return block
 
 
 def detach_runtime_context(
@@ -168,7 +208,20 @@ def detach_runtime_context(
             clean_content = content[: -(len(suffix) + 2)]
         else:
             return None
-        return clean_content, sources, [{"type": "text", "text": suffix}]
+        raw_parts = marker_data.get("parts")
+        parts = (
+            [part for part in cast(list[Any], raw_parts) if isinstance(part, str)]
+            if isinstance(raw_parts, list)
+            else []
+        )
+        if not parts or "\n\n".join(parts) != suffix:
+            parts = [suffix]
+        flags = _ephemeral_flags(marker_data, len(parts))
+        blocks = [
+            _with_ephemeral_flag({"type": "text", "text": part}, ephemeral)
+            for part, ephemeral in zip(parts, flags)
+        ]
+        return clean_content, sources, blocks
 
     expected = marker_data.get("blocks")
     if isinstance(content, list) and isinstance(expected, list) and expected:
@@ -177,7 +230,12 @@ def detach_runtime_context(
         count = len(expected_blocks)
         if content_blocks[-count:] != expected_blocks:
             return None
-        return content_blocks[:-count], sources, deepcopy(expected_blocks)
+        flags = _ephemeral_flags(marker_data, count)
+        blocks = [
+            _with_ephemeral_flag(deepcopy(block), ephemeral)
+            for block, ephemeral in zip(expected_blocks, flags)
+        ]
+        return content_blocks[:-count], sources, blocks
     return None
 
 
@@ -187,29 +245,75 @@ def reattach_runtime_context(
     blocks: Sequence[Mapping[str, Any]],
 ) -> tuple[Any, dict[str, Any]]:
     """Append detached runtime-context blocks after visible messages are merged."""
-    context_blocks = [deepcopy(dict(block)) for block in blocks]
+    context_blocks: list[dict[str, Any]] = []
+    ephemeral_flags: list[bool] = []
+    for block in blocks:
+        block_copy = deepcopy(dict(block))
+        ephemeral = block_copy.pop(_RUNTIME_CONTEXT_EPHEMERAL_KEY, False) is True
+        context_blocks.append(block_copy)
+        ephemeral_flags.append(ephemeral)
+
+    def marker_base() -> dict[str, Any]:
+        marker: dict[str, Any] = {
+            "version": 1,
+            "sources": list(sources),
+        }
+        if any(ephemeral_flags):
+            marker["ephemeral_blocks"] = ephemeral_flags
+        return marker
+
     if isinstance(content, str) and all(
         block.get("type") == "text" and isinstance(block.get("text"), str)
         for block in context_blocks
     ):
         suffix = "\n\n".join(block["text"] for block in context_blocks)
         merged = f"{content}\n\n{suffix}" if content else suffix
-        return merged, {
-            "version": 1,
-            "sources": list(sources),
-            "suffix": suffix,
-        }
+        marker = marker_base()
+        marker["suffix"] = suffix
+        if any(ephemeral_flags):
+            marker["parts"] = [block["text"] for block in context_blocks]
+        return merged, marker
 
     visible_blocks: list[Any] = (
         [*cast(list[Any], content)]
         if isinstance(content, list)
         else ([] if content is None else [{"type": "text", "text": str(content)}])
     )
-    return [*visible_blocks, *context_blocks], {
-        "version": 1,
-        "sources": list(sources),
-        "blocks": context_blocks,
-    }
+    marker = marker_base()
+    marker["blocks"] = context_blocks
+    return [*visible_blocks, *context_blocks], marker
+
+
+def project_runtime_context_for_persistence(
+    content: Any,
+    marker: Mapping[str, Any],
+) -> tuple[Any, dict[str, Any] | None] | None:
+    """Remove ephemeral blocks before a model message enters session history."""
+    # Existing durable markers do not carry per-block lifecycle metadata and
+    # must pass through unchanged. This also preserves their source ordering.
+    if not isinstance(marker.get("ephemeral_blocks"), list):
+        return content, dict(marker)
+
+    detached = detach_runtime_context(content, marker)
+    if detached is None:
+        return None
+
+    visible_content, sources, blocks = detached
+    persistent_sources: list[str] = []
+    persistent_blocks: list[dict[str, Any]] = []
+    for source, block in zip(sources, blocks):
+        ephemeral = block.pop(_RUNTIME_CONTEXT_EPHEMERAL_KEY, False) is True
+        if not ephemeral:
+            persistent_sources.append(source)
+            persistent_blocks.append(block)
+
+    if not persistent_blocks:
+        return visible_content, None
+    return reattach_runtime_context(
+        visible_content,
+        persistent_sources,
+        persistent_blocks,
+    )
 
 
 def public_history_message(message: Mapping[str, Any]) -> dict[str, Any]:

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -224,6 +224,34 @@ def test_persist_user_message_acknowledges_durable_followup(tmp_path: Path) -> N
     assert PENDING_FOLLOWUPS_KEY not in session.metadata
 
 
+def test_persist_user_message_early_excludes_ephemeral_runtime_context(tmp_path: Path) -> None:
+    loop = _make_full_loop(tmp_path)
+    session = loop.sessions.get_or_create("websocket:ephemeral")
+    blocks = [
+        RuntimeContextBlock(source="goal", content="durable goal guidance"),
+        RuntimeContextBlock(
+            source="voice",
+            content="ephemeral delivery contract",
+            ephemeral=True,
+        ),
+    ]
+
+    persisted = loop._persist_user_message_early(
+        InboundMessage(
+            channel="websocket",
+            sender_id="user",
+            chat_id="ephemeral",
+            content="hello world",
+        ),
+        session,
+        runtime_context_blocks=blocks,
+    )
+
+    assert persisted is True
+    assert session.messages[-1]["content"] == "hello world\n\ndurable goal guidance"
+    assert "ephemeral delivery contract" not in str(session.messages[-1])
+
+
 def test_persist_local_trigger_turn_uses_hidden_automation_marker(tmp_path: Path) -> None:
     loop = _make_full_loop(tmp_path)
     session = loop.sessions.get_or_create("websocket:auto")
@@ -592,6 +620,28 @@ def test_save_turn_persists_runtime_context_and_public_view_hides_it() -> None:
     assert session.messages[0]["content"] == "hello world\n\ninternal goal guidance"
     assert session.messages[0][RUNTIME_CONTEXT_HISTORY_META]["sources"] == ["goal"]
     assert public_history_message(session.messages[0])["content"] == "hello world"
+
+
+def test_save_turn_does_not_persist_ephemeral_runtime_context() -> None:
+    loop = _mk_loop()
+    session = Session(key="test:ephemeral-runtime-context")
+    blocks = [
+        RuntimeContextBlock(source="goal", content="durable goal guidance"),
+        RuntimeContextBlock(
+            source="voice",
+            content="ephemeral delivery contract",
+            ephemeral=True,
+        ),
+    ]
+
+    model_message = _runtime_message("hello world", blocks)
+    assert "ephemeral delivery contract" in model_message["content"]
+
+    loop._save_turn(session, [model_message], skip=0)
+
+    assert session.messages[0]["content"] == "hello world\n\ndurable goal guidance"
+    assert "ephemeral delivery contract" not in str(session.messages[0])
+    assert session.messages[0][RUNTIME_CONTEXT_HISTORY_META]["sources"] == ["goal"]
 
 
 def test_build_and_save_preserves_user_text_containing_goal_guidance_tag(tmp_path: Path) -> None:

--- a/tests/agent/test_runner_injections.py
+++ b/tests/agent/test_runner_injections.py
@@ -963,6 +963,41 @@ def test_runner_merge_preserves_runtime_markers_with_media() -> None:
     ]
 
 
+def test_runner_merge_preserves_ephemeral_runtime_context_lifecycle() -> None:
+    from nanobot.agent.runner import AgentRunner
+    from nanobot.runtime_context import (
+        RUNTIME_CONTEXT_MESSAGE_META,
+        RuntimeContextBlock,
+        append_runtime_context,
+    )
+
+    first_content, first_marker = append_runtime_context(
+        "first",
+        [RuntimeContextBlock(source="voice", content="temporary", ephemeral=True)],
+    )
+    second_content, second_marker = append_runtime_context(
+        "second",
+        [RuntimeContextBlock(source="goal", content="durable")],
+    )
+    messages: list[dict] = []
+
+    AgentRunner._append_injected_messages(messages, [
+        {
+            "role": "user",
+            "content": first_content,
+            "_meta": {RUNTIME_CONTEXT_MESSAGE_META: first_marker},
+        },
+        {
+            "role": "user",
+            "content": second_content,
+            "_meta": {RUNTIME_CONTEXT_MESSAGE_META: second_marker},
+        },
+    ])
+
+    marker = messages[0]["_meta"][RUNTIME_CONTEXT_MESSAGE_META]
+    assert marker["ephemeral_blocks"] == [True, False]
+
+
 @pytest.mark.asyncio
 async def test_injection_cycles_capped_at_max():
     """Injection cycles should be capped at _MAX_INJECTION_CYCLES."""

--- a/tests/agent/test_runtime_context.py
+++ b/tests/agent/test_runtime_context.py
@@ -13,7 +13,10 @@ from nanobot.runtime_context import (
     WEBUI_QUOTE_SOURCE,
     RuntimeContextBlock,
     append_runtime_context,
+    normalize_runtime_context_blocks,
     normalize_webui_quote,
+    persistent_runtime_context_blocks,
+    project_runtime_context_for_persistence,
     public_history_message,
     resolve_runtime_context,
     runtime_context_blocks_from_metadata,
@@ -47,6 +50,66 @@ async def test_resolve_runtime_context_preserves_provider_order() -> None:
         ("first", "one"),
         ("second", "two"),
     ]
+
+
+def test_runtime_context_normalization_preserves_ephemeral_flag() -> None:
+    block = RuntimeContextBlock(
+        source="voice",
+        content="keep replies short",
+        ephemeral=True,
+    )
+
+    normalized = normalize_runtime_context_blocks([block])
+
+    assert normalized == [block]
+    assert persistent_runtime_context_blocks(normalized) == []
+
+
+def test_runtime_context_persistence_projection_keeps_ephemeral_for_model_only() -> None:
+    blocks = [
+        RuntimeContextBlock(source="goal", content="durable guidance"),
+        RuntimeContextBlock(
+            source="voice",
+            content="ephemeral delivery contract",
+            ephemeral=True,
+        ),
+    ]
+
+    model_content, marker = append_runtime_context("hello", blocks)
+    assert "durable guidance" in model_content
+    assert "ephemeral delivery contract" in model_content
+    assert marker is not None
+
+    persisted_content, persisted_marker = project_runtime_context_for_persistence(
+        model_content,
+        marker,
+    )
+
+    assert persisted_content == "hello\n\ndurable guidance"
+    assert persisted_marker == {
+        "version": 1,
+        "sources": ["goal"],
+        "suffix": "durable guidance",
+    }
+
+
+def test_runtime_context_persistence_projection_drops_ephemeral_only_block() -> None:
+    block = RuntimeContextBlock(
+        source="voice",
+        content="ephemeral delivery contract",
+        ephemeral=True,
+    )
+
+    model_content, marker = append_runtime_context("hello", [block])
+    assert marker is not None
+
+    persisted_content, persisted_marker = project_runtime_context_for_persistence(
+        model_content,
+        marker,
+    )
+
+    assert persisted_content == "hello"
+    assert persisted_marker is None
 
 
 def test_webui_quote_is_bounded_and_projected_as_model_only_context() -> None:


### PR DESCRIPTION
## Summary

- Add an optional `ephemeral` flag to `RuntimeContextBlock`
- Keep ephemeral runtime context available to the current model request
- Prevent ephemeral context from being persisted or replayed in future turns
- Preserve lifecycle metadata when merging injected user messages

## Problem

Runtime context is currently appended to the user message and persisted in the session history. Session-level context, such as a voice response contract, can therefore be duplicated across many turns and consume an increasing amount of prompt tokens.

## Implementation

- `ephemeral=False` preserves the existing behavior
- `ephemeral=True` keeps the block visible to the current model request only
- Early persistence and final turn persistence filter out ephemeral blocks
- Existing durable runtime context markers remain backward compatible

## Tests

- `pytest tests/agent/test_runtime_context.py tests/agent/test_loop_save_turn.py tests/agent/test_runner_injections.py -q`
- Result: `130 passed`
- Python compilation check passed
- `git diff --check` passed

## Full test suite

The targeted tests for this change pass. The full test suite currently has 12 failures in unrelated provider, session, process, MCP, and web-fetch tests in the local Windows environment.

Closes #5586