### PR TITLE
fix(webui): preserve Hero model preset during chat creation

### DIFF
--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -1477,10 +1477,14 @@ function Shell({
     [activeChatId, activeChatRunning, activeKey, client, temporaryChatActive],
   );
 
-  const onCreateChat = useCallback(async (workspaceScope?: WorkspaceScopePayload | null) => {
+  const onCreateChat = useCallback(async (
+    workspaceScope?: WorkspaceScopePayload | null,
+    _initialMessage?: string,
+    modelPreset?: string | null,
+  ) => {
     try {
       const scope = workspaceScope ?? activeWorkspaceScope;
-      const chatId = await createChat(scope);
+      const chatId = await createChat(scope, modelPreset);
       const key = `websocket:${chatId}`;
       pendingCreatedSessionKeyRef.current = key;
       navigate({
@@ -1509,6 +1513,7 @@ function Shell({
     async (
       workspaceScope?: WorkspaceScopePayload | null,
       initialMessage?: string,
+      modelPreset?: string | null,
     ) => {
       try {
         const chatId = await client.newTemporaryChat();
@@ -1519,6 +1524,7 @@ function Shell({
         const nextSession: ChatSummary = {
           ...session,
           preview: initialMessage ?? "",
+          modelPreset: modelPreset ?? null,
           ...(restrictedScope ? { workspaceScope: restrictedScope } : {}),
         };
         setTemporarySessions((current) => ({

--- a/webui/src/components/thread/ThreadShell.tsx
+++ b/webui/src/components/thread/ThreadShell.tsx
@@ -336,6 +336,7 @@ interface ThreadShellProps {
   onCreateChat?: (
     workspaceScope?: WorkspaceScopePayload | null,
     initialMessage?: string,
+    modelPreset?: string | null,
   ) => Promise<string | null>;
   onForkChat?: (sourceChatId: string, beforeUserIndex: number) => Promise<string | null>;
   onTurnEnd?: () => void;
@@ -1348,7 +1349,7 @@ export function ThreadShell({
       setBooting(true);
       pendingFirstRef.current = { content, images, options: withWorkspaceScope(options) };
       setPendingFirstTargetChatId(null);
-      const newId = await onCreateChat?.(workspaceScope, content);
+      const newId = await onCreateChat?.(workspaceScope, content, localModelPreset);
       if (!newId) {
         pendingFirstRef.current = null;
         setPendingFirstTargetChatId(null);

--- a/webui/src/hooks/useSessions.ts
+++ b/webui/src/hooks/useSessions.ts
@@ -127,7 +127,10 @@ export function useSessions(): {
   loading: boolean;
   error: string | null;
   refresh: () => Promise<void>;
-  createChat: (workspaceScope?: WorkspaceScopePayload | null) => Promise<string>;
+  createChat: (
+    workspaceScope?: WorkspaceScopePayload | null,
+    modelPreset?: string | null,
+  ) => Promise<string>;
   forkChat: (sourceChatId: string, beforeUserIndex: number, title?: string) => Promise<string>;
   deleteChat: (
     key: string,
@@ -204,7 +207,10 @@ export function useSessions(): {
     };
   }, [client, refresh]);
 
-  const createChat = useCallback(async (workspaceScope?: WorkspaceScopePayload | null): Promise<string> => {
+  const createChat = useCallback(async (
+    workspaceScope?: WorkspaceScopePayload | null,
+    modelPreset?: string | null,
+  ): Promise<string> => {
     const chatId = await client.newChat(CHAT_CREATE_TIMEOUT_MS, workspaceScope);
     const key = `websocket:${chatId}`;
     optimisticKeysRef.current.add(key);
@@ -219,6 +225,7 @@ export function useSessions(): {
         updatedAt: new Date().toISOString(),
         title: "",
         preview: "",
+        modelPreset: modelPreset ?? null,
         workspaceScope: workspaceScope ?? null,
       },
       ...prev.filter((s) => s.key !== key),

--- a/webui/src/tests/thread-shell.test.tsx
+++ b/webui/src/tests/thread-shell.test.tsx
@@ -1162,7 +1162,7 @@ describe("ThreadShell", () => {
     fireEvent.click(screen.getByRole("button", { name: "Send message" }));
 
     await waitFor(() => expect(onCreateChat).toHaveBeenCalledTimes(1));
-    expect(onCreateChat).toHaveBeenCalledWith(null, "start for real");
+    expect(onCreateChat).toHaveBeenCalledWith(null, "start for real", null);
     expect(onNewChat).not.toHaveBeenCalled();
   });
 
@@ -1203,8 +1203,13 @@ describe("ThreadShell", () => {
       "chat-new",
       "/model fast",
     ));
+    expect(onCreateChat).toHaveBeenCalledWith(null, "use the selected model", "fast");
 
-    rerender(view(session("chat-new")));
+    await act(async () => {
+      rerender(view(session("chat-new", "fast")));
+    });
+    expect(screen.getByTitle("fast · gpt-5.5 · OpenAI Codex")).toBeInTheDocument();
+    expect(screen.queryByText("Default")).not.toBeInTheDocument();
     expect(client.sendMessage).not.toHaveBeenCalled();
 
     await act(async () => {

--- a/webui/src/tests/useSessions.test.tsx
+++ b/webui/src/tests/useSessions.test.tsx
@@ -390,6 +390,23 @@ describe("useSessions", () => {
     expect(result.current.sessions[0]?.workspaceScope).toEqual(workspaceScope);
   });
 
+  it("stores an optimistic model preset when creating a chat", async () => {
+    vi.mocked(api.listSessions).mockResolvedValue([]);
+    const client = fakeClient();
+    client.newChat.mockResolvedValue("chat-fast");
+
+    const { result } = renderHook(() => useSessions(), {
+      wrapper: wrap(client),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(async () => {
+      await result.current.createChat(null, "fast");
+    });
+
+    expect(result.current.sessions[0]?.modelPreset).toBe("fast");
+  });
+
   it("passes through WebUI transcript user media as images and media", async () => {
     vi.mocked(api.fetchWebuiThread).mockResolvedValue({
       schemaVersion: 3,


### PR DESCRIPTION
## Summary

- carry the Hero-selected model preset into the optimistic session created for the first message
- keep persistent and temporary chat composers on the selected preset while the session handoff completes
- add regression coverage for the Hero handoff and optimistic session metadata

## Verification

- `cd webui && bun run test` (1130 passed)
- `cd webui && bun run lint`
- `cd webui && bun run build`
- isolated gateway + Playwright: the composer stayed on `fast` throughout first-message creation and active generation, including after refresh; console reported 0 errors and 0 warnings