### PR TITLE
fix(webui): refresh skill suggestions when opening the picker

### DIFF
--- a/webui/src/components/thread/ThreadComposer.tsx
+++ b/webui/src/components/thread/ThreadComposer.tsx
@@ -108,6 +108,7 @@ import {
   logoFallbackUrls,
 } from "@/lib/provider-brand";
 import { sessionHandleColor } from "@/lib/session-handle";
+import { requestSkillsRefresh } from "@/lib/skill-events";
 import {
   isSideChannelLifecycle,
   slashCommandLifecycle,
@@ -1120,6 +1121,12 @@ export function ThreadComposer({
       text: match[1].toLowerCase(),
     };
   }, [cursorPosition, interactionDisabled, slashMenuDismissed, value]);
+
+  const skillMenuActive = skillQuery !== null;
+  useEffect(() => {
+    // Also refresh an empty menu: skills may have been installed by the agent.
+    if (skillMenuActive) requestSkillsRefresh();
+  }, [skillMenuActive]);
 
   const visibleSlashCommands = useMemo(() => {
     if (!(isStreaming && onStop)) return slashCommands;

--- a/webui/src/hooks/useSkills.ts
+++ b/webui/src/hooks/useSkills.ts
@@ -11,9 +11,16 @@ export function useSkills(getToken: () => string): SkillSummary[] {
     let cancelled = false;
     let payloadVersion = 0;
     let refreshing = false;
+    let refreshQueued = false;
     const refresh = () => {
-      if (cancelled || refreshing) return;
+      if (cancelled) return;
+      if (refreshing) {
+        // The in-flight response may predate installation. Keep one trailing refresh.
+        refreshQueued = true;
+        return;
+      }
       refreshing = true;
+      refreshQueued = false;
       const version = payloadVersion;
       fetchSkills(getToken())
         .then(({ skills: nextSkills }) => {
@@ -24,6 +31,7 @@ export function useSkills(getToken: () => string): SkillSummary[] {
         })
         .finally(() => {
           refreshing = false;
+          if (refreshQueued) refresh();
         });
     };
     const onSkillsChanged = (event: Event) => {

--- a/webui/src/hooks/useSkills.ts
+++ b/webui/src/hooks/useSkills.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { fetchSkills } from "@/lib/api";
-import { isSkillsPayload, SKILLS_CHANGED_EVENT } from "@/lib/skill-events";
+import { isSkillsPayload, SKILLS_CHANGED_EVENT, SKILLS_REFRESH_EVENT } from "@/lib/skill-events";
 import type { SkillSummary } from "@/lib/types";
 
 export function useSkills(getToken: () => string): SkillSummary[] {
@@ -10,14 +10,20 @@ export function useSkills(getToken: () => string): SkillSummary[] {
   useEffect(() => {
     let cancelled = false;
     let payloadVersion = 0;
+    let refreshing = false;
     const refresh = () => {
+      if (cancelled || refreshing) return;
+      refreshing = true;
       const version = payloadVersion;
       fetchSkills(getToken())
         .then(({ skills: nextSkills }) => {
           if (!cancelled && version === payloadVersion) setSkills(nextSkills);
         })
         .catch(() => {
-          if (!cancelled && version === payloadVersion) setSkills([]);
+          // Keep the last known list usable during transient refresh failures.
+        })
+        .finally(() => {
+          refreshing = false;
         });
     };
     const onSkillsChanged = (event: Event) => {
@@ -30,9 +36,11 @@ export function useSkills(getToken: () => string): SkillSummary[] {
 
     refresh();
     window.addEventListener(SKILLS_CHANGED_EVENT, onSkillsChanged);
+    window.addEventListener(SKILLS_REFRESH_EVENT, refresh);
     return () => {
       cancelled = true;
       window.removeEventListener(SKILLS_CHANGED_EVENT, onSkillsChanged);
+      window.removeEventListener(SKILLS_REFRESH_EVENT, refresh);
     };
   }, [getToken]);
 

--- a/webui/src/lib/skill-events.ts
+++ b/webui/src/lib/skill-events.ts
@@ -1,6 +1,12 @@
 import type { SkillsPayload } from "@/lib/types";
 
 export const SKILLS_CHANGED_EVENT = "nanobot:skills-changed";
+export const SKILLS_REFRESH_EVENT = "nanobot:skills-refresh";
+
+export function requestSkillsRefresh(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(SKILLS_REFRESH_EVENT));
+}
 
 export function isSkillsPayload(value: unknown): value is SkillsPayload {
   return (

--- a/webui/src/tests/skills-marketplace.test.tsx
+++ b/webui/src/tests/skills-marketplace.test.tsx
@@ -2,13 +2,14 @@ import { act, fireEvent, render, renderHook, screen } from "@testing-library/rea
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SkillsMarketplace } from "@/components/settings/SkillsMarketplace";
+import { ThreadComposer } from "@/components/thread/ThreadComposer";
 import {
   fetchSkills,
   fetchTrendingMarketplaceSkills,
   searchMarketplaceSkills,
 } from "@/lib/api";
 import type { NanobotClient } from "@/lib/nanobot-client";
-import { SKILLS_CHANGED_EVENT } from "@/lib/skill-events";
+import { requestSkillsRefresh, SKILLS_CHANGED_EVENT } from "@/lib/skill-events";
 import { ClientProvider } from "@/providers/ClientProvider";
 import { useSkills } from "@/hooks/useSkills";
 
@@ -37,6 +38,101 @@ function marketplace(token: string) {
 }
 
 describe("useSkills", () => {
+  it("discovers skills added after page load when opening the $ menu, not on each keystroke", async () => {
+    const installed = {
+      name: "simple-pr-review",
+      description: "Review pull requests.",
+      source: "workspace",
+      enabled: true,
+      available: true,
+    };
+    vi.mocked(fetchSkills).mockReset().mockResolvedValueOnce({ skills: [] })
+      .mockResolvedValue({ skills: [installed] });
+    const getToken = () => "tok";
+    function Composer() {
+      const skills = useSkills(getToken);
+      return <ThreadComposer onSend={vi.fn()} skills={skills} />;
+    }
+    render(<Composer />);
+    await act(async () => {});
+    expect(fetchSkills).toHaveBeenCalledTimes(1);
+
+    const input = screen.getByLabelText("Message input");
+    fireEvent.change(input, { target: { value: "/", selectionStart: 1 } });
+    fireEvent.change(input, { target: { value: "@", selectionStart: 1 } });
+    expect(fetchSkills).toHaveBeenCalledTimes(1);
+    fireEvent.change(input, { target: { value: "$", selectionStart: 1 } });
+    expect(await screen.findByRole("option", { name: /simple-pr-review/ })).toBeInTheDocument();
+    expect(fetchSkills).toHaveBeenCalledTimes(2);
+
+    fireEvent.change(input, { target: { value: "$simple", selectionStart: 7 } });
+    await act(async () => {});
+    expect(fetchSkills).toHaveBeenCalledTimes(2);
+    fireEvent.keyDown(input, { key: "Tab" });
+    expect(input).toHaveValue("$simple-pr-review ");
+
+    // A later open must also refresh removals without remounting the page.
+    vi.mocked(fetchSkills).mockResolvedValue({ skills: [] });
+    fireEvent.change(input, { target: { value: "$", selectionStart: 1 } });
+    await act(async () => {});
+    expect(fetchSkills).toHaveBeenCalledTimes(3);
+    expect(screen.queryByRole("listbox", { name: "Slash commands" })).not.toBeInTheDocument();
+  });
+
+  it("coalesces in-flight refreshes and stops listening after unmount", async () => {
+    let resolveSkills!: (value: Awaited<ReturnType<typeof fetchSkills>>) => void;
+    vi.mocked(fetchSkills).mockReset().mockImplementationOnce(
+      () => new Promise((resolve) => {
+        resolveSkills = resolve;
+      }),
+    );
+    const getToken = () => "tok";
+    const { result, unmount } = renderHook(() => useSkills(getToken));
+
+    act(() => {
+      requestSkillsRefresh();
+      requestSkillsRefresh();
+    });
+    expect(fetchSkills).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolveSkills({ skills: [] });
+    });
+    expect(result.current).toEqual([]);
+
+    unmount();
+    requestSkillsRefresh();
+    expect(fetchSkills).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps existing skills on refresh failure and retries on the next open", async () => {
+    const installed = {
+      name: "simple-pr-review",
+      description: "Review pull requests.",
+      source: "workspace",
+      available: true,
+    };
+    vi.mocked(fetchSkills).mockReset()
+      .mockResolvedValueOnce({ skills: [installed] })
+      .mockRejectedValueOnce(new Error("Temporarily offline"))
+      .mockResolvedValueOnce({ skills: [] });
+    const getToken = () => "tok";
+    const { result } = renderHook(() => useSkills(getToken));
+    await act(async () => {});
+    expect(result.current).toEqual([installed]);
+
+    await act(async () => {
+      requestSkillsRefresh();
+    });
+    expect(fetchSkills).toHaveBeenCalledTimes(2);
+    expect(result.current).toEqual([installed]);
+
+    await act(async () => {
+      requestSkillsRefresh();
+    });
+    expect(fetchSkills).toHaveBeenCalledTimes(3);
+    expect(result.current).toEqual([]);
+  });
+
   it("does not let an older request overwrite a newer skill event", async () => {
     let resolveSkills!: (value: Awaited<ReturnType<typeof fetchSkills>>) => void;
     vi.mocked(fetchSkills).mockReset().mockImplementationOnce(

--- a/webui/src/tests/skills-marketplace.test.tsx
+++ b/webui/src/tests/skills-marketplace.test.tsx
@@ -79,13 +79,19 @@ describe("useSkills", () => {
     expect(screen.queryByRole("listbox", { name: "Slash commands" })).not.toBeInTheDocument();
   });
 
-  it("coalesces in-flight refreshes and stops listening after unmount", async () => {
+  it("coalesces opens during an older fetch into one trailing refresh", async () => {
     let resolveSkills!: (value: Awaited<ReturnType<typeof fetchSkills>>) => void;
+    const installed = {
+      name: "simple-pr-review",
+      description: "Review pull requests.",
+      source: "workspace",
+      available: true,
+    };
     vi.mocked(fetchSkills).mockReset().mockImplementationOnce(
       () => new Promise((resolve) => {
         resolveSkills = resolve;
       }),
-    );
+    ).mockResolvedValue({ skills: [installed] });
     const getToken = () => "tok";
     const { result, unmount } = renderHook(() => useSkills(getToken));
 
@@ -97,11 +103,13 @@ describe("useSkills", () => {
     await act(async () => {
       resolveSkills({ skills: [] });
     });
-    expect(result.current).toEqual([]);
+    // The old response was captured before installation; it cannot satisfy the new opens.
+    expect(fetchSkills).toHaveBeenCalledTimes(2);
+    expect(result.current).toEqual([installed]);
 
     unmount();
     requestSkillsRefresh();
-    expect(fetchSkills).toHaveBeenCalledTimes(1);
+    expect(fetchSkills).toHaveBeenCalledTimes(2);
   });
 
   it("keeps existing skills on refresh failure and retries on the next open", async () => {
@@ -131,6 +139,27 @@ describe("useSkills", () => {
     });
     expect(fetchSkills).toHaveBeenCalledTimes(3);
     expect(result.current).toEqual([]);
+  });
+
+  it.each([false, true])("does not start a queued refresh after unmount (failure: %s)", async (fails) => {
+    let settle!: () => void;
+    vi.mocked(fetchSkills).mockReset().mockImplementationOnce(
+      () => new Promise((resolve, reject) => {
+        settle = () => fails ? reject(new Error("Offline")) : resolve({ skills: [] });
+      }),
+    );
+    const getToken = () => "tok";
+    const { unmount } = renderHook(() => useSkills(getToken));
+    act(() => {
+      requestSkillsRefresh();
+    });
+    unmount();
+
+    await act(async () => {
+      settle();
+    });
+    requestSkillsRefresh();
+    expect(fetchSkills).toHaveBeenCalledTimes(1);
   });
 
   it("does not let an older request overwrite a newer skill event", async () => {


### PR DESCRIPTION
## Summary

Fixes [NAN-108](https://linear.app/nanobot-ai/issue/NAN-108/fixwebui-refresh-skill-suggestions-when-opening-the-picker).

Skills installed by the agent after the page loads can already be invoked by name, but the WebUI picker keeps its previous list. Users should not have to reload the page to discover a newly installed skill.

- Refresh the shared skill list whenever the `$` picker opens, including when the cached list is empty.
- Keep filtering local while typing. Allow at most one request in flight, and coalesce opens during an older request into one trailing refresh so a pre-installation response cannot swallow the update.
- Preserve existing suggestions on transient failures and retain protection against stale responses overwriting newer settings updates.
- Cover post-load discovery, Tab completion, removals, trailing refreshes, listener cleanup, and retries.

No changes to skill installation, availability filtering, backend invocation, persisted data, or public APIs.

## Verification

- Confirmed the initial discovery regression test fails before the fix and passes afterward.
- Review reproduced a second race: opening the picker during an older request dropped the refresh. The strengthened regression fails on the original PR and passes with the trailing-refresh fix.
- `bun run test src/tests/skills-marketplace.test.tsx src/tests/thread-composer.test.tsx src/tests/app-layout.test.tsx` — 161 passed on the updated branch.
- `bun run lint` and `bun x tsc -p tsconfig.build.json` — passed on the updated branch.
- Initial production build passed; current-head production build is also covered by the WebUI CI job.
- `git diff --check` — passed.
