### PR TITLE
fix(webui): use styled tooltips for model presets and activity previews

### DIFF
--- a/webui/src/components/thread/ModelPresetBadge.tsx
+++ b/webui/src/components/thread/ModelPresetBadge.tsx
@@ -14,6 +14,7 @@ import {
   floatingItemFocusClassName,
 } from "@/components/ui/floating-surface";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useLogoFallback } from "@/hooks/useLogoFallback";
 import { inferProviderFromModelName, providerBrand } from "@/lib/provider-brand";
 import { cn } from "@/lib/utils";
@@ -114,6 +115,7 @@ export function ModelPresetBadge({
 }: ModelPresetBadgeProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
+  const [tooltipOpen, setTooltipOpen] = useState(false);
   const [motion, setMotion] = useState<PresetMotion | null>(null);
   const [motionWidth, setMotionWidth] = useState<number | null>(null);
   const gestureRef = useRef<PresetGesture | null>(null);
@@ -135,11 +137,14 @@ export function ModelPresetBadge({
   const displayLabel = fallbackDisplayLabel || label;
   const displayModelDetail = fallbackPreset
     ? fallbackPreset.model
-    : fallbackModelName
-      ? null
-      : modelDetail;
+    : fallbackModelName || modelDetail;
   const displayProvider = fallbackPreset?.provider
     || (fallbackModelName ? inferProviderFromModelName(fallbackModelName) : provider);
+  const tooltipLabel = [...new Set([
+    displayLabel,
+    displayModelDetail,
+    fallbackModelName ? null : providerLabel,
+  ].filter(Boolean))].join(" · ");
   const presets = !activeName
     ? modelPresets
     : listedIndex < 0
@@ -278,20 +283,19 @@ export function ModelPresetBadge({
       label={displayLabel}
       modelDetail={displayModelDetail}
       provider={displayProvider}
-      providerLabel={fallbackModelName ? null : providerLabel}
       needsSetup={needsSetup}
       needsAttention={needsSetup && attentionRequest > 0}
       fallbackModelName={fallbackModelName}
-      fallbackFromLabel={fallbackModelName ? label : null}
       isHero={isHero}
     />
   );
 
-  if (!canSwitch) {
-    const Container = opensSetup ? "button" : "span";
-    return (
+  const Container = opensSetup ? "button" : "span";
+  const badge = !canSwitch ? (
+    <TooltipTrigger asChild>
       <Container
-        aria-label={fallbackModelName ? `${displayLabel} (fallback from ${label})` : label}
+        aria-label={displayLabel}
+        tabIndex={opensSetup ? undefined : 0}
         type={opensSetup ? "button" : undefined}
         onClick={opensSetup ? onClick : undefined}
         className={cn(
@@ -302,10 +306,8 @@ export function ModelPresetBadge({
       >
         {pill}
       </Container>
-    );
-  }
-
-  return (
+    </TooltipTrigger>
+  ) : (
     <Popover
       open={open}
       onOpenChange={(nextOpen) => {
@@ -314,86 +316,88 @@ export function ModelPresetBadge({
       }}
     >
       <PopoverTrigger asChild>
-        <button
-          type="button"
-          data-switching={motion ? "true" : undefined}
-          aria-label={label}
-          aria-expanded={open}
-          onPointerDown={handlePointerDown}
-          onPointerMove={handlePointerMove}
-          onPointerLeave={(event) => {
-            const gesture = gestureRef.current;
-            if (gesture && gesture.pointerId === event.pointerId && !gesture.active) clearGesture();
-          }}
-          onPointerUp={(event) => finishGesture(event, true)}
-          onPointerCancel={(event) => finishGesture(event, false)}
-          onLostPointerCapture={(event) => finishGesture(event, false)}
-          onContextMenu={(event) => {
-            if (gestureRef.current?.active) event.preventDefault();
-          }}
-          onDragStart={(event) => event.preventDefault()}
-          onKeyDown={handleKeyDown}
-          onClickCapture={(event) => {
-            if (!suppressClickRef.current) return;
-            suppressClickRef.current = false;
-            event.preventDefault();
-            event.stopPropagation();
-          }}
-          style={{
-            touchAction: "manipulation",
-            width: motionWidth ? `${motionWidth}px` : undefined,
-          }}
-          className={cn(
-            "thread-composer-model-badge group relative inline-flex w-fit min-w-0 max-w-[min(18rem,44vw)] cursor-pointer appearance-none border-0 bg-transparent p-0 shadow-none focus-visible:outline-none",
-            motion && "z-10 cursor-grabbing",
-            !motion && "cursor-grab",
-            isHero ? "h-8" : "h-9",
-          )}
-        >
-          {motion ? (
-            <>
-              <span data-testid="composer-model-pill-layout" className="invisible inline-flex h-full shrink-0" aria-hidden>
-                {pill}
-              </span>
-              <span
-                data-testid="composer-model-pill-viewport"
-                className={cn(
-                  "composer-model-pill-viewport pointer-events-none absolute -left-2 right-0 overflow-hidden bg-transparent",
-                  isHero ? "-bottom-2.5 -top-2.5" : "-bottom-3 -top-3",
-                )}
-                aria-hidden
-              >
-                <span
-                  data-testid="composer-model-pill-track"
-                  data-settling={motion.settling ? "true" : undefined}
-                  className="composer-model-pill-track ml-auto flex w-[calc(100%-0.5rem)] flex-col items-end gap-1 will-change-transform"
-                  onTransitionEnd={(event) => {
-                    if (motion.settling && event.currentTarget === event.target) clearMotion();
-                  }}
-                  style={{
-                    paddingTop: isHero ? "10px" : "12px",
-                    transform: `translate3d(0, ${-pillStride * (2 + motion.remainder)}px, 0)`,
-                  }}
-                >
-                  {PILL_OFFSETS.map((offset) => {
-                    const preset = presets[wrapIndex(motion.index + offset, presets.length)];
-                    return (
-                      <PresetPill
-                        key={motion.index + offset}
-                        label={preset.name}
-                        modelDetail={preset.model}
-                        provider={preset.provider}
-                        isHero={isHero}
-                        offset={offset}
-                        scale={motion.settling ? 1 : dockScale(offset - motion.remainder)}
-                      />
-                    );
-                  })}
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            data-switching={motion ? "true" : undefined}
+            aria-label={displayLabel}
+            aria-expanded={open}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerLeave={(event) => {
+              const gesture = gestureRef.current;
+              if (gesture && gesture.pointerId === event.pointerId && !gesture.active) clearGesture();
+            }}
+            onPointerUp={(event) => finishGesture(event, true)}
+            onPointerCancel={(event) => finishGesture(event, false)}
+            onLostPointerCapture={(event) => finishGesture(event, false)}
+            onContextMenu={(event) => {
+              if (gestureRef.current?.active) event.preventDefault();
+            }}
+            onDragStart={(event) => event.preventDefault()}
+            onKeyDown={handleKeyDown}
+            onClickCapture={(event) => {
+              if (!suppressClickRef.current) return;
+              suppressClickRef.current = false;
+              event.preventDefault();
+              event.stopPropagation();
+            }}
+            style={{
+              touchAction: "manipulation",
+              width: motionWidth ? `${motionWidth}px` : undefined,
+            }}
+            className={cn(
+              "thread-composer-model-badge group relative inline-flex w-fit min-w-0 max-w-[min(18rem,44vw)] cursor-pointer appearance-none border-0 bg-transparent p-0 shadow-none focus-visible:outline-none",
+              motion && "z-10 cursor-grabbing",
+              !motion && "cursor-grab",
+              isHero ? "h-8" : "h-9",
+            )}
+          >
+            {motion ? (
+              <>
+                <span data-testid="composer-model-pill-layout" className="invisible inline-flex h-full shrink-0" aria-hidden>
+                  {pill}
                 </span>
-              </span>
-            </>
-          ) : pill}
-        </button>
+                <span
+                  data-testid="composer-model-pill-viewport"
+                  className={cn(
+                    "composer-model-pill-viewport pointer-events-none absolute -left-2 right-0 overflow-hidden bg-transparent",
+                    isHero ? "-bottom-2.5 -top-2.5" : "-bottom-3 -top-3",
+                  )}
+                  aria-hidden
+                >
+                  <span
+                    data-testid="composer-model-pill-track"
+                    data-settling={motion.settling ? "true" : undefined}
+                    className="composer-model-pill-track ml-auto flex w-[calc(100%-0.5rem)] flex-col items-end gap-1 will-change-transform"
+                    onTransitionEnd={(event) => {
+                      if (motion.settling && event.currentTarget === event.target) clearMotion();
+                    }}
+                    style={{
+                      paddingTop: isHero ? "10px" : "12px",
+                      transform: `translate3d(0, ${-pillStride * (2 + motion.remainder)}px, 0)`,
+                    }}
+                  >
+                    {PILL_OFFSETS.map((offset) => {
+                      const preset = presets[wrapIndex(motion.index + offset, presets.length)];
+                      return (
+                        <PresetPill
+                          key={motion.index + offset}
+                          label={preset.name}
+                          modelDetail={preset.model}
+                          provider={preset.provider}
+                          isHero={isHero}
+                          offset={offset}
+                          scale={motion.settling ? 1 : dockScale(offset - motion.remainder)}
+                        />
+                      );
+                    })}
+                  </span>
+                </span>
+              </>
+            ) : pill}
+          </button>
+        </TooltipTrigger>
       </PopoverTrigger>
       <PopoverContent
         align="end"
@@ -448,6 +452,15 @@ export function ModelPresetBadge({
       </PopoverContent>
     </Popover>
   );
+
+  return (
+    <TooltipProvider delayDuration={300} skipDelayDuration={80}>
+      <Tooltip open={tooltipOpen && !open && !motion} onOpenChange={setTooltipOpen}>
+        {badge}
+        <TooltipContent side="top">{tooltipLabel}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
 }
 
 function PresetOption({
@@ -495,11 +508,9 @@ function PresetPill({
   label,
   modelDetail,
   provider,
-  providerLabel,
   needsSetup = false,
   needsAttention = false,
   fallbackModelName,
-  fallbackFromLabel,
   isHero,
   offset,
   scale,
@@ -507,11 +518,9 @@ function PresetPill({
   label: string;
   modelDetail?: string | null;
   provider?: string | null;
-  providerLabel?: string | null;
   needsSetup?: boolean;
   needsAttention?: boolean;
   fallbackModelName?: string | null;
-  fallbackFromLabel?: string | null;
   isHero: boolean;
   offset?: number;
   scale?: number;
@@ -521,10 +530,6 @@ function PresetPill({
   const inferredProvider = needsSetup
     ? null
     : provider || inferProviderFromModelName(modelDetail || label);
-  const title = [...new Set([label, modelDetail, providerLabel].filter(Boolean))].join(" · ");
-  const fallbackTitle = fallbackModelName
-    ? `${fallbackFromLabel || label} · using ${fallbackModelName}`
-    : title;
 
   useLayoutEffect(() => {
     const node = labelRef.current;
@@ -541,7 +546,6 @@ function PresetPill({
       data-fallback={fallbackModelName ? "true" : undefined}
       data-needs-setup={needsSetup ? "true" : undefined}
       data-preset-offset={offset}
-      title={fallbackTitle || undefined}
       className={cn(
         "composer-model-badge composer-model-pill inline-flex h-full max-w-full min-w-0 shrink-0 items-center rounded-full border border-border/55 bg-card font-medium text-foreground/70",
         "w-fit",

--- a/webui/src/components/thread/activity/ActivityStep.tsx
+++ b/webui/src/components/thread/activity/ActivityStep.tsx
@@ -2,6 +2,7 @@ import type { CSSProperties, ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
 
 import { StreamingLabelSheen } from "@/components/MessageBubble";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 export type ActivityStepTone = "neutral" | "active" | "success" | "error";
@@ -33,6 +34,25 @@ export function ActivityStep({
   markerClassName,
   style,
 }: ActivityStepProps) {
+  const line = (
+    <div
+      data-testid="activity-line"
+      tabIndex={typeof label === "string" ? 0 : undefined}
+      className="flex min-w-0 items-center gap-1.5 overflow-hidden whitespace-nowrap"
+    >
+      <StreamingLabelSheen
+        active={active}
+        className={cn(
+          "min-w-0 flex-1 truncate font-medium",
+          tone === "error" ? "text-destructive/78" : "text-muted-foreground/85",
+          labelClassName,
+        )}
+      >
+        {label}
+      </StreamingLabelSheen>
+    </div>
+  );
+
   return (
     <div
       data-testid="activity-step"
@@ -65,22 +85,16 @@ export function ActivityStep({
         )}
       </span>
       <div className={cn("min-w-0", contentClassName)}>
-        <div
-          data-testid="activity-line"
-          title={typeof label === "string" ? label : undefined}
-          className="flex min-w-0 items-center gap-1.5 overflow-hidden whitespace-nowrap"
-        >
-          <StreamingLabelSheen
-            active={active}
-            className={cn(
-              "min-w-0 flex-1 truncate font-medium",
-              tone === "error" ? "text-destructive/78" : "text-muted-foreground/85",
-              labelClassName,
-            )}
-          >
-            {label}
-          </StreamingLabelSheen>
-        </div>
+        {typeof label === "string" ? (
+          <TooltipProvider delayDuration={300} skipDelayDuration={80}>
+            <Tooltip>
+              <TooltipTrigger asChild>{line}</TooltipTrigger>
+              <TooltipContent side="top" className="max-w-[min(32rem,calc(100vw-2rem))] whitespace-pre-wrap break-words">
+                {label}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : line}
       </div>
     </div>
   );

--- a/webui/src/tests/model-preset-badge.test.tsx
+++ b/webui/src/tests/model-preset-badge.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ModelPresetBadge } from "@/components/thread/ModelPresetBadge";
+
+const presets = [
+  { name: "zhipu", model: "glm-5", provider: "zhipu" },
+  { name: "codex", model: "openai-codex/gpt-5.5", provider: "openai_codex" },
+];
+
+describe("ModelPresetBadge fallback tooltip", () => {
+  it("shows only the effective preset on hover and preserves the preset picker", async () => {
+    const user = userEvent.setup();
+    const onPresetChange = vi.fn();
+    const { container } = render(
+      <ModelPresetBadge
+        label="zhipu"
+        modelPreset="zhipu"
+        modelDetail="glm-5"
+        provider="zhipu"
+        modelPresets={presets}
+        fallbackModelName="openai-codex/gpt-5.5"
+        onPresetChange={onPresetChange}
+        isHero={false}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "codex" });
+    expect(container.querySelector("[title]")).toBeNull();
+    await user.hover(trigger);
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("codex · openai-codex/gpt-5.5");
+    expect(tooltip).not.toHaveTextContent("zhipu");
+    await user.click(trigger);
+    expect(await screen.findByRole("listbox")).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
+    await user.click(screen.getByRole("option", { name: "codex" }));
+    expect(onPresetChange).toHaveBeenCalledWith("codex");
+  });
+
+  it("exposes the current preset to keyboard focus without a picker", async () => {
+    render(
+      <ModelPresetBadge
+        label="zhipu"
+        modelPresets={presets}
+        fallbackModelName="openai-codex/gpt-5.5"
+        isHero
+      />,
+    );
+    const trigger = screen.getByLabelText("codex");
+    expect(trigger).toHaveAttribute("tabindex", "0");
+    fireEvent.focus(trigger);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "codex · openai-codex/gpt-5.5",
+    );
+    fireEvent.keyDown(trigger, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
+  });
+});

--- a/webui/src/tests/reasoning-row.test.tsx
+++ b/webui/src/tests/reasoning-row.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { expect, it } from "vitest";
+
+import { ReasoningRow } from "@/components/thread/activity/ReasoningRow";
+
+it("shows the reasoning preview in the shared tooltip on hover and keyboard focus", async () => {
+  const user = userEvent.setup();
+  const text = 'The user is saying "hi" again. I should respond in Chinese, concisely and in a friendly manner.';
+  const { container } = render(<ReasoningRow text={text} streaming={false} />);
+  const line = screen.getByTestId("activity-line");
+
+  expect(container.querySelector("[title]")).toBeNull();
+  await user.hover(line);
+  expect(await screen.findByRole("tooltip")).toHaveTextContent(text);
+  await user.unhover(line);
+  await user.tab();
+  expect(line).toHaveFocus();
+  expect(await screen.findByRole("tooltip")).toHaveTextContent(text);
+  await user.keyboard("{Escape}");
+  expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+});

--- a/webui/src/tests/thread-shell.test.tsx
+++ b/webui/src/tests/thread-shell.test.tsx
@@ -784,8 +784,10 @@ describe("ThreadShell", () => {
       ),
     );
 
-    expect(await screen.findByTitle("fast · gpt-5.5 · OpenAI Codex")).toBeInTheDocument();
-    expect(screen.queryByTitle("Default · deepseek-v4-pro · DeepSeek")).not.toBeInTheDocument();
+    fireEvent.focus(await screen.findByLabelText("fast"));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("fast · gpt-5.5 · OpenAI Codex");
+    fireEvent.blur(screen.getByLabelText("fast"));
+    expect(screen.queryByLabelText("Default")).not.toBeInTheDocument();
   });
 
   it("falls back to the current preset while a renamed session reference is stale", async () => {
@@ -809,7 +811,9 @@ describe("ThreadShell", () => {
       ),
     );
 
-    expect(await screen.findByTitle("fast · gpt-5.5 · OpenAI Codex")).toBeInTheDocument();
+    fireEvent.focus(await screen.findByLabelText("fast"));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("fast · gpt-5.5 · OpenAI Codex");
+    fireEvent.blur(screen.getByLabelText("fast"));
     expect(screen.queryByRole("button", { name: "Choose your AI" })).not.toBeInTheDocument();
   });
 
@@ -891,7 +895,9 @@ describe("ThreadShell", () => {
       ),
     );
 
-    expect(await screen.findByTitle("fast · gpt-4 · Company Proxy")).toBeInTheDocument();
+    fireEvent.focus(await screen.findByLabelText("fast"));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("fast · gpt-4 · Company Proxy");
+    fireEvent.blur(screen.getByLabelText("fast"));
     expect(screen.queryByRole("button", { name: "Choose your AI" })).not.toBeInTheDocument();
   });
 
@@ -943,10 +949,13 @@ describe("ThreadShell", () => {
     expect(screen.queryByText("Default")).not.toBeInTheDocument();
     expect(screen.getByText("deepseek-chat")).toBeInTheDocument();
     expect(badge).toHaveAttribute("data-fallback", "true");
-    expect(badge).toHaveAttribute(
-      "title",
-      "Default · using deepseek/deepseek-chat",
+    expect(badge).not.toHaveAttribute("title");
+    fireEvent.focus(screen.getByLabelText("deepseek-chat"));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "deepseek-chat · deepseek/deepseek-chat",
     );
+    expect(screen.getByRole("tooltip")).not.toHaveTextContent("Default");
+    fireEvent.blur(screen.getByLabelText("deepseek-chat"));
     expect(logo).toBeInTheDocument();
 
     act(() => {
@@ -1328,7 +1337,9 @@ describe("ThreadShell", () => {
     await act(async () => {
       rerender(view(session("chat-new", "fast")));
     });
-    expect(screen.getByTitle("fast · gpt-5.5 · OpenAI Codex")).toBeInTheDocument();
+    fireEvent.focus(await screen.findByLabelText("fast"));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("fast · gpt-5.5 · OpenAI Codex");
+    fireEvent.blur(screen.getByLabelText("fast"));
     expect(screen.queryByText("Default")).not.toBeInTheDocument();
     expect(client.sendMessage).not.toHaveBeenCalled();
 


### PR DESCRIPTION
When a turn falls back to another preset, the composer tooltip combines the original preset name with the fallback model, and the switch button retains the original accessible name. Reasoning and other activity previews also use browser-native tooltips.

Show the effective preset consistently in the badge, tooltip, and accessible name. Use the existing nanobot Tooltip component for model badges and activity previews, with hover and keyboard focus support. Wrap long activity text within the viewport and hide the model tooltip while the picker or switching gesture is active.

Fixes [NAN-75](https://linear.app/nanobot-ai/issue/NAN-75).

Validation:
- 71 model-preset-badge and thread-shell tests passed for the model tooltip change.
- 56 reasoning-row, agent-activity-cluster, and thinking-reasoning-shell tests passed for the activity tooltip change.
- WebUI production build, targeted ESLint, and git diff --check passed for both changes.