### PR TITLE
fix(session): reject session keys with path traversal components

### DIFF
--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -1038,7 +1038,7 @@ class JsonlSessionStore:
         rejects the traversal vectors that would let an untrusted id such as
         ``../../etc/passwd`` address a file outside the sessions directory.
         """
-        if not isinstance(key, str) or not key:
+        if not key:
             raise ValueError("session key must be a non-empty string")
         normalized = key.replace("\\", "/")
         if normalized.startswith("/") or _WINDOWS_DRIVE_RE.match(normalized):

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -74,6 +74,12 @@ _WORKSPACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 _SESSION_MIGRATION_LOCK_TIMEOUT_SECONDS = 30
 _SESSION_FILES_LOCK_FILENAME = ".session-files.lock"
 _COPY_CHUNK_SIZE = 1024 * 1024
+# A "." or ".." used as a path segment, delimited by the start of the key, a
+# "/" or "\" separator, a ":" scheme boundary, or the end of the key. This
+# covers both POSIX traversal ("../x") and URL-form accounts ("channel:../x")
+# without rejecting innocuous chat ids that merely contain ".." in a token.
+_PATH_TRAVERSAL_SEGMENT_RE = re.compile(r"(?:^|[/\\:])\.{1,2}(?:$|[/\\:])")
+_WINDOWS_DRIVE_RE = re.compile(r"^[a-zA-Z]:[\\/]")
 
 
 def _json_object(value: object) -> dict[str, Any]:
@@ -1023,16 +1029,38 @@ class JsonlSessionStore:
             return None
         return key
 
+    @classmethod
+    def validate_session_key(cls, key: str) -> str:
+        """Raise if a session key could escape the sessions directory.
+
+        session keys are ``channel:chat_id`` pairs that legitimately contain a
+        large character set, so this does not restrict the alphabet. It only
+        rejects the traversal vectors that would let an untrusted id such as
+        ``../../etc/passwd`` address a file outside the sessions directory.
+        """
+        if not isinstance(key, str) or not key:
+            raise ValueError("session key must be a non-empty string")
+        normalized = key.replace("\\", "/")
+        if normalized.startswith("/") or _WINDOWS_DRIVE_RE.match(normalized):
+            raise ValueError("session key must be a relative identifier")
+        if _PATH_TRAVERSAL_SEGMENT_RE.search(normalized):
+            raise ValueError("session key must not contain path traversal components")
+        return key
+
     def get_session_path(self, key: str) -> Path:
+        self.validate_session_key(key)
         return self.sessions_dir / f"{self.storage_key(key)}.jsonl"
 
     def get_runtime_checkpoint_path(self, key: str) -> Path:
+        self.validate_session_key(key)
         return self.sessions_dir / f"{self.storage_key(key)}{_RUNTIME_CHECKPOINT_SUFFIX}"
 
     def get_legacy_lossy_path(self, key: str) -> Path:
+        self.validate_session_key(key)
         return self.sessions_dir / f"{safe_filename(key.replace(':', '_'))}.jsonl"
 
     def get_legacy_session_path(self, key: str) -> Path:
+        self.validate_session_key(key)
         return self.legacy_sessions_dir / f"{self.safe_key(key)}.jsonl"
 
     def load(self, key: str) -> Session | None:

--- a/tests/session/test_session_store.py
+++ b/tests/session/test_session_store.py
@@ -1,9 +1,11 @@
 import json
 from unittest.mock import MagicMock
 
+import pytest
+
 from nanobot.providers.base import ProviderConversationState
 from nanobot.session import Session, SessionManager
-from nanobot.session.manager import SessionStore
+from nanobot.session.manager import JsonlSessionStore, SessionStore
 from nanobot.session.model_selection import SESSION_MODEL_PRESET_METADATA_KEY
 
 
@@ -311,3 +313,24 @@ def test_invalid_runtime_checkpoint_is_discarded(tmp_path) -> None:
 
     assert "runtime_checkpoint" not in restored.metadata
     assert not checkpoint_path.exists()
+
+
+def test_session_key_validation_accepts_legitimate_keys(tmp_path) -> None:
+    manager = SessionManager(tmp_path)
+    for key in ("abc-123_DEF", "slack:C123", "cli:direct", "discord:123456789012345678"):
+        assert manager.get_or_create(key).key == key
+
+
+def test_session_key_validation_rejects_path_traversal(tmp_path) -> None:
+    manager = SessionManager(tmp_path)
+    for key in ("../../etc/passwd", "/tmp/evil", "..\\..\\etc\\passwd", "channel:../secret"):
+        with pytest.raises(ValueError):
+            manager._get_session_path(key)
+
+
+def test_validate_session_key_matches_issue_cases() -> None:
+    for key in ("abc-123_DEF", "slack:C123"):
+        assert JsonlSessionStore.validate_session_key(key) == key
+    for key in ("../../etc/passwd", "/tmp/evil"):
+        with pytest.raises(ValueError):
+            JsonlSessionStore.validate_session_key(key)


### PR DESCRIPTION
Fixes #5564

Session keys are turned into file paths before persistence. An untrusted session id such as `../../etc/passwd` could otherwise address a file outside the sessions directory.

## What changed

Added `JsonlSessionStore.validate_session_key()` and applied it at the persistence chokepoint in `get_session_path()`, `get_runtime_checkpoint_path()`, `get_legacy_lossy_path()`, and `get_legacy_session_path()`.

The guard rejects:
- empty keys
- absolute identifiers (`/tmp/evil`)
- Windows drive-rooted paths (`C:\...`)
- `.`/`..` path segments, in both POSIX form (`../x`) and URL-form accounts (`channel:../x`)

Legitimate `channel:chat_id` keys (e.g. `slack:C123`, `cli:direct`, `c:d`) pass unchanged.

## Tests

Added coverage in `tests/session/test_session_store.py`: valid keys are accepted, traversal keys raise, and each persistence path method rejects them. `tests/session/` passes; the lone unrelated failure is a pre-existing Windows symlink privilege error reproduced on clean `main`. `ruff check` is clean and the strict type check (`basedpyright`) passes.