### PR TITLE
docs: unify personal agent installation with quick start

### DIFF
--- a/docs/guides/build-a-personal-ai-agent.md
+++ b/docs/guides/build-a-personal-ai-agent.md
@@ -20,13 +20,9 @@ delivery.
 
 ## Install
 
-```bash
-python -m pip install nanobot-ai
-nanobot onboard --wizard
-```
-
-The wizard creates `~/.nanobot/config.json` and helps you choose a provider and
-model. If terminals and config files are new to you, use
+Follow [Quick Start](../quick-start.md) to install nanobot using the recommended
+method for your operating system and configure one model. Return here after
+you receive the first reply. If terminals and config files are new to you, use
 [Start Without Technical Background](../start-without-technical-background.md)
 instead.
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -4,7 +4,7 @@ This guide has one goal: get a normal nanobot reply in your browser. Do not add 
 
 If terminals, Python, or API keys are unfamiliar, use the [beginner walkthrough](./start-without-technical-background.md), which explains each term and screen.
 
-These repository docs follow current `main`. The recommended installer uses the stable package, so a newly documented WebUI screen may not appear until the next release. Each advanced guide also provides a CLI or manual config path.
+These repository docs describe `main`, which can be newer than the released package. The installer below installs the latest stable release. Check `nanobot --version` and use the [matching stable guide](https://nanobot.wiki/docs/latest/getting-started/quick-start) if its setup screens differ from this page.
 
 ## What You Need
 


### PR DESCRIPTION
The personal-agent guide starts with a separate pip/wizard flow while Quick Start recommends the platform installer. Link the guide to Quick Start for installation and initial model setup, so both entry points share one maintained path. Clarify that main documentation can be newer than the installed stable package and link to the stable Quick Start when setup screens differ.

This is the source-documentation companion to the nanobot.wiki installation-entry update, related to [NAN-107](https://linear.app/nanobot-ai/issue/NAN-107). It covers version guidance and installation entry points; the first useful task tutorial remains follow-up work.

Validation: local Markdown link targets resolve; `git diff --check` passes. The corresponding English and nine translated site pages are included in the companion website PR and checked through its documentation build.
