### PR TITLE
fix(mcp): bound browser OAuth flows

### DIFF
--- a/nanobot/webui/mcp_oauth_api.py
+++ b/nanobot/webui/mcp_oauth_api.py
@@ -22,6 +22,7 @@ from nanobot.webui.http_utils import is_loopback_host
 McpReload = Callable[[], Awaitable[dict[str, Any]]]
 _FLOW_TTL_S = 300
 _START_WAIT_S = 20
+_MCP_OAUTH_MAX_FLOWS = 8
 _OAUTH_ERROR_RE = re.compile(r"^[a-zA-Z0-9_.-]{1,80}$")
 
 
@@ -100,7 +101,10 @@ def prepare_mcp_oauth_redirect_uri(redirect_uri: str) -> tuple[str, bool]:
 class McpOAuthManager:
     """Own short-lived browser flows while the gateway process is running."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, max_flows: int = _MCP_OAUTH_MAX_FLOWS) -> None:
+        if max_flows < 1:
+            raise ValueError("max_flows must be at least one")
+        self._max_flows = max_flows
         self._flows: dict[str, _McpOAuthFlow] = {}
         self._states: dict[str, str] = {}
 
@@ -116,6 +120,8 @@ class McpOAuthManager:
         self._prune()
         redirect_uri, manual_callback = prepare_mcp_oauth_redirect_uri(redirect_uri)
         await self._cancel_name(name)
+        while len(self._flows) >= self._max_flows:
+            await self._discard_flow(next(iter(self._flows.values())))
 
         loop = asyncio.get_running_loop()
         now = time.monotonic()
@@ -399,6 +405,13 @@ class McpOAuthManager:
             task.cancel()
             with suppress(BaseException):
                 await task
+
+    async def _discard_flow(self, flow: _McpOAuthFlow) -> None:
+        await self._cancel_flow(flow)
+        callback_result = flow.callback_result
+        if callback_result is not None and not callback_result.done():
+            callback_result.cancel()
+        self._flows.pop(flow.flow_id, None)
 
     def _prune(self) -> None:
         now = time.monotonic()

--- a/tests/webui/test_mcp_oauth_api.py
+++ b/tests/webui/test_mcp_oauth_api.py
@@ -30,6 +30,47 @@ def _config() -> MCPServerConfig:
 
 
 @pytest.mark.asyncio
+async def test_browser_flow_registry_evicts_oldest_flow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = McpOAuthManager(max_flows=2)
+    monkeypatch.setattr(
+        "nanobot.webui.mcp_oauth_api.validate_url_target",
+        lambda _url: (True, ""),
+    )
+
+    async def connect(servers, _registry, *, oauth_handlers):
+        name = next(iter(servers))
+        handlers = oauth_handlers[name]
+        await handlers.redirect_handler(
+            f"https://accounts.example.com/authorize?state=state-{name}"
+        )
+        await handlers.callback_handler()
+        return {}
+
+    monkeypatch.setattr("nanobot.webui.mcp_oauth_api.connect_mcp_servers", connect)
+
+    async def reload_mcp() -> dict[str, bool]:
+        return {"ok": True}
+
+    started = [
+        await manager.start(
+            name,
+            _config(),
+            "https://agent.example.com/auth/mcp/callback",
+            reload_mcp=reload_mcp,
+        )
+        for name in ("first", "second", "third")
+    ]
+
+    assert len(manager._flows) == 2
+    with pytest.raises(McpOAuthError, match="Unknown or expired"):
+        await manager.status(started[0]["flow_id"])
+    with pytest.raises(McpOAuthError, match="expired"):
+        manager.submit_callback(state="state-first", code="code", error=None)
+
+
+@pytest.mark.asyncio
 async def test_browser_flow_retries_current_server_and_ignores_unrelated_reload_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Bounds the number of MCP browser OAuth flows retained in memory.

## Problem

Repeated OAuth attempts remained stored until their five-minute expiry. Rapid restarts could grow the flow registry without limit.

## Root Cause

`McpOAuthManager` had expiry cleanup but no capacity limit.

## Changes

* Limit the registry to eight flows.
* Cancel and remove the oldest flow when capacity is reached.
* Remove its associated callback state.
* Add regression coverage for eviction.

## Testing

* [x] Confirmed the test fails without the fix.
* [x] MCP OAuth tests pass: 8 passed.
* [x] Full WebUI suite passes: 300 passed.
* [x] MCP-related tests pass: 195 passed.
* [x] Ruff passes.
* [x] BasedPyright passes.
* [x] `git diff --check` passes.

## Compatibility and Risk

Low risk. Active flows within the limit behave as before.

## Related Issue

No related issue.