### PR TITLE
fix(agent): retrieve background task exceptions and log unexpected failures

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1596,7 +1596,18 @@ class AgentLoop:
         """Schedule a coroutine as a tracked background task (drained on shutdown)."""
         task = asyncio.create_task(coro)
         self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
+        task.add_done_callback(self._observe_background_task)
+
+    def _observe_background_task(self, task: asyncio.Task[Any]) -> None:
+        """Drop a finished background task; log unexpected failures with context."""
+        self._background_tasks.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            coro = task.get_coro()
+            name = getattr(coro, "__qualname__", type(coro).__name__)
+            logger.opt(exception=exc).error("background task {} failed", name)
 
     def stop(self) -> None:
         """Stop the agent loop."""

--- a/tests/agent/test_loop_background_tasks.py
+++ b/tests/agent/test_loop_background_tasks.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import asyncio
+import gc
+from contextlib import suppress
+
+import pytest
+from loguru import logger
+
+
+@pytest.mark.asyncio
+async def test_background_success_removed_without_error_log(
+    loop_factory,
+) -> None:
+    loop = loop_factory(patch_deps=True)
+    records: list[str] = []
+    sink_id = logger.add(records.append, level="ERROR")
+    try:
+        loop.schedule_background(asyncio.sleep(0))
+        await asyncio.sleep(0.2)
+        assert not loop._background_tasks
+        assert records == []
+    finally:
+        logger.remove(sink_id)
+
+
+@pytest.mark.asyncio
+async def test_background_failure_retrieved_and_logged(
+    loop_factory,
+) -> None:
+    loop = loop_factory(patch_deps=True)
+    running = asyncio.get_running_loop()
+    loop_errors: list[str] = []
+    old_handler = running.get_exception_handler()
+    running.set_exception_handler(
+        lambda _loop, ctx: loop_errors.append(str(ctx.get("message")))
+    )
+    records: list[str] = []
+    sink_id = logger.add(records.append, level="ERROR")
+    try:
+        async def boom() -> None:
+            raise RuntimeError("background failure")
+
+        loop.schedule_background(boom())
+        await asyncio.sleep(0.2)
+        gc.collect()
+        await asyncio.sleep(0.2)
+        assert not loop._background_tasks
+        assert loop_errors == []
+        assert any("background task" in r and "failed" in r for r in records)
+    finally:
+        logger.remove(sink_id)
+        running.set_exception_handler(old_handler)
+
+
+@pytest.mark.asyncio
+async def test_background_cancelled_removed_silently(
+    loop_factory,
+) -> None:
+    loop = loop_factory(patch_deps=True)
+    records: list[str] = []
+    sink_id = logger.add(records.append, level="ERROR")
+    try:
+        loop.schedule_background(asyncio.sleep(60))
+        (task,) = tuple(loop._background_tasks)
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+        await asyncio.sleep(0.2)
+        assert not loop._background_tasks
+        assert records == []
+    finally:
+        logger.remove(sink_id)


### PR DESCRIPTION
Related to #5429.

`AgentLoop.schedule_background` drops finished tasks with a bare `set.discard` callback and never retrieves the result, so a failed background task (post-turn consolidation, session archival, WebUI title generation, background commands) surfaces only as asyncio's generic "Task exception was never retrieved" warning, easy to miss in a long-running service. The shutdown drain in the same class uses `gather(..., return_exceptions=True)`, so the owner already intends to observe terminal state; only the early-finish path escapes it. Foreground `_active_task_done` keeps its shape: foreground tasks are awaited at dispatch, background ones are not.

The done-callback now discards, ignores cancellation, and logs unexpected failures with traceback and coroutine name via the repo's `logger.opt(exception=...)` idiom. No other behavior changes.

Validation at 25cfab6: 3 new regressions pass (success removed silently, failure retrieved/logged with no loop warning, cancellation silent); the failure case was verified red against the unpatched method. Related suite tests/agent/test_autocompact_unit.py: 48 passed. Ruff, BasedPyright, git diff --check clean. Full repo suite not run; CI remains required before merge.