### PR TITLE
fix(providers): allow model failover after runner deadlines

### DIFF
--- a/.agent/gotchas.md
+++ b/.agent/gotchas.md
@@ -38,3 +38,13 @@ Built-in skills live in `nanobot/skills/` (markdown + YAML frontmatter format). 
 ## Atomic Session Writes
 
 `agent/memory.py` writes `history.jsonl` atomically (temp file + fsync + rename + directory fsync). This guarantees durability across crashes. Do not replace this with a plain `open(..., "w")` write.
+
+## Model Request Deadlines and Fallback
+
+Runner wall-clock deadlines apply to each configured fallback candidate, including its
+internal retry work. A fallback chain is additionally bounded by the deadline times
+the number of configured models, so persistent retries cannot hold a session forever.
+Do not wrap the whole chain in a single candidate deadline: that cancels the primary
+before its timeout can advance to a fallback. The timeout scope must remain local to
+the request because a provider instance can serve concurrent turns. Explicit user
+cancellation still stops the chain; disabling the runner timeout still opts out.

--- a/.agent/gotchas.md
+++ b/.agent/gotchas.md
@@ -38,13 +38,3 @@ Built-in skills live in `nanobot/skills/` (markdown + YAML frontmatter format). 
 ## Atomic Session Writes
 
 `agent/memory.py` writes `history.jsonl` atomically (temp file + fsync + rename + directory fsync). This guarantees durability across crashes. Do not replace this with a plain `open(..., "w")` write.
-
-## Model Request Deadlines and Fallback
-
-Runner wall-clock deadlines apply to each configured fallback candidate, including its
-internal retry work. A fallback chain is additionally bounded by the deadline times
-the number of configured models, so persistent retries cannot hold a session forever.
-Do not wrap the whole chain in a single candidate deadline: that cancels the primary
-before its timeout can advance to a fallback. The timeout scope must remain local to
-the request because a provider instance can serve concurrent turns. Explicit user
-cancellation still stops the chain; disabling the runner timeout still opts out.

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -41,6 +41,7 @@ from nanobot.providers.base import (
     ProviderConversationState,
 )
 from nanobot.providers.conversation_state import ProviderConversationStateController
+from nanobot.providers.fallback_provider import FallbackProvider
 from nanobot.session.summary import SessionSummaryCheckpoint
 from nanobot.utils.helpers import (
     build_assistant_message,
@@ -1010,7 +1011,7 @@ class AgentRunner:
         try:
             response = (
                 await coro if outer_timeout_s is None
-                else await asyncio.wait_for(coro, timeout=outer_timeout_s)
+                else await self._await_provider_request(spec, coro, outer_timeout_s)
             )
         except asyncio.CancelledError:
             _pause_generation()
@@ -1270,7 +1271,7 @@ class AgentRunner:
             response = (
                 await coro
                 if timeout_s is None
-                else await asyncio.wait_for(coro, timeout=timeout_s)
+                else await self._await_provider_request(spec, coro, timeout_s)
             )
         except asyncio.TimeoutError:
             response = LLMResponse(
@@ -1285,6 +1286,15 @@ class AgentRunner:
         )
         request_state.provider_compaction_applied |= response.provider_compaction_applied
         return response
+
+    @staticmethod
+    async def _await_provider_request(
+        spec: AgentRunSpec, request: Awaitable[LLMResponse], timeout_s: float,
+    ) -> LLMResponse:
+        provider = spec.runtime.provider
+        if isinstance(provider, FallbackProvider):
+            return await provider.run_with_timeout(request, timeout_s)
+        return await asyncio.wait_for(request, timeout=timeout_s)
 
     @staticmethod
     def _resolve_llm_timeout_s(spec: AgentRunSpec) -> float | None:

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -41,7 +41,6 @@ from nanobot.providers.base import (
     ProviderConversationState,
 )
 from nanobot.providers.conversation_state import ProviderConversationStateController
-from nanobot.providers.fallback_provider import FallbackProvider
 from nanobot.session.summary import SessionSummaryCheckpoint
 from nanobot.utils.helpers import (
     build_assistant_message,
@@ -954,6 +953,17 @@ class AgentRunner:
             elif event.get("phase") in {"end", "error"}:
                 active_hosted_tools.pop(call_id, None)
 
+        # Streaming requests also have provider-level idle timeouts
+        # (NANOBOT_STREAM_IDLE_TIMEOUT_S), but a stream that keeps producing
+        # very slow deltas can still run forever. Use a more generous wall-clock
+        # timeout for streaming while preserving NANOBOT_LLM_TIMEOUT_S=0 as an
+        # opt-out for all LLM wall-clock timeouts.
+        request_timeout_s = (
+            max(300.0, timeout_s * 2)
+            if wants_streaming and timeout_s is not None
+            else timeout_s
+        )
+
         if wants_streaming:
             thinking_buf = ""
 
@@ -990,46 +1000,22 @@ class AgentRunner:
                 on_thinking_delta=_thinking,
                 on_tool_call_delta=_provider_tool_event,
                 on_stream_recover=_stream_recover,
+                request_timeout_s=request_timeout_s,
             )
         else:
             coro = spec.runtime.provider.chat_with_retry(
                 **kwargs,
                 provider_context=provider_context,
+                request_timeout_s=request_timeout_s,
             )
 
-        # Streaming requests also have provider-level idle timeouts
-        # (NANOBOT_STREAM_IDLE_TIMEOUT_S), but a stream that keeps producing
-        # very slow deltas can still run forever. Use a more generous wall-clock
-        # timeout for streaming while preserving NANOBOT_LLM_TIMEOUT_S=0 as an
-        # opt-out for all LLM wall-clock timeouts.
-        outer_timeout_s = (
-            max(300.0, timeout_s * 2)
-            if wants_streaming and timeout_s is not None
-            else timeout_s
-        )
         request_started_at = time.perf_counter()
         try:
-            response = (
-                await coro if outer_timeout_s is None
-                else await self._await_provider_request(spec, coro, outer_timeout_s)
-            )
+            response = await coro
         except asyncio.CancelledError:
             _pause_generation()
             await _close_native_reasoning()
             raise
-        except asyncio.TimeoutError:
-            if outer_timeout_s is None:
-                response = LLMResponse(
-                    content="Error calling LLM: stream stalled",
-                    finish_reason="error",
-                    error_kind="timeout",
-                )
-            else:
-                response = LLMResponse(
-                    content=f"Error calling LLM: timed out after {outer_timeout_s:g}s",
-                    finish_reason="error",
-                    error_kind="timeout",
-                )
         _pause_generation()
         await _close_native_reasoning()
         if first_output_at is not None:
@@ -1043,16 +1029,19 @@ class AgentRunner:
         )
         request_state.provider_compaction_applied |= response.provider_compaction_applied
         round_usage = self._record_request_usage(spec, request_state, response)
-        # chat_stream_with_retry may recover internally, so only fail unfinished
-        # hosted calls after the provider returns its final error response.
-        if response.finish_reason == "error":
+        if active_hosted_tools:
+            unfinished_error = (
+                "Provider-hosted tool did not report completion before "
+                "the model request finished."
+            )
+            if response.finish_reason == "error" and response.content:
+                unfinished_error = response.content
             for event in list(active_hosted_tools.values()):
                 await _provider_tool_event({
                     **event,
                     "phase": "error",
                     "result": None,
-                    "error": response.content
-                    or "Model request failed before the provider-hosted tool completed.",
+                    "error": unfinished_error,
                 })
         dropped, all_dropped, original_finish_reason = (
             self._drop_malformed_tool_calls(response)
@@ -1262,23 +1251,12 @@ class AgentRunner:
             messages,
             tools=None,
         )
-        coro = spec.runtime.provider.chat_with_retry(
+        timeout_s = self._resolve_llm_timeout_s(spec)
+        response = await spec.runtime.provider.chat_with_retry(
             **kwargs,
             provider_context=provider_context,
+            request_timeout_s=timeout_s,
         )
-        timeout_s = self._resolve_llm_timeout_s(spec)
-        try:
-            response = (
-                await coro
-                if timeout_s is None
-                else await self._await_provider_request(spec, coro, timeout_s)
-            )
-        except asyncio.TimeoutError:
-            response = LLMResponse(
-                content=f"Error calling LLM: timed out after {timeout_s:g}s",
-                finish_reason="error",
-                error_kind="timeout",
-            )
         await self.context_governor.summarize_provider_compaction(
             request_state,
             response,
@@ -1286,15 +1264,6 @@ class AgentRunner:
         )
         request_state.provider_compaction_applied |= response.provider_compaction_applied
         return response
-
-    @staticmethod
-    async def _await_provider_request(
-        spec: AgentRunSpec, request: Awaitable[LLMResponse], timeout_s: float,
-    ) -> LLMResponse:
-        provider = spec.runtime.provider
-        if isinstance(provider, FallbackProvider):
-            return await provider.run_with_timeout(request, timeout_s)
-        return await asyncio.wait_for(request, timeout=timeout_s)
 
     @staticmethod
     def _resolve_llm_timeout_s(spec: AgentRunSpec) -> float | None:

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -1451,6 +1451,7 @@ class LLMProvider(ABC):
         on_tool_call_delta: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
         on_stream_recover: Callable[[], Awaitable[None]] | None = None,
         retry_mode: str = "standard",
+        request_timeout_s: float | None = None,
         on_retry_wait: RetryEventCallback | None = None,
         provider_context: ProviderCallContext | None = None,
         on_retry_exhausted: RetryEventCallback | None = None,
@@ -1504,6 +1505,7 @@ class LLMProvider(ABC):
             on_retry_status=on_retry_status,
             should_retry_guard=lambda: not has_streamed_content,
             on_stream_recover=_recover_stream if on_stream_recover else None,
+            request_timeout_s=request_timeout_s,
         )
 
     async def chat_with_retry(
@@ -1516,6 +1518,7 @@ class LLMProvider(ABC):
         reasoning_effort: object = _SENTINEL,
         tool_choice: str | dict[str, Any] | None = None,
         retry_mode: str = "standard",
+        request_timeout_s: float | None = None,
         on_retry_wait: RetryEventCallback | None = None,
         provider_context: ProviderCallContext | None = None,
         on_retry_exhausted: RetryEventCallback | None = None,
@@ -1555,6 +1558,7 @@ class LLMProvider(ABC):
             on_retry_wait=on_retry_wait,
             on_retry_exhausted=on_retry_exhausted,
             on_retry_status=on_retry_status,
+            request_timeout_s=request_timeout_s,
         )
 
     @staticmethod
@@ -1593,10 +1597,11 @@ class LLMProvider(ABC):
         on_retry_status: RetryStatusCallback | None,
         should_retry_guard: Callable[[], bool] | None = None,
         on_stream_recover: Callable[[], Awaitable[None]] | None = None,
+        request_timeout_s: float | None = None,
     ) -> LLMResponse:
         """Run one chat entry point through this provider's retry policy."""
         call = self._safe_chat_stream if stream else self._safe_chat
-        return await self._run_with_retry(
+        request = self._run_with_retry(
             call,
             kw,
             original_messages,
@@ -1607,6 +1612,22 @@ class LLMProvider(ABC):
             should_retry_guard=should_retry_guard,
             on_stream_recover=on_stream_recover,
         )
+        return await self._await_request_timeout(request, request_timeout_s)
+
+    @staticmethod
+    async def _await_request_timeout(
+        request: Awaitable[LLMResponse], timeout_s: float | None,
+    ) -> LLMResponse:
+        if timeout_s is None:
+            return await request
+        try:
+            return await asyncio.wait_for(request, timeout=timeout_s)
+        except asyncio.TimeoutError:
+            return LLMResponse(
+                content=f"Error calling LLM: timed out after {timeout_s:g}s",
+                finish_reason="error",
+                error_kind="timeout",
+            )
 
     @classmethod
     def _extract_retry_after(cls, content: str | None) -> float | None:

--- a/nanobot/providers/fallback_provider.py
+++ b/nanobot/providers/fallback_provider.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import Awaitable, Callable
-from contextvars import ContextVar
 from dataclasses import replace
 from typing import Any
 
@@ -139,9 +138,6 @@ class FallbackProvider(LLMProvider):
         self._fallback_model_observer = fallback_model_observer
         self._primary_context_window_tokens = primary_context_window_tokens
         self._has_fallbacks = bool(fallback_presets)
-        self._request_timeout: ContextVar[float | None] = ContextVar(
-            "fallback_request_timeout", default=None
-        )
         self._primary_failures = 0
         self._primary_tripped_at: float | None = None
 
@@ -203,29 +199,6 @@ class FallbackProvider(LLMProvider):
             return True
         return False
 
-    async def run_with_timeout(
-        self, request: Awaitable[LLMResponse], timeout_s: float,
-    ) -> LLMResponse:
-        """Give each candidate a deadline without cancelling failover itself.
-
-        The outer bound also limits persistent retries of the whole chain.
-        Context-local state keeps concurrent requests on this provider isolated.
-        """
-        token = self._request_timeout.set(timeout_s)
-        chain_timeout_s = timeout_s * (1 + len(self._fallback_presets))
-        try:
-            return await asyncio.wait_for(
-                request, timeout=chain_timeout_s,
-            )
-        except asyncio.TimeoutError:
-            return LLMResponse(
-                content=f"Error calling LLM: timed out after {chain_timeout_s:g}s",
-                finish_reason="error",
-                error_kind="timeout",
-            )
-        finally:
-            self._request_timeout.reset(token)
-
     async def chat(self, **kwargs: Any) -> LLMResponse:
         if not self._has_fallbacks:
             return await self._primary.chat(**kwargs)
@@ -245,6 +218,7 @@ class FallbackProvider(LLMProvider):
         on_retry_status: RetryStatusCallback | None,
         should_retry_guard: Callable[[], bool] | None = None,
         on_stream_recover: Callable[[], Awaitable[None]] | None = None,
+        request_timeout_s: float | None = None,
     ) -> LLMResponse:
         """Retry each provider before advancing through the fallback chain."""
         call_kwargs = dict(kw)
@@ -262,8 +236,12 @@ class FallbackProvider(LLMProvider):
                 "on_retry_status": on_retry_status,
             })
             if stream:
-                return await self._primary.chat_stream_with_retry(**call_kwargs)
-            return await self._primary.chat_with_retry(**call_kwargs)
+                return await self._primary.chat_stream_with_retry(
+                    **call_kwargs, request_timeout_s=request_timeout_s,
+                )
+            return await self._primary.chat_with_retry(
+                **call_kwargs, request_timeout_s=request_timeout_s,
+            )
 
         has_streamed: list[bool] | None = None
         recover_stream = on_stream_recover
@@ -294,10 +272,14 @@ class FallbackProvider(LLMProvider):
             provider_kwargs: dict[str, Any],
         ) -> LLMResponse:
             if stream:
-                return await provider.chat_stream_with_retry(**provider_kwargs)
-            return await provider.chat_with_retry(**provider_kwargs)
+                return await provider.chat_stream_with_retry(
+                    **provider_kwargs, request_timeout_s=request_timeout_s,
+                )
+            return await provider.chat_with_retry(
+                **provider_kwargs, request_timeout_s=request_timeout_s,
+            )
 
-        return await self._retry_with_fallback(
+        request = self._retry_with_fallback(
             _call_provider,
             call_kwargs,
             original_messages,
@@ -309,6 +291,12 @@ class FallbackProvider(LLMProvider):
             on_stream_recover=recover_stream,
             persistent_retry_guard=should_retry_guard,
         )
+        chain_timeout_s = (
+            request_timeout_s * (1 + len(self._fallback_presets))
+            if request_timeout_s is not None
+            else None
+        )
+        return await self._await_request_timeout(request, chain_timeout_s)
 
     async def chat_with_context(
         self,
@@ -486,7 +474,7 @@ class FallbackProvider(LLMProvider):
         if self._primary_available():
             primary_was_attempted = True
             response, primary_exception = await self._call_provider(
-                call, self._primary, kwargs, timeout_s=self._request_timeout.get()
+                call, self._primary, kwargs
             )
             if primary_exception is not None:
                 logger.warning(
@@ -612,7 +600,7 @@ class FallbackProvider(LLMProvider):
             else:
                 fallback_kwargs["reasoning_effort"] = fallback.reasoning_effort
             fallback_response, fallback_exception = await self._call_provider(
-                call, fallback_provider, fallback_kwargs, timeout_s=self._request_timeout.get()
+                call, fallback_provider, fallback_kwargs
             )
             if fallback_exception is not None:
                 logger.warning(
@@ -672,17 +660,10 @@ class FallbackProvider(LLMProvider):
         call: Callable[[LLMProvider, dict[str, Any]], Awaitable[LLMResponse]],
         provider: LLMProvider,
         kwargs: dict[str, Any],
-        *,
-        timeout_s: float | None = None,
     ) -> tuple[LLMResponse, Exception | None]:
         """Turn provider exceptions into error responses without swallowing cancellation."""
         try:
-            request = call(provider, kwargs)
-            response = (
-                await request if timeout_s is None
-                else await asyncio.wait_for(request, timeout=timeout_s)
-            )
-            return response, None
+            return await call(provider, kwargs), None
         except asyncio.CancelledError:
             raise
         except Exception as exc:

--- a/nanobot/providers/fallback_provider.py
+++ b/nanobot/providers/fallback_provider.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import Awaitable, Callable
+from contextvars import ContextVar
 from dataclasses import replace
 from typing import Any
 
@@ -138,6 +139,9 @@ class FallbackProvider(LLMProvider):
         self._fallback_model_observer = fallback_model_observer
         self._primary_context_window_tokens = primary_context_window_tokens
         self._has_fallbacks = bool(fallback_presets)
+        self._request_timeout: ContextVar[float | None] = ContextVar(
+            "fallback_request_timeout", default=None
+        )
         self._primary_failures = 0
         self._primary_tripped_at: float | None = None
 
@@ -198,6 +202,29 @@ class FallbackProvider(LLMProvider):
             # Half-open: allow one probe attempt.
             return True
         return False
+
+    async def run_with_timeout(
+        self, request: Awaitable[LLMResponse], timeout_s: float,
+    ) -> LLMResponse:
+        """Give each candidate a deadline without cancelling failover itself.
+
+        The outer bound also limits persistent retries of the whole chain.
+        Context-local state keeps concurrent requests on this provider isolated.
+        """
+        token = self._request_timeout.set(timeout_s)
+        chain_timeout_s = timeout_s * (1 + len(self._fallback_presets))
+        try:
+            return await asyncio.wait_for(
+                request, timeout=chain_timeout_s,
+            )
+        except asyncio.TimeoutError:
+            return LLMResponse(
+                content=f"Error calling LLM: timed out after {chain_timeout_s:g}s",
+                finish_reason="error",
+                error_kind="timeout",
+            )
+        finally:
+            self._request_timeout.reset(token)
 
     async def chat(self, **kwargs: Any) -> LLMResponse:
         if not self._has_fallbacks:
@@ -459,7 +486,7 @@ class FallbackProvider(LLMProvider):
         if self._primary_available():
             primary_was_attempted = True
             response, primary_exception = await self._call_provider(
-                call, self._primary, kwargs
+                call, self._primary, kwargs, timeout_s=self._request_timeout.get()
             )
             if primary_exception is not None:
                 logger.warning(
@@ -585,7 +612,7 @@ class FallbackProvider(LLMProvider):
             else:
                 fallback_kwargs["reasoning_effort"] = fallback.reasoning_effort
             fallback_response, fallback_exception = await self._call_provider(
-                call, fallback_provider, fallback_kwargs
+                call, fallback_provider, fallback_kwargs, timeout_s=self._request_timeout.get()
             )
             if fallback_exception is not None:
                 logger.warning(
@@ -645,10 +672,17 @@ class FallbackProvider(LLMProvider):
         call: Callable[[LLMProvider, dict[str, Any]], Awaitable[LLMResponse]],
         provider: LLMProvider,
         kwargs: dict[str, Any],
+        *,
+        timeout_s: float | None = None,
     ) -> tuple[LLMResponse, Exception | None]:
         """Turn provider exceptions into error responses without swallowing cancellation."""
         try:
-            return await call(provider, kwargs), None
+            request = call(provider, kwargs)
+            response = (
+                await request if timeout_s is None
+                else await asyncio.wait_for(request, timeout=timeout_s)
+            )
+            return response, None
         except asyncio.CancelledError:
             raise
         except Exception as exc:

--- a/tests/agent/test_runner_core.py
+++ b/tests/agent/test_runner_core.py
@@ -674,12 +674,18 @@ async def test_runner_uses_no_tools_finalization_after_max_iterations():
 async def test_runner_times_out_hung_llm_request():
     from nanobot.agent.runner import AgentRunner
 
-    provider = MagicMock(spec=LLMProvider)
+    class HangingProvider(LLMProvider):
+        def __init__(self) -> None:
+            super().__init__(provider_name="test")
 
-    async def chat_with_retry(**kwargs):
-        await asyncio.sleep(3600)
+        def get_default_model(self) -> str:
+            return "test-model"
 
-    provider.chat_with_retry = chat_with_retry
+        async def chat(self, **kwargs) -> LLMResponse:
+            await asyncio.sleep(3600)
+            raise AssertionError("unreachable")
+
+    provider = HangingProvider()
     tools = MagicMock()
     tools.get_definitions.return_value = []
 
@@ -703,27 +709,32 @@ async def test_runner_times_out_hung_llm_request():
 async def test_runner_times_out_hung_max_iteration_finalization():
     from nanobot.agent.runner import AgentRunner
 
-    provider = MagicMock()
-    calls = 0
+    class ToolThenHangProvider(LLMProvider):
+        def __init__(self) -> None:
+            super().__init__(provider_name="test")
+            self.calls = 0
 
-    async def chat_with_retry(**kwargs):
-        nonlocal calls
-        calls += 1
-        if calls == 1:
-            return LLMResponse(
-                content="",
-                tool_calls=[
-                    ToolCallRequest(
-                        id="call_1",
-                        name="probe",
-                        arguments={},
-                    )
-                ],
-                finish_reason="tool_calls",
-            )
-        await asyncio.Event().wait()
+        def get_default_model(self) -> str:
+            return "test-model"
 
-    provider.chat_with_retry = chat_with_retry
+        async def chat(self, **kwargs) -> LLMResponse:
+            self.calls += 1
+            if self.calls == 1:
+                return LLMResponse(
+                    content="",
+                    tool_calls=[
+                        ToolCallRequest(
+                            id="call_1",
+                            name="probe",
+                            arguments={},
+                        )
+                    ],
+                    finish_reason="tool_calls",
+                )
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+    provider = ToolThenHangProvider()
     tools = MagicMock()
     tools.get_definitions.return_value = []
     tools.execute = AsyncMock(return_value="ok")
@@ -742,29 +753,37 @@ async def test_runner_times_out_hung_max_iteration_finalization():
         timeout=1.0,
     )
 
-    assert calls == 2
+    assert provider.calls == 2
     assert result.stop_reason == "max_iterations"
     assert result.error is None
     assert result.final_content == "fallback after 1 iteration"
 
 
 @pytest.mark.asyncio
-async def test_runner_applies_outer_wall_timeout_to_streaming_requests():
+async def test_runner_applies_wall_timeout_to_streaming_provider_request():
     from nanobot.agent.hook import AgentHook, AgentHookContext
     from nanobot.agent.runner import AgentRunner
 
-    provider = MagicMock(spec=LLMProvider)
     streamed: list[str] = []
 
-    async def chat_stream_with_retry(*, on_content_delta, **kwargs):
-        await asyncio.sleep(0)
-        await on_content_delta("still ")
-        await asyncio.sleep(0)
-        await on_content_delta("alive")
-        return LLMResponse(content="still alive", tool_calls=[])
+    class StreamingProvider(LLMProvider):
+        def __init__(self) -> None:
+            super().__init__(provider_name="test")
 
-    provider.chat_stream_with_retry = chat_stream_with_retry
-    provider.chat_with_retry = AsyncMock()
+        def get_default_model(self) -> str:
+            return "test-model"
+
+        async def chat(self, **kwargs) -> LLMResponse:
+            raise AssertionError("non-streaming path should not run")
+
+        async def chat_stream(self, *, on_content_delta, **kwargs) -> LLMResponse:
+            await asyncio.sleep(0)
+            await on_content_delta("still ")
+            await asyncio.sleep(0)
+            await on_content_delta("alive")
+            return LLMResponse(content="still alive", tool_calls=[])
+
+    provider = StreamingProvider()
     tools = MagicMock()
     tools.get_definitions.return_value = []
 
@@ -782,7 +801,7 @@ async def test_runner_applies_outer_wall_timeout_to_streaming_requests():
         wait_for_calls.append(timeout)
         return await coro
 
-    with patch("nanobot.agent.runner.asyncio.wait_for", fake_wait_for):
+    with patch("nanobot.providers.base.asyncio.wait_for", fake_wait_for):
         result = await runner.run(make_run_spec(provider,
             initial_messages=[{"role": "user", "content": "think for a while"}],
             tools=tools,
@@ -796,7 +815,6 @@ async def test_runner_applies_outer_wall_timeout_to_streaming_requests():
     assert result.stop_reason == "completed"
     assert result.final_content == "still alive"
     assert streamed == ["still ", "alive"]
-    provider.chat_with_retry.assert_not_awaited()
     assert wait_for_calls == [300.0]
 
 
@@ -805,13 +823,21 @@ async def test_runner_times_out_never_ending_streaming_request():
     from nanobot.agent.hook import AgentHook
     from nanobot.agent.runner import AgentRunner
 
-    provider = MagicMock(spec=LLMProvider)
+    class HangingStreamingProvider(LLMProvider):
+        def __init__(self) -> None:
+            super().__init__(provider_name="test")
 
-    async def chat_stream_with_retry(*, on_content_delta, **kwargs):
-        await asyncio.sleep(3600)
+        def get_default_model(self) -> str:
+            return "test-model"
 
-    provider.chat_stream_with_retry = chat_stream_with_retry
-    provider.chat_with_retry = AsyncMock()
+        async def chat(self, **kwargs) -> LLMResponse:
+            raise AssertionError("non-streaming path should not run")
+
+        async def chat_stream(self, **kwargs) -> LLMResponse:
+            await asyncio.sleep(3600)
+            raise AssertionError("unreachable")
+
+    provider = HangingStreamingProvider()
     tools = MagicMock()
     tools.get_definitions.return_value = []
 
@@ -824,7 +850,7 @@ async def test_runner_times_out_never_ending_streaming_request():
         raise asyncio.TimeoutError
 
     runner = AgentRunner()
-    with patch("nanobot.agent.runner.asyncio.wait_for", fake_wait_for):
+    with patch("nanobot.providers.base.asyncio.wait_for", fake_wait_for):
         result = await runner.run(make_run_spec(provider,
             initial_messages=[{"role": "user", "content": "think forever"}],
             tools=tools,
@@ -837,7 +863,6 @@ async def test_runner_times_out_never_ending_streaming_request():
 
     assert result.stop_reason == "error"
     assert result.final_content == "Error calling LLM: timed out after 400s"
-    provider.chat_with_retry.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_runner_fallback.py
+++ b/tests/agent/test_runner_fallback.py
@@ -1837,8 +1837,8 @@ async def test_deadline_bounds_all_hanging_candidates() -> None:
     primary = _HangingProvider()
     fallback = _HangingProvider()
     provider = FallbackProvider(primary, [_fallback("backup")], lambda _: fallback)
-    result = await asyncio.wait_for(provider.run_with_timeout(
-        provider.chat_with_retry(messages=[], model="primary"), 0.02,
+    result = await asyncio.wait_for(provider.chat_with_retry(
+        messages=[], model="primary", request_timeout_s=0.02,
     ), timeout=1)
     assert result.error_kind == "timeout"
     assert result.content == "Error calling LLM: timed out after 0.04s"
@@ -1850,8 +1850,8 @@ async def test_deadline_does_not_convert_user_cancellation_to_failover() -> None
     primary = _HangingProvider()
     fallback = _FakeProvider()
     provider = FallbackProvider(primary, [_fallback("backup")], lambda _: fallback)
-    task = asyncio.create_task(provider.run_with_timeout(
-        provider.chat_with_retry(messages=[], model="primary"), 1,
+    task = asyncio.create_task(provider.chat_with_retry(
+        messages=[], model="primary", request_timeout_s=1,
     ))
     while not primary.chat_calls:
         await asyncio.sleep(0)
@@ -1859,7 +1859,6 @@ async def test_deadline_does_not_convert_user_cancellation_to_failover() -> None
     with pytest.raises(asyncio.CancelledError):
         await task
     assert fallback.chat_calls == []
-    assert provider._request_timeout.get() is None
 
 
 @pytest.mark.asyncio
@@ -1881,11 +1880,74 @@ async def test_candidate_deadline_recovers_stream_after_partial_output() -> None
     async def recover() -> None:
         events.append("recover")
 
-    result = await provider.run_with_timeout(provider.chat_stream_with_retry(
+    result = await provider.chat_stream_with_retry(
         messages=[], on_content_delta=delta, on_stream_recover=recover,
-    ), 0.02)
+        request_timeout_s=0.02,
+    )
     assert result.content == "recovered"
     assert events == ["partial", "recover", "recovered"]
+
+
+@pytest.mark.asyncio
+async def test_successful_fallback_closes_abandoned_hosted_tool() -> None:
+    from agent.runner_helpers import make_run_spec
+    from nanobot.agent.progress_hook import AgentProgressHook
+    from nanobot.agent.runner import AgentRunner
+    from nanobot.utils.progress_events import output_events
+
+    class HostedToolTimeoutProvider(_FakeProvider):
+        _CHAT_RETRY_DELAYS = ()
+
+        async def chat_stream(self, **kwargs: Any) -> LLMResponse:
+            await kwargs["on_tool_call_delta"]({
+                "kind": "hosted_tool",
+                "phase": "start",
+                "call_id": "search-1",
+                "name": "x_search",
+                "arguments": {"query": "nanobot"},
+                "result": None,
+            })
+            return LLMResponse(
+                content="primary timed out",
+                finish_reason="error",
+                error_kind="timeout",
+            )
+
+    primary = HostedToolTimeoutProvider("primary")
+    fallback = _FakeProvider("fallback", _make_response("recovered"))
+    provider = FallbackProvider(primary, [_fallback("backup")], lambda _: fallback)
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    progress_events: list[dict[str, Any]] = []
+
+    async def progress_cb(_content, *, tool_events=None, **_kwargs):
+        progress_events.extend(tool_events or [])
+
+    async def stream_cb(_content: str) -> None:
+        pass
+
+    hook = AgentProgressHook(
+        output_events(on_progress=progress_cb, on_stream=stream_cb),
+        streaming=True,
+    )
+    result = await AgentRunner().run(make_run_spec(
+        provider,
+        model="primary",
+        initial_messages=[{"role": "user", "content": "search"}],
+        tools=tools,
+        max_iterations=1,
+        max_tool_result_chars=16000,
+        hook=hook,
+    ))
+
+    assert result.final_content == "recovered"
+    assert [(event["phase"], event["call_id"]) for event in progress_events] == [
+        ("start", "search-1"),
+        ("error", "search-1"),
+    ]
+    assert progress_events[-1]["error"] == (
+        "Provider-hosted tool did not report completion before the model request finished."
+    )
 
 
 @pytest.mark.asyncio
@@ -1901,17 +1963,16 @@ async def test_candidate_deadlines_are_isolated_between_concurrent_requests() ->
     primary = WaitingProvider()
     fallback = _FakeProvider(response=_make_response("backup"))
     provider = FallbackProvider(primary, [_fallback("backup")], lambda _: fallback)
-    long_request = asyncio.create_task(provider.run_with_timeout(
-        provider.chat_with_retry(messages=[]), 1,
+    long_request = asyncio.create_task(provider.chat_with_retry(
+        messages=[], request_timeout_s=1,
     ))
-    short_request = asyncio.create_task(provider.run_with_timeout(
-        provider.chat_with_retry(messages=[]), 0.02,
+    short_request = asyncio.create_task(provider.chat_with_retry(
+        messages=[], request_timeout_s=0.02,
     ))
     assert (await short_request).content == "backup"
     assert not long_request.done()
     release.set()
     assert (await long_request).content == "primary"
-    assert provider._request_timeout.get() is None
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_runner_fallback.py
+++ b/tests/agent/test_runner_fallback.py
@@ -1804,3 +1804,142 @@ class TestGenerationForwarded:
         )
         assert fb.generation.temperature == 0.5
         assert fb.generation.max_tokens == 1024
+
+
+class _HangingProvider(_FakeProvider):
+    async def chat(self, **kwargs: Any) -> LLMResponse:
+        self.chat_calls.append(dict(kwargs))
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+
+@pytest.mark.asyncio
+async def test_runner_deadline_allows_configured_fallback() -> None:
+    from agent.runner_helpers import make_run_spec
+    from nanobot.agent.runner import AgentRunner
+
+    primary = _HangingProvider()
+    fallback = _FakeProvider(response=_make_response("recovered"))
+    provider = FallbackProvider(primary, [_fallback("backup")], lambda _: fallback)
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    result = await AgentRunner().run(make_run_spec(
+        provider, model="primary", initial_messages=[{"role": "user", "content": "hello"}],
+        tools=tools, max_iterations=1, max_tool_result_chars=16000, llm_timeout_s=0.02,
+    ))
+    assert result.final_content == "recovered"
+    assert result.error is None
+    assert len(primary.chat_calls) == len(fallback.chat_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_deadline_bounds_all_hanging_candidates() -> None:
+    primary = _HangingProvider()
+    fallback = _HangingProvider()
+    provider = FallbackProvider(primary, [_fallback("backup")], lambda _: fallback)
+    result = await asyncio.wait_for(provider.run_with_timeout(
+        provider.chat_with_retry(messages=[], model="primary"), 0.02,
+    ), timeout=1)
+    assert result.error_kind == "timeout"
+    assert result.content == "Error calling LLM: timed out after 0.04s"
+    assert len(primary.chat_calls) == len(fallback.chat_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_deadline_does_not_convert_user_cancellation_to_failover() -> None:
+    primary = _HangingProvider()
+    fallback = _FakeProvider()
+    provider = FallbackProvider(primary, [_fallback("backup")], lambda _: fallback)
+    task = asyncio.create_task(provider.run_with_timeout(
+        provider.chat_with_retry(messages=[], model="primary"), 1,
+    ))
+    while not primary.chat_calls:
+        await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert fallback.chat_calls == []
+    assert provider._request_timeout.get() is None
+
+
+@pytest.mark.asyncio
+async def test_candidate_deadline_recovers_stream_after_partial_output() -> None:
+    class PartialProvider(_FakeProvider):
+        async def chat_stream(self, **kwargs: Any) -> LLMResponse:
+            await kwargs["on_content_delta"]("partial")
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+    primary = PartialProvider()
+    fallback = _FakeProvider(response=_make_response("recovered"))
+    provider = FallbackProvider(primary, [_fallback("backup")], lambda _: fallback)
+    events: list[str] = []
+
+    async def delta(text: str) -> None:
+        events.append(text)
+
+    async def recover() -> None:
+        events.append("recover")
+
+    result = await provider.run_with_timeout(provider.chat_stream_with_retry(
+        messages=[], on_content_delta=delta, on_stream_recover=recover,
+    ), 0.02)
+    assert result.content == "recovered"
+    assert events == ["partial", "recover", "recovered"]
+
+
+@pytest.mark.asyncio
+async def test_candidate_deadlines_are_isolated_between_concurrent_requests() -> None:
+    release = asyncio.Event()
+
+    class WaitingProvider(_FakeProvider):
+        async def chat(self, **kwargs: Any) -> LLMResponse:
+            self.chat_calls.append(kwargs)
+            await release.wait()
+            return _make_response("primary")
+
+    primary = WaitingProvider()
+    fallback = _FakeProvider(response=_make_response("backup"))
+    provider = FallbackProvider(primary, [_fallback("backup")], lambda _: fallback)
+    long_request = asyncio.create_task(provider.run_with_timeout(
+        provider.chat_with_retry(messages=[]), 1,
+    ))
+    short_request = asyncio.create_task(provider.run_with_timeout(
+        provider.chat_with_retry(messages=[]), 0.02,
+    ))
+    assert (await short_request).content == "backup"
+    assert not long_request.done()
+    release.set()
+    assert (await long_request).content == "primary"
+    assert provider._request_timeout.get() is None
+
+
+@pytest.mark.asyncio
+async def test_finalization_request_can_fail_over_after_deadline() -> None:
+    from agent.runner_helpers import make_run_spec
+    from nanobot.agent.runner import AgentRunner
+    from nanobot.providers.base import ToolCallRequest
+
+    class ToolThenHang(_HangingProvider):
+        async def chat(self, **kwargs: Any) -> LLMResponse:
+            if not self.chat_calls:
+                self.chat_calls.append(kwargs)
+                return LLMResponse(content="", tool_calls=[
+                    ToolCallRequest(id="probe", name="probe", arguments={}),
+                ], finish_reason="tool_calls")
+            return await super().chat(**kwargs)
+
+    primary = ToolThenHang()
+    fallback = _FakeProvider(response=_make_response("finalized"))
+    provider = FallbackProvider(primary, [_fallback("backup")], lambda _: fallback)
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    tools.execute = AsyncMock(return_value="done")
+    result = await AgentRunner().run(make_run_spec(
+        provider, model="primary", initial_messages=[{"role": "user", "content": "hello"}],
+        tools=tools, max_iterations=1, max_tool_result_chars=16000, llm_timeout_s=0.02,
+        max_iterations_message="budget reached",
+    ))
+    assert result.final_content == "finalized"
+    assert len(fallback.chat_calls) == 1
+    assert fallback.chat_calls[0]["tools"] is None


### PR DESCRIPTION
Fixes #5674.

A hanging primary model exhausts the runner's deadline before `FallbackProvider` can see a timeout response. The runner cancels the entire chain, so a configured healthy fallback is never attempted. A controlled reproduction through `AgentRunner.run` showed one primary call, zero fallback calls, and a terminal timeout.

Thread the runner deadline through the generic provider retry API. Plain providers enforce it around their own retry policy; `FallbackProvider` gives every candidate the same deadline and bounds the complete chain by that deadline times the number of configured models. Runner no longer depends on the concrete fallback type, and timeout state is passed explicitly instead of stored on a shared provider instance. Both normal requests and no-tools finalization use the same boundary. Explicit cancellation still stops the chain, existing streaming recovery handles partially emitted output, and hosted-tool activity abandoned by an earlier candidate is closed with an error event.

This intentionally lets configurations with fallbacks take longer than the previous single-chain deadline: for example, a 300-second non-streaming deadline with one fallback allows up to 600 seconds total. No-fallback requests retain their existing bound, and disabling the runner wall-clock timeout retains its opt-out behavior. No configuration or persisted-data migration is needed.

Validation:
- Real-runner regressions cover ordinary requests and no-tools finalization.
- 160 relevant tests pass; 2 live MCP reconnection tests are skipped locally.
- Ruff and `git diff --check` pass.
- Strict BasedPyright was unavailable in the local environment; pushed CI provides the platform-matrix verification.
- Additional coverage includes partial-stream recovery, concurrent request isolation, all candidates hanging, explicit cancellation, and abandoned hosted-tool cleanup.

Tests use controlled local providers; no live NVIDIA NIM call is claimed.

Implemented and tested with OpenAI Codex (AI-generated contribution; no human code review performed before submission).