### PR TITLE
feat: make context compaction visible in channels

### DIFF
--- a/nanobot/agent/autocompact.py
+++ b/nanobot/agent/autocompact.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Callable, Coroutine
 
 from loguru import logger
 
+from nanobot.bus.outbound_events import ContextCompactionEvent
 from nanobot.session.manager import MIN_COMPACTED_REPLAY_MESSAGES, Session, SessionManager
 from nanobot.session.summary import SessionSummary, session_summary_from_metadata
 
@@ -15,18 +16,22 @@ if TYPE_CHECKING:
     from nanobot.agent.memory import Consolidator
     from nanobot.utils.llm_runtime import LLMRuntime
 
+IdleCompactionCallback = Callable[[str, ContextCompactionEvent], Coroutine[Any, Any, None]]
+
 
 class AutoCompact:
     _RECENT_SUFFIX_MESSAGES = MIN_COMPACTED_REPLAY_MESSAGES
     _INTERNAL_SESSION_PREFIXES = ("dream:",)
 
     def __init__(self, sessions: SessionManager, consolidator: Consolidator,
-                 session_ttl_minutes: int = 0):
+                 session_ttl_minutes: int = 0,
+                 on_compaction: IdleCompactionCallback | None = None):
         self.sessions = sessions
         self.consolidator = consolidator
         self._ttl = session_ttl_minutes
         self._archiving: set[str] = set()
         self._summaries: dict[str, SessionSummary] = {}
+        self._on_compaction = on_compaction
 
     def _is_expired(self, ts: datetime | str | None,
                     now: datetime | None = None) -> bool:
@@ -84,10 +89,18 @@ class AutoCompact:
             self._archiving.discard(key)
             return
         try:
+            async def _publish(event: ContextCompactionEvent) -> None:
+                if self._on_compaction is not None:
+                    await self._on_compaction(key, event)
+
+            event_callback: dict[str, Any] = {}
+            if self._on_compaction is not None:
+                event_callback["on_compaction"] = _publish
             summary = await self.consolidator.compact_idle_session(
                 key,
                 runtime=runtime,
                 max_suffix=self._RECENT_SUFFIX_MESSAGES,
+                **event_callback,
             )
             if summary and summary != "(nothing)":
                 session = self.sessions.get_or_create(key)

--- a/nanobot/agent/autocompact.py
+++ b/nanobot/agent/autocompact.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Callable, Coroutine
 
 from loguru import logger
 
-from nanobot.bus.outbound_events import ContextCompactionEvent
+from nanobot.bus.outbound_events import ContextCompactionCallback
 from nanobot.session.manager import MIN_COMPACTED_REPLAY_MESSAGES, Session, SessionManager
 from nanobot.session.summary import SessionSummary, session_summary_from_metadata
 
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from nanobot.agent.memory import Consolidator
     from nanobot.utils.llm_runtime import LLMRuntime
 
-IdleCompactionCallback = Callable[[str, ContextCompactionEvent], Coroutine[Any, Any, None]]
+IdleCompactionCallback = Callable[[str], ContextCompactionCallback | None]
 
 
 class AutoCompact:
@@ -25,13 +25,13 @@ class AutoCompact:
 
     def __init__(self, sessions: SessionManager, consolidator: Consolidator,
                  session_ttl_minutes: int = 0,
-                 on_compaction: IdleCompactionCallback | None = None):
+                 bind_compaction: IdleCompactionCallback | None = None):
         self.sessions = sessions
         self.consolidator = consolidator
         self._ttl = session_ttl_minutes
         self._archiving: set[str] = set()
         self._summaries: dict[str, SessionSummary] = {}
-        self._on_compaction = on_compaction
+        self._bind_compaction = bind_compaction
 
     def _is_expired(self, ts: datetime | str | None,
                     now: datetime | None = None) -> bool:
@@ -53,7 +53,10 @@ class AutoCompact:
 
     def _has_unarchived_messages(self, key: str) -> bool:
         session = self.sessions.get_or_create(key)
-        return session.last_archived < len(session.messages)
+        return any(
+            not message.get("_command")
+            for message in session.messages[session.last_archived:]
+        )
 
     @classmethod
     def _is_internal_session(cls, key: str) -> bool:
@@ -89,18 +92,11 @@ class AutoCompact:
             self._archiving.discard(key)
             return
         try:
-            async def _publish(event: ContextCompactionEvent) -> None:
-                if self._on_compaction is not None:
-                    await self._on_compaction(key, event)
-
-            event_callback: dict[str, Any] = {}
-            if self._on_compaction is not None:
-                event_callback["on_compaction"] = _publish
             summary = await self.consolidator.compact_idle_session(
                 key,
                 runtime=runtime,
                 max_suffix=self._RECENT_SUFFIX_MESSAGES,
-                **event_callback,
+                on_compaction=self._bind_compaction(key) if self._bind_compaction else None,
             )
             if summary and summary != "(nothing)":
                 session = self.sessions.get_or_create(key)

--- a/nanobot/agent/context_governance.py
+++ b/nanobot/agent/context_governance.py
@@ -14,10 +14,16 @@ from dataclasses import dataclass, replace
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
+from uuid import uuid4
 
 from loguru import logger
 
 from nanobot.agent.context import TranscriptInput
+from nanobot.bus.outbound_events import (
+    ContextCompactionCallback,
+    ContextCompactionEvent,
+    emit_context_compaction,
+)
 from nanobot.providers.base import (
     LLMResponse,
     LLMUsage,
@@ -36,6 +42,7 @@ from nanobot.runtime_context import (
 from nanobot.session.history_visibility import is_hidden_history_message
 from nanobot.session.summary import (
     SUMMARY_CONTINUATION_TEXT,
+    CompactionResult,
     SessionSummaryCheckpoint,
 )
 from nanobot.utils.helpers import (
@@ -54,11 +61,11 @@ if TYPE_CHECKING:
 TranscriptBuilder = Callable[[TranscriptInput], list[dict[str, Any]]]
 HistoryConsolidator = Callable[
     [list[dict[str, Any]], str | None],
-    Awaitable[str | None],
+    Awaitable[CompactionResult | None],
 ]
 ProviderCompactionConsolidator = Callable[
     [ProviderConversationState, list[dict[str, Any]], str | None],
-    Awaitable[str | None],
+    Awaitable[CompactionResult | None],
 ]
 
 SNIP_SAFETY_BUFFER = 1024
@@ -198,6 +205,7 @@ class ModelRequestState:
     tool_definitions: list[dict[str, Any]] | None = None
     compaction: ContextCompactionState | None = None
     provider_compaction_applied: bool = False
+    compaction_callback: ContextCompactionCallback | None = None
 
 
 class ContextGovernor:
@@ -493,17 +501,42 @@ class ContextGovernor:
             )
             return
 
-        summary = await compaction.consolidate_provider_compaction(
-            response.provider_compaction_state,
-            deepcopy(accepted_messages),
-            compaction.active_summary,
+        compaction_id = uuid4().hex
+        await emit_context_compaction(
+            state.compaction_callback,
+            ContextCompactionEvent(compaction_id=compaction_id, phase="started"),
         )
-        if not summary:
+        try:
+            result = await compaction.consolidate_provider_compaction(
+                response.provider_compaction_state,
+                deepcopy(accepted_messages),
+                compaction.active_summary,
+            )
+        except Exception:
+            await emit_context_compaction(
+                state.compaction_callback,
+                ContextCompactionEvent(compaction_id=compaction_id, phase="failed"),
+            )
+            raise
+        if result is None or not result.summary:
+            await emit_context_compaction(
+                state.compaction_callback,
+                ContextCompactionEvent(compaction_id=compaction_id, phase="failed"),
+            )
             return
+        summary = result.summary
         compaction.active_summary = summary
         compaction.summary_checkpoint = SessionSummaryCheckpoint(
             summary=summary,
             transcript_boundary=transcript_boundary,
+        )
+        await emit_context_compaction(
+            state.compaction_callback,
+            ContextCompactionEvent(
+                compaction_id=compaction_id,
+                phase="succeeded",
+                checkpoint_source=result.checkpoint_source,
+            ),
         )
 
     async def _compact_request_history(
@@ -516,46 +549,67 @@ class ContextGovernor:
         tool_definitions: list[dict[str, Any]] | None,
     ) -> list[dict[str, Any]]:
         """Replace accepted history H with a checkpoint while preserving delta."""
-        delta_messages = compaction.delta_after_accepted(messages)
-        consolidation_prefix = self.prepare_messages_for_model(
-            state.config,
-            compaction.accepted_messages,
+        measured, _source = pressure
+        compaction_id = uuid4().hex
+        await emit_context_compaction(
+            state.compaction_callback,
+            ContextCompactionEvent(compaction_id=compaction_id, phase="started"),
         )
-        summary = await compaction.consolidate_history(
-            deepcopy(consolidation_prefix),
-            compaction.active_summary,
-        )
-        if not summary:
-            measured, source = pressure
-            raise ContextWindowExceededError(
-                session_key=state.config.session_key,
-                estimated_tokens=measured,
-                input_budget=self.input_budget(state.config),
-                source=source,
+        try:
+            delta_messages = compaction.delta_after_accepted(messages)
+            consolidation_prefix = self.prepare_messages_for_model(
+                state.config,
+                compaction.accepted_messages,
             )
+            result = await compaction.consolidate_history(
+                deepcopy(consolidation_prefix),
+                compaction.active_summary,
+            )
+            if result is None or not result.summary:
+                raise ContextWindowExceededError(
+                    session_key=state.config.session_key,
+                    estimated_tokens=measured,
+                    input_budget=self.input_budget(state.config),
+                    source=_source,
+                )
 
-        compaction.active_summary = summary
-        prepared = self.prepare_messages_for_model(
-            state.config,
-            [
-                *self._summary_transcript(compaction, summary),
-                {"role": "user", "content": SUMMARY_CONTINUATION_TEXT},
-                *delta_messages,
-            ],
-        )
-        # Responses-style state is append-only. Replacing H with a
-        # checkpoint requires a fresh request; a successful response may
-        # establish a new provider-owned state at the rewritten boundary.
-        state.conversation.replace_transcript(compaction.raw_messages)
-        state.usage = None
-        prepared = self.ensure_request_fits(
-            state.config,
-            prepared,
-            tool_definitions=tool_definitions,
-        )
-        compaction.summary_checkpoint = SessionSummaryCheckpoint(
-            summary=summary,
-            transcript_boundary=compaction.raw_accepted_boundary,
+            summary = result.summary
+            compaction.active_summary = summary
+            prepared = self.prepare_messages_for_model(
+                state.config,
+                [
+                    *self._summary_transcript(compaction, summary),
+                    {"role": "user", "content": SUMMARY_CONTINUATION_TEXT},
+                    *delta_messages,
+                ],
+            )
+            # Responses-style state is append-only. Replacing H with a
+            # checkpoint requires a fresh request; a successful response may
+            # establish a new provider-owned state at the rewritten boundary.
+            state.conversation.replace_transcript(compaction.raw_messages)
+            state.usage = None
+            prepared = self.ensure_request_fits(
+                state.config,
+                prepared,
+                tool_definitions=tool_definitions,
+            )
+            compaction.summary_checkpoint = SessionSummaryCheckpoint(
+                summary=summary,
+                transcript_boundary=compaction.raw_accepted_boundary,
+            )
+        except Exception:
+            await emit_context_compaction(
+                state.compaction_callback,
+                ContextCompactionEvent(compaction_id=compaction_id, phase="failed"),
+            )
+            raise
+        await emit_context_compaction(
+            state.compaction_callback,
+            ContextCompactionEvent(
+                compaction_id=compaction_id,
+                phase="succeeded",
+                checkpoint_source=result.checkpoint_source,
+            ),
         )
         return prepared
 
@@ -590,7 +644,7 @@ class ContextGovernor:
         request_was_fitted = False
         compaction = state.compaction
         if compaction is None:
-            prepared, request_was_fitted = self.fit_request(
+            pressure = self.request_pressure(
                 state.config,
                 prepared,
                 state.usage,
@@ -598,6 +652,29 @@ class ContextGovernor:
                 tool_definitions=tool_definitions,
                 request_context_tokens=request_context_tokens,
             )
+            if pressure is not None:
+                compaction_id = uuid4().hex
+                await emit_context_compaction(
+                    state.compaction_callback,
+                    ContextCompactionEvent(compaction_id=compaction_id, phase="started"),
+                )
+                try:
+                    prepared = self.fit_to_budget(
+                        state.config,
+                        prepared,
+                        tool_definitions=tool_definitions,
+                    )
+                except Exception:
+                    await emit_context_compaction(
+                        state.compaction_callback,
+                        ContextCompactionEvent(compaction_id=compaction_id, phase="failed"),
+                    )
+                    raise
+                await emit_context_compaction(
+                    state.compaction_callback,
+                    ContextCompactionEvent(compaction_id=compaction_id, phase="succeeded"),
+                )
+                request_was_fitted = True
         else:
             pressure = self.request_pressure(
                 state.config,

--- a/nanobot/agent/context_governance.py
+++ b/nanobot/agent/context_governance.py
@@ -8,6 +8,7 @@ session history list in place.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable
 from copy import deepcopy
 from dataclasses import dataclass, replace
@@ -42,7 +43,6 @@ from nanobot.runtime_context import (
 from nanobot.session.history_visibility import is_hidden_history_message
 from nanobot.session.summary import (
     SUMMARY_CONTINUATION_TEXT,
-    CompactionResult,
     SessionSummaryCheckpoint,
 )
 from nanobot.utils.helpers import (
@@ -61,11 +61,11 @@ if TYPE_CHECKING:
 TranscriptBuilder = Callable[[TranscriptInput], list[dict[str, Any]]]
 HistoryConsolidator = Callable[
     [list[dict[str, Any]], str | None],
-    Awaitable[CompactionResult | None],
+    Awaitable[str | None],
 ]
 ProviderCompactionConsolidator = Callable[
     [ProviderConversationState, list[dict[str, Any]], str | None],
-    Awaitable[CompactionResult | None],
+    Awaitable[str | None],
 ]
 
 SNIP_SAFETY_BUFFER = 1024
@@ -420,33 +420,6 @@ class ContextGovernor:
             return None
         return measured, source
 
-    def fit_request(
-        self,
-        config: ContextGovernanceConfig,
-        messages: list[dict[str, Any]],
-        usage: LLMUsage | None,
-        *,
-        usage_matches_messages: bool,
-        tool_definitions: list[dict[str, Any]] | None,
-        request_context_tokens: int | None = None,
-    ) -> tuple[list[dict[str, Any]], bool]:
-        """Fit the request when its measured or estimated input is pressured."""
-        pressure = self.request_pressure(
-            config,
-            messages,
-            usage,
-            usage_matches_messages=usage_matches_messages,
-            tool_definitions=tool_definitions,
-            request_context_tokens=request_context_tokens,
-        )
-        if pressure is None:
-            return messages, False
-        return self.fit_to_budget(
-            config,
-            messages,
-            tool_definitions=tool_definitions,
-        ), True
-
     @staticmethod
     def _summary_transcript(
         compaction: ContextCompactionState,
@@ -507,24 +480,26 @@ class ContextGovernor:
             ContextCompactionEvent(compaction_id=compaction_id, phase="started"),
         )
         try:
-            result = await compaction.consolidate_provider_compaction(
+            summary = await compaction.consolidate_provider_compaction(
                 response.provider_compaction_state,
                 deepcopy(accepted_messages),
                 compaction.active_summary,
             )
-        except Exception:
+        except (Exception, asyncio.CancelledError) as exc:
             await emit_context_compaction(
                 state.compaction_callback,
-                ContextCompactionEvent(compaction_id=compaction_id, phase="failed"),
+                ContextCompactionEvent(
+                    compaction_id=compaction_id,
+                    phase="cancelled" if isinstance(exc, asyncio.CancelledError) else "failed",
+                ),
             )
             raise
-        if result is None or not result.summary:
+        if not summary:
             await emit_context_compaction(
                 state.compaction_callback,
                 ContextCompactionEvent(compaction_id=compaction_id, phase="failed"),
             )
             return
-        summary = result.summary
         compaction.active_summary = summary
         compaction.summary_checkpoint = SessionSummaryCheckpoint(
             summary=summary,
@@ -535,7 +510,6 @@ class ContextGovernor:
             ContextCompactionEvent(
                 compaction_id=compaction_id,
                 phase="succeeded",
-                checkpoint_source=result.checkpoint_source,
             ),
         )
 
@@ -561,11 +535,11 @@ class ContextGovernor:
                 state.config,
                 compaction.accepted_messages,
             )
-            result = await compaction.consolidate_history(
+            summary = await compaction.consolidate_history(
                 deepcopy(consolidation_prefix),
                 compaction.active_summary,
             )
-            if result is None or not result.summary:
+            if not summary:
                 raise ContextWindowExceededError(
                     session_key=state.config.session_key,
                     estimated_tokens=measured,
@@ -573,7 +547,6 @@ class ContextGovernor:
                     source=_source,
                 )
 
-            summary = result.summary
             compaction.active_summary = summary
             prepared = self.prepare_messages_for_model(
                 state.config,
@@ -597,10 +570,13 @@ class ContextGovernor:
                 summary=summary,
                 transcript_boundary=compaction.raw_accepted_boundary,
             )
-        except Exception:
+        except (Exception, asyncio.CancelledError) as exc:
             await emit_context_compaction(
                 state.compaction_callback,
-                ContextCompactionEvent(compaction_id=compaction_id, phase="failed"),
+                ContextCompactionEvent(
+                    compaction_id=compaction_id,
+                    phase="cancelled" if isinstance(exc, asyncio.CancelledError) else "failed",
+                ),
             )
             raise
         await emit_context_compaction(
@@ -608,7 +584,6 @@ class ContextGovernor:
             ContextCompactionEvent(
                 compaction_id=compaction_id,
                 phase="succeeded",
-                checkpoint_source=result.checkpoint_source,
             ),
         )
         return prepared

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -52,13 +52,12 @@ from nanobot.agent.turn_hooks import AgentTurnHookSpec, build_agent_turn_hook
 from nanobot.bus.events import INBOUND_META_USER_SHELL, InboundMessage, OutboundMessage
 from nanobot.bus.outbound_events import (
     ContextCompactionCallback,
-    ContextCompactionEvent,
     StreamedResponseEvent,
-    outbound_message_for_event,
 )
 from nanobot.bus.queue import MessageBus
 from nanobot.bus.runtime_events import RuntimeEventBus
 from nanobot.command import CommandContext, CommandRouter, register_builtin_commands
+from nanobot.command.router import normalize_command_text
 from nanobot.config.schema import AgentDefaults, ModelPresetConfig
 from nanobot.llm_usage.context import source_from_request
 from nanobot.providers.base import LLMProvider, LLMUsage, ProviderConversationState
@@ -84,11 +83,7 @@ from nanobot.session.goal_state import (
     runner_wall_llm_timeout_s,
 )
 from nanobot.session.history_visibility import HIDDEN_HISTORY_META
-from nanobot.session.keys import (
-    UNIFIED_SESSION_KEY,
-    last_channel_from_metadata,
-    remember_last_channel,
-)
+from nanobot.session.keys import UNIFIED_SESSION_KEY, remember_last_channel
 from nanobot.session.manager import SESSION_CACHE_MAX_SIZE, Session, SessionManager
 from nanobot.session.model_selection import (
     SESSION_MODEL_PRESET_METADATA_KEY,
@@ -465,7 +460,7 @@ class AgentLoop:
             sessions=self.sessions,
             consolidator=self.consolidator,
             session_ttl_minutes=session_ttl_minutes,
-            on_compaction=self._publish_idle_compaction,
+            bind_compaction=self._idle_compaction_callback,
         )
         self._idle_compact_check_interval_s = idle_compact_check_interval_seconds
         self._next_idle_compact_check_at = time.monotonic()
@@ -808,6 +803,14 @@ class AgentLoop:
         dispatch_fn: Callable[[CommandContext], Awaitable[OutboundMessage | None]],
     ) -> None:
         """Dispatch a command directly from the run() loop and publish the result."""
+        if normalize_command_text(raw).lower() == "/compact":
+            # Compaction must wait for the active turn to commit its session.
+            task = asyncio.create_task(self._dispatch(msg))
+            self._track_active_task(key, task)
+            # Enter dispatch's cancellation handler before consuming a queued /stop.
+            await asyncio.sleep(0)
+            return
+
         async def dispatch_and_publish() -> None:
             ctx = CommandContext(msg=msg, session=None, key=key, raw=raw, loop=self)
             result = await dispatch_fn(ctx)
@@ -919,50 +922,27 @@ class AgentLoop:
             return UNIFIED_SESSION_KEY
         return msg.session_key
 
-    async def _publish_idle_compaction(
+    def _idle_compaction_callback(
         self,
         session_key: str,
-        event: ContextCompactionEvent,
-    ) -> None:
-        """Route an idle compaction back to its last concrete channel."""
+    ) -> ContextCompactionCallback | None:
+        """Bind one idle compaction to its current user-facing destination."""
         session = self.sessions.get_or_create(session_key)
-        route = (
-            last_channel_from_metadata(session.metadata)
-            if session_key == UNIFIED_SESSION_KEY
-            else None
-        )
-        metadata: dict[str, Any] = {}
-        if route is None:
-            if ":" not in session_key:
-                logger.debug("No channel route for idle compaction of {}", session_key)
-                return
-            channel, chat_id = session_key.split(":", 1)
-            if channel == "slack" and ":" in chat_id:
-                chat_id, thread_ts = chat_id.split(":", 1)
-                metadata = {"slack": {"thread_ts": thread_ts}}
-            route = (channel, chat_id)
-        channel, chat_id = route
-        await self.bus.publish_outbound(
-            outbound_message_for_event(
-                channel=channel,
-                chat_id=chat_id,
-                event=event,
-                metadata=metadata,
-            )
+        return self.turn_delivery_factory.session_compaction_callback(
+            session_key, session.metadata,
         )
 
-    def _remember_unified_session_route(
+    def _remember_session_route(
         self,
         session: Session,
         msg: InboundMessage,
         *,
+        delivery: TurnDelivery,
         is_user_turn: bool,
     ) -> None:
-        """Remember the latest user-facing route for unified-session delivery."""
+        """Remember the latest user-facing destination, including channel threads."""
         if (
-            not self._unified_session
-            or session.key != UNIFIED_SESSION_KEY
-            or not is_user_turn
+            not is_user_turn
             or msg.channel in {"cli", "system"}
             or msg.sender_id == "subagent"
         ):
@@ -970,7 +950,9 @@ class AgentLoop:
         _, automation_metadata = automation_history_overrides(msg.metadata)
         if automation_metadata:
             return
-        remember_last_channel(session.metadata, msg.channel, msg.chat_id)
+        delivery.remember_session_route(session.metadata)
+        if self._unified_session and session.key == UNIFIED_SESSION_KEY:
+            remember_last_channel(session.metadata, msg.channel, msg.chat_id)
 
     async def _run_agent_loop(
         self,
@@ -1463,6 +1445,7 @@ class AgentLoop:
 
         delivery = self.turn_delivery_factory.unrouted(msg, session_key)
         pending: asyncio.Queue[InboundMessage] | None = None
+        completion_published = False
         try:
             async with lock, gate:
                 # Only the task that owns the session lock may publish the
@@ -1487,6 +1470,7 @@ class AgentLoop:
                         response,
                         publish_completion=not continuing,
                     )
+                    completion_published = not continuing
                     for _, coordinator in self._automation_turn_coordinators:
                         coordinator.complete(msg, response=response)
                 except asyncio.CancelledError:
@@ -1564,6 +1548,10 @@ class AgentLoop:
                     if not turn_continuation.internal_continuation_pending(msg.metadata):
                         await delivery.idle()
                     await self._publish_next_deferred_automation_turn(session_key)
+        except asyncio.CancelledError:
+            if not completion_published and normalize_command_text(msg.content).lower() == "/compact":
+                await delivery.complete(None, publish_completion=True)
+            raise
         finally:
             if (
                 recovery_task_registered
@@ -1855,9 +1843,10 @@ class AgentLoop:
         else:
             logger.info("Processing message from {}:{}: [content hidden]", msg.channel, msg.sender_id)
 
-        self._remember_unified_session_route(
+        self._remember_session_route(
             session,
             msg,
+            delivery=ctx.delivery,
             is_user_turn=ctx.original_user_text is not None,
         )
         await ctx.delivery.started()
@@ -1904,11 +1893,8 @@ class AgentLoop:
         )
         result = await self.commands.dispatch(cmd_ctx)
         if cmd_ctx.raw.lower() == "/compact":
-            # Manual compaction reloads the session under its consolidation
-            # lock. Continue command persistence against that committed object.
-            self.sessions.invalidate(ctx.session_key)
-            session = self.sessions.get_or_create(ctx.session_key)
-            ctx.session = session
+            # Compaction reports through events, not an archiveable command reply.
+            return True
         if result is not None:
             ctx.outbound = result
             # Shortcut commands skip BUILD and SAVE, so we must persist the

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -50,7 +50,12 @@ from nanobot.agent.turn_delivery import (
 from nanobot.agent.turn_delivery import TurnRoute as TurnRoute
 from nanobot.agent.turn_hooks import AgentTurnHookSpec, build_agent_turn_hook
 from nanobot.bus.events import INBOUND_META_USER_SHELL, InboundMessage, OutboundMessage
-from nanobot.bus.outbound_events import StreamedResponseEvent
+from nanobot.bus.outbound_events import (
+    ContextCompactionCallback,
+    ContextCompactionEvent,
+    StreamedResponseEvent,
+    outbound_message_for_event,
+)
 from nanobot.bus.queue import MessageBus
 from nanobot.bus.runtime_events import RuntimeEventBus
 from nanobot.command import CommandContext, CommandRouter, register_builtin_commands
@@ -79,7 +84,11 @@ from nanobot.session.goal_state import (
     runner_wall_llm_timeout_s,
 )
 from nanobot.session.history_visibility import HIDDEN_HISTORY_META
-from nanobot.session.keys import UNIFIED_SESSION_KEY, remember_last_channel
+from nanobot.session.keys import (
+    UNIFIED_SESSION_KEY,
+    last_channel_from_metadata,
+    remember_last_channel,
+)
 from nanobot.session.manager import SESSION_CACHE_MAX_SIZE, Session, SessionManager
 from nanobot.session.model_selection import (
     SESSION_MODEL_PRESET_METADATA_KEY,
@@ -456,6 +465,7 @@ class AgentLoop:
             sessions=self.sessions,
             consolidator=self.consolidator,
             session_ttl_minutes=session_ttl_minutes,
+            on_compaction=self._publish_idle_compaction,
         )
         self._idle_compact_check_interval_s = idle_compact_check_interval_seconds
         self._next_idle_compact_check_at = time.monotonic()
@@ -909,6 +919,38 @@ class AgentLoop:
             return UNIFIED_SESSION_KEY
         return msg.session_key
 
+    async def _publish_idle_compaction(
+        self,
+        session_key: str,
+        event: ContextCompactionEvent,
+    ) -> None:
+        """Route an idle compaction back to its last concrete channel."""
+        session = self.sessions.get_or_create(session_key)
+        route = (
+            last_channel_from_metadata(session.metadata)
+            if session_key == UNIFIED_SESSION_KEY
+            else None
+        )
+        metadata: dict[str, Any] = {}
+        if route is None:
+            if ":" not in session_key:
+                logger.debug("No channel route for idle compaction of {}", session_key)
+                return
+            channel, chat_id = session_key.split(":", 1)
+            if channel == "slack" and ":" in chat_id:
+                chat_id, thread_ts = chat_id.split(":", 1)
+                metadata = {"slack": {"thread_ts": thread_ts}}
+            route = (channel, chat_id)
+        channel, chat_id = route
+        await self.bus.publish_outbound(
+            outbound_message_for_event(
+                channel=channel,
+                chat_id=chat_id,
+                event=event,
+                metadata=metadata,
+            )
+        )
+
     def _remember_unified_session_route(
         self,
         session: Session,
@@ -937,6 +979,7 @@ class AgentLoop:
         on_stream: Callable[[str], Awaitable[None]] | None = None,
         on_stream_end: Callable[..., Awaitable[None]] | None = None,
         on_retry_wait: Callable[[str], Awaitable[None]] | None = None,
+        on_context_compaction: ContextCompactionCallback | None = None,
         *,
         runtime: LLMRuntime,
         session: Session | None = None,
@@ -1222,6 +1265,7 @@ class AgentLoop:
                     channel=request_ctx.channel,
                     metadata=request_metadata,
                 ),
+                compaction_callback=on_context_compaction,
             ))
         finally:
             turn_scope_stack.close()
@@ -1859,6 +1903,12 @@ class AgentLoop:
             turn_scopes=ctx.turn_scopes,
         )
         result = await self.commands.dispatch(cmd_ctx)
+        if cmd_ctx.raw.lower() == "/compact":
+            # Manual compaction reloads the session under its consolidation
+            # lock. Continue command persistence against that committed object.
+            self.sessions.invalidate(ctx.session_key)
+            session = self.sessions.get_or_create(ctx.session_key)
+            ctx.session = session
         if result is not None:
             ctx.outbound = result
             # Shortcut commands skip BUILD and SAVE, so we must persist the
@@ -2022,6 +2072,7 @@ class AgentLoop:
                 tools=ctx.tools,
                 request_context=ctx.request_context,
                 provider_state=ctx.provider_state,
+                on_context_compaction=ctx.delivery.context_compaction,
             )
         ctx.final_content = result.final_content
         ctx.all_messages = result.messages

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -34,7 +34,7 @@ from nanobot.session.manager import (
     Session,
     SessionManager,
 )
-from nanobot.session.summary import CompactionResult, session_summary_from_metadata
+from nanobot.session.summary import session_summary_from_metadata
 from nanobot.utils.gitstore import GitStore
 from nanobot.utils.helpers import (
     content_with_media_breadcrumbs,
@@ -784,16 +784,13 @@ class MemoryArchiver:
         session_key: str,
         previous_summary: str | None,
         max_tokens: int,
-    ) -> CompactionResult:
+    ) -> str:
         """Persist the failed chunk and return a bounded replacement checkpoint."""
         raw = self.store.raw_archive(messages, session_key=session_key)
-        return CompactionResult(
-            summary=self._combine_raw_checkpoint(
-                raw,
-                previous_summary=previous_summary,
-                max_tokens=max_tokens,
-            ),
-            checkpoint_source="raw_fallback",
+        return self._combine_raw_checkpoint(
+            raw,
+            previous_summary=previous_summary,
+            max_tokens=max_tokens,
         )
 
     @staticmethod
@@ -840,12 +837,12 @@ class MemoryArchiver:
         input_token_budget: int | None = None,
         fallback_max_tokens: int | None = None,
         provider_state: ProviderConversationState | None = None,
-    ) -> CompactionResult | None:
+    ) -> str | None:
         """Append the archive prompt to H and persist its summary."""
         if not source_messages:
             return None
 
-        def raw_fallback() -> CompactionResult:
+        def raw_fallback() -> str:
             return self._raw_checkpoint(
                 source_messages,
                 session_key=session_key,
@@ -939,11 +936,9 @@ class MemoryArchiver:
         if not summary:
             logger.warning("Memory archive provider summary was not safe to replay, raw-dumping")
             return raw_fallback()
-        if summary == "(nothing)":
-            return CompactionResult(summary=summary, checkpoint_source="llm_summary")
-        self.store.append_history(summary, session_key=session_key)
-        logger.debug("Memory archive LLM summary for {}:\n{}", session_key, summary)
-        return CompactionResult(summary=summary, checkpoint_source="llm_summary")
+        if summary != "(nothing)":
+            self.store.append_history(summary, session_key=session_key)
+        return summary
 
     async def archive_session(
         self,
@@ -952,9 +947,12 @@ class MemoryArchiver:
         archive_end: int,
         runtime: LLMRuntime,
         input_token_budget: int,
-    ) -> CompactionResult | None:
+    ) -> str | None:
         """Archive a captured session prefix without mutating the session."""
-        messages = list(session.messages[session.last_archived:archive_end])
+        messages = [
+            message for message in session.messages[session.last_archived:archive_end]
+            if not message.get("_command")
+        ]
         if not messages:
             return None
         session_summary = session_summary_from_metadata(
@@ -1058,7 +1056,7 @@ class Consolidator:
         session_key: str,
         tools: list[dict[str, Any]],
         provider_state: ProviderConversationState | None = None,
-    ) -> CompactionResult | None:
+    ) -> str | None:
         """Summarize the exact transcript prefix already accepted by the model."""
         source_messages = [
             dict(message)
@@ -1075,7 +1073,7 @@ class Consolidator:
             max(1, (input_token_budget - self._SAFETY_BUFFER) // 2),
         )
 
-        result = await self.archiver.archive(
+        summary = await self.archiver.archive(
             source_messages,
             runtime=runtime,
             session_key=session_key,
@@ -1086,19 +1084,16 @@ class Consolidator:
             fallback_max_tokens=max(1, checkpoint_tokens),
             provider_state=provider_state,
         )
-        if result is not None and result.summary == "(nothing)":
-            result = self.archiver._raw_checkpoint(
+        if summary == "(nothing)":
+            summary = self.archiver._raw_checkpoint(
                 source_messages,
                 session_key=session_key,
                 previous_summary=previous_summary,
                 max_tokens=max_output_tokens,
             )
-        if result is None:
+        if summary is None:
             return None
-        return CompactionResult(
-            summary=truncate_text_to_tokens(result.summary, max(1, max_output_tokens)),
-            checkpoint_source=result.checkpoint_source,
-        )
+        return truncate_text_to_tokens(summary, max(1, max_output_tokens))
 
     async def summarize_provider_compaction(
         self,
@@ -1109,7 +1104,7 @@ class Consolidator:
         runtime: LLMRuntime,
         session_key: str,
         tools: list[dict[str, Any]],
-    ) -> CompactionResult | None:
+    ) -> str | None:
         """Prompt a native compacted state without replaying its raw history."""
         return await self.summarize_transcript(
             fallback_messages,
@@ -1182,7 +1177,7 @@ class Consolidator:
         *,
         archive_end: int,
         runtime: LLMRuntime,
-    ) -> CompactionResult | None:
+    ) -> str | None:
         """Archive one captured session range through the shared Memory path."""
         return await self.archiver.archive_session(
             session,
@@ -1219,7 +1214,7 @@ class Consolidator:
 
             archive_start = session.last_archived
             messages_to_archive = list(session.messages[archive_start:])
-            if not messages_to_archive:
+            if not any(not message.get("_command") for message in messages_to_archive):
                 return ""
 
             compaction_id = uuid4().hex
@@ -1230,15 +1225,15 @@ class Consolidator:
             last_active = session.updated_at
             archive_end = archive_start + len(messages_to_archive)
             try:
-                result = await self.archive_session(
+                summary = await self.archive_session(
                     session,
                     archive_end=archive_end,
                     runtime=runtime,
                 )
-                if result is not None:
+                if summary is not None:
                     self._set_last_summary(
                         session,
-                        result.summary,
+                        summary,
                         last_active=last_active,
                     )
 
@@ -1246,13 +1241,16 @@ class Consolidator:
                     # through the captured batch so new messages remain eligible next time.
                     session.last_archived = archive_end
                     self.sessions.save(session)
-            except Exception:
+            except (Exception, asyncio.CancelledError) as exc:
                 await emit_context_compaction(
                     on_compaction,
-                    ContextCompactionEvent(compaction_id=compaction_id, phase="failed"),
+                    ContextCompactionEvent(
+                        compaction_id=compaction_id,
+                        phase="cancelled" if isinstance(exc, asyncio.CancelledError) else "failed",
+                    ),
                 )
                 raise
-            if result is None:
+            if summary is None:
                 await emit_context_compaction(
                     on_compaction,
                     ContextCompactionEvent(compaction_id=compaction_id, phase="failed"),
@@ -1264,7 +1262,6 @@ class Consolidator:
                 ContextCompactionEvent(
                     compaction_id=compaction_id,
                     phase="succeeded",
-                    checkpoint_source=result.checkpoint_source,
                 ),
             )
 
@@ -1279,7 +1276,7 @@ class Consolidator:
                 len(messages_to_archive),
                 len(visible),
                 len(session.messages),
-                bool(result.summary),
+                bool(summary),
             )
 
-            return result.summary
+            return summary

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -17,9 +17,15 @@ from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Iterator, cast
+from uuid import uuid4
 
 from loguru import logger
 
+from nanobot.bus.outbound_events import (
+    ContextCompactionCallback,
+    ContextCompactionEvent,
+    emit_context_compaction,
+)
 from nanobot.llm_usage.context import llm_usage_source
 from nanobot.providers.base import ProviderCallContext, ProviderConversationState
 from nanobot.runtime_context import public_history_messages
@@ -28,7 +34,7 @@ from nanobot.session.manager import (
     Session,
     SessionManager,
 )
-from nanobot.session.summary import session_summary_from_metadata
+from nanobot.session.summary import CompactionResult, session_summary_from_metadata
 from nanobot.utils.gitstore import GitStore
 from nanobot.utils.helpers import (
     content_with_media_breadcrumbs,
@@ -778,13 +784,16 @@ class MemoryArchiver:
         session_key: str,
         previous_summary: str | None,
         max_tokens: int,
-    ) -> str:
+    ) -> CompactionResult:
         """Persist the failed chunk and return a bounded replacement checkpoint."""
         raw = self.store.raw_archive(messages, session_key=session_key)
-        return self._combine_raw_checkpoint(
-            raw,
-            previous_summary=previous_summary,
-            max_tokens=max_tokens,
+        return CompactionResult(
+            summary=self._combine_raw_checkpoint(
+                raw,
+                previous_summary=previous_summary,
+                max_tokens=max_tokens,
+            ),
+            checkpoint_source="raw_fallback",
         )
 
     @staticmethod
@@ -831,12 +840,12 @@ class MemoryArchiver:
         input_token_budget: int | None = None,
         fallback_max_tokens: int | None = None,
         provider_state: ProviderConversationState | None = None,
-    ) -> str | None:
+    ) -> CompactionResult | None:
         """Append the archive prompt to H and persist its summary."""
         if not source_messages:
             return None
 
-        def raw_fallback() -> str:
+        def raw_fallback() -> CompactionResult:
             return self._raw_checkpoint(
                 source_messages,
                 session_key=session_key,
@@ -931,9 +940,10 @@ class MemoryArchiver:
             logger.warning("Memory archive provider summary was not safe to replay, raw-dumping")
             return raw_fallback()
         if summary == "(nothing)":
-            return "(nothing)"
+            return CompactionResult(summary=summary, checkpoint_source="llm_summary")
         self.store.append_history(summary, session_key=session_key)
-        return summary
+        logger.debug("Memory archive LLM summary for {}:\n{}", session_key, summary)
+        return CompactionResult(summary=summary, checkpoint_source="llm_summary")
 
     async def archive_session(
         self,
@@ -942,7 +952,7 @@ class MemoryArchiver:
         archive_end: int,
         runtime: LLMRuntime,
         input_token_budget: int,
-    ) -> str | None:
+    ) -> CompactionResult | None:
         """Archive a captured session prefix without mutating the session."""
         messages = list(session.messages[session.last_archived:archive_end])
         if not messages:
@@ -1048,7 +1058,7 @@ class Consolidator:
         session_key: str,
         tools: list[dict[str, Any]],
         provider_state: ProviderConversationState | None = None,
-    ) -> str | None:
+    ) -> CompactionResult | None:
         """Summarize the exact transcript prefix already accepted by the model."""
         source_messages = [
             dict(message)
@@ -1065,7 +1075,7 @@ class Consolidator:
             max(1, (input_token_budget - self._SAFETY_BUFFER) // 2),
         )
 
-        summary = await self.archiver.archive(
+        result = await self.archiver.archive(
             source_messages,
             runtime=runtime,
             session_key=session_key,
@@ -1076,16 +1086,19 @@ class Consolidator:
             fallback_max_tokens=max(1, checkpoint_tokens),
             provider_state=provider_state,
         )
-        if summary == "(nothing)":
-            summary = self.archiver._raw_checkpoint(
+        if result is not None and result.summary == "(nothing)":
+            result = self.archiver._raw_checkpoint(
                 source_messages,
                 session_key=session_key,
                 previous_summary=previous_summary,
                 max_tokens=max_output_tokens,
             )
-        if summary is None:
+        if result is None:
             return None
-        return truncate_text_to_tokens(summary, max(1, max_output_tokens))
+        return CompactionResult(
+            summary=truncate_text_to_tokens(result.summary, max(1, max_output_tokens)),
+            checkpoint_source=result.checkpoint_source,
+        )
 
     async def summarize_provider_compaction(
         self,
@@ -1096,7 +1109,7 @@ class Consolidator:
         runtime: LLMRuntime,
         session_key: str,
         tools: list[dict[str, Any]],
-    ) -> str | None:
+    ) -> CompactionResult | None:
         """Prompt a native compacted state without replaying its raw history."""
         return await self.summarize_transcript(
             fallback_messages,
@@ -1169,7 +1182,7 @@ class Consolidator:
         *,
         archive_end: int,
         runtime: LLMRuntime,
-    ) -> str | None:
+    ) -> CompactionResult | None:
         """Archive one captured session range through the shared Memory path."""
         return await self.archiver.archive_session(
             session,
@@ -1184,6 +1197,7 @@ class Consolidator:
         *,
         runtime: LLMRuntime,
         max_suffix: int = MIN_COMPACTED_REPLAY_MESSAGES,
+        on_compaction: ContextCompactionCallback | None = None,
     ) -> str | None:
         """Archive the full idle tail while keeping recent messages replayable.
 
@@ -1208,22 +1222,51 @@ class Consolidator:
             if not messages_to_archive:
                 return ""
 
+            compaction_id = uuid4().hex
+            await emit_context_compaction(
+                on_compaction,
+                ContextCompactionEvent(compaction_id=compaction_id, phase="started"),
+            )
             last_active = session.updated_at
             archive_end = archive_start + len(messages_to_archive)
-            summary = await self.archive_session(
-                session,
-                archive_end=archive_end,
-                runtime=runtime,
-            )
-            if summary is None:
+            try:
+                result = await self.archive_session(
+                    session,
+                    archive_end=archive_end,
+                    runtime=runtime,
+                )
+                if result is not None:
+                    self._set_last_summary(
+                        session,
+                        result.summary,
+                        last_active=last_active,
+                    )
+
+                    # A turn can append while the provider call is in flight. Advance only
+                    # through the captured batch so new messages remain eligible next time.
+                    session.last_archived = archive_end
+                    self.sessions.save(session)
+            except Exception:
+                await emit_context_compaction(
+                    on_compaction,
+                    ContextCompactionEvent(compaction_id=compaction_id, phase="failed"),
+                )
+                raise
+            if result is None:
+                await emit_context_compaction(
+                    on_compaction,
+                    ContextCompactionEvent(compaction_id=compaction_id, phase="failed"),
+                )
                 return None
 
-            self._set_last_summary(session, summary, last_active=last_active)
-
-            # A turn can append while the provider call is in flight. Advance only
-            # through the captured batch so new messages remain eligible next time.
-            session.last_archived = archive_end
-            self.sessions.save(session)
+            await emit_context_compaction(
+                on_compaction,
+                ContextCompactionEvent(
+                    compaction_id=compaction_id,
+                    phase="succeeded",
+                    checkpoint_source=result.checkpoint_source,
+                ),
+            )
 
             visible = session.get_history(
                 max_messages=MIN_COMPACTED_REPLAY_MESSAGES,
@@ -1236,7 +1279,7 @@ class Consolidator:
                 len(messages_to_archive),
                 len(visible),
                 len(session.messages),
-                bool(summary),
+                bool(result.summary),
             )
 
-            return summary
+            return result.summary

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -27,6 +27,7 @@ from nanobot.agent.context_governance import (
 from nanobot.agent.hook import AgentHook, AgentHookContext, AgentRunHookContext
 from nanobot.agent.tools.execution import execute_tool_calls
 from nanobot.agent.tools.registry import ToolRegistry
+from nanobot.bus.outbound_events import ContextCompactionCallback
 from nanobot.llm_usage.context import (
     LLMUsageSource,
     bind_llm_usage_source,
@@ -116,6 +117,7 @@ class AgentRunSpec:
     finalize_on_max_iterations: bool = True
     provider_state: ProviderConversationState | None = None
     llm_usage_source: LLMUsageSource | None = None
+    compaction_callback: ContextCompactionCallback | None = None
 
 
 @dataclass(slots=True)
@@ -431,6 +433,7 @@ class AgentRunner:
             config=governance_config,
             conversation=conversation_state,
             compaction=compaction,
+            compaction_callback=spec.compaction_callback,
         )
 
         for iteration in range(spec.max_iterations):

--- a/nanobot/agent/turn_delivery.py
+++ b/nanobot/agent/turn_delivery.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.outbound_events import (
+    ContextCompactionEvent,
     RetryWaitEvent,
     StreamDeltaEvent,
     StreamedResponseEvent,
@@ -173,6 +174,17 @@ class TurnDelivery:
             )
 
         return _on_retry_wait
+
+    async def context_compaction(self, event: ContextCompactionEvent) -> None:
+        """Publish one compaction transition without completing the active turn."""
+        await self.bus.publish_outbound(
+            outbound_message_for_event(
+                channel=self.delivery_message.channel,
+                chat_id=self.delivery_message.chat_id,
+                event=event,
+                metadata=self.delivery_message.metadata,
+            )
+        )
 
     async def started(self) -> None:
         if self.route.publish_lifecycle:

--- a/nanobot/agent/turn_delivery.py
+++ b/nanobot/agent/turn_delivery.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import dataclasses
 import time
 from collections.abc import Awaitable, Callable
+from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
 
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.outbound_events import (
+    ContextCompactionCallback,
     ContextCompactionEvent,
     RetryWaitEvent,
     StreamDeltaEvent,
@@ -21,6 +23,7 @@ from nanobot.bus.progress import build_bus_progress_callback
 from nanobot.bus.queue import MessageBus
 from nanobot.bus.runtime_events import RuntimeEventBus, RuntimeEventPublisher
 from nanobot.providers.base import LLMUsage
+from nanobot.session.keys import UNIFIED_SESSION_KEY, last_channel_from_metadata
 
 if TYPE_CHECKING:
     from nanobot.utils.llm_runtime import LLMRuntime
@@ -44,7 +47,7 @@ RetryWaitCallback = Callable[[str], Awaitable[None]]
 
 
 class TurnDeliveryFactory:
-    """Create per-turn delivery objects from an optional edge-owned route policy."""
+    """Route turn delivery and session-level notifications."""
 
     def __init__(
         self,
@@ -91,6 +94,45 @@ class TurnDeliveryFactory:
                 metadata=dict(msg.metadata or {}),
             ),
         )
+
+    def session_compaction_callback(
+        self,
+        session_key: str,
+        session_metadata: dict[str, Any],
+    ) -> ContextCompactionCallback | None:
+        """Bind idle notifications to one route without acquiring a turn owner."""
+        saved_route = session_metadata.get("_compaction_route")
+        if isinstance(saved_route, dict):
+            saved_route = cast(dict[str, Any], saved_route)
+            channel, chat_id = saved_route.get("channel"), saved_route.get("chat_id")
+            metadata = saved_route.get("metadata", {})
+            if not isinstance(channel, str) or not isinstance(chat_id, str):
+                return
+            if not isinstance(metadata, dict):
+                return
+            metadata = cast(dict[str, Any], metadata)
+        else:
+            # Older sessions have no route snapshot. Only direct clients have a
+            # session key that is also an unambiguous delivery address.
+            route = (
+                last_channel_from_metadata(session_metadata)
+                if session_key == UNIFIED_SESSION_KEY
+                else tuple(session_key.split(":", 1))
+            )
+            if not route or len(route) != 2 or route[0] not in {"websocket", "cli"}:
+                return
+            channel, chat_id = route
+            metadata = {}
+        metadata = deepcopy(metadata)
+
+        async def publish(event: ContextCompactionEvent) -> None:
+            await self.bus.publish_outbound(
+                outbound_message_for_event(
+                    channel=channel, chat_id=chat_id, event=event, metadata=metadata,
+                )
+            )
+
+        return publish
 
     @staticmethod
     def _default_route(msg: InboundMessage, session_key: str) -> TurnRoute:
@@ -185,6 +227,30 @@ class TurnDelivery:
                 metadata=self.delivery_message.metadata,
             )
         )
+
+    def remember_session_route(self, session_metadata: dict[str, Any]) -> None:
+        """Keep only routing fields needed to deliver a later idle notification."""
+        source = self.route.metadata
+        channel_type = self.route.channel.split(".", 1)[0]
+        fields = {
+            "telegram": ("message_thread_id",),
+            "matrix": ("thread_root_event_id", "thread_reply_to_event_id"),
+            "feishu": ("message_id", "thread_id", "chat_type"),
+        }.get(channel_type, ())
+        metadata = {
+            key: source[key] for key in fields if key in source
+        }
+        if channel_type in {"slack", "mattermost"}:
+            nested = source.get(channel_type)
+            if isinstance(nested, dict):
+                nested = cast(dict[str, Any], nested)
+                fields = ("thread_ts",) if channel_type == "slack" else ("root_id", "thread_ts")
+                metadata[channel_type] = {key: nested[key] for key in fields if key in nested}
+        session_metadata["_compaction_route"] = {
+            "channel": self.route.channel,
+            "chat_id": self.route.chat_id,
+            "metadata": metadata,
+        }
 
     async def started(self) -> None:
         if self.route.publish_lifecycle:

--- a/nanobot/bus/outbound_events.py
+++ b/nanobot/bus/outbound_events.py
@@ -15,7 +15,6 @@ from loguru import logger
 
 from nanobot.bus.events import OutboundMessage
 from nanobot.providers.base import LLMUsage
-from nanobot.session.summary import CheckpointSource
 
 
 class OutboundEvent:
@@ -122,9 +121,7 @@ class ContextCompactionEvent(OutboundEvent):
     """A channel-safe transition for one logical context compaction."""
 
     compaction_id: str
-    phase: Literal["started", "succeeded", "failed"]
-    checkpoint_source: CheckpointSource | None = None
-    completes_command: bool = False
+    phase: Literal["started", "succeeded", "failed", "cancelled"]
 
 
 ContextCompactionCallback = Callable[[ContextCompactionEvent], Awaitable[None]]
@@ -196,10 +193,8 @@ def _event_content(event: OutboundEvent) -> str:
             return "Compressing context…"
         if event.phase == "failed":
             return "Unable to compact context."
-        if event.checkpoint_source == "raw_fallback":
-            return "Context compacted · raw fallback"
-        if event.checkpoint_source == "llm_summary":
-            return "Context compacted · LLM summary"
+        if event.phase == "cancelled":
+            return "Context compaction cancelled."
         return "Context compacted."
     return ""
 

--- a/nanobot/bus/outbound_events.py
+++ b/nanobot/bus/outbound_events.py
@@ -7,12 +7,15 @@ message's explicit ``event`` field rather than in reserved metadata flags.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, replace
-from typing import Any, cast
+from typing import Any, Literal, cast
+
+from loguru import logger
 
 from nanobot.bus.events import OutboundMessage
 from nanobot.providers.base import LLMUsage
+from nanobot.session.summary import CheckpointSource
 
 
 class OutboundEvent:
@@ -114,6 +117,32 @@ class TurnModelUpdatedEvent(OutboundEvent):
     fallback: bool = False
 
 
+@dataclass(frozen=True)
+class ContextCompactionEvent(OutboundEvent):
+    """A channel-safe transition for one logical context compaction."""
+
+    compaction_id: str
+    phase: Literal["started", "succeeded", "failed"]
+    checkpoint_source: CheckpointSource | None = None
+    completes_command: bool = False
+
+
+ContextCompactionCallback = Callable[[ContextCompactionEvent], Awaitable[None]]
+
+
+async def emit_context_compaction(
+    callback: ContextCompactionCallback | None,
+    event: ContextCompactionEvent,
+) -> None:
+    """Notify observers without allowing delivery failure to alter compaction."""
+    if callback is None:
+        return
+    try:
+        await callback(event)
+    except Exception:
+        logger.exception("Failed to publish context compaction event")
+
+
 def outbound_message_for_event(
     *,
     channel: str,
@@ -162,6 +191,16 @@ def _event_content(event: OutboundEvent) -> str:
         ProgressEvent | RetryWaitEvent | StreamDeltaEvent | StreamEndEvent | UserInputEvent,
     ):
         return event.content
+    if isinstance(event, ContextCompactionEvent):
+        if event.phase == "started":
+            return "Compressing context…"
+        if event.phase == "failed":
+            return "Unable to compact context."
+        if event.checkpoint_source == "raw_fallback":
+            return "Context compacted · raw fallback"
+        if event.checkpoint_source == "llm_summary":
+            return "Context compacted · LLM summary"
+        return "Context compacted."
     return ""
 
 

--- a/nanobot/channels/websocket/runtime.py
+++ b/nanobot/channels/websocket/runtime.py
@@ -1388,7 +1388,14 @@ class WebSocketChannel(BaseChannel):
         """Persist as requested, frame, and fan out one encoded WebUI payload."""
         conns = list(self._subs.get(chat_id, ()))
         body: dict[str, Any] = dict(payload)
-        if persistence == "turn_complete":
+        if persistence == "turn_activity":
+            self._persist_turn_transcript_event(
+                chat_id,
+                body,
+                metadata=metadata,
+                phase="activity",
+            )
+        elif persistence == "turn_complete":
             canonical_webui_turn = (metadata or {}).get("webui") is True
             prior_persistence_failure = (
                 canonical_webui_turn

--- a/nanobot/channels/websocket/tests/test_websocket_channel.py
+++ b/nanobot/channels/websocket/tests/test_websocket_channel.py
@@ -2854,7 +2854,6 @@ async def test_context_compaction_is_structured_persisted_and_summary_free() -> 
         event=ContextCompactionEvent(
             compaction_id="compact-1",
             phase="succeeded",
-            checkpoint_source="llm_summary",
         ),
     ))
 
@@ -2863,12 +2862,10 @@ async def test_context_compaction_is_structured_persisted_and_summary_free() -> 
         "chat_id": "chat-compaction",
         "compaction_id": "compact-1",
         "phase": "succeeded",
-        "checkpoint_source": "llm_summary",
     }
     assert _sent_ws_payloads(mock_ws) == [expected]
     [persisted] = read_transcript_lines("websocket:chat-compaction")
     assert {key: persisted[key] for key in expected} == expected
-    assert "summary" not in persisted
 
 
 @pytest.mark.asyncio

--- a/nanobot/channels/websocket/tests/test_websocket_channel.py
+++ b/nanobot/channels/websocket/tests/test_websocket_channel.py
@@ -24,6 +24,7 @@ from nanobot.bus.events import (
     OutboundMessage,
 )
 from nanobot.bus.outbound_events import (
+    ContextCompactionEvent,
     GoalStateSyncEvent,
     GoalStatusEvent,
     ProgressEvent,
@@ -2803,6 +2804,71 @@ async def test_send_turn_end_emits_turn_end_event() -> None:
         {"event": "turn_end", "chat_id": "chat-1"},
         {"event": "session_updated", "chat_id": "chat-1", "scope": "thread"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_context_compaction_started_is_live_only() -> None:
+    bus = MagicMock()
+    channel = WebSocketChannel(
+        {"enabled": True, "allowFrom": ["*"]},
+        bus,
+        gateway=_basic_handler(bus),
+    )
+    mock_ws = AsyncMock()
+    channel._attach(mock_ws, "chat-compaction-started")
+
+    await channel.send(OutboundMessage(
+        channel="websocket",
+        chat_id="chat-compaction-started",
+        content="Compressing context…",
+        event=ContextCompactionEvent(
+            compaction_id="compact-started",
+            phase="started",
+        ),
+    ))
+
+    assert _sent_ws_payloads(mock_ws) == [{
+        "event": "context_compaction",
+        "chat_id": "chat-compaction-started",
+        "compaction_id": "compact-started",
+        "phase": "started",
+    }]
+    assert read_transcript_lines("websocket:chat-compaction-started") == []
+
+
+@pytest.mark.asyncio
+async def test_context_compaction_is_structured_persisted_and_summary_free() -> None:
+    bus = MagicMock()
+    channel = WebSocketChannel(
+        {"enabled": True, "allowFrom": ["*"]},
+        bus,
+        gateway=_basic_handler(bus),
+    )
+    mock_ws = AsyncMock()
+    channel._attach(mock_ws, "chat-compaction")
+
+    await channel.send(OutboundMessage(
+        channel="websocket",
+        chat_id="chat-compaction",
+        content="Context compacted · LLM summary",
+        event=ContextCompactionEvent(
+            compaction_id="compact-1",
+            phase="succeeded",
+            checkpoint_source="llm_summary",
+        ),
+    ))
+
+    expected = {
+        "event": "context_compaction",
+        "chat_id": "chat-compaction",
+        "compaction_id": "compact-1",
+        "phase": "succeeded",
+        "checkpoint_source": "llm_summary",
+    }
+    assert _sent_ws_payloads(mock_ws) == [expected]
+    [persisted] = read_transcript_lines("websocket:chat-compaction")
+    assert {key: persisted[key] for key in expected} == expected
+    assert "summary" not in persisted
 
 
 @pytest.mark.asyncio

--- a/nanobot/cli/agent.py
+++ b/nanobot/cli/agent.py
@@ -121,6 +121,7 @@ def agent(
     from nanobot.agent.tools.mcp import MCPProvider
     from nanobot.agent.tools.registry import ToolRegistry
     from nanobot.bus.outbound_events import (
+        ContextCompactionEvent,
         StreamDeltaEvent,
         StreamedResponseEvent,
         StreamEndEvent,
@@ -346,6 +347,11 @@ def agent(
                             renderer,
                             reasoning_buffer,
                         ):
+                            if (
+                                isinstance(event, ContextCompactionEvent)
+                                and event.completes_command
+                            ):
+                                turn_done.set()
                             continue
 
                         if not turn_done.is_set():

--- a/nanobot/cli/agent.py
+++ b/nanobot/cli/agent.py
@@ -121,7 +121,6 @@ def agent(
     from nanobot.agent.tools.mcp import MCPProvider
     from nanobot.agent.tools.registry import ToolRegistry
     from nanobot.bus.outbound_events import (
-        ContextCompactionEvent,
         StreamDeltaEvent,
         StreamedResponseEvent,
         StreamEndEvent,
@@ -347,11 +346,6 @@ def agent(
                             renderer,
                             reasoning_buffer,
                         ):
-                            if (
-                                isinstance(event, ContextCompactionEvent)
-                                and event.completes_command
-                            ):
-                                turn_done.set()
                             continue
 
                         if not turn_done.is_set():

--- a/nanobot/cli/terminal.py
+++ b/nanobot/cli/terminal.py
@@ -24,6 +24,7 @@ from rich.text import Text
 
 from nanobot import __logo__
 from nanobot.bus.outbound_events import (
+    ContextCompactionEvent,
     ProgressEvent,
     RetryWaitEvent,
     outbound_event_from_message,
@@ -369,6 +370,9 @@ async def _maybe_print_interactive_progress(
     reasoning_buffer: _ReasoningBuffer | None = None,
 ) -> bool:
     event = outbound_event_from_message(msg)
+    if isinstance(event, ContextCompactionEvent):
+        await _print_interactive_progress_line(msg.content, thinking, renderer)
+        return True
     if isinstance(event, RetryWaitEvent):
         await _print_interactive_progress_line(msg.content, thinking, renderer)
         return True

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -11,12 +11,10 @@ from contextlib import suppress
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Literal, cast
 
+from loguru import logger
+
 from nanobot import __version__
 from nanobot.bus.events import INBOUND_META_USER_SHELL, OutboundMessage
-from nanobot.bus.outbound_events import (
-    ContextCompactionEvent,
-    outbound_message_for_event,
-)
 from nanobot.command.router import CommandContext, CommandRouter, normalize_command_text
 from nanobot.providers.base import LLMUsage
 from nanobot.utils.helpers import build_status_content
@@ -347,52 +345,27 @@ async def cmd_new(ctx: CommandContext) -> OutboundMessage:
     )
 
 
-async def cmd_compact(ctx: CommandContext) -> OutboundMessage:
+async def cmd_compact(ctx: CommandContext) -> None:
     """Compact the current session without resetting the conversation."""
     loop = ctx.loop
     session = ctx.session or loop.sessions.get_or_create(ctx.key)
     runtime = ctx.runtime or loop.runtime_for_session(session)
     delivery = loop.turn_delivery_factory.create(ctx.msg, ctx.key)
-    terminal_event: ContextCompactionEvent | None = None
-
-    async def _on_compaction(event: ContextCompactionEvent) -> None:
-        nonlocal terminal_event
-        if event.phase == "started":
-            await delivery.context_compaction(event)
-        else:
-            terminal_event = replace(event, completes_command=True)
 
     try:
         summary = await loop.consolidator.compact_idle_session(
             ctx.key,
             runtime=runtime,
-            on_compaction=_on_compaction,
+            on_compaction=delivery.context_compaction,
         )
     except Exception:
-        summary = None
+        logger.exception("Manual context compaction failed for {}", ctx.key)
+        return
 
     if summary:
         refreshed = loop.sessions.get_or_create(ctx.key)
         refreshed.provider_state = None
         loop.sessions.save(refreshed)
-    if terminal_event is not None:
-        return outbound_message_for_event(
-            channel=ctx.msg.channel,
-            chat_id=ctx.msg.chat_id,
-            event=terminal_event,
-            metadata=dict(ctx.msg.metadata or {}),
-        )
-    content = (
-        "Nothing to compact."
-        if summary == ""
-        else "Unable to compact context. Check the logs and try again."
-    )
-    return OutboundMessage(
-        channel=ctx.msg.channel,
-        chat_id=ctx.msg.chat_id,
-        content=content,
-        metadata={**dict(ctx.msg.metadata or {}), "render_as": "text"},
-    )
 
 
 def _format_preset_names(names: list[str]) -> str:

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -13,6 +13,10 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 
 from nanobot import __version__
 from nanobot.bus.events import INBOUND_META_USER_SHELL, OutboundMessage
+from nanobot.bus.outbound_events import (
+    ContextCompactionEvent,
+    outbound_message_for_event,
+)
 from nanobot.command.router import CommandContext, CommandRouter, normalize_command_text
 from nanobot.providers.base import LLMUsage
 from nanobot.utils.helpers import build_status_content
@@ -70,6 +74,12 @@ BUILTIN_COMMAND_SPECS: tuple[BuiltinCommandSpec, ...] = (
         "Reset this chat and start a fresh conversation.",
         "square-pen",
         lifecycle="finalize_active_turn",
+    ),
+    BuiltinCommandSpec(
+        "/compact",
+        "Compact context",
+        "Compact this chat's context and continue the conversation.",
+        "archive",
     ),
     BuiltinCommandSpec(
         "/stop",
@@ -334,6 +344,54 @@ async def cmd_new(ctx: CommandContext) -> OutboundMessage:
         channel=ctx.msg.channel, chat_id=ctx.msg.chat_id,
         content="New session started.",
         metadata=dict(ctx.msg.metadata or {})
+    )
+
+
+async def cmd_compact(ctx: CommandContext) -> OutboundMessage:
+    """Compact the current session without resetting the conversation."""
+    loop = ctx.loop
+    session = ctx.session or loop.sessions.get_or_create(ctx.key)
+    runtime = ctx.runtime or loop.runtime_for_session(session)
+    delivery = loop.turn_delivery_factory.create(ctx.msg, ctx.key)
+    terminal_event: ContextCompactionEvent | None = None
+
+    async def _on_compaction(event: ContextCompactionEvent) -> None:
+        nonlocal terminal_event
+        if event.phase == "started":
+            await delivery.context_compaction(event)
+        else:
+            terminal_event = replace(event, completes_command=True)
+
+    try:
+        summary = await loop.consolidator.compact_idle_session(
+            ctx.key,
+            runtime=runtime,
+            on_compaction=_on_compaction,
+        )
+    except Exception:
+        summary = None
+
+    if summary:
+        refreshed = loop.sessions.get_or_create(ctx.key)
+        refreshed.provider_state = None
+        loop.sessions.save(refreshed)
+    if terminal_event is not None:
+        return outbound_message_for_event(
+            channel=ctx.msg.channel,
+            chat_id=ctx.msg.chat_id,
+            event=terminal_event,
+            metadata=dict(ctx.msg.metadata or {}),
+        )
+    content = (
+        "Nothing to compact."
+        if summary == ""
+        else "Unable to compact context. Check the logs and try again."
+    )
+    return OutboundMessage(
+        channel=ctx.msg.channel,
+        chat_id=ctx.msg.chat_id,
+        content=content,
+        metadata={**dict(ctx.msg.metadata or {}), "render_as": "text"},
     )
 
 
@@ -1044,6 +1102,7 @@ def register_builtin_commands(router: CommandRouter) -> None:
     router.priority("/restart", cmd_restart)
     router.priority("/status", cmd_status)
     router.exact("/new", cmd_new)
+    router.exact("/compact", cmd_compact)
     router.exact("/status", cmd_status)
     router.exact("/model", cmd_model)
     router.prefix("/model ", cmd_model)

--- a/nanobot/session/summary.py
+++ b/nanobot/session/summary.py
@@ -5,11 +5,22 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TypedDict, cast
+from typing import Literal, TypedDict, cast
 
 SUMMARY_CONTINUATION_TEXT = (
     "Continue the active task from the working-memory checkpoint above."
 )
+
+CheckpointSource = Literal["llm_summary", "raw_fallback"]
+
+
+@dataclass(frozen=True, slots=True)
+class CompactionResult:
+    """A replacement summary and how it was produced."""
+
+    summary: str
+    checkpoint_source: CheckpointSource
+
 
 class SessionSummary(TypedDict):
     text: str

--- a/nanobot/session/summary.py
+++ b/nanobot/session/summary.py
@@ -5,22 +5,11 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Literal, TypedDict, cast
+from typing import TypedDict, cast
 
 SUMMARY_CONTINUATION_TEXT = (
     "Continue the active task from the working-memory checkpoint above."
 )
-
-CheckpointSource = Literal["llm_summary", "raw_fallback"]
-
-
-@dataclass(frozen=True, slots=True)
-class CompactionResult:
-    """A replacement summary and how it was produced."""
-
-    summary: str
-    checkpoint_source: CheckpointSource
-
 
 class SessionSummary(TypedDict):
     text: str

--- a/nanobot/webui/outbound_projection.py
+++ b/nanobot/webui/outbound_projection.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.outbound_events import (
+    ContextCompactionEvent,
     GoalStateSyncEvent,
     GoalStatusEvent,
     ProgressEvent,
@@ -28,6 +29,7 @@ from nanobot.webui.metadata import (
 from nanobot.webui.outbound_wire import (
     WebUIWirePayload,
     WebUIWirePersistence,
+    encode_context_compaction,
     encode_recovery_state,
     encode_turn_end,
 )
@@ -152,6 +154,7 @@ class WebUIOutboundProjector:
                 SessionUpdatedEvent,
                 GoalStatusEvent,
                 GoalStateSyncEvent,
+                ContextCompactionEvent,
             )
             log = (
                 logger.debug
@@ -186,6 +189,14 @@ class WebUIOutboundProjector:
                     encode_recovery_state(msg.chat_id, event),
                     persistence="transient",
                 )
+            return
+        if isinstance(event, ContextCompactionEvent):
+            await self._transport.send_payload(
+                msg.chat_id,
+                encode_context_compaction(msg.chat_id, event),
+                persistence="transient" if event.phase == "started" else "turn_activity",
+                metadata=msg.metadata,
+            )
             return
         if isinstance(event, GoalStateSyncEvent):
             if conns:

--- a/nanobot/webui/outbound_wire.py
+++ b/nanobot/webui/outbound_wire.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, Literal, NotRequired, TypeAlias, TypedDict
 
-from nanobot.bus.outbound_events import RecoveryStateEvent, TurnEndEvent
+from nanobot.bus.outbound_events import (
+    ContextCompactionEvent,
+    RecoveryStateEvent,
+    TurnEndEvent,
+)
 from nanobot.webui.metadata import WEBUI_TURN_METADATA_KEY
 
 
@@ -32,8 +36,22 @@ class TurnEndWirePayload(_ChatWirePayload):
     context_window_tokens: NotRequired[int]
 
 
-WebUIWirePayload: TypeAlias = RecoveryStateWirePayload | TurnEndWirePayload
-WebUIWirePersistence: TypeAlias = Literal["transient", "turn_complete"]
+class ContextCompactionWirePayload(_ChatWirePayload):
+    event: Literal["context_compaction"]
+    compaction_id: str
+    phase: str
+    checkpoint_source: NotRequired[str]
+    completes_command: NotRequired[bool]
+
+
+WebUIWirePayload: TypeAlias = (
+    ContextCompactionWirePayload | RecoveryStateWirePayload | TurnEndWirePayload
+)
+WebUIWirePersistence: TypeAlias = Literal[
+    "transient",
+    "turn_activity",
+    "turn_complete",
+]
 
 
 def encode_recovery_state(
@@ -52,6 +70,24 @@ def encode_recovery_state(
         payload["reason"] = event.reason
     if event.can_continue is not None:
         payload["can_continue"] = event.can_continue
+    return payload
+
+
+def encode_context_compaction(
+    chat_id: str,
+    event: ContextCompactionEvent,
+) -> ContextCompactionWirePayload:
+    """Project one summary-free compaction transition onto its stable wire shape."""
+    payload: ContextCompactionWirePayload = {
+        "event": "context_compaction",
+        "chat_id": chat_id,
+        "compaction_id": event.compaction_id,
+        "phase": event.phase,
+    }
+    if event.checkpoint_source is not None:
+        payload["checkpoint_source"] = event.checkpoint_source
+    if event.completes_command:
+        payload["completes_command"] = True
     return payload
 
 

--- a/nanobot/webui/outbound_wire.py
+++ b/nanobot/webui/outbound_wire.py
@@ -40,8 +40,6 @@ class ContextCompactionWirePayload(_ChatWirePayload):
     event: Literal["context_compaction"]
     compaction_id: str
     phase: str
-    checkpoint_source: NotRequired[str]
-    completes_command: NotRequired[bool]
 
 
 WebUIWirePayload: TypeAlias = (
@@ -84,10 +82,6 @@ def encode_context_compaction(
         "compaction_id": event.compaction_id,
         "phase": event.phase,
     }
-    if event.checkpoint_source is not None:
-        payload["checkpoint_source"] = event.checkpoint_source
-    if event.completes_command:
-        payload["completes_command"] = True
     return payload
 
 

--- a/nanobot/webui/transcript.py
+++ b/nanobot/webui/transcript.py
@@ -2321,6 +2321,53 @@ def replay_transcript_to_ui_messages(
             close_reasoning(messages)
             continue
 
+        if ev == "context_compaction":
+            compaction_id = rec.get("compaction_id")
+            phase = rec.get("phase")
+            if (
+                not isinstance(compaction_id, str)
+                or not compaction_id
+                or phase not in {"started", "succeeded", "failed"}
+            ):
+                continue
+            checkpoint_source = rec.get("checkpoint_source")
+            if checkpoint_source not in {"llm_summary", "raw_fallback"}:
+                checkpoint_source = None
+            compaction: dict[str, Any] = {
+                "id": compaction_id,
+                "phase": phase,
+            }
+            if checkpoint_source is not None:
+                compaction["checkpointSource"] = checkpoint_source
+            payload: dict[str, Any] = {
+                "id": f"compaction-{compaction_id}",
+                "role": "assistant",
+                "content": "",
+                "kind": "compaction",
+                "createdAt": _created_at_ms(rec, idx),
+                "compaction": compaction,
+                **_turn_fields(rec, "activity"),
+            }
+            existing = next(
+                (
+                    message_index
+                    for message_index, message in enumerate(messages)
+                    if message.get("id") == payload["id"]
+                ),
+                None,
+            )
+            if existing is None:
+                messages.append(payload)
+            else:
+                payload["createdAt"] = messages[existing].get(
+                    "createdAt",
+                    payload["createdAt"],
+                )
+                messages[existing] = payload
+            active_activity_segment_id = None
+            active_file_edit_segment_id = None
+            continue
+
         if ev == "message":
             if suppress_until_turn_end and rec.get("kind") in (
                 "tool_hint",

--- a/nanobot/webui/transcript.py
+++ b/nanobot/webui/transcript.py
@@ -2327,18 +2327,13 @@ def replay_transcript_to_ui_messages(
             if (
                 not isinstance(compaction_id, str)
                 or not compaction_id
-                or phase not in {"started", "succeeded", "failed"}
+                or phase not in {"started", "succeeded", "failed", "cancelled"}
             ):
                 continue
-            checkpoint_source = rec.get("checkpoint_source")
-            if checkpoint_source not in {"llm_summary", "raw_fallback"}:
-                checkpoint_source = None
             compaction: dict[str, Any] = {
                 "id": compaction_id,
                 "phase": phase,
             }
-            if checkpoint_source is not None:
-                compaction["checkpointSource"] = checkpoint_source
             payload: dict[str, Any] = {
                 "id": f"compaction-{compaction_id}",
                 "role": "assistant",

--- a/tests/agent/test_auto_compact.py
+++ b/tests/agent/test_auto_compact.py
@@ -83,7 +83,14 @@ def _make_fake_compact(
 ):
     state = {"count": 0}
 
-    async def _fake_compact(key: str, *, runtime, max_suffix: int = 8) -> str:
+    async def _fake_compact(
+        key: str,
+        *,
+        runtime,
+        max_suffix: int = 8,
+        trigger: str = "policy",
+        on_compaction=None,
+    ) -> str:
         state["count"] += 1
         session = loop.sessions.get_or_create(key)
 
@@ -884,7 +891,7 @@ class TestProactiveAutoCompact:
         started = asyncio.Event()
         block_forever = asyncio.Event()
 
-        async def _slow_compact(key, *, runtime, max_suffix=8):
+        async def _slow_compact(key, *, runtime, max_suffix=8, **_kwargs):
             nonlocal archive_count
             archive_count += 1
             started.set()
@@ -916,7 +923,7 @@ class TestProactiveAutoCompact:
         session.updated_at = datetime.now() - timedelta(minutes=20)
         loop.sessions.save(session)
 
-        async def _failing_compact(key, *, runtime, max_suffix=8):
+        async def _failing_compact(key, *, runtime, max_suffix=8, **_kwargs):
             raise RuntimeError("LLM down")
 
         loop.consolidator.compact_idle_session = _failing_compact

--- a/tests/agent/test_autocompact_unit.py
+++ b/tests/agent/test_autocompact_unit.py
@@ -269,6 +269,7 @@ class TestCheckExpired:
             "cli:old",
             runtime=admitted,
             max_suffix=ac._RECENT_SUFFIX_MESSAGES,
+            on_compaction=None,
         )
 
     @pytest.mark.parametrize("resolution_error", [KeyError, ValueError])
@@ -444,6 +445,7 @@ class TestArchiveDelegates:
             "cli:test",
             runtime=runtime,
             max_suffix=ac._RECENT_SUFFIX_MESSAGES,
+            on_compaction=None,
         )
 
     @pytest.mark.asyncio
@@ -452,8 +454,10 @@ class TestArchiveDelegates:
         consolidator = MagicMock()
         observed: list[tuple[str, ContextCompactionEvent]] = []
 
-        async def publish(key: str, event: ContextCompactionEvent) -> None:
-            observed.append((key, event))
+        def bind(key: str):
+            async def publish(event: ContextCompactionEvent) -> None:
+                observed.append((key, event))
+            return publish
 
         async def compact(key: str, **kwargs):
             event = ContextCompactionEvent(compaction_id="compact-1", phase="started")
@@ -465,7 +469,7 @@ class TestArchiveDelegates:
             sessions=sessions,
             consolidator=consolidator,
             session_ttl_minutes=15,
-            on_compaction=publish,
+            bind_compaction=bind,
         )
 
         await ac._archive("cli:test", runtime=_runtime())

--- a/tests/agent/test_autocompact_unit.py
+++ b/tests/agent/test_autocompact_unit.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from nanobot.agent.autocompact import AutoCompact
+from nanobot.bus.outbound_events import ContextCompactionEvent
 from nanobot.session.manager import Session, SessionManager
 
 
@@ -444,6 +445,34 @@ class TestArchiveDelegates:
             runtime=runtime,
             max_suffix=ac._RECENT_SUFFIX_MESSAGES,
         )
+
+    @pytest.mark.asyncio
+    async def test_forwards_timeout_compaction_events_with_session_key(self):
+        sessions = MagicMock(spec=SessionManager)
+        consolidator = MagicMock()
+        observed: list[tuple[str, ContextCompactionEvent]] = []
+
+        async def publish(key: str, event: ContextCompactionEvent) -> None:
+            observed.append((key, event))
+
+        async def compact(key: str, **kwargs):
+            event = ContextCompactionEvent(compaction_id="compact-1", phase="started")
+            await kwargs["on_compaction"](event)
+            return "Summary."
+
+        consolidator.compact_idle_session = AsyncMock(side_effect=compact)
+        ac = AutoCompact(
+            sessions=sessions,
+            consolidator=consolidator,
+            session_ttl_minutes=15,
+            on_compaction=publish,
+        )
+
+        await ac._archive("cli:test", runtime=_runtime())
+
+        assert len(observed) == 1
+        assert observed[0][0] == "cli:test"
+        assert observed[0][1].phase == "started"
 
     @pytest.mark.asyncio
     async def test_dream_session_is_ignored(self):

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -4,7 +4,6 @@ from dataclasses import replace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from loguru import logger
 
 from nanobot.agent.memory import (
     _HISTORY_ENTRY_HARD_CAP,
@@ -25,7 +24,6 @@ from nanobot.runtime_context import (
 )
 from nanobot.session.keys import UNIFIED_SESSION_KEY, remember_last_channel
 from nanobot.session.manager import Session
-from nanobot.session.summary import CompactionResult
 from nanobot.utils.llm_runtime import LLMRuntime
 from nanobot.utils.prompt_templates import render_template
 
@@ -152,7 +150,7 @@ class TestTurnTranscriptSummary:
             tools=tools,
         )
 
-        assert result == CompactionResult("replacement checkpoint", "llm_summary")
+        assert result == "replacement checkpoint"
         call = mock_provider.chat_with_retry.await_args.kwargs
         assert call["messages"][:-1] == accepted
         assert call["messages"][-1]["role"] == "user"
@@ -184,7 +182,7 @@ class TestTurnTranscriptSummary:
             tools=[{"type": "function", "function": {"name": "inspect"}}],
         )
 
-        assert result == CompactionResult("replacement checkpoint", "llm_summary")
+        assert result == "replacement checkpoint"
         call = mock_provider.chat_with_retry.await_args.kwargs
         assert call["messages"][0] == accepted[0]
         assert call["messages"][-1]["content"] == _ARCHIVE_PROMPT
@@ -245,7 +243,7 @@ class TestConsolidatorSummarize:
     async def test_summarize_appends_to_history(
         self, consolidator, mock_provider, store, runtime
     ):
-        """Consolidator should call LLM to summarize, then append to HISTORY.md."""
+        """Consolidator should persist the LLM summary in history.jsonl."""
         mock_provider.chat_with_retry.return_value = MagicMock(
             content="User fixed a bug in the auth module."
         )
@@ -253,14 +251,8 @@ class TestConsolidatorSummarize:
             {"role": "user", "content": "fix the auth bug"},
             {"role": "assistant", "content": "Done, fixed the race condition."},
         ]
-        debug_logs: list[str] = []
-        sink_id = logger.add(debug_logs.append, level="DEBUG", format="{message}")
-        try:
-            result = await _archive(consolidator, messages, runtime)
-        finally:
-            logger.remove(sink_id)
-        assert result == CompactionResult("User fixed a bug in the auth module.", "llm_summary")
-        assert any("User fixed a bug in the auth module." in line for line in debug_logs)
+        result = await _archive(consolidator, messages, runtime)
+        assert result == "User fixed a bug in the auth module."
         entries = store.read_unprocessed_history(since_cursor=0)
         assert len(entries) == 1
 
@@ -295,9 +287,8 @@ class TestConsolidatorSummarize:
         messages = [{"role": "user", "content": "hello"}]
         result = await _archive(consolidator, messages, runtime)
         assert result is not None
-        assert result.checkpoint_source == "raw_fallback"
-        assert "[RAW]" in result.summary
-        assert "hello" in result.summary
+        assert "[RAW]" in result
+        assert "hello" in result
         entries = store.read_unprocessed_history(since_cursor=0)
         assert len(entries) == 1
         assert "[RAW]" in entries[0]["content"]
@@ -339,11 +330,11 @@ class TestConsolidatorSummarize:
         )
 
         assert result is not None
-        assert "[Previous archived context]" in result.summary
-        assert "OLD_MARKER" in result.summary
-        assert "[Newly archived raw context]" in result.summary
-        assert "NEW_MARKER" in result.summary
-        assert "... (truncated)" in result.summary
+        assert "[Previous archived context]" in result
+        assert "OLD_MARKER" in result
+        assert "[Newly archived raw context]" in result
+        assert "NEW_MARKER" in result
+        assert "... (truncated)" in result
 
     async def test_summarize_skips_empty_messages(self, consolidator, runtime):
         result = await _archive(consolidator, [], runtime)
@@ -397,7 +388,7 @@ class TestConsolidatorArchiveErrorHandling:
         ]
         result = await _archive(consolidator, messages, runtime)
         assert result is not None
-        assert "[RAW]" in result.summary
+        assert "[RAW]" in result
         entries = store.read_unprocessed_history(since_cursor=0)
         assert len(entries) == 1
         assert "[RAW]" in entries[0]["content"]
@@ -416,7 +407,7 @@ class TestConsolidatorArchiveErrorHandling:
             {"role": "assistant", "content": "Done."},
         ]
         result = await _archive(consolidator, messages, runtime)
-        assert result == CompactionResult("User fixed a bug in the auth module.", "llm_summary")
+        assert result == "User fixed a bug in the auth module."
         entries = store.read_unprocessed_history(since_cursor=0)
         assert len(entries) == 1
         assert "[RAW]" not in entries[0]["content"]
@@ -566,7 +557,7 @@ class TestCompactIdleSession:
         assert reloaded.updated_at == old_ts
 
     @pytest.mark.asyncio
-    async def test_emits_manual_compaction_lifecycle_with_checkpoint_source(
+    async def test_emits_manual_compaction_lifecycle(
         self, real_consolidator, mock_provider, runtime
     ):
         mock_provider.chat_with_retry.return_value = MagicMock(
@@ -590,7 +581,6 @@ class TestCompactIdleSession:
         assert result == "Summary."
         assert [event.phase for event in events] == ["started", "succeeded"]
         assert events[0].compaction_id == events[1].compaction_id
-        assert events[1].checkpoint_source == "llm_summary"
 
     @pytest.mark.asyncio
     async def test_event_callback_failure_does_not_abort_compaction(
@@ -955,6 +945,8 @@ class TestCompactIdleSession:
         mock_provider.chat_with_retry.side_effect = RuntimeError("LLM unavailable")
         sessions = real_consolidator.sessions
         session = sessions.get_or_create("cli:fail")
+        session.add_message("user", "/compact", _command=True)
+        session.add_message("assistant", "Nothing to compact.", _command=True)
         for i in range(10):
             session.add_message("user", f"u{i}")
             session.add_message("assistant", f"a{i}")
@@ -968,12 +960,11 @@ class TestCompactIdleSession:
 
         # raw_archive should have been called (history.jsonl gets an entry)
         entries = store.read_unprocessed_history(since_cursor=0)
-        assert any("[RAW]" in e["content"] for e in entries)
+        assert entries[0]["content"].startswith("[RAW] 20 messages")
 
         reloaded = sessions.get_or_create("cli:fail")
-        assert len(reloaded.messages) == 20
-        assert reloaded.messages[0]["content"] == "u0"
-        assert reloaded.last_archived == 20
+        assert reloaded.messages == session.messages
+        assert reloaded.last_archived == 22
         assert reloaded.metadata["_last_summary"]["text"] == result
         assert [m["content"] for m in reloaded.get_history(max_messages=20)] == [
             "u6",
@@ -1418,7 +1409,7 @@ class TestArchivePersistence:
 
         persisted = store.read_unprocessed_history(since_cursor=0)[0]["content"]
         assert summary is not None
-        assert summary.summary == persisted == "safe summary"
+        assert summary == persisted == "safe summary"
 
     async def test_oversized_summary_uses_history_emergency_cap(
         self, consolidator, mock_provider, store, runtime
@@ -1439,4 +1430,4 @@ class TestArchivePersistence:
         entry = store.read_unprocessed_history(since_cursor=0)[0]
         assert len(entry["content"]) <= _HISTORY_ENTRY_HARD_CAP + 50
         assert summary is not None
-        assert summary.summary == entry["content"]
+        assert summary == entry["content"]

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -4,12 +4,14 @@ from dataclasses import replace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from loguru import logger
 
 from nanobot.agent.memory import (
     _HISTORY_ENTRY_HARD_CAP,
     Consolidator,
     MemoryStore,
 )
+from nanobot.bus.outbound_events import ContextCompactionEvent
 from nanobot.providers.base import (
     GenerationSettings,
     LLMResponse,
@@ -23,6 +25,7 @@ from nanobot.runtime_context import (
 )
 from nanobot.session.keys import UNIFIED_SESSION_KEY, remember_last_channel
 from nanobot.session.manager import Session
+from nanobot.session.summary import CompactionResult
 from nanobot.utils.llm_runtime import LLMRuntime
 from nanobot.utils.prompt_templates import render_template
 
@@ -141,7 +144,7 @@ class TestTurnTranscriptSummary:
             content="replacement checkpoint",
         )
 
-        summary = await consolidator.summarize_transcript(
+        result = await consolidator.summarize_transcript(
             accepted,
             "previous checkpoint",
             runtime=runtime,
@@ -149,7 +152,7 @@ class TestTurnTranscriptSummary:
             tools=tools,
         )
 
-        assert summary == "replacement checkpoint"
+        assert result == CompactionResult("replacement checkpoint", "llm_summary")
         call = mock_provider.chat_with_retry.await_args.kwargs
         assert call["messages"][:-1] == accepted
         assert call["messages"][-1]["role"] == "user"
@@ -172,7 +175,7 @@ class TestTurnTranscriptSummary:
             content="replacement checkpoint",
         )
 
-        summary = await consolidator.summarize_provider_compaction(
+        result = await consolidator.summarize_provider_compaction(
             state,
             accepted,
             "previous checkpoint",
@@ -181,7 +184,7 @@ class TestTurnTranscriptSummary:
             tools=[{"type": "function", "function": {"name": "inspect"}}],
         )
 
-        assert summary == "replacement checkpoint"
+        assert result == CompactionResult("replacement checkpoint", "llm_summary")
         call = mock_provider.chat_with_retry.await_args.kwargs
         assert call["messages"][0] == accepted[0]
         assert call["messages"][-1]["content"] == _ARCHIVE_PROMPT
@@ -250,8 +253,14 @@ class TestConsolidatorSummarize:
             {"role": "user", "content": "fix the auth bug"},
             {"role": "assistant", "content": "Done, fixed the race condition."},
         ]
-        result = await _archive(consolidator, messages, runtime)
-        assert result == "User fixed a bug in the auth module."
+        debug_logs: list[str] = []
+        sink_id = logger.add(debug_logs.append, level="DEBUG", format="{message}")
+        try:
+            result = await _archive(consolidator, messages, runtime)
+        finally:
+            logger.remove(sink_id)
+        assert result == CompactionResult("User fixed a bug in the auth module.", "llm_summary")
+        assert any("User fixed a bug in the auth module." in line for line in debug_logs)
         entries = store.read_unprocessed_history(since_cursor=0)
         assert len(entries) == 1
 
@@ -286,8 +295,9 @@ class TestConsolidatorSummarize:
         messages = [{"role": "user", "content": "hello"}]
         result = await _archive(consolidator, messages, runtime)
         assert result is not None
-        assert "[RAW]" in result
-        assert "hello" in result
+        assert result.checkpoint_source == "raw_fallback"
+        assert "[RAW]" in result.summary
+        assert "hello" in result.summary
         entries = store.read_unprocessed_history(since_cursor=0)
         assert len(entries) == 1
         assert "[RAW]" in entries[0]["content"]
@@ -329,11 +339,11 @@ class TestConsolidatorSummarize:
         )
 
         assert result is not None
-        assert "[Previous archived context]" in result
-        assert "OLD_MARKER" in result
-        assert "[Newly archived raw context]" in result
-        assert "NEW_MARKER" in result
-        assert "... (truncated)" in result
+        assert "[Previous archived context]" in result.summary
+        assert "OLD_MARKER" in result.summary
+        assert "[Newly archived raw context]" in result.summary
+        assert "NEW_MARKER" in result.summary
+        assert "... (truncated)" in result.summary
 
     async def test_summarize_skips_empty_messages(self, consolidator, runtime):
         result = await _archive(consolidator, [], runtime)
@@ -387,7 +397,7 @@ class TestConsolidatorArchiveErrorHandling:
         ]
         result = await _archive(consolidator, messages, runtime)
         assert result is not None
-        assert "[RAW]" in result
+        assert "[RAW]" in result.summary
         entries = store.read_unprocessed_history(since_cursor=0)
         assert len(entries) == 1
         assert "[RAW]" in entries[0]["content"]
@@ -406,7 +416,7 @@ class TestConsolidatorArchiveErrorHandling:
             {"role": "assistant", "content": "Done."},
         ]
         result = await _archive(consolidator, messages, runtime)
-        assert result == "User fixed a bug in the auth module."
+        assert result == CompactionResult("User fixed a bug in the auth module.", "llm_summary")
         entries = store.read_unprocessed_history(since_cursor=0)
         assert len(entries) == 1
         assert "[RAW]" not in entries[0]["content"]
@@ -554,6 +564,57 @@ class TestCompactIdleSession:
         assert meta["text"] == "Summary of old conversation."
         assert "last_active" in meta
         assert reloaded.updated_at == old_ts
+
+    @pytest.mark.asyncio
+    async def test_emits_manual_compaction_lifecycle_with_checkpoint_source(
+        self, real_consolidator, mock_provider, runtime
+    ):
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="Summary.", finish_reason="stop"
+        )
+        session = real_consolidator.sessions.get_or_create("cli:events")
+        session.add_message("user", "question")
+        session.add_message("assistant", "answer")
+        real_consolidator.sessions.save(session)
+        events: list[ContextCompactionEvent] = []
+
+        async def observe(event: ContextCompactionEvent) -> None:
+            events.append(event)
+
+        result = await real_consolidator.compact_idle_session(
+            "cli:events",
+            runtime=runtime,
+            on_compaction=observe,
+        )
+
+        assert result == "Summary."
+        assert [event.phase for event in events] == ["started", "succeeded"]
+        assert events[0].compaction_id == events[1].compaction_id
+        assert events[1].checkpoint_source == "llm_summary"
+
+    @pytest.mark.asyncio
+    async def test_event_callback_failure_does_not_abort_compaction(
+        self, real_consolidator, mock_provider, runtime
+    ):
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="Summary.", finish_reason="stop"
+        )
+        session = real_consolidator.sessions.get_or_create("cli:event-callback-failure")
+        session.add_message("user", "question")
+        real_consolidator.sessions.save(session)
+
+        async def fail_observer(_event: ContextCompactionEvent) -> None:
+            raise RuntimeError("channel unavailable")
+
+        result = await real_consolidator.compact_idle_session(
+            "cli:event-callback-failure",
+            runtime=runtime,
+            on_compaction=fail_observer,
+        )
+
+        assert result == "Summary."
+        reloaded = real_consolidator.sessions.get_or_create("cli:event-callback-failure")
+        assert reloaded.last_archived == 1
 
     @pytest.mark.asyncio
     async def test_short_idle_session_archives_once(
@@ -1356,7 +1417,8 @@ class TestArchivePersistence:
         )
 
         persisted = store.read_unprocessed_history(since_cursor=0)[0]["content"]
-        assert summary == persisted == "safe summary"
+        assert summary is not None
+        assert summary.summary == persisted == "safe summary"
 
     async def test_oversized_summary_uses_history_emergency_cap(
         self, consolidator, mock_provider, store, runtime
@@ -1376,4 +1438,5 @@ class TestArchivePersistence:
 
         entry = store.read_unprocessed_history(since_cursor=0)[0]
         assert len(entry["content"]) <= _HISTORY_ENTRY_HARD_CAP + 50
-        assert summary == entry["content"]
+        assert summary is not None
+        assert summary.summary == entry["content"]

--- a/tests/agent/test_loop_consolidation_tokens.py
+++ b/tests/agent/test_loop_consolidation_tokens.py
@@ -9,7 +9,7 @@ from nanobot.providers.base import (
     LLMResponse,
     ProviderConversationState,
 )
-from nanobot.session.summary import SUMMARY_CONTINUATION_TEXT, CompactionResult
+from nanobot.session.summary import SUMMARY_CONTINUATION_TEXT
 
 
 def _make_loop(
@@ -121,7 +121,7 @@ async def test_native_provider_compaction_commits_portable_terminal_checkpoint(
         provider_compaction_scope="current_request",
     ))
     loop.consolidator.summarize_provider_compaction = AsyncMock(
-        return_value=CompactionResult("portable terminal checkpoint", "llm_summary"),
+        return_value="portable terminal checkpoint",
     )
 
     result = await loop.process_direct("continue", session_key="cli:native")

--- a/tests/agent/test_loop_consolidation_tokens.py
+++ b/tests/agent/test_loop_consolidation_tokens.py
@@ -9,7 +9,7 @@ from nanobot.providers.base import (
     LLMResponse,
     ProviderConversationState,
 )
-from nanobot.session.summary import SUMMARY_CONTINUATION_TEXT
+from nanobot.session.summary import SUMMARY_CONTINUATION_TEXT, CompactionResult
 
 
 def _make_loop(
@@ -121,7 +121,7 @@ async def test_native_provider_compaction_commits_portable_terminal_checkpoint(
         provider_compaction_scope="current_request",
     ))
     loop.consolidator.summarize_provider_compaction = AsyncMock(
-        return_value="portable terminal checkpoint",
+        return_value=CompactionResult("portable terminal checkpoint", "llm_summary"),
     )
 
     result = await loop.process_direct("continue", session_key="cli:native")

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -1197,6 +1197,9 @@ async def test_process_message_persists_unified_session_delivery_route(tmp_path:
     loop.sessions.invalidate(UNIFIED_SESSION_KEY)
     persisted = loop.sessions.get_or_create(UNIFIED_SESSION_KEY)
     assert persisted.metadata[LAST_CHANNEL_METADATA_KEY] == "feishu:oc_123"
+    assert persisted.metadata["_compaction_route"] == {
+        "channel": "feishu", "chat_id": "oc_123", "metadata": {},
+    }
 
 
 @pytest.mark.parametrize(
@@ -1251,7 +1254,10 @@ def test_unified_session_route_ignores_non_user_destinations(
     session = loop.sessions.get_or_create(UNIFIED_SESSION_KEY)
     session.metadata[LAST_CHANNEL_METADATA_KEY] = "telegram:existing"
 
-    loop._remember_unified_session_route(session, msg, is_user_turn=is_user_turn)
+    loop._remember_session_route(
+        session, msg, is_user_turn=is_user_turn,
+        delivery=loop.turn_delivery_factory.unrouted(msg, session.key),
+    )
 
     assert session.metadata[LAST_CHANNEL_METADATA_KEY] == "telegram:existing"
 

--- a/tests/agent/test_runner_governance.py
+++ b/tests/agent/test_runner_governance.py
@@ -15,6 +15,7 @@ from nanobot.agent.context_governance import (
     ContextWindowExceededError,
 )
 from nanobot.agent.runner import AgentRunner, AgentRunSpec
+from nanobot.bus.outbound_events import ContextCompactionEvent
 from nanobot.config.schema import AgentDefaults
 from nanobot.providers.base import (
     LLMProvider,
@@ -23,7 +24,7 @@ from nanobot.providers.base import (
     ProviderConversationState,
     ToolCallRequest,
 )
-from nanobot.session.summary import SUMMARY_CONTINUATION_TEXT
+from nanobot.session.summary import SUMMARY_CONTINUATION_TEXT, CompactionResult
 
 _MAX_TOOL_RESULT_CHARS = AgentDefaults().max_tool_result_chars
 
@@ -188,7 +189,7 @@ async def test_runner_summarizes_history_and_preserves_current_input(monkeypatch
             else (100, "test-counter")
         ),
     )
-    consolidate = AsyncMock(return_value="fresh checkpoint")
+    consolidate = AsyncMock(return_value=CompactionResult("fresh checkpoint", "llm_summary"))
     previous = {"text": "existing checkpoint", "last_active": "2026-08-30T00:00:00"}
 
     result = await AgentRunner().run(make_run_spec(
@@ -286,7 +287,7 @@ async def test_runner_governs_history_before_summarizing_it(monkeypatch):
             else (600, "test-counter")
         ),
     )
-    consolidate = AsyncMock(return_value="fresh checkpoint")
+    consolidate = AsyncMock(return_value=CompactionResult("fresh checkpoint", "llm_summary"))
 
     await AgentRunner().run(make_run_spec(
         provider,
@@ -368,8 +369,14 @@ async def test_native_compaction_uses_provider_request_boundary(
         "nanobot.agent.context_governance.estimate_prompt_tokens_chain",
         lambda *_args: (100, "test-counter"),
     )
-    consolidate = AsyncMock(return_value="portable checkpoint")
-    consolidate_native = AsyncMock(return_value="portable checkpoint")
+    consolidate = AsyncMock(return_value=CompactionResult("portable checkpoint", "llm_summary"))
+    consolidate_native = AsyncMock(
+        return_value=CompactionResult("portable checkpoint", "llm_summary")
+    )
+    compaction_events: list[ContextCompactionEvent] = []
+
+    async def observe_compaction(event: ContextCompactionEvent) -> None:
+        compaction_events.append(event)
 
     result = await AgentRunner().run(make_run_spec(
         provider,
@@ -391,6 +398,7 @@ async def test_native_compaction_uses_provider_request_boundary(
         max_tokens=100,
         max_iterations=2,
         max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        compaction_callback=observe_compaction,
     ))
 
     consolidate.assert_not_awaited()
@@ -405,6 +413,11 @@ async def test_native_compaction_uses_provider_request_boundary(
     assert result.provider_compaction_applied is True
     assert any(message.get("content") == "inspect the project" for message in result.messages)
     assert any(message.get("content") == "complete tool result" for message in result.messages)
+    assert [event.phase for event in compaction_events] == ["started", "succeeded"]
+    assert {event.compaction_id for event in compaction_events} == {
+        compaction_events[0].compaction_id
+    }
+    assert compaction_events[-1].checkpoint_source == "llm_summary"
 
 
 async def test_runner_keeps_current_tool_exchange_outside_summary(monkeypatch):
@@ -441,7 +454,7 @@ async def test_runner_keeps_current_tool_exchange_outside_summary(monkeypatch):
         "nanobot.agent.context_governance.estimate_prompt_tokens_chain",
         estimate,
     )
-    consolidate = AsyncMock(return_value="fresh checkpoint")
+    consolidate = AsyncMock(return_value=CompactionResult("fresh checkpoint", "llm_summary"))
 
     result = await AgentRunner().run(make_run_spec(
         provider,
@@ -506,7 +519,14 @@ async def test_repeated_pressure_advances_summary_boundary(monkeypatch):
         "nanobot.agent.context_governance.estimate_prompt_tokens_chain",
         estimate,
     )
-    consolidate = AsyncMock(side_effect=["checkpoint-1", "checkpoint-2"])
+    consolidate = AsyncMock(side_effect=[
+        CompactionResult(summary="checkpoint-1", checkpoint_source="llm_summary"),
+        CompactionResult(summary="checkpoint-2", checkpoint_source="raw_fallback"),
+    ])
+    compaction_events: list[ContextCompactionEvent] = []
+
+    async def observe_compaction(event: ContextCompactionEvent) -> None:
+        compaction_events.append(event)
 
     result = await AgentRunner().run(make_run_spec(
         provider,
@@ -521,6 +541,7 @@ async def test_repeated_pressure_advances_summary_boundary(monkeypatch):
         max_tokens=100,
         max_iterations=3,
         max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        compaction_callback=observe_compaction,
     ))
 
     assert consolidate.await_count == 2
@@ -533,6 +554,15 @@ async def test_repeated_pressure_advances_summary_boundary(monkeypatch):
     assert result.summary_checkpoint is not None
     assert result.summary_checkpoint.summary == "checkpoint-2"
     assert result.summary_checkpoint.transcript_boundary == 4
+    assert [event.phase for event in compaction_events] == [
+        "started", "succeeded", "started", "succeeded",
+    ]
+    first_id, second_id = compaction_events[0].compaction_id, compaction_events[2].compaction_id
+    assert first_id == compaction_events[1].compaction_id
+    assert second_id == compaction_events[3].compaction_id
+    assert first_id != second_id
+    assert compaction_events[1].checkpoint_source == "llm_summary"
+    assert compaction_events[3].checkpoint_source == "raw_fallback"
 
 
 async def test_runner_refuses_checkpoint_that_cannot_fit_with_delta(monkeypatch):
@@ -553,7 +583,7 @@ async def test_runner_refuses_checkpoint_that_cannot_fit_with_delta(monkeypatch)
         "nanobot.agent.context_governance.estimate_prompt_tokens_chain",
         estimate,
     )
-    consolidate = AsyncMock(return_value="small checkpoint")
+    consolidate = AsyncMock(return_value=CompactionResult("small checkpoint", "llm_summary"))
 
     with pytest.raises(ContextWindowExceededError):
         await AgentRunner().run(make_run_spec(

--- a/tests/agent/test_runner_governance.py
+++ b/tests/agent/test_runner_governance.py
@@ -13,6 +13,7 @@ from nanobot.agent.context_governance import (
     ContextGovernanceConfig,
     ContextGovernor,
     ContextWindowExceededError,
+    ModelRequestState,
 )
 from nanobot.agent.runner import AgentRunner, AgentRunSpec
 from nanobot.bus.outbound_events import ContextCompactionEvent
@@ -24,7 +25,8 @@ from nanobot.providers.base import (
     ProviderConversationState,
     ToolCallRequest,
 )
-from nanobot.session.summary import SUMMARY_CONTINUATION_TEXT, CompactionResult
+from nanobot.providers.conversation_state import ProviderConversationStateController
+from nanobot.session.summary import SUMMARY_CONTINUATION_TEXT
 
 _MAX_TOOL_RESULT_CHARS = AgentDefaults().max_tool_result_chars
 
@@ -189,7 +191,7 @@ async def test_runner_summarizes_history_and_preserves_current_input(monkeypatch
             else (100, "test-counter")
         ),
     )
-    consolidate = AsyncMock(return_value=CompactionResult("fresh checkpoint", "llm_summary"))
+    consolidate = AsyncMock(return_value="fresh checkpoint")
     previous = {"text": "existing checkpoint", "last_active": "2026-08-30T00:00:00"}
 
     result = await AgentRunner().run(make_run_spec(
@@ -287,7 +289,7 @@ async def test_runner_governs_history_before_summarizing_it(monkeypatch):
             else (600, "test-counter")
         ),
     )
-    consolidate = AsyncMock(return_value=CompactionResult("fresh checkpoint", "llm_summary"))
+    consolidate = AsyncMock(return_value="fresh checkpoint")
 
     await AgentRunner().run(make_run_spec(
         provider,
@@ -369,9 +371,9 @@ async def test_native_compaction_uses_provider_request_boundary(
         "nanobot.agent.context_governance.estimate_prompt_tokens_chain",
         lambda *_args: (100, "test-counter"),
     )
-    consolidate = AsyncMock(return_value=CompactionResult("portable checkpoint", "llm_summary"))
+    consolidate = AsyncMock(return_value="portable checkpoint")
     consolidate_native = AsyncMock(
-        return_value=CompactionResult("portable checkpoint", "llm_summary")
+        return_value="portable checkpoint"
     )
     compaction_events: list[ContextCompactionEvent] = []
 
@@ -417,7 +419,6 @@ async def test_native_compaction_uses_provider_request_boundary(
     assert {event.compaction_id for event in compaction_events} == {
         compaction_events[0].compaction_id
     }
-    assert compaction_events[-1].checkpoint_source == "llm_summary"
 
 
 async def test_runner_keeps_current_tool_exchange_outside_summary(monkeypatch):
@@ -454,7 +455,7 @@ async def test_runner_keeps_current_tool_exchange_outside_summary(monkeypatch):
         "nanobot.agent.context_governance.estimate_prompt_tokens_chain",
         estimate,
     )
-    consolidate = AsyncMock(return_value=CompactionResult("fresh checkpoint", "llm_summary"))
+    consolidate = AsyncMock(return_value="fresh checkpoint")
 
     result = await AgentRunner().run(make_run_spec(
         provider,
@@ -520,8 +521,8 @@ async def test_repeated_pressure_advances_summary_boundary(monkeypatch):
         estimate,
     )
     consolidate = AsyncMock(side_effect=[
-        CompactionResult(summary="checkpoint-1", checkpoint_source="llm_summary"),
-        CompactionResult(summary="checkpoint-2", checkpoint_source="raw_fallback"),
+        "checkpoint-1",
+        "checkpoint-2",
     ])
     compaction_events: list[ContextCompactionEvent] = []
 
@@ -561,8 +562,6 @@ async def test_repeated_pressure_advances_summary_boundary(monkeypatch):
     assert first_id == compaction_events[1].compaction_id
     assert second_id == compaction_events[3].compaction_id
     assert first_id != second_id
-    assert compaction_events[1].checkpoint_source == "llm_summary"
-    assert compaction_events[3].checkpoint_source == "raw_fallback"
 
 
 async def test_runner_refuses_checkpoint_that_cannot_fit_with_delta(monkeypatch):
@@ -583,7 +582,7 @@ async def test_runner_refuses_checkpoint_that_cannot_fit_with_delta(monkeypatch)
         "nanobot.agent.context_governance.estimate_prompt_tokens_chain",
         estimate,
     )
-    consolidate = AsyncMock(return_value=CompactionResult("small checkpoint", "llm_summary"))
+    consolidate = AsyncMock(return_value="small checkpoint")
 
     with pytest.raises(ContextWindowExceededError):
         await AgentRunner().run(make_run_spec(
@@ -904,7 +903,7 @@ async def test_runner_fits_max_iteration_finalization_before_dispatch(monkeypatc
     ("input_tokens", "expected_fitted"),
     [(500, True), (100, False)],
 )
-def test_matching_reported_provider_usage_avoids_local_estimate(
+async def test_matching_reported_provider_usage_avoids_local_estimate(
     monkeypatch,
     input_tokens,
     expected_fitted,
@@ -931,18 +930,25 @@ def test_matching_reported_provider_usage_avoids_local_estimate(
 
     governor = ContextGovernor()
     monkeypatch.setattr(governor, "fit_to_budget", lambda *_args, **_kwargs: [])
-    _messages, fitted = governor.fit_request(
-        _governance_config(provider, tools, spec),
+    state = ModelRequestState(
+        config=_governance_config(provider, tools, spec),
+        conversation=ProviderConversationStateController(
+            provider=provider, model=spec.runtime.model, messages=spec.initial_messages,
+        ),
+        usage=LLMUsage.reported(input_tokens=input_tokens, output_tokens=10),
+        messages=spec.initial_messages,
+        tool_definitions=[],
+    )
+    messages, _context = await governor.prepare_request(
+        state,
         spec.initial_messages,
-        LLMUsage.reported(input_tokens=input_tokens, output_tokens=10),
-        usage_matches_messages=True,
         tool_definitions=tools.get_definitions(),
     )
 
-    assert fitted is expected_fitted
+    assert messages == ([] if expected_fitted else spec.initial_messages)
 
 
-def test_changed_messages_use_local_estimate_after_reported_usage(monkeypatch):
+async def test_changed_messages_use_local_estimate_after_reported_usage(monkeypatch):
     provider = MagicMock(spec=LLMProvider)
     tools = MagicMock()
     tools.get_definitions.return_value = []
@@ -964,15 +970,22 @@ def test_changed_messages_use_local_estimate_after_reported_usage(monkeypatch):
 
     governor = ContextGovernor()
     monkeypatch.setattr(governor, "fit_to_budget", lambda *_args, **_kwargs: [])
-    _messages, fitted = governor.fit_request(
-        _governance_config(provider, tools, spec),
+    state = ModelRequestState(
+        config=_governance_config(provider, tools, spec),
+        conversation=ProviderConversationStateController(
+            provider=provider, model=spec.runtime.model, messages=spec.initial_messages,
+        ),
+        usage=LLMUsage.reported(input_tokens=900, output_tokens=10),
+        messages=[{"role": "user", "content": "previous request"}],
+        tool_definitions=[],
+    )
+    messages, _context = await governor.prepare_request(
+        state,
         spec.initial_messages,
-        LLMUsage.reported(input_tokens=900, output_tokens=10),
-        usage_matches_messages=False,
         tool_definitions=tools.get_definitions(),
     )
 
-    assert fitted is True
+    assert messages == []
     estimate.assert_called_once()
 
 

--- a/tests/agent/test_turn_delivery.py
+++ b/tests/agent/test_turn_delivery.py
@@ -4,6 +4,7 @@ import pytest
 
 from nanobot.agent.turn_delivery import TurnDeliveryFactory
 from nanobot.bus.events import InboundMessage
+from nanobot.bus.outbound_events import ContextCompactionEvent
 from nanobot.bus.queue import MessageBus
 from nanobot.bus.runtime_events import RuntimeEventBus
 from nanobot.session.manager import SessionManager
@@ -12,6 +13,80 @@ from nanobot.webui.metadata import (
     WEBSOCKET_TURN_OWNER_METADATA_KEY,
     WEBUI_TURN_METADATA_KEY,
 )
+
+
+@pytest.mark.parametrize("unified", [False, True])
+@pytest.mark.parametrize(("key", "channel", "chat_id", "metadata"), [
+    ("slack:C123:1700000000.000100", "slack", "C123",
+     {"slack": {"thread_ts": "1700000000.000100"}}),
+    ("telegram:-100123:topic:42", "telegram", "-100123", {"message_thread_id": 42}),
+    ("discord:456:thread:777", "discord", "777", {}),
+    ("mattermost:channel:root", "mattermost", "channel", {"mattermost": {"root_id": "root"}}),
+    ("matrix:!room:example.org:thread:$root", "matrix", "!room:example.org",
+     {"thread_root_event_id": "$root", "thread_reply_to_event_id": "$reply"}),
+    ("feishu:chat:thread:root", "feishu", "chat",
+     {"message_id": "reply", "thread_id": "root", "chat_type": "group"}),
+    ("dingtalk:group:conversation:user", "dingtalk", "group:conversation", {}),
+])
+async def test_idle_compaction_uses_the_session_delivery_route(
+    key, channel, chat_id, metadata, unified,
+) -> None:
+    factory = TurnDeliveryFactory(MessageBus(), RuntimeEventBus())
+    event = ContextCompactionEvent(compaction_id="compact-1", phase="started")
+    key = "unified:default" if unified else key
+    msg = InboundMessage(
+        channel=channel, sender_id="user", chat_id=chat_id, content="hello",
+        metadata={
+            "webui_turn_id": "turn-1", "sender_name": "User",
+            "message_id": "received-1", "thread_id": "received-thread", **metadata,
+        },
+    )
+    delivery = factory.create(msg, key)
+    session_metadata = {}
+    delivery.remember_session_route(session_metadata)
+
+    callback = factory.session_compaction_callback(key, session_metadata)
+    assert callback is not None
+    await callback(event)
+
+    outbound = factory.bus.outbound.get_nowait()
+    assert (outbound.channel, outbound.chat_id, outbound.metadata) == (channel, chat_id, metadata)
+    assert outbound.event is event
+
+
+async def test_idle_compaction_keeps_its_route_when_a_unified_session_moves() -> None:
+    factory = TurnDeliveryFactory(MessageBus(), RuntimeEventBus())
+    key = "unified:default"
+    session_metadata = {}
+    original = InboundMessage(
+        channel="slack", sender_id="user", chat_id="C123", content="hello",
+        metadata={"slack": {"thread_ts": "1700000000.000100"}},
+    )
+    factory.create(original, key).remember_session_route(session_metadata)
+    callback = factory.session_compaction_callback(key, session_metadata)
+    assert callback is not None
+    await callback(ContextCompactionEvent("compact-1", "started"))
+
+    latest = InboundMessage(
+        channel="telegram", sender_id="user", chat_id="42", content="next question",
+    )
+    factory.create(latest, key).remember_session_route(session_metadata)
+    await callback(ContextCompactionEvent("compact-1", "succeeded"))
+
+    events = [factory.bus.outbound.get_nowait() for _ in range(2)]
+    assert [(msg.channel, msg.chat_id, msg.metadata) for msg in events] == [
+        ("slack", "C123", {"slack": {"thread_ts": "1700000000.000100"}}),
+    ] * 2
+
+
+async def test_idle_compaction_can_deliver_to_a_legacy_websocket_session() -> None:
+    factory = TurnDeliveryFactory(MessageBus(), RuntimeEventBus())
+    event = ContextCompactionEvent(compaction_id="compact-1", phase="succeeded")
+    callback = factory.session_compaction_callback("websocket:chat", {})
+    assert callback is not None
+    await callback(event)
+    outbound = factory.bus.outbound.get_nowait()
+    assert (outbound.channel, outbound.chat_id, outbound.event) == ("websocket", "chat", event)
 
 
 def test_websocket_lifecycles_get_distinct_internal_owners(tmp_path: Path) -> None:

--- a/tests/bus/test_outbound_events.py
+++ b/tests/bus/test_outbound_events.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.outbound_events import (
+    ContextCompactionEvent,
     GoalStateSyncEvent,
     GoalStatusEvent,
     ProgressEvent,
@@ -16,6 +17,18 @@ from nanobot.bus.outbound_events import (
     outbound_message_for_event,
     replace_outbound_event,
 )
+
+
+def test_compaction_events_have_readable_channel_fallbacks() -> None:
+    for event, expected in [
+        (ContextCompactionEvent("1", "started"), "Compressing context…"),
+        (ContextCompactionEvent("1", "succeeded"), "Context compacted."),
+        (ContextCompactionEvent("1", "failed"), "Unable to compact context."),
+        (ContextCompactionEvent("1", "cancelled"), "Context compaction cancelled."),
+    ]:
+        msg = outbound_message_for_event(channel="cli", chat_id="direct", event=event)
+        assert msg.content == expected
+        assert msg.event is event
 
 
 def test_progress_event_lives_on_outbound_message_event_field() -> None:

--- a/tests/command/test_compact_command.py
+++ b/tests/command/test_compact_command.py
@@ -1,5 +1,7 @@
 """Manual context compaction command behavior."""
 
+import asyncio
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -8,11 +10,14 @@ from nanobot.agent.loop import AgentLoop
 from nanobot.bus.events import InboundMessage
 from nanobot.bus.outbound_events import ContextCompactionEvent
 from nanobot.bus.queue import MessageBus
+from nanobot.bus.runtime_events import TurnCompleted
+from nanobot.command.builtin import cmd_stop
+from nanobot.command.router import CommandContext
 from nanobot.providers.base import GenerationSettings, LLMResponse, ProviderConversationState
 
 
-@pytest.mark.asyncio
-async def test_compact_emits_one_lifecycle_and_keeps_the_session(tmp_path) -> None:
+@pytest.fixture
+async def loop(tmp_path):
     bus = MessageBus()
     provider = MagicMock()
     provider.get_default_model.return_value = "test-model"
@@ -30,6 +35,16 @@ async def test_compact_emits_one_lifecycle_and_keeps_the_session(tmp_path) -> No
         context_window_tokens=128_000,
     )
     loop.tools.get_definitions = MagicMock(return_value=[])
+    try:
+        yield loop
+    finally:
+        await loop.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("command", ["/compact", " /COMPACT@nanobot "])
+async def test_compact_emits_one_lifecycle_and_keeps_the_session(loop, command) -> None:
+    bus = loop.bus
     session = loop.sessions.get_or_create("cli:test")
     session.add_message("user", "important question")
     session.add_message("assistant", "important answer")
@@ -42,48 +57,152 @@ async def test_compact_emits_one_lifecycle_and_keeps_the_session(tmp_path) -> No
     )
     loop.sessions.save(session)
 
-    try:
-        response = await loop._process_message(
-            InboundMessage(
-                channel="cli",
-                sender_id="user",
-                chat_id="test",
-                content="/compact",
-            ),
-            runtime=loop.llm_runtime(),
-        )
+    msg = InboundMessage(channel="cli", sender_id="user", chat_id="test", content=command)
+    response = await loop._process_message(msg, runtime=loop.llm_runtime())
 
-        started = await bus.consume_outbound()
-        assert response is not None
-        assert isinstance(started.event, ContextCompactionEvent)
-        assert isinstance(response.event, ContextCompactionEvent)
-        assert started.event.phase == "started"
-        assert response.event.phase == "succeeded"
-        assert started.event.compaction_id == response.event.compaction_id
-        assert response.event.checkpoint_source == "llm_summary"
-        assert response.event.completes_command is True
+    assert response is None
+    assert bus.outbound_size == 2
+    started = bus.outbound.get_nowait().event
+    completed = bus.outbound.get_nowait().event
+    assert isinstance(started, ContextCompactionEvent)
+    assert isinstance(completed, ContextCompactionEvent)
+    assert started.phase == "started"
+    assert completed.phase == "succeeded"
+    assert started.compaction_id == completed.compaction_id
 
-        reloaded = loop.sessions.get_or_create("cli:test")
-        assert reloaded.provider_state is None
-        assert any(message.get("content") == "important answer" for message in reloaded.messages)
-    finally:
-        await loop.aclose()
+    loop.sessions.invalidate("cli:test")
+    reloaded = loop.sessions.get_or_create("cli:test")
+    assert reloaded.provider_state is None
+    assert reloaded.messages == session.messages
+    assert reloaded.last_archived == 2
+    assert len(loop.consolidator.store.read_unprocessed_history(0)) == 1
+
+    response = await loop._process_message(msg, runtime=loop.llm_runtime())
+    assert response is None
+    assert bus.outbound_size == 0
+    loop.provider.chat_with_retry.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_idle_compaction_routes_back_to_a_slack_thread() -> None:
-    loop = MagicMock()
-    loop.sessions.get_or_create.return_value = MagicMock(metadata={})
-    loop.bus = MessageBus()
-    event = ContextCompactionEvent(compaction_id="compact-1", phase="started")
+@pytest.mark.parametrize("legacy_commands", [False, True])
+async def test_empty_compact_finishes_silently_and_does_not_schedule_idle_archive(
+    loop, legacy_commands,
+) -> None:
+    key = "websocket:test"
+    session = loop.sessions.get_or_create(key)
+    session.add_message("user", "already archived")
+    session.add_message("assistant", "old answer")
+    session.last_archived = 2
+    if legacy_commands:
+        session.add_message("user", "/compact", _command=True)
+        session.add_message("assistant", "Nothing to compact.", _command=True)
+    loop.sessions.save(session)
+    completions = []
+    loop.runtime_events.subscribe(completions.append, TurnCompleted)
 
-    await AgentLoop._publish_idle_compaction(
-        loop,
-        "slack:C123:1700000000.000100",
-        event,
+    await loop._dispatch(InboundMessage(
+        channel="websocket", sender_id="user", chat_id="test", content="/compact",
+        metadata={"webui_turn_id": "compact-turn"},
+    ))
+
+    assert loop.bus.outbound_size == 0
+    assert len(completions) == 1
+    assert completions[0].context.metadata["webui_turn_id"] == "compact-turn"
+    loop.sessions.invalidate(key)
+    reloaded = loop.sessions.get_or_create(key)
+    assert reloaded.messages == session.messages
+    assert reloaded.last_archived == 2
+    assert loop.consolidator.store.read_unprocessed_history(0) == []
+
+    reloaded.updated_at = datetime.now() - timedelta(minutes=30)
+    loop.sessions.save(reloaded)
+    loop.auto_compact._ttl = 1
+    schedule = MagicMock()
+    loop.auto_compact.check_expired(schedule, loop.runtime_for_session)
+    schedule.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_compact_during_active_turn_waits_for_the_session_lock(loop) -> None:
+    key = "websocket:test"
+    msg = InboundMessage(
+        channel="websocket", sender_id="user", chat_id="test", content="/COMPACT@nanobot",
     )
+    lock = loop._get_session_lock(key)
+    async with lock:
+        await loop._dispatch_command_inline(msg, key, msg.content, loop.commands.dispatch)
+        tasks = list(loop._active_tasks[key])
+        assert len(tasks) == 1
+        await asyncio.sleep(0)
+        assert not tasks[0].done()
+        assert loop.bus.outbound_size == 0
+        session = loop.sessions.get_or_create(key)
+        session.add_message("user", "active turn question")
+        session.add_message("assistant", "active turn answer")
+        loop.sessions.save(session)
 
-    outbound = await loop.bus.consume_outbound()
-    assert outbound.channel == "slack"
-    assert outbound.chat_id == "C123"
-    assert outbound.metadata == {"slack": {"thread_ts": "1700000000.000100"}}
+    await asyncio.wait_for(asyncio.gather(*tasks), timeout=5)
+    assert loop.bus.outbound_size == 2
+    assert loop.sessions.get_or_create(key).last_archived == 2
+    loop.provider.chat_with_retry.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stop_completes_a_compact_command_waiting_for_the_session_lock(loop) -> None:
+    key = "websocket:test"
+    msg = InboundMessage(
+        channel="websocket", sender_id="user", chat_id="test", content="/compact",
+        metadata={"webui_turn_id": "queued-compact"},
+    )
+    completions = []
+    loop.runtime_events.subscribe(completions.append, TurnCompleted)
+    async with loop._get_session_lock(key):
+        await loop._dispatch_command_inline(msg, key, msg.content, loop.commands.dispatch)
+        reply = await cmd_stop(CommandContext(
+            msg=msg, session=None, key=key, raw="/stop", loop=loop,
+        ))
+    assert reply.content == "Stopped 1 task(s)."
+    assert len(completions) == 1
+    assert completions[0].context.metadata["webui_turn_id"] == "queued-compact"
+
+
+@pytest.mark.asyncio
+async def test_stop_finishes_inflight_compaction_as_cancelled(loop) -> None:
+    key = "websocket:test"
+    session = loop.sessions.get_or_create(key)
+    session.add_message("user", "important question")
+    session.add_message("assistant", "important answer")
+    loop.sessions.save(session)
+    entered = asyncio.Event()
+
+    async def wait_for_cancel(**_kwargs):
+        entered.set()
+        await asyncio.Event().wait()
+
+    loop.provider.chat_with_retry.side_effect = wait_for_cancel
+    completions = []
+    loop.runtime_events.subscribe(completions.append, TurnCompleted)
+    msg = InboundMessage(
+        channel="websocket", sender_id="user", chat_id="test", content="/compact",
+        metadata={"webui_turn_id": "compact-turn"},
+    )
+    task = asyncio.create_task(loop._dispatch(msg))
+    loop._track_active_task(key, task)
+    await asyncio.wait_for(entered.wait(), timeout=5)
+
+    reply = await cmd_stop(CommandContext(
+        msg=msg, session=session, key=key, raw="/stop", loop=loop,
+    ))
+
+    assert reply.content == "Stopped 1 task(s)."
+    assert task.cancelled()
+    assert len(completions) == 1
+    assert completions[0].context.metadata["webui_turn_id"] == "compact-turn"
+    events = [loop.bus.outbound.get_nowait().event for _ in range(loop.bus.outbound_size)]
+    assert all(isinstance(event, ContextCompactionEvent) for event in events)
+    assert [event.phase for event in events] == ["started", "cancelled"]
+    assert events[0].compaction_id == events[1].compaction_id
+    loop.sessions.invalidate(key)
+    reloaded = loop.sessions.get_or_create(key)
+    assert reloaded.messages == session.messages
+    assert reloaded.last_archived == 0

--- a/tests/command/test_compact_command.py
+++ b/tests/command/test_compact_command.py
@@ -1,0 +1,89 @@
+"""Manual context compaction command behavior."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.bus.events import InboundMessage
+from nanobot.bus.outbound_events import ContextCompactionEvent
+from nanobot.bus.queue import MessageBus
+from nanobot.providers.base import GenerationSettings, LLMResponse, ProviderConversationState
+
+
+@pytest.mark.asyncio
+async def test_compact_emits_one_lifecycle_and_keeps_the_session(tmp_path) -> None:
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.generation = GenerationSettings(max_tokens=100)
+    provider.can_resume_conversation_state.return_value = True
+    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(
+        content="Portable checkpoint.",
+        finish_reason="stop",
+    ))
+    loop = AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+        context_window_tokens=128_000,
+    )
+    loop.tools.get_definitions = MagicMock(return_value=[])
+    session = loop.sessions.get_or_create("cli:test")
+    session.add_message("user", "important question")
+    session.add_message("assistant", "important answer")
+    session.provider_state = ProviderConversationState(
+        kind="openai_responses",
+        provider="openai:test",
+        model="test-model",
+        version=1,
+        payload={"items": []},
+    )
+    loop.sessions.save(session)
+
+    try:
+        response = await loop._process_message(
+            InboundMessage(
+                channel="cli",
+                sender_id="user",
+                chat_id="test",
+                content="/compact",
+            ),
+            runtime=loop.llm_runtime(),
+        )
+
+        started = await bus.consume_outbound()
+        assert response is not None
+        assert isinstance(started.event, ContextCompactionEvent)
+        assert isinstance(response.event, ContextCompactionEvent)
+        assert started.event.phase == "started"
+        assert response.event.phase == "succeeded"
+        assert started.event.compaction_id == response.event.compaction_id
+        assert response.event.checkpoint_source == "llm_summary"
+        assert response.event.completes_command is True
+
+        reloaded = loop.sessions.get_or_create("cli:test")
+        assert reloaded.provider_state is None
+        assert any(message.get("content") == "important answer" for message in reloaded.messages)
+    finally:
+        await loop.aclose()
+
+
+@pytest.mark.asyncio
+async def test_idle_compaction_routes_back_to_a_slack_thread() -> None:
+    loop = MagicMock()
+    loop.sessions.get_or_create.return_value = MagicMock(metadata={})
+    loop.bus = MessageBus()
+    event = ContextCompactionEvent(compaction_id="compact-1", phase="started")
+
+    await AgentLoop._publish_idle_compaction(
+        loop,
+        "slack:C123:1700000000.000100",
+        event,
+    )
+
+    outbound = await loop.bus.consume_outbound()
+    assert outbound.channel == "slack"
+    assert outbound.chat_id == "C123"
+    assert outbound.metadata == {"slack": {"thread_ts": "1700000000.000100"}}

--- a/tests/webui/test_context_compaction.py
+++ b/tests/webui/test_context_compaction.py
@@ -1,9 +1,12 @@
 """WebUI replay behavior for structured context-compaction events."""
 
+import pytest
+
 from nanobot.webui.transcript import replay_transcript_to_ui_messages
 
 
-def test_replay_folds_compaction_lifecycle_into_one_stable_message() -> None:
+@pytest.mark.parametrize("phase", ["succeeded", "cancelled"])
+def test_replay_folds_compaction_lifecycle_into_one_stable_message(phase) -> None:
     messages = replay_transcript_to_ui_messages([
         {
             "event": "context_compaction",
@@ -14,8 +17,7 @@ def test_replay_folds_compaction_lifecycle_into_one_stable_message() -> None:
         {
             "event": "context_compaction",
             "compaction_id": "compact-1",
-            "phase": "succeeded",
-            "checkpoint_source": "raw_fallback",
+            "phase": phase,
             "created_at_ms": 1_700_000_001_000,
         },
     ])
@@ -29,8 +31,7 @@ def test_replay_folds_compaction_lifecycle_into_one_stable_message() -> None:
         "turnPhase": "activity",
         "compaction": {
             "id": "compact-1",
-            "phase": "succeeded",
-            "checkpointSource": "raw_fallback",
+            "phase": phase,
         },
     }]
 

--- a/tests/webui/test_context_compaction.py
+++ b/tests/webui/test_context_compaction.py
@@ -1,0 +1,53 @@
+"""WebUI replay behavior for structured context-compaction events."""
+
+from nanobot.webui.transcript import replay_transcript_to_ui_messages
+
+
+def test_replay_folds_compaction_lifecycle_into_one_stable_message() -> None:
+    messages = replay_transcript_to_ui_messages([
+        {
+            "event": "context_compaction",
+            "compaction_id": "compact-1",
+            "phase": "started",
+            "created_at_ms": 1_700_000_000_000,
+        },
+        {
+            "event": "context_compaction",
+            "compaction_id": "compact-1",
+            "phase": "succeeded",
+            "checkpoint_source": "raw_fallback",
+            "created_at_ms": 1_700_000_001_000,
+        },
+    ])
+
+    assert messages == [{
+        "id": "compaction-compact-1",
+        "role": "assistant",
+        "content": "",
+        "kind": "compaction",
+        "createdAt": 1_700_000_000_000,
+        "turnPhase": "activity",
+        "compaction": {
+            "id": "compact-1",
+            "phase": "succeeded",
+            "checkpointSource": "raw_fallback",
+        },
+    }]
+
+
+def test_replay_keeps_distinct_compactions_in_one_turn() -> None:
+    messages = replay_transcript_to_ui_messages([
+        {
+            "event": "context_compaction",
+            "compaction_id": compaction_id,
+            "phase": phase,
+        }
+        for compaction_id in ("compact-1", "compact-2")
+        for phase in ("started", "succeeded")
+    ])
+
+    assert [message["id"] for message in messages] == [
+        "compaction-compact-1",
+        "compaction-compact-2",
+    ]
+    assert all(message["compaction"]["phase"] == "succeeded" for message in messages)

--- a/tests/webui/test_outbound_wire.py
+++ b/tests/webui/test_outbound_wire.py
@@ -1,9 +1,39 @@
 from __future__ import annotations
 
-from nanobot.bus.outbound_events import RecoveryStateEvent, TurnEndEvent
+from nanobot.bus.outbound_events import (
+    ContextCompactionEvent,
+    RecoveryStateEvent,
+    TurnEndEvent,
+)
 from nanobot.providers.base import LLMUsage
 from nanobot.webui.metadata import WEBUI_TURN_METADATA_KEY
-from nanobot.webui.outbound_wire import encode_recovery_state, encode_turn_end
+from nanobot.webui.outbound_wire import (
+    encode_context_compaction,
+    encode_recovery_state,
+    encode_turn_end,
+)
+
+
+def test_encode_context_compaction_projects_safe_provenance_without_summary() -> None:
+    payload = encode_context_compaction(
+        "chat-1",
+        ContextCompactionEvent(
+            compaction_id="compact-1",
+            phase="succeeded",
+            checkpoint_source="raw_fallback",
+            completes_command=True,
+        ),
+    )
+
+    assert payload == {
+        "event": "context_compaction",
+        "chat_id": "chat-1",
+        "compaction_id": "compact-1",
+        "phase": "succeeded",
+        "checkpoint_source": "raw_fallback",
+        "completes_command": True,
+    }
+    assert "summary" not in payload
 
 
 def test_encode_recovery_state_omits_absent_optional_fields() -> None:

--- a/tests/webui/test_outbound_wire.py
+++ b/tests/webui/test_outbound_wire.py
@@ -14,14 +14,12 @@ from nanobot.webui.outbound_wire import (
 )
 
 
-def test_encode_context_compaction_projects_safe_provenance_without_summary() -> None:
+def test_encode_context_compaction_projects_the_lifecycle() -> None:
     payload = encode_context_compaction(
         "chat-1",
         ContextCompactionEvent(
             compaction_id="compact-1",
             phase="succeeded",
-            checkpoint_source="raw_fallback",
-            completes_command=True,
         ),
     )
 
@@ -30,10 +28,7 @@ def test_encode_context_compaction_projects_safe_provenance_without_summary() ->
         "chat_id": "chat-1",
         "compaction_id": "compact-1",
         "phase": "succeeded",
-        "checkpoint_source": "raw_fallback",
-        "completes_command": True,
     }
-    assert "summary" not in payload
 
 
 def test_encode_recovery_state_omits_absent_optional_fields() -> None:

--- a/tui/src/app.test.ts
+++ b/tui/src/app.test.ts
@@ -2785,6 +2785,136 @@ describe("NanobotTui layout", () => {
     expect(ui.status.plainText).not.toContain("attempt")
   })
 
+  test.each([
+    ["succeeded", "Conversation compacted"],
+    ["cancelled", "Conversation compaction cancelled"],
+  ] as const)("updates idle compaction in place to %s", async (phase, copy) => {
+    setup = await createRenderer({ width: 80, height: 24, screenMode: "alternate-screen" })
+    const app = mount(setup)
+    const ui = app as unknown as {
+      activeTurn: boolean
+      transcript: Transcript
+      composer: TextareaRenderable
+    }
+    ui.composer.setText("unfinished draft")
+    const event = { event: "context_compaction", chat_id: "chat", compaction_id: "idle" } as const
+    app.accept({ ...event, phase: "started" })
+    await setup.renderOnce()
+    expect(setup.captureCharFrame()).toContain("Compacting conversation…")
+    const rows = ui.transcript.root.getChildren()
+    app.accept({ ...event, phase })
+    app.accept({ ...event, phase })
+    app.accept({ ...event, phase: "started" })
+    app.accept({ ...event, chat_id: "another-chat", compaction_id: "other", phase: "failed" })
+    await setup.renderOnce()
+    const frame = setup.captureCharFrame()
+    expect(occurrences(frame, copy)).toBe(1)
+    expect(frame).not.toContain("Compacting conversation")
+    expect(frame).not.toContain("Could not compact")
+    expect(ui.transcript.root.getChildren()).toEqual(rows)
+    expect(ui.activeTurn).toBe(false)
+    expect(ui.composer.plainText).toBe("unfinished draft")
+  })
+
+  test("keeps compaction separate from progress and streamed answers", async () => {
+    setup = await createRenderer({ width: 80, height: 30, screenMode: "alternate-screen" })
+    const app = mount(setup)
+    app.accept({ event: "delta", chat_id: "chat", text: "Answer before " })
+    app.accept({ event: "message", chat_id: "chat", text: "First step", kind: "progress" })
+    const event = { event: "context_compaction", chat_id: "chat", compaction_id: "capacity" } as const
+    app.accept({ ...event, phase: "started" })
+    app.accept({ event: "message", chat_id: "chat", text: "Second step", kind: "progress" })
+    app.accept({ ...event, phase: "succeeded" })
+    app.accept({ event: "delta", chat_id: "chat", text: "and after compaction" })
+    expect((app as unknown as { activeTurn: boolean }).activeTurn).toBe(true)
+    app.accept({ event: "stream_end", chat_id: "chat" })
+    app.accept({ event: "turn_end", chat_id: "chat" })
+    await setup.flush()
+    const frame = setup.captureCharFrame()
+    expect(frame).toContain("Answer before and after compaction")
+    expect(frame.indexOf("First step")).toBeLessThan(frame.indexOf("Conversation compacted"))
+    expect(frame.indexOf("Conversation compacted")).toBeLessThan(frame.indexOf("Second step"))
+    expect(occurrences(frame, "Conversation compacted")).toBe(1)
+  })
+
+  test("preserves compaction rows through pagination, theming, and session reset", async () => {
+    setup = await createRenderer({ width: 80, height: 28, screenMode: "alternate-screen" })
+    const app = mount(setup)
+    const ui = app as unknown as {
+      transcript: Transcript
+      palette: { error: string }
+    }
+    ui.transcript.history([
+      { role: "activity", content: "", compaction: { id: "recent", phase: "succeeded" } },
+      { role: "assistant", content: "Recent answer" },
+    ])
+    await setup.flush()
+    await ui.transcript.prependHistory([
+      { role: "assistant", content: "Earlier answer" },
+      { role: "activity", content: "", compaction: { id: "older", phase: "failed" } },
+      { role: "activity", content: "", compaction: { id: "recent", phase: "started" } },
+    ])
+    await setup.flush()
+    ui.transcript.scrollToEdge("top")
+    await setup.renderOnce()
+    const frame = setup.captureCharFrame()
+    expect(occurrences(frame, "Conversation compacted")).toBe(1)
+    expect(frame).not.toContain("Compacting conversation")
+    expect(frame).toContain("Earlier answer")
+    expect(frame.indexOf("Earlier answer")).toBeLessThan(frame.indexOf("Could not compact conversation"))
+    expect(frame).toContain("Recent answer")
+    expect(frame.indexOf("Could not compact conversation")).toBeLessThan(frame.indexOf("Recent answer"))
+    setup.renderer.emit(CliRenderEvents.THEME_MODE, "light")
+    await setup.flush()
+    const failure = ui.transcript.root.getChildren()
+      .flatMap((row) => row.getChildren())
+      .find((child) => child instanceof TextRenderable && child.plainText.includes("Could not compact"))
+    expect(failure).toBeInstanceOf(TextRenderable)
+    expect((failure as TextRenderable).fg.toInts().slice(0, 3)).toEqual([
+      1, 3, 5,
+    ].map((offset) => Number.parseInt(ui.palette.error.slice(offset, offset + 2), 16)))
+    ui.transcript.reset({ model: "model", workspace: "workspace", version: "test", access: "workspace" })
+    app.accept({ event: "context_compaction", chat_id: "chat", compaction_id: "recent", phase: "started" })
+    await setup.renderOnce()
+    expect(setup.captureCharFrame()).toContain("Compacting conversation…")
+    expect(setup.captureCharFrame()).not.toContain("Conversation compacted")
+  })
+
+  test("deduplicates compaction history against events queued during hydration", async () => {
+    setup = await createRenderer({ width: 80, height: 22, screenMode: "alternate-screen" })
+    const original = globalThis.fetch
+    let resolveFetch: (value: Response) => void = () => undefined
+    globalThis.fetch = (() => new Promise<Response>((resolve) => {
+      resolveFetch = resolve
+    })) as unknown as typeof fetch
+    const app = NanobotTui.mount(
+      setup.renderer,
+      { ...options, apiUrl: "http://nanobot.test", apiToken: "token", chatId: "chat" },
+      client(),
+      new MockTreeSitterClient({ autoResolveTimeout: 0 }),
+    )
+    try {
+      app.accept({ event: "attached", chat_id: "chat" })
+      const event = { event: "context_compaction", chat_id: "chat", compaction_id: "idle" } as const
+      app.accept({ ...event, phase: "started" })
+      app.accept({ ...event, phase: "succeeded" })
+      resolveFetch(Response.json({
+        messages: [{
+          role: "assistant", kind: "compaction", content: "",
+          compaction: { id: "idle", phase: "succeeded" },
+        }],
+      }))
+      await waitUntil(() => (app as unknown as { ready: boolean }).ready)
+      await setup.renderOnce()
+      const frame = setup.captureCharFrame()
+      expect(occurrences(frame, "Conversation compacted")).toBe(1)
+      expect(frame).not.toContain("Compacting conversation")
+      expect((app as unknown as { activeTurn: boolean }).activeTurn).toBe(false)
+    } finally {
+      globalThis.fetch = original
+    }
+  })
+
   test("replays events after asynchronous history hydration", async () => {
     setup = await createRenderer({ width: 80, height: 22, screenMode: "alternate-screen" })
     const original = globalThis.fetch

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -1063,6 +1063,9 @@ export class NanobotTui {
     }
 
     switch (event.event) {
+      case "context_compaction":
+        this.transcript.compaction({ id: event.compaction_id, phase: event.phase })
+        return
       case "message_accepted":
         this.reconcileTurnOwnership(event)
         return

--- a/tui/src/protocol.test.ts
+++ b/tui/src/protocol.test.ts
@@ -706,6 +706,54 @@ describe("gateway protocol", () => {
     }
   })
 
+  test("receives compaction phases and rejects malformed compaction events", () => {
+    const original = globalThis.WebSocket
+    let socket: FakeSocket | undefined
+    Object.defineProperty(globalThis, "WebSocket", {
+      configurable: true,
+      value: class extends FakeSocket {
+        constructor() {
+          super()
+          socket = this
+        }
+      },
+    })
+    const events: InboundEvent[] = []
+    const statuses: string[] = []
+    const client = new NanobotClient({
+      url: "ws://nanobot.test/ws",
+      onEvent: (event) => events.push(event),
+      onStatus: (status, detail) => statuses.push(`${status}:${detail || ""}`),
+    })
+    try {
+      client.connect()
+      if (!socket) throw new Error("socket was not created")
+      const base = { event: "context_compaction", chat_id: "chat", compaction_id: "compact-1" }
+      for (const phase of ["started", "succeeded", "failed", "cancelled"]) {
+        socket.emit("message", { data: JSON.stringify({
+          ...base, phase,
+        }) })
+      }
+      for (const invalid of [
+        { phase: "unknown" },
+        { phase: "started", compaction_id: "" },
+        { phase: "started", compaction_id: 42 },
+        { phase: "started", compaction_id: undefined },
+        { phase: "started", chat_id: undefined },
+      ]) {
+        socket.emit("message", { data: JSON.stringify({ ...base, ...invalid }) })
+      }
+      expect(events.map((event) => event.event)).toEqual(Array(4).fill("context_compaction"))
+      expect(events.map((event) => "phase" in event ? event.phase : null)).toEqual([
+        "started", "succeeded", "failed", "cancelled",
+      ])
+      expect(statuses.filter((status) => status.includes("invalid event"))).toHaveLength(5)
+    } finally {
+      client.close()
+      Object.defineProperty(globalThis, "WebSocket", { configurable: true, value: original })
+    }
+  })
+
   test("validates nested unified diff payloads at the websocket boundary", () => {
     const original = globalThis.WebSocket
     let socket: FakeSocket | undefined
@@ -922,6 +970,43 @@ describe("gateway protocol", () => {
         userMessageOffset: 0,
       })
       expect(requested).toContain("before=newer-page")
+    } finally {
+      globalThis.fetch = original
+    }
+  })
+
+  test("loads compaction history as activity rows", async () => {
+    const original = globalThis.fetch
+    globalThis.fetch = Object.assign(async () => Response.json({
+      messages: [
+        { role: "assistant", content: "before" },
+        ...["started", "succeeded", "failed", "cancelled"].map((phase) => ({
+          role: "assistant",
+          kind: "compaction",
+          content: "",
+          compaction: { id: phase, phase },
+        })),
+        { role: "assistant", kind: "compaction", content: "invalid", compaction: null },
+        {
+          role: "assistant", kind: "compaction", content: "invalid",
+          compaction: { id: "", phase: "succeeded" },
+        },
+        {
+          role: "assistant", kind: "compaction", content: "invalid",
+          compaction: { id: "unknown", phase: "unknown" },
+        },
+        { role: "assistant", content: "after" },
+      ],
+    }), { preconnect: original.preconnect })
+    try {
+      const history = await fetchHistory("http://nanobot.test", "token", "chat")
+      expect(history.messages).toEqual([
+        { role: "assistant", content: "before", forkIndex: 0 },
+        ...(["started", "succeeded", "failed", "cancelled"] as const).map((phase) => ({
+          role: "activity" as const, content: "", compaction: { id: phase, phase },
+        })),
+        { role: "assistant", content: "after", forkIndex: 0 },
+      ])
     } finally {
       globalThis.fetch = original
     }

--- a/tui/src/protocol.ts
+++ b/tui/src/protocol.ts
@@ -86,6 +86,11 @@ export interface RecoveryState {
   can_continue?: boolean
 }
 
+export interface ContextCompaction {
+  id: string
+  phase: "started" | "succeeded" | "failed" | "cancelled"
+}
+
 export type InboundEvent =
   | { event: "ready"; chat_id: string; client_id: string }
   | {
@@ -152,6 +157,12 @@ export type InboundEvent =
     }
   | { event: "goal_state"; chat_id: string; goal_state: Record<string, unknown> }
   | ({ event: "recovery_state"; chat_id: string } & RecoveryState)
+  | {
+      event: "context_compaction"
+      chat_id: string
+      compaction_id: string
+      phase: ContextCompaction["phase"]
+    }
   | {
       event: "session_updated"
       chat_id: string
@@ -234,6 +245,7 @@ export interface HistoryMessage {
   media?: MediaAttachment[]
   toolEvents?: ToolProgressEvent[]
   fileEdits?: FileEditEvent[]
+  compaction?: ContextCompaction
   forkIndex?: number
 }
 
@@ -356,6 +368,7 @@ const CHAT_EVENTS = new Set([
   "goal_status",
   "goal_state",
   "recovery_state",
+  "context_compaction",
   "session_updated",
   "turn_model_updated",
   "error",
@@ -367,6 +380,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function optional(value: unknown, type: "boolean" | "number" | "string"): boolean {
   return value === undefined || typeof value === type
+}
+
+function isCompactionPhase(value: unknown): value is ContextCompaction["phase"] {
+  return value === "started" || value === "succeeded" || value === "failed" || value === "cancelled"
 }
 
 function isToolEvent(value: unknown): value is ToolProgressEvent {
@@ -545,6 +562,12 @@ function decodeInboundEvent(value: unknown): InboundEvent | null | undefined {
   if (name === "goal_state" && !isRecord(record.goal_state)) return null
   if (name === "recovery_state" && !isRecoveryState(record)) return null
   if (
+    name === "context_compaction"
+    && (typeof record.compaction_id !== "string"
+      || !record.compaction_id
+      || !isCompactionPhase(record.phase))
+  ) return null
+  if (
     name === "session_updated"
     && (!optional(record.scope, "string")
       || (record.workspace_scope !== undefined && !isWorkspaceScope(record.workspace_scope)))
@@ -608,6 +631,20 @@ export async function fetchHistory(
   for (const message of payload.messages || []) {
     const role = message.role
     const content = message.content
+    if (message.kind === "compaction") {
+      const compaction = message.compaction
+      if (isRecord(compaction)
+        && typeof compaction.id === "string"
+        && compaction.id
+        && isCompactionPhase(compaction.phase)) {
+        messages.push({
+          role: "activity",
+          content: "",
+          compaction: { id: compaction.id, phase: compaction.phase },
+        })
+      }
+      continue
+    }
     if (role === "tool" && message.kind === "trace") {
       const traces = Array.isArray(message.traces)
         ? message.traces.filter((value): value is string => typeof value === "string")

--- a/tui/src/transcript.ts
+++ b/tui/src/transcript.ts
@@ -13,6 +13,7 @@ import {
 } from "@opentui/core"
 
 import type {
+  ContextCompaction,
   FileEditEvent,
   HistoryMessage,
   MediaAttachment,
@@ -124,6 +125,10 @@ export class Transcript {
   }> = []
   private readonly markdown = new Set<MarkdownRenderable>()
   private readonly activities = new Set<Activity>()
+  private readonly compactions = new Map<string, {
+    phase: ContextCompaction["phase"]
+    text: TextRenderable
+  }>()
   private readonly frames = new Set<BoxRenderable>()
   private readonly userRows = new Set<BoxRenderable>()
   private readonly userMessages = new Set<{
@@ -176,6 +181,9 @@ export class Transcript {
     const previousSyntax = this.theme.syntax
     this.theme = theme
     for (const { renderable, tone } of this.styledText) renderable.fg = theme[tone]
+    for (const { text, phase } of this.compactions.values()) {
+      text.fg = phase === "failed" ? theme.error : theme.muted
+    }
     for (const message of this.userMessages) {
       message.renderable.content = this.userMessageContent(
         message.content,
@@ -235,6 +243,7 @@ export class Transcript {
     this.styledText.length = 0
     this.markdown.clear()
     this.activities.clear()
+    this.compactions.clear()
     this.frames.clear()
     this.userRows.clear()
     this.userMessages.clear()
@@ -249,7 +258,8 @@ export class Transcript {
 
   history(messages: HistoryMessage[]): void {
     for (const message of messages) {
-      if (message.role === "user") {
+      if (message.compaction) this.compaction(message.compaction)
+      else if (message.role === "user") {
         this.user(message.content, message.turnId, message.media)
       }
       else if (message.role === "assistant") this.assistant(message.content)
@@ -265,7 +275,9 @@ export class Transcript {
     const previousHeight = this.root.scrollHeight
     let index = 1 // Keep the launch header first.
     for (const message of messages) {
-      if (message.role === "user") {
+      if (message.compaction) {
+        if (this.compaction(message.compaction, index)) index += 1
+      } else if (message.role === "user") {
         if (message.turnId && this.userTurnIds.has(message.turnId)) continue
         this.writeUser(message.content, message.media, index++)
         if (message.turnId) this.userTurnIds.add(message.turnId)
@@ -318,6 +330,36 @@ export class Transcript {
     this.noteOutput()
     this.finishActivity()
     this.writeRole(error ? "×" : "·", content, error ? "error" : "muted")
+  }
+
+  compaction(compaction: ContextCompaction, index?: number): boolean {
+    let entry = this.compactions.get(compaction.id)
+    // Hydration can replay a terminal state before an already queued start event.
+    if (entry && (entry.phase !== "started" || entry.phase === compaction.phase)) return false
+    const added = !entry
+    if (index === undefined) {
+      this.noteOutput()
+      if (added) this.finishActivity()
+    }
+    if (!entry) {
+      const row = this.createRow("compaction")
+      const text = this.createText("", "muted", false, "compaction-status")
+      row.add(text)
+      this.root.add(row, index)
+      this.wrote = true
+      entry = { phase: compaction.phase, text }
+      this.compactions.set(compaction.id, entry)
+    }
+    entry.phase = compaction.phase
+    entry.text.content = compaction.phase === "started"
+      ? "  ≋ Compacting conversation…"
+      : compaction.phase === "succeeded"
+        ? "  ✓ Conversation compacted"
+        : compaction.phase === "cancelled"
+          ? "  · Conversation compaction cancelled"
+          : "  × Could not compact conversation"
+    entry.text.fg = compaction.phase === "failed" ? this.theme.error : this.theme.muted
+    return added
   }
 
   stream(delta: string): void {
@@ -408,6 +450,7 @@ export class Transcript {
     this.pendingStream = ""
     this.live = null
     this.activity = null
+    this.compactions.clear()
     this.frames.clear()
     this.userRows.clear()
     this.userMessages.clear()

--- a/webui/src/components/MessageBubble.tsx
+++ b/webui/src/components/MessageBubble.tsx
@@ -445,7 +445,12 @@ export function MessageBubble({
     );
   }
 
-  const empty = message.content.trim().length === 0;
+  const assistantContent = message.compactReply === "empty"
+    ? t("thread.compaction.empty")
+    : message.compactReply === "failed"
+      ? t("thread.compaction.failed")
+      : message.content;
+  const empty = assistantContent.trim().length === 0;
   const media = message.media ?? [];
   const reasoning = message.role === "assistant" ? message.reasoning ?? "" : "";
   const reasoningStreaming = !!(message.role === "assistant" && message.reasoningStreaming);
@@ -512,7 +517,7 @@ export function MessageBubble({
               preserveStreamingLayout
               onOpenFilePreview={onOpenFilePreview}
             >
-              {message.content}
+              {assistantContent}
             </MarkdownText>
           </div>
           {media.length > 0 ? <MessageMedia media={media} align="left" /> : null}
@@ -533,7 +538,7 @@ export function MessageBubble({
             )}
           >
             {showCopyButton ? (
-              <MessageCopyButton content={message.content} />
+              <MessageCopyButton content={assistantContent} />
             ) : null}
             {showForkButton ? (
               <Tooltip>

--- a/webui/src/components/MessageBubble.tsx
+++ b/webui/src/components/MessageBubble.tsx
@@ -25,6 +25,7 @@ import { ImageLightbox } from "@/components/ImageLightbox";
 import { MarkdownText } from "@/components/MarkdownText";
 import { SlashCommandText } from "@/components/SlashCommandText";
 import { ReasoningRow } from "@/components/thread/activity/ReasoningRow";
+import { ContextCompactionNotice } from "@/components/thread/ContextCompactionNotice";
 import { UserMessageText } from "@/components/UserMessageText";
 import {
   Tooltip,
@@ -342,6 +343,10 @@ export function MessageBubble({
     () => mergeMcpMentionPresets(mcpPresets, message.mcpPresets),
     [mcpPresets, message.mcpPresets],
   );
+
+  if (message.kind === "compaction" && message.compaction) {
+    return <ContextCompactionNotice compaction={message.compaction} />;
+  }
 
   if (message.kind === "trace") {
     return <TraceGroup message={message} />;

--- a/webui/src/components/thread/ContextCompactionNotice.tsx
+++ b/webui/src/components/thread/ContextCompactionNotice.tsx
@@ -1,0 +1,64 @@
+import { Archive, CircleAlert, LoaderCircle, TriangleAlert } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { cn } from "@/lib/utils";
+import type { UIContextCompaction } from "@/lib/types";
+
+interface ContextCompactionNoticeProps {
+  compaction: UIContextCompaction;
+}
+
+export function ContextCompactionNotice({ compaction }: ContextCompactionNoticeProps) {
+  const { t } = useTranslation();
+  const rawFallback = compaction.checkpointSource === "raw_fallback";
+  const title = compaction.phase === "started"
+    ? t("thread.compaction.started", { defaultValue: "Compressing context…" })
+    : compaction.phase === "failed"
+      ? t("thread.compaction.failed", { defaultValue: "Context compaction failed" })
+      : t("thread.compaction.succeeded", { defaultValue: "Context compacted" });
+  const source = compaction.phase === "succeeded"
+    ? rawFallback
+      ? t("thread.compaction.source.raw", { defaultValue: "Raw fallback" })
+      : compaction.checkpointSource === "llm_summary"
+        ? t("thread.compaction.source.llm", { defaultValue: "LLM summary" })
+        : null
+    : null;
+  const Icon = compaction.phase === "started"
+    ? LoaderCircle
+    : compaction.phase === "failed"
+      ? CircleAlert
+      : rawFallback
+        ? TriangleAlert
+        : Archive;
+
+  return (
+    <div
+      role={compaction.announce ? "status" : undefined}
+      aria-live={compaction.announce ? "polite" : undefined}
+      aria-busy={compaction.phase === "started"}
+      data-context-compaction={compaction.phase}
+      className="mx-auto flex w-full max-w-[49.5rem] items-center gap-2.5 py-1 text-xs text-muted-foreground"
+    >
+      <span
+        className={cn(
+          "flex size-6 shrink-0 items-center justify-center rounded-full bg-muted/60",
+          compaction.phase === "failed" && "text-destructive",
+          rawFallback && compaction.phase === "succeeded"
+            && "text-amber-600 dark:text-amber-400",
+        )}
+      >
+        <Icon
+          className={cn(
+            "size-3.5",
+            compaction.phase === "started" && "animate-spin motion-reduce:animate-none",
+          )}
+          aria-hidden
+        />
+      </span>
+      <p className="min-w-0 leading-5">
+        <span className="font-medium text-foreground/80">{title}</span>
+        {source ? <span className="ml-1.5">{source}</span> : null}
+      </p>
+    </div>
+  );
+}

--- a/webui/src/components/thread/ContextCompactionNotice.tsx
+++ b/webui/src/components/thread/ContextCompactionNotice.tsx
@@ -1,4 +1,4 @@
-import { Archive, CircleAlert, LoaderCircle, TriangleAlert } from "lucide-react";
+import { Archive, CircleAlert, LoaderCircle } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/utils";
@@ -10,26 +10,18 @@ interface ContextCompactionNoticeProps {
 
 export function ContextCompactionNotice({ compaction }: ContextCompactionNoticeProps) {
   const { t } = useTranslation();
-  const rawFallback = compaction.checkpointSource === "raw_fallback";
   const title = compaction.phase === "started"
     ? t("thread.compaction.started", { defaultValue: "Compressing context…" })
     : compaction.phase === "failed"
       ? t("thread.compaction.failed", { defaultValue: "Context compaction failed" })
-      : t("thread.compaction.succeeded", { defaultValue: "Context compacted" });
-  const source = compaction.phase === "succeeded"
-    ? rawFallback
-      ? t("thread.compaction.source.raw", { defaultValue: "Raw fallback" })
-      : compaction.checkpointSource === "llm_summary"
-        ? t("thread.compaction.source.llm", { defaultValue: "LLM summary" })
-        : null
-    : null;
+      : compaction.phase === "cancelled"
+        ? t("thread.compaction.cancelled", { defaultValue: "Context compaction cancelled" })
+        : t("thread.compaction.succeeded", { defaultValue: "Context compacted" });
   const Icon = compaction.phase === "started"
     ? LoaderCircle
     : compaction.phase === "failed"
       ? CircleAlert
-      : rawFallback
-        ? TriangleAlert
-        : Archive;
+      : Archive;
 
   return (
     <div
@@ -43,8 +35,6 @@ export function ContextCompactionNotice({ compaction }: ContextCompactionNoticeP
         className={cn(
           "flex size-6 shrink-0 items-center justify-center rounded-full bg-muted/60",
           compaction.phase === "failed" && "text-destructive",
-          rawFallback && compaction.phase === "succeeded"
-            && "text-amber-600 dark:text-amber-400",
         )}
       >
         <Icon
@@ -55,10 +45,7 @@ export function ContextCompactionNotice({ compaction }: ContextCompactionNoticeP
           aria-hidden
         />
       </span>
-      <p className="min-w-0 leading-5">
-        <span className="font-medium text-foreground/80">{title}</span>
-        {source ? <span className="ml-1.5">{source}</span> : null}
-      </p>
+      <p className="min-w-0 font-medium leading-5 text-foreground/80">{title}</p>
     </div>
   );
 }

--- a/webui/src/components/thread/ThreadComposer.tsx
+++ b/webui/src/components/thread/ThreadComposer.tsx
@@ -21,6 +21,7 @@ import {
 import { INLINE_TOKEN_HIGHLIGHT_COLOR } from "@/components/InlineTokenHighlight";
 import {
   Activity,
+  Archive,
   ArrowUp,
   BookOpen,
   Brain,
@@ -235,6 +236,7 @@ interface ThreadComposerProps {
 
 const COMMAND_ICONS: Record<string, LucideIcon> = {
   activity: Activity,
+  archive: Archive,
   "book-open": BookOpen,
   brain: Brain,
   "circle-help": CircleHelp,

--- a/webui/src/components/thread/ThreadMessages.tsx
+++ b/webui/src/components/thread/ThreadMessages.tsx
@@ -39,6 +39,16 @@ export function assistantForkFlags(units: DisplayUnit[]): boolean[] {
       hasLaterUnitBeforeUser = false;
       continue;
     }
+    if (
+      unit.type === "message"
+      && unit.message.role === "assistant"
+      && unit.message.kind === "compaction"
+    ) {
+      // Compaction notices are session lifecycle markers, not assistant answers.
+      // They must neither expose nor displace the answer-level fork action.
+      flags[i] = false;
+      continue;
+    }
     if (unit.type === "message" && unit.message.role === "assistant") {
       flags[i] = !hasLaterUnitBeforeUser;
     }

--- a/webui/src/hooks/useNanobotStream.ts
+++ b/webui/src/hooks/useNanobotStream.ts
@@ -771,6 +771,39 @@ export function useNanobotStream(
         return;
       }
       const sideChannelEvent = isSideChannelEvent(ev);
+      if (ev.event === "context_compaction") {
+        flushPendingStreamEvents({ closeAnswerSegment: true });
+        clearActivitySegment();
+        const compaction = {
+          id: ev.compaction_id,
+          phase: ev.phase,
+          ...(ev.checkpoint_source ? { checkpointSource: ev.checkpoint_source } : {}),
+          announce: true,
+        };
+        setMessages((prev) => {
+          const id = `compaction-${ev.compaction_id}`;
+          const existing = prev.findIndex((message) => message.id === id);
+          const next = {
+            id,
+            role: "assistant" as const,
+            content: "",
+            kind: "compaction" as const,
+            createdAt: Date.now(),
+            compaction,
+            ...turnFieldsFromEvent(ev, "activity"),
+          };
+          if (existing < 0) return [...prev, next];
+          return prev.map((message, index) => (
+            index === existing
+              ? { ...next, createdAt: message.createdAt }
+              : message
+          ));
+        });
+        if (ev.completes_command && typeof ev.turn_id === "string") {
+          sideChannelTurnIdsRef.current.delete(ev.turn_id);
+        }
+        return;
+      }
       if (ev.event === "delta") {
         if (suppressStreamUntilTurnEndRef.current) return;
         const chunk = typeof ev.text === "string" ? ev.text : "";

--- a/webui/src/hooks/useNanobotStream.ts
+++ b/webui/src/hooks/useNanobotStream.ts
@@ -777,7 +777,6 @@ export function useNanobotStream(
         const compaction = {
           id: ev.compaction_id,
           phase: ev.phase,
-          ...(ev.checkpoint_source ? { checkpointSource: ev.checkpoint_source } : {}),
           announce: true,
         };
         setMessages((prev) => {
@@ -799,9 +798,6 @@ export function useNanobotStream(
               : message
           ));
         });
-        if (ev.completes_command && typeof ev.turn_id === "string") {
-          sideChannelTurnIdsRef.current.delete(ev.turn_id);
-        }
         return;
       }
       if (ev.event === "delta") {
@@ -887,6 +883,7 @@ export function useNanobotStream(
       }
 
       if (ev.event === "turn_end") {
+        if (typeof ev.turn_id === "string") sideChannelTurnIdsRef.current.delete(ev.turn_id);
         if ("goal_state" in ev && ev.goal_state != null && typeof ev.goal_state === "object") {
           setGoalState(ev.goal_state);
         }

--- a/webui/src/i18n/locales/en/common.json
+++ b/webui/src/i18n/locales/en/common.json
@@ -1083,6 +1083,12 @@
     "error": "Connection error"
   },
   "thread": {
+    "compaction": {
+      "started": "Compressing context…",
+      "failed": "Context compaction failed",
+      "succeeded": "Context compacted",
+      "source": { "llm": "LLM summary", "raw": "Raw fallback" }
+    },
     "loadingConversation": "Loading conversation…",
     "empty": {
       "greetings": {
@@ -1276,6 +1282,10 @@
           "new": {
             "title": "New chat",
             "description": "Reset this chat and start a fresh conversation."
+          },
+          "compact": {
+            "title": "Compact context",
+            "description": "Compact this chat's context and continue the conversation."
           },
           "stop": {
             "title": "Stop current task",

--- a/webui/src/i18n/locales/en/common.json
+++ b/webui/src/i18n/locales/en/common.json
@@ -1084,10 +1084,11 @@
   },
   "thread": {
     "compaction": {
+      "cancelled": "Context compaction cancelled",
+      "empty": "Nothing to compact.",
       "started": "Compressing context…",
       "failed": "Context compaction failed",
-      "succeeded": "Context compacted",
-      "source": { "llm": "LLM summary", "raw": "Raw fallback" }
+      "succeeded": "Context compacted"
     },
     "loadingConversation": "Loading conversation…",
     "empty": {

--- a/webui/src/i18n/locales/es/common.json
+++ b/webui/src/i18n/locales/es/common.json
@@ -1070,6 +1070,12 @@
     "error": "Error de conexión"
   },
   "thread": {
+    "compaction": {
+      "started": "Comprimiendo el contexto…",
+      "failed": "La compresión del contexto falló",
+      "succeeded": "Contexto comprimido",
+      "source": { "llm": "Resumen del LLM", "raw": "Respaldo sin procesar" }
+    },
     "loadingConversation": "Cargando conversación…",
     "empty": {
       "greetings": {
@@ -1253,6 +1259,10 @@
           "new": {
             "title": "Nuevo chat",
             "description": "Restablece este chat e inicia una conversación nueva."
+          },
+          "compact": {
+            "title": "Compactar contexto",
+            "description": "Compacta el contexto de este chat y continúa la conversación."
           },
           "stop": {
             "title": "Detener tarea actual",

--- a/webui/src/i18n/locales/es/common.json
+++ b/webui/src/i18n/locales/es/common.json
@@ -1071,10 +1071,11 @@
   },
   "thread": {
     "compaction": {
+      "cancelled": "Compresión de contexto cancelada",
+      "empty": "No hay contexto que comprimir.",
       "started": "Comprimiendo el contexto…",
       "failed": "La compresión del contexto falló",
-      "succeeded": "Contexto comprimido",
-      "source": { "llm": "Resumen del LLM", "raw": "Respaldo sin procesar" }
+      "succeeded": "Contexto comprimido"
     },
     "loadingConversation": "Cargando conversación…",
     "empty": {

--- a/webui/src/i18n/locales/fr/common.json
+++ b/webui/src/i18n/locales/fr/common.json
@@ -1070,10 +1070,11 @@
   },
   "thread": {
     "compaction": {
+      "cancelled": "Compression du contexte annulée",
+      "empty": "Aucun contexte à compresser.",
       "started": "Compression du contexte…",
       "failed": "Échec de la compression du contexte",
-      "succeeded": "Contexte compressé",
-      "source": { "llm": "Résumé LLM", "raw": "Repli brut" }
+      "succeeded": "Contexte compressé"
     },
     "loadingConversation": "Chargement de la conversation…",
     "empty": {

--- a/webui/src/i18n/locales/fr/common.json
+++ b/webui/src/i18n/locales/fr/common.json
@@ -1069,6 +1069,12 @@
     "error": "Erreur de connexion"
   },
   "thread": {
+    "compaction": {
+      "started": "Compression du contexte…",
+      "failed": "Échec de la compression du contexte",
+      "succeeded": "Contexte compressé",
+      "source": { "llm": "Résumé LLM", "raw": "Repli brut" }
+    },
     "loadingConversation": "Chargement de la conversation…",
     "empty": {
       "greetings": {
@@ -1252,6 +1258,10 @@
           "new": {
             "title": "Nouvelle discussion",
             "description": "Réinitialiser cette discussion et démarrer une nouvelle conversation."
+          },
+          "compact": {
+            "title": "Compacter le contexte",
+            "description": "Compacter le contexte de cette discussion et poursuivre la conversation."
           },
           "stop": {
             "title": "Arrêter la tâche en cours",

--- a/webui/src/i18n/locales/id/common.json
+++ b/webui/src/i18n/locales/id/common.json
@@ -1069,6 +1069,12 @@
     "error": "Kesalahan koneksi"
   },
   "thread": {
+    "compaction": {
+      "started": "Memadatkan konteks…",
+      "failed": "Pemadatan konteks gagal",
+      "succeeded": "Konteks dipadatkan",
+      "source": { "llm": "Ringkasan LLM", "raw": "Fallback mentah" }
+    },
     "loadingConversation": "Memuat percakapan…",
     "empty": {
       "greetings": {
@@ -1252,6 +1258,10 @@
           "new": {
             "title": "Obrolan baru",
             "description": "Reset chat ini dan mulai percakapan baru."
+          },
+          "compact": {
+            "title": "Ringkas konteks",
+            "description": "Ringkas konteks chat ini, lalu lanjutkan percakapan."
           },
           "stop": {
             "title": "Hentikan tugas saat ini",

--- a/webui/src/i18n/locales/id/common.json
+++ b/webui/src/i18n/locales/id/common.json
@@ -1070,10 +1070,11 @@
   },
   "thread": {
     "compaction": {
+      "cancelled": "Pemadatan konteks dibatalkan",
+      "empty": "Tidak ada konteks yang perlu dipadatkan.",
       "started": "Memadatkan konteks…",
       "failed": "Pemadatan konteks gagal",
-      "succeeded": "Konteks dipadatkan",
-      "source": { "llm": "Ringkasan LLM", "raw": "Fallback mentah" }
+      "succeeded": "Konteks dipadatkan"
     },
     "loadingConversation": "Memuat percakapan…",
     "empty": {

--- a/webui/src/i18n/locales/ja/common.json
+++ b/webui/src/i18n/locales/ja/common.json
@@ -1069,6 +1069,12 @@
     "error": "接続エラー"
   },
   "thread": {
+    "compaction": {
+      "started": "コンテキストを圧縮中…",
+      "failed": "コンテキストの圧縮に失敗しました",
+      "succeeded": "コンテキストを圧縮しました",
+      "source": { "llm": "LLM 要約", "raw": "Raw フォールバック" }
+    },
     "loadingConversation": "会話を読み込み中…",
     "empty": {
       "greetings": {
@@ -1252,6 +1258,10 @@
           "new": {
             "title": "新しいチャット",
             "description": "このチャットをリセットして、新しい会話を開始します。"
+          },
+          "compact": {
+            "title": "コンテキストを圧縮",
+            "description": "このチャットのコンテキストを圧縮して、会話を続けます。"
           },
           "stop": {
             "title": "現在のタスクを停止",

--- a/webui/src/i18n/locales/ja/common.json
+++ b/webui/src/i18n/locales/ja/common.json
@@ -1070,10 +1070,11 @@
   },
   "thread": {
     "compaction": {
+      "cancelled": "コンテキストの圧縮をキャンセルしました",
+      "empty": "圧縮するコンテキストはありません。",
       "started": "コンテキストを圧縮中…",
       "failed": "コンテキストの圧縮に失敗しました",
-      "succeeded": "コンテキストを圧縮しました",
-      "source": { "llm": "LLM 要約", "raw": "Raw フォールバック" }
+      "succeeded": "コンテキストを圧縮しました"
     },
     "loadingConversation": "会話を読み込み中…",
     "empty": {

--- a/webui/src/i18n/locales/ko/common.json
+++ b/webui/src/i18n/locales/ko/common.json
@@ -1070,10 +1070,11 @@
   },
   "thread": {
     "compaction": {
+      "cancelled": "컨텍스트 압축이 취소되었습니다",
+      "empty": "압축할 컨텍스트가 없습니다.",
       "started": "컨텍스트 압축 중…",
       "failed": "컨텍스트 압축 실패",
-      "succeeded": "컨텍스트를 압축했습니다",
-      "source": { "llm": "LLM 요약", "raw": "원시 대체" }
+      "succeeded": "컨텍스트를 압축했습니다"
     },
     "loadingConversation": "대화 불러오는 중…",
     "empty": {

--- a/webui/src/i18n/locales/ko/common.json
+++ b/webui/src/i18n/locales/ko/common.json
@@ -1069,6 +1069,12 @@
     "error": "연결 오류"
   },
   "thread": {
+    "compaction": {
+      "started": "컨텍스트 압축 중…",
+      "failed": "컨텍스트 압축 실패",
+      "succeeded": "컨텍스트를 압축했습니다",
+      "source": { "llm": "LLM 요약", "raw": "원시 대체" }
+    },
     "loadingConversation": "대화 불러오는 중…",
     "empty": {
       "greetings": {
@@ -1252,6 +1258,10 @@
           "new": {
             "title": "새 채팅",
             "description": "이 채팅을 초기화하고 새 대화를 시작합니다."
+          },
+          "compact": {
+            "title": "컨텍스트 압축",
+            "description": "이 채팅의 컨텍스트를 압축하고 대화를 계속합니다."
           },
           "stop": {
             "title": "현재 작업 중지",

--- a/webui/src/i18n/locales/pt-BR/common.json
+++ b/webui/src/i18n/locales/pt-BR/common.json
@@ -1084,10 +1084,11 @@
   },
   "thread": {
     "compaction": {
+      "cancelled": "Compactação do contexto cancelada",
+      "empty": "Não há contexto para compactar.",
       "started": "Compactando contexto…",
       "failed": "Falha ao compactar o contexto",
-      "succeeded": "Contexto compactado",
-      "source": { "llm": "Resumo do LLM", "raw": "Fallback bruto" }
+      "succeeded": "Contexto compactado"
     },
     "loadingConversation": "Carregando conversa…",
     "empty": {

--- a/webui/src/i18n/locales/pt-BR/common.json
+++ b/webui/src/i18n/locales/pt-BR/common.json
@@ -1083,6 +1083,12 @@
     "error": "Erro de conexão"
   },
   "thread": {
+    "compaction": {
+      "started": "Compactando contexto…",
+      "failed": "Falha ao compactar o contexto",
+      "succeeded": "Contexto compactado",
+      "source": { "llm": "Resumo do LLM", "raw": "Fallback bruto" }
+    },
     "loadingConversation": "Carregando conversa…",
     "empty": {
       "greetings": {
@@ -1276,6 +1282,10 @@
           "new": {
             "title": "Nova conversa",
             "description": "Reinicia esta conversa e inicia uma conversa nova."
+          },
+          "compact": {
+            "title": "Compactar contexto",
+            "description": "Compacte o contexto desta conversa e continue conversando."
           },
           "stop": {
             "title": "Parar tarefa atual",

--- a/webui/src/i18n/locales/vi/common.json
+++ b/webui/src/i18n/locales/vi/common.json
@@ -1070,10 +1070,11 @@
   },
   "thread": {
     "compaction": {
+      "cancelled": "Đã hủy nén ngữ cảnh",
+      "empty": "Không có ngữ cảnh cần nén.",
       "started": "Đang nén ngữ cảnh…",
       "failed": "Nén ngữ cảnh không thành công",
-      "succeeded": "Đã nén ngữ cảnh",
-      "source": { "llm": "Bản tóm tắt LLM", "raw": "Dữ liệu thô dự phòng" }
+      "succeeded": "Đã nén ngữ cảnh"
     },
     "loadingConversation": "Đang tải cuộc trò chuyện…",
     "empty": {

--- a/webui/src/i18n/locales/vi/common.json
+++ b/webui/src/i18n/locales/vi/common.json
@@ -1069,6 +1069,12 @@
     "error": "Lỗi kết nối"
   },
   "thread": {
+    "compaction": {
+      "started": "Đang nén ngữ cảnh…",
+      "failed": "Nén ngữ cảnh không thành công",
+      "succeeded": "Đã nén ngữ cảnh",
+      "source": { "llm": "Bản tóm tắt LLM", "raw": "Dữ liệu thô dự phòng" }
+    },
     "loadingConversation": "Đang tải cuộc trò chuyện…",
     "empty": {
       "greetings": {
@@ -1252,6 +1258,10 @@
           "new": {
             "title": "Cuộc trò chuyện mới",
             "description": "Đặt lại cuộc trò chuyện này và bắt đầu một cuộc trò chuyện mới."
+          },
+          "compact": {
+            "title": "Nén ngữ cảnh",
+            "description": "Nén ngữ cảnh của cuộc trò chuyện này và tiếp tục hội thoại."
           },
           "stop": {
             "title": "Dừng tác vụ hiện tại",

--- a/webui/src/i18n/locales/zh-CN/common.json
+++ b/webui/src/i18n/locales/zh-CN/common.json
@@ -1084,10 +1084,11 @@
   },
   "thread": {
     "compaction": {
+      "cancelled": "上下文压缩已取消",
+      "empty": "无需压缩上下文",
       "started": "正在压缩上下文…",
       "failed": "上下文压缩失败",
-      "succeeded": "上下文已压缩",
-      "source": { "llm": "LLM 摘要", "raw": "原始内容回退" }
+      "succeeded": "上下文已压缩"
     },
     "loadingConversation": "正在加载话题…",
     "empty": {

--- a/webui/src/i18n/locales/zh-CN/common.json
+++ b/webui/src/i18n/locales/zh-CN/common.json
@@ -1083,6 +1083,12 @@
     "error": "连接出错"
   },
   "thread": {
+    "compaction": {
+      "started": "正在压缩上下文…",
+      "failed": "上下文压缩失败",
+      "succeeded": "上下文已压缩",
+      "source": { "llm": "LLM 摘要", "raw": "原始内容回退" }
+    },
     "loadingConversation": "正在加载话题…",
     "empty": {
       "greetings": {
@@ -1275,6 +1281,10 @@
           "new": {
             "title": "新建话题",
             "description": "重置当前话题，并开始一个新的话题。"
+          },
+          "compact": {
+            "title": "压缩上下文",
+            "description": "压缩当前对话的上下文并继续对话。"
           },
           "stop": {
             "title": "停止当前任务",

--- a/webui/src/i18n/locales/zh-TW/common.json
+++ b/webui/src/i18n/locales/zh-TW/common.json
@@ -1070,10 +1070,11 @@
   },
   "thread": {
     "compaction": {
+      "cancelled": "上下文壓縮已取消",
+      "empty": "無需壓縮上下文",
       "started": "正在壓縮上下文…",
       "failed": "上下文壓縮失敗",
-      "succeeded": "上下文已壓縮",
-      "source": { "llm": "LLM 摘要", "raw": "原始內容回退" }
+      "succeeded": "上下文已壓縮"
     },
     "loadingConversation": "正在載入話題…",
     "empty": {

--- a/webui/src/i18n/locales/zh-TW/common.json
+++ b/webui/src/i18n/locales/zh-TW/common.json
@@ -1069,6 +1069,12 @@
     "error": "連線錯誤"
   },
   "thread": {
+    "compaction": {
+      "started": "正在壓縮上下文…",
+      "failed": "上下文壓縮失敗",
+      "succeeded": "上下文已壓縮",
+      "source": { "llm": "LLM 摘要", "raw": "原始內容回退" }
+    },
     "loadingConversation": "正在載入話題…",
     "empty": {
       "greetings": {
@@ -1252,6 +1258,10 @@
           "new": {
             "title": "新增話題",
             "description": "重置目前話題，並開始新的話題。"
+          },
+          "compact": {
+            "title": "壓縮上下文",
+            "description": "壓縮目前對話的上下文並繼續對話。"
           },
           "stop": {
             "title": "停止目前任務",

--- a/webui/src/lib/activity-timeline.ts
+++ b/webui/src/lib/activity-timeline.ts
@@ -175,6 +175,16 @@ function projectOrderedTurn(
   };
 
   for (const message of messages) {
+    if (message.kind === "compaction") {
+      flushActivity();
+      flushAnswers();
+      units.push({
+        type: "message",
+        message,
+        sourceMessageCount: 1 + claimLeadingNoops(),
+      });
+      continue;
+    }
     if (isCompletedDisplayNoop(message)) {
       absorbDisplayNoop();
       continue;

--- a/webui/src/lib/thread-display-compat.ts
+++ b/webui/src/lib/thread-display-compat.ts
@@ -62,6 +62,23 @@ function deriveAssistantCompletionTimes(messages: UIMessage[]): UIMessage[] {
   });
 }
 
+function identifyCompactReplies(messages: UIMessage[]): UIMessage[] {
+  const turns = new Set(messages.flatMap((message) => (
+    message.role === "user" && message.content.trim().toLowerCase() === "/compact" && message.turnId
+      ? [message.turnId]
+      : []
+  )));
+  return messages.map((message) => {
+    if (message.role !== "assistant" || message.kind || message.isStreaming
+      || !message.turnId || !turns.has(message.turnId)) return message;
+    if (message.content === "Nothing to compact.") return { ...message, compactReply: "empty" };
+    if (message.content === "Unable to compact context. Check the logs and try again.") {
+      return { ...message, compactReply: "failed" };
+    }
+    return message;
+  });
+}
+
 export function projectWebuiThreadMessages(messages: UIMessage[]): UIMessage[] {
   const normalized = scrubSubagentUiMessages(normalizeLegacyLongTaskMessages(messages));
   const hiddenTurns = new Set(normalized.flatMap((message) => (
@@ -75,5 +92,5 @@ export function projectWebuiThreadMessages(messages: UIMessage[]): UIMessage[] {
     && !(message.role === "user" && isModelCommandText(message.content))
     && !(message.role === "assistant" && isModelCommandResponseText(message.content))
   ));
-  return deriveAssistantCompletionTimes(visible);
+  return deriveAssistantCompletionTimes(identifyCompactReplies(visible));
 }

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -6,8 +6,7 @@ type MessageKind = "message" | "trace" | "compaction";
 
 export interface UIContextCompaction {
   id: string;
-  phase: "started" | "succeeded" | "failed";
-  checkpointSource?: "llm_summary" | "raw_fallback" | string;
+  phase: "started" | "succeeded" | "failed" | "cancelled";
   /** Live wire transitions announce; hydrated transcript rows stay silent. */
   announce?: boolean;
 }
@@ -96,6 +95,8 @@ export interface UIMessage {
   activityKind?: "model";
   /** Context-compaction lifecycle rendered as a standalone channel notice. */
   compaction?: UIContextCompaction;
+  /** Display-only localization marker for fixed /compact command replies. */
+  compactReply?: "empty" | "failed";
   /** User turn: optimistic blob URLs for preview. Replay: placeholder chips. */
   images?: UIImage[];
   /** Signed or local UI-renderable media attachments. */
@@ -1389,9 +1390,7 @@ export type InboundEvent =
       event: "context_compaction";
       chat_id: string;
       compaction_id: string;
-      phase: "started" | "succeeded" | "failed";
-      checkpoint_source?: string;
-      completes_command?: boolean;
+      phase: UIContextCompaction["phase"];
     } & InboundTurnMetadata)
   | ({
       event: "file_edit";

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -2,7 +2,15 @@ type Role = "user" | "assistant" | "tool" | "system";
 
 /** "trace" rows are intermediate agent breadcrumbs (tool-call hints,
  * progress pings) that should not be rendered as conversational replies. */
-type MessageKind = "message" | "trace";
+type MessageKind = "message" | "trace" | "compaction";
+
+export interface UIContextCompaction {
+  id: string;
+  phase: "started" | "succeeded" | "failed";
+  checkpointSource?: "llm_summary" | "raw_fallback" | string;
+  /** Live wire transitions announce; hydrated transcript rows stay silent. */
+  announce?: boolean;
+}
 
 export type UITurnPhase = "user" | "reasoning" | "activity" | "answer" | "complete";
 export type MessageDeliveryStatus = "sending" | "accepted" | "failed";
@@ -86,6 +94,8 @@ export interface UIMessage {
   /** Internal projection marker for assistant text emitted before a later tool.
    * It is not a wire message and is rendered as a compact activity row. */
   activityKind?: "model";
+  /** Context-compaction lifecycle rendered as a standalone channel notice. */
+  compaction?: UIContextCompaction;
   /** User turn: optimistic blob URLs for preview. Replay: placeholder chips. */
   images?: UIImage[];
   /** Signed or local UI-renderable media attachments. */
@@ -1375,6 +1385,14 @@ export type InboundEvent =
       event: "recovery_state";
       chat_id: string;
     } & RecoveryState)
+  | ({
+      event: "context_compaction";
+      chat_id: string;
+      compaction_id: string;
+      phase: "started" | "succeeded" | "failed";
+      checkpoint_source?: string;
+      completes_command?: boolean;
+    } & InboundTurnMetadata)
   | ({
       event: "file_edit";
       chat_id: string;

--- a/webui/src/tests/i18n.test.tsx
+++ b/webui/src/tests/i18n.test.tsx
@@ -7,8 +7,10 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import { MessageBubble } from "@/components/MessageBubble";
+import { ContextCompactionNotice } from "@/components/thread/ContextCompactionNotice";
 import { ThreadComposer } from "@/components/thread/ThreadComposer";
-import { resources } from "@/i18n";
+import { resources, setAppLanguage } from "@/i18n";
 import {
   LOCALE_STORAGE_KEY,
   resolveInitialLocale,
@@ -417,6 +419,30 @@ describe("webui i18n", () => {
     expect(INDEX_HTML.indexOf(PREBOOT_SCRIPT ?? "")).toBeGreaterThan(
       INDEX_HTML.indexOf(BOOT_COPY_MARKUP),
     );
+  });
+
+  it.each(supportedLocales)("localizes compaction states in $code", async ({ code }) => {
+    await setAppLanguage(code);
+    const copy = resources[code].common.thread.compaction;
+    const { container, rerender } = render(
+      <ContextCompactionNotice compaction={{ id: "compact-1", phase: "started", announce: true }} />,
+    );
+    for (const phase of ["started", "succeeded", "failed", "cancelled"] as const) {
+      rerender(<ContextCompactionNotice compaction={{
+        id: "compact-1", phase, announce: true,
+      }} />);
+      const notice = container.querySelector("[data-context-compaction]");
+      expect(copy[phase]).toBeTruthy();
+      expect(notice?.textContent).toBe(copy[phase]);
+      expect(notice).toHaveAttribute("aria-busy", String(phase === "started"));
+    }
+    for (const compactReply of ["empty", "failed"] as const) {
+      rerender(<MessageBubble message={{
+        id: "reply", role: "assistant", content: "original command reply",
+        compactReply, createdAt: 1,
+      }} />);
+      expect(screen.getByText(copy[compactReply])).toBeInTheDocument();
+    }
   });
 
   it("keeps preboot copy aligned with every registered locale", () => {

--- a/webui/src/tests/i18n.test.tsx
+++ b/webui/src/tests/i18n.test.tsx
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { runInNewContext } from "node:vm";
 
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -20,6 +20,7 @@ const IMAGE_QUICK_ACTION_KEYS = ["icon", "sticker", "poster", "product", "portra
 const HERO_GREETING_KEYS = ["workOn", "start", "build", "tackle"];
 const SLASH_COMMAND_KEYS = [
   "new",
+  "compact",
   "stop",
   "restart",
   "status",
@@ -497,6 +498,36 @@ describe("webui i18n", () => {
     });
 
     expect(screen.getByLabelText("メッセージ入力欄")).toBeInTheDocument();
+  });
+
+  it("localizes a backend-provided compact slash command", async () => {
+    await act(async () => {
+      const { setAppLanguage } = await import("@/i18n");
+      await setAppLanguage("zh-CN");
+    });
+
+    render(
+      <ThreadComposer
+        onSend={vi.fn()}
+        slashCommands={[{
+          command: "/compact",
+          title: "Compact context",
+          description: "Compact this chat's context and continue the conversation.",
+          icon: "archive",
+          lifecycle: "side_channel",
+          acceptsArgs: false,
+        }]}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("消息输入框"), {
+      target: { value: "/co" },
+    });
+
+    expect(screen.getByRole("listbox", { name: "斜杠命令" })).toBeInTheDocument();
+    expect(screen.getByText("压缩上下文")).toBeInTheDocument();
+    expect(screen.getByText("压缩当前对话的上下文并继续对话。")).toBeInTheDocument();
+    expect(screen.getByText("/compact")).toBeInTheDocument();
   });
 
   it("keeps empty landing resources localized for every registered locale", () => {

--- a/webui/src/tests/message-bubble.test.tsx
+++ b/webui/src/tests/message-bubble.test.tsx
@@ -95,6 +95,30 @@ const SLASH_COMMANDS: SlashCommand[] = [
 ];
 
 describe("MessageBubble", () => {
+  it("renders raw-fallback compaction as a distinct warning notice", () => {
+    const message: UIMessage = {
+      id: "compaction-1",
+      role: "assistant",
+      content: "",
+      kind: "compaction",
+      createdAt: Date.now(),
+      compaction: {
+        id: "compact-1",
+        phase: "succeeded",
+        checkpointSource: "raw_fallback",
+        announce: true,
+      },
+    };
+
+    const { container } = render(<MessageBubble message={message} />);
+
+    const notice = container.querySelector("[data-context-compaction='succeeded']");
+    expect(notice).toHaveAttribute("role", "status");
+    expect(notice).toHaveAttribute("aria-live", "polite");
+    expect(screen.getByText("Context compacted")).toBeInTheDocument();
+    expect(screen.getByText("Raw fallback")).toBeInTheDocument();
+  });
+
   it("renders user messages as right-aligned pills", () => {
     const message: UIMessage = {
       id: "u1",

--- a/webui/src/tests/message-bubble.test.tsx
+++ b/webui/src/tests/message-bubble.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest";
 
 import { MessageBubble } from "@/components/MessageBubble";
+import { setAppLanguage } from "@/i18n";
 import { fmtDateTime, formatMessageEndTime } from "@/lib/format";
 import type {
   CliAppInfo,
@@ -95,7 +96,23 @@ const SLASH_COMMANDS: SlashCommand[] = [
 ];
 
 describe("MessageBubble", () => {
-  it("renders raw-fallback compaction as a distinct warning notice", () => {
+  it("copies the localized compact reply instead of the stored English text", async () => {
+    await setAppLanguage("zh-CN");
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    render(<MessageBubble message={{
+      id: "compact-empty", role: "assistant", content: "Nothing to compact.",
+      compactReply: "empty", createdAt: 1,
+    }} />);
+    expect(screen.getByText("无需压缩上下文")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "复制" }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("无需压缩上下文"));
+  });
+
+  it("renders a compacted context notice", () => {
     const message: UIMessage = {
       id: "compaction-1",
       role: "assistant",
@@ -105,7 +122,6 @@ describe("MessageBubble", () => {
       compaction: {
         id: "compact-1",
         phase: "succeeded",
-        checkpointSource: "raw_fallback",
         announce: true,
       },
     };
@@ -116,7 +132,8 @@ describe("MessageBubble", () => {
     expect(notice).toHaveAttribute("role", "status");
     expect(notice).toHaveAttribute("aria-live", "polite");
     expect(screen.getByText("Context compacted")).toBeInTheDocument();
-    expect(screen.getByText("Raw fallback")).toBeInTheDocument();
+    expect(notice).toHaveTextContent(/^Context compacted$/);
+    expect(notice?.querySelector(".lucide-archive")).toBeInTheDocument();
   });
 
   it("renders user messages as right-aligned pills", () => {

--- a/webui/src/tests/thread-display-compat.test.ts
+++ b/webui/src/tests/thread-display-compat.test.ts
@@ -66,6 +66,26 @@ describe("normalizeLegacyLongTaskMessages", () => {
 });
 
 describe("projectWebuiThreadMessages", () => {
+  it("marks only fixed replies belonging to a compact command turn", () => {
+    const rows = [
+      message("user", { content: " /COMPACT ", turnId: "compact" }),
+      message("assistant", { content: "Nothing to compact.", turnId: "compact" }),
+      message("assistant", {
+        content: "Unable to compact context. Check the logs and try again.", turnId: "compact",
+      }),
+      message("assistant", { content: "Nothing to compact.", turnId: "unrelated" }),
+      message("assistant", { content: "Nothing to compact." }),
+      message("assistant", { content: "Nothing to compact.", turnId: "compact", isStreaming: true }),
+      message("assistant", { content: "Quoted: Nothing to compact.", turnId: "compact" }),
+    ];
+    const projected = projectWebuiThreadMessages(rows);
+    expect(projected.map(({ compactReply }) => compactReply)).toEqual([
+      undefined, "empty", "failed", undefined, undefined, undefined, undefined,
+    ]);
+    expect(projected.map(({ content }) => content)).toEqual(rows.map(({ content }) => content));
+    expect(projectWebuiThreadMessages(projected)).toEqual(projected);
+  });
+
   it("derives replayed completion time from the matching user turn", () => {
     const firstOutputAt = STARTED_AT + 5_000;
     const latencyMs = 13_000;

--- a/webui/src/tests/thread-messages.test.tsx
+++ b/webui/src/tests/thread-messages.test.tsx
@@ -1678,4 +1678,33 @@ describe("ThreadMessages", () => {
       ["a3", true],
     ]);
   });
+
+  it("keeps compaction notices out of assistant fork selection", () => {
+    const units = buildDisplayUnits([
+      { id: "u1", role: "user", content: "one", createdAt: 1 },
+      { id: "a1", role: "assistant", content: "answer", createdAt: 2 },
+      {
+        id: "compaction-1",
+        role: "assistant",
+        content: "",
+        kind: "compaction",
+        createdAt: 3,
+        compaction: {
+          id: "compact-1",
+          phase: "succeeded",
+          checkpointSource: "llm_summary",
+        },
+      },
+    ]);
+
+    const flags = assistantForkFlags(units);
+    expect(units.map((unit, index) => [
+      unit.type === "message" ? unit.message.id : "activity",
+      flags[index],
+    ])).toEqual([
+      ["u1", true],
+      ["a1", true],
+      ["compaction-1", false],
+    ]);
+  });
 });

--- a/webui/src/tests/thread-messages.test.tsx
+++ b/webui/src/tests/thread-messages.test.tsx
@@ -1692,7 +1692,6 @@ describe("ThreadMessages", () => {
         compaction: {
           id: "compact-1",
           phase: "succeeded",
-          checkpointSource: "llm_summary",
         },
       },
     ]);

--- a/webui/src/tests/useNanobotStream.test.tsx
+++ b/webui/src/tests/useNanobotStream.test.tsx
@@ -197,7 +197,7 @@ async function flushStreamFrame() {
 }
 
 describe("useNanobotStream", () => {
-  it("updates one stable row across a context-compaction lifecycle", () => {
+  it.each(["succeeded", "cancelled"] as const)("updates one stable compaction row to %s", (phase) => {
     const fake = fakeClient();
     const { result } = renderHook(
       () => useNanobotStream("chat-compaction", EMPTY_MESSAGES),
@@ -230,8 +230,7 @@ describe("useNanobotStream", () => {
         event: "context_compaction",
         chat_id: "chat-compaction",
         compaction_id: "compact-1",
-        phase: "succeeded",
-        checkpoint_source: "raw_fallback",
+        phase,
       });
     });
 
@@ -240,8 +239,7 @@ describe("useNanobotStream", () => {
       id: "compaction-compact-1",
       createdAt,
       compaction: {
-        phase: "succeeded",
-        checkpointSource: "raw_fallback",
+        phase,
         announce: true,
       },
     });

--- a/webui/src/tests/useNanobotStream.test.tsx
+++ b/webui/src/tests/useNanobotStream.test.tsx
@@ -197,6 +197,56 @@ async function flushStreamFrame() {
 }
 
 describe("useNanobotStream", () => {
+  it("updates one stable row across a context-compaction lifecycle", () => {
+    const fake = fakeClient();
+    const { result } = renderHook(
+      () => useNanobotStream("chat-compaction", EMPTY_MESSAGES),
+      { wrapper: wrap(fake.client) },
+    );
+
+    act(() => {
+      fake.emit("chat-compaction", {
+        event: "context_compaction",
+        chat_id: "chat-compaction",
+        compaction_id: "compact-1",
+        phase: "started",
+      });
+    });
+
+    expect(result.current.messages).toHaveLength(1);
+    const createdAt = result.current.messages[0].createdAt;
+    expect(result.current.messages[0]).toMatchObject({
+      id: "compaction-compact-1",
+      kind: "compaction",
+      compaction: {
+        id: "compact-1",
+        phase: "started",
+        announce: true,
+      },
+    });
+
+    act(() => {
+      fake.emit("chat-compaction", {
+        event: "context_compaction",
+        chat_id: "chat-compaction",
+        compaction_id: "compact-1",
+        phase: "succeeded",
+        checkpoint_source: "raw_fallback",
+      });
+    });
+
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0]).toMatchObject({
+      id: "compaction-compact-1",
+      createdAt,
+      compaction: {
+        phase: "succeeded",
+        checkpointSource: "raw_fallback",
+        announce: true,
+      },
+    });
+  });
+
   it("batches answer deltas into one animation-frame update", async () => {
     const fake = fakeClient();
     const requestFrame = vi.spyOn(window, "requestAnimationFrame");


### PR DESCRIPTION
## Summary

- add `/compact` to consolidate the current conversation into `memory/history.jsonl` while retaining session messages
- emit structured lifecycle events for manual, in-turn, and idle background compaction
- show a dedicated compaction indicator in WebUI and TUI, with localized WebUI copy and history replay

## Behavior notes

- Started events are live-only; terminal events are persisted for replay.
- Events carry a compaction ID and phase, without summary content or checkpoint-source metadata.
- Notification delivery failures do not change compaction behavior.
- `/new` remains a session reset/archive operation.

## Testing

- focused Python compaction, command, replay, routing, and wire tests: 511 passed
- targeted WebUI tests: 278 passed
- TUI tests: 170 passed
- WebUI build passed
- isolated real-gateway browser verification passed for cancellation, success, empty compaction, and Chinese/English replay
- real LLM and external chat-channel end-to-end verification remains untested

Linear: https://linear.app/nanobot-ai/issue/NAN-44/所有上下文压缩都应在-channel-内可见
