### PR TITLE
fix(webui): preserve multiline dollar math with attached delimiters

### DIFF
--- a/webui/bun.lock
+++ b/webui/bun.lock
@@ -16,6 +16,7 @@
         "diff": "^9.0.0",
         "i18next": "^26.0.6",
         "lucide-react": "^0.469.0",
+        "micromark-factory-space": "^2.0.1",
         "qrcode": "^1.5.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/webui/package.json
+++ b/webui/package.json
@@ -24,6 +24,7 @@
     "diff": "^9.0.0",
     "i18next": "^26.0.6",
     "lucide-react": "^0.469.0",
+    "micromark-factory-space": "^2.0.1",
     "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/webui/src/lib/remark-tex-math.ts
+++ b/webui/src/lib/remark-tex-math.ts
@@ -1,4 +1,5 @@
 import type { Root } from "mdast";
+import { factorySpace } from "micromark-factory-space";
 import type { Code, Construct, Effects, Extension, State, Token } from "micromark-util-types";
 import type { Plugin } from "unified";
 import type {} from "micromark-extension-math";
@@ -30,6 +31,11 @@ const texMathSyntax: Extension = {
       tokenize: tokenizeTexMathFlow,
       concrete: true,
       name: "texMathFlow",
+    },
+    [DOLLAR]: {
+      tokenize: tokenizeDollarMathFlow,
+      concrete: true,
+      name: "dollarMathFlow",
     },
   },
   text: {
@@ -79,6 +85,11 @@ function isMathSignal(code: Code): boolean {
 
 const texMathFlowClose: Construct = {
   tokenize: tokenizeTexMathFlowClose,
+  partial: true,
+};
+
+const dollarMathFlowClose: Construct = {
+  tokenize: tokenizeDollarMathFlowClose,
   partial: true,
 };
 
@@ -202,6 +213,18 @@ function tokenizeTexMathText(effects: Effects, ok: State, nok: State): State {
 }
 
 function tokenizeTexMathFlow(effects: Effects, ok: State, nok: State): State {
+  return tokenizeMathFlow(effects, ok, nok, LEFT_BRACKET, BACKSLASH, texMathFlowClose);
+}
+
+// Treat text after an opening $$ as formula content, not Markdown fence metadata.
+function tokenizeDollarMathFlow(effects: Effects, ok: State, nok: State): State {
+  return tokenizeMathFlow(effects, ok, nok, DOLLAR, DOLLAR, dollarMathFlowClose);
+}
+
+function tokenizeMathFlow(
+  effects: Effects, ok: State, nok: State,
+  openingTail: number, closingStart: number, closing: Construct,
+): State {
   return start;
 
   function start(code: Code): State | undefined {
@@ -213,12 +236,18 @@ function tokenizeTexMathFlow(effects: Effects, ok: State, nok: State): State {
   }
 
   function open(code: Code): State | undefined {
-    if (code !== LEFT_BRACKET) return nok(code);
+    if (code !== openingTail) return nok(code);
 
     effects.consume(code);
     effects.exit("mathFlowFenceSequence");
     effects.exit("mathFlowFence");
-    return contentStart;
+    return afterOpen;
+  }
+
+  function afterOpen(code: Code): State | undefined {
+    // Leave longer dollar fences to remark-math.
+    if (openingTail === DOLLAR && code === DOLLAR) return nok(code);
+    return contentStart(code);
   }
 
   function contentStart(code: Code): State | undefined {
@@ -231,8 +260,8 @@ function tokenizeTexMathFlow(effects: Effects, ok: State, nok: State): State {
       return contentStart;
     }
 
-    if (code === BACKSLASH) {
-      return effects.attempt(texMathFlowClose, done, contentStartAfterBackslash)(code);
+    if (code === closingStart) {
+      return effects.attempt(closing, done, contentStartAfterDelimiter)(code);
     }
 
     effects.enter("mathFlowValue");
@@ -253,16 +282,22 @@ function tokenizeTexMathFlow(effects: Effects, ok: State, nok: State): State {
       return contentStart;
     }
 
-    if (code === BACKSLASH) {
+    if (code === closingStart) {
       effects.exit("mathFlowValue");
-      return effects.attempt(texMathFlowClose, done, contentStartAfterBackslash)(code);
+      return effects.attempt(closing, done, contentStartAfterDelimiter)(code);
     }
 
+    effects.consume(code);
+    return openingTail === DOLLAR && code === BACKSLASH ? escaped : content;
+  }
+
+  function escaped(code: Code): State | undefined {
+    if (code === null || isLineEnding(code)) return content(code);
     effects.consume(code);
     return content;
   }
 
-  function contentStartAfterBackslash(code: Code): State | undefined {
+  function contentStartAfterDelimiter(code: Code): State | undefined {
     effects.enter("mathFlowValue");
     effects.consume(code);
     return content;
@@ -270,11 +305,25 @@ function tokenizeTexMathFlow(effects: Effects, ok: State, nok: State): State {
 
   function done(code: Code): State | undefined {
     effects.exit("mathFlow");
+    if (openingTail === DOLLAR) return factorySpace(effects, afterClose, "whitespace")(code);
     return ok(code);
+  }
+
+  function afterClose(code: Code): State | undefined {
+    // Inline formulas followed by prose belong to remark-math's text tokenizer.
+    return code === null || isLineEnding(code) ? ok(code) : nok(code);
   }
 }
 
 function tokenizeTexMathFlowClose(effects: Effects, ok: State, nok: State): State {
+  return tokenizeMathFlowClose(effects, ok, nok, RIGHT_BRACKET);
+}
+
+function tokenizeDollarMathFlowClose(effects: Effects, ok: State, nok: State): State {
+  return tokenizeMathFlowClose(effects, ok, nok, DOLLAR);
+}
+
+function tokenizeMathFlowClose(effects: Effects, ok: State, nok: State, tail: number): State {
   return start;
 
   function start(code: Code): State | undefined {
@@ -285,7 +334,7 @@ function tokenizeTexMathFlowClose(effects: Effects, ok: State, nok: State): Stat
   }
 
   function close(code: Code): State | undefined {
-    if (code !== RIGHT_BRACKET) return nok(code);
+    if (code !== tail) return nok(code);
 
     effects.consume(code);
     effects.exit("mathFlowFenceSequence");

--- a/webui/src/tests/markdown-text-renderer.test.tsx
+++ b/webui/src/tests/markdown-text-renderer.test.tsx
@@ -671,6 +671,61 @@ describe("MarkdownTextRenderer", () => {
     expect(screen.getByText("\\[x^2\\]")).toBeInTheDocument();
   });
 
+  it.each([false, true])("renders multiline dollar math with attached fences (streaming=%s)", (streaming) => {
+    const formula = String.raw`C = \sum_i \underbrace{\alpha_i T_i}_{w_i}\, c_i`;
+    const sources = [
+      "$$C\n" + formula.slice(2) + "$$",
+      "$$\n" + formula + "$$",
+      "$$" + formula + "\n$$",
+      "$$\n" + formula + "\n$$",
+    ];
+    const { container, rerender } = render(<MarkdownTextRenderer>{""}</MarkdownTextRenderer>);
+
+    for (const source of sources) {
+      rerender(
+        <MarkdownTextRenderer streaming={streaming}>
+          {source + "\n\nAfter the formula: $z_i$."}
+        </MarkdownTextRenderer>,
+      );
+      expect(container.querySelector(".katex-error")).toBeNull();
+      expect(container.querySelector(".katex-display annotation")?.textContent?.replace(/\s+/g, " ")).toBe(formula);
+      expect(container.querySelectorAll(".katex")).toHaveLength(2);
+      expect(container).toHaveTextContent("After the formula:");
+    }
+  });
+
+  it("keeps multiline dollar formulas in code literal", () => {
+    const source = "$$C\n= x_i$$";
+    const { container } = render(
+      <MarkdownTextRenderer highlightCode={false}>{"```latex\n" + source + "\n```"}</MarkdownTextRenderer>,
+    );
+    expect(container.querySelector(".katex")).toBeNull();
+    expect(container).toHaveTextContent("$$C");
+    expect(container).toHaveTextContent("= x_i$$");
+  });
+
+  it.each([
+    "$$x_i$$ and $y_i$ afterwards.",
+    "Before $$x_i$$ and $y_i$ afterwards.",
+    "$$$\nx_i\n$$$\n\nAnd $y_i$ afterwards.",
+    "$$\\text{cost: \\$} + x_i$$\n\nAnd $y_i$ afterwards.",
+  ])("preserves surrounding text and existing dollar syntax: %s", (source) => {
+    const { container } = render(<MarkdownTextRenderer>{source}</MarkdownTextRenderer>);
+    expect(container.querySelector(".katex-error")).toBeNull();
+    expect(container.querySelectorAll(".katex")).toHaveLength(2);
+    expect(container).toHaveTextContent("afterwards.");
+  });
+
+  it("renders the complete formula after partial streaming updates", () => {
+    const source = "$$C\n= \\sum_i c_i$$";
+    const { container, rerender } = render(<MarkdownTextRenderer>{""}</MarkdownTextRenderer>);
+    for (let end = 1; end <= source.length; end += 1) {
+      rerender(<MarkdownTextRenderer streaming>{source.slice(0, end)}</MarkdownTextRenderer>);
+    }
+    expect(container.querySelector(".katex-error")).toBeNull();
+    expect(container.querySelector("annotation")).toHaveTextContent("C = \\sum_i c_i");
+  });
+
   it("still renders explicit math blocks", () => {
     const { container } = render(
       <MarkdownTextRenderer>{"$$x^2 + y^2 = z^2$$"}</MarkdownTextRenderer>,


### PR DESCRIPTION
Fix display formulas such as `$$C` followed by a newline and `= ...$$`: the WebUI currently treats `C` as fence metadata, leaves the closing dollars in the formula, and displays a red KaTeX error. Preserve the full equation when either dollar delimiter shares a line with formula content.

Extend the existing math tokenizer to recognize paired double-dollar display delimiters across lines, reusing its TeX block parser. Keep code fences literal, preserve single-dollar currency guards, and defer inline formulas followed by prose and longer dollar fences to remark-math. Declare the already-transitive whitespace helper as a direct dependency.

Validation:
- 56 focused Markdown renderer and boundary tests pass; the new regression fails on the base implementation in both static and streaming modes.
- Production WebUI build, targeted ESLint, and `git diff --check` pass.
- Real gateway and headless Chromium: all four display variants render, inline math and surrounding prose survive, code and prices stay literal, and refresh replays the persisted messages with no KaTeX or browser runtime errors. Isolated runtime cleaned up.
