### PR TITLE
fix(webui): keep queued prompts scoped across session switches

### DIFF
--- a/webui/src/components/thread/ThreadComposer.tsx
+++ b/webui/src/components/thread/ThreadComposer.tsx
@@ -963,7 +963,7 @@ export function ThreadComposer({
   const secondEnterPromptIdRef = useRef<string | null>(null);
   const draggedQueuedPromptIdRef = useRef<string | null>(null);
   const previousPendingQueueKeyRef = useRef(pendingQueueKey);
-  const wasStreamingRef = useRef(isStreaming);
+  const previousQueueRunRef = useRef({ key: pendingQueueKey, isStreaming });
   const skipNextQueuedFlushRef = useRef(false);
   const skipQueuedPromptPersistRef = useRef(false);
   const voiceShortcutDownRef = useRef(false);
@@ -1895,16 +1895,21 @@ export function ThreadComposer({
   }, [onSend, queuedPrompts]);
 
   useEffect(() => {
-    const wasStreaming = wasStreamingRef.current;
-    wasStreamingRef.current = isStreaming;
+    const previous = previousQueueRunRef.current;
+    previousQueueRunRef.current = { key: pendingQueueKey, isStreaming };
     if (!isStreaming) secondEnterPromptIdRef.current = null;
-    if (!wasStreaming || isStreaming || queuedPrompts.length === 0) return;
+    // Switching to an idle session is not completion of the previous session's run.
+    if (previous.key !== pendingQueueKey) {
+      skipNextQueuedFlushRef.current = false;
+      return;
+    }
+    if (!previous.isStreaming || isStreaming || queuedPrompts.length === 0) return;
     if (skipNextQueuedFlushRef.current) {
       skipNextQueuedFlushRef.current = false;
       return;
     }
     sendNextQueuedPrompt();
-  }, [sendNextQueuedPrompt, isStreaming, queuedPrompts.length]);
+  }, [sendNextQueuedPrompt, isStreaming, pendingQueueKey, queuedPrompts.length]);
 
   const handleStop = useCallback(() => {
     secondEnterPromptIdRef.current = null;

--- a/webui/src/tests/thread-composer.test.tsx
+++ b/webui/src/tests/thread-composer.test.tsx
@@ -3053,6 +3053,39 @@ describe("ThreadComposer", () => {
     });
   });
 
+  it("keeps queued guidance in its session when switching from running to idle", () => {
+    const sendA = vi.fn();
+    const sendB = vi.fn();
+    const view = render(
+      <ThreadComposer onSend={sendA} isStreaming pendingQueueKey="chat-a" />,
+    );
+    fireEvent.change(screen.getByLabelText("Message input"), {
+      target: { value: "follow-up for A" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Message input"), { key: "Enter" });
+    expect(screen.getByText("follow-up for A")).toBeInTheDocument();
+    expect(sendA).not.toHaveBeenCalled();
+
+    view.rerender(
+      <ThreadComposer onSend={sendB} isStreaming={false} pendingQueueKey="chat-b" />,
+    );
+    expect(sendB).not.toHaveBeenCalled();
+    expect(screen.queryByText("follow-up for A")).not.toBeInTheDocument();
+
+    view.rerender(
+      <ThreadComposer onSend={sendA} isStreaming pendingQueueKey="chat-a" />,
+    );
+    expect(screen.getByText("follow-up for A")).toBeInTheDocument();
+    expect(sendA).not.toHaveBeenCalled();
+    view.rerender(
+      <ThreadComposer onSend={sendA} isStreaming={false} pendingQueueKey="chat-a" />,
+    );
+    expect(sendA).toHaveBeenCalledTimes(1);
+    expect(sendA).toHaveBeenCalledWith("follow-up for A");
+    expect(sendB).not.toHaveBeenCalled();
+    expect(screen.queryByText("follow-up for A")).not.toBeInTheDocument();
+  });
+
   it("persists queued guidance per chat across remounts", async () => {
     const onSend = vi.fn();
     const { rerender, unmount } = render(


### PR DESCRIPTION
Switching from running session A with queued guidance to idle session B could send A's queued prompt through B's send callback. Track the session key alongside the previous running state so a session switch cannot trigger an automatic queue flush, and reset the stop-related flush flag on the same boundary.

The regression test reproduces the incorrect send on main and verifies that switching to B sends nothing, returning to A preserves the queue, and completing A sends its prompt exactly once.

Validation:
- ThreadComposer and ThreadShell: 160 tests passed; new regression failed before the fix.
- Production build and focused ESLint passed.
- Built WebUI with isolated gateway and Playwright: held an outgoing request to keep A running, queued a prompt, switched A -> idle B -> A, and refreshed; the prompt stayed in A's queue. This uses controlled WebSocket delay, not a live model turn.
- Browser verification limitation: an additional direct transcript API check returned 401 with the diagnostic auth setup, so backend replay was not verified. Initial empty-topic history requests returned 404. Gateway cleanup confirmed runtime removal and released ports.
