### PR TITLE
fix(webui): keep working timer consistent across first output

### DIFF
--- a/webui/src/components/thread/ThreadMessages.tsx
+++ b/webui/src/components/thread/ThreadMessages.tsx
@@ -188,9 +188,8 @@ export function ThreadMessages({
             hasBodyBelow={false}
             retryStatus={retryStatus}
             startedAtMs={
-              runStartedAt != null
-                ? runStartedAt * 1000
-                : pendingActivity.startedAtMs
+              // Match the activity timeline's prompt-based clock across the first output.
+              pendingActivity.startedAtMs ?? (runStartedAt != null ? runStartedAt * 1000 : undefined)
             }
           />
         </div>

--- a/webui/src/tests/thread-messages.test.tsx
+++ b/webui/src/tests/thread-messages.test.tsx
@@ -16,52 +16,89 @@ afterEach(() => {
 });
 
 describe("ThreadMessages", () => {
-  it("shows optimistic turn progress in the thread before the first agent output", () => {
+  it.each([0, -13_000, -14_000, -15_000, 15_000])(
+    "keeps the optimistic timer through acknowledgement and output with %i ms server clock skew",
+    (clockSkewMs) => {
+      vi.useFakeTimers();
+      const now = new Date("2026-08-13T10:00:05.000Z").getTime();
+      vi.setSystemTime(now);
+      const prompt: UIMessage = {
+        id: "u-optimistic",
+        role: "user",
+        content: "check this",
+        turnId: "turn-optimistic",
+        turnPhase: "user",
+        deliveryStatus: "sending",
+        createdAt: now,
+      };
+      const { rerender } = render(
+        <ThreadMessages
+          messages={[prompt]}
+          isStreaming
+          activeTurnId="turn-optimistic"
+        />,
+      );
+
+      expect(screen.getByRole("status", { name: "Working for 0s" })).toBeInTheDocument();
+
+      rerender(
+        <ThreadMessages
+          messages={[{ ...prompt, deliveryStatus: "accepted" }]}
+          isStreaming
+          activeTurnId="turn-optimistic"
+          runStartedAt={(now + clockSkewMs) / 1000}
+        />,
+      );
+      expect(screen.getByRole("status", { name: "Working for 0s" })).toBeInTheDocument();
+      act(() => { vi.advanceTimersByTime(1000); });
+
+      rerender(
+        <ThreadMessages
+          messages={[
+            { ...prompt, deliveryStatus: "accepted" },
+            {
+              id: "t-optimistic",
+              role: "tool",
+              kind: "trace",
+              content: "web_search()",
+              traces: ["web_search()"],
+              turnId: "turn-optimistic",
+              turnPhase: "activity",
+              createdAt: now,
+            },
+          ]}
+          isStreaming
+          activeTurnId="turn-optimistic"
+          runStartedAt={(now + clockSkewMs) / 1000}
+        />,
+      );
+
+      expect(screen.getByRole("button", { name: "Working for 1s" })).toBeInTheDocument();
+    },
+  );
+
+  it("restores pending progress from the original prompt when guidance arrives", () => {
     vi.useFakeTimers();
-    const now = new Date("2026-08-13T10:00:05.000Z").getTime();
+    const now = 1_800_000_000_000;
     vi.setSystemTime(now);
-    const prompt: UIMessage = {
-      id: "u-optimistic",
-      role: "user",
-      content: "check this",
-      turnId: "turn-optimistic",
-      turnPhase: "user",
-      deliveryStatus: "sending",
-      createdAt: now - 5_000,
-    };
-    const { rerender } = render(
-      <ThreadMessages
-        messages={[prompt]}
-        isStreaming
-        activeTurnId="turn-optimistic"
-        runStartedAt={(now - 5_000) / 1000}
-      />,
-    );
-
-    expect(screen.getByRole("status", { name: "Working for 5s" })).toBeInTheDocument();
-
-    rerender(
+    render(
       <ThreadMessages
         messages={[
-          { ...prompt, deliveryStatus: "accepted" },
           {
-            id: "t-optimistic",
-            role: "tool",
-            kind: "trace",
-            content: "web_search()",
-            traces: ["web_search()"],
-            turnId: "turn-optimistic",
-            turnPhase: "activity",
-            createdAt: now,
+            id: "original", role: "user", content: "research this",
+            turnId: "original-turn", createdAt: now - 30_000,
+          },
+          {
+            id: "guidance", role: "user", content: "also check this",
+            turnId: "guidance-turn", createdAt: now,
           },
         ]}
         isStreaming
-        activeTurnId="turn-optimistic"
-        runStartedAt={(now - 5_000) / 1000}
+        activeTurnId="original-turn"
+        runStartedAt={(now - 43_000) / 1000}
       />,
     );
-
-    expect(screen.getByRole("button", { name: "Working for 5s" })).toBeInTheDocument();
+    expect(screen.getByRole("status", { name: "Working for 30s" })).toBeInTheDocument();
   });
 
   it("does not move a mounted tail answer into offscreen rendering on the next turn", () => {


### PR DESCRIPTION
When the server clock is behind the browser, a newly sent message can immediately show “Working for 13–15s” and then jump back to 1s when the first activity arrives. Pending progress uses the server run start, while the activity timeline uses the user prompt timestamp.

Prefer the owning prompt timestamp for pending progress too, keeping the same clock across acknowledgement and first output. Retain the server run start as a fallback when the prompt timestamp is unavailable. Regression coverage includes both clock-skew directions and restored pending progress with a later guidance message.

Validation:

- 197 tests passed across `thread-messages`, `thread-shell`, and `useNanobotStream`.
- `bun run build`, focused ESLint with zero warnings, and `git diff --check` passed.
- Playwright against the production build served by an isolated gateway: two consecutive sends with controlled WebSocket responses simulating a server 15 seconds behind both stayed at 1s across first reasoning output; no page errors. Runtime and ports were cleaned up.

The browser timing check uses controlled transport frames, not a real LLM turn. Restored timer behavior is covered by component tests; end-to-end active-turn refresh was not verified.
