### PR TITLE
fix(webui): show language names only in their native form

### DIFF
--- a/webui/src/components/LanguageSwitcher.tsx
+++ b/webui/src/components/LanguageSwitcher.tsx
@@ -50,14 +50,7 @@ export function LanguageSwitcher() {
         >
           {supportedLocales.map((option) => (
             <DropdownMenuRadioItem key={option.code} value={option.code}>
-              <span className="flex min-w-0 items-center gap-2">
-                <span>{option.nativeLabel}</span>
-                {option.nativeLabel !== option.label ? (
-                  <span className="truncate text-xs text-muted-foreground">
-                    {option.label}
-                  </span>
-                ) : null}
-              </span>
+              {option.nativeLabel}
             </DropdownMenuRadioItem>
           ))}
         </DropdownMenuRadioGroup>

--- a/webui/src/i18n/config.ts
+++ b/webui/src/i18n/config.ts
@@ -1,16 +1,16 @@
 export const LOCALE_STORAGE_KEY = "nanobot.locale";
 
 export const supportedLocales = [
-  { code: "en", label: "English", nativeLabel: "English" },
-  { code: "zh-CN", label: "Chinese (Simplified)", nativeLabel: "简体中文" },
-  { code: "zh-TW", label: "Chinese (Traditional)", nativeLabel: "繁體中文" },
-  { code: "fr", label: "French", nativeLabel: "Français" },
-  { code: "ja", label: "Japanese", nativeLabel: "日本語" },
-  { code: "ko", label: "Korean", nativeLabel: "한국어" },
-  { code: "es", label: "Spanish", nativeLabel: "Español" },
-  { code: "pt-BR", label: "Portuguese (Brazil)", nativeLabel: "Português (Brasil)" },
-  { code: "vi", label: "Vietnamese", nativeLabel: "Tiếng Việt" },
-  { code: "id", label: "Indonesian", nativeLabel: "Bahasa Indonesia" },
+  { code: "en", nativeLabel: "English" },
+  { code: "zh-CN", nativeLabel: "简体中文" },
+  { code: "zh-TW", nativeLabel: "繁體中文" },
+  { code: "fr", nativeLabel: "Français" },
+  { code: "ja", nativeLabel: "日本語" },
+  { code: "ko", nativeLabel: "한국어" },
+  { code: "es", nativeLabel: "Español" },
+  { code: "pt-BR", nativeLabel: "Português (Brasil)" },
+  { code: "vi", nativeLabel: "Tiếng Việt" },
+  { code: "id", nativeLabel: "Bahasa Indonesia" },
 ] as const;
 
 export type SupportedLocale = (typeof supportedLocales)[number]["code"];

--- a/webui/src/tests/i18n.test.tsx
+++ b/webui/src/tests/i18n.test.tsx
@@ -452,6 +452,19 @@ describe("webui i18n", () => {
     expect(resolveInitialLocale()).toBe("zh-CN");
   });
 
+  it("lists languages by their native names without English translations", async () => {
+    const user = userEvent.setup();
+
+    render(<LanguageSwitcher />);
+    await user.click(screen.getByRole("button", { name: "Change language" }));
+
+    for (const { nativeLabel } of supportedLocales) {
+      expect(screen.getByRole("menuitemradio", { name: nativeLabel })).toBeInTheDocument();
+    }
+    expect(screen.queryByText("Chinese (Simplified)")).not.toBeInTheDocument();
+    expect(screen.queryByText("Chinese (Traditional)")).not.toBeInTheDocument();
+  });
+
   it("switches UI copy and document locale through the language switcher", async () => {
     const user = userEvent.setup();
 

--- a/webui/src/tests/i18n.test.tsx
+++ b/webui/src/tests/i18n.test.tsx
@@ -452,7 +452,7 @@ describe("webui i18n", () => {
     expect(resolveInitialLocale()).toBe("zh-CN");
   });
 
-  it("lists languages by their native names without English translations", async () => {
+  it("lists each language by its native name", async () => {
     const user = userEvent.setup();
 
     render(<LanguageSwitcher />);
@@ -461,8 +461,6 @@ describe("webui i18n", () => {
     for (const { nativeLabel } of supportedLocales) {
       expect(screen.getByRole("menuitemradio", { name: nativeLabel })).toBeInTheDocument();
     }
-    expect(screen.queryByText("Chinese (Simplified)")).not.toBeInTheDocument();
-    expect(screen.queryByText("Chinese (Traditional)")).not.toBeInTheDocument();
   });
 
   it("switches UI copy and document locale through the language switcher", async () => {


### PR DESCRIPTION
## Summary

- show each language only by its native name in the language picker
- remove the unused English display names from the locale registry
- add regression coverage for exact native-language menu labels

## Why

A language picker should not require people to understand English before they can identify and select their language.

## Verification

- `bun run test -- src/tests/i18n.test.tsx` — 16 passed
- `bun run build`
- `bun run lint`
- Real gateway + Playwright: verified all 10 native labels on desktop and at 390×600, no English translations, `zh-CN` persistence after refresh, and 0 console errors/warnings