### PR TITLE
fix(agent): restore current-time runtime context via a built-in provider

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -37,6 +37,7 @@ from nanobot.agent.runner import (
     AgentRunSpec,
 )
 from nanobot.agent.subagent import SubagentManager
+from nanobot.agent.time_context import current_time_provider
 from nanobot.agent.tools.context import RequestContext, bind_request_context, reset_request_context
 from nanobot.agent.tools.exec_session import ExecSessionManager
 from nanobot.agent.tools.file_state import FileStateStore, bind_file_states, reset_file_states
@@ -408,6 +409,11 @@ class AgentLoop:
         self._unified_session = unified_session
         self._running = False
         self._runtime_context_providers: list[RuntimeContextProvider] = []
+        # Restore model-level time awareness that the #4891 provider refactor
+        # dropped from ContextBuilder's defaults (issue #5645): with a
+        # timezone configured, every user turn carries a Current Time block.
+        if timezone:
+            self.register_runtime_context_provider(current_time_provider(timezone))
         self._active_tasks: dict[str, set[asyncio.Task[Any]]] = {}
         self._discarding_sessions: set[str] = set()
         self._background_tasks: set[asyncio.Task[Any]] = set()

--- a/nanobot/agent/time_context.py
+++ b/nanobot/agent/time_context.py
@@ -1,0 +1,50 @@
+"""Built-in current-time runtime context provider.
+
+PR #4891 replaced ContextBuilder's default runtime-context injection with
+pluggable per-turn providers, but no built-in provider was registered to keep
+model-level time awareness, so a configured ``agents.defaults.timezone``
+stopped having any effect on turns (issue #5645). This module restores that
+capability on the provider mechanism the refactor introduced, using the same
+time format as the pre-#4891 ContextBuilder block.
+"""
+
+from typing import Any
+
+from nanobot.runtime_context import RuntimeContextBlock
+
+TIME_CONTEXT_SOURCE = "current_time"
+
+
+def current_time_str(timezone: str | None = None) -> str:
+    """Return the current time string (same format as the pre-#4891 block)."""
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+
+    try:
+        tz = ZoneInfo(timezone) if timezone else None
+    except Exception:
+        tz = None
+
+    now = datetime.now(tz=tz) if tz else datetime.now().astimezone()
+    offset = now.strftime("%z")
+    offset_fmt = f"{offset[:3]}:{offset[3:]}" if len(offset) == 5 else offset
+    tz_name = timezone or (now.strftime("%Z") or "UTC")
+    return f"{now.strftime('%Y-%m-%d %H:%M (%A)')} ({tz_name}, UTC{offset_fmt})"
+
+
+def current_time_provider(timezone: str | None = None):
+    """Build a per-turn provider that reports the current time in ``timezone``."""
+
+    async def _provider(_request: Any) -> list[RuntimeContextBlock]:
+        return [
+            RuntimeContextBlock(
+                source=TIME_CONTEXT_SOURCE,
+                content=(
+                    "[Runtime Context — current time]\n"
+                    f"Current Time: {current_time_str(timezone)}\n"
+                    "[/Runtime Context]"
+                ),
+            )
+        ]
+
+    return _provider

--- a/tests/agent/test_time_context.py
+++ b/tests/agent/test_time_context.py
@@ -1,0 +1,94 @@
+"""Tests for the built-in current-time runtime context provider (#5645)."""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from nanobot.agent.time_context import (
+    TIME_CONTEXT_SOURCE,
+    current_time_provider,
+    current_time_str,
+)
+
+
+class TestCurrentTimeStr:
+    def test_explicit_timezone_is_used(self):
+        result = current_time_str("Europe/Berlin")
+        assert "Europe/Berlin" in result
+        assert "UTC+" in result or "UTC-" in result
+
+    def test_invalid_timezone_falls_back_to_local(self):
+        # Must not raise; falls back to local time.
+        result = current_time_str("Not/AZone")
+        assert "Current" not in result  # sanity: this is the raw time string
+        assert len(result) > 0
+
+    def test_format_matches_pre_4891_shape(self):
+        result = current_time_str("UTC")
+        # YYYY-MM-DD HH:MM (Weekday) (TZ, UTC±HH:MM)
+        assert "(" in result and ")" in result
+        assert "UTC+00:00" in result
+
+
+class TestCurrentTimeProvider:
+    def test_provider_returns_block(self):
+        provider = current_time_provider("Europe/Berlin")
+        blocks = asyncio.run(provider(object()))
+        assert len(blocks) == 1
+        assert blocks[0].source == TIME_CONTEXT_SOURCE
+        assert "Current Time:" in blocks[0].content
+        assert "Europe/Berlin" in blocks[0].content
+
+    def test_content_is_delimited(self):
+        provider = current_time_provider(None)
+        blocks = asyncio.run(provider(object()))
+        assert blocks[0].content.startswith("[Runtime Context")
+        assert blocks[0].content.endswith("[/Runtime Context]")
+
+
+class TestAgentLoopRegistration:
+    @staticmethod
+    def _make_loop(tmp_path, **extra):
+        from nanobot.agent.loop import AgentLoop
+        from nanobot.bus.queue import MessageBus
+
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+
+        return AgentLoop(
+            bus=MessageBus(),
+            provider=provider,
+            workspace=tmp_path,
+            model="test-model",
+            **extra,
+        )
+
+    def test_loop_registers_provider_when_timezone_configured(self, tmp_path):
+        loop = self._make_loop(tmp_path, timezone="Europe/Berlin")
+        assert len(loop._runtime_context_providers) >= 1
+
+    def test_loop_skips_registration_without_timezone(self, tmp_path):
+        loop = self._make_loop(tmp_path)
+        assert len(loop._runtime_context_providers) == 0
+
+    @pytest.mark.asyncio
+    async def test_registered_provider_surfaces_current_time_block(self, tmp_path):
+        loop = self._make_loop(tmp_path, timezone="Europe/Berlin")
+        blocks = await loop._resolve_runtime_context_for_request(
+            request=type(
+                "R",
+                (),
+                {
+                    "metadata": {},
+                    "original_user_text": "",
+                    "session_key": "test-session",
+                    "workspace": None,
+                },
+            )(),
+            tools=loop.tools,
+        )
+        assert any(
+            b.source == TIME_CONTEXT_SOURCE and "Europe/Berlin" in b.content
+            for b in blocks
+        )


### PR DESCRIPTION
## Description

The #4891 runtime-context provider refactor removed `ContextBuilder`'s default injection, including the `Current Time` block. No built-in provider was registered on the new mechanism, so from 0.3.0 a configured `agents.defaults.timezone` has no effect on model turns — while the configuration docs still describe runtime time context (#5645). Verified against 0.2.2 vs 0.3.0 with the issue's reproduction: the runtime-context block disappears entirely.

This restores the capability on the provider mechanism the refactor introduced, rather than reverting the refactor:

- new `nanobot/agent/time_context.py` — `current_time_provider(timezone)` emits a `current_time`-sourced runtime context block per turn, using the same time format as the pre-#4891 block;
- `AgentLoop` registers it at construction when a timezone is configured.

No timezone configured, SDK-registered custom providers (`register_runtime_context_provider`), and `ContextBuilder`'s explicit `runtime_context_blocks` path behave exactly as before. The existing `test_runtime_context_is_not_injected_by_default` contract is untouched.

## Test plan

- [x] `tests/agent/test_time_context.py` — format parity with the pre-#4891 line, timezone fallback on invalid names, provider block shape/delimiters, loop registration (with/without timezone), and end-to-end resolution through `_resolve_runtime_context_for_request`
- [x] Full `test_context_builder.py` suite passes (60 tests) — default-injection contract unchanged
- [x] `ruff check` clean; `basedpyright` 0 errors

Fixes #5645