### PR TITLE
fix(cron): defer timer rearming while jobs execute

### DIFF
--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -517,6 +517,11 @@ class CronService:
 
     def _arm_timer(self) -> None:
         """Schedule the next timer tick."""
+        # The timer task also owns the agent callback. Store edits during a
+        # callback must not cancel it or start another tick for the same due
+        # job. The final execution rearms after persisting its result.
+        if self._active_executions:
+            return
         if self._timer_task:
             self._timer_task.cancel()
 

--- a/tests/cron/test_cron_active_rearm.py
+++ b/tests/cron/test_cron_active_rearm.py
@@ -1,0 +1,88 @@
+"""Job-store edits must not cancel the timer task executing an agent turn."""
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from nanobot.cron.service import CronService
+from nanobot.cron.types import CronJob, CronSchedule
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["add", "update", "remove", "disable"])
+@pytest.mark.parametrize("edit_from_callback", [True, False])
+async def test_edit_during_timer_execution_preserves_turn(
+    tmp_path: Path, action: str, edit_from_callback: bool,
+) -> None:
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    settled = asyncio.Event()
+    outcomes: list[str] = []
+
+    def add_job(name: str) -> CronJob:
+        return service.add_job(
+            name=name,
+            schedule=CronSchedule(kind="every", every_ms=3_600_000),
+            message=name,
+            session_key=f"websocket:{name}",
+            origin_channel="websocket",
+            origin_chat_id=name,
+        )
+
+    def edit_store() -> None:
+        if action == "add":
+            add_job("new-job")
+        elif action == "update":
+            service.update_job(other.id, message="updated")
+        elif action == "remove":
+            service.remove_job(other.id)
+        else:
+            service.enable_job(other.id, False)
+
+    async def on_job(job: CronJob) -> None:
+        entered.set()
+        try:
+            if edit_from_callback:
+                edit_store()
+            await release.wait()
+            outcomes.append("completed")
+        except asyncio.CancelledError:
+            outcomes.append("cancelled")
+            raise
+        finally:
+            settled.set()
+
+    service = CronService(tmp_path / "cron" / "jobs.json", on_job=on_job)
+    await service.start()
+    try:
+        other = add_job("other")
+        active = add_job("active")
+        active.state.next_run_at_ms = 1
+        service._save_store()
+        service._arm_timer()
+        async with asyncio.timeout(2):
+            await entered.wait()
+            if not edit_from_callback:
+                edit_store()
+            release.set()
+            await settled.wait()
+        assert outcomes == ["completed"]
+
+        async with asyncio.timeout(2):
+            while service._active_executions:
+                await asyncio.sleep(0)
+        restored = CronService(service.store_path).get_job(active.id)
+        assert restored is not None
+        assert restored.state.last_status == "ok"
+        assert len(restored.state.run_history) == 1
+        assert restored.state.next_run_at_ms is not None
+        assert restored.state.last_run_at_ms is not None
+        assert restored.state.next_run_at_ms > restored.state.last_run_at_ms
+        assert service._timer_task is not None
+        assert not service._timer_task.done()
+    finally:
+        timer = service._timer_task
+        service.stop()
+        if timer is not None:
+            await asyncio.gather(timer, return_exceptions=True)


### PR DESCRIPTION
When a cron callback edits the job store (or another task edits it while the callback is awaiting), `_arm_timer()` cancels the timer task that is also executing that callback. The turn receives `CancelledError` before its result and advanced schedule are saved. Even changing a different job interrupts the active turn.

Defer timer rearming while an execution owns the store. The existing execution-finalization paths rearm after the last active execution settles, preserving the current serial timer design and public APIs. This is a focused fix for current `main`; the older, broader scheduler redesign in #364 replaces the timer architecture instead.

Before starting each job from the due list, look it up in the current store and verify that it remains enabled and due. Removing, disabling, or rescheduling a waiting job skips its old occurrence while later eligible jobs still run.

Regression coverage uses the real asyncio timer and a temporary on-disk job store. It covers add, update, remove, and disable operations, both from inside the callback and from another task, then verifies successful completion, one persisted run-history entry, the advanced schedule, and a newly armed timer. Three additional cases cover removing, disabling, and rescheduling a waiting due job, including persisted state and execution of the unaffected jobs.

The WebSocket connection-delivery test uses an in-memory transcript recorder, so its synchronization checks do not depend on filesystem latency.

Validation on Windows, CPython 3.14.6:

- The 8 active-callback cases failed on the original source with `['cancelled'] != ['completed']`.
- The 3 waiting-job cases failed before the execution-time check: the edited job still ran.
- `python -m pytest tests/cron tests/agent/test_loop_cron_timezone.py tests/triggers -q --tb=short`: **150 passed**.
- `python -m ruff check nanobot/cron/service.py tests/cron/test_cron_active_rearm.py`: passed.
- `python -m basedpyright --pythonpath <venv-python> nanobot/cron/service.py`: **0 errors, 0 warnings**.

- `python -m pytest nanobot/channels/websocket/tests/test_websocket_outbound_delivery.py -q --tb=short`: **17 passed**; Ruff on that file passed.
- With an injected 2.1-second transcript write, the connection-delivery test timed out before recorder isolation and passed after it.

No model API calls or external channel sends were made. The full repository suite, Linux execution, and live providers/channels were not tested locally.

No linked issue; found through source inspection.