### PR TITLE
feat(providers): add aimlapi.com as an OpenAI-compatible gateway provider

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -269,6 +269,7 @@ Tracing covers the providers that go through nanobot's OpenAI-compatible client 
 | `custom` | Any OpenAI-compatible endpoint | — |
 | `openrouter` | LLM gateway for hosted model families + Voice transcription (STT models) | [openrouter.ai](https://openrouter.ai) |
 | `edenai` | LLM gateway for Eden AI's OpenAI-compatible model catalog | [app.edenai.run](https://app.edenai.run/) |
+| `aimlapi` | LLM gateway for aimlapi.com's OpenAI-compatible model catalog | [aimlapi.com](https://aimlapi.com) |
 | `opencode` | LLM gateway (OpenCode Zen coding-agent models) | [opencode.ai/docs/zen](https://opencode.ai/docs/zen/) |
 | `opencode_zen` | LLM gateway (legacy alias for OpenCode Zen) | [opencode.ai/docs/zen](https://opencode.ai/docs/zen/) |
 | `opencode_go` | LLM gateway (OpenCode Go low-cost coding models) | [opencode.ai/docs/go](https://opencode.ai/docs/go/) |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -190,6 +190,45 @@ Eden AI's [model listing](https://www.edenai.co/docs/v3/llms/listing-models)
 to choose a currently available model. The WebUI can also load that catalog
 after the Eden AI API key is saved under **Settings → Models**.
 
+### aimlapi.com Gateway
+
+[aimlapi.com](https://aimlapi.com) exposes an OpenAI-compatible chat-completions
+endpoint at `https://api.aimlapi.com/v1`. Configure the built-in `aimlapi`
+provider and use the full `vendor/model` identifier from its catalog:
+
+```json
+{
+  "providers": {
+    "aimlapi": {
+      "apiKey": "${AIMLAPI_API_KEY}"
+    }
+  },
+  "modelPresets": {
+    "primary": {
+      "provider": "aimlapi",
+      "model": "openai/gpt-5",
+      "maxTokens": 8192
+    }
+  },
+  "agents": {
+    "defaults": {
+      "modelPreset": "primary"
+    }
+  }
+}
+```
+
+Nanobot sends the model ID unchanged, including its vendor prefix, and passes
+`reasoning_effort` as the normal top-level Chat Completions parameter. Other
+valid IDs include `anthropic/claude-sonnet-4-6` and `google/gemini-3.1-pro-preview`.
+The public catalog at `https://api.aimlapi.com/v1/models` lists the current IDs;
+entries with `"type": "openai/chat-completions"` are the chat models. The WebUI
+can also load that catalog after the API key is saved under **Settings → Models**.
+
+Note that `https://api.aimlapi.com/v1/models` answers `200` for any credential,
+including an invalid one, so a successful model list does not prove the key
+works. The first chat completion is what verifies it.
+
 ### OpenCode Zen and Go
 
 OpenCode Zen and OpenCode Go are OpenCode-managed gateways for coding-agent models.

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -280,6 +280,7 @@ class ProvidersConfig(Base):
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
     siliconflow: ProviderConfig = Field(default_factory=ProviderConfig)  # SiliconFlow (硅基流动)
     edenai: ProviderConfig = Field(default_factory=ProviderConfig)  # Eden AI API gateway
+    aimlapi: ProviderConfig = Field(default_factory=ProviderConfig)  # AI/ML API gateway
     novita: ProviderConfig = Field(default_factory=ProviderConfig)  # Novita AI
     volcengine: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine (火山引擎)
     volcengine_coding_plan: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine Coding Plan

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -226,6 +226,26 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         detect_by_base_keyword="edenai",
         default_api_base="https://api.edenai.run/v3",
     ),
+    # AI/ML API: OpenAI-compatible gateway. Models use the "vendor/model" naming
+    # scheme (e.g. "openai/gpt-5"); the full id is sent upstream. The default
+    # headers identify nanobot to the gateway, the same way the OpenRouter
+    # attribution headers do; they ride only on this provider's requests.
+    ProviderSpec(
+        name="aimlapi",
+        keywords=("aimlapi",),
+        env_key="AIMLAPI_API_KEY",
+        display_name="aimlapi.com",
+        backend="openai_compat",
+        default_extra_headers=(
+            ("HTTP-Referer", "https://github.com/HKUDS/nanobot"),
+            ("X-Title", "nanobot"),
+            ("X-AIMLAPI-Source", "agent/hkuds-nanobot"),
+            ("X-AIMLAPI-Partner-ID", "part_TcTxHfamJ2kkNiFsYzEVELTy"),
+        ),
+        is_gateway=True,
+        detect_by_base_keyword="aimlapi",
+        default_api_base="https://api.aimlapi.com/v1",
+    ),
     # OpenCode Zen: OpenAI-compatible chat-completions gateway for coding models.
     # models.dev/OpenCode use provider id "opencode" and model ids like
     # "opencode/<model>"; send the bare model upstream.

--- a/tests/providers/test_aimlapi_provider.py
+++ b/tests/providers/test_aimlapi_provider.py
@@ -1,0 +1,119 @@
+"""Tests for the aimlapi.com provider registration."""
+
+import re
+from unittest.mock import patch
+
+from nanobot.config.schema import Config, ProviderConfig, ProvidersConfig
+from nanobot.providers.factory import _provider_extra_headers
+from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+from nanobot.providers.registry import PROVIDERS, find_by_name
+
+# The gateway silently drops a malformed partner id, so only a test catches a typo.
+PARTNER_ID_PATTERN = re.compile(r"^part_[A-Za-z0-9]{1,64}$")
+SOURCE_PATTERN = re.compile(r"^(web|agent|mcp)/[a-z0-9-]{1,32}$")
+
+
+def test_aimlapi_config_field_exists() -> None:
+    assert hasattr(ProvidersConfig(), "aimlapi")
+
+
+def test_aimlapi_registry_contract() -> None:
+    specs = {spec.name: spec for spec in PROVIDERS}
+
+    assert "aimlapi" in specs
+    aimlapi = specs["aimlapi"]
+    assert aimlapi.backend == "openai_compat"
+    assert aimlapi.env_key == "AIMLAPI_API_KEY"
+    assert aimlapi.display_name == "aimlapi.com"
+    assert aimlapi.is_gateway is True
+    assert aimlapi.detect_by_base_keyword == "aimlapi"
+    assert aimlapi.default_api_base == "https://api.aimlapi.com/v1"
+    assert aimlapi.strip_model_prefix is False
+    # aimlapi.com accepts OpenAI's top-level reasoning_effort parameter. Do not add
+    # OpenRouter's separate {"reasoning": {"effort": ...}} request shape.
+    assert aimlapi.gateway_reasoning_style == ""
+
+
+def test_aimlapi_forced_provider_uses_default_api_base() -> None:
+    config = Config.model_validate(
+        {
+            "providers": {"aimlapi": {"apiKey": "aimlapi-key"}},
+            "agents": {
+                "defaults": {
+                    "provider": "aimlapi",
+                    "model": "openai/gpt-5",
+                }
+            },
+        }
+    )
+
+    model = "openai/gpt-5"
+    assert config.get_provider_name(model) == "aimlapi"
+    assert config.get_api_key(model) == "aimlapi-key"
+    assert config.get_api_base(model) == "https://api.aimlapi.com/v1"
+
+
+def test_aimlapi_preserves_model_id_and_reasoning_effort() -> None:
+    spec = find_by_name("aimlapi")
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        provider = OpenAICompatProvider(
+            api_key="aimlapi-key",
+            default_model="openai/gpt-5",
+            spec=spec,
+        )
+
+    kwargs = provider._build_kwargs(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        model="openai/gpt-5",
+        max_tokens=1024,
+        temperature=0.7,
+        reasoning_effort="medium",
+        tool_choice=None,
+    )
+
+    assert kwargs["model"] == "openai/gpt-5"
+    assert kwargs["reasoning_effort"] == "medium"
+    assert "reasoning" not in kwargs.get("extra_body", {})
+
+
+def test_aimlapi_default_headers_identify_nanobot() -> None:
+    spec = find_by_name("aimlapi")
+
+    assert spec is not None
+    headers = _provider_extra_headers(spec, ProviderConfig())
+    assert headers == {
+        "HTTP-Referer": "https://github.com/HKUDS/nanobot",
+        "X-Title": "nanobot",
+        "X-AIMLAPI-Source": "agent/hkuds-nanobot",
+        "X-AIMLAPI-Partner-ID": "part_TcTxHfamJ2kkNiFsYzEVELTy",
+    }
+    assert PARTNER_ID_PATTERN.match(headers["X-AIMLAPI-Partner-ID"])
+    assert SOURCE_PATTERN.match(headers["X-AIMLAPI-Source"])
+
+
+def test_aimlapi_default_headers_are_scoped_to_this_provider() -> None:
+    for spec in PROVIDERS:
+        if spec.name == "aimlapi":
+            continue
+        assert not any(
+            name.lower().startswith("x-aimlapi-") for name, _ in spec.default_extra_headers
+        )
+
+
+def test_aimlapi_user_headers_win_without_mutating_the_spec() -> None:
+    spec = find_by_name("aimlapi")
+    assert spec is not None
+    before = dict(spec.default_extra_headers)
+
+    provider = ProviderConfig.model_validate({
+        "extraHeaders": {"X-Title": "my-fork", "X-Custom": "1"},
+    })
+    headers = _provider_extra_headers(spec, provider)
+
+    assert headers["X-Title"] == "my-fork"
+    assert headers["X-Custom"] == "1"
+    assert headers["X-AIMLAPI-Partner-ID"] == "part_TcTxHfamJ2kkNiFsYzEVELTy"
+    # The registry entry is a shared constant; building the per-request dict
+    # must not write back into it.
+    assert dict(spec.default_extra_headers) == before

--- a/tests/webui/test_settings_api.py
+++ b/tests/webui/test_settings_api.py
@@ -98,6 +98,26 @@ def test_settings_payload_includes_versioned_docs(
     }
 
 
+def test_settings_payload_exposes_aimlapi_provider(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config()
+    config.providers.aimlapi.api_key = "aimlapi-test-key"
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    payload = settings_payload()
+    aimlapi = next(row for row in payload["providers"] if row["name"] == "aimlapi")
+
+    assert aimlapi["label"] == "aimlapi.com"
+    assert aimlapi["configured"] is True
+    assert aimlapi["default_api_base"] == "https://api.aimlapi.com/v1"
+    assert aimlapi["model_catalog"] == "catalog"
+    assert aimlapi["model_selectable"] is True
+
+
 def test_settings_payload_exposes_edenai_provider(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/webui/src/components/settings/shared/ModelControls.tsx
+++ b/webui/src/components/settings/shared/ModelControls.tsx
@@ -43,6 +43,7 @@ import { cn } from "@/lib/utils";
 
 const DEFERRED_MODEL_LIST_PROVIDERS = new Set([
   "aihubmix",
+  "aimlapi",
   "atomic_chat",
   "byteplus",
   "byteplus_coding_plan",
@@ -583,6 +584,7 @@ export const PROVIDER_ICONS: Record<string, LucideIcon> = {
   orcarouter: Sparkles,
   skywork: Sparkles,
   aihubmix: Triangle,
+  aimlapi: Sparkles,
   anthropic: Brain,
   openai: Bot,
   deepseek: Waves,

--- a/webui/src/lib/provider-brand.ts
+++ b/webui/src/lib/provider-brand.ts
@@ -150,6 +150,7 @@ const PROVIDER_LABEL_ALIASES: Record<string, string> = {
 
 const PROVIDER_BRANDS: Record<string, ProviderBrand> = {
   aihubmix: brand("aihubmix.com", "#111827", "AH"),
+  aimlapi: brand("aimlapi.com", "#111827", "AM"),
   ant_ling: brand("ant-ling.com", "#7C3AED", "AL"),
   anthropic: brand("anthropic.com", "#D97757", "A"),
   assemblyai: brand("assemblyai.com", "#111827", "AA"),


### PR DESCRIPTION
Hi! I'm Hugo from aimlapi.com — an AI aggregator that gives access to 1000+ models in one API, trusted by 400k+ users.

We'd love to be available as a built-in provider option inside nanobot — so we went ahead and did all the technical work on our side.

To build our partnership, we offer a 50/50 revenue share on all traffic from this integration. (P.S.: tracking starts as soon as this release goes live, so no earnings will be lost during setup)

My contacts: hugo@aimlapi.com (email / Slack), Telegram: @hug0the

## Why

aimlapi.com already works through the `custom` provider, but users must know the base URL, and they lose preset detection, the `nanobot status` check and the Settings model catalog. And those requests carry no attribution, unlike OpenRouter's.

## Summary

- `nanobot/providers/registry.py`: add an `aimlapi` `ProviderSpec` to the gateway block — `openai_compat` backend, `AIMLAPI_API_KEY`, default base `https://api.aimlapi.com/v1`, display name `aimlapi.com`. Model IDs keep their catalog `vendor/model` form (no prefix stripping), and `reasoning_effort` stays the plain top-level Chat Completions parameter — not OpenRouter's nested `{"reasoning": {"effort": ...}}` shape.
- - Attribution headers on the same spec (`HTTP-Referer`, `X-Title`, `X-AIMLAPI-Source`, `X-AIMLAPI-Partner-ID`), built per provider by `factory._provider_extra_headers()` — the same mechanism as the existing OpenRouter attribution. They ride only on this provider's requests; user-supplied `extraHeaders` still win; no env vars touched.
- - `nanobot/config/schema.py`: `providers.aimlapi` config field.
- - WebUI: brand label and icon (`provider-brand.ts`, `ModelControls.tsx`) plus deferred model search — the catalog is several hundred models.
- - Docs: setup section in `docs/providers.md`, gateway row in `docs/configuration.md`.
- - Tests in `tests/providers/test_aimlapi_provider.py` (registry contract, config resolution, model-ID and reasoning pass-through, header scoping and user-override) and `tests/webui/test_settings_api.py`.
## How to Test

```
uv run pytest tests/providers/test_aimlapi_provider.py tests/webui/test_settings_api.py -q
```

```
uv run python -c "
from nanobot.config.schema import ProviderConfig
from nanobot.providers.factory import _provider_extra_headers
from nanobot.providers.registry import find_by_name
for name in ('aimlapi', 'openai'):
    print(name, '->', _provider_extra_headers(find_by_name(name), ProviderConfig()))
"
# aimlapi -> {'HTTP-Referer': 'https://github.com/HKUDS/nanobot', 'X-Title': 'nanobot', 'X-AIMLAPI-Source': 'agent/hkuds-nanobot', 'X-AIMLAPI-Partner-ID': 'part_TcTxHfamJ2kkNiFsYzEVELTy'}
# openai -> None
```

Live run: use the `config.json` from the new `docs/providers.md` section, then
`AIMLAPI_API_KEY=<aimlapi key> nanobot agent -m "Hello!"` (`nanobot status` validates the provider/model config first).

## Video/Screenshots

No layout changes — the provider appears under Settings → Models like the other gateways.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Follows the existing OpenRouter attribution pattern (`HTTP-Referer` / `X-OpenRouter-Title` in `openai_compat_provider.py`). Nothing in the agent loop or routing changes; previously saved settings load unchanged.