### PR TITLE
fix(exec): preserve UTF-8 across streaming output chunks

### DIFF
--- a/nanobot/agent/tools/exec_session.py
+++ b/nanobot/agent/tools/exec_session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import codecs
 import time
 import uuid
 from collections import deque
@@ -149,13 +150,14 @@ class _ExecSession:
     ) -> None:
         if stream is None:
             return
+        decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
         while True:
             chunk = await stream.read(4096)
-            if not chunk:
-                break
-            text = chunk.decode("utf-8", errors="replace")
+            text = decoder.decode(chunk, final=not chunk)
             async with self._lock:
                 buffer.append(text)
+            if not chunk:
+                break
 
     async def write(self, chars: str) -> str | None:
         if self.process.returncode is not None:

--- a/tests/tools/test_exec_session_tools.py
+++ b/tests/tools/test_exec_session_tools.py
@@ -20,6 +20,7 @@ from nanobot.agent.tools.exec_session import (
     ExecSessionTool,
     ListExecSessionsTool,
     _BoundedOutputBuffer,
+    _ExecSession,
     _SessionPoll,
     _truncate_output,
 )
@@ -149,6 +150,32 @@ def test_bounded_output_buffer_keeps_head_tail_and_exact_drop_count():
     assert buffer.retained_chars == 10
     assert buffer.drain() == ("01234BCDEF", 6)
     assert buffer.retained_chars == 0
+
+
+async def test_exec_session_preserves_utf8_across_stdout_and_stderr_chunks():
+    stdout = asyncio.StreamReader()
+    stderr = asyncio.StreamReader()
+    stdout_bytes = b"a" * 4095 + "你好🙂".encode() + b"\xe2\x82"
+    stderr_bytes = b"b" * 4094 + "🙂é".encode() + b"\xff"
+    stdout.feed_data(stdout_bytes[:4096])
+    stderr.feed_data(stderr_bytes[:4096])
+    session = _ExecSession(
+        session_id="utf8-output",
+        process=SimpleNamespace(stdout=stdout, stderr=stderr),
+        command="test",
+        cwd=".",
+        timeout=None,
+    )
+
+    await asyncio.sleep(0)
+    stdout.feed_data(stdout_bytes[4096:])
+    stderr.feed_data(stderr_bytes[4096:])
+    stdout.feed_eof()
+    stderr.feed_eof()
+    await asyncio.gather(session._stdout_task, session._stderr_task)
+
+    assert session._stdout.drain() == ("a" * 4095 + "你好🙂\ufffd", 0)
+    assert session._stderr.drain() == ("b" * 4094 + "🙂é\ufffd", 0)
 
 
 def test_exec_session_bounds_unpolled_stdout_and_stderr(tmp_path):


### PR DESCRIPTION
## Summary

Long-running exec sessions decode each 4,096-byte read separately. A valid UTF-8 character spanning two reads is therefore replaced with invalid-character markers in tool output.

Use a separate incremental decoder for each stdout/stderr reader and flush it at EOF. Output limits stay character-based, and malformed or unfinished UTF-8 still uses replacement characters.

## Verification

- Added a deterministic regression with two real `asyncio.StreamReader` objects. Both hold incomplete characters concurrently before receiving their remaining bytes. It checks Chinese text, emoji, malformed bytes, and an incomplete sequence at EOF.
- The regression failed before the fix; `python -m pytest tests/tools/test_exec_session_tools.py -q` now reports **42 passed**, including the existing process/session tests.
- Ruff and `git diff --check` pass. No formatting-only changes.
- Scoped BasedPyright reports eight existing `ctx.config.exec.enable` diagnostics on both unchanged main and this patch; no new diagnostics. The full optional-channel type-check environment was not installed.

AI assistance: Codex helped reproduce, implement, independently review, and test this fix. No model completion calls were used.
