### PR TITLE
fix(exec): resolve relative working_dir from workspace

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -411,8 +411,15 @@ class ExecTool(Tool):
             sandbox_restricts_workspace=bool(self.sandbox),
         )
         workspace_root = str(access.project_path) if access.project_path is not None else self.working_dir
-        cwd = working_dir or workspace_root or os.getcwd()
-
+        if working_dir:
+            requested_dir = Path(working_dir).expanduser()
+            cwd = str(
+                requested_dir
+                if requested_dir.is_absolute()
+                else Path(workspace_root or os.getcwd()) / requested_dir
+            )
+        else:
+            cwd = workspace_root or os.getcwd()
         # Prevent an LLM-supplied working_dir from escaping the configured
         # workspace when restrict_to_workspace is enabled (#2826). Without
         # this, a caller can pass working_dir="/etc" and then all absolute

--- a/tests/agent/test_workspace_scope.py
+++ b/tests/agent/test_workspace_scope.py
@@ -315,6 +315,37 @@ async def test_exec_tool_uses_scope_project_as_default_cwd(
 
 
 @pytest.mark.asyncio
+async def test_exec_tool_resolves_relative_working_dir_from_scope_project(
+    tmp_path: Path,
+    cmd_python: str,
+) -> None:
+    project = tmp_path / "project"
+    subdir = project / "subdir"
+    subdir.mkdir(parents=True)
+
+    tool = ExecTool(working_dir=str(tmp_path), restrict_to_workspace=False, timeout=5)
+    scope = validate_workspace_scope_payload(
+        {"project_path": str(project), "access_mode": "full"},
+        default_workspace=tmp_path,
+        default_restrict_to_workspace=False,
+    )
+    token = bind_workspace_scope(scope)
+    try:
+        result = await tool.execute(
+            command=(
+                f'{cmd_python} -c "from pathlib import Path; '
+                "print(Path.cwd())\""
+            ),
+            working_dir="subdir",
+        )
+    finally:
+        reset_workspace_scope(token)
+
+    assert "Exit code: 0" in result
+    assert str(subdir.resolve()) in result
+
+
+@pytest.mark.asyncio
 async def test_exec_full_scope_allows_explicit_cwd_outside_project(
     tmp_path: Path,
     cmd_python: str,

--- a/tests/tools/test_exec_security.py
+++ b/tests/tools/test_exec_security.py
@@ -236,6 +236,28 @@ async def test_exec_blocks_working_dir_outside_workspace(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_exec_blocks_relative_working_dir_outside_workspace(tmp_path):
+    """A relative working_dir that escapes the workspace must be rejected."""
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+
+    tool = ExecTool(
+        working_dir=str(workspace),
+        restrict_to_workspace=True,
+        timeout=5,
+    )
+
+    result = await tool.execute(
+        command="echo ok",
+        working_dir="../outside",
+    )
+
+    assert "outside the configured workspace" in result
+
+
+@pytest.mark.asyncio
 async def test_exec_blocks_absolute_rm_via_hijacked_working_dir(tmp_path):
     """Regression for #2826: `rm /abs/path` via working_dir hijack."""
     workspace = tmp_path / "workspace"


### PR DESCRIPTION
## Summary

Fix `ExecTool` so that a relative `working_dir` is resolved relative to the effective workspace/project path.

Previously, when a relative `working_dir` was supplied, it was interpreted relative to the process's current working directory rather than the configured/effective workspace. This was inconsistent with the default working directory behaviour and could cause commands to run in an unexpected directory.

### Behaviour

* Relative `working_dir` → resolved relative to the effective workspace
* Absolute `working_dir` → preserved as-is
* Omitted `working_dir` → existing workspace/default behaviour is preserved
* Workspace boundary enforcement remains in place

### Tests

Added tests covering:

* Relative `working_dir` resolution when a scoped `project_path` is active
* Rejection of a relative `working_dir` that escapes the configured workspace

Applied the existing main-branch MCP test fixture fix so the idle-timeout reconnect tests work with MCP SDK 1.30. Local validation: 234 related tests passed, 9 POSIX-specific tests skipped on Windows; Ruff passed.
