### PR TITLE
fix(webui): align standalone page widths with conversations

### DIFF
--- a/webui/src/components/settings/SettingsPage.tsx
+++ b/webui/src/components/settings/SettingsPage.tsx
@@ -721,6 +721,7 @@ export function SettingsPage({
             "mx-auto w-full animate-in fade-in-0 slide-in-from-bottom-1 py-6 duration-200 ease-out",
             "motion-reduce:animate-none sm:py-8 lg:py-12",
             "settings-grid",
+            !showSidebar && "settings-feature-page",
             hostChromeInset && "pt-[4.25rem] sm:pt-[4.25rem] lg:pt-[4.75rem]",
           )}
         >

--- a/webui/src/components/settings/system/AutomationsSettings.tsx
+++ b/webui/src/components/settings/system/AutomationsSettings.tsx
@@ -124,10 +124,10 @@ export function AutomationsSettings({
   }, [filtered, selectedJobId]);
 
   return (
-    <div className="space-y-5">
+    <div className="automations-page space-y-5">
       {jobs.length ? (
         <section className="shrink-0">
-          <div className="mx-auto flex w-full max-w-[56rem] flex-col gap-3">
+          <div className="flex w-full flex-col gap-3">
             <div className="-mx-1 overflow-x-auto px-1 pb-0.5">
               <div className="grid w-full min-w-[36rem] grid-cols-5 gap-1 rounded-floating bg-muted p-1">
                 {summaryOptions.map((option) => (
@@ -209,8 +209,8 @@ export function AutomationsSettings({
           {tx("settings.automations.loading", "Loading automations...")}
         </div>
       ) : filtered.length && selectedJob ? (
-        <section className="grid min-h-0 overflow-hidden rounded-panel bg-settings-surface xl:grid-cols-[minmax(16rem,18rem)_minmax(0,1fr)] xl:items-stretch">
-          <aside className="flex min-h-0 flex-col overflow-hidden border-b border-border/35 bg-settings-surface xl:border-b-0 xl:border-r">
+        <section className="automations-workspace grid min-h-0 overflow-hidden rounded-panel bg-settings-surface">
+          <aside className="automations-queue flex min-h-0 flex-col overflow-hidden border-b border-border/35 bg-settings-surface">
             <div className="flex shrink-0 items-center justify-between gap-3 px-4 py-3">
               <h2 className="text-[13px] font-semibold tracking-[-0.01em] text-foreground/85">
                 {tx("settings.automations.queue", "Queue")}
@@ -220,7 +220,7 @@ export function AutomationsSettings({
               </span>
             </div>
             <div
-              className="max-h-[28rem] space-y-1 overflow-y-auto overscroll-contain px-2 pb-2 xl:max-h-[calc(100vh-24rem)]"
+              className="automations-queue-list max-h-[28rem] space-y-1 overflow-y-auto overscroll-contain px-2 pb-2"
               role="list"
               aria-label={tx("settings.automations.queue", "Queue")}
             >
@@ -404,9 +404,9 @@ function AutomationDetailPanel({
   }, [job.id]);
 
   return (
-    <article className="flex min-h-0 min-w-0 flex-col overflow-hidden bg-settings-surface">
+    <article className="automation-detail-panel flex min-h-0 min-w-0 flex-col overflow-hidden bg-settings-surface">
       <div className="shrink-0 border-b border-border/35 px-4 py-3.5 dark:border-white/10 sm:px-5">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="min-w-0">
             <div className="flex min-w-0 flex-wrap items-center gap-2">
               <h3 className="min-w-0 truncate text-[18px] font-medium leading-7 text-foreground">
@@ -431,7 +431,7 @@ function AutomationDetailPanel({
         </div>
       </div>
 
-      <div className="grid min-h-0 min-w-0 flex-1 overflow-hidden lg:grid-cols-[minmax(0,1fr)_14.5rem]">
+      <div className="automation-detail-body grid min-h-0 min-w-0 flex-1 overflow-hidden">
         <div className="min-h-0 min-w-0 space-y-3 overflow-y-auto overscroll-contain p-4 sm:p-5">
           <section className="rounded-floating bg-background/55 px-4 py-3.5">
             <div className="flex items-center justify-between gap-3">
@@ -483,7 +483,7 @@ function AutomationDetailPanel({
             ) : null}
           </section>
 
-          <div className="grid gap-3 md:grid-cols-2">
+          <div className="grid grid-cols-[repeat(auto-fit,minmax(min(100%,10rem),1fr))] gap-3">
             <AutomationDetail
               label={tx("settings.automations.labels.next", "Next")}
               title={formatAutomationNextTitle(job, locale, tx)}
@@ -512,7 +512,7 @@ function AutomationDetailPanel({
           ) : null}
         </div>
 
-        <aside className="min-h-0 overflow-y-auto overscroll-contain border-t border-border/35 bg-settings-surface p-4 text-[12px] text-muted-foreground lg:border-l lg:border-t-0">
+        <aside className="automation-detail-metadata min-h-0 overflow-y-auto overscroll-contain border-t border-border/35 bg-settings-surface p-4 text-[12px] text-muted-foreground">
           <div className="grid gap-3">
             <AutomationDetail
               label={tx("settings.automations.labels.schedule", "Schedule")}

--- a/webui/src/components/thread/ThreadViewport.tsx
+++ b/webui/src/components/thread/ThreadViewport.tsx
@@ -873,7 +873,7 @@ export const ThreadViewport = forwardRef<ThreadViewportHandle, ThreadViewportPro
                 hasVerticalOverflow ? "overflow-y-auto" : "overflow-hidden",
               )}
             >
-              <div ref={messageContentRef} className="mx-auto w-full max-w-[49.5rem]">
+              <div ref={messageContentRef} className="mx-auto w-full max-w-[var(--content-column-width)]">
                 <ThreadMessages
                   messages={visibleMessages}
                   temporary={temporary}

--- a/webui/src/globals.css
+++ b/webui/src/globals.css
@@ -50,6 +50,7 @@
     --radius-modal: 1.375rem;
     --radius-prominent: 1.75rem;
     --radius-pill: 9999px;
+    --content-column-width: 49.5rem;
     --sidebar: 40 8% 96.8%;
     --sidebar-foreground: 0 0% 3.9%;
     --sidebar-content: 240 3% 30%;
@@ -998,7 +999,7 @@
   }
 }
 
-/* Settings grid: 4px baseline; 920px frame; 12 columns / 24px gutter on
+/* Settings grid: 4px baseline; 720px frame; 12 columns / 24px gutter on
    desktop, 4 columns / 16px gutter on mobile. Rows share the same tracks. */
 @layer components {
   .settings-grid {
@@ -1011,6 +1012,36 @@
     container-type: inline-size;
     max-inline-size: 720px;
     padding-inline: var(--settings-margin);
+  }
+  .settings-grid.settings-feature-page {
+    --settings-margin: 0.75rem;
+    max-inline-size: calc(var(--content-column-width) + 2 * var(--settings-margin));
+  }
+  /* Standalone feature pages have room for catalogs and multi-pane layouts.
+     Split automations only when each container can actually fit its columns. */
+  .automations-page {
+    container: automations / inline-size;
+  }
+  .automation-detail-panel {
+    container: automation-detail / inline-size;
+  }
+  @container automations (min-width: 48rem) {
+    .automations-workspace {
+      grid-template-columns: minmax(16rem, 18rem) minmax(0, 1fr);
+      align-items: stretch;
+    }
+    .automations-workspace > .automations-queue {
+      border-bottom-width: 0;
+      border-right-width: 1px;
+    }
+    .automations-queue > .automations-queue-list { max-height: calc(100vh - 24rem); }
+  }
+  @container automation-detail (min-width: 40rem) {
+    .automation-detail-body { grid-template-columns: minmax(0, 1fr) 14.5rem; }
+    .automation-detail-body > .automation-detail-metadata {
+      border-top-width: 0;
+      border-left-width: 1px;
+    }
   }
   .settings-stack > :not([hidden]) ~ :not([hidden]) {
     margin-block-start: var(--settings-module-gap, 20px);
@@ -1082,6 +1113,7 @@
   .settings-editor { padding: 16px var(--settings-inset, 16px); }
   @media (min-width: 640px) {
     .settings-grid { --settings-margin: 32px; }
+    .settings-grid.settings-feature-page { --settings-margin: 1rem; }
   }
   @container (min-width: 640px) {
     .settings-grid .settings-row, .settings-grid .settings-footer {

--- a/webui/src/tests/settings-system.test.tsx
+++ b/webui/src/tests/settings-system.test.tsx
@@ -146,6 +146,22 @@ describe("Settings system domains", () => {
   });
 
 
+  it.each(["apps", "skills", "automations", "channels"] as const)(
+    "uses the conversation-width content frame for the standalone %s page",
+    (initialSection) => {
+      renderSettingsView({ initialSection, initialSettings: settingsPayload(), showSidebar: false });
+
+      expect(screen.getByTestId("settings-section-transition")).toHaveClass("settings-feature-page");
+    },
+  );
+
+  it("keeps the regular settings page at its existing width", () => {
+    renderSettingsView({ initialSection: "models", initialSettings: settingsPayload() });
+
+    expect(screen.getByTestId("settings-section-transition")).toHaveClass("settings-grid");
+    expect(screen.getByTestId("settings-section-transition")).not.toHaveClass("settings-feature-page");
+  });
+
   it("does not show the Settings kicker on the standalone Automations surface", async () => {
     const onBackToChat = vi.fn();
     vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {

--- a/webui/src/tests/settings-test-utils.tsx
+++ b/webui/src/tests/settings-test-utils.tsx
@@ -128,6 +128,7 @@ export function renderSettingsView(
       | "overview"
       | "appearance"
       | "apps"
+      | "skills"
       | "channels"
       | "automations"
       | "advanced"

--- a/webui/src/tests/thread-viewport.test.tsx
+++ b/webui/src/tests/thread-viewport.test.tsx
@@ -306,6 +306,14 @@ describe("ThreadViewport", () => {
     expect(screen.getByTestId("thread-message-region")).toHaveClass("min-w-0");
   });
 
+  it("uses the shared content-column width for conversation messages", () => {
+    render(<ThreadViewport messages={messages} isStreaming={false} composer={<div>composer</div>} />);
+
+    expect(screen.getByTestId("thread-message-region").firstElementChild).toHaveClass(
+      "mx-auto", "w-full", "max-w-[var(--content-column-width)]",
+    );
+  });
+
   it("top-aligns a short active turn while the agent is responding", () => {
     render(
       <ThreadViewport


### PR DESCRIPTION
## Summary

- Give Apps, Skills, Automations, and Channels the same centered, responsive content width as session conversations: a shared `49.5rem` cap with matching `0.75rem` / `1rem` side gutters.
- Account for page padding outside the content width, while preserving ordinary settings sizing and the existing conversation appearance.
- Make Automations queue/detail and message/metadata columns respond to their container widths, keeping filters aligned and avoiding cramped content in narrow panes.
- Add regression coverage for the four standalone pages, unchanged regular settings, and the shared conversation width.

## Validation

- `bun run test src/tests/settings-system.test.tsx src/tests/thread-viewport.test.tsx src/tests/app-layout.test.tsx` — 133 passed.
- `bun run lint` — passed.
- `bun run build` — passed.
- Browser layout checks confirmed matching conversation and feature content widths across small and large viewports, a constrained main pane, and a larger root font size.

## Compatibility

No backend, API, configuration, or persisted-data changes. Sidebar dimensions and conversation appearance remain unchanged.

Fixes [NAN-111](https://linear.app/nanobot-ai/issue/NAN-111/fixwebui-align-standalone-page-widths-with-conversations).