### PR TITLE
fix(tui): show context window usage in footer

### DIFF
--- a/tui/src/app.test.ts
+++ b/tui/src/app.test.ts
@@ -2310,7 +2310,7 @@ describe("NanobotTui layout", () => {
     expect(assistantMarker?.renderable.fg.toInts().slice(0, 3)).toEqual([161, 161, 170])
   })
 
-  test("uses the idle footer for context usage instead of permanent shortcuts", async () => {
+  test("shows context usage in the idle footer", async () => {
     setup = await createRenderer({ width: 88, height: 24, screenMode: "alternate-screen" })
     const app = mount(setup)
     app.accept({ event: "attached", chat_id: "chat" })
@@ -2319,10 +2319,7 @@ describe("NanobotTui layout", () => {
       chat_id: "chat",
       latency_ms: 1700,
       usage: {
-        prompt_tokens: 12_000_000,
-        completion_tokens: 64_000,
         context_tokens: 14_700,
-        cached_tokens: 11_640_000,
       },
       context_window_tokens: 128_000,
     })
@@ -2331,18 +2328,6 @@ describe("NanobotTui layout", () => {
     const footer = setup.captureCharFrame().split("\n").find((line) => line.includes("Ready · 1.7s")) || ""
     expect(footer).toContain("Ready · 1.7s")
     expect(footer).toContain("11% context")
-    expect(footer).not.toContain("tok/s")
-    expect(footer).not.toContain("cached")
-    expect(footer).not.toContain("64K out")
-    expect(footer).not.toContain("enter send")
-
-    app.accept({ event: "reasoning_delta", chat_id: "chat", text: "hidden" })
-    await Bun.sleep(130)
-    await setup.renderOnce()
-    const activeFooter = setup.captureCharFrame().split("\n").find((line) => line.includes("Thinking")) || ""
-    expect(activeFooter).not.toContain("ctrl+c stop")
-    expect(activeFooter).not.toContain("enter steer")
-    app.accept({ event: "turn_end", chat_id: "chat" })
   })
 
   test("keeps an explicit theme stable when the terminal reports another mode", async () => {

--- a/tui/src/app.test.ts
+++ b/tui/src/app.test.ts
@@ -2310,7 +2310,7 @@ describe("NanobotTui layout", () => {
     expect(assistantMarker?.renderable.fg.toInts().slice(0, 3)).toEqual([161, 161, 170])
   })
 
-  test("uses the idle footer for model telemetry instead of permanent shortcuts", async () => {
+  test("uses the idle footer for context usage instead of permanent shortcuts", async () => {
     setup = await createRenderer({ width: 88, height: 24, screenMode: "alternate-screen" })
     const app = mount(setup)
     app.accept({ event: "attached", chat_id: "chat" })
@@ -2319,13 +2319,10 @@ describe("NanobotTui layout", () => {
       chat_id: "chat",
       latency_ms: 1700,
       usage: {
-        prompt_tokens: 1200,
-        completion_tokens: 80,
-        cached_tokens: 900,
-        generation_ms: 1600,
-        measured_completion_tokens: 80,
-        ttft_ms: 240,
-        timed_requests: 1,
+        prompt_tokens: 12_000_000,
+        completion_tokens: 64_000,
+        context_tokens: 14_700,
+        cached_tokens: 11_640_000,
       },
       context_window_tokens: 128_000,
     })
@@ -2333,9 +2330,10 @@ describe("NanobotTui layout", () => {
 
     const footer = setup.captureCharFrame().split("\n").find((line) => line.includes("Ready · 1.7s")) || ""
     expect(footer).toContain("Ready · 1.7s")
-    expect(footer).toContain("50 tok/s")
-    expect(footer).toContain("1.2K in (75% cached) · 80 out")
-    expect(footer).not.toContain("TTFT")
+    expect(footer).toContain("11% context")
+    expect(footer).not.toContain("tok/s")
+    expect(footer).not.toContain("cached")
+    expect(footer).not.toContain("64K out")
     expect(footer).not.toContain("enter send")
 
     app.accept({ event: "reasoning_delta", chat_id: "chat", text: "hidden" })

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -1915,7 +1915,7 @@ export class NanobotTui {
     if (mode === "ready") {
       this.meta.content = footerTelemetry(
         this.lastUsage,
-        this.renderer.width,
+        this.contextWindowTokens,
         footerHintTheme(this.palette),
       )
       return

--- a/tui/src/app.ts
+++ b/tui/src/app.ts
@@ -1914,7 +1914,7 @@ export class NanobotTui {
       : "ready"
     if (mode === "ready") {
       this.meta.content = footerTelemetry(
-        this.lastUsage,
+        this.lastUsage?.context_tokens ?? null,
         this.contextWindowTokens,
         footerHintTheme(this.palette),
       )

--- a/tui/src/footer-hints.test.ts
+++ b/tui/src/footer-hints.test.ts
@@ -30,12 +30,7 @@ describe("footerHints", () => {
   })
 
   test("shows the measured request's context-window percentage", () => {
-    const result = footerTelemetry({
-      prompt_tokens: 12_000_000,
-      completion_tokens: 64_000,
-      context_tokens: 14_700,
-      cached_tokens: 11_640_000,
-    }, 128_000, theme)
+    const result = footerTelemetry(14_700, 128_000, theme)
 
     expect(result.chunks.map(({ text }) => text).join(""))
       .toBe("11% context")
@@ -43,18 +38,16 @@ describe("footerHints", () => {
   })
 
   test("clamps usage above the configured window", () => {
-    const result = footerTelemetry({
-      context_tokens: 220_000,
-    }, 200_000, theme)
+    const result = footerTelemetry(220_000, 200_000, theme)
 
     expect(result.chunks.map(({ text }) => text).join(""))
       .toBe("100% context")
   })
 
   test("does not guess without measured context or a valid window", () => {
-    const missingContext = footerTelemetry({ prompt_tokens: 1000 }, 128_000, theme)
-    const missingWindow = footerTelemetry({ context_tokens: 1000 }, null, theme)
-    const invalidWindow = footerTelemetry({ context_tokens: 1000 }, 0, theme)
+    const missingContext = footerTelemetry(null, 128_000, theme)
+    const missingWindow = footerTelemetry(1000, null, theme)
+    const invalidWindow = footerTelemetry(1000, 0, theme)
 
     expect(missingContext.chunks).toHaveLength(0)
     expect(missingWindow.chunks).toHaveLength(0)

--- a/tui/src/footer-hints.test.ts
+++ b/tui/src/footer-hints.test.ts
@@ -29,44 +29,35 @@ describe("footerHints", () => {
     expect(active.chunks).toHaveLength(0)
   })
 
-  test("groups the cache ratio with input telemetry", () => {
+  test("shows the measured request's context-window percentage", () => {
     const result = footerTelemetry({
-      prompt_tokens: 1200,
-      completion_tokens: 80,
-      cached_tokens: 900,
-      generation_ms: 1600,
-      measured_completion_tokens: 80,
-      ttft_ms: 500,
-      timed_requests: 2,
-    }, 120, theme)
+      prompt_tokens: 12_000_000,
+      completion_tokens: 64_000,
+      context_tokens: 14_700,
+      cached_tokens: 11_640_000,
+    }, 128_000, theme)
 
     expect(result.chunks.map(({ text }) => text).join(""))
-      .toBe("50 tok/s · 1.2K in (75% cached) · 80 out")
+      .toBe("11% context")
     expect(result.chunks[0]?.fg?.toInts().slice(0, 3)).toEqual([239, 142, 48])
   })
 
-  test("uses familiar compact units for large token counts", () => {
+  test("clamps usage above the configured window", () => {
     const result = footerTelemetry({
-      prompt_tokens: 4_500_000,
-      completion_tokens: 19_000,
-      cached_tokens: 3_600_000,
-      generation_ms: 135_714,
-      measured_completion_tokens: 19_000,
-    }, 120, theme)
+      context_tokens: 220_000,
+    }, 200_000, theme)
 
     expect(result.chunks.map(({ text }) => text).join(""))
-      .toBe("140 tok/s · 4.5M in (80% cached) · 19K out")
+      .toBe("100% context")
   })
 
-  test("degrades telemetry instead of guessing missing provider metrics", () => {
-    const compact = footerTelemetry({
-      prompt_tokens: 1000,
-      completion_tokens: 20,
-      cached_tokens: 0,
-    }, 60, theme)
-    const unsupported = footerTelemetry({ prompt_tokens: 1000, completion_tokens: 20 }, 60, theme)
+  test("does not guess without measured context or a valid window", () => {
+    const missingContext = footerTelemetry({ prompt_tokens: 1000 }, 128_000, theme)
+    const missingWindow = footerTelemetry({ context_tokens: 1000 }, null, theme)
+    const invalidWindow = footerTelemetry({ context_tokens: 1000 }, 0, theme)
 
-    expect(compact.chunks.map(({ text }) => text).join("")).toBe("0% cached")
-    expect(unsupported.chunks).toHaveLength(0)
+    expect(missingContext.chunks).toHaveLength(0)
+    expect(missingWindow.chunks).toHaveLength(0)
+    expect(invalidWindow.chunks).toHaveLength(0)
   })
 })

--- a/tui/src/footer-hints.ts
+++ b/tui/src/footer-hints.ts
@@ -37,57 +37,25 @@ export function contextualFooterHints(
   return footerHints(hintsFor(mode, width), theme)
 }
 
-/** Last-turn model telemetry. Passive chrome reports the system, not its manual. */
+/** Latest measured request's context-window occupancy. */
 export function footerTelemetry(
   usage: TokenUsage | null,
-  width: number,
+  contextWindowTokens: number | null,
   theme: FooterHintTheme,
 ): StyledText {
-  if (!usage) return new StyledText([])
-  const parts: string[] = []
-  const duration = usage.generation_ms
-  const measured = usage.measured_completion_tokens
-  if (typeof duration === "number" && duration > 0 && typeof measured === "number") {
-    const rate = measured * 1000 / duration
-    const value = rate < 10 ? rate.toFixed(1) : String(Math.round(rate))
-    const estimated = (usage.estimated_tokens || 0) > 0 ? "~" : ""
-    parts.push(`${estimated}${value} tok/s`)
-  }
-  const cacheHitRate = (
-    typeof usage.cached_tokens === "number"
-    && typeof usage.prompt_tokens === "number"
-    && usage.prompt_tokens > 0
-  )
-    ? Math.min(100, Math.max(0, Math.round(
-        usage.cached_tokens * 100 / usage.prompt_tokens,
-      )))
-    : null
-  if (width >= 72) {
-    const prompt = usage.prompt_tokens
-    const completion = usage.completion_tokens
-    if (typeof prompt === "number" || typeof completion === "number") {
-      const cache = cacheHitRate === null ? "" : ` (${cacheHitRate}% cached)`
-      parts.push(`${formatTelemetryTokens(prompt || 0)} in${cache}`)
-      parts.push(`${formatTelemetryTokens(completion || 0)} out`)
-    }
-  } else if (cacheHitRate !== null) {
-    parts.push(`${cacheHitRate}% cached`)
-  }
-  if (width >= 128 && typeof usage.cost_usd === "number" && usage.cost_usd > 0) {
-    parts.push(`$${usage.cost_usd < 0.01 ? usage.cost_usd.toFixed(4) : usage.cost_usd.toFixed(2)}`)
-  }
-  return footerMetrics(parts, theme)
-}
-
-function formatTelemetryTokens(value: number): string {
-  const count = Math.max(0, value)
-  for (const [threshold, suffix] of [[1_000_000_000, "B"], [1_000_000, "M"], [1_000, "K"]] as const) {
-    if (count < threshold) continue
-    const scaled = count / threshold
-    const compact = scaled >= 10 ? Math.round(scaled) : Math.round(scaled * 10) / 10
-    return `${compact}${suffix}`
-  }
-  return String(Math.round(count))
+  const contextTokens = usage?.context_tokens
+  if (
+    typeof contextTokens !== "number"
+    || !Number.isFinite(contextTokens)
+    || contextTokens < 0
+    || typeof contextWindowTokens !== "number"
+    || !Number.isFinite(contextWindowTokens)
+    || contextWindowTokens <= 0
+  ) return new StyledText([])
+  const percentage = Math.min(100, Math.max(0, Math.round(
+    contextTokens * 100 / contextWindowTokens,
+  )))
+  return footerMetrics([`${percentage}% context`], theme)
 }
 
 function footerMetrics(parts: readonly string[], theme: FooterHintTheme): StyledText {

--- a/tui/src/footer-hints.ts
+++ b/tui/src/footer-hints.ts
@@ -1,7 +1,5 @@
 import { RGBA, StyledText, TextAttributes, type TextChunk } from "@opentui/core"
 
-import type { TokenUsage } from "./protocol"
-
 export interface FooterHint {
   key: string
   label: string
@@ -39,11 +37,10 @@ export function contextualFooterHints(
 
 /** Latest measured request's context-window occupancy. */
 export function footerTelemetry(
-  usage: TokenUsage | null,
+  contextTokens: number | null,
   contextWindowTokens: number | null,
   theme: FooterHintTheme,
 ): StyledText {
-  const contextTokens = usage?.context_tokens
   if (
     typeof contextTokens !== "number"
     || !Number.isFinite(contextTokens)
@@ -52,19 +49,10 @@ export function footerTelemetry(
     || !Number.isFinite(contextWindowTokens)
     || contextWindowTokens <= 0
   ) return new StyledText([])
-  const percentage = Math.min(100, Math.max(0, Math.round(
+  const percentage = Math.min(100, Math.round(
     contextTokens * 100 / contextWindowTokens,
-  )))
-  return footerMetrics([`${percentage}% context`], theme)
-}
-
-function footerMetrics(parts: readonly string[], theme: FooterHintTheme): StyledText {
-  const chunks: TextChunk[] = []
-  parts.forEach((text, index) => {
-    if (index) chunks.push(chunk(" · ", theme.separator))
-    chunks.push(chunk(text, index === 0 ? theme.accent : theme.muted, index === 0))
-  })
-  return new StyledText(chunks)
+  ))
+  return new StyledText([chunk(`${percentage}% context`, theme.accent, true)])
 }
 
 /** Give shortcuts visual hierarchy without turning the footer into a toolbar. */


### PR DESCRIPTION
## Summary

The TUI footer currently reports aggregate token throughput and cache/input/output counts, which can misrepresent the current request context. This changes the idle footer to show measured context-window occupancy, such as `11% context`.

## Changes

- Use `context_tokens / context_window_tokens` for the footer percentage.
- Clamp displayed usage to 100% and hide it when either value is unavailable.
- Update focused and full TUI tests.

## Validation

- `bun run check`
- `bun run build`
- `bun test` (171 passed)
