### PR TITLE
fix(webui): generate session title when envelope omits webui flag (#5…

### DIFF
--- a/nanobot/session/webui_turns.py
+++ b/nanobot/session/webui_turns.py
@@ -302,8 +302,15 @@ async def maybe_generate_webui_title_after_turn(
     provider: LLMProvider,
     model: str,
 ) -> bool:
-    if channel != "websocket" or metadata.get(WEBUI_SESSION_METADATA_KEY) is not True:
+    if channel != "websocket":
         return False
+    if metadata.get(WEBUI_SESSION_METADATA_KEY) is not True:
+        # The frontend WebSocket envelope does not always carry ``webui: true``.
+        # ``mark_webui_session`` records the flag on the session object itself, so
+        # fall back to that authoritative marker before skipping title generation.
+        session = sessions.get_or_create(session_key)
+        if session.metadata.get(WEBUI_SESSION_METADATA_KEY) is not True:
+            return False
     origin_session_key = f"{channel}:{chat_id}"
     return await maybe_generate_webui_title(
         sessions=sessions,
@@ -775,9 +782,16 @@ class WebuiTurnCoordinator:
 
     def _schedule_title_update_from_event(self, event: TurnCompleted) -> None:
         title_context = _validated_llm_runtime(event.runtime)
+        if title_context is None:
+            return
+        # ``event.context.metadata`` mirrors the frontend envelope, which does not
+        # always include ``webui: true``. The session object is marked via
+        # ``mark_webui_session`` when the WebUI turn starts, so treat that as an
+        # authoritative fallback; otherwise WebUI titles are silently skipped.
+        session = self.sessions.get_or_create(event.context.session_key)
         if (
-            event.context.metadata.get("webui") is not True
-            or title_context is None
+            event.context.metadata.get(WEBUI_SESSION_METADATA_KEY) is not True
+            and session.metadata.get(WEBUI_SESSION_METADATA_KEY) is not True
         ):
             return
 

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -494,6 +494,63 @@ async def test_projected_title_generation_skips_existing_chat_title(tmp_path: Pa
     loop.provider.chat_with_retry.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_generate_webui_title_when_envelope_omits_webui_flag(
+    tmp_path: Path,
+) -> None:
+    """A session marked WebUI must still get a title even when the frontend
+    envelope omits ``webui: true`` (regression for issue #5647)."""
+    loop = _make_full_loop(tmp_path)
+    loop.provider.chat_with_retry = AsyncMock(
+        return_value=LLMResponse(content='"优化 WebUI 侧边栏"', finish_reason="stop")
+    )
+    session = loop.sessions.get_or_create("websocket:chat-no-envelope-flag")
+    session.metadata[WEBUI_SESSION_METADATA_KEY] = True
+    session.add_message("user", "帮我优化一下 webui 的 sidebar")
+    session.add_message("assistant", "好的，我来优化侧边栏。")
+    loop.sessions.save(session)
+
+    generated = await maybe_generate_webui_title_after_turn(
+        channel="websocket",
+        chat_id="chat-no-envelope-flag",
+        metadata={},  # frontend envelope did not include ``webui: true``
+        sessions=loop.sessions,
+        session_key="websocket:chat-no-envelope-flag",
+        provider=loop.provider,
+        model=loop.model,
+    )
+
+    assert generated is True
+    assert session.metadata[WEBUI_TITLE_METADATA_KEY] == "优化 WebUI 侧边栏"
+
+
+@pytest.mark.asyncio
+async def test_skip_title_for_plain_websocket_when_envelope_omits_webui_flag(
+    tmp_path: Path,
+) -> None:
+    """A plain (non-WebUI) websocket session must not get a title when neither the
+    envelope nor the session object is marked WebUI."""
+    loop = _make_full_loop(tmp_path)
+    session = loop.sessions.get_or_create("websocket:plain-chat")
+    session.add_message("user", "hello there")
+    session.add_message("assistant", "hi")
+    loop.sessions.save(session)
+
+    generated = await maybe_generate_webui_title_after_turn(
+        channel="websocket",
+        chat_id="plain-chat",
+        metadata={},
+        sessions=loop.sessions,
+        session_key="websocket:plain-chat",
+        provider=loop.provider,
+        model=loop.model,
+    )
+
+    assert generated is False
+    assert WEBUI_TITLE_METADATA_KEY not in session.metadata
+    loop.provider.chat_with_retry.assert_not_awaited()
+
+
 def test_save_turn_keeps_multimodal_runtime_context_for_model_replay() -> None:
     loop = _mk_loop()
     session = Session(key="test:runtime-only")


### PR DESCRIPTION
## Summary

Fixes #5647. WebUI session titles were never generated whenever the frontend WebSocket envelope did not include `webui: true`, even for sessions already marked as WebUI via `mark_webui_session()`.

## Root cause

Two guards only consulted the frontend envelope metadata:

- `_schedule_title_update_from_event` returned early when `event.context.metadata.get("webui")` was not `True`.
- `maybe_generate_webui_title_after_turn` returned `False` on the same envelope-only check.

But `mark_webui_session()` writes `webui=True` onto the **session object** when the WebUI turn starts. Whenever the envelope omitted the flag, both guards bailed out and the title was silently skipped, regardless of whether the session was actually a WebUI session.

## Fix

Both guards now fall back to the session object's `webui` metadata marker (the authoritative source) before skipping. The default behavior for non-WebUI websocket sessions is unchanged: they still skip title generation.

## Tests

Adds two regression tests in `tests/agent/test_loop_save_turn.py`:

- `test_generate_webui_title_when_envelope_omits_webui_flag` — a WebUI-marked session still gets a title when the envelope omits the flag (fails without this fix).
- `test_skip_title_for_plain_websocket_when_envelope_omits_webui_flag` — a plain websocket session is still correctly skipped.

## Verification

- `ruff check nanobot tests conftest.py` passes
- `basedpyright` (strict) reports 0 errors on the changed file
- Targeted + broad websocket/webui suites: 385 passed, 2 skipped
- Confirmed the new test fails when the fix is reverted

