### PR TITLE
feat(gateway): add signed direct delivery webhook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -67,6 +67,7 @@ Use reference pages to look up an exact option after you know what you are tryin
 | WebSocket authentication and wire protocol | [WebSocket](./websocket.md) |
 | Python SDK classes, events, sessions, and hooks | [Python SDK](./python-sdk.md) |
 | OpenAI-compatible HTTP routes and payloads | [OpenAI-Compatible API](./openai-api.md) |
+| Send authenticated notifications without an LLM call | [Direct Delivery Webhook](./direct-delivery.md) |
 | Runtime self-inspection and tuning | [My Tool](./my-tool.md) |
 
 Configuration examples are usually snippets to merge into `~/.nanobot/config.json`, not complete replacement files. The docs use camelCase because nanobot writes config that way. Keep real API keys, bot tokens, and passwords out of issues and public logs.

--- a/docs/direct-delivery.md
+++ b/docs/direct-delivery.md
@@ -1,0 +1,85 @@
+# Direct Delivery Webhook
+
+The gateway can accept authenticated HTTP notifications and deliver them directly to an enabled
+chat channel **without invoking the agent loop or an LLM**. This is useful for deterministic alerts
+from CI, monitoring, billing, or other trusted systems.
+
+Direct delivery is disabled by default and listens on a separate, loopback-only port by default.
+
+## Configuration
+
+Merge this into `~/.nanobot/config.json`:
+
+```json
+{
+  "gateway": {
+    "directDelivery": {
+      "enabled": true,
+      "host": "127.0.0.1",
+      "port": 18791,
+      "path": "/deliver",
+      "secret": "replace-with-a-long-random-secret",
+      "channel": "telegram",
+      "chatId": "123456789",
+      "maxBodyBytes": 65536,
+      "maxAgeSeconds": 300,
+      "maxRequestsPerMinute": 60
+    }
+  }
+}
+```
+
+`channel` must name an enabled channel and `chatId` is that channel's destination identifier.
+Keep the listener private when possible. If it must be exposed, place it behind TLS and a reverse
+proxy; the shared secret authenticates messages but does not encrypt traffic.
+
+## Request format
+
+Send a JSON object containing the final text to deliver:
+
+```json
+{"content":"Production deployment completed"}
+```
+
+Required headers:
+
+- `Content-Type: application/json`
+- `X-Nanobot-Timestamp`: current Unix timestamp in seconds
+- `X-Nanobot-Request-ID`: unique identifier for this delivery attempt
+- `X-Nanobot-Signature-256`: `sha256=<hex digest>`
+
+The signature is HMAC-SHA256 over these exact bytes:
+
+```text
+<timestamp>.<request-id>.<raw request body>
+```
+
+For example, in Python:
+
+```python
+import hashlib
+import hmac
+import json
+import time
+import uuid
+
+body = json.dumps(
+    {"content": "Production deployment completed"},
+    separators=(",", ":"),
+).encode()
+timestamp = str(int(time.time()))
+request_id = str(uuid.uuid4())
+signature = hmac.new(
+    secret.encode(),
+    f"{timestamp}.{request_id}.".encode() + body,
+    hashlib.sha256,
+).hexdigest()
+```
+
+The endpoint rejects stale timestamps, invalid signatures, duplicate request IDs, oversized bodies,
+and requests above the configured per-minute limit. Replay tracking is kept in memory for the
+configured freshness window, so senders should still use globally unique request IDs after a gateway
+restart.
+
+A successful request returns HTTP 200 only after the message has been accepted by nanobot's outbound
+channel queue. Channel delivery then uses the same retry behavior as other outbound messages.

--- a/nanobot/cli/gateway_runtime.py
+++ b/nanobot/cli/gateway_runtime.py
@@ -444,6 +444,7 @@ def _run_gateway(
 
     # Use the same runtime identity for foreground and managed gateway processes.
     from nanobot.config.loader import get_config_path
+    from nanobot.gateway.direct_delivery import run_direct_delivery_server
     from nanobot.gateway.runtime import (
         GatewayClientLease,
         GatewayRuntime,
@@ -763,6 +764,15 @@ def _run_gateway(
     else:
         console.print("[yellow]✗[/yellow] Heartbeat: disabled")
 
+    direct_delivery_cfg = config.gateway.direct_delivery
+    if direct_delivery_cfg.enabled:
+        console.print(
+            "[green]✓[/green] Direct delivery: "
+            f"http://{direct_delivery_cfg.host}:{direct_delivery_cfg.port}"
+            f"{direct_delivery_cfg.path} → {direct_delivery_cfg.channel}:"
+            f"{direct_delivery_cfg.chat_id}"
+        )
+
     async def _health_server(host: str, health_port: int) -> None:
         """Lightweight HTTP health endpoint on the gateway port."""
         import json as _json
@@ -944,6 +954,14 @@ def _run_gateway(
                 ),
                 asyncio.create_task(_run_agent(), name="nanobot-agent-loop"),
                 asyncio.create_task(channels.start_all(), name="nanobot-channels"),
+                *(
+                    [asyncio.create_task(
+                        run_direct_delivery_server(direct_delivery_cfg, bus),
+                        name="nanobot-direct-delivery",
+                    )]
+                    if direct_delivery_cfg.enabled
+                    else []
+                ),
                 asyncio.create_task(
                     run_local_trigger_queue(
                         store=trigger_store,

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -351,6 +351,35 @@ class ApiConfig(Base):
         )
 
 
+class DirectDeliveryConfig(Base):
+    """Configuration for the optional zero-model delivery webhook."""
+
+    enabled: bool = False
+    host: str = "127.0.0.1"
+    port: int = Field(default=18791, ge=1, le=65535)
+    path: str = "/deliver"
+    secret: str = ""
+    channel: str = ""
+    chat_id: str = ""
+    max_body_bytes: int = Field(default=65_536, ge=1, le=1_048_576)
+    max_age_seconds: int = Field(default=300, ge=1, le=3600)
+    max_requests_per_minute: int = Field(default=60, ge=1, le=10_000)
+
+    @field_validator("path")
+    @classmethod
+    def normalize_path(cls, value: str) -> str:
+        value = value.strip()
+        if not value.startswith("/"):
+            value = f"/{value}"
+        return value.rstrip("/") or "/deliver"
+
+    @model_validator(mode="after")
+    def require_delivery_target(self) -> DirectDeliveryConfig:
+        if self.enabled and not all((self.secret.strip(), self.channel.strip(), self.chat_id.strip())):
+            raise ValueError("enabled direct delivery requires secret, channel, and chat_id")
+        return self
+
+
 class GatewayConfig(Base):
     """Gateway/server configuration."""
 
@@ -358,6 +387,7 @@ class GatewayConfig(Base):
     port: int = 18790
     restart_mode: Literal["auto", "exec", "spawn", "exit"] = "auto"
     heartbeat: HeartbeatConfig = Field(default_factory=HeartbeatConfig)
+    direct_delivery: DirectDeliveryConfig = Field(default_factory=DirectDeliveryConfig)
 
 
 class MCPServerConfig(Base):

--- a/nanobot/gateway/direct_delivery.py
+++ b/nanobot/gateway/direct_delivery.py
@@ -1,0 +1,191 @@
+"""Authenticated HTTP ingress for messages that bypass the agent loop."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import time
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.config.schema import DirectDeliveryConfig
+
+
+class DirectDeliveryError(Exception):
+    """A request error safe to return to the webhook caller."""
+
+    def __init__(self, status: int, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+        self.message = message
+
+
+@dataclass
+class DirectDeliveryGuard:
+    """Validate signatures and retain a bounded replay/rate-limit window."""
+
+    config: DirectDeliveryConfig
+    _seen: dict[str, int] = field(default_factory=dict)
+    _request_times: list[int] = field(default_factory=list)
+
+    def authenticate(self, headers: dict[str, str], body: bytes, *, now: int) -> str:
+        timestamp = self._required_header(headers, "x-nanobot-timestamp")
+        request_id = self._required_header(headers, "x-nanobot-request-id")
+        signature = self._required_header(headers, "x-nanobot-signature-256")
+
+        try:
+            sent_at = int(timestamp)
+        except ValueError as exc:
+            raise DirectDeliveryError(401, "invalid timestamp") from exc
+        if abs(now - sent_at) > self.config.max_age_seconds:
+            raise DirectDeliveryError(401, "stale request")
+
+        expected = hmac.new(
+            self.config.secret.encode(),
+            f"{timestamp}.{request_id}.".encode() + body,
+            hashlib.sha256,
+        ).hexdigest()
+        supplied = signature.removeprefix("sha256=")
+        if not hmac.compare_digest(supplied, expected):
+            raise DirectDeliveryError(401, "invalid signature")
+
+        self._prune(now)
+        if request_id in self._seen:
+            raise DirectDeliveryError(409, "duplicate request")
+        if len(self._request_times) >= self.config.max_requests_per_minute:
+            raise DirectDeliveryError(429, "rate limit exceeded")
+        self._seen[request_id] = now
+        self._request_times.append(now)
+        return request_id
+
+    @staticmethod
+    def _required_header(headers: dict[str, str], key: str) -> str:
+        value = headers.get(key, "").strip()
+        if not value:
+            raise DirectDeliveryError(401, f"missing {key} header")
+        return value
+
+    def _prune(self, now: int) -> None:
+        replay_cutoff = now - self.config.max_age_seconds
+        self._seen = {
+            request_id: timestamp
+            for request_id, timestamp in self._seen.items()
+            if timestamp >= replay_cutoff
+        }
+        rate_cutoff = now - 60
+        self._request_times = [timestamp for timestamp in self._request_times if timestamp > rate_cutoff]
+
+
+def parse_delivery_body(body: bytes) -> str:
+    try:
+        payload = json.loads(body)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise DirectDeliveryError(400, "body must be valid JSON") from exc
+    if not isinstance(payload, dict):
+        raise DirectDeliveryError(400, "body must be a JSON object")
+    record = cast(dict[str, object], payload)
+    if set(record) != {"content"}:
+        raise DirectDeliveryError(400, "body must contain only content")
+    content = record.get("content")
+    if not isinstance(content, str) or not content.strip():
+        raise DirectDeliveryError(400, "content must be a non-empty string")
+    if len(content) > 50_000:
+        raise DirectDeliveryError(400, "content is too long")
+    return content.strip()
+
+
+def signed_delivery_headers(
+    secret: str,
+    request_id: str,
+    body: bytes,
+    *,
+    timestamp: int | None = None,
+) -> dict[str, str]:
+    """Build headers for clients and tests using the documented signature format."""
+    sent_at = str(int(time.time()) if timestamp is None else timestamp)
+    signature = hmac.new(
+        secret.encode(),
+        f"{sent_at}.{request_id}.".encode() + body,
+        hashlib.sha256,
+    ).hexdigest()
+    return {
+        "Content-Type": "application/json",
+        "X-Nanobot-Timestamp": sent_at,
+        "X-Nanobot-Request-ID": request_id,
+        "X-Nanobot-Signature-256": f"sha256={signature}",
+    }
+
+
+async def run_direct_delivery_server(
+    config: DirectDeliveryConfig,
+    bus: MessageBus,
+) -> None:
+    """Serve the direct-delivery endpoint until the surrounding task is cancelled."""
+    guard = DirectDeliveryGuard(config)
+
+    async def respond(writer: asyncio.StreamWriter, status: int, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        reason = {200: "OK", 400: "Bad Request", 401: "Unauthorized", 404: "Not Found",
+                  405: "Method Not Allowed", 409: "Conflict", 413: "Content Too Large",
+                  429: "Too Many Requests"}.get(status, "Error")
+        writer.write(
+            f"HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\n"
+            f"Content-Length: {len(body)}\r\nConnection: close\r\n\r\n".encode() + body
+        )
+        await writer.drain()
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            try:
+                header_data = await asyncio.wait_for(
+                    reader.readuntil(b"\r\n\r\n"),
+                    timeout=5,
+                )
+            except asyncio.LimitOverrunError as exc:
+                raise DirectDeliveryError(413, "headers too large") from exc
+            if len(header_data) > 16_384:
+                raise DirectDeliveryError(413, "headers too large")
+            lines = header_data[:-4].decode("latin-1").split("\r\n")
+            request = lines[0].split(" ")
+            if len(request) < 2 or request[0] != "POST":
+                raise DirectDeliveryError(405, "POST required")
+            request_path = request[1].split("?", 1)[0]
+            if request_path != config.path:
+                raise DirectDeliveryError(404, "not found")
+            headers = {
+                key.strip().lower(): value.strip()
+                for line in lines[1:]
+                if ":" in line
+                for key, value in [line.split(":", 1)]
+            }
+            try:
+                length = int(headers.get("content-length", ""))
+            except ValueError as exc:
+                raise DirectDeliveryError(400, "valid content-length required") from exc
+            if length < 1 or length > config.max_body_bytes:
+                raise DirectDeliveryError(413, "body too large")
+            body = await asyncio.wait_for(reader.readexactly(length), timeout=5)
+            content = parse_delivery_body(body)
+            request_id = guard.authenticate(headers, body, now=int(time.time()))
+            await bus.publish_outbound(OutboundMessage(
+                channel=config.channel,
+                chat_id=config.chat_id,
+                content=content,
+                metadata={"direct_delivery": True, "request_id": request_id},
+            ))
+            await respond(writer, 200, {"ok": True, "request_id": request_id})
+        except DirectDeliveryError as exc:
+            await respond(writer, exc.status, {"ok": False, "error": exc.message})
+        except (asyncio.IncompleteReadError, asyncio.TimeoutError):
+            await respond(writer, 400, {"ok": False, "error": "invalid HTTP request"})
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    server = await asyncio.start_server(handle, config.host, config.port)
+    async with server:
+        await server.serve_forever()

--- a/tests/config/test_gateway_config.py
+++ b/tests/config/test_gateway_config.py
@@ -22,3 +22,29 @@ def test_heartbeat_ignores_removed_retention_limit():
 
     heartbeat = config.model_dump(by_alias=True)["gateway"]["heartbeat"]
     assert "keepRecentMessages" not in heartbeat
+
+
+def test_direct_delivery_accepts_camel_case_and_normalizes_path():
+    config = Config.model_validate({
+        "gateway": {
+            "directDelivery": {
+                "enabled": True,
+                "path": "hooks/deliver/",
+                "secret": "secret",
+                "channel": "telegram",
+                "chatId": "123",
+                "maxAgeSeconds": 120,
+            }
+        }
+    })
+
+    delivery = config.gateway.direct_delivery
+    assert delivery.path == "/hooks/deliver"
+    assert delivery.chat_id == "123"
+    assert delivery.max_age_seconds == 120
+    assert config.model_dump(by_alias=True)["gateway"]["directDelivery"]["chatId"] == "123"
+
+
+def test_enabled_direct_delivery_requires_secret_and_target():
+    with pytest.raises(ValueError, match="secret, channel, and chat_id"):
+        Config.model_validate({"gateway": {"directDelivery": {"enabled": True}}})

--- a/tests/gateway/test_direct_delivery.py
+++ b/tests/gateway/test_direct_delivery.py
@@ -1,0 +1,132 @@
+import asyncio
+import json
+import socket
+import time
+
+import httpx
+import pytest
+
+from nanobot.bus.queue import MessageBus
+from nanobot.config.schema import DirectDeliveryConfig
+from nanobot.gateway.direct_delivery import run_direct_delivery_server, signed_delivery_headers
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+async def _wait_ready(url: str) -> None:
+    for _ in range(50):
+        try:
+            async with httpx.AsyncClient() as client:
+                await client.post(url, content=b"{}")
+            return
+        except httpx.ConnectError:
+            await asyncio.sleep(0.01)
+    raise AssertionError("direct delivery server did not start")
+
+
+@pytest.fixture
+def config() -> DirectDeliveryConfig:
+    return DirectDeliveryConfig(
+        enabled=True,
+        host="127.0.0.1",
+        port=_free_port(),
+        path="/deliver",
+        secret="test-secret",
+        channel="telegram",
+        chat_id="12345",
+    )
+
+
+@pytest.mark.asyncio
+async def test_signed_request_publishes_only_to_outbound_bus(config: DirectDeliveryConfig) -> None:
+    bus = MessageBus()
+    task = asyncio.create_task(run_direct_delivery_server(config, bus))
+    url = f"http://{config.host}:{config.port}{config.path}"
+    try:
+        await _wait_ready(url)
+        body = json.dumps({"content": "Build complete"}).encode()
+        headers = signed_delivery_headers(config.secret, "request-1", body)
+        async with httpx.AsyncClient() as client:
+            response = await client.post(url, content=body, headers=headers)
+
+        assert response.status_code == 200
+        message = await asyncio.wait_for(bus.consume_outbound(), timeout=1)
+        assert (message.channel, message.chat_id, message.content) == (
+            "telegram", "12345", "Build complete"
+        )
+        assert message.metadata == {"direct_delivery": True, "request_id": "request-1"}
+        assert bus.inbound_size == 0
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_rejects_bad_signatures_stale_and_replayed_requests(
+    config: DirectDeliveryConfig,
+) -> None:
+    bus = MessageBus()
+    task = asyncio.create_task(run_direct_delivery_server(config, bus))
+    url = f"http://{config.host}:{config.port}{config.path}"
+    body = json.dumps({"content": "Do not duplicate"}).encode()
+    try:
+        await _wait_ready(url)
+        async with httpx.AsyncClient() as client:
+            bad = await client.post(
+                url,
+                content=body,
+                headers=signed_delivery_headers("wrong", "bad", body),
+            )
+            stale = await client.post(url, content=body, headers=signed_delivery_headers(
+                config.secret, "stale", body,
+                timestamp=int(time.time()) - config.max_age_seconds - 1,
+            ))
+            headers = signed_delivery_headers(config.secret, "same", body)
+            accepted = await client.post(url, content=body, headers=headers)
+            replayed = await client.post(url, content=body, headers=headers)
+
+        assert bad.status_code == 401
+        assert stale.status_code == 401
+        assert accepted.status_code == 200
+        assert replayed.status_code == 409
+        await asyncio.wait_for(bus.consume_outbound(), timeout=1)
+        assert bus.outbound_size == 0
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_rejects_invalid_payloads_and_oversized_bodies(config: DirectDeliveryConfig) -> None:
+    config.max_body_bytes = 30
+    bus = MessageBus()
+    task = asyncio.create_task(run_direct_delivery_server(config, bus))
+    url = f"http://{config.host}:{config.port}{config.path}"
+    try:
+        await _wait_ready(url)
+        invalid = json.dumps({"content": ""}).encode()
+        oversized = json.dumps({"content": "x" * 50}).encode()
+        async with httpx.AsyncClient() as client:
+            empty = await client.post(
+                url,
+                content=invalid,
+                headers=signed_delivery_headers(config.secret, "empty", invalid),
+            )
+            large = await client.post(
+                url,
+                content=oversized,
+                headers=signed_delivery_headers(config.secret, "large", oversized),
+            )
+        assert empty.status_code == 400
+        assert large.status_code == 413
+        assert bus.outbound_size == 0
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task


### PR DESCRIPTION
## Summary

Add an optional authenticated webhook that routes final notification text directly to nanobot's outbound message bus, bypassing the agent loop and all model calls.

This enables deterministic notifications from trusted systems such as CI, monitoring, and billing services while reusing existing channel delivery and retry behavior.

## Design

- disabled by default
- separate loopback-only listener by default
- fixed configured `channel` and `chatId` (callers cannot choose a destination)
- HMAC-SHA256 authentication over timestamp, request ID, and raw body
- bounded timestamp freshness window and in-memory replay detection
- body-size and per-minute request limits
- strict `{ "content": "..." }` payload
- publishes only `OutboundMessage`; no inbound event reaches `AgentLoop`
- complete configuration and signing documentation

## Security

The signature input is:

```text
<timestamp>.<request-id>.<raw request body>
```

The listener rejects missing or invalid signatures, stale timestamps, duplicate request IDs, oversized payloads, and rate-limit excesses. Documentation recommends loopback/private networking or TLS behind a reverse proxy.

## Tests

Updated against upstream main on 2026-09-16. Resolved the configuration-test conflict by keeping upstream's removal of the obsolete heartbeat test and retaining the direct-delivery tests.

- Focused direct-delivery, gateway configuration, and gateway-runtime tests: 17 passed.
- Gateway, configuration, message-bus, and gateway-runtime regression tests: 210 passed, 2 skipped.
- `ruff check` on the changed Python files: passed.
- Targeted BasedPyright check on `direct_delivery.py`, `schema.py`, and `gateway_runtime.py`: 0 errors, 0 warnings.
- The full repository suite was not rerun for this upstream-sync update.
