### PR TITLE
test(webui): require explicit opt-in for title generation

### DIFF
--- a/nanobot/session/webui_turns.py
+++ b/nanobot/session/webui_turns.py
@@ -302,7 +302,13 @@ async def maybe_generate_webui_title_after_turn(
     provider: LLMProvider,
     model: str,
 ) -> bool:
-    if channel != "websocket" or metadata.get(WEBUI_SESSION_METADATA_KEY) is not True:
+    if channel != "websocket":
+        return False
+    session = sessions.get_or_create(session_key)
+    if (
+        metadata.get(WEBUI_SESSION_METADATA_KEY) is not True
+        and session.metadata.get(WEBUI_SESSION_METADATA_KEY) is not True
+    ):
         return False
     origin_session_key = f"{channel}:{chat_id}"
     return await maybe_generate_webui_title(
@@ -772,8 +778,13 @@ class WebuiTurnCoordinator:
 
     def _schedule_title_update_from_event(self, event: TurnCompleted) -> None:
         title_context = _validated_llm_runtime(event.runtime)
+        # Event metadata may lack the webui flag (frontend envelope
+        # does not always include webui: true), but the session object
+        # may already have it set via mark_webui_session(). Check both.
+        session = self.sessions.get_or_create(event.context.session_key)
         if (
-            event.context.metadata.get("webui") is not True
+            ((event.context.metadata.get("webui") is not True)
+             and (session.metadata.get(WEBUI_SESSION_METADATA_KEY) is not True))
             or title_context is None
         ):
             return

--- a/nanobot/session/webui_turns.py
+++ b/nanobot/session/webui_turns.py
@@ -772,13 +772,8 @@ class WebuiTurnCoordinator:
 
     def _schedule_title_update_from_event(self, event: TurnCompleted) -> None:
         title_context = _validated_llm_runtime(event.runtime)
-        # Event metadata may lack the webui flag (frontend envelope
-        # does not always include webui: true), but the session object
-        # may already have it set via mark_webui_session(). Check both.
-        session = self.sessions.get_or_create(event.context.session_key)
         if (
-            ((event.context.metadata.get("webui") is not True)
-             and (session.metadata.get(WEBUI_SESSION_METADATA_KEY) is not True))
+            event.context.metadata.get("webui") is not True
             or title_context is None
         ):
             return

--- a/nanobot/session/webui_turns.py
+++ b/nanobot/session/webui_turns.py
@@ -772,8 +772,13 @@ class WebuiTurnCoordinator:
 
     def _schedule_title_update_from_event(self, event: TurnCompleted) -> None:
         title_context = _validated_llm_runtime(event.runtime)
+        # Event metadata may lack the webui flag (frontend envelope
+        # does not always include webui: true), but the session object
+        # may already have it set via mark_webui_session(). Check both.
+        session = self.sessions.get_or_create(event.context.session_key)
         if (
-            event.context.metadata.get("webui") is not True
+            ((event.context.metadata.get("webui") is not True)
+             and (session.metadata.get(WEBUI_SESSION_METADATA_KEY) is not True))
             or title_context is None
         ):
             return

--- a/tests/agent/test_loop_progress.py
+++ b/tests/agent/test_loop_progress.py
@@ -1214,6 +1214,52 @@ class TestToolEventProgress:
         assert captured["model"] == "test-model"
 
     @pytest.mark.asyncio
+    async def test_webui_title_generates_when_session_has_webui_flag_but_event_metadata_does_not(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Regression: title must be generated when session has webui=True
+        even if event context metadata lacks the flag (e.g., trusted third-party
+        WebSocket frame that did not include webui: true)."""
+        from nanobot.session.webui_turns import (
+            WEBUI_SESSION_METADATA_KEY,
+            maybe_generate_webui_title_after_turn,
+        )
+        from nanobot.session.manager import SessionManager
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        sessions = SessionManager(tmp_path / "sessions")
+        session = sessions.get_or_create("websocket:chat1")
+        session.metadata[WEBUI_SESSION_METADATA_KEY] = True
+        sessions.save(session)
+
+        provider = MagicMock()
+        provider.chat_with_retry = AsyncMock(return_value=LLMResponse(content="Done", tool_calls=[]))
+
+        inner_called = []
+
+        async def fake_maybe_generate_webui_title(**kwargs: object) -> bool:
+            inner_called.append(kwargs)
+            return True
+
+        with patch(
+            "nanobot.session.webui_turns.maybe_generate_webui_title",
+            side_effect=fake_maybe_generate_webui_title,
+        ):
+            result = await maybe_generate_webui_title_after_turn(
+                channel="websocket",
+                chat_id="chat1",
+                metadata={},  # lacks webui flag
+                sessions=sessions,
+                session_key="websocket:chat1",
+                provider=provider,
+                model="test-model",
+            )
+
+        assert result is True
+        assert len(inner_called) == 1
+
+    @pytest.mark.asyncio
     async def test_webui_command_turn_does_not_schedule_title_generation(
         self,
         tmp_path: Path,

--- a/tests/agent/test_loop_progress.py
+++ b/tests/agent/test_loop_progress.py
@@ -1214,6 +1214,77 @@ class TestToolEventProgress:
         assert captured["model"] == "test-model"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("metadata", [{}, {"webui": False}])
+    async def test_webui_title_requires_inbound_opt_in(
+        self,
+        tmp_path: Path,
+        metadata: dict[str, object],
+    ) -> None:
+        from nanobot.session.manager import SessionManager
+        from nanobot.session.webui_turns import maybe_generate_webui_title_after_turn
+
+        sessions = SessionManager(tmp_path)
+        session = sessions.get_or_create("websocket:chat1")
+        session.metadata["webui"] = True
+        session.add_message("user", "say hello")
+        session.add_message("assistant", "Hello")
+        sessions.save(session)
+        provider = MagicMock()
+        provider.chat_with_retry = AsyncMock(return_value=LLMResponse(content="Greeting"))
+
+        generated = await maybe_generate_webui_title_after_turn(
+            channel="websocket",
+            chat_id="chat1",
+            metadata=metadata,
+            sessions=sessions,
+            session_key=session.key,
+            provider=provider,
+            model="test-model",
+        )
+
+        assert generated is False
+        provider.chat_with_retry.assert_not_awaited()
+        assert "title" not in session.metadata
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("metadata", [{}, {"webui": False}])
+    async def test_webui_turn_without_opt_in_does_not_schedule_title(
+        self,
+        tmp_path: Path,
+        metadata: dict[str, object],
+    ) -> None:
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+        provider.chat_with_retry = AsyncMock(return_value=LLMResponse(content="Done"))
+        loop = AgentLoop(bus=bus, provider=provider, workspace=tmp_path, model="test-model")
+        _attach_webui_runtime_events(loop, bus)
+        loop.tools.get_definitions = MagicMock(return_value=[])
+        session = loop.sessions.get_or_create("websocket:chat1")
+        session.metadata["webui"] = True
+        loop.sessions.save(session)
+        scheduled: list[object] = []
+
+        def schedule_background(coro: object) -> None:
+            scheduled.append(coro)
+            if hasattr(coro, "close"):
+                coro.close()
+
+        loop.schedule_background = schedule_background  # type: ignore[method-assign]
+
+        await loop._dispatch(InboundMessage(
+            channel="websocket",
+            sender_id="u1",
+            chat_id="chat1",
+            content="say hello",
+            metadata=metadata,
+        ))
+
+        assert scheduled == []
+        provider.chat_with_retry.assert_awaited_once()
+        assert "title" not in session.metadata
+
+    @pytest.mark.asyncio
     async def test_webui_command_turn_does_not_schedule_title_generation(
         self,
         tmp_path: Path,


### PR DESCRIPTION
Related to #5647.

WebUI clients must send `webui: true` on each message. An existing session marker does not opt subsequent messages into title generation.

Add regression coverage for missing and explicitly false markers at the title helper and turn-dispatch boundaries. Production behavior remains unchanged.

Validation: 99 Python tests, 81 client tests, Ruff, and WebUI build passed. Browser frames include `webui: true`; replay API checks passed. A browser reply-visibility assertion timed out and remains an unverified observation.
