### PR TITLE
feat(providers): send x-opencode-session header for OpenCode session

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -902,6 +902,26 @@ class OpenAICompatProvider(LLMProvider):
         name = model_name.lower()
         return not any(token in name for token in ("gpt-5", "o1", "o3", "o4"))
 
+    def _opencode_affinity_headers(
+        self,
+        provider_context: "ProviderCallContext | None",
+    ) -> dict[str, str] | None:
+        """Per-request OpenCode session-affinity header.
+
+        OpenCode Zen/Go relays route backend affinity and prompt-cache by
+        ``x-opencode-session``; the generic ``x-session-affinity`` default
+        header does not activate it. Applies to registered ``opencode*``
+        providers or base URLs aimed at ``opencode.ai``, keyed by the stable
+        conversation-scoped ``session_id``.
+        """
+        if provider_context is None or not provider_context.session_id:
+            return None
+        spec_name = (self._spec.name if self._spec else "") or ""
+        base = self._effective_base or ""
+        if not spec_name.lower().startswith("opencode") and "opencode.ai" not in base.lower():
+            return None
+        return {"x-opencode-session": provider_context.session_id}
+
     def _build_kwargs(
         self,
         messages: list[dict[str, Any]],
@@ -911,6 +931,7 @@ class OpenAICompatProvider(LLMProvider):
         temperature: float,
         reasoning_effort: str | None,
         tool_choice: str | dict[str, Any] | None,
+        extra_headers: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         model_name = model or self.default_model
         spec = self._spec
@@ -1074,6 +1095,8 @@ class OpenAICompatProvider(LLMProvider):
         # otherwise lets extra_body.tools replace nanobot's generated functions.
         if self._extra_body:
             kwargs = _merge_chat_extra_body(kwargs, self._extra_body)
+        if extra_headers:
+            kwargs["extra_headers"] = extra_headers
 
         return kwargs
 
@@ -1343,10 +1366,11 @@ class OpenAICompatProvider(LLMProvider):
         self,
         client: Any,
         body: dict[str, Any],
+        extra_headers: dict[str, str] | None = None,
     ) -> Any:
         """Retry Responses once without server compaction on compatibility errors."""
         try:
-            return await client.responses.create(**body)
+            return await client.responses.create(**body, extra_headers=extra_headers)
         except Exception as exc:
             if (
                 "context_management" not in body
@@ -1360,7 +1384,7 @@ class OpenAICompatProvider(LLMProvider):
                 "(status={})",
                 getattr(exc, "status_code", None),
             )
-            return await client.responses.create(**body)
+            return await client.responses.create(**body, extra_headers=extra_headers)
 
     # ------------------------------------------------------------------
     # Response parsing
@@ -1935,6 +1959,7 @@ class OpenAICompatProvider(LLMProvider):
         provider_context: ProviderCallContext | None = None,
     ) -> LLMResponse:
         client = await self._ensure_client()
+        affinity = self._opencode_affinity_headers(provider_context)
         try:
             if self._should_use_responses_api(model, reasoning_effort):
                 try:
@@ -1946,6 +1971,7 @@ class OpenAICompatProvider(LLMProvider):
                     responses_raw = await self._create_response_with_compaction_fallback(
                         client,
                         body,
+                        extra_headers=affinity,
                     )
                     result = parse_response_output(
                         responses_raw,
@@ -1970,6 +1996,7 @@ class OpenAICompatProvider(LLMProvider):
             kwargs = self._build_kwargs(
                 messages, tools, model, max_tokens, temperature,
                 reasoning_effort, tool_choice,
+                extra_headers=affinity,
             )
             chat_raw = cast(
                 Any,
@@ -1995,6 +2022,7 @@ class OpenAICompatProvider(LLMProvider):
     ) -> LLMResponse:
         client = await self._ensure_client()
         idle_timeout_s = resolve_stream_idle_timeout_s()
+        affinity = self._opencode_affinity_headers(provider_context)
         try:
             if self._should_use_responses_api(model, reasoning_effort):
                 try:
@@ -2007,6 +2035,7 @@ class OpenAICompatProvider(LLMProvider):
                     responses_stream = await self._create_response_with_compaction_fallback(
                         client,
                         body,
+                        extra_headers=affinity,
                     )
 
                     async def _timed_stream() -> AsyncIterator[Any]:
@@ -2078,6 +2107,7 @@ class OpenAICompatProvider(LLMProvider):
             kwargs = self._build_kwargs(
                 messages, tools, model, max_tokens, temperature,
                 reasoning_effort, tool_choice,
+                extra_headers=affinity,
             )
             if self._spec and self._spec.name == "zhipu" and tools and on_tool_call_delta:
                 # Z.AI/GLM keeps streaming tool-call arguments behind an

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -358,6 +358,13 @@ def _uses_openrouter_attribution(spec: "ProviderSpec | None", api_base: str | No
     return bool(api_base and "openrouter" in api_base.lower())
 
 
+def _uses_opencode_affinity(spec: ProviderSpec | None, api_base: str | None) -> bool:
+    if spec and spec.name in {"opencode", "opencode_zen", "opencode_go"}:
+        return True
+    host = (urlparse(api_base or "").hostname or "").rstrip(".")
+    return host == "opencode.ai" or host.endswith(".opencode.ai")
+
+
 _RESPONSES_FAILURE_THRESHOLD = 3
 _RESPONSES_PROBE_INTERVAL_S = 300  # 5 minutes
 
@@ -538,6 +545,12 @@ class OpenAICompatProvider(LLMProvider):
             self._default_headers.update(_DEFAULT_OPENROUTER_HEADERS)
         if extra_headers:
             self._default_headers.update(extra_headers)
+        self._opencode_session_affinity = _uses_opencode_affinity(spec, effective_base) and not any(
+            name.lower() == "x-opencode-session" for name in self.extra_headers
+        )
+        if self._opencode_session_affinity:
+            # Calls without conversation context still need a stable routing header.
+            self._default_headers["x-opencode-session"] = uuid.uuid4().hex
         self._api_key_for_client = api_key or "no-key"
         self._is_local = _is_local_endpoint(spec, effective_base)
 
@@ -906,21 +919,15 @@ class OpenAICompatProvider(LLMProvider):
         self,
         provider_context: "ProviderCallContext | None",
     ) -> dict[str, str] | None:
-        """Per-request OpenCode session-affinity header.
-
-        OpenCode Zen/Go relays route backend affinity and prompt-cache by
-        ``x-opencode-session``; the generic ``x-session-affinity`` default
-        header does not activate it. Applies to registered ``opencode*``
-        providers or base URLs aimed at ``opencode.ai``, keyed by the stable
-        conversation-scoped ``session_id``.
-        """
-        if provider_context is None or not provider_context.session_id:
+        """Override the instance fallback with an opaque, ASCII-safe conversation key."""
+        if (
+            not self._opencode_session_affinity
+            or provider_context is None
+            or not provider_context.session_id
+        ):
             return None
-        spec_name = (self._spec.name if self._spec else "") or ""
-        base = self._effective_base or ""
-        if not spec_name.lower().startswith("opencode") and "opencode.ai" not in base.lower():
-            return None
-        return {"x-opencode-session": provider_context.session_id}
+        session_key = hashlib.sha256(provider_context.session_id.encode("utf-8")).hexdigest()
+        return {"x-opencode-session": session_key}
 
     def _build_kwargs(
         self,

--- a/tests/providers/test_opencode_provider.py
+++ b/tests/providers/test_opencode_provider.py
@@ -1,6 +1,11 @@
 """Tests for the OpenCode Zen and OpenCode Go provider registrations."""
 
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
 from nanobot.config.schema import Config, ProvidersConfig
+from nanobot.providers.base import ProviderCallContext
 from nanobot.providers.openai_compat_provider import OpenAICompatProvider
 from nanobot.providers.registry import PROVIDERS, find_by_name
 
@@ -120,3 +125,98 @@ def test_opencode_prefixes_are_stripped_before_request() -> None:
         tool_choice=None,
     )
     assert go_kwargs["model"] == "o3"
+
+
+def _fake_chat_response() -> SimpleNamespace:
+    message = SimpleNamespace(content="ok", tool_calls=None, reasoning_content=None)
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+def _fake_responses_output() -> dict[str, object]:
+    return {
+        "output": [{
+            "type": "message",
+            "content": [{"type": "output_text", "text": "ok"}],
+        }],
+        "status": "completed",
+        "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+    }
+
+
+def _affinity_provider(name: str) -> OpenAICompatProvider:
+    return OpenAICompatProvider(api_key=None, default_model="opencode/o3", spec=find_by_name(name))
+
+
+def test_opencode_affinity_headers_enabled():
+    ctx = ProviderCallContext(session_id="s-1")
+    expected = {"x-opencode-session": "s-1"}
+    for name in ("opencode", "opencode_go", "opencode_zen"):
+        assert _affinity_provider(name)._opencode_affinity_headers(ctx) == expected
+    relayed = OpenAICompatProvider(api_key=None, default_model="o3", api_base="https://opencode.ai/zen/v1")
+    assert relayed._opencode_affinity_headers(ctx) == expected
+
+
+def test_opencode_affinity_headers_disabled():
+    assert _affinity_provider("opencode")._opencode_affinity_headers(ProviderCallContext()) is None
+    plain = OpenAICompatProvider(api_key=None, default_model="gpt-4o", spec=find_by_name("openai"))
+    assert plain._opencode_affinity_headers(ProviderCallContext(session_id="s-1")) is None
+    openai_base = OpenAICompatProvider(api_key=None, default_model="gpt-4o", api_base="https://api.openai.com/v1")
+    assert openai_base._opencode_affinity_headers(ProviderCallContext(session_id="s-1")) is None
+
+
+def test_opencode_chat_injects_session_header():
+    provider = _affinity_provider("opencode")
+    client = AsyncMock()
+    client.chat.completions.create.return_value = _fake_chat_response()
+    provider._client = client
+    result = asyncio.run(provider.chat(
+        messages=[{"role": "user", "content": "hi"}],
+        model="opencode/o3",
+        provider_context=ProviderCallContext(session_id="convo-xyz"),
+    ))
+    assert client.chat.completions.create.call_args.kwargs["extra_headers"] == {"x-opencode-session": "convo-xyz"}
+    assert result.content == "ok"
+
+
+def test_opencode_chat_stream_injects_session_header():
+    provider = _affinity_provider("opencode")
+    client = AsyncMock()
+
+    async def _chunks():
+        for text, finish in (("hel", None), ("lo", "stop")):
+            delta = SimpleNamespace(content=text)
+            yield SimpleNamespace(choices=[SimpleNamespace(delta=delta, finish_reason=finish)], usage=None)
+
+    client.chat.completions.create.return_value = _chunks()
+    provider._client = client
+    result = asyncio.run(provider.chat_stream(
+        messages=[{"role": "user", "content": "hi"}],
+        model="opencode/o3",
+        provider_context=ProviderCallContext(session_id="convo-stream"),
+    ))
+    assert client.chat.completions.create.call_args.kwargs["extra_headers"] == {"x-opencode-session": "convo-stream"}
+    assert result.content == "hello"
+
+
+def test_opencode_responses_api_injects_session_header():
+    # Config-reachable combo: providers.openai + apiType=responses + base
+    # aimed at opencode.ai => affinity on, header must reach /responses too.
+    provider = OpenAICompatProvider(
+        api_key=None,
+        default_model="gpt-5",
+        api_base="https://opencode.ai/zen/v1",
+        spec=find_by_name("openai"),
+        api_type="responses",
+    )
+    client = AsyncMock()
+    client.responses.create.return_value = _fake_responses_output()
+    provider._client = client
+    result = asyncio.run(provider.chat(
+        messages=[{"role": "user", "content": "hi"}],
+        model="gpt-5",
+        provider_context=ProviderCallContext(session_id="convo-rsp"),
+    ))
+    assert client.responses.create.call_args.kwargs["extra_headers"] == {"x-opencode-session": "convo-rsp"}
+    assert result.content == "ok"

--- a/tests/providers/test_opencode_provider.py
+++ b/tests/providers/test_opencode_provider.py
@@ -1,8 +1,11 @@
 """Tests for the OpenCode Zen and OpenCode Go provider registrations."""
 
 import asyncio
-from types import SimpleNamespace
-from unittest.mock import AsyncMock
+import hashlib
+import json
+
+import httpx
+import pytest
 
 from nanobot.config.schema import Config, ProvidersConfig
 from nanobot.providers.base import ProviderCallContext
@@ -127,13 +130,6 @@ def test_opencode_prefixes_are_stripped_before_request() -> None:
     assert go_kwargs["model"] == "o3"
 
 
-def _fake_chat_response() -> SimpleNamespace:
-    message = SimpleNamespace(content="ok", tool_calls=None, reasoning_content=None)
-    choice = SimpleNamespace(message=message, finish_reason="stop")
-    usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15)
-    return SimpleNamespace(choices=[choice], usage=usage)
-
-
 def _fake_responses_output() -> dict[str, object]:
     return {
         "output": [{
@@ -151,7 +147,7 @@ def _affinity_provider(name: str) -> OpenAICompatProvider:
 
 def test_opencode_affinity_headers_enabled():
     ctx = ProviderCallContext(session_id="s-1")
-    expected = {"x-opencode-session": "s-1"}
+    expected = {"x-opencode-session": hashlib.sha256(b"s-1").hexdigest()}
     for name in ("opencode", "opencode_go", "opencode_zen"):
         assert _affinity_provider(name)._opencode_affinity_headers(ctx) == expected
     relayed = OpenAICompatProvider(api_key=None, default_model="o3", api_base="https://opencode.ai/zen/v1")
@@ -166,57 +162,123 @@ def test_opencode_affinity_headers_disabled():
     assert openai_base._opencode_affinity_headers(ProviderCallContext(session_id="s-1")) is None
 
 
-def test_opencode_chat_injects_session_header():
-    provider = _affinity_provider("opencode")
-    client = AsyncMock()
-    client.chat.completions.create.return_value = _fake_chat_response()
-    provider._client = client
-    result = asyncio.run(provider.chat(
-        messages=[{"role": "user", "content": "hi"}],
-        model="opencode/o3",
-        provider_context=ProviderCallContext(session_id="convo-xyz"),
-    ))
-    assert client.chat.completions.create.call_args.kwargs["extra_headers"] == {"x-opencode-session": "convo-xyz"}
-    assert result.content == "ok"
+@pytest.mark.parametrize(("base", "enabled"), [
+    ("https://OPENCODE.AI/zen/v1", True),
+    ("https://relay.opencode.ai/v1", True),
+    ("https://opencode.ai./zen/v1", True),
+    ("https://opencode.ai.example.com/v1", False),
+    ("https://notopencode.ai/v1", False),
+    ("https://example.com/opencode.ai", False),
+    ("https://example.com/v1?target=opencode.ai", False),
+    ("https://opencode.ai@example.com/v1", False),
+])
+def test_opencode_affinity_matches_hostname(base, enabled):
+    provider = OpenAICompatProvider(api_base=base)
+    assert ("x-opencode-session" in provider._default_headers) is enabled
 
 
-def test_opencode_chat_stream_injects_session_header():
-    provider = _affinity_provider("opencode")
-    client = AsyncMock()
+@pytest.mark.parametrize("api_type", ["chat_completions", "responses", "responses_compaction"])
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("configured_header", [None, "x-opencode-session", "X-OpenCode-Session"])
+async def test_opencode_wire_affinity(monkeypatch, api_type, stream, configured_header):
+    """Exercise SDK header encoding/merging through the public provider entrypoints."""
+    from openai import AsyncOpenAI
 
-    async def _chunks():
-        for text, finish in (("hel", None), ("lo", "stop")):
-            delta = SimpleNamespace(content=text)
-            yield SimpleNamespace(choices=[SimpleNamespace(delta=delta, finish_reason=finish)], usage=None)
+    from nanobot.providers import openai_compat_provider
 
-    client.chat.completions.create.return_value = _chunks()
-    provider._client = client
-    result = asyncio.run(provider.chat_stream(
-        messages=[{"role": "user", "content": "hi"}],
-        model="opencode/o3",
-        provider_context=ProviderCallContext(session_id="convo-stream"),
-    ))
-    assert client.chat.completions.create.call_args.kwargs["extra_headers"] == {"x-opencode-session": "convo-stream"}
-    assert result.content == "hello"
+    requests: list[httpx.Request] = []
+    rejected: list[httpx.Request] = []
+    compaction = api_type == "responses_compaction"
+    if compaction:
+        api_type = "responses"
 
+    async def handle(request: httpx.Request) -> httpx.Response:
+        if "context_management" in json.loads(request.content):
+            rejected.append(request)
+            return httpx.Response(400, json={"error": {
+                "message": "Unsupported parameter: context_management",
+                "type": "invalid_request_error",
+            }})
+        requests.append(request)
+        await asyncio.sleep(0)
+        if api_type == "responses":
+            output = _fake_responses_output()
+            output.update(id="resp_test", object="response", created_at=0, model="gpt-5")
+            events = [
+                {"type": "response.output_text.delta", "delta": "ok"},
+                {"type": "response.completed", "response": output},
+            ]
+        else:
+            output = {
+                "id": "chatcmpl-test", "object": "chat.completion", "created": 0,
+                "model": "gpt-5", "choices": [{
+                    "index": 0, "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }],
+            }
+            events = [{
+                "id": "chatcmpl-test", "object": "chat.completion.chunk", "created": 0,
+                "model": "gpt-5", "choices": [{
+                    "index": 0, "delta": {"content": "ok"}, "finish_reason": "stop",
+                }],
+            }]
+        if stream:
+            payload = "".join(f"data: {json.dumps(event)}\n\n" for event in events)
+            return httpx.Response(200, text=payload, headers={"content-type": "text/event-stream"})
+        return httpx.Response(200, json=output)
 
-def test_opencode_responses_api_injects_session_header():
-    # Config-reachable combo: providers.openai + apiType=responses + base
-    # aimed at opencode.ai => affinity on, header must reach /responses too.
-    provider = OpenAICompatProvider(
-        api_key=None,
-        default_model="gpt-5",
-        api_base="https://opencode.ai/zen/v1",
-        spec=find_by_name("openai"),
-        api_type="responses",
-    )
-    client = AsyncMock()
-    client.responses.create.return_value = _fake_responses_output()
-    provider._client = client
-    result = asyncio.run(provider.chat(
-        messages=[{"role": "user", "content": "hi"}],
-        model="gpt-5",
-        provider_context=ProviderCallContext(session_id="convo-rsp"),
-    ))
-    assert client.responses.create.call_args.kwargs["extra_headers"] == {"x-opencode-session": "convo-rsp"}
-    assert result.content == "ok"
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as transport:
+        def make_client(**kwargs):
+            return AsyncOpenAI(**{**kwargs, "http_client": transport})
+
+        monkeypatch.setattr(openai_compat_provider, "AsyncOpenAI", make_client)
+        headers = {"x-custom": "preserved", "x-session-affinity": "existing"}
+        if configured_header:
+            headers[configured_header] = "configured"
+        provider = OpenAICompatProvider(
+            api_key="test", api_base="https://opencode.ai/zen/v1",
+            spec=find_by_name("openai"), api_type=api_type, extra_headers=headers,
+            default_model="gpt-5",
+            extra_body={"context_management": [{"type": "compaction"}]} if compaction else None,
+        )
+        call = provider.chat_stream_with_retry if stream else provider.chat_with_retry
+
+        async def send(session_id):
+            context = ProviderCallContext(session_id=session_id) if session_id is not None else None
+            result = await call(
+                messages=[{"role": "user", "content": session_id or "no-context"}],
+                provider_context=context,
+            )
+            assert result.content == "ok"
+
+        await send(None)
+        fallback = requests[-1].headers["x-opencode-session"]
+        assert fallback.isascii() and fallback
+        await asyncio.gather(send("sdk:中文"), send("sdk:other"))
+        for request in requests[1:]:
+            body = json.loads(request.content)
+            messages = body["input"] if api_type == "responses" else body["messages"]
+            content = messages[0]["content"]
+            session_id = content if isinstance(content, str) else content[0]["text"]
+            expected = "configured" if configured_header else hashlib.sha256(
+                session_id.encode("utf-8"),
+            ).hexdigest()
+            assert request.headers["x-opencode-session"] == expected
+        await send("sdk:中文")
+        await send("")
+        await send(None)
+        assert len(requests) == 6
+        assert requests[3].headers["x-opencode-session"] == (
+            "configured" if configured_header else hashlib.sha256("sdk:中文".encode()).hexdigest()
+        )
+        assert requests[4].headers["x-opencode-session"] == fallback
+        assert requests[5].headers["x-opencode-session"] == fallback
+        if compaction:
+            assert len(rejected) == 6
+            assert [r.headers["x-opencode-session"] for r in rejected] == [
+                r.headers["x-opencode-session"] for r in requests
+            ]
+        for request in [*requests, *rejected]:
+            assert request.headers["x-custom"] == "preserved"
+            assert request.headers["x-session-affinity"] == "existing"
+            assert len(request.headers.get_list("x-opencode-session")) == 1


### PR DESCRIPTION
Closes #5661

## What

OpenCode's [official announcement](https://x.com/opencode/status/2095410501400289576): requests to OpenCode Zen/Go missing the `x-opencode-session` header lose prompt-cache optimization and **may error starting 2026-09-06**.

This PR makes `OpenAICompatProvider` send `x-opencode-session` for registered `opencode`, `opencode_zen`, and `opencode_go` providers, and custom endpoints whose hostname is `opencode.ai` or a subdomain.

- Explicitly configured session headers take precedence, with case-insensitive header-name detection.
- Conversation requests use a stable SHA-256 hash of `ProviderCallContext.session_id`, including non-ASCII IDs.
- Requests without conversation context use a provider-instance UUID fallback.
- Non-streaming and streaming Chat Completions and Responses requests are covered, including compaction-fallback retries. Per-request headers preserve concurrent session isolation and other configured headers.

## Testing

- 285 related tests passed across the OpenCode, request kwargs, Responses, and circuit-breaker suites.
- Real OpenAI SDK with MockTransport covers header encoding/merging, configuration precedence, missing context, Unicode session IDs, concurrent requests, and compaction retries.
- Ruff passed; targeted strict BasedPyright reported 0 issues.
- Live OpenCode service validation has not been performed.

## Context

Deadline-driven: OpenCode enforcement starts 2026-09-06. Alternatives considered (static config header / reusing `x-session-affinity` / body-level `prompt_cache_key`) are documented in #5661.