### PR TITLE
test: stabilize flaky and environment-dependent tests

### DIFF
--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -35,7 +35,7 @@ def make_provider(
         temperature=0.1,
         reasoning_effort=None,
     )
-    provider.estimate_prompt_tokens.return_value = (10_000, "test")
+    provider.estimate_prompt_tokens = MagicMock(return_value=(10_000, "test"))
     return provider
 
 

--- a/tests/providers/test_oauth_model_catalog.py
+++ b/tests/providers/test_oauth_model_catalog.py
@@ -387,10 +387,16 @@ def test_catalog_bounds_failure_only_keys() -> None:
         calls += 1
         raise httpx.ConnectError("offline")
 
+    # Real monotonic time can serve identical timestamps to all three
+    # lookups, making the eviction victim in _reserve() depend on set
+    # iteration order (hash-seeded). A synthetic strictly-increasing clock
+    # pins the oldest entry deterministically.
+    ticks = iter(range(10_000))
     catalog = OAuthModelCatalog(
         fallback_models=(_fallback_model(),),
         fetch=fetch,
         max_entries=2,
+        monotonic=lambda: float(next(ticks)),
     )
 
     for key in ("one", "two", "three"):

--- a/tests/session/test_session_location.py
+++ b/tests/session/test_session_location.py
@@ -193,7 +193,11 @@ def test_equivalent_workspace_paths_share_one_store(tmp_path: Path) -> None:
     real_workspace = tmp_path / "real_ws"
     real_workspace.mkdir()
     link_workspace = tmp_path / "link_ws"
-    link_workspace.symlink_to(real_workspace, target_is_directory=True)
+    try:
+        link_workspace.symlink_to(real_workspace, target_is_directory=True)
+    except OSError as exc:
+        # Creating directory symlinks needs admin/developer mode on Windows.
+        pytest.skip(f"directory symlink unavailable: {exc}")
 
     # Save via the real path, then read via a symlink to the same directory.
     manager = SessionManager(workspace=real_workspace)

--- a/tests/session/test_session_location.py
+++ b/tests/session/test_session_location.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
+import subprocess
 import uuid
 from pathlib import Path
 from unittest.mock import patch
@@ -193,13 +195,22 @@ def test_equivalent_workspace_paths_share_one_store(tmp_path: Path) -> None:
     real_workspace = tmp_path / "real_ws"
     real_workspace.mkdir()
     link_workspace = tmp_path / "link_ws"
-    try:
-        link_workspace.symlink_to(real_workspace, target_is_directory=True)
-    except OSError as exc:
-        # Creating directory symlinks needs admin/developer mode on Windows.
-        pytest.skip(f"directory symlink unavailable: {exc}")
+    if os.name == "nt":
+        completed = subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(link_workspace), str(real_workspace)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            pytest.skip(completed.stderr.strip() or completed.stdout.strip())
+    else:
+        try:
+            link_workspace.symlink_to(real_workspace, target_is_directory=True)
+        except OSError as exc:
+            pytest.skip(f"directory symlink unavailable: {exc}")
 
-    # Save via the real path, then read via a symlink to the same directory.
+    # Save via the real path, then read via an equivalent directory link.
     manager = SessionManager(workspace=real_workspace)
     session = manager.get_or_create("telegram:1")
     session.add_message("user", "via-real")


### PR DESCRIPTION
## Summary

Three small test-only fixes for tests that are currently nondeterministic or environment-dependent. No production code changes.

## 1. \`test_catalog_bounds_failure_only_keys\` — flaky, 3 failures / 5 runs on Windows

The test asserts that storing the third failure entry evicts the oldest key (\`"one"\`), so a fourth \`get("one")\` refetches. \`_reserve()\` picks the victim via \`min()\` over \`stored_at\` timestamps — but all three lookups land within a single \`time.monotonic()\` tick on Windows, so the recency keys tie and \`min()\` over a \`set\` resolves by hash-seeded iteration order. The eviction victim is a coin flip.

The catalog constructor already accepts an injectable clock; pin it to a strictly-increasing synthetic sequence so the eviction order is deterministic. Verified: 5 runs → 3 failures before the change, 5/5 passes after.

## 2. \`test_equivalent_workspace_paths_share_one_store\` — privileged symlink creation on Windows

The test used a directory symlink, which requires admin/developer-mode privilege on Windows (\`OSError: [WinError 1314] A required privilege is not held by the client\`). Create an unprivileged directory junction on Windows and keep the symlink on POSIX, so equivalent workspace paths remain covered instead of skipping the assertion.

## 3. \`tests/agent/conftest.py::make_provider\` — latent AttributeError

\`provider.estimate_prompt_tokens.return_value = ...\` reads the attribute off a \`spec=LLMProvider\` mock first; the attribute is not on the class spec (it is bound per-instance), so this raises \`AttributeError\` and every caller of \`make_provider()\` without an explicit provider would fail. No current test hits the default path — assigning a \`MagicMock\` directly fixes the latent break without changing behavior.

## Verification

- Affected suites pass locally: \`tests/providers/test_oauth_model_catalog.py\`, \`tests/session/test_session_location.py\`, \`tests/agent/\` (full).
- Maintainer follow-up on stock Windows: \`test_equivalent_workspace_paths_share_one_store\` passes; the full session-location suite reports \`13 passed, 2 skipped\` (the remaining skips are symlink-security tests).
- No production code is touched.