### PR TITLE
feat(runtime-context): opt-out ephemeral runtime-context blocks (#5586)

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -64,6 +64,7 @@ from nanobot.runtime_context import (
     RuntimeContextBlock,
     RuntimeContextProvider,
     append_runtime_context,
+    persistable_runtime_context_blocks,
     resolve_runtime_context,
     runtime_context_blocks_from_metadata,
 )
@@ -707,7 +708,12 @@ class AgentLoop:
         ]
         content_value = cast(object, msg.content)
         has_text = isinstance(content_value, str) and content_value.strip()
-        if has_text or media_paths or runtime_context_blocks:
+        # Ephemeral blocks are request-only: they must never enter the session
+        # row, which is replayed verbatim on every later turn via get_history.
+        persistable_blocks = persistable_runtime_context_blocks(
+            runtime_context_blocks or ()
+        )
+        if has_text or media_paths or persistable_blocks:
             extra: dict[str, Any] = ({"media": list(media_paths)} if media_paths else {}) | agent_context.session_extra(msg.metadata)
             extra.update(kwargs)
             text = content_value if isinstance(content_value, str) else ""
@@ -717,7 +723,7 @@ class AgentLoop:
             extra.update(automation_extra)
             text, runtime_context_meta = append_runtime_context(
                 text,
-                runtime_context_blocks or (),
+                persistable_blocks,
             )
             if runtime_context_meta is not None:
                 extra[RUNTIME_CONTEXT_HISTORY_META] = runtime_context_meta
@@ -1029,9 +1035,12 @@ class AgentLoop:
                         pending_request,
                         effective_tools,
                     )
+                    # This coalesced row is persisted and replayed via
+                    # get_history, so ephemeral blocks must be excluded; the
+                    # active turn's current message still carries them.
                     row["content"], runtime_marker = append_runtime_context(
                         user_content,
-                        blocks,
+                        persistable_runtime_context_blocks(blocks),
                     )
                     if runtime_marker is not None:
                         row["_meta"] = {

--- a/nanobot/runtime_context.py
+++ b/nanobot/runtime_context.py
@@ -26,10 +26,18 @@ class RuntimeContextBlock:
     """Provider-owned context appended verbatim to the current user content.
 
     Callers must bound and delimit content obtained from untrusted sources.
+
+    ``ephemeral`` blocks are appended to the in-flight request only. They are
+    never written to the session row, never replayed on later turns, and never
+    reach the display/strip paths. Use them for session-constant riders (for
+    example a channel delivery contract) that would otherwise be duplicated into
+    history on every turn. The default (``False``) preserves the durable
+    lifecycle: appended, persisted, and replayed on every later turn.
     """
 
     source: str
     content: str
+    ephemeral: bool = False
 
 
 def normalize_webui_quote(value: Any) -> str | None:
@@ -92,8 +100,26 @@ def normalize_runtime_context_blocks(result: RuntimeContextResult) -> list[Runti
         if not source:
             raise ValueError("runtime context block source must not be empty")
         if content:
-            blocks.append(RuntimeContextBlock(source=source, content=content))
+            blocks.append(
+                RuntimeContextBlock(
+                    source=source,
+                    content=content,
+                    ephemeral=block.ephemeral,
+                )
+            )
     return blocks
+
+
+def persistable_runtime_context_blocks(
+    blocks: Sequence[RuntimeContextBlock],
+) -> list[RuntimeContextBlock]:
+    """Return only blocks that belong in durable history.
+
+    Ephemeral blocks are appended to the in-flight request but never written to
+    the session row, so they are dropped here. The result feeds every path that
+    persists a user message and is later replayed via ``get_history``.
+    """
+    return [block for block in blocks if not block.ephemeral]
 
 
 def runtime_context_blocks_from_metadata(

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -228,6 +228,71 @@ def test_persist_user_message_acknowledges_durable_followup(tmp_path: Path) -> N
     assert PENDING_FOLLOWUPS_KEY not in session.metadata
 
 
+def test_persist_user_message_excludes_ephemeral_runtime_context(
+    tmp_path: Path,
+) -> None:
+    """Ephemeral blocks must never be written to the replayed session row, while
+    durable blocks keep today's persist-and-replay behavior (issue #5586)."""
+    loop = _make_full_loop(tmp_path)
+    session = loop.sessions.get_or_create("websocket:chat")
+
+    persisted = loop._persist_user_message_early(
+        InboundMessage(
+            channel="websocket",
+            sender_id="user",
+            chat_id="chat",
+            content="what's the weather",
+        ),
+        session,
+        runtime_context_blocks=[
+            RuntimeContextBlock(source="goal", content="durable goal context"),
+            RuntimeContextBlock(
+                source="voice_contract",
+                content="replies here are spoken aloud; keep to short plain prose",
+                ephemeral=True,
+            ),
+        ],
+    )
+
+    assert persisted is True
+    message = session.messages[-1]
+    assert "durable goal context" in message["content"]
+    assert "spoken aloud" not in message["content"]
+    # The durable marker must only reference the durable block's source.
+    assert message[RUNTIME_CONTEXT_HISTORY_META]["sources"] == ["goal"]
+    # Display strips the durable block and never sees the ephemeral rider.
+    visible = public_history_message(message)["content"]
+    assert visible == "what's the weather"
+
+
+def test_persist_user_message_skips_row_for_ephemeral_only_context(
+    tmp_path: Path,
+) -> None:
+    """An ephemeral block with no user text leaves no history row behind."""
+    loop = _make_full_loop(tmp_path)
+    session = loop.sessions.get_or_create("websocket:chat")
+
+    persisted = loop._persist_user_message_early(
+        InboundMessage(
+            channel="websocket",
+            sender_id="user",
+            chat_id="chat",
+            content="",
+        ),
+        session,
+        runtime_context_blocks=[
+            RuntimeContextBlock(
+                source="voice_contract",
+                content="replies here are spoken aloud",
+                ephemeral=True,
+            ),
+        ],
+    )
+
+    assert persisted is False
+    assert session.messages == []
+
+
 def test_persist_local_trigger_turn_uses_hidden_automation_marker(tmp_path: Path) -> None:
     loop = _make_full_loop(tmp_path)
     session = loop.sessions.get_or_create("websocket:auto")

--- a/tests/agent/test_runtime_context.py
+++ b/tests/agent/test_runtime_context.py
@@ -13,7 +13,9 @@ from nanobot.runtime_context import (
     WEBUI_QUOTE_SOURCE,
     RuntimeContextBlock,
     append_runtime_context,
+    normalize_runtime_context_blocks,
     normalize_webui_quote,
+    persistable_runtime_context_blocks,
     public_history_message,
     resolve_runtime_context,
     runtime_context_blocks_from_metadata,
@@ -23,6 +25,40 @@ from nanobot.sdk.types import snapshot_from_session
 from nanobot.session.manager import Session, _message_preview_text
 from nanobot.session.webui_turns import _title_inputs
 from nanobot.webui.transcript import _session_user_event
+
+
+def test_runtime_context_block_defaults_to_durable() -> None:
+    assert RuntimeContextBlock(source="s", content="c").ephemeral is False
+
+
+def test_normalize_preserves_ephemeral_flag() -> None:
+    normalized = normalize_runtime_context_blocks([
+        RuntimeContextBlock(source="durable", content="keep"),
+        RuntimeContextBlock(source="rider", content="drop", ephemeral=True),
+    ])
+    assert [(b.source, b.ephemeral) for b in normalized] == [
+        ("durable", False),
+        ("rider", True),
+    ]
+
+
+def test_persistable_filter_drops_ephemeral_blocks() -> None:
+    durable = RuntimeContextBlock(source="durable", content="keep")
+    ephemeral = RuntimeContextBlock(source="rider", content="drop", ephemeral=True)
+
+    kept = persistable_runtime_context_blocks([durable, ephemeral])
+
+    assert kept == [durable]
+
+
+def test_ephemeral_block_survives_metadata_round_trip() -> None:
+    blocks = runtime_context_blocks_from_metadata({
+        RUNTIME_CONTEXT_INPUT_META: [
+            RuntimeContextBlock(source="rider", content="spoken contract", ephemeral=True),
+        ]
+    })
+    assert blocks[0].ephemeral is True
+    assert persistable_runtime_context_blocks(blocks) == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #5586. Adds an `ephemeral` opt-out flag to `RuntimeContextBlock` so a runtime-context provider can attach session-constant information to the in-flight request without persisting and replaying it on every later turn.

## Problem

Runtime-context blocks had a single lifecycle: appended to the user message, persisted into the session row, and replayed on every later turn via `get_history`. That is correct for per-turn facts (a WebUI quote), but a provider stating session-constant information — for example a channel delivery contract — could only restate it every turn, and each copy was then persisted and replayed forever. On small context windows the duplicates evict the conversation itself.

## Solution

```python
RuntimeContextBlock(source=..., content=..., ephemeral=True)
```

Ephemeral blocks are appended to the current request only. They are never written to the session row, never replayed, and never reach the display/strip paths. The default (`ephemeral=False`) preserves today's durable lifecycle exactly, so every existing producer is unchanged.

## Implementation

- `runtime_context.py`: add the field, preserve it through `normalize_runtime_context_blocks`, and add `persistable_runtime_context_blocks()` to drop ephemeral blocks.
- `agent/loop.py`: filter ephemeral out of the two paths that persist a user message into replayed history — the early-persist path (`_persist_user_message_early`) and the pending catch-up build. Request-build and provider-state staging keep every block, so the model still sees ephemeral context on the current turn (sent once, not replayed).

## Tests

- Unit: the flag default, normalization preserving it, the persistable filter, and a metadata round-trip.
- Loop-level: an ephemeral rider reaches neither the session row nor the display projection, while a durable block keeps its persist-and-replay behavior; and an ephemeral-only message leaves no history row.

## Verification

- `ruff check nanobot tests conftest.py` passes
- `basedpyright` (strict): 0 errors on changed files
- `tests/agent` suite passes (full run, exit 0)


