### PR TITLE
fix(webui): prevent italic activity labels from clipping

### DIFF
--- a/webui/src/components/MessageBubble.tsx
+++ b/webui/src/components/MessageBubble.tsx
@@ -887,7 +887,7 @@ export function StreamingLabelSheen({
       <span
         data-sheen-text={active ? sheenText : undefined}
         className={cn(
-          "block w-fit max-w-full truncate font-medium leading-normal",
+          "block w-fit max-w-full truncate pr-0.5 font-medium leading-normal after:pr-0.5",
           active ? "streaming-text-sheen" : "text-muted-foreground",
         )}
       >


### PR DESCRIPTION
Italic activity labels could clip the final character because the inner text container uses fit-content sizing with hidden overflow. Add 2px of right padding to the text and its streaming highlight so overhanging strokes remain visible while long labels still truncate with an ellipsis.

Validation:
- 94 related tests passed across reasoning-row, agent-activity-cluster, and message-bubble.
- `bun run build` passed.
- Chromium component checks confirmed completed and streaming labels, narrow-container truncation, and keyboard tooltip access; no runtime errors.
