### PR TITLE
fix(webui): honor persisted session marker for titles

### DIFF
--- a/nanobot/session/webui_turns.py
+++ b/nanobot/session/webui_turns.py
@@ -795,10 +795,14 @@ class WebuiTurnCoordinator:
     def _schedule_title_update_from_event(self, event: TurnCompleted) -> None:
         title_context = _validated_llm_runtime(event.runtime)
         session = self.sessions.get_or_create(event.context.session_key)
+        target_session = self.sessions.get_or_create(
+            f"{event.context.channel}:{event.context.chat_id}"
+        )
         if (
             (
                 event.context.metadata.get(WEBUI_SESSION_METADATA_KEY) is not True
                 and session.metadata.get(WEBUI_SESSION_METADATA_KEY) is not True
+                and target_session.metadata.get(WEBUI_SESSION_METADATA_KEY) is not True
             )
             or title_context is None
         ):

--- a/nanobot/session/webui_turns.py
+++ b/nanobot/session/webui_turns.py
@@ -301,7 +301,7 @@ async def maybe_generate_webui_title_after_turn(
     provider: LLMProvider,
     model: str,
 ) -> bool:
-    if channel != "websocket" or metadata.get(WEBUI_SESSION_METADATA_KEY) is not True:
+    if channel != "websocket":
         return False
     origin_session_key = f"{channel}:{chat_id}"
     return await maybe_generate_webui_title(
@@ -794,8 +794,12 @@ class WebuiTurnCoordinator:
 
     def _schedule_title_update_from_event(self, event: TurnCompleted) -> None:
         title_context = _validated_llm_runtime(event.runtime)
+        session = self.sessions.get_or_create(event.context.session_key)
         if (
-            event.context.metadata.get("webui") is not True
+            (
+                event.context.metadata.get(WEBUI_SESSION_METADATA_KEY) is not True
+                and session.metadata.get(WEBUI_SESSION_METADATA_KEY) is not True
+            )
             or title_context is None
         ):
             return

--- a/tests/agent/test_loop_progress.py
+++ b/tests/agent/test_loop_progress.py
@@ -1,6 +1,7 @@
 """Tests for structured tool-event progress metadata emitted by AgentLoop."""
 
 import asyncio
+from collections.abc import Awaitable
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -1241,6 +1242,62 @@ class TestToolEventProgress:
         assert generated is True
         provider.chat_with_retry.assert_awaited_once()
         assert session.metadata["title"] == "Greeting"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("metadata", [{}, {"webui": False}])
+    @pytest.mark.parametrize("marked_session_key", ["websocket:chat1", "unified:default", None])
+    async def test_unified_webui_title_uses_reloaded_session_markers(
+        self,
+        tmp_path: Path,
+        metadata: dict[str, object],
+        marked_session_key: str | None,
+    ) -> None:
+        from nanobot.session.manager import SessionManager
+
+        sessions = SessionManager(tmp_path)
+        if marked_session_key is not None:
+            session = sessions.get_or_create(marked_session_key)
+            session.metadata["webui"] = True
+            sessions.save(session)
+        sessions = SessionManager(tmp_path)
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+        provider.chat_with_retry = AsyncMock(side_effect=[
+            LLMResponse(content="Hello"),
+            LLMResponse(content="Greeting"),
+        ])
+        loop = AgentLoop(
+            bus=bus,
+            provider=provider,
+            workspace=tmp_path,
+            model="test-model",
+            session_manager=sessions,
+            unified_session=True,
+        )
+        loop.tools.get_definitions = MagicMock(return_value=[])
+        loop.turn_delivery_factory.route_policy = WebuiTurnRoutePolicy(sessions)
+        scheduled: list[Awaitable[None]] = []
+        coordinator = WebuiTurnCoordinator(
+            bus=bus, sessions=sessions, schedule_background=scheduled.append,
+        )
+        with coordinator.connected():
+            await loop._dispatch(InboundMessage(
+                channel="websocket",
+                sender_id="u1",
+                chat_id="chat1",
+                content="say hello",
+                metadata=metadata,
+            ))
+            for coro in scheduled:
+                await coro
+
+        expected_title = "Greeting" if marked_session_key is not None else None
+        reloaded = SessionManager(tmp_path)
+        assert reloaded.get_or_create("websocket:chat1").metadata.get("title") == expected_title
+        assert "title" not in reloaded.get_or_create("unified:default").metadata
+        assert provider.chat_with_retry.await_count == (2 if expected_title else 1)
+        assert len(scheduled) == (1 if expected_title else 0)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("metadata", [{}, {"webui": False}])

--- a/tests/agent/test_loop_progress.py
+++ b/tests/agent/test_loop_progress.py
@@ -1161,6 +1161,9 @@ class TestToolEventProgress:
         loop = AgentLoop(bus=bus, provider=provider, workspace=tmp_path, model="test-model")
         _attach_webui_runtime_events(loop, bus)
         loop.tools.get_definitions = MagicMock(return_value=[])
+        session = loop.sessions.get_or_create("websocket:chat1")
+        session.metadata["webui"] = True
+        loop.sessions.save(session)
 
         captured: dict[str, object] = {}
 
@@ -1188,7 +1191,7 @@ class TestToolEventProgress:
             sender_id="u1",
             chat_id="chat1",
             content="say hello",
-            metadata={"webui": True},
+            metadata={},
         ))
 
         assert len(scheduled_title) == 1
@@ -1208,7 +1211,7 @@ class TestToolEventProgress:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("metadata", [{}, {"webui": False}])
-    async def test_webui_title_requires_inbound_opt_in(
+    async def test_webui_title_uses_persisted_session_marker(
         self,
         tmp_path: Path,
         metadata: dict[str, object],
@@ -1235,9 +1238,9 @@ class TestToolEventProgress:
             model="test-model",
         )
 
-        assert generated is False
-        provider.chat_with_retry.assert_not_awaited()
-        assert "title" not in session.metadata
+        assert generated is True
+        provider.chat_with_retry.assert_awaited_once()
+        assert session.metadata["title"] == "Greeting"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("metadata", [{}, {"webui": False}])
@@ -1254,7 +1257,6 @@ class TestToolEventProgress:
         _attach_webui_runtime_events(loop, bus)
         loop.tools.get_definitions = MagicMock(return_value=[])
         session = loop.sessions.get_or_create("websocket:chat1")
-        session.metadata["webui"] = True
         loop.sessions.save(session)
         scheduled: list[object] = []
 


### PR DESCRIPTION
Fix WebUI session titles after restart when the envelope omits the `webui` flag

## Problem and reproduction

WebUI sessions persist a `metadata.webui = true` marker. After a gateway restart, a frontend envelope can omit the transient `webui` field even though the session is still a WebUI session. On the next completed turn, title generation is skipped because the coordinator checks only the current event metadata.

Minimal reproduction:

1. Create `websocket:chat1` and persist `metadata.webui = true`.
2. Dispatch a WebSocket turn with `metadata = {}` (an envelope without the WebUI flag).
3. The turn completes, but `_schedule_title_update_from_event` returns before scheduling title generation.

## Root cause

The scheduling guard treated the inbound metadata as the only source of WebUI ownership. The persisted session marker, which is specifically retained across restarts, was not consulted. The lower-level title generator already validates persisted routed/target session metadata, but the guard prevented it from being reached.

## Changes

- Allow `maybe_generate_webui_title_after_turn` to consult the persisted session marker instead of requiring a transient inbound flag.
- Update the coordinator guard to accept the current event marker or a persisted marker on either the routed session or the target chat session.
- Preserve the existing websocket-only restriction and the no-marker behavior for ordinary sessions.
- Add regression coverage for title generation and model snapshot scheduling after the envelope loses the transient flag.
- Add regression coverage for reloaded session markers under unified routing, including target-only, routed-only, and unmarked sessions; verify titles are persisted on the target chat.

## Validation

- `python -m pytest tests/agent/test_loop_progress.py -q`: 33 passed.
- `python -m ruff check nanobot/session/webui_turns.py tests/agent/test_loop_progress.py`: passed.
- `python -m basedpyright nanobot/session/webui_turns.py`: 0 errors, 0 warnings, 0 notes.
- `git diff --check`: passed.

The change is limited to session title eligibility; command turns, non-WebSocket channels, and sessions without a persisted WebUI marker remain excluded. Closes #5647.
