### PR TITLE
feat(webui): refine sidebar hierarchy and selection feedback

### DIFF
--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -2782,7 +2782,7 @@ function Shell({
                           hideSidebarToggleForHostChrome={context.active}
                           hideThemeButton={!context.active}
                           hideHeaderTitle
-                          inlineHandle={workbenchPaneSessions.length > 1}
+                          inlineHandle={!mobileWorkbench && workbenchPaneSessions.length > 1}
                           headerActions={context.headerActions}
                           headerPortalTarget={context.headerPortalTarget}
                           headerActive={context.active}

--- a/webui/src/components/ChatList.tsx
+++ b/webui/src/components/ChatList.tsx
@@ -13,8 +13,6 @@ import {
   ArchiveRestore,
   AlertTriangle,
   ChevronDown,
-  Folder,
-  FolderTree,
   ListChecks,
   MessageCircleDashed,
   MoreHorizontal,
@@ -50,7 +48,10 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { MAX_WORKBENCH_PANES } from "@/components/workbench/workbench-model";
-import { SIDEBAR_SELECTION_ITEM_CLASS } from "@/components/SidebarSelectionHighlight";
+import {
+  SIDEBAR_SELECTION_ITEM_CLASS,
+  SidebarSelectionHighlight,
+} from "@/components/SidebarSelectionHighlight";
 import { relativeTime, visibleSessionPreview } from "@/lib/format";
 import {
   COLLAPSED_CHATS_VISIBLE_COUNT,
@@ -100,30 +101,6 @@ function SidebarItemTooltip({
         {label}
       </TooltipContent>
     </Tooltip>
-  );
-}
-
-function SidebarSelectionTrack({
-  active,
-  handle,
-}: {
-  active: boolean;
-  handle: ChatSummary["handle"];
-}) {
-  return (
-    <span
-      data-sidebar-selection-track
-      data-active={active ? "true" : "false"}
-      aria-hidden
-      className={cn(
-        "pointer-events-none absolute inset-x-0 bottom-0 h-0.5 origin-left rounded-full",
-        "transition-transform duration-200 ease-out motion-reduce:transition-none",
-        active ? "scale-x-100" : "scale-x-0",
-      )}
-      style={{
-        backgroundColor: handle ? sessionHandleColor(handle.id) : "currentColor",
-      }}
-    />
   );
 }
 
@@ -317,6 +294,34 @@ export const ChatList = memo(function ChatList({
 }: ChatListProps) {
   const { t } = useTranslation();
   const [visibleLimit, setVisibleLimit] = useState(INITIAL_VISIBLE_SESSIONS);
+  const scrollViewportRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    const viewport = scrollViewportRef.current;
+    if (!viewport) return;
+    const updateEdges = () => {
+      const remaining = viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop;
+      viewport.style.setProperty("--sidebar-fade-top", `${Math.min(8, Math.max(0, viewport.scrollTop))}px`);
+      viewport.style.setProperty("--sidebar-fade-bottom", `${Math.min(8, Math.max(0, remaining))}px`);
+    };
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+    const onScroll = () => {
+      updateEdges();
+      viewport.dataset.scrolling = "true";
+      clearTimeout(idleTimer);
+      idleTimer = setTimeout(() => { delete viewport.dataset.scrolling; }, 800);
+    };
+    updateEdges();
+    viewport.addEventListener("scroll", onScroll, { passive: true });
+    const observer = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(updateEdges);
+    observer?.observe(viewport);
+    if (viewport.firstElementChild) observer?.observe(viewport.firstElementChild);
+    return () => {
+      viewport.removeEventListener("scroll", onScroll);
+      clearTimeout(idleTimer);
+      delete viewport.dataset.scrolling;
+      observer?.disconnect();
+    };
+  }, [loading, sessions.length, temporarySessions.length]);
   const layoutRowRefs = useRef(new Map<string, HTMLElement>());
   const pendingLayoutRectsRef = useRef<Map<string, DOMRect> | null>(null);
   const layoutAnimationsRef = useRef(new Map<string, Animation>());
@@ -628,8 +633,11 @@ export const ChatList = memo(function ChatList({
   };
   return (
     <TooltipProvider>
-    <div className="sidebar-scroll-fade h-full min-h-0 min-w-0 overflow-x-hidden overflow-y-auto overscroll-contain py-4 scrollbar-thin scrollbar-track-transparent">
-      <div
+    <div ref={scrollViewportRef} className="sidebar-scroll-fade sidebar-scrollbar h-full min-h-0 min-w-0 overflow-x-hidden overflow-y-auto overscroll-contain pb-2">
+      <SidebarSelectionHighlight
+        scope="chats"
+        activeId={activeKey}
+        targetSelector="[data-chat-row]:has([aria-current])"
         data-chat-list-content
         data-pane-detach-target={
           paneDropTarget === DETACH_PANE_DROP_TARGET ? "true" : undefined
@@ -713,7 +721,7 @@ export const ChatList = memo(function ChatList({
           return (
             <section key={group.id} aria-label={group.label} className="relative z-[1]">
               {index === firstProjectGroupIndex ? (
-                <div className="px-2 pb-1 text-[12px] font-medium text-sidebar-muted-foreground">
+                <div className="px-2 pb-2 pt-2 text-[11px] font-medium leading-4 text-sidebar-muted-foreground">
                   {labels.projects}
                 </div>
               ) : null}
@@ -729,6 +737,7 @@ export const ChatList = memo(function ChatList({
                   {group.kind === "project" ? (
                     <ProjectGroupHeader
                       label={group.label}
+                      active={group.sessions.some((session) => session.key === activeKey)}
                       path={group.projectPath}
                       actionMenuId={`project:${group.id}`}
                       actionMenus={actionMenus}
@@ -756,7 +765,7 @@ export const ChatList = memo(function ChatList({
                   data-sidebar-project-surface={group.kind === "project" ? "true" : undefined}
                   className={cn(
                     group.kind === "project"
-                      && "rounded-es-[16px] border-s-2 border-sidebar-foreground/10 pb-1",
+                      && "sidebar-child-list ms-4 pb-1",
                   )}
                 >
                   <ul className="space-y-0.5">
@@ -800,7 +809,7 @@ export const ChatList = memo(function ChatList({
                           data-pane-drop-target={
                             paneDropTarget === resolvedPaneGroup.tabKey ? "true" : undefined
                           }
-                          className="relative my-1.5 min-w-0"
+                          className="relative min-w-0"
                         >
                           <div
                             data-workbench-tab-surface
@@ -845,7 +854,6 @@ export const ChatList = memo(function ChatList({
                             }}
                             className={cn(
                               "min-w-0 transition-[background-color,box-shadow]",
-                              projectMode && "-ms-0.5",
                               deleteSelectionMode && (tabSelected || tabPartiallySelected)
                                 && "ring-1 ring-inset ring-sidebar-foreground/25",
                               paneDropTarget === resolvedPaneGroup.tabKey
@@ -853,6 +861,7 @@ export const ChatList = memo(function ChatList({
                             )}
                           >
                               <WorkbenchTabHeader
+                                active={topicActive}
                                 title={title}
                                 actionMenuId={`tab:${resolvedPaneGroup.tabKey}`}
                                 actionMenus={actionMenus}
@@ -948,7 +957,7 @@ export const ChatList = memo(function ChatList({
                             actionMenus.openFromContextMenu(event, actionMenuId)
                           )}
                           className={cn(
-                            "group flex min-w-0 max-w-full items-center gap-1 rounded-control px-2 text-[13px] font-normal leading-5",
+                            "group flex min-w-0 max-w-full items-center gap-1 rounded-xl px-2 text-[13px] font-normal leading-5",
                             SIDEBAR_SELECTION_ITEM_CLASS,
                             compact ? "min-h-7" : "min-h-8",
                             topicActive
@@ -1004,7 +1013,7 @@ export const ChatList = memo(function ChatList({
                                         {timestamp}
                                       </span>
                                     ) : null}
-                                    <SidebarSelectionTrack active={topicActive} handle={s.handle} />
+
                                   </span>
                                 ) : (
                                   <span className="relative flex w-full min-w-0 items-center gap-1.5">
@@ -1013,7 +1022,7 @@ export const ChatList = memo(function ChatList({
                                       {title}
                                     </span>
                                     {isPinned ? <PinnedChatIndicator /> : null}
-                                    <SidebarSelectionTrack active={topicActive} handle={s.handle} />
+
                                   </span>
                                 )}
                                 {showPreview ? (
@@ -1172,13 +1181,14 @@ export const ChatList = memo(function ChatList({
             </button>
           </div>
         ) : null}
-      </div>
+      </SidebarSelectionHighlight>
     </div>
     </TooltipProvider>
   );
 });
 
 function WorkbenchTabHeader({
+  active,
   title,
   actionMenuId,
   actionMenus,
@@ -1194,6 +1204,7 @@ function WorkbenchTabHeader({
   onRequestDelete,
   actionMenuPortalContainer,
 }: {
+  active: boolean;
   title: string;
   actionMenuId: string;
   actionMenus: SidebarActionMenuController;
@@ -1220,10 +1231,36 @@ function WorkbenchTabHeader({
       data-workbench-tab
       onContextMenu={(event) => actionMenus.openFromContextMenu(event, actionMenuId)}
       className={cn(
-        "group/tab flex min-w-0 items-center gap-0.5 rounded-control px-1.5 text-sidebar-content",
-        collapsed ? "min-h-6" : "min-h-7",
+        "group/tab flex min-h-8 min-w-0 items-center gap-0.5 rounded-xl px-2",
+        active ? "text-sidebar-foreground" : "text-sidebar-content",
       )}
     >
+      {!deleteSelectionMode ? (
+          <SidebarItemTooltip label={disclosureLabel}>
+            <button
+              type="button"
+              aria-expanded={!collapsed}
+              aria-controls={controlsId}
+              aria-label={disclosureLabel}
+              onClick={onToggle}
+              className={cn(
+                "relative inline-flex h-6 w-3.5 shrink-0 items-center justify-center rounded-md before:absolute before:-inset-x-1 before:inset-y-0",
+                "text-sidebar-muted-foreground transition-[background-color,color,transform] duration-150 ease-out",
+                "hover:bg-sidebar-accent hover:text-sidebar-foreground active:scale-[0.96]",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60",
+                "motion-reduce:transition-none motion-reduce:active:scale-100",
+              )}
+            >
+              <ChevronDown
+                aria-hidden
+                className={cn(
+                  "relative -start-1 h-3.5 w-3.5 transition-transform duration-200 ease-out motion-reduce:transition-none",
+                  collapsed && "-rotate-90",
+                )}
+              />
+            </button>
+          </SidebarItemTooltip>
+      ) : null}
       <SidebarItemTooltip label={title}>
         <button
           type="button"
@@ -1237,19 +1274,15 @@ function WorkbenchTabHeader({
           aria-controls={deleteSelectionMode ? undefined : controlsId}
           aria-pressed={deleteSelectionMode ? selected : undefined}
           className={cn(
-            "flex min-w-0 flex-1 items-center gap-2 overflow-hidden px-0.5 py-1 text-left",
-            "text-[13px] font-normal leading-5",
+            "flex min-w-0 flex-1 items-center gap-2 overflow-hidden py-1 text-left",
+            "text-[13px] leading-5",
+            active ? "font-medium" : "font-normal",
             deleteSelectionMode && "cursor-default",
           )}
         >
           {deleteSelectionMode ? (
             <SelectionIndicator checked={selected} partial={partiallySelected} />
           ) : null}
-          <FolderTree
-            className="h-3.5 w-3.5 shrink-0 text-sidebar-muted-foreground"
-            strokeWidth={1.75}
-            aria-hidden
-          />
           <span className="min-w-0 flex-1 truncate">{title}</span>
         </button>
       </SidebarItemTooltip>
@@ -1299,30 +1332,7 @@ function WorkbenchTabHeader({
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-          <SidebarItemTooltip label={disclosureLabel}>
-            <button
-              type="button"
-              aria-expanded={!collapsed}
-              aria-controls={controlsId}
-              aria-label={disclosureLabel}
-              onClick={onToggle}
-              className={cn(
-                "inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md",
-                "text-sidebar-muted-foreground transition-[background-color,color,transform] duration-150 ease-out",
-                "hover:bg-sidebar-accent hover:text-sidebar-foreground active:scale-[0.96]",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60",
-                "motion-reduce:transition-none motion-reduce:active:scale-100",
-              )}
-            >
-              <ChevronDown
-                aria-hidden
-                className={cn(
-                  "h-3.5 w-3.5 transition-transform duration-200 ease-out motion-reduce:transition-none",
-                  collapsed && "rotate-90",
-                )}
-              />
-            </button>
-          </SidebarItemTooltip>
+
         </>
       ) : null}
     </div>
@@ -1393,7 +1403,7 @@ function ActivePaneRows({
     <ul
       id={id}
       aria-label={t("workbench.panesInTab", { title: tabTitle })}
-      className="mt-0.5 space-y-0.5 rounded-es-[14px] border-s-2 border-sidebar-foreground/25 pb-1"
+      className="sidebar-child-list ms-4 space-y-0.5 pb-1"
     >
       {panes.map((pane) => {
         const active = tabActive && pane.key === group.activePaneKey;
@@ -1426,7 +1436,7 @@ function ActivePaneRows({
                 actionMenus.openFromContextMenu(event, actionMenuId)
               )}
               className={cn(
-                "group/pane flex min-w-0 max-w-full items-center gap-1 rounded-control px-2 text-[13px] font-normal leading-5",
+                "group/pane flex min-w-0 max-w-full items-center gap-1 rounded-xl px-2 text-[13px] font-normal leading-5",
                 SIDEBAR_SELECTION_ITEM_CLASS,
                 compact ? "min-h-7" : "min-h-8",
                 active
@@ -1470,7 +1480,7 @@ function ActivePaneRows({
                     <SidebarSessionHandle handle={pane.handle} />
                     <span className="min-w-0 flex-1 truncate">{pane.title}</span>
                     {isPinned ? <PinnedChatIndicator /> : null}
-                    <SidebarSelectionTrack active={active} handle={pane.handle} />
+
                   </span>
               </button>
               <SessionActivityIndicator state={activityState} />
@@ -1641,11 +1651,12 @@ function TemporaryChatSection({
             <li key={session.key} className="min-w-0">
               <div
                 data-temporary-chat-row={session.key}
+                data-chat-row={session.key}
                 className={cn(
                   "group flex min-h-8 min-w-0 max-w-full items-center gap-2 rounded-xl px-2 text-[13px] font-normal leading-5",
                   SIDEBAR_SELECTION_ITEM_CLASS,
                   active
-                    ? "bg-sidebar-selected text-sidebar-accent-foreground"
+                    ? "text-sidebar-accent-foreground"
                     : "text-sidebar-content settings-hover hover:text-sidebar-accent-foreground",
                 )}
               >
@@ -1684,6 +1695,7 @@ function TemporaryChatSection({
 }
 
 function ProjectGroupHeader({
+  active,
   label,
   path,
   actionMenuId,
@@ -1695,6 +1707,7 @@ function ProjectGroupHeader({
   actionMenuPortalContainer,
   updatedAt,
 }: {
+  active: boolean;
   label: string;
   path?: string;
   actionMenuId: string;
@@ -1712,9 +1725,11 @@ function ProjectGroupHeader({
       type="button"
       aria-expanded={!collapsed}
       onClick={onToggle}
-      className="flex min-w-0 flex-1 items-center gap-2 rounded-lg px-1.5 py-1 text-left transition-colors hover:bg-sidebar-accent/45 hover:text-sidebar-foreground"
+      className={cn(
+        "flex min-w-0 flex-1 items-center gap-2 rounded-lg py-1 text-left transition-colors hover:text-sidebar-foreground",
+        active ? "font-medium text-sidebar-foreground" : "font-normal",
+      )}
     >
-      <Folder className="h-3.5 w-3.5 shrink-0" aria-hidden />
       <span className="min-w-0 flex-1 truncate">{label}</span>
     </button>
   );
@@ -1725,8 +1740,32 @@ function ProjectGroupHeader({
         onContextMenu={onRequestRename || onNewChat
           ? (event) => actionMenus.openFromContextMenu(event, actionMenuId)
           : undefined}
-        className="group flex min-w-0 items-center gap-1 px-1 pb-1 pt-1 text-[13px] font-normal leading-5 text-sidebar-content"
+        className="group flex min-h-8 min-w-0 items-center gap-0.5 rounded-xl px-2 text-[13px] leading-5 text-sidebar-content"
       >
+        <SidebarItemTooltip label={disclosureLabel}>
+          <button
+            type="button"
+            aria-expanded={!collapsed}
+            aria-label={disclosureLabel}
+            onClick={onToggle}
+            className={cn(
+              "relative inline-flex h-6 w-3.5 shrink-0 items-center justify-center rounded-md before:absolute before:-inset-x-1 before:inset-y-0",
+              "text-sidebar-muted-foreground transition-[background-color,color,transform] duration-150 ease-out",
+              "hover:bg-sidebar-accent hover:text-sidebar-foreground active:scale-[0.96]",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60",
+              "motion-reduce:transition-none motion-reduce:active:scale-100",
+            )}
+          >
+            <ChevronDown
+              data-sidebar-project-disclosure-icon
+              aria-hidden
+              className={cn(
+                "relative -start-1 h-3.5 w-3.5 transition-transform duration-200 ease-out motion-reduce:transition-none",
+                collapsed && "-rotate-90",
+              )}
+            />
+          </button>
+        </SidebarItemTooltip>
         {path ? (
           <Tooltip>
             <TooltipTrigger asChild>{projectButton}</TooltipTrigger>
@@ -1778,37 +1817,14 @@ function ProjectGroupHeader({
             </DropdownMenuContent>
           </DropdownMenu>
         ) : null}
-        <SidebarItemTooltip label={disclosureLabel}>
-          <button
-            type="button"
-            aria-expanded={!collapsed}
-            aria-label={disclosureLabel}
-            onClick={onToggle}
-            className={cn(
-              "inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md",
-              "text-sidebar-muted-foreground transition-[background-color,color,transform] duration-150 ease-out",
-              "hover:bg-sidebar-accent hover:text-sidebar-foreground active:scale-[0.96]",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60",
-              "motion-reduce:transition-none motion-reduce:active:scale-100",
-            )}
-          >
-            <ChevronDown
-              data-sidebar-project-disclosure-icon
-              aria-hidden
-              className={cn(
-                "h-3.5 w-3.5 transition-transform duration-200 ease-out motion-reduce:transition-none",
-                collapsed && "rotate-90",
-              )}
-            />
-          </button>
-        </SidebarItemTooltip>
+
       </div>
   );
 }
 
 function ChatsGroupHeader({ label }: { label: string }) {
   return (
-    <div className="px-2 pb-1 text-[12px] font-medium text-sidebar-muted-foreground">
+    <div className="px-2 pb-2 pt-2 text-[11px] font-medium leading-4 text-sidebar-muted-foreground">
       {label}
     </div>
   );
@@ -1841,7 +1857,7 @@ function ChatsFoldFooter({
     : `${hiddenCount} hidden topics`;
 
   return (
-    <div className="px-2 pb-1 pt-1">
+    <div className="pb-1 pt-1">
       <button
         type="button"
         onClick={onToggle}

--- a/webui/src/components/Sidebar.tsx
+++ b/webui/src/components/Sidebar.tsx
@@ -204,7 +204,7 @@ export function Sidebar(props: SidebarProps) {
         activeId={activeActionId}
         scope="actions"
         className={cn(
-          "relative gap-0.5 pb-3",
+          "relative gap-0.5 pb-1",
           collapsed ? "flex w-14 flex-col items-center px-0" : "flex flex-col px-2",
         )}
       >
@@ -265,7 +265,6 @@ export function Sidebar(props: SidebarProps) {
       <div
         className={cn(
           "flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden transition-opacity duration-200",
-          props.onExpand && !collapsed && "me-3",
           collapsed && "pointer-events-none opacity-0",
         )}
       >

--- a/webui/src/components/SidebarSelectionHighlight.tsx
+++ b/webui/src/components/SidebarSelectionHighlight.tsx
@@ -6,7 +6,8 @@ import {
 } from "react";
 
 interface SidebarSelectionHighlightProps extends HTMLAttributes<HTMLDivElement> {
-  targetRef: RefObject<HTMLElement>;
+  targetRef?: RefObject<HTMLElement>;
+  targetSelector?: string;
   activeId: string | null;
   scope: string;
 }
@@ -19,6 +20,7 @@ export const SIDEBAR_SELECTION_ACTION_ITEM_CLASS =
 
 export function SidebarSelectionHighlight({
   targetRef,
+  targetSelector,
   activeId,
   scope,
   children,
@@ -31,7 +33,9 @@ export function SidebarSelectionHighlight({
   useLayoutEffect(() => {
     const highlight = highlightRef.current;
     const container = containerRef.current;
-    const target = targetRef.current;
+    const target = targetRef?.current ?? (targetSelector
+      ? container?.querySelector<HTMLElement>(targetSelector)
+      : null);
     if (!highlight) return;
     if (!activeId || !container || !target) {
       highlight.style.opacity = "0";

--- a/webui/src/components/thread/ThreadShell.tsx
+++ b/webui/src/components/thread/ThreadShell.tsx
@@ -1686,7 +1686,6 @@ export function ThreadShell({
   const threadHeader = !hideHeader ? (
     <ThreadHeader
       title={title}
-      handle={temporary || (hideHeaderTitle && inlineHandle) ? null : session?.handle}
       onToggleSidebar={onToggleSidebar}
       theme={theme}
       onToggleTheme={onToggleTheme}

--- a/webui/src/globals.css
+++ b/webui/src/globals.css
@@ -1095,7 +1095,76 @@
 }
 
 .sidebar-scroll-fade {
-  scroll-padding-block: 1rem;
-  -webkit-mask-image: linear-gradient(to bottom, transparent, #000 1rem, #000 calc(100% - 1rem), transparent);
-  mask-image: linear-gradient(to bottom, transparent, #000 1rem, #000 calc(100% - 1rem), transparent);
+  --sidebar-fade-top: 0px;
+  --sidebar-fade-bottom: 0px;
+  -webkit-mask-image: linear-gradient(to bottom, transparent, #000 var(--sidebar-fade-top), #000 calc(100% - var(--sidebar-fade-bottom)), transparent);
+  mask-image: linear-gradient(to bottom, transparent, #000 var(--sidebar-fade-top), #000 calc(100% - var(--sidebar-fade-bottom)), transparent);
+}
+
+.sidebar-child-list {
+  position: relative;
+}
+
+.sidebar-child-list::before {
+  content: "";
+  position: absolute;
+  inset-block: 4px;
+  inset-inline-start: -5px;
+  width: 1px;
+  background: hsl(var(--sidebar-foreground) / 0.12);
+  pointer-events: none;
+}
+
+.sidebar-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+.sidebar-scrollbar:is(:hover, :has(:focus-visible), [data-scrolling="true"]) {
+  scrollbar-color: hsl(var(--sidebar-foreground) / 0.2) transparent;
+}
+
+@supports selector(::-webkit-scrollbar) {
+  .sidebar-scrollbar,
+  .sidebar-scrollbar:is(:hover, :has(:focus-visible), [data-scrolling="true"]) {
+    scrollbar-width: auto;
+    scrollbar-color: auto;
+  }
+
+  .sidebar-scrollbar::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  .sidebar-scrollbar::-webkit-scrollbar-button {
+    display: none;
+    width: 0;
+    height: 0;
+  }
+
+  .sidebar-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .sidebar-scrollbar::-webkit-scrollbar-thumb {
+    min-height: 32px;
+    border: 3.5px solid transparent;
+    border-radius: 999px;
+    background: transparent;
+    background-clip: padding-box;
+    transition: background-color 180ms ease-out;
+  }
+
+  .sidebar-scrollbar:is(:hover, :has(:focus-visible), [data-scrolling="true"])::-webkit-scrollbar-thumb {
+    background-color: hsl(var(--sidebar-foreground) / 0.2);
+  }
+
+  .sidebar-scrollbar::-webkit-scrollbar-thumb:hover,
+  .sidebar-scrollbar::-webkit-scrollbar-thumb:active {
+    background-color: hsl(var(--sidebar-foreground) / 0.38);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-scrollbar::-webkit-scrollbar-thumb { transition: none; }
 }

--- a/webui/src/tests/chat-list.test.tsx
+++ b/webui/src/tests/chat-list.test.tsx
@@ -94,13 +94,9 @@ describe("ChatList", () => {
     expect(underline?.getAttribute("style"))
       .toContain(sessionHandleColor("handle_1234"));
 
-    const activeTrack = conversation.querySelector("[data-sidebar-selection-track]");
-    expect(activeTrack).toHaveClass(
-      "origin-left",
-      "scale-x-100",
-      "transition-transform",
-      "motion-reduce:transition-none",
-    );
+    expect(conversation.closest("[data-chat-row]"))
+      .toHaveClass("rounded-xl");
+    expect(conversation.querySelector("[data-sidebar-selection-track]")).toBeNull();
   });
 
   it("marks a conversation that needs recovery attention with a warning indicator", () => {
@@ -683,25 +679,21 @@ describe("ChatList", () => {
     expect(tabHeader).not.toHaveAttribute("data-chat-row");
     expect(tabHeader).not.toHaveAttribute("data-sidebar-pane");
     expect(tabButton).not.toHaveAttribute("aria-current");
-    expect(tabButton.querySelector(".lucide-folder-tree")).toBeInTheDocument();
+    expect(tabHeader.querySelector(".lucide-folder-tree")).toBeNull();
     const paneList = within(tabGroup).getByRole("list", { name: "Panes in Root topic" });
     expect(tabSurface).toContainElement(paneList);
     const activePane = within(tabGroup).getByRole("button", { name: "Research pane" });
     expect(activePane).toHaveAttribute("aria-current", "true");
-    expect(activePane.closest("[data-sidebar-pane]")).toHaveClass("rounded-control");
-    expect(activePane.querySelector("[data-sidebar-selection-track]"))
-      .toHaveAttribute("data-active", "true");
+    expect(activePane.closest("[data-sidebar-pane]")).toHaveClass("rounded-xl");
+    expect(screen.getByTestId("chats-selection-highlight"))
+      .toHaveAttribute("data-active-id", "websocket:root");
     expect(screen.getByRole("button", {
       name: "Research pane pane actions",
     })).toHaveClass("opacity-0");
     expect(within(tabGroup).getByRole("button", { name: "Root topic" }))
       .not.toHaveAttribute("aria-current");
     expect(tabGroup).not.toHaveTextContent("2/4");
-    expect(paneList).toHaveClass(
-      "rounded-es-[14px]",
-      "border-s-2",
-      "border-sidebar-foreground/25",
-    );
+    expect(paneList).toHaveClass("ms-4");
 
     const collapse = within(tabGroup).getByRole("button", {
       name: "Collapse panes in Root topic",
@@ -1025,11 +1017,7 @@ describe("ChatList", () => {
     );
 
     expect(screen.getByRole("region", { name: "nanobot-bench" })).toBeInTheDocument();
-    expect(projectSurface).toHaveClass(
-      "rounded-es-[16px]",
-      "border-s-2",
-      "border-sidebar-foreground/10",
-    );
+    expect(projectSurface).toHaveClass("ms-4");
     expect(within(nanobotSection).getByText("Alpha task")).toBeInTheDocument();
     expect(
       within(nanobotSection)
@@ -1090,7 +1078,7 @@ describe("ChatList", () => {
     expect(within(chatsSection).queryByText("Project chat")).not.toBeInTheDocument();
   });
 
-  it("grows and retracts the row-owned selection track", () => {
+  it("moves the selected background between topic rows", () => {
     const props = {
       sessions: [
         session({ chatId: "active", title: "Active topic" }),
@@ -1112,10 +1100,9 @@ describe("ChatList", () => {
 
     const activeButton = screen.getByRole("button", { name: "Active topic" });
     expect(activeButton).toHaveAttribute("aria-current", "page");
-    expect(activeButton.querySelector("[data-sidebar-selection-track]"))
-      .toHaveClass("origin-left", "scale-x-100", "transition-transform");
-    expect(activeButton.querySelector("[data-sidebar-selection-track]"))
-      .toHaveStyle({ backgroundColor: "currentColor" });
+    expect(screen.getByTestId("chats-selection-highlight"))
+      .toHaveAttribute("data-active-id", "websocket:active");
+    expect(activeButton.querySelector("[data-sidebar-selection-track]")).toBeNull();
 
     rerender(
       <ChatList
@@ -1129,11 +1116,10 @@ describe("ChatList", () => {
     expect(screen.getByRole("button", { name: "Inactive topic" }))
       .toHaveAttribute("aria-current", "page");
     expect(screen.getByRole("button", { name: "Active topic" })
-      .querySelector("[data-sidebar-selection-track]"))
-      .toHaveClass("scale-x-0");
-    expect(screen.getByRole("button", { name: "Inactive topic" })
-      .querySelector("[data-sidebar-selection-track]"))
-      .toHaveClass("scale-x-100");
+      .closest("[data-chat-row]"))
+      .not.toHaveClass("bg-sidebar-foreground/[0.055]");
+    expect(screen.getByTestId("chats-selection-highlight"))
+      .toHaveAttribute("data-active-id", "websocket:inactive");
   });
 
   it("restores collapsed tabs from the local UI preference", () => {
@@ -1282,9 +1268,9 @@ describe("ChatList", () => {
       "ease-out",
       "motion-reduce:transition-none",
     );
-    expect(expandedIcon).not.toHaveClass("rotate-90");
+    expect(expandedIcon).not.toHaveClass("-rotate-90");
     expect(screen.getByRole("button", { name: "Topic actions for Alpha project" })
-      .compareDocumentPosition(disclosureButton) & Node.DOCUMENT_POSITION_FOLLOWING)
+      .compareDocumentPosition(disclosureButton) & Node.DOCUMENT_POSITION_PRECEDING)
       .toBeTruthy();
 
     fireEvent.click(disclosureButton);
@@ -1296,7 +1282,7 @@ describe("ChatList", () => {
 
     expect(screen.getByRole("button", { name: "Projects: Alpha project" })
       .querySelector("[data-sidebar-project-disclosure-icon]"))
-      .toHaveClass("rotate-90");
+      .toHaveClass("-rotate-90");
     expect(projectButton).toHaveAttribute("aria-expanded", "false");
     expect(animate).toHaveBeenCalledWith(
       [

--- a/webui/src/tests/thread-shell.test.tsx
+++ b/webui/src/tests/thread-shell.test.tsx
@@ -569,7 +569,7 @@ describe("ThreadShell", () => {
       />,
     ));
 
-    expect(within(portal).getByText("@soro")).toBeInTheDocument();
+    expect(within(portal).queryByText("@soro")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Session @soro")).not.toBeInTheDocument();
 
     unmount();


### PR DESCRIPTION
The sidebar used expanding underlines for topic selection and gave project and pane-group contents weak hierarchy. This change uses the same sliding rounded background as navigation, aligns nested topics with their parent titles, and adds subtle vertical guides with disclosure arrows on the left.

- Keep selection, collapse, project, and pane behavior in the existing sidebar.
- Reduce excess spacing and show narrow scrollbar thumbs on hover or scroll, with conditional edge feathering.
- Hide session handles in single-pane views, including mobile; retain them when multiple panes are displayed.

Validation: all 1,266 WebUI tests, production build, and lint passed. Isolated gateway/Chromium checks covered selection geometry and motion, nested alignment, collapse persistence, scrollbar and feather states, single/split/mobile handles, dark theme, and reduced motion. Local simplify and candidate review passed. Firefox and native-host behavior were not exercised; remote CI and formal PR review are pending.
