### PR TITLE
fix(copilot): store OAuth token in data directory

### DIFF
--- a/nanobot/providers/github_copilot_provider.py
+++ b/nanobot/providers/github_copilot_provider.py
@@ -17,6 +17,7 @@ import httpx
 from oauth_cli_kit.models import OAuthToken
 from oauth_cli_kit.storage import FileTokenStorage
 
+from nanobot.config.paths import get_data_dir
 from nanobot.providers.base import LLMResponse, ProviderCallContext
 from nanobot.providers.oauth_model_catalog import (
     OAuthModelCatalog,
@@ -51,6 +52,7 @@ def get_storage() -> FileTokenStorage:
     return FileTokenStorage(
         token_filename=TOKEN_FILENAME,
         app_name=TOKEN_APP_NAME,
+        data_dir=get_data_dir(),
         import_codex_cli=False,
     )
 

--- a/tests/providers/test_github_copilot_enterprise.py
+++ b/tests/providers/test_github_copilot_enterprise.py
@@ -9,6 +9,14 @@ import pytest
 from nanobot.providers import github_copilot_provider as gc
 
 
+def test_storage_uses_nanobot_data_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "nanobot.config.loader.get_config_path", lambda: tmp_path / "config.json"
+    )
+
+    assert gc.get_storage().get_token_path() == tmp_path / "auth" / gc.TOKEN_FILENAME
+
+
 def test_resolve_falls_back_to_default_without_env(monkeypatch):
     monkeypatch.delenv("NANOBOT_COPILOT_BASE_URL", raising=False)
     assert gc._resolve("NANOBOT_COPILOT_BASE_URL", gc.DEFAULT_COPILOT_BASE_URL) == (


### PR DESCRIPTION
## Summary

Store GitHub Copilot OAuth credentials in Nanobot's managed data directory.

## Problem

GitHub Copilot tokens used oauth-cli-kit's default directory. In container deployments, this location may not be persistent or writable.

## Changes

* Pass Nanobot's data directory to the existing token storage helper.
* Add a regression test for the resolved token path.

## Testing

* [x] Provider tests pass: 1,000 passed.
* [x] Targeted CLI, WebUI and OAuth tests pass: 267 passed.
* [x] `ruff check` passes.
* [x] `basedpyright` passes.
* [x] `git diff --check` passes.

## Compatibility and Risk

Low risk. The OAuth token location changes to Nanobot's existing managed data directory. Provider behaviour and public APIs are unchanged.

## Related Issue

No related issue.