### PR TITLE
fix(mattermost): bound thread context cache

### DIFF
--- a/nanobot/channels/mattermost/runtime.py
+++ b/nanobot/channels/mattermost/runtime.py
@@ -89,6 +89,7 @@ class MattermostChannel(BaseChannel):
 
     name = "mattermost"
     display_name = "Mattermost"
+    _THREAD_CONTEXT_CACHE_LIMIT = 10_000
 
     @classmethod
     def default_config(cls) -> dict[str, Any]:
@@ -454,6 +455,8 @@ class MattermostChannel(BaseChannel):
         key = f"{channel_id}:{root_id}"
         if key in self._thread_context_attempted:
             return text
+        if len(self._thread_context_attempted) >= self._THREAD_CONTEXT_CACHE_LIMIT:
+            self._thread_context_attempted.clear()
         self._thread_context_attempted.add(key)
 
         try:

--- a/nanobot/channels/mattermost/tests/test_mattermost_channel.py
+++ b/nanobot/channels/mattermost/tests/test_mattermost_channel.py
@@ -881,6 +881,19 @@ async def test_team_filtering_resolves_missing_broadcast_team_and_rejects_wrong_
 
 
 @pytest.mark.asyncio
+async def test_thread_context_attempt_cache_is_bounded():
+    channel, fake = _make_channel()
+    channel._thread_context_attempted.update(
+        f"channel:root-{index}" for index in range(channel._THREAD_CONTEXT_CACHE_LIMIT)
+    )
+
+    await channel._with_thread_context("current", channel_id="new-channel", root_id="new-root")
+
+    assert channel._thread_context_attempted == {"new-channel:new-root"}
+    assert fake.get_calls[-1]["path"].startswith("/api/v4/posts/new-root/thread")
+
+
+@pytest.mark.asyncio
 async def test_thread_session_key():
     channel, fake = _make_channel()
     channel._self_id = "bot_id"


### PR DESCRIPTION
## Summary

Bounds the Mattermost thread context cache to prevent indefinite memory growth.

## Problem

Each checked Mattermost thread added an identifier to a process-lifetime set that was never cleared.

## Root Cause

`_thread_context_attempted` had no size limit or eviction behaviour.

## Changes

* Cap the cache at 10,000 entries, matching the existing Slack safeguard.
* Add a regression test for cache eviction.

## Testing

* [x] Full Mattermost suite passes: 62 passed.
* [x] `ruff check` passes.
* [x] Targeted `basedpyright` passes with 0 errors and 0 warnings.
* [x] `git diff --check` passes.

## Compatibility and Risk

Low risk. Thread routing and context behaviour remain unchanged.

## Related Issue

No related issue.
