### PR TITLE
fix(tool_hints): respect max_length for plain (non-path/non-command) tool values

### DIFF
--- a/nanobot/utils/tool_hints.py
+++ b/nanobot/utils/tool_hints.py
@@ -104,6 +104,10 @@ def _fmt_known(tc: ToolCallRequest, fmt: ToolFormat, max_length: int = 40) -> st
         val = abbreviate_path(val, max_len=max_length)
     elif fmt[3]:  # is_command
         val = _abbreviate_command(val, max_len=max_length)
+    elif len(val) > max_length:
+        # Plain values (grep patterns, search queries, ...) have no path or
+        # command structure to fold, so fall back to a hard truncation.
+        val = val[:max_length - 1] + "\u2026"
     return fmt[1].format(val)
 
 

--- a/tests/agent/test_tool_hint.py
+++ b/tests/agent/test_tool_hint.py
@@ -303,6 +303,43 @@ class TestToolHintMaxLength:
         long = _hint([_tc("list_dir", {"path": long_path})], max_length=120)
         assert len(long) > len(short)
 
+    def test_plain_value_tools_respect_max_length(self):
+        """Plain-value tools must truncate like the is_path/is_command branches.
+
+        grep, web_search, x_search and find_files carry no path or command
+        structure to fold, so their raw value used to reach the progress hint
+        untruncated: a 400-char search query produced a 400-char hint.
+        """
+        for name, key in (
+            ("grep", "pattern"),
+            ("web_search", "query"),
+            ("x_search", "query"),
+            ("find_files", "query"),
+        ):
+            short = _hint([_tc(name, {key: "x" * 400})], max_length=40)
+            long = _hint([_tc(name, {key: "x" * 400})], max_length=120)
+            assert len(long) > len(short), name
+            # Longest template is 'search X "{}"' — 12 chars of overhead.
+            assert len(short) <= 40 + 12, name
+            assert "\u2026" in short, name
+
+    def test_plain_value_short_value_untouched(self):
+        """Values inside the budget must not gain an ellipsis."""
+        result = _hint([_tc("grep", {"pattern": "TODO|FIXME"})], max_length=40)
+        assert result == 'grep "TODO|FIXME"'
+
+    def test_plain_value_exactly_at_max_length_untouched(self):
+        """A value exactly at max_length already fits."""
+        query = "a" * 40
+        result = _hint([_tc("web_search", {"query": query})], max_length=40)
+        assert result == f'search "{query}"'
+        assert "\u2026" not in result
+
+    def test_plain_value_one_over_max_length_truncates(self):
+        """One character over the budget truncates instead of overflowing."""
+        result = _hint([_tc("grep", {"pattern": "a" * 41})], max_length=40)
+        assert result == 'grep "' + "a" * 39 + "\u2026" + '"'
+
 
 class TestToolHintMalformedCalls:
     """Malformed tool calls must not crash hint formatting (see HKUDS/nanobot)."""


### PR DESCRIPTION
### Summary

`format_tool_hints()` honors `max_length` for `is_path` tools (`abbreviate_path`) and
`is_command` tools (`_abbreviate_command`), but **plain values** (e.g. `grep` patterns,
`web_search` / `x_search` queries, `find_files` globs) are never truncated. When a tool
argument is long, the rendered hint overflows the configured budget and is pushed to the
chat/UI verbatim.

### Problem / Impact

- `grep`, `web_search`, `x_search`, `find_files` (and any plain-value / unknown tool) ignore
  `tool_hint_max_length`.
- Example: `grep` with a 300-char pattern renders ~307 chars even when `max_length=40`.
- These hints are surfaced to chat channels (Feishu/Lark, etc.) and the TUI, so the overflow
  floods the conversation/UI with raw long arguments.

### Root cause

In `nanobot/utils/tool_hints.py`, `_fmt_known()` only folds `is_path` and `is_command`
branches; the `else` path returns the value unchanged:

```python
if fmt[2]:  # is_path
    val = abbreviate_path(val, max_len=max_length)
elif fmt[3]:  # is_command
    val = _abbreviate_command(val, max_len=max_length)
return fmt[1].format(val)   # <- plain values skip max_length entirely
```

This is the same class of bug fixed earlier for `is_path` tools in
`99209a80 fix(tool_hints): pass max_length to abbreviate_path for is_path tools`, but the
plain-value branch was missed.

### Fix

Add a hard-truncation fallback for plain values, mirroring the existing truncation style used
by `abbreviate_path` / `_abbreviate_command`:

```python
elif len(val) > max_length:
    # Plain values (grep patterns, search queries, ...) have no path or
    # command structure to fold, so fall back to a hard truncation.
    val = val[:max_length - 1] + "\u2026"
```

### Related

- Complements #3641 (`feat(config): add toolHintMaxLength ...`), which introduced the
  `toolHintMaxLength` config and fixed the `is_path` branch of `_fmt_known()`. This PR covers
  the **remaining plain-value branch** (`grep` / `web_search` / `x_search` / `find_files`) that
  #3641 did not touch.
- Branch `fix-tool-hints-plain-value-max-length` is distinct from #3641's
  `cherry-pick-tool-hint`; this is a separate, additive bug fix, not a re-submission.

### Testing

Added 4 tests to `tests/agent/test_tool_hint.py`
(`TestToolHintMaxLength`):

- `test_plain_value_tools_respect_max_length` — parametrized over `grep`, `web_search`,
  `x_search`, `find_files`; asserts `len(short) < len(long)` for the same input at
  `max_length=40` vs `120`.
- `test_plain_value_short_value_untouched` — short values are unchanged.
- `test_plain_value_exactly_at_max_length_untouched` — a value exactly at `max_length` fits.
- `test_plain_value_one_over_max_length_truncates` — a value one char over is truncated with
  the ellipsis.

Two of these fail against the pre-fix code, confirming they guard the regression.
Full `tests/agent/test_tool_hint.py` suite: **49 passed**.
`ruff check nanobot tests conftest.py` passes on the changed files.

### Scope / Notes

- Change is isolated to one leaf helper (`_fmt_known`); no behavior change for path/command
  tools, folding, or MCP formatting.
- No new dependencies, no CI workflow changes.
- Per `CONTRIBUTING.md`, formatting churn was NOT mixed in: only the intentionally touched
  lines were adjusted (the pre-existing file predates `ruff format`).