### PR TITLE
feat(webui): show model generation speed in context usage popover (#5631)

### DIFF
--- a/webui/src/components/thread/ComposerUsagePopover.tsx
+++ b/webui/src/components/thread/ComposerUsagePopover.tsx
@@ -12,7 +12,11 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { formatCompactTokenCount, formatTurnLatency } from "@/lib/format";
+import {
+  formatCompactTokenCount,
+  formatTokensPerSecond,
+  formatTurnLatency,
+} from "@/lib/format";
 import { cn } from "@/lib/utils";
 
 export interface ComposerContextUsage {
@@ -28,6 +32,9 @@ export interface ComposerRoundUsage {
   cachedTokens?: number;
   estimatedTokens?: number;
   generationMs?: number;
+  /** Output tokens measured during the timed generation window, paired with
+   * generationMs for an accurate tokens-per-second rate. */
+  measuredCompletionTokens?: number;
 }
 
 interface NormalizedRoundUsage extends ComposerRoundUsage {
@@ -306,6 +313,25 @@ export function ComposerUsagePopover({
                               value: formatTurnLatency(round.generationMs, i18n.language),
                             }
                           : null,
+                        (() => {
+                          const speed =
+                            typeof round.generationMs === "number"
+                              ? formatTokensPerSecond(
+                                  round.measuredCompletionTokens ?? round.outputTokens,
+                                  round.generationMs,
+                                  i18n.language,
+                                )
+                              : null;
+                          return speed
+                            ? {
+                                key: "speed",
+                                label: t("thread.composer.context.speed", {
+                                  defaultValue: "Generation speed",
+                                }),
+                                value: speed,
+                              }
+                            : null;
+                        })(),
                       ].filter((row): row is NonNullable<typeof row> => !!row);
                       const detailNote = (round.estimatedTokens ?? 0) > 0
                         ? t("message.usage.estimated", {

--- a/webui/src/components/thread/ThreadShell.tsx
+++ b/webui/src/components/thread/ThreadShell.tsx
@@ -145,6 +145,7 @@ function recentComposerRoundUsage(messages: UIMessage[]): ComposerRoundUsage[] {
       const cachedTokens = round.cached_tokens;
       const estimatedTokens = round.estimated_tokens;
       const generationMs = round.generation_ms;
+      const measuredCompletionTokens = round.measured_completion_tokens;
       recent.push({
         id: `${turnKey}:${roundIndex}`,
         timestamp: message.completedAt ?? message.createdAt,
@@ -160,6 +161,10 @@ function recentComposerRoundUsage(messages: UIMessage[]): ComposerRoundUsage[] {
           : {}),
         ...(typeof generationMs === "number" && Number.isFinite(generationMs)
           ? { generationMs }
+          : {}),
+        ...(typeof measuredCompletionTokens === "number"
+          && Number.isFinite(measuredCompletionTokens)
+          ? { measuredCompletionTokens }
           : {}),
       });
     }

--- a/webui/src/i18n/locales/en/common.json
+++ b/webui/src/i18n/locales/en/common.json
@@ -1208,7 +1208,9 @@
         "input": "Input tokens",
         "cacheHitRate": "KV cache hit rate",
         "output": "Output tokens",
-        "duration": "Generation time"
+        "duration": "Generation time",
+        "speed": "Generation speed",
+        "speedValue": "{{value}} tok/s"
       },
       "queued": {
         "label": "Queued guidance",

--- a/webui/src/i18n/locales/es/common.json
+++ b/webui/src/i18n/locales/es/common.json
@@ -1195,7 +1195,9 @@
         "input": "Tokens de entrada",
         "cacheHitRate": "Tasa de aciertos de KV Cache",
         "output": "Tokens de salida",
-        "duration": "Tiempo de generación"
+        "duration": "Tiempo de generación",
+        "speed": "Velocidad de generación",
+        "speedValue": "{{value}} tok/s"
       },
       "queued": {
         "label": "Guía en cola",

--- a/webui/src/i18n/locales/fr/common.json
+++ b/webui/src/i18n/locales/fr/common.json
@@ -1194,7 +1194,9 @@
         "input": "Jetons d’entrée",
         "cacheHitRate": "Taux de succès du cache KV",
         "output": "Jetons de sortie",
-        "duration": "Temps de génération"
+        "duration": "Temps de génération",
+        "speed": "Vitesse de génération",
+        "speedValue": "{{value}} tok/s"
       },
       "queued": {
         "label": "Guidage en attente",

--- a/webui/src/i18n/locales/id/common.json
+++ b/webui/src/i18n/locales/id/common.json
@@ -1194,7 +1194,9 @@
         "input": "Token masukan",
         "cacheHitRate": "Rasio hit KV cache",
         "output": "Token keluaran",
-        "duration": "Waktu pembuatan"
+        "duration": "Waktu pembuatan",
+        "speed": "Kecepatan pembuatan",
+        "speedValue": "{{value}} tok/s"
       },
       "queued": {
         "label": "Panduan antrean",

--- a/webui/src/i18n/locales/ja/common.json
+++ b/webui/src/i18n/locales/ja/common.json
@@ -1194,7 +1194,9 @@
         "input": "入力トークン",
         "cacheHitRate": "KV キャッシュヒット率",
         "output": "出力トークン",
-        "duration": "生成時間"
+        "duration": "生成時間",
+        "speed": "生成速度",
+        "speedValue": "{{value}} tok/s"
       },
       "queued": {
         "label": "保留中のガイド",

--- a/webui/src/i18n/locales/ko/common.json
+++ b/webui/src/i18n/locales/ko/common.json
@@ -1194,7 +1194,9 @@
         "input": "입력 토큰",
         "cacheHitRate": "KV 캐시 적중률",
         "output": "출력 토큰",
-        "duration": "생성 시간"
+        "duration": "생성 시간",
+        "speed": "생성 속도",
+        "speedValue": "{{value}} tok/s"
       },
       "queued": {
         "label": "대기 중인 안내",

--- a/webui/src/i18n/locales/pt-BR/common.json
+++ b/webui/src/i18n/locales/pt-BR/common.json
@@ -1208,7 +1208,9 @@
         "input": "Tokens de entrada",
         "cacheHitRate": "Taxa de acertos do cache KV",
         "output": "Tokens de saída",
-        "duration": "Tempo de geração"
+        "duration": "Tempo de geração",
+        "speed": "Velocidade de geração",
+        "speedValue": "{{value}} tok/s"
       },
       "queued": {
         "label": "Guia em fila",

--- a/webui/src/i18n/locales/vi/common.json
+++ b/webui/src/i18n/locales/vi/common.json
@@ -1194,7 +1194,9 @@
         "input": "Token đầu vào",
         "cacheHitRate": "Tỷ lệ hit KV cache",
         "output": "Token đầu ra",
-        "duration": "Thời gian tạo"
+        "duration": "Thời gian tạo",
+        "speed": "Tốc độ tạo",
+        "speedValue": "{{value}} tok/s"
       },
       "queued": {
         "label": "Hướng dẫn đang chờ",

--- a/webui/src/i18n/locales/zh-CN/common.json
+++ b/webui/src/i18n/locales/zh-CN/common.json
@@ -1207,7 +1207,9 @@
         "input": "输入 Token",
         "cacheHitRate": "KV Cache 命中率",
         "output": "输出 Token",
-        "duration": "生成耗时"
+        "duration": "生成耗时",
+        "speed": "生成速度",
+        "speedValue": "{{value}} tok/s"
       },
       "queued": {
         "label": "排队中的引导消息",

--- a/webui/src/i18n/locales/zh-TW/common.json
+++ b/webui/src/i18n/locales/zh-TW/common.json
@@ -1194,7 +1194,9 @@
         "input": "輸入 Token",
         "cacheHitRate": "KV Cache 命中率",
         "output": "輸出 Token",
-        "duration": "生成耗時"
+        "duration": "生成耗時",
+        "speed": "生成速度",
+        "speedValue": "{{value}} tok/s"
       },
       "queued": {
         "label": "佇列中的引導訊息",

--- a/webui/src/lib/format.ts
+++ b/webui/src/lib/format.ts
@@ -196,3 +196,38 @@ export function formatTurnLatency(ms: number, locale?: string): string {
   }).format(remSec);
   return `${minStr}\u00a0${secStr}`;
 }
+
+/**
+ * Localized generation speed in tokens per second.
+ *
+ * Returns null when the inputs cannot yield a meaningful rate, so callers can
+ * omit the metric rather than render a misleading zero or Infinity.
+ */
+export function formatTokensPerSecond(
+  tokens: number,
+  ms: number,
+  locale?: string,
+): string | null {
+  if (
+    !Number.isFinite(tokens)
+    || !Number.isFinite(ms)
+    || tokens <= 0
+    || ms <= 0
+  ) {
+    return null;
+  }
+  const perSecond = tokens / (ms / 1000);
+  if (!Number.isFinite(perSecond) || perSecond <= 0) {
+    return null;
+  }
+  const loc = activeLocale(locale);
+  const digits = perSecond < 10 ? 1 : 0;
+  const value = new Intl.NumberFormat(loc, {
+    maximumFractionDigits: digits,
+    minimumFractionDigits: 0,
+  }).format(perSecond);
+  return i18n.t("thread.composer.context.speedValue", {
+    defaultValue: "{{value}} tok/s",
+    value,
+  });
+}

--- a/webui/src/tests/format.i18n.test.ts
+++ b/webui/src/tests/format.i18n.test.ts
@@ -4,6 +4,7 @@ import { setAppLanguage } from "@/i18n";
 import {
   fmtDateTime,
   formatMessageEndTime,
+  formatTokensPerSecond,
   formatTurnLatency,
   relativeTime,
 } from "@/lib/format";
@@ -111,5 +112,20 @@ describe("localized format helpers", () => {
     const minutePlus = formatTurnLatency(90_000, "en");
     expect(minutePlus).toContain("m");
     expect(minutePlus).toContain("s");
+  });
+
+  it("formats generation speed as tokens per second", async () => {
+    await setAppLanguage("en");
+    // 240 tokens over 2000ms == 120 tok/s.
+    expect(formatTokensPerSecond(240, 2000, "en")).toBe("120 tok/s");
+    // Slow rates keep one decimal for readability.
+    expect(formatTokensPerSecond(3, 2000, "en")).toBe("1.5 tok/s");
+  });
+
+  it("omits generation speed when inputs cannot yield a rate", () => {
+    expect(formatTokensPerSecond(0, 2000, "en")).toBeNull();
+    expect(formatTokensPerSecond(100, 0, "en")).toBeNull();
+    expect(formatTokensPerSecond(Number.NaN, 2000, "en")).toBeNull();
+    expect(formatTokensPerSecond(100, -5, "en")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Addresses #5631 (在 webui 里面展示上下文、模型速度这些信息). The composer context usage popover already showed per-round context and token usage; this adds the missing **model generation speed** (tokens per second) beside the existing generation time.

The backend already reports the needed data on each turn (`measured_completion_tokens` paired with `generation_ms`), so this is a display-only change.

## Changes

- `lib/format.ts`: add `formatTokensPerSecond(tokens, ms, locale)`, returning a localized `"N tok/s"` string, or `null` when the inputs cannot yield a meaningful rate (so callers omit the row instead of showing `0` or `Infinity`).
- `ComposerUsagePopover`: carry `measuredCompletionTokens` on each round and render a **Generation speed** row, in both the visible tooltip grid and the accessible `aria-label`.
- `ThreadShell`: thread `measured_completion_tokens` through into the round usage summary, falling back to output tokens when absent.
- i18n: add the speed labels to English and both Chinese locales (`生成速度`); other locales fall back to the English default until translated.

## Tests

Adds `formatTokensPerSecond` tests covering the rate calculation, the one-decimal formatting for slow rates, and the guard cases that yield `null`.

## Verification

- `tsc -p tsconfig.build.json --noEmit`: 0 errors
- ESLint on changed files: clean
- `vitest run src/tests/format.i18n.test.ts`: 7 passed


