### PR TITLE
perf: reduce streaming text processing and classic CLI redraws

### DIFF
--- a/nanobot/cli/stream.py
+++ b/nanobot/cli/stream.py
@@ -9,7 +9,9 @@ that plagued earlier approaches.
 
 from __future__ import annotations
 
+import asyncio
 import sys
+import time
 from contextlib import contextmanager, nullcontext
 from typing import Literal
 
@@ -17,6 +19,8 @@ from rich.console import Console
 from rich.live import Live
 from rich.markdown import Markdown
 from rich.text import Text
+
+_STREAM_REFRESH_INTERVAL = 0.05
 
 
 def _clear_current_line(console: Console) -> None:
@@ -107,6 +111,8 @@ class StreamRenderer:
         self.streamed = False
         self._console = _make_console()
         self._live: Live | None = None
+        self._refresh_handle: asyncio.TimerHandle | None = None
+        self._next_refresh_at = 0.0
         self._spinner: ThinkingSpinner | None = None
         self._header_printed = False
         self._start_spinner()
@@ -160,6 +166,7 @@ class StreamRenderer:
         """Context manager: temporarily stop transient output for clean trace lines."""
         @contextmanager
         def _pause():
+            self._cancel_refresh()
             live_was_active = self._live is not None
             if self._live:
                 # Trace/reasoning can arrive after answer streaming has started.
@@ -191,11 +198,33 @@ class StreamRenderer:
                 transient=True,
             )
             self._live.start()
-        else:
-            self._live.update(self._renderable())
+            self._live.refresh()
+            self._next_refresh_at = time.monotonic() + _STREAM_REFRESH_INTERVAL
+        elif self._refresh_handle is None:
+            delay = max(0.0, self._next_refresh_at - time.monotonic())
+            if delay == 0:
+                self._refresh_stream()
+            else:
+                self._refresh_handle = asyncio.get_running_loop().call_later(
+                    delay, self._refresh_stream,
+                )
+
+    def _refresh_stream(self) -> None:
+        self._refresh_handle = None
+        if self._live is None:
+            return
+        self._live.update(self._renderable())
         self._live.refresh()
+        # Leave a quiet interval even when rendering itself exceeds the frame budget.
+        self._next_refresh_at = time.monotonic() + _STREAM_REFRESH_INTERVAL
+
+    def _cancel_refresh(self) -> None:
+        if self._refresh_handle is not None:
+            self._refresh_handle.cancel()
+            self._refresh_handle = None
 
     async def on_end(self, *, resuming: bool = False) -> None:
+        self._cancel_refresh()
         if self._live:
             # Double-refresh to sync _shape before stop() calls refresh().
             self._live.refresh()
@@ -225,6 +254,7 @@ class StreamRenderer:
 
     async def close(self) -> None:
         """Stop spinner/live without rendering a final streamed round."""
+        self._cancel_refresh()
         if self._live:
             self._live.stop()
             self._live = None

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -191,6 +191,9 @@ def strip_think(text: str) -> str:
     tokens mid-text would silently rewrite any message where a user or the
     assistant discusses the tokens themselves.
     """
+    # Every supported control tag contains '<'; ordinary text only needs trimming.
+    if "<" not in text:
+        return text.strip()
     # Well-formed blocks first.
     text = re.sub(rf"<(?P<tag>{_THINKING_TAG})>[\s\S]*?</(?P=tag)>", "", text)
     text = re.sub(rf"^\s*<{_THINKING_TAG}>[\s\S]*$", "", text)
@@ -224,6 +227,8 @@ def strip_reasoning_tags(text: object) -> str:
     """Remove wrapper tags from text that is already known to be reasoning."""
     if not isinstance(text, str):
         return ""
+    if "<" not in text:
+        return text.strip()
     text = re.sub(rf"^\s*<{_THINKING_TAG}/>\s*", "", text)
     text = re.sub(rf"\s*<{_THINKING_TAG}/>\s*$", "", text)
     text = re.sub(rf"^\s*<{_THINKING_TAG}>\s*", "", text)
@@ -239,6 +244,8 @@ def extract_think(text: str) -> tuple[str | None, str]:
     extracted; unclosed streaming prefixes are stripped from the cleaned
     text but not surfaced — :func:`strip_think` handles that case.
     """
+    if "<" not in text:
+        return None, text.strip()
     parts: list[str] = []
     for m in re.finditer(rf"<(?P<tag>{_THINKING_TAG})>([\s\S]*?)</(?P=tag)>", text):
         parts.append(m.group(2).strip())

--- a/tests/cli/test_stream_refresh.py
+++ b/tests/cli/test_stream_refresh.py
@@ -1,0 +1,75 @@
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nanobot.cli import stream
+
+
+@pytest.fixture(autouse=True)
+def fixed_arrival_time():
+    # Keep a burst inside one refresh window without changing asyncio's timer clock.
+    with patch.object(stream, "time") as clock:
+        clock.monotonic.return_value = 0.0
+        yield
+
+
+@pytest.mark.asyncio
+async def test_stream_coalesces_burst_and_flushes_during_provider_pause():
+    with patch.object(stream, "Live") as live_class, patch.object(stream, "_make_console"):
+        live = live_class.return_value
+        renderer = stream.StreamRenderer(show_spinner=False)
+        await renderer.on_delta("first")
+        live.refresh.assert_called_once()
+        for _ in range(100):
+            await renderer.on_delta(" token")
+        live.update.assert_not_called()
+        await asyncio.sleep(stream._STREAM_REFRESH_INTERVAL * 2)
+        live.update.assert_called_once()
+        assert live.update.call_args.args[0].markup == "first" + " token" * 100
+        assert live.refresh.call_count == 2
+        await renderer.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("finish", ["end", "close", "pause"])
+async def test_pending_refresh_cannot_write_after_stream_teardown(finish):
+    with patch.object(stream, "Live") as live_class, patch.object(stream, "_make_console"):
+        live = live_class.return_value
+        renderer = stream.StreamRenderer(show_spinner=False)
+        await renderer.on_delta("first")
+        await renderer.on_delta(" last")
+        handle = renderer._refresh_handle
+        assert handle is not None
+        if finish == "end":
+            with patch.object(renderer, "_render_str", return_value="first last\n"), \
+                 patch.object(stream.sys, "stdout") as output:
+                await renderer.on_end(resuming=True)
+                output.write.assert_called_once_with("first last\n")
+            assert renderer._buf == ""
+        elif finish == "close":
+            await renderer.close()
+        else:
+            with renderer.pause_spinner():
+                pass
+            assert renderer._buf == "first last"
+        assert handle.cancelled()
+        live.reset_mock()
+        await asyncio.sleep(stream._STREAM_REFRESH_INTERVAL * 2)
+        live.update.assert_not_called()
+        live.refresh.assert_not_called()
+        await renderer.close()
+
+
+@pytest.mark.asyncio
+async def test_resuming_after_trace_renders_the_buffered_tail():
+    with patch.object(stream, "Live") as live_class, patch.object(stream, "_make_console"):
+        live_class.side_effect = [MagicMock(), MagicMock()]
+        renderer = stream.StreamRenderer(show_spinner=False)
+        await renderer.on_delta("before")
+        await renderer.on_delta(" trace")
+        with renderer.pause_spinner():
+            pass
+        await renderer.on_delta(" after")
+        assert live_class.call_args.args[0].markup == "before trace after"
+        await renderer.close()


### PR DESCRIPTION
Long streamed replies repeatedly scan the accumulated text for control tags, and the classic Python CLI reparses and redraws the entire Markdown answer for every arriving chunk. This makes local CPU cost grow with answer length even when the model is remote.

Skip tag parsing when the text contains no `<`, retaining the existing trimming and tag-handling behavior. In the classic CLI, paint the first chunk immediately, then coalesce later chunks during a 50ms interval after each completed render. A pending update still flushes when the provider pauses; end, close, and trace output cancel the timer so it cannot repaint after teardown.

### Measured effect

Local Windows/i5-13400 comparison against `d7de5d53`, three-run medians with alternating control/treatment order and the same Python environment:

| Scenario | Before CPU | After CPU | Reduction |
|---|---:|---:|---:|
| Plain reasoning, 50,000 accumulated characters, per chunk | 2.969ms | 0.00354ms | 99.88% |
| Plain answer hook, 50,000 accumulated characters, per chunk | 3.281ms | 0.00537ms | 99.84% |
| Classic CLI, 10,000-character prefix + 100 chunks | 2.063s | 0.359s | 82.58% |
| Classic CLI, 50,000-character prefix + 100 chunks | 11.859s | 1.047s | 91.17% |

The CLI replay offers one ` more text` chunk every 10ms into a 100×30 Rich terminal backed by an in-memory output sink. Timing includes final rendering but excludes the initial prefix frame. At 50,000 characters, total replay time drops from 11.97s to 1.40s and refresh calls from 103 to a median of 10. Final rendered output hashes match.

These measurements cover the individual processing paths, excluding model/network and terminal-emulator work. Text containing `<` retains the fallback path and has no consistent measured speedup. This reduces common-case scanning cost; it does not introduce fully incremental tag parsing or optimize native TUI paragraph layout. The CLI's visible update interval includes rendering time in addition to the 50ms coalescing window.

### Validation

- 119 tests passed: `tests/utils/test_strip_think.py`, `tests/agent/test_runner_progress_deltas.py`, `tests/agent/test_loop_progress.py`, `tests/cli/test_cli_input.py`, and `tests/cli/test_stream_refresh.py`.
- Added coverage for immediate first output, burst coalescing, provider pauses, end/close/trace timer cancellation, and resuming buffered content after a trace.
- Identical cleaning results across 43,732 deterministic text prefixes, including Unicode, malformed tags, partial tags, and literal tag references.
- Real `python -m nanobot agent --classic --message ... --config ...` against an isolated local SSE provider: ordinary text and split `<think>` tags both complete successfully, including Chinese text and emoji.
- Ruff and targeted BasedPyright checks passed for the changed files.
