### PR TITLE
fix(cli): skip WebUI bundle check in dev mode

### DIFF
--- a/nanobot/cli/webui.py
+++ b/nanobot/cli/webui.py
@@ -216,11 +216,9 @@ def webui(
                 f"{config_path}, or rerun without --no-open to open the authenticated URL.[/dim]"
             )
 
-    webui_bundle_mode = _webui_build_mode_for_interactive(yes=yes)
-    _prepare_webui_bundle_for_gateway(
-        runtime_config,
-        mode="skip" if dev else webui_bundle_mode,
-    )
+    if not dev:
+        webui_bundle_mode = _webui_build_mode_for_interactive(yes=yes)
+        _prepare_webui_bundle_for_gateway(runtime_config, mode=webui_bundle_mode)
 
     instance = GatewayInstance.resolve(
         config_path=config_path,

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -2289,6 +2289,10 @@ def test_webui_dev_starts_vite_sidecar_and_gateway(monkeypatch, tmp_path: Path) 
     monkeypatch.setattr("nanobot.cli.webui.run_webui_dev_server", fake_dev_server)
     _patch_webui_managed_gateway(monkeypatch, seen)
     monkeypatch.setattr(
+        "nanobot.cli.webui._prepare_webui_bundle_for_gateway",
+        lambda *_args, **_kwargs: pytest.fail("dev mode must not inspect the bundled WebUI"),
+    )
+    monkeypatch.setattr(
         "nanobot.cli.webui._attach_to_background_gateway",
         lambda runtime, **kwargs: seen.update(
             attached_runtime=runtime,

--- a/tests/cli/test_webui_support.py
+++ b/tests/cli/test_webui_support.py
@@ -21,7 +21,7 @@ def test_source_checkout_preserves_warn_only_gateway_startup(monkeypatch) -> Non
     assert modes == ["warn"]
 
 
-def test_vite_mode_does_not_build_the_source_webui_bundle(monkeypatch) -> None:
+def test_skip_mode_does_not_build_the_source_webui_bundle(monkeypatch) -> None:
     modes: list[str] = []
     monkeypatch.setattr(
         "nanobot.cli.webui_support.inspect_webui_bundle",


### PR DESCRIPTION
`nanobot webui --dev` previously ran the bundled WebUI freshness check in skip mode, so a stale or missing production bundle emitted a warning even though Vite serves the current source tree.

This change bypasses bundled asset preparation in dev mode while preserving the existing production WebUI and gateway checks. The CLI regression test now fails if dev mode invokes bundle preparation.

Validation:

- `uv run pytest tests/cli/test_commands.py::test_webui_dev_starts_vite_sidecar_and_gateway tests/cli/test_webui_support.py tests/webui/test_build.py -q`
- `uv run ruff check nanobot/cli/webui.py tests/cli/test_commands.py tests/cli/test_webui_support.py`
