### PR TITLE
fix(webui): resume incomplete model setup in the browser

### DIFF
--- a/nanobot/cli/webui.py
+++ b/nanobot/cli/webui.py
@@ -27,7 +27,6 @@ from nanobot.cli.webui_support import (
     _prepare_webui_bundle_for_gateway,
     _print_foreground_port_conflict,
     _resolve_webui_config_path,
-    _run_quick_start_for_webui,
     _tcp_endpoint_reachable,
     _warn_webui_bind_scope,
     _webui_browser_url,
@@ -143,19 +142,9 @@ def webui(
         raise typer.Exit(1) from exc
 
     provider_error = _provider_setup_error(resolved_setup_config)
-    settings_setup_error = provider_error if provider_error and created_config else None
-    if settings_setup_error:
+    if provider_error:
         console.print(f"[yellow]Model setup is incomplete: {provider_error}[/yellow]")
         console.print("Configure a provider and model in WebUI Settings → Models.")
-    elif provider_error:
-        console.print(f"[dim]Provider check: {provider_error}[/dim]")
-        setup_config = _run_quick_start_for_webui(
-            setup_config,
-            yes=yes,
-            config_path=config_path,
-        )
-        if workspace:
-            setup_config.agents.defaults.workspace = workspace
 
     try:
         changed_webui, generated_bootstrap_secret = _ensure_local_webui_channel(

--- a/nanobot/cli/webui_support.py
+++ b/nanobot/cli/webui_support.py
@@ -50,7 +50,6 @@ __all__ = [
     "_print_foreground_port_conflict",
     "_print_webui_foreground_lifecycle",
     "_resolve_webui_config_path",
-    "_run_quick_start_for_webui",
     "_tcp_endpoint_reachable",
     "_validate_gateway_startup",
     "_warn_webui_bind_scope",
@@ -574,43 +573,3 @@ def _gateway_instance_command(
         workspace_path = str(Path(workspace).expanduser().resolve(strict=False))
         parts.extend(["--workspace", workspace_path])
     return " ".join(shlex.quote(part) for part in parts)
-
-
-def _run_quick_start_for_webui(
-    config: Config,
-    *,
-    yes: bool,
-    config_path: Path,
-) -> Config:
-    """Offer the existing Quick Start flow when provider setup is missing."""
-    if yes:
-        console.print(
-            "[red]Error: provider/model setup is incomplete, and --yes cannot answer "
-            "provider credentials.[/red]"
-        )
-        console.print("Complete provider/model setup:")
-        _print_model_setup_steps(config_path)
-        raise typer.Exit(1)
-
-    console.print()
-    console.print("[yellow]Model provider setup is not ready.[/yellow]")
-    console.print(
-        "Quick Start will ask for provider, API key/base URL, model, and WebUI password."
-    )
-    _confirm_webui_action("Run Quick Start now?", yes=False)
-
-    from nanobot.cli.onboard import run_quick_start_onboard
-
-    try:
-        result = run_quick_start_onboard(config)
-    except RuntimeError as exc:
-        console.print(f"[red]Error: {exc}[/red]")
-        console.print(
-            "[yellow]Run `nanobot onboard --wizard` "
-            "after installing wizard dependencies.[/yellow]"
-        )
-        raise typer.Exit(1) from exc
-    if not result.should_save:
-        console.print("[yellow]Quick Start cancelled. No changes were saved.[/yellow]")
-        raise typer.Exit(1)
-    return result.config

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -2424,7 +2424,10 @@ def test_browser_readiness_rejects_connection_error(monkeypatch) -> None:
     ) is False
 
 
-def test_webui_yes_starts_first_run_without_provider_setup(monkeypatch, tmp_path: Path) -> None:
+@pytest.mark.parametrize("resume_args", [[], ["--yes"]])
+def test_webui_resumes_first_run_without_provider_setup(
+    monkeypatch, tmp_path: Path, resume_args: list[str],
+) -> None:
     config_file = tmp_path / "config.json"
     seen: dict[str, object] = {}
 
@@ -2440,12 +2443,25 @@ def test_webui_yes_starts_first_run_without_provider_setup(monkeypatch, tmp_path
     monkeypatch.setattr("nanobot.cli.webui.sync_workspace_templates", lambda _path: None)
     _patch_webui_managed_gateway(monkeypatch, seen)
 
-    result = runner.invoke(app, ["webui", "--config", str(config_file), "--yes", "--no-open"])
+    args = ["webui", "--config", str(config_file), "--workspace", str(tmp_path / "workspace")]
+    result = runner.invoke(app, [*args, "--yes", "--no-open"])
 
     assert result.exit_code == 0
     assert config_file.exists()
     assert seen["start_options"].config_path == str(config_file.resolve(strict=False))
     assert "Configure a provider and model in WebUI Settings → Models." in result.stdout
+
+    saved_config = json.loads(config_file.read_text(encoding="utf-8"))
+    seen.clear()
+    resumed = runner.invoke(app, [*args, *resume_args, "--no-open"])
+
+    assert resumed.exit_code == 0, resumed.stdout
+    assert seen["start_options"].config_path == str(config_file.resolve(strict=False))
+    assert "Configure a provider and model in WebUI Settings → Models." in resumed.stdout
+    assert "Quick Start" not in resumed.stdout
+    assert json.loads(config_file.read_text(encoding="utf-8")) == saved_config
+    assert saved_config["channels"]["websocket"]["host"] == "127.0.0.1"
+    assert saved_config["channels"]["websocket"]["tokenIssueSecret"]
 
 
 def test_webui_missing_runtime_env_fails_before_starting_gateway(
@@ -2483,7 +2499,7 @@ def test_webui_missing_runtime_env_fails_before_starting_gateway(
     assert f"${{{missing_env}}}" in config_file.read_text(encoding="utf-8")
 
 
-def test_webui_yes_still_refuses_invalid_custom_model_setup(
+def test_webui_yes_opens_settings_for_incomplete_custom_model_setup(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
@@ -2505,14 +2521,20 @@ def test_webui_yes_still_refuses_invalid_custom_model_setup(
         encoding="utf-8",
     )
 
-    result = runner.invoke(app, ["webui", "--config", str(config_file), "--yes"])
+    _patch_gateway_ports_free(monkeypatch)
+    seen = _patch_webui_managed_gateway(monkeypatch)
+    result = runner.invoke(app, [
+        "webui", "--config", str(config_file), "--workspace", str(tmp_path / "workspace"),
+        "--yes", "--no-open",
+    ])
 
-    assert result.exit_code == 1
-    assert "provider/model setup is incomplete" in result.stdout
+    assert result.exit_code == 0, result.stdout
+    assert seen["start_options"].config_path == str(config_file.resolve(strict=False))
+    assert "Model setup is incomplete" in result.stdout
     assert "Settings → Models" in _without_rendered_line_breaks(result.stdout)
-    assert "nanobot onboard --wizard" in result.stdout
-    assert "nanobot status --config" in result.stdout
-    assert config_file.name in result.stdout
+    saved = json.loads(config_file.read_text(encoding="utf-8"))
+    assert saved["agents"]["defaults"]["model"] == "custom/test-model"
+    assert saved["providers"]["custom"]["displayName"] == "Custom"
 
 
 def test_open_webui_browser_redacts_bootstrap_secret(monkeypatch, capsys) -> None:


### PR DESCRIPTION
When a user closes the first-run WebUI before configuring a model, the next `nanobot webui` launch currently switches to the terminal Quick Start wizard; adding `--yes` makes it exit instead. Keep incomplete model setup in the WebUI on subsequent launches so users can continue in Settings → Models with their saved configuration.

Remove the unused WebUI-to-wizard helper. Existing configuration validation and local WebUI authentication remain in place.

Validation:

- 49 related CLI and configuration diagnostics tests passed, including first launch followed by restart with and without `--yes`, configuration preservation, and incomplete custom-provider setup.
- Ruff and `git diff --check` passed.
- With isolated configuration and real CLI/gateway processes, first launch and both restart variants returned HTTP 200 from authenticated bootstrap and settings endpoints; saved configuration stayed identical. Test gateways stopped and both ports were released.
- No external model calls or browser visual verification were performed.
