### PR TITLE
fix(webui): preserve project when creating a topic from its menu

### DIFF
--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -316,7 +316,11 @@ function writeShellRoute(route: ShellRoute, replace = false): void {
     );
     return;
   }
-  window.location.hash = nextHash;
+  window.history.pushState(
+    null,
+    "",
+    `${window.location.pathname}${window.location.search}${nextHash}`,
+  );
 }
 
 function bootstrapTokenExpiresAt(expiresInSeconds: number): number {
@@ -1135,7 +1139,11 @@ function Shell({
       }
     };
     window.addEventListener("hashchange", applyRoute);
-    return () => window.removeEventListener("hashchange", applyRoute);
+    window.addEventListener("popstate", applyRoute);
+    return () => {
+      window.removeEventListener("hashchange", applyRoute);
+      window.removeEventListener("popstate", applyRoute);
+    };
   }, []);
 
   useEffect(() => {

--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -766,6 +766,45 @@ describe("App layout", () => {
     expect(screen.queryByText("connection-sensitive message")).not.toBeInTheDocument();
   });
 
+  it("keeps the context-menu project through navigation and first-message creation", async () => {
+    const projectScope = {
+      project_path: "/tmp/selected-project",
+      project_name: "selected-project",
+      access_mode: "full" as const,
+      restrict_to_workspace: false,
+    };
+    mockSessions = [{
+      key: "websocket:existing-chat",
+      channel: "websocket",
+      chatId: "existing-chat",
+      preview: "Existing topic",
+      workspaceScope: projectScope,
+    }];
+    mockFetchRoutes({
+      "/api/workspaces": {
+        schema_version: 1,
+        default_access_mode: "full",
+        default_scope: { ...projectScope, project_path: "/tmp/workspace", project_name: "workspace" },
+        controls: { can_change_project: true, can_use_full_access: true },
+      },
+    });
+    window.history.replaceState(null, "", "/#/chat/websocket%3Aexisting-chat");
+    render(<App />);
+    await waitFor(() => expect(connectSpy).toHaveBeenCalled());
+    const projectSection = screen.getByRole("region", { name: "selected-project" });
+    fireEvent.contextMenu(within(projectSection).getByRole("button", { name: "selected-project" }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "New topic" }));
+    expect(window.location.hash).toBe("#/new");
+    // Let queued browser navigation events settle before sending the first message.
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 50)); });
+    expect(await screen.findByRole("button", { name: "Choose project" })).toHaveTextContent("selected-project");
+    fireEvent.change(screen.getByLabelText("Message input"), {
+      target: { value: "project topic" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() => expect(createChatSpy).toHaveBeenCalledWith(projectScope));
+  });
+
   it("uses the restricted default scope without offering project selection", async () => {
     mockFetchRoutes({
       "/api/workspaces": {


### PR DESCRIPTION
Creating a topic from a project’s context menu now keeps that project selected and uses it when the first message creates the session. Previously, changing the URL hash queued a route event that cleared the project selection after the menu handler set it.

Use `history.pushState` for navigation already applied by the shell, and handle `popstate` for browser back/forward navigation. Direct hash navigation still uses the existing handler. Add an app-level test covering the project menu through first-message session creation.

Validation: 93 app-layout and chat-list tests passed; WebUI build and lint passed. Verified the built UI against an isolated gateway in a headless browser: project context-menu creation, first-message submission with `/model`, project grouping after reload, persisted thread replay via the API, ordinary new-topic reset, and browser back/forward. The native folder-picker result was stubbed only to prepare the initial project; session creation and persistence used the real gateway. No console errors during the verified flow. Isolated runtime cleanup released both ports.