### PR TITLE
fix(webui): keep every concurrently loaded channel locale registered

### DIFF
--- a/webui/src/channel-plugins/locale-registry.ts
+++ b/webui/src/channel-plugins/locale-registry.ts
@@ -73,7 +73,13 @@ async function loadChannelLocale(
   channel: string,
   locale: SupportedLocale,
 ): Promise<ChannelMessages> {
-  const translations = translationsByChannel.get(channel) ?? new Map();
+  // Get-or-create the shared per-channel map synchronously so concurrent locale
+  // loads append to one Map instead of replacing each other's registration.
+  let translations = translationsByChannel.get(channel);
+  if (!translations) {
+    translations = new Map();
+    translationsByChannel.set(channel, translations);
+  }
   const loaded = translations.get(locale);
   if (loaded) return loaded;
 
@@ -87,6 +93,5 @@ async function loadChannelLocale(
     throw new Error(`Channel '${channel}' locale '${locale}' has no default export`);
   }
   translations.set(locale, messages);
-  translationsByChannel.set(channel, translations);
   return messages;
 }

--- a/webui/src/tests/channel-locale-registry.test.ts
+++ b/webui/src/tests/channel-locale-registry.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { channelFieldMessageKey } from "@/channel-plugins/i18n";
 import { registeredChannelLocales } from "@/channel-plugins/locale-registry";
@@ -111,5 +111,28 @@ describe("channel locale registry", () => {
     expect(i18nEntry).toContain("import.meta.glob");
     expect(i18nEntry).not.toMatch(/import\s+\w+Common\s+from/);
     expect(i18nEntry).not.toContain("channel-plugins/registry");
+  });
+});
+
+describe("channel locale registry concurrency", () => {
+  it("registers every locale loaded concurrently for the same channel", async () => {
+    // A fresh module instance starts with an empty registry, which is the state
+    // startup reaches when the stored locale differs from the fallback locale.
+    vi.resetModules();
+    const registry = await import("@/channel-plugins/locale-registry");
+
+    await Promise.all([
+      registry.channelLocaleResources("en"),
+      registry.channelLocaleResources("zh-CN"),
+    ]);
+
+    const registrations = registry.registeredChannelLocales();
+    expect([...registrations.keys()].sort()).toEqual(expectedChannels);
+    for (const [channel, locales] of registrations) {
+      expect([...locales.keys()].sort(), `${channel} concurrent locales`).toEqual([
+        "en",
+        "zh-CN",
+      ]);
+    }
   });
 });


### PR DESCRIPTION
Closes #5644

## Summary

Create and register the per-channel translation map synchronously, before awaiting the locale loader, so concurrent loads for one channel append to a single shared `Map`.

## Root cause

`loadChannelLocale()` captured the per-channel map before the await and re-registered it afterwards:

```ts
const translations = translationsByChannel.get(channel) ?? new Map();
// ... await loader() ...
translations.set(locale, messages);
translationsByChannel.set(channel, translations);
```

`initializeI18n()` loads `[fallbackLocale, initialLocale]` concurrently, so for any user whose stored locale is not `en` two calls run per channel package. Both find no existing map, each creates its own, and the one resolving last replaces the other's registration — one locale is silently dropped from every channel. `registeredChannelLocales()` then reports 9 of the 10 supported locales, and `channelLocaleMessages(channel, "en")` returns `undefined`, so channel setup labels lose their English fallback.

## Changes

- `webui/src/channel-plugins/locale-registry.ts`: get-or-create and register the per-channel map before any await; drop the now-redundant re-registration after it.
- `webui/src/tests/channel-locale-registry.test.ts`: add a concurrency regression test that loads `en` and `zh-CN` against a fresh registry instance.

## Verification

- The new regression test fails before this change (`expected [ 'zh-CN' ] to deeply equal [ 'en', 'zh-CN' ]`) and passes after it.
- `vitest run` — 73 files / 1131 tests passed.
- `vitest run --coverage` — passed.
- `tsc -p tsconfig.build.json --noEmit` — clean.
- `eslint --config webui/eslint.config.js` on both changed files with `--max-warnings 0` — clean.
- Reproduced the reported condition by temporarily setting `defaultLocale = "zh-CN"`: the four files named in the issue (`channel-locale-registry`, `settings-channels`, `settings-system`, `channel-identity` — 35 tests) all pass with this change. That temporary edit is not part of this PR.

Checks were run with Node 24.16.0 + vitest 2.1.9 rather than Bun.

## Compatibility and risk

Low. No public API or behavior change, other than the registry now holding a channel's map from the moment its first load starts instead of after the first successful load. A loader rejection already propagates and aborts startup, so the only difference in that already-failing path is an empty map for the channel.
