### PR TITLE
feat(exec): enforce user deny patterns in full access with case-insensitive matching

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -212,7 +212,8 @@ class ExecTool(Tool):
         self.timeout = timeout
         self.working_dir = working_dir
         self.sandbox = sandbox
-        self.deny_patterns = (deny_patterns or []) + [
+        self.user_deny_patterns = list(deny_patterns or [])
+        self.deny_patterns = self.user_deny_patterns + [
             r"\brm\s+-[rf]{1,2}\b",          # rm -r, rm -rf, rm -fr
             r"\bdel\s+/[fq]\b",              # del /f, del /q
             r"\brmdir\s+/s\b",               # rmdir /s
@@ -432,6 +433,16 @@ class ExecTool(Tool):
                     "Error: working_dir is outside the configured workspace"
                     + _WORKSPACE_BOUNDARY_NOTE
                 )
+
+        # User-configured deny patterns are treated as an explicit, intentional safety
+        # boundary that must be enforced across all access modes (including Full Access mode).
+        # While Full Access grants full filesystem and working directory freedom, explicit user
+        # deny patterns (e.g. blocking destructive commands like Remove-Item) still apply unless
+        # explicitly exempted by allow_patterns.
+        if self.user_deny_patterns:
+            user_guard_error = self._check_deny_patterns(command, self.user_deny_patterns)
+            if user_guard_error:
+                return user_guard_error
 
         # Full access is an explicit trust decision. Keep the application-level
         # command guard aligned with the selected access mode instead of
@@ -797,6 +808,20 @@ class ExecTool(Tool):
                 env[key] = val
         return env
 
+    def _check_deny_patterns(self, command: str, patterns: list[str]) -> str | None:
+        """Check command against a deny pattern list, respecting allow_patterns priority."""
+        cmd = command.strip()
+        segments = self._split_shell_segments(cmd)
+        explicitly_allowed = bool(self.allow_patterns) and bool(segments) and all(
+            any(re.fullmatch(pattern, segment, re.IGNORECASE) for pattern in self.allow_patterns)
+            for segment in segments
+        )
+        if not explicitly_allowed:
+            for pattern in patterns:
+                if re.search(pattern, cmd, re.IGNORECASE):
+                    return ToolResult.error("Error: Command blocked by deny pattern filter")
+        return None
+
     def _guard_command(
         self,
         command: str,
@@ -807,23 +832,22 @@ class ExecTool(Tool):
     ) -> str | None:
         """Best-effort safety guard for potentially destructive commands."""
         cmd = command.strip()
-        lower = cmd.lower()
 
         # allow_patterns take priority over deny_patterns so that users can
         # exempt specific commands (e.g. "rm -rf" inside a build directory)
         # from the hardcoded deny list via configuration. A chained command is
         # only explicitly allowed when every top-level shell segment matches.
-        segments = self._split_shell_segments(lower)
-        explicitly_allowed = bool(self.allow_patterns) and bool(segments) and all(
-            any(re.fullmatch(pattern, segment) for pattern in self.allow_patterns)
-            for segment in segments
-        )
-        if not explicitly_allowed:
-            for pattern in self.deny_patterns:
-                if re.search(pattern, lower):
-                    return ToolResult.error("Error: Command blocked by deny pattern filter")
+        deny_error = self._check_deny_patterns(command, self.deny_patterns)
+        if deny_error:
+            return deny_error
 
-            if self.allow_patterns:
+        if self.allow_patterns:
+            segments = self._split_shell_segments(cmd)
+            explicitly_allowed = bool(segments) and all(
+                any(re.fullmatch(pattern, segment, re.IGNORECASE) for pattern in self.allow_patterns)
+                for segment in segments
+            )
+            if not explicitly_allowed:
                 return ToolResult.error("Error: Command blocked by allowlist filter (not in allowlist)")
 
         from nanobot.security.network import contains_internal_url

--- a/tests/tools/test_exec_security.py
+++ b/tests/tools/test_exec_security.py
@@ -111,23 +111,67 @@ def test_exec_full_workspace_scope_still_blocks_metadata(tmp_path):
     assert "internal/private" in error
 
 
-@pytest.mark.parametrize(
-    "command",
-    [
-        "echo blocked",
-        "echo http://169.254.169.254/latest/meta-data/",
-    ],
-)
-async def test_exec_full_access_skips_command_guard(tmp_path, command):
+async def test_exec_full_access_skips_command_guard(tmp_path):
+    tool = ExecTool(
+        working_dir=str(tmp_path),
+        restrict_to_workspace=False,
+    )
+    result = await tool.execute(
+        command="echo http://169.254.169.254/latest/meta-data/",
+    )
+
+    assert "Exit code: 0" in result
+    assert "Command blocked" not in result
+
+
+async def test_exec_full_access_enforces_user_deny_patterns(tmp_path):
     tool = ExecTool(
         working_dir=str(tmp_path),
         restrict_to_workspace=False,
         deny_patterns=[r"echo\s+blocked"],
     )
+    result = await tool.execute(command="echo blocked")
+
+    assert "Command blocked by deny pattern filter" in result
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "remove-item test",
+        "Remove-Item test",
+        "REMOVE-ITEM test",
+    ],
+)
+async def test_exec_deny_patterns_case_insensitive(command):
+    tool = ExecTool(deny_patterns=[r"Remove-Item"])
+    guard_result = tool._guard_command(command, "/tmp")
+    assert guard_result is not None
+    assert "Command blocked by deny pattern filter" in guard_result
     result = await tool.execute(command=command)
+    assert "Command blocked by deny pattern filter" in result
+
+
+async def test_exec_user_deny_patterns_allow_priority(tmp_path):
+    tool = ExecTool(
+        working_dir=str(tmp_path),
+        restrict_to_workspace=False,
+        deny_patterns=[r"echo\s+blocked"],
+        allow_patterns=[r"echo\s+blocked"],
+    )
+    result = await tool.execute(command="echo blocked")
 
     assert "Exit code: 0" in result
     assert "Command blocked" not in result
+
+    denied_tool = ExecTool(
+        working_dir=str(tmp_path),
+        restrict_to_workspace=False,
+        deny_patterns=[r"echo\s+blocked"],
+        allow_patterns=[r"echo\s+allowed"],
+    )
+    denied_result = await denied_tool.execute(command="echo blocked")
+    assert "Command blocked by deny pattern filter" in denied_result
 
 
 async def test_exec_full_workspace_scope_skips_command_guard(tmp_path):


### PR DESCRIPTION
@'
## Summary

When users configure 	ools.exec.denyPatterns (e.g. [\Remove-Item\]), commands were previously still executed without restriction if the workspace permission was set to Full Access. This occurred because commit 09d3bd76 bypassed _guard_command in Full Access mode under the rationale that Full Access is an explicit trust decision.

However, user-configured denyPatterns represent an explicit, intentional safety boundary (e.g. blocking destructive commands like Remove-Item) that users expect to be enforced even when granting filesystem freedom via Full Access. Furthermore, pattern matching was previously case-sensitive against lowercased command strings, which prevented uppercase or mixed-case patterns like Remove-Item from matching.

This PR:
1. Treats user-configured deny_patterns as an explicit safety policy enforced across all access modes (including Full Access mode).
2. Uses case-insensitive regex matching (e.IGNORECASE) for both allow and deny patterns.
3. Preserves llow_patterns priority so users can explicitly exempt commands.
4. Keeps workspace path boundaries and network/URL safety guards restricted to estrict_to_workspace=True mode, maintaining Full Access filesystem freedom.
5. Adds explanatory comments and comprehensive unit test coverage.

## Changes

- **
anobot/agent/tools/shell.py**:
  - Store self.user_deny_patterns = list(deny_patterns or []) in ExecTool.__init__.
  - Add helper _check_deny_patterns with case-insensitive matching and llow_patterns precedence.
  - In _prepare_command, enforce self.user_deny_patterns before the workspace restriction check, with clear code comments.
  - Refactor _guard_command to reuse _check_deny_patterns.
- **	ests/tools/test_exec_security.py**:
  - Update 	est_exec_full_access_skips_command_guard to test metadata URL guard skipping without conflicting with user deny rules.
  - Add 	est_exec_full_access_enforces_user_deny_patterns to assert user deny patterns block execution in Full Access.
  - Add 	est_exec_deny_patterns_case_insensitive to verify case-insensitive pattern matching (e.g. Remove-Item).
  - Add 	est_exec_user_deny_patterns_allow_priority to assert allowlist exemptions function in Full Access.

## Verification

- uv run ruff check nanobot/agent/tools/shell.py tests/tools/test_exec_security.py: All checks passed.
- uv run pytest tests/tools/test_exec_security.py: 79 passed, 9 skipped.
- uv run pytest tests/tools/test_exec_allow_patterns.py tests/tools/test_exec_session_tools.py: 59 passed.
'@