### PR TITLE
fix(memory): add workspace override for the Archive consolidation prompt

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -82,6 +82,7 @@ class MemoryStore:
         self._malformed_entry_logged = False  # rate-limit bad history shape warning
         self._oversize_logged = False  # rate-limit oversized-entry warning
         self._dream_prompt_oversize_logged = False
+        self._archive_prompt_oversize_logged = False
         self._append_lock = threading.Lock()  # serialize cursor allocation + append
         self._git = GitStore(workspace, tracked_files=[
             "SOUL.md", "USER.md", "memory/MEMORY.md", "memory/.dream_cursor",
@@ -538,6 +539,33 @@ class MemoryStore:
             return text
         return self.default_dream_prompt()
 
+    @property
+    def archive_prompt_file(self) -> Path:
+        return workspace_prompt_file(self.workspace, "consolidator_archive")
+
+    def has_archive_prompt_override(self) -> bool:
+        return has_workspace_prompt_override(self.archive_prompt_file)
+
+    @staticmethod
+    def default_archive_prompt() -> str:
+        return render_template("agent/consolidator_archive.md", strip=True)
+
+    def _archive_template(self) -> str:
+        text, original_chars = load_workspace_prompt_override(self.archive_prompt_file)
+        if text is not None:
+            if (
+                original_chars > WORKSPACE_PROMPT_MAX_CHARS
+                and not self._archive_prompt_oversize_logged
+            ):
+                self._archive_prompt_oversize_logged = True
+                logger.warning(
+                    "workspace Archive prompt exceeds {} chars ({}); truncating. "
+                    "Further occurrences suppressed.",
+                    WORKSPACE_PROMPT_MAX_CHARS, original_chars,
+                )
+            return text
+        return self.default_archive_prompt()
+
     def build_dream_prompt(self, *, max_entries: int = 20) -> tuple[str, int] | None:
         """Build the Dream prompt with unprocessed history context.
 
@@ -846,11 +874,7 @@ class MemoryArchiver:
                 ),
             )
 
-        prompt = render_template(
-            "agent/consolidator_archive.md",
-            strip=True,
-            archive_count=len(source_messages),
-        )
+        prompt = self.store._archive_template()
         prompt_message = {"role": "user", "content": prompt}
         provider_context = None
         call_tools = request_tools

--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -484,6 +484,7 @@ class TelegramChannel(BaseChannel):
         BotCommand("dream_log", "Show the latest Dream memory change"),
         BotCommand("dream_restore", "Restore Dream memory to an earlier version"),
         BotCommand("dream_prompt", "Tell Dream how to organize memory"),
+        BotCommand("archive_prompt", "Tell Archive what to keep when compacting history"),
         BotCommand("help", "Show available commands"),
     ]
 
@@ -552,6 +553,8 @@ class TelegramChannel(BaseChannel):
             return content.replace("/dream_restore", "/dream-restore", 1)
         if content == "/dream_prompt" or content.startswith("/dream_prompt "):
             return content.replace("/dream_prompt", "/dream-prompt", 1)
+        if content == "/archive_prompt" or content.startswith("/archive_prompt "):
+            return content.replace("/archive_prompt", "/archive-prompt", 1)
         return content
 
     async def start(self) -> None:
@@ -649,7 +652,8 @@ class TelegramChannel(BaseChannel):
         self._app.add_handler(
             MessageHandler(
                 filters.Regex(
-                    r"^/(dream-log|dream_log|dream-restore|dream_restore|dream-prompt|dream_prompt)(?:@\w+)?(?:\s+.*)?$"
+                    r"^/(dream-log|dream_log|dream-restore|dream_restore|dream-prompt|dream_prompt"
+                    r"|archive-prompt|archive_prompt)(?:@\w+)?(?:\s+.*)?$"
                 ),
                 self._forward_command,
             )

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -2067,6 +2067,14 @@ async def test_forward_command_normalizes_telegram_safe_dream_aliases() -> None:
     assert len(handled) == 1
     assert handled[0]["content"] == "/dream-prompt init"
 
+    handled.clear()
+    update = _make_telegram_update(text="/archive_prompt@nanobot_test init", reply_to_message=None)
+
+    await channel._forward_command(update, None)
+
+    assert len(handled) == 1
+    assert handled[0]["content"] == "/archive-prompt init"
+
 
 def test_telegram_bus_slash_command_regex_matches_agent_loop_commands() -> None:
     """Bus-routed slash commands must match the Telegram handler regex (see builtin router)."""
@@ -2086,6 +2094,7 @@ def test_telegram_bus_slash_command_regex_matches_agent_loop_commands() -> None:
     assert pat.fullmatch("/dream-log deadbeef") is None
     assert pat.fullmatch("/dream-restore deadbeef") is None
     assert pat.fullmatch("/dream-prompt init") is None
+    assert pat.fullmatch("/archive-prompt init") is None
 
 
 @pytest.mark.asyncio
@@ -2107,6 +2116,7 @@ async def test_on_help_includes_restart_command() -> None:
     assert "/dream" in help_text
     assert "/dream-log" in help_text
     assert "/dream-prompt" in help_text
+    assert "/archive-prompt" in help_text
     assert "/goal" in help_text
     assert "/trigger" in help_text
     assert "/pairing" in help_text

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -160,6 +160,14 @@ BUILTIN_COMMAND_SPECS: tuple[BuiltinCommandSpec, ...] = (
         accepts_args=True,
     ),
     BuiltinCommandSpec(
+        "/archive-prompt",
+        "Archive consolidation",
+        "Tell Archive what to keep when compacting this workspace's session history.",
+        "file-text",
+        "[init]",
+        accepts_args=True,
+    ),
+    BuiltinCommandSpec(
         "/evaluator-prompt",
         "Heartbeat evaluator",
         "Customize the heartbeat notification gate prompt for this workspace.",
@@ -561,6 +569,49 @@ async def cmd_dream_prompt(ctx: CommandContext) -> OutboundMessage:
             "Dream memory instructions: nanobot default\n\n"
             f"- Editable file: `{display_path}`\n"
             "- Run `/dream-prompt init` to create an editable copy."
+        )
+
+    return OutboundMessage(
+        channel=ctx.msg.channel,
+        chat_id=ctx.msg.chat_id,
+        content=content,
+        metadata={**dict(ctx.msg.metadata or {}), "render_as": "text"},
+    )
+
+
+async def cmd_archive_prompt(ctx: CommandContext) -> OutboundMessage:
+    """Show or set up the workspace Archive consolidation prompt."""
+    store = ctx.loop.context.memory
+    path = store.archive_prompt_file
+    display_path = path.relative_to(store.workspace).as_posix()
+    args = ctx.args.strip().lower()
+
+    if args == "init":
+        if not initialize_workspace_prompt(path, store.default_archive_prompt()):
+            content = (
+                f"Archive consolidation prompt already exists at `{display_path}`.\n\n"
+                "Edit that file, or delete/empty it to return to nanobot's default."
+            )
+        else:
+            content = (
+                f"Created Archive consolidation prompt at `{display_path}`.\n\n"
+                "Edit that file to teach Archive what to keep when compacting session "
+                "history. This fully replaces nanobot's default Archive guide for this "
+                "workspace. Delete or empty it to return to nanobot's default."
+            )
+    elif args:
+        content = "Usage: /archive-prompt [init]"
+    elif store.has_archive_prompt_override():
+        content = (
+            "Archive consolidation prompt: custom for this workspace\n\n"
+            f"- Path: `{display_path}`\n"
+            "- Delete or empty this file to return to nanobot's default."
+        )
+    else:
+        content = (
+            "Archive consolidation prompt: nanobot default\n\n"
+            f"- Editable file: `{display_path}`\n"
+            "- Run `/archive-prompt init` to create an editable copy."
         )
 
     return OutboundMessage(
@@ -1092,6 +1143,8 @@ def register_builtin_commands(router: CommandRouter) -> None:
     router.prefix("/dream-restore ", cmd_dream_restore)
     router.exact("/dream-prompt", cmd_dream_prompt)
     router.prefix("/dream-prompt ", cmd_dream_prompt)
+    router.exact("/archive-prompt", cmd_archive_prompt)
+    router.prefix("/archive-prompt ", cmd_archive_prompt)
     router.exact("/evaluator-prompt", cmd_evaluator_prompt)
     router.prefix("/evaluator-prompt ", cmd_evaluator_prompt)
     router.exact("/skill", cmd_skill)

--- a/nanobot/templates/prompts/README.md
+++ b/nanobot/templates/prompts/README.md
@@ -12,6 +12,18 @@ This folder holds plain-language prompt overrides for this workspace.
 
 That creates `prompts/dream.md`. Edit it in plain Markdown. Delete or empty it to return to nanobot's default memory behavior.
 
+## Archive consolidation
+
+`consolidator_archive.md` tells Archive what to keep when it compacts session history into a checkpoint summary. Adjust it if Dream keeps losing signal it never got a chance to see — Archive runs first and decides what survives into Dream's input.
+
+To create an editable copy, run:
+
+```text
+/archive-prompt init
+```
+
+That creates `prompts/consolidator_archive.md`. Edit it in plain Markdown. Delete or empty it to return to nanobot's default archive behavior.
+
 ## Heartbeat evaluator
 
 `evaluator.md` overrides the system prompt for the heartbeat notification gate — the model that decides whether a heartbeat result is worth delivering. This is an advanced override; you rarely need it. Before editing, read the evaluator code and the default `evaluator.md`.

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -457,6 +457,82 @@ class TestConsolidatorArchiveErrorHandling:
         consolidator.store.raw_archive.assert_not_called()
 
 
+class TestConsolidatorArchivePromptOverride:
+    """Archive prompt should honor a workspace-local override, like Dream."""
+
+    async def test_default_prompt_used_without_override(
+        self, consolidator, mock_provider, store, runtime
+    ):
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="Summary.",
+            finish_reason="stop",
+        )
+
+        await _archive(consolidator, [{"role": "user", "content": "hello"}], runtime)
+
+        call = mock_provider.chat_with_retry.call_args.kwargs
+        sent_prompt = call["messages"][-1]["content"]
+        assert sent_prompt == _ARCHIVE_PROMPT
+
+    async def test_workspace_archive_prompt_overrides_default(
+        self, consolidator, mock_provider, store, runtime
+    ):
+        store.archive_prompt_file.parent.mkdir(parents=True)
+        store.archive_prompt_file.write_text(
+            "Custom Archive prompt.",
+            encoding="utf-8",
+        )
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="Summary.",
+            finish_reason="stop",
+        )
+
+        await _archive(consolidator, [{"role": "user", "content": "hello"}], runtime)
+
+        call = mock_provider.chat_with_retry.call_args.kwargs
+        sent_prompt = call["messages"][-1]["content"]
+        assert sent_prompt == "Custom Archive prompt."
+
+    async def test_empty_workspace_archive_prompt_uses_default(
+        self, consolidator, mock_provider, store, runtime
+    ):
+        store.archive_prompt_file.parent.mkdir(parents=True)
+        store.archive_prompt_file.write_text("  \n", encoding="utf-8")
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="Summary.",
+            finish_reason="stop",
+        )
+
+        await _archive(consolidator, [{"role": "user", "content": "hello"}], runtime)
+
+        call = mock_provider.chat_with_retry.call_args.kwargs
+        sent_prompt = call["messages"][-1]["content"]
+        assert sent_prompt == _ARCHIVE_PROMPT
+
+    async def test_workspace_archive_prompt_override_is_capped(
+        self, consolidator, mock_provider, store, runtime
+    ):
+        store.archive_prompt_file.parent.mkdir(parents=True)
+        store.archive_prompt_file.write_text("x" * 40_000, encoding="utf-8")
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="Summary.",
+            finish_reason="stop",
+        )
+
+        await _archive(consolidator, [{"role": "user", "content": "hello"}], runtime)
+
+        call = mock_provider.chat_with_retry.call_args.kwargs
+        sent_prompt = call["messages"][-1]["content"]
+        assert "x" * 40_000 not in sent_prompt
+        assert "... (truncated)" in sent_prompt
+
+    def test_has_archive_prompt_override_reflects_file_state(self, store):
+        assert store.has_archive_prompt_override() is False
+        store.archive_prompt_file.parent.mkdir(parents=True)
+        store.archive_prompt_file.write_text("Custom.", encoding="utf-8")
+        assert store.has_archive_prompt_override() is True
+
+
 class TestConsolidatorPromptEstimate:
     async def test_estimate_uses_full_unarchived_tail(self, consolidator, runtime):
         """Consolidation pressure must account for the full unarchived tail."""

--- a/tests/command/test_builtin_archive_prompt.py
+++ b/tests/command/test_builtin_archive_prompt.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nanobot.agent.memory import MemoryStore
+from nanobot.bus.events import InboundMessage
+from nanobot.command.builtin import (
+    build_help_text,
+    builtin_command_palette,
+    cmd_archive_prompt,
+)
+from nanobot.command.router import CommandContext
+
+
+def _make_ctx(tmp_path, raw: str = "/archive-prompt", args: str = "") -> CommandContext:
+    msg = InboundMessage(channel="cli", sender_id="u1", chat_id="direct", content=raw)
+    loop = SimpleNamespace(context=SimpleNamespace(memory=MemoryStore(tmp_path)))
+    return CommandContext(msg=msg, session=None, key=msg.session_key, raw=raw, args=args, loop=loop)
+
+
+@pytest.mark.asyncio
+async def test_archive_prompt_reports_default_prompt(tmp_path) -> None:
+    out = await cmd_archive_prompt(_make_ctx(tmp_path))
+
+    assert "Archive consolidation prompt: nanobot default" in out.content
+    assert "prompts/consolidator_archive.md" in out.content
+    assert str(tmp_path) not in out.content
+    assert "/archive-prompt init" in out.content
+
+
+@pytest.mark.asyncio
+async def test_archive_prompt_init_copies_default_prompt(tmp_path) -> None:
+    ctx = _make_ctx(tmp_path, "/archive-prompt init", "init")
+
+    out = await cmd_archive_prompt(ctx)
+
+    prompt_file = tmp_path / "prompts" / "consolidator_archive.md"
+    assert "Created Archive consolidation prompt" in out.content
+    assert "prompts/consolidator_archive.md" in out.content
+    assert str(tmp_path) not in out.content
+    assert "fully replaces nanobot's default Archive guide" in out.content
+    assert (
+        prompt_file.read_text(encoding="utf-8")
+        == MemoryStore.default_archive_prompt() + "\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_archive_prompt_init_does_not_overwrite_existing_prompt(tmp_path) -> None:
+    prompt_file = tmp_path / "prompts" / "consolidator_archive.md"
+    prompt_file.parent.mkdir()
+    prompt_file.write_text("custom", encoding="utf-8")
+    ctx = _make_ctx(tmp_path, "/archive-prompt init", "init")
+
+    out = await cmd_archive_prompt(ctx)
+
+    assert "already exist" in out.content
+    assert "prompts/consolidator_archive.md" in out.content
+    assert str(tmp_path) not in out.content
+    assert prompt_file.read_text(encoding="utf-8") == "custom"
+
+
+@pytest.mark.asyncio
+async def test_archive_prompt_init_recreates_empty_prompt(tmp_path) -> None:
+    prompt_file = tmp_path / "prompts" / "consolidator_archive.md"
+    prompt_file.parent.mkdir()
+    prompt_file.write_text("  \n", encoding="utf-8")
+    ctx = _make_ctx(tmp_path, "/archive-prompt init", "init")
+
+    out = await cmd_archive_prompt(ctx)
+
+    assert "Created Archive consolidation prompt" in out.content
+    assert (
+        prompt_file.read_text(encoding="utf-8")
+        == MemoryStore.default_archive_prompt() + "\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_archive_prompt_reports_override(tmp_path) -> None:
+    prompt_file = tmp_path / "prompts" / "consolidator_archive.md"
+    prompt_file.parent.mkdir()
+    prompt_file.write_text("custom", encoding="utf-8")
+
+    out = await cmd_archive_prompt(_make_ctx(tmp_path))
+
+    assert "Archive consolidation prompt: custom for this workspace" in out.content
+    assert "prompts/consolidator_archive.md" in out.content
+
+
+@pytest.mark.asyncio
+async def test_archive_prompt_rejects_unknown_args(tmp_path) -> None:
+    out = await cmd_archive_prompt(_make_ctx(tmp_path, "/archive-prompt nope", "nope"))
+
+    assert out.content == "Usage: /archive-prompt [init]"
+
+
+def test_archive_prompt_command_in_help_and_palette() -> None:
+    palette = builtin_command_palette()
+    entry = next(item for item in palette if item["command"] == "/archive-prompt")
+
+    assert entry["arg_hint"] == "[init]"
+    assert entry["lifecycle"] == "side_channel"
+    assert entry["accepts_args"] is True
+    assert "/archive-prompt [init]" in build_help_text()


### PR DESCRIPTION
## Summary

- Dream's memory-organization prompt already supports a workspace-local
  override via `/dream-prompt init` (writes `prompts/dream.md`, checked
  before falling back to the packaged default). The Archive prompt — which
  decides what survives session compaction into Dream's input — had no
  equivalent path; customizing it meant editing the packaged
  `consolidator_archive.md` template directly, which a package upgrade
  silently overwrites.
- Adds `/archive-prompt [init]`, mirroring the existing Dream/evaluator
  workspace-prompt mechanism exactly: `prompts/consolidator_archive.md` is
  checked first, falling back to the built-in default when absent or empty.
  Same oversize-truncation and empty-file-restores-default behavior as the
  other two workspace prompts.
- Includes the Telegram command-alias plumbing (`archive_prompt` →
  `archive-prompt`) needed for parity with `/dream-prompt` and
  `/evaluator-prompt` there, since Telegram command names can't contain
  hyphens.
- No default behavior changes — this only adds an opt-in override path.

Prompted by [@chengyongru's post](https://x.com/chengyongru/status/2096890060893511873) noting that
Dream's prompt has a documented workspace-override entry point while
Archive's equivalent customization currently requires editing the packaged
template — a "geek entry point" with no documented, upgrade-safe path. This
closes that gap using the same mechanism already shipped for Dream and the
heartbeat evaluator.

## Test plan

- [x] `ruff check nanobot/`
- [x] `uv run --no-sync basedpyright` (0 errors on changed files)
- [x] `pytest` — new coverage in `tests/agent/test_consolidator.py`
      (override applied / empty file falls back to default / oversize
      truncation / `has_archive_prompt_override`) and
      `tests/command/test_builtin_archive_prompt.py` (status text, `init`,
      re-`init` no-op, empty-file recreation, unknown-args usage message,
      command palette/help registration), mirroring the existing Dream and
      evaluator test suites
- [x] Telegram alias/regex/help-text coverage extended in
      `nanobot/channels/telegram/tests/test_telegram_channel.py`
- [x] Manually exercised the full command flow end-to-end (status → init →
      re-init → edit → status → verify `MemoryArchiver` actually consumes
      the override → empty file → confirm fallback to default → invalid args)

🤖 Generated with [Claude Code](https://claude.com/claude-code)