### PR TITLE
fix(tg): route /compact and /evaluator-prompt to the command router

### DIFF
--- a/nanobot/channels/telegram/runtime.py
+++ b/nanobot/channels/telegram/runtime.py
@@ -477,6 +477,7 @@ class TelegramChannel(BaseChannel):
     BOT_COMMANDS: list[BotCommand] = [
         BotCommand("start", "Start the bot"),
         BotCommand("new", "Start a new conversation"),
+        BotCommand("compact", "Compact this chat's context"),
         BotCommand("stop", "Stop the current task"),
         BotCommand("restart", "Restart the bot"),
         BotCommand("status", "Show bot status"),
@@ -495,8 +496,10 @@ class TelegramChannel(BaseChannel):
 
     # Regex for slash commands routed to AgentLoop via ``_forward_command``.
     # Hyphenated ``dream-*`` commands stay on a separate handler (below).
+    # Must cover every builtin router command; ``test_telegram_bus_slash_command_regex_matches_agent_loop_commands``
+    # pins the pairing.
     TELEGRAM_BUS_SLASH_COMMAND_RE = re.compile(
-        r"^/(?:new|stop|restart|status|dream|history|goal|trigger|pairing|model|skill)(?:@\w+)?(?:\s+.*)?$"
+        r"^/(?:new|compact|stop|restart|status|dream|history|goal|trigger|pairing|model|skill|evaluator-prompt)(?:@\w+)?(?:\s+.*)?$"
     )
 
     @classmethod

--- a/nanobot/channels/telegram/tests/test_telegram_channel.py
+++ b/nanobot/channels/telegram/tests/test_telegram_channel.py
@@ -2491,6 +2491,11 @@ def test_telegram_bus_slash_command_regex_matches_agent_loop_commands() -> None:
     assert pat.fullmatch("/new@nanobot_bot")
     assert pat.fullmatch("/goal@nanobot_bot refine objective")
     assert pat.fullmatch("/trigger@nanobot_bot CI summary")
+    assert pat.fullmatch("/compact")
+    assert pat.fullmatch("/compact@nanobot_bot")
+    assert pat.fullmatch("/evaluator-prompt")
+    assert pat.fullmatch("/evaluator-prompt init")
+    assert not pat.fullmatch("/unknown-command")
     assert pat.fullmatch("/dream-log deadbeef") is None
     assert pat.fullmatch("/dream-restore deadbeef") is None
     assert pat.fullmatch("/dream-prompt init") is None


### PR DESCRIPTION
## Summary

`/compact` and `/evaluator-prompt` are registered in the builtin command router and shown in `/help`, but the Telegram channel silently dropped them: its slash-command allowlist regex did not include either command, and messages starting with `/` never reach the generic text handler. Pressing `/compact` in Telegram did nothing at all — no log, no reply.

## What it does

- Adds `compact` and `evaluator-prompt` to the Telegram slash-command allowlist so both reach the command router.
- Registers `/compact` in the Telegram bot command menu (it was advertised in `/help` but missing from the menu).
- Extends the existing regex test to pin the router/allowlist pairing, including a negative case.

## Testing

- `pytest nanobot/channels/telegram/tests/` — 125 passed
- `ruff check nanobot/` — clean
- Strict type check per CI (`uv sync --all-extras --dev`, channel deps, `basedpyright`) — 0 errors