### PR TITLE
fix(tools): support recursive glob filters in file searches

### DIFF
--- a/nanobot/agent/tools/search.py
+++ b/nanobot/agent/tools/search.py
@@ -107,6 +107,22 @@ def _match_glob(rel_path: str, name: str, pattern: str) -> bool:
     if not normalized:
         return False
     if "/" in normalized or normalized.startswith("**"):
+        pattern_parts = PurePosixPath(normalized).parts
+        if "**" in pattern_parts:
+            path_parts = PurePosixPath(rel_path).parts
+            # Keep relative patterns suffix-matched, as with PurePath.match.
+            matched = [True] * (len(path_parts) + 1)
+            for part in pattern_parts:
+                if part == "**":
+                    # A globstar consumes zero or more complete path segments.
+                    for index in range(1, len(matched)):
+                        matched[index] = matched[index] or matched[index - 1]
+                else:
+                    matched = [False] + [
+                        matched[index] and fnmatch.fnmatchcase(path_part, part)
+                        for index, path_part in enumerate(path_parts)
+                    ]
+            return matched[-1]
         return PurePosixPath(rel_path).match(normalized)
     return fnmatch.fnmatch(name, normalized)
 

--- a/tests/tools/test_search_tools.py
+++ b/tests/tools/test_search_tools.py
@@ -61,6 +61,38 @@ async def test_find_files_filters_by_query_glob_and_type(tmp_path: Path) -> None
     assert result.splitlines() == ["src/settings_view.tsx"]
 
 
+@pytest.mark.parametrize("tool_name", ["find_files", "grep"])
+@pytest.mark.parametrize(
+    ("glob", "expected"),
+    [
+        ("**/*.py", ["main.py", "src/api.py", "src/nested/deep/worker.py"]),
+        ("src/**/*.py", ["src/api.py", "src/nested/deep/worker.py"]),
+        ("src/**", ["src/api.py", "src/nested/deep/worker.py"]),
+        ("src/*.py", ["src/api.py"]),
+        ("src/**/deep/*.py", ["src/nested/deep/worker.py"]),
+        (r"src\**\*.py", ["src/api.py", "src/nested/deep/worker.py"]),
+    ],
+)
+async def test_search_recursive_glob_matches_zero_or_more_directories(
+    tmp_path: Path, tool_name: str, glob: str, expected: list[str]
+) -> None:
+    for name in ["main.py", "src/api.py", "src/nested/deep/worker.py", "notes.md"]:
+        path = tmp_path / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("needle\n", encoding="utf-8")
+
+    if tool_name == "find_files":
+        result = await FindFilesTool(workspace=tmp_path, allowed_dir=tmp_path).execute(
+            path=".", glob=glob,
+        )
+    else:
+        result = await GrepTool(workspace=tmp_path, allowed_dir=tmp_path).execute(
+            pattern="needle", path=".", glob=glob, output_mode="files_with_matches",
+        )
+
+    assert sorted(result.splitlines()) == expected
+
+
 @pytest.mark.asyncio
 async def test_find_files_can_include_directories(tmp_path: Path) -> None:
     (tmp_path / "src" / "settings").mkdir(parents=True)


### PR DESCRIPTION
Recursive glob filters currently miss files in both `find_files` and `grep`. The shared matcher uses `PurePosixPath.match()`, where `**` behaves like a single-segment wildcard rather than matching zero or more directories.

For a workspace containing `main.py`, `src/api.py`, and `src/nested/deep/worker.py` (all containing `needle`):

| Glob | Current results | Expected results |
| --- | --- | --- |
| `**/*.py` | Both files under src | All three files |
| `src/**/*.py` | No files | Both files under src |
| `src/**` | src/api.py | Both files under src |

Reproduce with `await FindFilesTool(workspace=root, allowed_dir=root).execute(path=".", glob=...)`, or `await GrepTool(workspace=root, allowed_dir=root).execute(pattern="needle", path=".", glob=..., output_mode="files_with_matches")`.

The shared matcher now handles standalone `**` segments with a small iterative match-state table, allowing zero or more complete path segments. It preserves existing relative suffix matching and leaves patterns without globstars on the existing matching path. No dependencies or tool parameters change.

Adds parameterized tests through both tools for root files, zero/multiple directory levels, trailing globstars, ordinary `*`, an intermediate literal directory, and backslash normalization.

Validation on Windows with Python 3.12.14, against main `c4a25c9`:
- The six original recursive-glob regression cases fail before the fix.
- `python -m pytest tests/tools/test_search_tools.py -q --tb=short`: 48 passed.
- `ruff check nanobot/ tests/tools/test_search_tools.py`: passed.
- `basedpyright`: 0 errors, 0 warnings (after installing the optional `setproctitle` package locally).


### CI follow-up

[Workflow run 34157364982](https://github.com/HKUDS/nanobot/actions/runs/34157364982) fails on the same existing test in all three Python jobs: `tests/agent/test_mcp_reconnect_crash.py::test_mcp_reconnect_during_shutdown_does_not_crash`, at line 215 (`await asyncio.wait_for(reconnect_started.wait(), timeout=5)`). Linux jobs report 6,768 passing tests each; Windows reports 6,689 passing tests. Lint, strict type checking, Docker, and Windows process compatibility pass.

I reproduced this exact timeout using `python -m pytest tests/agent/test_mcp_reconnect_crash.py -q --tb=short` on both the PR branch and a clean detached worktree at the unchanged base `c4a25c9a0977f5729ffabde0b10f641dae08774d`, using the same Python 3.12.14 environment on Windows. Both return 1 failed, 1 passed. Confirmed that the baseline run imports its own worktree's MCP module. The failure therefore also occurs without this patch; no MCP code or tests are changed here.
