### PR TITLE
fix(agent): add size guardrails to Dream memory files and requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ exp/
 .playwright-mcp/
 bridge/node_modules/
 webui/.verify-*
+
+# Personal research data — not part of the nanobot project, never upstream
+baseline_runs/

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -3,9 +3,12 @@
 import base64
 import mimetypes
 import platform
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence, cast
+
+from loguru import logger
 
 from nanobot.agent.memory import MemoryStore
 from nanobot.agent.skills import SkillsLoader
@@ -87,15 +90,28 @@ class TranscriptInput:
 
 
 class ContextBuilder:
-    """Builds the context (system prompt + messages) for the agent."""
+    """Builds the context (system prompt + memory) for the agent."""
 
     BOOTSTRAP_FILES = ["AGENTS.md", "SOUL.md", "USER.md"]
     _SKIPPABLE_DEFAULTS = {"AGENTS.md", "USER.md"}
+    # Bootstrap files subject to the per-file display cap (Dream-managed
+    # durable memory; excludes AGENTS.md, which is project instructions).
+    _CAPPABLE_BOOTSTRAP_FILES = {"SOUL.md", "USER.md"}
 
-    def __init__(self, workspace: Path, timezone: str | None = None, disabled_skills: list[str] | None = None):
+    def __init__(
+        self,
+        workspace: Path,
+        timezone: str | None = None,
+        disabled_skills: list[str] | None = None,
+        memory_max_file_chars: int | None = None,
+    ):
         self.workspace = workspace
         self.timezone = timezone
-        self.memory = MemoryStore(workspace)
+        self.memory = (
+            MemoryStore(workspace, max_file_chars=memory_max_file_chars)
+            if memory_max_file_chars is not None
+            else MemoryStore(workspace)
+        )
         self.skills = SkillsLoader(workspace, disabled_skills=set(disabled_skills) if disabled_skills else None)
 
     def build_system_prompt(
@@ -105,12 +121,21 @@ class ContextBuilder:
         session_summary: SessionSummary | None = None,
         workspace: Path | None = None,
         include_memory: bool = True,
+        is_dream: bool = False,
     ) -> str:
-        """Build the system prompt from identity, bootstrap files, memory, and skills."""
+        """Build the system prompt from identity, bootstrap files, memory, and skills.
+
+        ``is_dream`` skips the per-file display cap on SOUL.md/USER.md/MEMORY.md:
+        Dream is the only writer of these files and needs the full, uncapped
+        content to make correct edit decisions — a truncated view risks Dream
+        assuming omitted content doesn't exist and overwriting it. Dream runs
+        infrequently (hours apart by default), so the extra token cost of an
+        uncapped injection is negligible.
+        """
         root = workspace or self.workspace
         parts = [self._get_identity(channel=channel, workspace=root)]
 
-        bootstrap = self._load_bootstrap_files(root)
+        bootstrap = self._load_bootstrap_files(root, is_dream=is_dream)
         if bootstrap:
             parts.append(bootstrap)
 
@@ -127,6 +152,8 @@ class ContextBuilder:
         if include_memory:
             memory = self.memory.read_memory()
             if memory and not self._is_template_content(memory, "memory/MEMORY.md"):
+                if not is_dream:
+                    memory = self._cap_file_display(memory, "memory/MEMORY.md")
                 parts.append(f"# Memory\n\n## Long-term Memory\n{memory}")
 
         active_skills = self.skills.get_always_skills()
@@ -191,7 +218,7 @@ class ContextBuilder:
 
         return _to_blocks(left) + _to_blocks(right)
 
-    def _load_bootstrap_files(self, workspace: Path | None = None) -> str:
+    def _load_bootstrap_files(self, workspace: Path | None = None, *, is_dream: bool = False) -> str:
         """Load project instructions plus the agent's global profile files."""
         parts: list[str] = []
         project_root = workspace or self.workspace
@@ -216,9 +243,79 @@ class ContextBuilder:
                     content, filename
                 ):
                     continue
+                if not is_dream and filename in self._CAPPABLE_BOOTSTRAP_FILES:
+                    content = self._cap_file_display(content, filename)
                 parts.append(f"## {filename}\n\n{content}")
 
         return "\n\n".join(parts) if parts else ""
+
+    @staticmethod
+    def _cap_note(label: str, limit: int, dropped: int) -> str:
+        return (
+            f"\n\n[Note: {label} exceeds the {limit}-char display limit; "
+            f"{dropped} earlier section(s) omitted above. Call "
+            f"read_file(\"{label}\") for the complete content.]"
+        )
+
+    def _cap_file_display(self, content: str, label: str) -> str:
+        """Cap *content* to ``max_file_chars`` by dropping whole leading sections.
+
+        Splits on top-level ``## `` markdown headings and keeps whichever
+        trailing run of *complete* sections fits the budget, so a section is
+        never cut mid-sentence. This does not guarantee the freshest edits
+        are kept (Dream updates existing sections in place, so section order
+        isn't a reliable recency signal) — it only guarantees the displayed
+        content stays a set of intact sections (or one hard-truncated section,
+        see below) and the model is told more exists. A trailing note tells
+        the model it can call ``read_file`` for the full content; the note's
+        own length is reserved out of the section budget so ``kept + note``
+        stays within ``max_file_chars``. If even the single most-recent
+        section alone exceeds the budget (common for a file Dream hasn't yet
+        split into multiple headings — e.g. a large SOUL.md under one
+        heading), that section is hard-truncated by character count rather
+        than kept in full, so the limit always holds.
+        """
+        limit = self.memory.max_file_chars
+        if len(content) <= limit:
+            return content
+
+        # A leading fragment before the first "## " heading (or the whole
+        # content, if it has no headings) is preserved as its own unit rather
+        # than dropped silently.
+        sections = [s for s in re.split(r"(?=^## )", content, flags=re.MULTILINE) if s]
+
+        def select(section_budget: int) -> list[str]:
+            kept: list[str] = []
+            total = 0
+            for section in reversed(sections):
+                if total + len(section) > section_budget:
+                    if not kept:
+                        kept.append(section[:max(0, section_budget)])
+                    break
+                kept.insert(0, section)
+                total += len(section)
+            return kept
+
+        # The note text includes the dropped-section count, which depends on
+        # the selection — reserve budget using a worst-case (all sections
+        # dropped) note length, which is always >= the note that's actually
+        # emitted, since the count's digit width only shrinks as more
+        # sections are kept.
+        worst_case_note = self._cap_note(label, limit, len(sections))
+        kept = select(max(0, limit - len(worst_case_note)))
+        dropped = len(sections) - len(kept)
+        note = self._cap_note(label, limit, dropped)
+        total = sum(len(s) for s in kept)
+        logger.info(
+            "Capped {} in system prompt: {} chars -> {} chars, {} of {} section(s) dropped",
+            label,
+            len(content),
+            total,
+            dropped,
+            len(sections),
+        )
+
+        return "".join(kept) + note
 
     @staticmethod
     def _is_template_content(content: str, template_path: str) -> bool:
@@ -240,6 +337,7 @@ class ContextBuilder:
         runtime_context_blocks: Sequence[RuntimeContextBlock] | None = None,
         workspace: Path | None = None,
         include_memory: bool = True,
+        is_dream: bool = False,
     ) -> list[dict[str, Any]]:
         """Compatibility wrapper for callers that need merged adjacent roles."""
         messages = self.build_transcript(
@@ -254,6 +352,7 @@ class ContextBuilder:
             channel=channel,
             workspace=workspace,
             include_memory=include_memory,
+            is_dream=is_dream,
         )
         if current_message is None:
             return messages
@@ -280,6 +379,7 @@ class ContextBuilder:
         channel: str | None = None,
         workspace: Path | None = None,
         include_memory: bool = True,
+        is_dream: bool = False,
     ) -> list[dict[str, Any]]:
         """Build a model transcript while preserving the fresh-turn boundary."""
         root = workspace or self.workspace
@@ -291,6 +391,7 @@ class ContextBuilder:
                     session_summary=transcript.session_summary,
                     workspace=root,
                     include_memory=include_memory,
+                    is_dream=is_dream,
                 ),
             },
             *transcript.history,

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -304,6 +304,7 @@ class AgentLoop:
         local_trigger_store: LocalTriggerStore | None = None,
         idle_compact_check_interval_seconds: int = 0,
         recovery_admission: RecoveryAdmission | None = None,
+        memory_max_file_chars: int | None = None,
     ):
         from nanobot.config.schema import ToolsConfig
 
@@ -376,7 +377,12 @@ class AgentLoop:
         self._extra_hooks: list[AgentHook] = hooks or []
         self._hook_factories: list[AgentTurnHookFactory] = hook_factories or []
 
-        self.context = ContextBuilder(workspace, timezone=timezone, disabled_skills=disabled_skills)
+        self.context = ContextBuilder(
+            workspace,
+            timezone=timezone,
+            disabled_skills=disabled_skills,
+            memory_max_file_chars=memory_max_file_chars,
+        )
         self.sessions = session_manager or SessionManager(workspace)
         # One file-read/write tracker per logical session. The tool registry is
         # shared by this loop, so tools resolve the active state via contextvars.
@@ -516,6 +522,7 @@ class AgentLoop:
             disabled_skills=defaults.disabled_skills,
             session_ttl_minutes=defaults.session_ttl_minutes,
             idle_compact_check_interval_seconds=defaults.idle_compact_check_interval_seconds,
+            memory_max_file_chars=defaults.memory.max_file_chars,
             tools_config=config.tools,
             model_presets=preset_helpers.configured_model_presets(config),
             model_preset=defaults.model_preset,
@@ -1128,6 +1135,7 @@ class AgentLoop:
             channel=request_ctx.channel,
             workspace=effective_scope.project_path,
             include_memory=session.policy.persist if session is not None else True,
+            is_dream=bool(active_session_key and active_session_key.startswith("dream:")),
         )
         if request_context is None:
             request_ctx = dataclasses.replace(

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -14,6 +14,7 @@ import re
 import threading
 import weakref
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Iterator, cast
@@ -61,6 +62,11 @@ class MemoryStore:
     """Pure file I/O for memory files: MEMORY.md, history.jsonl, SOUL.md, USER.md."""
 
     _DEFAULT_MAX_HISTORY = 1000
+    # Per-file default (not a combined budget) for SOUL.md / USER.md /
+    # memory/MEMORY.md. Mirrors the historical _DREAM_FILE_EMBED_CAP that
+    # existed before PR #5622 unified Dream onto the shared system-prompt
+    # path. Overridable via config.agents.defaults.memory.max_file_chars.
+    _DEFAULT_MEMORY_FILE_MAX_CHARS = 8_000
     # Durable files whose real working-tree delta grounds Dream commit messages.
     # Deliberately excludes memory/.dream_cursor so progress bookkeeping never
     # appears as a durable-memory edit in the audit record.
@@ -71,9 +77,17 @@ class MemoryStore:
         r"^\[\d{4}-\d{2}-\d{2}[^\]]*\]\s+[A-Z][A-Z0-9_]*(?:\s+\[tools:\s*[^\]]+\])?:"
     )
 
-    def __init__(self, workspace: Path, max_history_entries: int = _DEFAULT_MAX_HISTORY):
+    def __init__(
+        self,
+        workspace: Path,
+        max_history_entries: int = _DEFAULT_MAX_HISTORY,
+        max_file_chars: int = _DEFAULT_MEMORY_FILE_MAX_CHARS,
+    ):
         self.workspace = workspace
         self.max_history_entries = max_history_entries
+        # Per-file cap (not a combined budget): SOUL.md, USER.md, and
+        # memory/MEMORY.md are each checked against this limit independently.
+        self.max_file_chars = max_file_chars
         self.memory_dir = ensure_dir(workspace / "memory")
         self.memory_file = self.memory_dir / "MEMORY.md"
         self.history_file = self.memory_dir / "history.jsonl"
@@ -86,6 +100,7 @@ class MemoryStore:
         self._malformed_entry_logged = False  # rate-limit bad history shape warning
         self._oversize_logged = False  # rate-limit oversized-entry warning
         self._dream_prompt_oversize_logged = False
+        self._memory_file_oversize_logged: dict[str, bool] = {}
         self._append_lock = threading.Lock()  # serialize cursor allocation + append
         self._git = GitStore(workspace, tracked_files=[
             "SOUL.md", "USER.md", "memory/MEMORY.md", "memory/.dream_cursor",
@@ -232,6 +247,7 @@ class MemoryStore:
         return self.read_file(self.memory_file)
 
     def write_memory(self, content: str) -> None:
+        self._warn_if_oversize("memory/MEMORY.md", content)
         self.memory_file.write_text(content, encoding="utf-8")
 
     # -- SOUL.md -------------------------------------------------------------
@@ -240,6 +256,7 @@ class MemoryStore:
         return self.read_file(self.soul_file)
 
     def write_soul(self, content: str) -> None:
+        self._warn_if_oversize("SOUL.md", content)
         self.soul_file.write_text(content, encoding="utf-8")
 
     # -- USER.md -------------------------------------------------------------
@@ -248,7 +265,27 @@ class MemoryStore:
         return self.read_file(self.user_file)
 
     def write_user(self, content: str) -> None:
+        self._warn_if_oversize("USER.md", content)
         self.user_file.write_text(content, encoding="utf-8")
+
+    def _warn_if_oversize(self, label: str, content: str) -> None:
+        """Log once per file when a durable memory file exceeds the per-file cap.
+
+        Warn-only: the write still proceeds. Dream is the sole writer of these
+        files, so rejecting or truncating on write risks stalling Dream or
+        losing content; the cap is enforced instead where these files are
+        injected into the system prompt (see ContextBuilder).
+        """
+        if len(content) <= self.max_file_chars or self._memory_file_oversize_logged.get(label):
+            return
+        self._memory_file_oversize_logged[label] = True
+        logger.warning(
+            "{} exceeds the {}-char per-file guideline ({} chars); consider "
+            "pruning via Dream. Further occurrences for this file suppressed.",
+            label,
+            self.max_file_chars,
+            len(content),
+        )
 
     # -- context injection (used by context.py) ------------------------------
 
@@ -742,6 +779,116 @@ class MemoryStore:
                     logger.warning("Failed to prune dream session {}", path)
 
 
+# Extra headroom for tokenizer estimation drift, reserved out of the input
+# token budget. Shared by dream_prompt_within_budget() and
+# Consolidator._input_token_budget() — both guard an LLM request's input
+# size against the same kind of estimator drift.
+_INPUT_TOKEN_SAFETY_BUFFER = 1024
+
+
+# ---------------------------------------------------------------------------
+# Dream request-size guard
+# ---------------------------------------------------------------------------
+
+_DREAM_MIN_ENTRIES = 1
+
+
+@dataclass(frozen=True, slots=True)
+class DreamPromptResult:
+    """Outcome of :func:`dream_prompt_within_budget`.
+
+    ``batch`` is ``(prompt, last_cursor)`` on success, ``None`` otherwise —
+    kept as one coupled field (not two independent ``| None`` fields) so a
+    successful result can't have one set without the other. When ``batch``
+    is ``None``, ``over_budget`` distinguishes "no unprocessed history"
+    (False) from "history exists but doesn't fit even at the minimum batch"
+    (True), so callers can show the right diagnostic instead of conflating
+    the two.
+    """
+
+    batch: tuple[str, int] | None
+    over_budget: bool = False
+
+
+def dream_prompt_within_budget(
+    store: MemoryStore,
+    *,
+    runtime: LLMRuntime,
+    build_messages: Callable[..., list[dict[str, Any]]],
+    max_entries: int = 20,
+) -> DreamPromptResult:
+    """Build a Dream prompt that fits the runtime's input token budget.
+
+    Mirrors Consolidator._input_token_budget / estimate_session_prompt_tokens
+    for the Dream request path, which (unlike the regular-turn consolidation
+    path) had no equivalent check: build_dream_prompt() was handed straight
+    to process_direct() with no estimate of the assembled request size.  An
+    oversized request doesn't crash — the provider call fails or truncates,
+    dream_run_completed() reports "did not complete", and the cursor never
+    advances — so Dream stalls on the same batch indefinitely with no clear
+    diagnostic pointing at prompt size as the cause.
+
+    Halves max_entries and re-estimates until the assembled request (system
+    prompt + Dream prompt, via the same build_messages/estimate_prompt_tokens_chain
+    path as a real turn) fits the budget, or until even ``_DREAM_MIN_ENTRIES``
+    overflows it.
+
+    Tool definitions come from ``store.build_dream_tools()`` — the same small
+    restricted registry the real Dream turn runs with — not the caller's full
+    tool registry, so the estimate matches the actual request size instead of
+    being inflated by tools Dream's turn never sees.
+    """
+    if runtime.context_window_tokens <= 0:
+        return DreamPromptResult(batch=store.build_dream_prompt(max_entries=max_entries))
+
+    budget = (
+        runtime.context_window_tokens
+        - runtime.generation.max_tokens
+        - _INPUT_TOKEN_SAFETY_BUFFER
+    )
+    if budget <= 0:
+        return DreamPromptResult(batch=None, over_budget=True)
+
+    tools = store.build_dream_tools().get_definitions()
+    entries = max_entries
+    while True:
+        result = store.build_dream_prompt(max_entries=entries)
+        if result is None:
+            return DreamPromptResult(batch=None)
+        prompt, _ = result
+        request_messages = build_messages(
+            history=[],
+            current_message=prompt,
+            is_dream=True,
+        )
+        estimated, source = estimate_prompt_tokens_chain(
+            runtime.provider,
+            runtime.model,
+            request_messages,
+            tools,
+        )
+        if estimated <= budget:
+            return DreamPromptResult(batch=result)
+        if entries <= _DREAM_MIN_ENTRIES:
+            logger.warning(
+                "Dream prompt exceeds input budget even at {} history entries "
+                "({}/{} via {}); skipping this run",
+                entries,
+                estimated,
+                budget,
+                source,
+            )
+            return DreamPromptResult(batch=None, over_budget=True)
+        logger.debug(
+            "Dream prompt exceeds input budget at {} entries ({}/{} via {}); retrying smaller",
+            entries,
+            estimated,
+            budget,
+            source,
+        )
+        entries = max(_DREAM_MIN_ENTRIES, entries // 2)
+
+
 # ---------------------------------------------------------------------------
 # Memory ingestion and context-pressure coordination
 # ---------------------------------------------------------------------------
@@ -1015,7 +1162,7 @@ class MemoryArchiver:
 class Consolidator:
     """Coordinate session Memory checkpoints through ``MemoryArchiver``."""
 
-    _SAFETY_BUFFER = 1024  # extra headroom for tokenizer estimation drift
+    _SAFETY_BUFFER = _INPUT_TOKEN_SAFETY_BUFFER
 
     def __init__(
         self,

--- a/nanobot/cli/gateway_runtime.py
+++ b/nanobot/cli/gateway_runtime.py
@@ -560,7 +560,7 @@ def _run_gateway(
 
         # Dream is an internal job — run directly, not through the agent loop.
         if job.name == "dream":
-            from nanobot.agent.memory import MemoryStore
+            from nanobot.agent.memory import MemoryStore, dream_prompt_within_budget
 
             dream_session_key = MemoryStore.dream_session_key
             prune_dream_sessions = MemoryStore.prune_dream_sessions
@@ -569,13 +569,23 @@ def _run_gateway(
             resp = None
             diff_body = ""
             try:
-                result = store.build_dream_prompt()
-                if result is None:
-                    logger.info("Dream: nothing to process")
+                dream_runtime = agent.dream_runtime() or agent.llm_runtime()
+                result = dream_prompt_within_budget(
+                    store,
+                    runtime=dream_runtime,
+                    build_messages=agent.context.build_messages,
+                )
+                if result.batch is None:
+                    if result.over_budget:
+                        logger.warning(
+                            "Dream: prompt exceeds context window even at the "
+                            "minimum history batch; skipping this run"
+                        )
+                    else:
+                        logger.info("Dream: nothing to process")
                     return None
-                prompt, last_cursor = result
+                prompt, last_cursor = result.batch
                 key = dream_session_key()
-                dream_runtime = agent.dream_runtime()
                 await mcp_provider.connect()
                 resp = await agent.process_direct(
                     prompt,

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -456,7 +456,7 @@ async def cmd_dream(ctx: CommandContext) -> OutboundMessage:
     msg = ctx.msg
 
     async def _run_dream():
-        from nanobot.agent.memory import MemoryStore
+        from nanobot.agent.memory import MemoryStore, dream_prompt_within_budget
 
         async def _silent(*_args: Any, **_kwargs: Any) -> None:
             pass
@@ -471,17 +471,25 @@ async def cmd_dream(ctx: CommandContext) -> OutboundMessage:
         diff_body = ""
         t0 = time.monotonic()
         try:
-            result = store.build_dream_prompt()
-            if result is None:
+            dream_runtime = loop.dream_runtime() or loop.llm_runtime()
+            result = dream_prompt_within_budget(
+                store,
+                runtime=dream_runtime,
+                build_messages=loop.context.build_messages,
+            )
+            if result.batch is None:
                 await loop.bus.publish_outbound(OutboundMessage(
                     channel=msg.channel, chat_id=msg.chat_id,
-                    content=_format_dream_no_input_message(),
+                    content=(
+                        _format_dream_over_budget_message()
+                        if result.over_budget
+                        else _format_dream_no_input_message()
+                    ),
                     metadata={"render_as": "text"},
                 ))
                 return
-            prompt, last_cursor = result
+            prompt, last_cursor = result.batch
             key = dream_session_key()
-            dream_runtime = loop.dream_runtime()
             resp = await loop.process_direct(
                 prompt,
                 session_key=key,
@@ -636,6 +644,20 @@ def _format_dream_no_input_message() -> str:
         "- Compact the current chat into memory once that manual action is available.",
         "- If you expected history to exist, check whether `memory/history.jsonl` has new entries after the Dream cursor.",
         "- Use `/dream-prompt` to see or change how Dream organizes memory.",
+    ])
+
+
+def _format_dream_over_budget_message() -> str:
+    return "\n".join([
+        "Dream has history to process, but the assembled request doesn't fit "
+        "the current model's context window even at the smallest history batch.",
+        "",
+        "This usually means `SOUL.md`, `USER.md`, or `memory/MEMORY.md` has grown large.",
+        "",
+        "Next steps:",
+        "- Check the size of `SOUL.md`, `USER.md`, and `memory/MEMORY.md`.",
+        "- Switch Dream to a model with a larger context window "
+        "(`agents.defaults.dream.modelOverride`).",
     ])
 
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -80,6 +80,16 @@ class DreamConfig(Base):
         return f"every {hours}h"
 
 
+class MemoryConfig(Base):
+    """Durable memory file size guardrails (SOUL.md, USER.md, memory/MEMORY.md)."""
+
+    # Per-file cap, not a combined budget across the three files: each of
+    # SOUL.md / USER.md / memory/MEMORY.md is checked against this limit
+    # independently. Mirrors the historical _DREAM_FILE_EMBED_CAP that
+    # existed before PR #5622 unified Dream onto the shared system-prompt path.
+    max_file_chars: int = Field(default=8_000, ge=1)
+
+
 class InlineFallbackConfig(Base):
     """One inline fallback model configuration."""
 
@@ -155,6 +165,7 @@ class AgentDefaults(Base):
         ge=0,
     )  # Minimum interval in seconds between scans for idle sessions
     dream: DreamConfig = Field(default_factory=DreamConfig)
+    memory: MemoryConfig = Field(default_factory=MemoryConfig)
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/agent/test_context_builder.py
+++ b/tests/agent/test_context_builder.py
@@ -177,6 +177,161 @@ class TestLoadBootstrapFiles:
 
 
 # ---------------------------------------------------------------------------
+# Per-file display cap (SOUL.md / USER.md / memory/MEMORY.md)
+# ---------------------------------------------------------------------------
+
+
+class TestPerFileDisplayCap:
+    """Regular turns cap oversize SOUL/USER/MEMORY content at section
+    boundaries; Dream turns (is_dream=True) always see the full content."""
+
+    @staticmethod
+    def _sectioned(*bodies: str) -> str:
+        """Build content with N top-level '## ' sections, each ~len(body) chars."""
+        return "\n\n".join(f"## Section {i}\n\n{body}" for i, body in enumerate(bodies))
+
+    def test_content_under_cap_is_unchanged(self, tmp_path):
+        (tmp_path / "SOUL.md").write_text("short", encoding="utf-8")
+        builder = _builder(tmp_path, memory_max_file_chars=1000)
+        result = builder._load_bootstrap_files()
+        assert "short" in result
+        assert "[Note:" not in result
+
+    def test_single_oversized_section_is_hard_truncated_not_kept_whole(self, tmp_path):
+        """A file with exactly one '## ' heading (the common shape before
+        Dream ever splits a file into multiple sections — SOUL.md ships with
+        a single heading) must still be capped, not pass through whole just
+        because there's nothing to drop."""
+        content = "## Core Identity\n\n" + ("fact. " * 10_000)  # ~60000 chars
+        (tmp_path / "SOUL.md").write_text(content, encoding="utf-8")
+        builder = _builder(tmp_path, memory_max_file_chars=8000)
+
+        result = builder._load_bootstrap_files()
+
+        soul_part = result.split("## SOUL.md\n\n", 1)[1]
+        assert len(soul_part) <= 8000
+        assert "[Note: SOUL.md exceeds" in soul_part
+
+    def test_regular_turn_truncates_at_section_boundary(self, tmp_path):
+        content = self._sectioned("a" * 300, "b" * 300, "c" * 300)
+        (tmp_path / "SOUL.md").write_text(content, encoding="utf-8")
+        # Each section is ~316 chars and the note is ~141 chars; 500 fits the
+        # trailing section plus the note, but not all three sections.
+        builder = _builder(tmp_path, memory_max_file_chars=500)
+
+        result = builder._load_bootstrap_files()
+
+        # The kept section is intact (no mid-section cut); earlier sections dropped.
+        assert "c" * 300 in result
+        assert "a" * 300 not in result
+        assert "[Note: SOUL.md exceeds" in result
+        assert 'read_file("SOUL.md")' in result
+
+    def test_capped_output_including_note_never_exceeds_limit(self, tmp_path):
+        """kept sections + the trailing note together must not exceed max_file_chars."""
+        content = self._sectioned(*[chr(97 + i % 26) * 500 for i in range(30)])
+        (tmp_path / "SOUL.md").write_text(content, encoding="utf-8")
+        builder = _builder(tmp_path, memory_max_file_chars=8000)
+
+        result = builder._load_bootstrap_files()
+
+        soul_part = result.split("## SOUL.md\n\n", 1)[1]
+        assert len(soul_part) <= 8000
+
+    def test_note_budget_extreme_case_hard_truncates_the_kept_section(self, tmp_path):
+        """When the note itself nearly fills a tiny limit, the one section
+        that would be kept is hard-truncated by character count so the
+        combined output still never exceeds max_file_chars — never sacrifice
+        the limit to keep a section whole."""
+        content = self._sectioned("a" * 100, "b" * 100, "c" * 100)
+        (tmp_path / "SOUL.md").write_text(content, encoding="utf-8")
+        builder = _builder(tmp_path, memory_max_file_chars=150)
+
+        result = builder._load_bootstrap_files()
+
+        soul_part = result.split("## SOUL.md\n\n", 1)[1]
+        assert len(soul_part) <= 150
+        assert "c" * 100 not in soul_part  # truncated, not kept whole
+        assert "[Note: SOUL.md exceeds" in soul_part
+
+    def test_regular_turn_keeps_trailing_complete_sections(self, tmp_path):
+        content = self._sectioned("a" * 300, "b" * 300, "c" * 300)
+        (tmp_path / "USER.md").write_text(content, encoding="utf-8")
+        # Each section is ~316 chars and the note is ~141 chars; 800 fits the
+        # trailing two sections plus the note, but not all three sections
+        # (total content is 946 chars).
+        builder = _builder(tmp_path, memory_max_file_chars=800)
+
+        result = builder._load_bootstrap_files()
+
+        # Only whole sections are kept — never a partial section.
+        assert "b" * 300 in result
+        assert "c" * 300 in result
+        assert "a" * 300 not in result
+
+    def test_dream_turn_sees_full_content_uncapped(self, tmp_path):
+        content = self._sectioned("a" * 100, "b" * 100, "c" * 100)
+        (tmp_path / "SOUL.md").write_text(content, encoding="utf-8")
+        builder = _builder(tmp_path, memory_max_file_chars=150)
+
+        result = builder._load_bootstrap_files(is_dream=True)
+
+        assert "a" * 100 in result
+        assert "b" * 100 in result
+        assert "c" * 100 in result
+        assert "[Note:" not in result
+
+    def test_dream_turn_memory_md_sees_full_content_uncapped(self, tmp_path):
+        from nanobot.agent.memory import MemoryStore
+
+        content = self._sectioned("a" * 100, "b" * 100, "c" * 100)
+        store = MemoryStore(tmp_path, max_file_chars=150)
+        store.write_memory(content)
+        builder = _builder(tmp_path, memory_max_file_chars=150)
+
+        prompt = builder.build_system_prompt(is_dream=True)
+
+        assert "a" * 100 in prompt
+        assert "b" * 100 in prompt
+        assert "[Note:" not in prompt
+
+    def test_regular_turn_memory_md_is_capped(self, tmp_path):
+        from nanobot.agent.memory import MemoryStore
+
+        content = self._sectioned("a" * 300, "b" * 300, "c" * 300)
+        store = MemoryStore(tmp_path, max_file_chars=500)
+        store.write_memory(content)
+        builder = _builder(tmp_path, memory_max_file_chars=500)
+
+        prompt = builder.build_system_prompt(is_dream=False)
+
+        assert "a" * 300 not in prompt
+        assert "c" * 300 in prompt
+        assert '[Note: memory/MEMORY.md exceeds' in prompt
+
+    def test_capping_logs_dropped_section_count(self, tmp_path, monkeypatch):
+        records: list[str] = []
+        monkeypatch.setattr(
+            "nanobot.agent.context.logger.info",
+            lambda message, *args: records.append(message.format(*args)),
+        )
+        content = self._sectioned("a" * 100, "b" * 100, "c" * 100)
+        (tmp_path / "SOUL.md").write_text(content, encoding="utf-8")
+        # Each section is ~116 chars; 150 fits only the trailing section.
+        builder = _builder(tmp_path, memory_max_file_chars=150)
+
+        builder._load_bootstrap_files()
+
+        capped_logs = [r for r in records if "Capped SOUL.md" in r]
+        assert len(capped_logs) == 1
+        assert "2 of 3 section(s) dropped" in capped_logs[0]
+
+    def test_default_cap_matches_historical_value(self, tmp_path):
+        builder = _builder(tmp_path)
+        assert builder.memory.max_file_chars == 8_000
+
+
+# ---------------------------------------------------------------------------
 # _is_template_content (static)
 # ---------------------------------------------------------------------------
 

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -172,6 +172,174 @@ class TestBuildDreamPrompt:
         assert "Always strip these bracketed tags from saved memory content" in prompt
 
 
+class TestDreamPromptWithinBudget:
+    """dream_prompt_within_budget guards the request size the way
+    Consolidator._input_token_budget guards regular-turn consolidation —
+    build_dream_prompt() alone has no equivalent check."""
+
+    @staticmethod
+    def _runtime(context_window_tokens: int, max_tokens: int = 100):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from nanobot.providers.base import GenerationSettings
+        from nanobot.utils.llm_runtime import LLMRuntime
+
+        provider = MagicMock()
+        provider.chat_with_retry = AsyncMock()
+        provider.generation = GenerationSettings(max_tokens=max_tokens)
+        # No estimate_prompt_tokens attribute -> falls through to the
+        # byte-length heuristic in estimate_prompt_tokens_chain, which is
+        # predictable enough for these tests without mocking a tokenizer.
+        del provider.estimate_prompt_tokens
+        return LLMRuntime.capture(
+            provider, "test-model", context_window_tokens=context_window_tokens,
+        )
+
+    @staticmethod
+    def _build_messages(**kwargs) -> list[dict]:
+        return [{"role": "system", "content": "sys"}, {"role": "user", "content": kwargs["current_message"]}]
+
+    def test_returns_none_batch_when_no_history(self, store):
+        from nanobot.agent.memory import dream_prompt_within_budget
+
+        result = dream_prompt_within_budget(
+            store,
+            runtime=self._runtime(context_window_tokens=100_000),
+            build_messages=self._build_messages,
+        )
+
+        assert result.batch is None
+        assert result.over_budget is False
+
+    def test_fits_within_generous_budget(self, store):
+        from nanobot.agent.memory import dream_prompt_within_budget
+
+        store.append_history("a short fact")
+
+        result = dream_prompt_within_budget(
+            store,
+            runtime=self._runtime(context_window_tokens=100_000),
+            build_messages=self._build_messages,
+        )
+
+        assert result.batch is not None
+        assert result.over_budget is False
+        prompt, _ = result.batch
+        assert "a short fact" in prompt
+
+    def test_shrinks_entries_until_it_fits(self, store):
+        from nanobot.agent.memory import dream_prompt_within_budget
+
+        for i in range(20):
+            store.append_history(f"entry-{i:02d} " + "x" * 500)
+
+        calls: list[list[dict]] = []
+
+        def counting_build_messages(**kwargs) -> list[dict]:
+            messages = self._build_messages(**kwargs)
+            calls.append(messages)
+            return messages
+
+        # 20 entries estimate to ~4198 tokens, 10 to ~3398, 5 to ~2998 (with
+        # this fixture's dream template + real dream tool schemas + tiktoken
+        # estimator). A budget of 3000 (context_window_tokens=4074,
+        # max_tokens=50, buffer=1024) rejects 20 and 10 but fits at 5,
+        # exercising two shrink iterations.
+        result = dream_prompt_within_budget(
+            store,
+            runtime=self._runtime(context_window_tokens=4074, max_tokens=50),
+            build_messages=counting_build_messages,
+        )
+
+        assert result.batch is not None
+        assert result.over_budget is False
+        assert len(calls) > 1  # retried at least once with a smaller batch
+        prompt, _ = result.batch
+        # build_dream_prompt() always takes the oldest unprocessed entries
+        # first (Dream must advance the cursor sequentially) — a shrunk
+        # batch is a smaller prefix, not a differently-chosen slice.
+        assert "entry-00" in prompt
+        assert "entry-19" not in prompt
+
+    def test_over_budget_even_at_minimum_entries(self, store):
+        from nanobot.agent.memory import dream_prompt_within_budget
+
+        store.append_history("x" * 5000)
+
+        result = dream_prompt_within_budget(
+            store,
+            runtime=self._runtime(context_window_tokens=10, max_tokens=1),
+            build_messages=self._build_messages,
+        )
+
+        assert result.batch is None
+        assert result.over_budget is True
+
+    def test_estimates_against_the_real_restricted_dream_tools(self, store, monkeypatch):
+        """The budget estimate must use store.build_dream_tools() (the small
+        registry Dream's real request actually sends), not a caller-supplied
+        full tool registry — otherwise the estimate is wrong in either
+        direction depending on what the caller happens to pass."""
+        from nanobot.agent.memory import dream_prompt_within_budget
+
+        store.append_history("hello")
+
+        seen_tools: list[list[dict]] = []
+        real_chain = __import__(
+            "nanobot.utils.helpers", fromlist=["estimate_prompt_tokens_chain"]
+        ).estimate_prompt_tokens_chain
+
+        def spy_chain(provider, model, messages, tools=None):
+            seen_tools.append(tools or [])
+            return real_chain(provider, model, messages, tools)
+
+        monkeypatch.setattr("nanobot.agent.memory.estimate_prompt_tokens_chain", spy_chain)
+
+        dream_prompt_within_budget(
+            store,
+            runtime=self._runtime(context_window_tokens=100_000),
+            build_messages=self._build_messages,
+        )
+
+        assert len(seen_tools) == 1
+        # store.build_dream_tools() registers read_file/edit_file/apply_patch/write_file.
+        tool_names = {t.get("function", {}).get("name") or t.get("name") for t in seen_tools[0]}
+        assert "read_file" in tool_names
+        assert "edit_file" in tool_names
+
+    def test_zero_or_negative_budget_short_circuits(self, store):
+        from nanobot.agent.memory import dream_prompt_within_budget
+
+        store.append_history("hello")
+
+        # max_tokens alone consumes the whole window, before the safety buffer.
+        result = dream_prompt_within_budget(
+            store,
+            runtime=self._runtime(context_window_tokens=50, max_tokens=50),
+            build_messages=self._build_messages,
+        )
+
+        assert result.batch is None
+        assert result.over_budget is True
+
+    def test_non_positive_context_window_skips_the_check(self, store):
+        """A runtime with no known context window (0) can't be budgeted
+        against — fall back to the unguarded build_dream_prompt() rather than
+        always reporting over_budget."""
+        from nanobot.agent.memory import dream_prompt_within_budget
+
+        store.append_history("hello")
+
+        result = dream_prompt_within_budget(
+            store,
+            runtime=self._runtime(context_window_tokens=0),
+            build_messages=self._build_messages,
+        )
+
+        assert result.batch is not None
+        assert result.over_budget is False
+
+
 class TestDreamRunCompletion:
     """The runner's terminal state gates Dream cursor advancement."""
 
@@ -652,6 +820,61 @@ class TestEphemeralDirect:
             assert marker in system_prompt
             assert request_text.count(marker) == 1
         assert loop.sessions._get_session_path(session_key).exists()
+
+    async def test_dream_session_key_bypasses_the_display_cap_end_to_end(self, tmp_path):
+        """A real `dream:` turn must see the full, uncapped SOUL.md — driven
+        through AgentLoop.process_direct so the ``session_key.startswith("dream:")``
+        wiring in loop.py is itself under test, not just ContextBuilder in
+        isolation. A `cli:` turn with the same oversize file must be capped.
+
+        This guards the highest-risk part of the design: if the Dream
+        detection ever silently breaks, Dream would start seeing a truncated
+        view of the files it's the sole writer of, risking exactly the kind
+        of overwrite-on-incomplete-view data loss the cap was designed to avoid.
+        """
+        from unittest.mock import MagicMock
+
+        from nanobot.agent.loop import AgentLoop
+        from nanobot.bus.queue import MessageBus
+
+        store = MemoryStore(tmp_path, max_file_chars=150)
+        oversize_soul = "\n\n".join(
+            f"## Section {i}\n\n{chr(97 + i) * 100}" for i in range(3)
+        )
+        store.write_soul(oversize_soul)
+
+        captured: dict[str, list[dict]] = {}
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+        provider.supports_tools = True
+        provider.generation = MagicMock(max_tokens=4096)
+
+        async def chat_with_retry(**kwargs):
+            captured["messages"] = kwargs["messages"]
+            return LLMResponse(content="done", finish_reason="stop")
+
+        provider.chat_with_retry = chat_with_retry
+        loop = AgentLoop(
+            bus=MessageBus(),
+            provider=provider,
+            workspace=tmp_path,
+            context_window_tokens=32_000,
+            memory_max_file_chars=150,
+        )
+
+        await loop.process_direct(
+            "hello", session_key="dream:cap-check", ephemeral=True,
+        )
+        dream_prompt = str(captured["messages"][0]["content"])
+
+        await loop.process_direct("hello", session_key="cli:cap-check")
+        regular_prompt = str(captured["messages"][0]["content"])
+
+        assert "a" * 100 in dream_prompt
+        assert "[Note:" not in dream_prompt
+
+        assert "a" * 100 not in regular_prompt
+        assert "[Note: SOUL.md exceeds" in regular_prompt
 
 
 class TestEphemeralHooks:

--- a/tests/agent/test_memory_store.py
+++ b/tests/agent/test_memory_store.py
@@ -46,6 +46,70 @@ class TestMemoryStoreBasicIO:
         assert "important fact" in ctx
 
 
+class TestPerFileOversizeWarning:
+    """write_memory/write_soul/write_user warn (but never block) on oversize."""
+
+    def test_write_memory_under_cap_is_silent(self, store, monkeypatch):
+        records: list[str] = []
+        monkeypatch.setattr(
+            "nanobot.agent.memory.logger.warning",
+            lambda message, *args: records.append(message.format(*args)),
+        )
+        store.write_memory("short content")
+        assert records == []
+
+    def test_write_memory_over_cap_warns_but_still_writes(self, tmp_path, monkeypatch):
+        store = MemoryStore(tmp_path, max_file_chars=100)
+        records: list[str] = []
+        monkeypatch.setattr(
+            "nanobot.agent.memory.logger.warning",
+            lambda message, *args: records.append(message.format(*args)),
+        )
+        content = "x" * 200
+        store.write_memory(content)
+        assert store.read_memory() == content  # write is never blocked or truncated
+        oversize_warnings = [r for r in records if "memory/MEMORY.md" in r and "exceeds" in r]
+        assert len(oversize_warnings) == 1
+
+    def test_write_soul_over_cap_warns(self, tmp_path, monkeypatch):
+        store = MemoryStore(tmp_path, max_file_chars=100)
+        records: list[str] = []
+        monkeypatch.setattr(
+            "nanobot.agent.memory.logger.warning",
+            lambda message, *args: records.append(message.format(*args)),
+        )
+        store.write_soul("x" * 200)
+        assert any("SOUL.md" in r and "exceeds" in r for r in records)
+
+    def test_write_user_over_cap_warns(self, tmp_path, monkeypatch):
+        store = MemoryStore(tmp_path, max_file_chars=100)
+        records: list[str] = []
+        monkeypatch.setattr(
+            "nanobot.agent.memory.logger.warning",
+            lambda message, *args: records.append(message.format(*args)),
+        )
+        store.write_user("x" * 200)
+        assert any("USER.md" in r and "exceeds" in r for r in records)
+
+    def test_oversize_warning_is_emitted_once_per_file(self, tmp_path, monkeypatch):
+        store = MemoryStore(tmp_path, max_file_chars=100)
+        records: list[str] = []
+        monkeypatch.setattr(
+            "nanobot.agent.memory.logger.warning",
+            lambda message, *args: records.append(message.format(*args)),
+        )
+        content = "x" * 200
+        store.write_memory(content)
+        store.write_memory(content)
+        store.write_memory(content)
+        oversize_warnings = [r for r in records if "memory/MEMORY.md" in r and "exceeds" in r]
+        assert len(oversize_warnings) == 1
+
+    def test_default_max_file_chars_matches_historical_cap(self, store):
+        """Default matches the pre-#5622 _DREAM_FILE_EMBED_CAP value (8000)."""
+        assert store.max_file_chars == 8_000
+
+
 class TestHistoryWithCursor:
     def test_append_history_returns_cursor(self, store):
         cursor = store.append_history("event 1")

--- a/tests/command/test_builtin_dream.py
+++ b/tests/command/test_builtin_dream.py
@@ -37,7 +37,7 @@ class _FakeStore:
     def get_last_dream_cursor(self) -> int:
         return self._last_dream_cursor
 
-    def build_dream_prompt(self):
+    def build_dream_prompt(self, *, max_entries: int = 20):
         return self._dream_prompt_result
 
     def build_dream_tools(self):
@@ -115,6 +115,14 @@ def _make_sessions(tmp_path) -> SessionManager:
     )
 
 
+def _fake_runtime():
+    """A runtime with context_window_tokens=0, so dream_prompt_within_budget
+    takes its unguarded passthrough branch — these fixtures test cmd_dream's
+    own control flow, not the budget check (covered separately in
+    tests/agent/test_dream.py::TestDreamPromptWithinBudget)."""
+    return SimpleNamespace(context_window_tokens=0)
+
+
 def _make_ctx(raw: str, git: _FakeGit, *, args: str = "", last_dream_cursor: int = 1) -> CommandContext:
     msg = InboundMessage(channel="cli", sender_id="u1", chat_id="direct", content=raw)
     store = _FakeStore(git, last_dream_cursor=last_dream_cursor)
@@ -128,8 +136,10 @@ def _make_dream_ctx(tmp_path) -> tuple[CommandContext, _FakeBus]:
     bus = _FakeBus()
     loop = SimpleNamespace(
         bus=bus,
-        context=SimpleNamespace(memory=store, timezone="UTC"),
+        context=SimpleNamespace(memory=store, timezone="UTC", build_messages=None),
         sessions=_make_sessions(tmp_path),
+        dream_runtime=lambda: None,
+        llm_runtime=_fake_runtime,
     )
     ctx = CommandContext(msg=msg, session=None, key=msg.session_key, raw="/dream", args="", loop=loop)
     return ctx, bus
@@ -175,10 +185,10 @@ async def test_dream_internal_run_silences_progress(tmp_path) -> None:
             metadata={"_stop_reason": "completed"},
         )
 
-    dream_runtime = object()
+    dream_runtime = _fake_runtime()
     loop = SimpleNamespace(
         bus=bus,
-        context=SimpleNamespace(memory=store, timezone="UTC"),
+        context=SimpleNamespace(memory=store, timezone="UTC", build_messages=None),
         sessions=_make_sessions(tmp_path),
         process_direct=process_direct,
         dream_runtime=lambda: dream_runtime,
@@ -230,10 +240,11 @@ def _build_runnable_dream(
     bus = _FakeBus()
     loop = SimpleNamespace(
         bus=bus,
-        context=SimpleNamespace(memory=store, timezone="UTC"),
+        context=SimpleNamespace(memory=store, timezone="UTC", build_messages=None),
         sessions=_make_sessions(tmp_path),
         process_direct=process_direct,
         dream_runtime=lambda: None,
+        llm_runtime=_fake_runtime,
     )
     ctx = CommandContext(msg=msg, session=None, key=msg.session_key, raw="/dream", args="", loop=loop)
     return ctx, store
@@ -315,10 +326,11 @@ async def test_dream_noop_batch_unlocks_following_history(tmp_path) -> None:
     bus = _FakeBus()
     loop = SimpleNamespace(
         bus=bus,
-        context=SimpleNamespace(memory=store, timezone="UTC"),
+        context=SimpleNamespace(memory=store, timezone="UTC", build_messages=None),
         sessions=_make_sessions(tmp_path),
         process_direct=process_direct,
         dream_runtime=lambda: None,
+        llm_runtime=_fake_runtime,
     )
     ctx = CommandContext(msg=msg, session=None, key=msg.session_key, raw="/dream", args="", loop=loop)
 


### PR DESCRIPTION
## Summary

PR #5622 fixed Dream's system-prompt duplication bug, but as a side effect
removed the only existing size cap on SOUL.md / USER.md / memory/MEMORY.md
(the old `_DREAM_FILE_EMBED_CAP = 8000` mechanism). Since then these
Dream-managed files can grow unbounded and get injected into every regular
turn's system prompt with no limit, and Dream's own consolidation request
has no check against the model's context window either.

This adds two related guardrails:

**Per-file display cap** (`nanobot/agent/context.py`, `nanobot/agent/memory.py`)
- Regular turns: SOUL.md/USER.md/MEMORY.md are truncated at markdown `## `
  section boundaries when they exceed `max_file_chars` (default 8000,
  configurable via `agents.defaults.memory.maxFileChars`) — trailing
  complete sections are kept, a note tells the model to call `read_file`
  for the full content. A single section that alone exceeds the budget
  (e.g. a large file under one heading) is hard-truncated by character
  count so the limit always holds.
- Dream turns are exempt: Dream is the sole writer of these files and needs
  the full view to avoid overwriting content it can't see. Detected via the
  existing `session_key.startswith("dream:")` convention.
- Writes (`write_memory`/`write_soul`/`write_user`) warn once per file when
  oversize but never block or truncate — Dream stays free to write, pruning
  stays Dream's own MECE responsibility.

**Dream request token budget** (`nanobot/agent/memory.py`, wired into the
`/dream` command and the periodic cron job)
- `dream_prompt_within_budget()` estimates the assembled Dream request
  (mirroring `Consolidator._input_token_budget`, and sharing its safety
  buffer constant) and, if it's over budget, halves the history batch and
  retries down to 1 entry. Estimates against the actual restricted Dream
  tool set (`store.build_dream_tools()`), not the caller's full tool
  registry, so the estimate matches the real request size.
- Distinguishes "no history to process" from "history exists but doesn't
  fit even at the minimum batch" so the user gets an accurate diagnostic
  instead of a misleading one.

## Why

Without these, a long-running Dream deployment could grow these files
without any pressure toward the context window, since #5622 removed the
only cap and never added a replacement. This restores an equivalent
safety net at both points where these files matter: display (regular
turns) and the Dream request itself.

## Test plan

- [x] New tests for section-boundary capping (including the case where a
  single section alone exceeds the budget) and Dream-turn bypass, in
  `tests/agent/test_context_builder.py`
- [x] New tests for write-side warnings in `tests/agent/test_memory_store.py`
- [x] New tests for the budget check (fits/shrinks/over-budget/zero-window,
  and that the estimate uses the real restricted Dream tools) in
  `tests/agent/test_dream.py`, including an end-to-end test driving a real
  `dream:` session through `AgentLoop.process_direct`
- [x] Full test suite passes (`pytest`), `ruff check`, `basedpyright`

🤖 Generated with [Claude Code](https://claude.com/claude-code)