### PR TITLE
fix(webui): preserve less-than comparisons in streaming math

### DIFF
--- a/webui/src/components/MarkdownTextRenderer.tsx
+++ b/webui/src/components/MarkdownTextRenderer.tsx
@@ -287,6 +287,9 @@ const remarkPlugins: NonNullable<StreamdownProps["remarkPlugins"]> = [
 ];
 const rehypePlugins: NonNullable<StreamdownProps["rehypePlugins"]> = [rehypeKatex];
 
+// Remend mistakes math comparisons like `j<i` for incomplete HTML and truncates
+// the remaining text. HTML is handled by remarkSafeHtmlSubset, not raw rendering.
+const REMEND_OPTIONS = { htmlTags: false } as const;
 const DIRECT_LINKS = { enabled: false } as const;
 const SAFE_MARKDOWN_PROTOCOL = /^(https?|ircs?|mailto|xmpp)$/i;
 
@@ -797,6 +800,7 @@ export default function MarkdownTextRenderer({
     <Streamdown
       mode={streaming ? "streaming" : "static"}
       parseIncompleteMarkdown
+      remend={REMEND_OPTIONS}
       isAnimating={false}
       animated={false}
       linkSafety={DIRECT_LINKS}

--- a/webui/src/tests/markdown-text-renderer.test.tsx
+++ b/webui/src/tests/markdown-text-renderer.test.tsx
@@ -377,9 +377,9 @@ describe("MarkdownTextRenderer", () => {
     expect(screen.queryByRole("button", { name: "Code" })).not.toBeInTheDocument();
   });
 
-  it("renders a safe subset of inline HTML", () => {
+  it.each([false, true])("renders a safe subset of inline HTML (streaming=%s)", (streaming) => {
     const { container } = render(
-      <MarkdownTextRenderer>
+      <MarkdownTextRenderer streaming={streaming}>
         {"<mark>高亮文本</mark>\n\n上标：x<sup>2</sup>\n下标：H<sub>2</sub>O"}
       </MarkdownTextRenderer>,
     );
@@ -389,9 +389,9 @@ describe("MarkdownTextRenderer", () => {
     expect(container.querySelector("sub")).toHaveTextContent("2");
   });
 
-  it("keeps unsafe HTML as text", () => {
+  it.each([false, true])("keeps unsafe HTML as text (streaming=%s)", (streaming) => {
     const { container } = render(
-      <MarkdownTextRenderer>
+      <MarkdownTextRenderer streaming={streaming}>
         {"<script>alert(1)</script>\n\n<mark onclick=\"alert(1)\">bad</mark>"}
       </MarkdownTextRenderer>,
     );
@@ -400,6 +400,16 @@ describe("MarkdownTextRenderer", () => {
     expect(container.querySelector("mark")).toBeNull();
     expect(container).toHaveTextContent("<script>alert(1)</script>");
     expect(container).toHaveTextContent("<mark onclick=\"alert(1)\">bad</mark>");
+  });
+
+  it("keeps incomplete unsafe HTML inert throughout streaming", () => {
+    const source = '<img src=x onerror="alert(1)">';
+    const { container, rerender } = render(<MarkdownTextRenderer>{""}</MarkdownTextRenderer>);
+    for (let end = 1; end <= source.length; end += 1) {
+      rerender(<MarkdownTextRenderer streaming>{source.slice(0, end)}</MarkdownTextRenderer>);
+      expect(container.querySelector("img, [onerror]")).toBeNull();
+    }
+    expect(container).toHaveTextContent(source);
   });
 
   it("renders safe details blocks", () => {
@@ -692,6 +702,85 @@ describe("MarkdownTextRenderer", () => {
       expect(container.querySelectorAll(".katex")).toHaveLength(2);
       expect(container).toHaveTextContent("After the formula:");
     }
+  });
+
+  it.each([false, true])("preserves less-than comparisons in math and following content (streaming=%s)", (streaming) => {
+    const formula = String.raw`\hat d(u,v) = \sum_{i} \frac{1}{z_i}\,\alpha_i\, T_i, \qquad T_i = \prod_{j<i}(1-\alpha_j)`;
+    const { container } = render(
+      <MarkdownTextRenderer streaming={streaming}>
+        {"## Expected inverse depth\n\n$$\n" + formula + "\n$$\n\n## Supervision loss\n\nThe next section stays visible."}
+      </MarkdownTextRenderer>,
+    );
+
+    expect(container.querySelector(".katex-error")).toBeNull();
+    expect(container.querySelector(".katex-display annotation")?.textContent).toBe(formula);
+    expect(screen.getByRole("heading", { name: "Supervision loss" })).toBeInTheDocument();
+    expect(container).toHaveTextContent("The next section stays visible.");
+  });
+
+  it.each([
+    "$j<i$",
+    "$$j<i$$",
+    String.raw`\(j<i\)`,
+    String.raw`\[j<i\]`,
+  ])("preserves less-than comparisons across math delimiters: %s", (source) => {
+    const { container, rerender } = render(<MarkdownTextRenderer>{""}</MarkdownTextRenderer>);
+    rerender(<MarkdownTextRenderer streaming>{source}</MarkdownTextRenderer>);
+    expect(container.querySelector(".katex-error")).toBeNull();
+    expect(container.querySelector("annotation")?.textContent).toBe("j<i");
+
+    rerender(<MarkdownTextRenderer>{source}</MarkdownTextRenderer>);
+    expect(container.querySelector(".katex-error")).toBeNull();
+    expect(container.querySelector("annotation")?.textContent).toBe("j<i");
+  });
+
+  it.each(["$j<i$", "$$j<i$$"])("preserves comparisons after partial streaming updates: %s", (source) => {
+    const { container, rerender } = render(<MarkdownTextRenderer>{""}</MarkdownTextRenderer>);
+    for (let end = 1; end <= source.length; end += 1) {
+      rerender(<MarkdownTextRenderer streaming>{source.slice(0, end)}</MarkdownTextRenderer>);
+    }
+    expect(container.querySelector(".katex-error")).toBeNull();
+    expect(container.querySelector("annotation")?.textContent).toBe("j<i");
+  });
+
+  it("preserves a block formula and following section across streaming updates", () => {
+    const prefix = "$$\n" + String.raw`T_i = \prod_{j`;
+    const comparison = prefix + "<i";
+    const formula = comparison + String.raw`}(1-\alpha_j)` + "\n$$";
+    const content = formula + "\n\n## Supervision loss\n\nThe next section stays visible.";
+    const { container, rerender } = render(<MarkdownTextRenderer streaming>{prefix}</MarkdownTextRenderer>);
+
+    rerender(<MarkdownTextRenderer streaming>{comparison}</MarkdownTextRenderer>);
+    expect(container).toHaveTextContent("<i");
+
+    for (const source of [formula, content]) {
+      rerender(<MarkdownTextRenderer streaming>{source}</MarkdownTextRenderer>);
+      expect(container.querySelector(".katex-error")).toBeNull();
+      expect(container.querySelector(".katex-display annotation")?.textContent).toBe(
+        String.raw`T_i = \prod_{j<i}(1-\alpha_j)`,
+      );
+    }
+    expect(screen.getByRole("heading", { name: "Supervision loss" })).toBeInTheDocument();
+    expect(container).toHaveTextContent("The next section stays visible.");
+
+    rerender(<MarkdownTextRenderer>{content}</MarkdownTextRenderer>);
+    expect(container.querySelector(".katex-error")).toBeNull();
+    expect(container.querySelector(".katex-display annotation")?.textContent).toBe(
+      String.raw`T_i = \prod_{j<i}(1-\alpha_j)`,
+    );
+    expect(screen.getByRole("heading", { name: "Supervision loss" })).toBeInTheDocument();
+    expect(container).toHaveTextContent("The next section stays visible.");
+  });
+
+  it("keeps less-than comparisons literal inside streaming code", () => {
+    const { container } = render(
+      <MarkdownTextRenderer streaming highlightCode={false}>
+        {"Inline `$j<i$`.\n\n```latex\n$$\\prod_{j<i}(1-\\alpha_j)$$\n```"}
+      </MarkdownTextRenderer>,
+    );
+    expect(container.querySelector(".katex")).toBeNull();
+    expect(screen.getByText("$j<i$").tagName).toBe("CODE");
+    expect(container).toHaveTextContent(String.raw`$$\prod_{j<i}(1-\alpha_j)$$`);
   });
 
   it("keeps multiline dollar formulas in code literal", () => {


### PR DESCRIPTION
## Summary

Fix streamed WebUI responses being truncated at less-than comparisons in math, such as `\prod_{j<i}(1-\alpha_j)`. The formula can turn into a red KaTeX error and every following section disappears while the response is streaming.

Streamdown runs Remend over the whole response before remark parses math. Remend's incomplete-HTML handler treats `<i` as an unfinished tag and drops it together with everything after it. Disable only that handler with `remend={{ htmlTags: false }}`; keep the other incomplete-Markdown repairs enabled.

## Reproduction

Stream this response through the WebUI:

```markdown
$$
T_i = \prod_{j<i}(1-\alpha_j)
$$

## Supervision loss

The next section stays visible.
```

Before the fix, the formula is cut off at `\prod_{j` and the following heading/prose is absent. Reproduced in the real gateway with a deterministic loopback provider and in renderer regression tests. Static rendering is unaffected by the original Remend bug.

## Coverage and behavior

- Preserve the full formula and following content during streaming and after completion.
- Cover dollar and TeX delimiters, partial `<i` updates, completed block math, following text, and streaming-to-static transitions.
- Keep inline/fenced code literal and incomplete unsafe HTML inert; exercise the existing safe/unsafe HTML cases in both modes.
- HTML and URL safety policies are unchanged. Incomplete HTML-like text and angle-bracket autolinks may now be shown literally while streaming instead of being hidden until complete.

## Validation

- `bun run test src/tests/markdown-text-renderer.test.tsx src/tests/nanobot-client.test.ts --maxWorkers=2 --minWorkers=1` — 145 passed, including 64 renderer tests.
- `bun run test --maxWorkers=2 --minWorkers=1` — 77 files, 1203 tests passed.
- `bun run build` — passed.
- Targeted ESLint for both changed files with `--max-warnings 0` — passed.
- Built WebUI + isolated real gateway + headless Chromium: exact KaTeX source and following section preserved while streaming, after completion, and after refresh; canonical `webui-thread` replay checked through the browser's authenticated request.
- `git diff --check` — passed.

The initial unrestricted-worker test run on Windows hit a timeout and worker `EPIPE` during resource exhaustion. The full bounded-worker rerun passed without changing test timeouts or repository configuration. The browser provider was deterministic and local; no external model was needed.

Runtime-health observation: during refresh the gateway logged one `websockets` `AssertionError: assert not self.eof_sent` while sending an HTTP 200 response. Browser reconnection, canonical replay, and post-refresh rendering assertions still passed. This separate gateway/dependency trace was not investigated or changed in this renderer-only fix.
