### PR TITLE
fix(channels): use deterministic hash for wecom/weixin media fallback names

### DIFF
--- a/nanobot/channels/wecom/runtime.py
+++ b/nanobot/channels/wecom/runtime.py
@@ -2,6 +2,7 @@
 """WeCom (Enterprise WeChat) channel implementation using wecom_aibot_sdk."""
 
 import asyncio
+import hashlib
 import importlib.util
 import os
 import re
@@ -383,7 +384,7 @@ class WecomChannel(BaseChannel):
                 return None
 
             media_dir = get_media_dir("wecom")
-            fallback_name = fname or f"{media_type}_{hash(file_url) % 100000}"
+            fallback_name = fname or f"{media_type}_{hashlib.sha1(file_url.encode()).hexdigest()[:10]}"
             filename = _sanitize_filename(cast(str, filename or fallback_name), fallback=fallback_name)
 
             file_path = media_dir / filename

--- a/nanobot/channels/weixin/runtime.py
+++ b/nanobot/channels/weixin/runtime.py
@@ -1495,7 +1495,7 @@ class WeixinChannel(BaseChannel):
             if not filename:
                 ts = int(time.time())
                 hash_seed = encrypt_query_param or full_url
-                h = abs(hash(hash_seed)) % 100000
+                h = hashlib.sha1(hash_seed.encode()).hexdigest()[:10]
                 filename = f"{media_type}_{ts}_{h}{ext}"
             safe_name = os.path.basename(filename)
             file_path = media_dir / safe_name


### PR DESCRIPTION
## What changed
Both the wecom and weixin channel media downloaders build a fallback filename with Python's built-in `hash()`:

```python
fallback_name = fname or f"{media_type}_{hash(file_url) % 100000}"
```
```python
h = abs(hash(hash_seed)) % 100000
```

This is replaced with a SHA1-based digest of the same input in both files.

## Why
`hash()` on `str` is salted per-process via `PYTHONHASHSEED` (randomized by default since Python 3.3). The fallback filename it produces is therefore not reproducible across process restarts, and within a single process there's meaningful collision risk from folding into only 100000 buckets. Neither channel needs unpredictability here — a stable, content-derived name is strictly better for a fallback path.

## How I tested
- `python -m ast` syntax-checked both modified files.
- Verified via `git diff` that the change is a minimal, localized swap of the hash function with no change to surrounding control flow.
- Could not run the project's `pytest`/`ruff` locally in this environment; happy to address CI feedback if further changes are needed.