### PR TITLE
perf(ui): reduce long-text streaming refresh overhead

### DIFF
--- a/tui/src/streaming-markdown.test.ts
+++ b/tui/src/streaming-markdown.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, expect, test } from "bun:test"
+import { MarkdownRenderable, SyntaxStyle, TextRenderable } from "@opentui/core"
+import { createTestRenderer, MockTreeSitterClient, type TestRendererSetup } from "@opentui/core/testing"
+
+import { StreamingMarkdownRenderable } from "./streaming-markdown"
+
+let setup: TestRendererSetup | undefined
+let syntax: SyntaxStyle | undefined
+
+afterEach(() => {
+  setup?.renderer.destroy()
+  syntax?.destroy()
+  setup = undefined
+  syntax = undefined
+})
+
+async function mount(content = "", streaming = true) {
+  setup = await createTestRenderer({ width: 80, height: 24 })
+  syntax = SyntaxStyle.fromStyles({ default: { fg: "#eeeeee" } })
+  const options = {
+    content, streaming, width: "100%" as const, syntaxStyle: syntax,
+    fg: "#eeeeee", internalBlockMode: "top-level" as const,
+    treeSitterClient: new MockTreeSitterClient({ autoResolveTimeout: 0 }),
+  }
+  const markdown = new StreamingMarkdownRenderable(setup.renderer, { ...options, id: "optimized" })
+  setup.renderer.root.add(markdown)
+  return { markdown, options }
+}
+
+test("retains the plain text node through streaming updates and rethemes it", async () => {
+  const { markdown } = await mount("Hello 中文")
+  const node = markdown.getChildren()[0]
+  expect(node).toBeInstanceOf(TextRenderable)
+  markdown.content += " more words".repeat(100)
+  expect(markdown.getChildren()[0]).toBe(node)
+  expect(markdown.content).toBe("Hello 中文" + " more words".repeat(100))
+  markdown.fg = "#112233"
+  expect((node as TextRenderable).fg.toInts()).toEqual([17, 34, 51, 255])
+})
+
+test("keeps unformatted text on the same node after completion", async () => {
+  const { markdown } = await mount("first")
+  const plain = markdown.getChildren()[0]
+  markdown.content += " final words"
+  markdown.streaming = false
+  expect(markdown.content).toBe("first final words")
+  expect(markdown.streaming).toBe(false)
+  expect(plain?.isDestroyed).toBe(false)
+  expect(markdown.getChildren()[0]).toBe(plain)
+  expect(setup!.renderer.root.getChildren()[0]).toBe(markdown)
+  await setup!.flush()
+  expect(setup!.captureCharFrame()).toContain("first final words")
+  markdown.content += " reconciled"
+  expect(markdown.getChildren()[0]).toBe(plain)
+  expect(markdown.content).toBe("first final words reconciled")
+})
+
+test.each([
+  "plain words and 中文，内容。",
+  "1. ordered item",
+  "1) ordered item",
+  "1.",
+  "first\n2) ordered item",
+  "first\n2.\nthird",
+  "    indented code",
+  "# heading",
+  "first\n---",
+  "first\nsecond",
+  "first\n\nsecond",
+  "first\n\n\nsecond",
+  "first\n",
+  "first\n\n",
+  "first  \nsecond",
+  "first\n===",
+  "first\n- item",
+  "first\n+ item",
+  "first\n1. ordered item",
+  "first\n    indented line",
+  "The equation is x² + y² = z².\n\nThe equation is $x^2 + y^2",
+  "Prices are $5 (USD) and $6.",
+  "Hello **bold** and _emphasis_",
+  "[link](https://example.com)",
+  "https://example.com",
+  "www.example.com",
+  "user@example.com",
+  "Hello &amp; world",
+  "Hello 🚀",
+  "Hello\tworld",
+  "first\rsecond",
+])("matches the Markdown renderer for %s", async (content) => {
+  const { markdown, options } = await mount(content)
+  await setup!.flush()
+  const actual = setup!.captureCharFrame()
+  const spans = setup!.captureSpans()
+  setup!.renderer.root.remove(markdown)
+  markdown.destroyRecursively()
+  const reference = new MarkdownRenderable(setup!.renderer, { ...options, id: "reference" })
+  setup!.renderer.root.add(reference)
+  await setup!.flush()
+  expect(setup!.captureCharFrame()).toBe(actual)
+  expect(setup!.captureSpans()).toEqual(spans)
+})
+
+test("retains plain paragraphs and the exact source including trailing newlines", async () => {
+  const { markdown } = await mount("first\n\nsecond\n\n")
+  const node = markdown.getChildren()[0]
+  expect(node).toBeInstanceOf(TextRenderable)
+  expect(markdown.content).toBe("first\n\nsecond\n\n")
+  markdown.content += "The equation is x² + y² = z²."
+  expect(markdown.getChildren()[0]).toBe(node)
+})
+
+test("hands off to Markdown when formatting arrives and keeps subsequent parser state", async () => {
+  const { markdown } = await mount("first")
+  const plain = markdown.getChildren()[0]
+  markdown.content += " **bold**"
+  expect(plain?.isDestroyed).toBe(true)
+  expect(markdown.content).toBe("first **bold**")
+  const formatted = markdown.getChildren()[0]
+  markdown.content += " tail"
+  expect(markdown.getChildren()[0]).toBe(formatted)
+  expect(markdown.content).toBe("first **bold** tail")
+})
+
+test("leaves completed history on the Markdown path", async () => {
+  const { markdown } = await mount("plain history", false)
+  expect(markdown.getChildren()[0]).not.toBeInstanceOf(TextRenderable)
+  markdown.destroyRecursively()
+  markdown.content = "late update"
+  expect(markdown.content).toBe("plain history")
+})

--- a/tui/src/streaming-markdown.ts
+++ b/tui/src/streaming-markdown.ts
@@ -1,0 +1,73 @@
+import {
+  MarkdownRenderable,
+  TextRenderable,
+  type ColorInput,
+  type MarkdownOptions,
+  type RenderContext,
+  type RGBA,
+} from "@opentui/core"
+
+function isPlainText(content: string): boolean {
+  return /^[\p{L}\p{N}][\p{L}\p{N}\p{Zs},.!?;'"，。！？、；：“”‘’（）$^+=()\n-]*$/u.test(content)
+    && !/\n[^\p{L}\p{N}\n]/u.test(content)
+    && !/\n{3}/u.test(content)
+    && !/^\d+[.)](?: |$)/mu.test(content)
+    && !/\bwww\./iu.test(content)
+}
+
+/** Keeps unformatted paragraphs on a retained text node until Markdown is needed. */
+export class StreamingMarkdownRenderable extends MarkdownRenderable {
+  private plainText: TextRenderable | null = null
+  private plainContent: string | null = null
+
+  constructor(context: RenderContext, options: MarkdownOptions) {
+    super(context, { ...options, content: "" })
+    this.content = options.content ?? ""
+  }
+
+  override get content(): string {
+    return this.plainContent ?? super.content
+  }
+
+  override set content(value: string) {
+    if (this.isDestroyed) return
+    // Once Markdown has appeared, keep its retained blocks and parser state.
+    if ((super.streaming || this.plainText) && !super.content && isPlainText(value)) {
+      const displayed = value.replace(/\n+$/u, "")
+      if (!this.plainText) {
+        this.plainText = new TextRenderable(this.ctx, {
+          id: this.id + "-plain",
+          width: "100%",
+          wrapMode: "word",
+          fg: this.fg,
+          content: displayed,
+        })
+        this.add(this.plainText)
+      } else {
+        this.plainText.content = displayed
+      }
+      this.plainContent = value
+      return
+    }
+    this.clearPlainText()
+    super.content = value
+  }
+
+  override get fg(): RGBA | undefined {
+    return super.fg
+  }
+
+  override set fg(value: ColorInput | undefined) {
+    super.fg = value
+    if (this.plainText) this.plainText.fg = value
+  }
+
+  private clearPlainText(): void {
+    if (this.plainText) {
+      this.remove(this.plainText)
+      this.plainText.destroyRecursively()
+      this.plainText = null
+    }
+    this.plainContent = null
+  }
+}

--- a/tui/src/transcript.ts
+++ b/tui/src/transcript.ts
@@ -22,6 +22,7 @@ import type {
   ToolProgressEvent,
 } from "./protocol"
 import { renderLatexAsUnicode } from "./latex"
+import { StreamingMarkdownRenderable } from "./streaming-markdown"
 import { hideScrollbars } from "./scrollbox"
 import { mergeToolEvent, renderToolEvent } from "./tool-renderers"
 
@@ -714,7 +715,7 @@ export class Transcript {
   }
 
   private createMarkdown(content: string, streaming: boolean, id = "markdown"): MarkdownRenderable {
-    const markdown = new MarkdownRenderable(this.renderer, {
+    const markdown = new StreamingMarkdownRenderable(this.renderer, {
       id: this.id(id),
       content: renderLatexAsUnicode(content),
       width: "auto",

--- a/webui/src/components/thread/activity/ActivityStep.tsx
+++ b/webui/src/components/thread/activity/ActivityStep.tsx
@@ -12,8 +12,10 @@ export interface ActivityStepProps {
   marker?: ReactNode;
   showMarker?: boolean;
   label: ReactNode;
+  tooltipContent?: ReactNode;
   ariaLabel?: string;
   active?: boolean;
+  animateLabel?: boolean;
   tone?: ActivityStepTone;
   className?: string;
   contentClassName?: string;
@@ -27,8 +29,10 @@ export function ActivityStep({
   marker,
   showMarker = true,
   label,
+  tooltipContent,
   ariaLabel,
   active = false,
+  animateLabel = true,
   tone = active ? "active" : "neutral",
   className,
   contentClassName,
@@ -43,7 +47,7 @@ export function ActivityStep({
       className="flex min-w-0 items-center gap-1.5 overflow-hidden whitespace-nowrap"
     >
       <StreamingLabelSheen
-        active={active}
+        active={active && animateLabel}
         className={cn(
           "min-w-0 flex-1 truncate font-medium",
           tone === "error" ? "text-destructive/78" : "text-muted-foreground/85",
@@ -95,7 +99,7 @@ export function ActivityStep({
             <Tooltip>
               <TooltipTrigger asChild>{line}</TooltipTrigger>
               <TooltipContent side="top" className="max-w-[min(32rem,calc(100vw-2rem))] whitespace-pre-wrap break-words">
-                {label}
+                {tooltipContent ?? label}
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>

--- a/webui/src/components/thread/activity/ReasoningRow.tsx
+++ b/webui/src/components/thread/activity/ReasoningRow.tsx
@@ -21,12 +21,19 @@ export function ReasoningRow({
     ? t("message.reasoningStreaming", { defaultValue: "Thinking…" })
     : t("message.reasoning", { defaultValue: "Thinking" });
   const preview = compactReasoningPreview(text) || fallback;
+  // CSS ellipsis still lays out the full string, including the animated copy.
+  const truncated = preview.length > 512;
+  const label = truncated
+    ? preview.slice(0, 512).replace(/[\uD800-\uDBFF]$/, "") + "…"
+    : preview;
   return (
     <ActivityStep
       marker={<ReasoningMarker streaming={streaming} />}
       active={streaming}
+      animateLabel={!truncated}
       tone={streaming ? "active" : "success"}
-      label={preview}
+      label={label}
+      tooltipContent={preview}
       labelClassName="italic text-muted-foreground/78"
       contentClassName="overflow-hidden"
       className={className}

--- a/webui/src/hooks/useNanobotStream.ts
+++ b/webui/src/hooks/useNanobotStream.ts
@@ -63,6 +63,8 @@ type PendingStreamEvent =
   | { kind: "reasoning"; text: string; turn: UIMessageTurnFields };
 
 const BACKGROUND_STREAM_FLUSH_INTERVAL_MS = 1_000;
+// Markdown and layout work must leave room for input between visible updates.
+const VISIBLE_STREAM_FLUSH_INTERVAL_MS = 50;
 
 /**
  * Append a reasoning chunk to the last open reasoning stream in ``prev``.
@@ -303,6 +305,7 @@ export function useNanobotStream(
   const pendingStreamEventsRef = useRef<PendingStreamEvent[]>([]);
   const streamFrameRef = useRef<number | null>(null);
   const streamTimerRef = useRef<number | null>(null);
+  const lastStreamFlushRef = useRef(0);
   const suppressStreamUntilTurnEndRef = useRef(false);
   const sideChannelTurnIdsRef = useRef<Set<string>>(new Set());
 
@@ -328,6 +331,7 @@ export function useNanobotStream(
       streamTimerRef.current = null;
     }
     pendingStreamEventsRef.current = [];
+    lastStreamFlushRef.current = 0;
   }, []);
 
   const isSideChannelEvent = useCallback((ev: InboundEvent) => {
@@ -580,6 +584,7 @@ export function useNanobotStream(
     turn?: UIMessageTurnFields;
     source?: UIMessage["source"];
   }) => {
+    lastStreamFlushRef.current = 0;
     if (streamFrameRef.current !== null) {
       window.cancelAnimationFrame(streamFrameRef.current);
       streamFrameRef.current = null;
@@ -659,7 +664,7 @@ export function useNanobotStream(
     });
   }, [applyPendingStreamEvents, closeActiveAssistantStream, resolveActiveAssistantIndex]);
 
-  const schedulePendingStreamFlush = useCallback(() => {
+  const schedulePendingStreamFlush = useCallback(function schedule() {
     if (streamFrameRef.current !== null || streamTimerRef.current !== null) return;
     if (document.visibilityState === "hidden" || !threadVisibleRef.current) {
       streamTimerRef.current = window.setTimeout(() => {
@@ -671,11 +676,21 @@ export function useNanobotStream(
       }, BACKGROUND_STREAM_FLUSH_INTERVAL_MS);
       return;
     }
+    const delay = VISIBLE_STREAM_FLUSH_INTERVAL_MS
+      - (performance.now() - lastStreamFlushRef.current);
+    if (delay > 0) {
+      streamTimerRef.current = window.setTimeout(() => {
+        streamTimerRef.current = null;
+        schedule();
+      }, delay);
+      return;
+    }
     streamFrameRef.current = window.requestAnimationFrame(() => {
       streamFrameRef.current = null;
       const events = pendingStreamEventsRef.current;
       if (events.length === 0) return;
       pendingStreamEventsRef.current = [];
+      lastStreamFlushRef.current = performance.now();
       setMessages((prev) => applyPendingStreamEvents(prev, events));
     });
   }, [applyPendingStreamEvents]);
@@ -683,22 +698,31 @@ export function useNanobotStream(
   useEffect(() => {
     if (threadVisible) {
       flushPendingStreamEvents();
-    } else if (streamFrameRef.current !== null) {
-      window.cancelAnimationFrame(streamFrameRef.current);
+    } else if (streamFrameRef.current !== null || streamTimerRef.current !== null) {
+      if (streamFrameRef.current !== null) window.cancelAnimationFrame(streamFrameRef.current);
       streamFrameRef.current = null;
+      if (streamTimerRef.current !== null) window.clearTimeout(streamTimerRef.current);
+      streamTimerRef.current = null;
       schedulePendingStreamFlush();
     }
   }, [threadVisible, flushPendingStreamEvents, schedulePendingStreamFlush]);
 
   useEffect(() => {
-    const flushOnReturn = () => {
-      if (document.visibilityState !== "visible" || !threadVisibleRef.current) return;
+    const onVisibilityChange = () => {
       if (pendingStreamEventsRef.current.length === 0) return;
-      flushPendingStreamEvents();
+      if (document.visibilityState === "visible" && threadVisibleRef.current) {
+        flushPendingStreamEvents();
+      } else {
+        if (streamFrameRef.current !== null) window.cancelAnimationFrame(streamFrameRef.current);
+        streamFrameRef.current = null;
+        if (streamTimerRef.current !== null) window.clearTimeout(streamTimerRef.current);
+        streamTimerRef.current = null;
+        schedulePendingStreamFlush();
+      }
     };
-    document.addEventListener("visibilitychange", flushOnReturn);
-    return () => document.removeEventListener("visibilitychange", flushOnReturn);
-  }, [flushPendingStreamEvents]);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, [flushPendingStreamEvents, schedulePendingStreamFlush]);
 
   useEffect(() => {
     if (!chatId) return;

--- a/webui/src/tests/reasoning-row.test.tsx
+++ b/webui/src/tests/reasoning-row.test.tsx
@@ -20,3 +20,34 @@ it("shows the reasoning preview in the shared tooltip on hover and keyboard focu
   await user.keyboard("{Escape}");
   expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 });
+
+it("bounds reasoning text without repainting a truncated label and keeps the complete tooltip current", async () => {
+  const user = userEvent.setup();
+  const text = "A long reasoning paragraph. ".repeat(2_000) + "original tail";
+  const { container, rerender } = render(<ReasoningRow text={text} streaming />);
+  const line = screen.getByTestId("activity-line");
+
+  expect(line.textContent).toBe(text.slice(0, 512) + "…");
+  expect(container.querySelector("[data-sheen-text]")).toBeNull();
+  expect(screen.getByTestId("activity-reasoning-marker")).toHaveAttribute("data-state", "thinking");
+  expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+  await user.tab();
+  expect(line).toHaveFocus();
+  expect(await screen.findByRole("tooltip")).toHaveTextContent(text);
+  rerender(<ReasoningRow text={text + " latest tail"} streaming />);
+  expect(screen.getByRole("tooltip")).toHaveTextContent(text + " latest tail");
+  await user.keyboard("{Escape}");
+  expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  expect(line.textContent).toBe(text.slice(0, 512) + "…");
+});
+
+it("keeps the existing text animation for short active reasoning", () => {
+  const { container } = render(<ReasoningRow text="Short active reasoning" streaming />);
+  expect(container.querySelector("[data-sheen-text]")).toHaveAttribute("data-sheen-text", "Short active reasoning");
+});
+
+it("does not split a surrogate pair at the reasoning preview boundary", () => {
+  render(<ReasoningRow text={"x".repeat(511) + "🚀 tail"} streaming />);
+  expect(screen.getByTestId("activity-line").textContent).toBe("x".repeat(511) + "…");
+});

--- a/webui/src/tests/useNanobotStream.test.tsx
+++ b/webui/src/tests/useNanobotStream.test.tsx
@@ -296,6 +296,95 @@ describe("useNanobotStream", () => {
     requestFrame.mockRestore();
   });
 
+  it("paces visible updates and immediately flushes the final ordered text", () => {
+    vi.useFakeTimers();
+    const now = vi.spyOn(performance, "now").mockReturnValue(1_000);
+    const frames: FrameRequestCallback[] = [];
+    const requestFrame = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    const fake = fakeClient();
+    const { result, unmount } = renderHook(() => useNanobotStream("paced", EMPTY_MESSAGES), {
+      wrapper: wrap(fake.client),
+    });
+    try {
+      act(() => fake.emit("paced", { event: "delta", chat_id: "paced", text: "first" }));
+      expect(frames).toHaveLength(1);
+      act(() => frames.shift()!(1_000));
+      expect(result.current.messages[0].content).toBe("first");
+      act(() => {
+        fake.emit("paced", { event: "delta", chat_id: "paced", text: " 中文" });
+        fake.emit("paced", { event: "delta", chat_id: "paced", text: "🚀" });
+        vi.advanceTimersByTime(49);
+      });
+      expect(frames).toHaveLength(0);
+      expect(result.current.messages[0].content).toBe("first");
+      now.mockReturnValue(1_050);
+      act(() => vi.advanceTimersByTime(1));
+      expect(frames).toHaveLength(1);
+      act(() => frames.shift()!(1_050));
+      expect(result.current.messages[0].content).toBe("first 中文🚀");
+      act(() => {
+        fake.emit("paced", { event: "delta", chat_id: "paced", text: " tail" });
+        fake.emit("paced", { event: "stream_end", chat_id: "paced" });
+      });
+      expect(result.current.messages[0].content).toBe("first 中文🚀 tail");
+      act(() => fake.emit("paced", { event: "turn_end", chat_id: "paced" }));
+      expect(result.current.messages[0].isStreaming).toBe(false);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      unmount();
+      requestFrame.mockRestore();
+      now.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it.each(["frame", "timer"] as const)("moves a pending visible %s to background cadence and flushes on return", (pending) => {
+    vi.useFakeTimers();
+    const descriptor = Object.getOwnPropertyDescriptor(document, "visibilityState");
+    const now = vi.spyOn(performance, "now").mockReturnValue(1_000);
+    const frames: FrameRequestCallback[] = [];
+    const requestFrame = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    const fake = fakeClient();
+    const { result, unmount } = renderHook(() => useNanobotStream("visibility", EMPTY_MESSAGES), {
+      wrapper: wrap(fake.client),
+    });
+    const visibility = (value: string) => {
+      Object.defineProperty(document, "visibilityState", { configurable: true, value });
+      document.dispatchEvent(new Event("visibilitychange"));
+    };
+    try {
+      act(() => fake.emit("visibility", { event: "delta", chat_id: "visibility", text: "first" }));
+      if (pending === "timer") act(() => frames.shift()!(1_000));
+      act(() => {
+        fake.emit("visibility", { event: "delta", chat_id: "visibility", text: " hidden" });
+        visibility("hidden");
+        vi.advanceTimersByTime(999);
+      });
+      expect(result.current.messages[0]?.content).toBe(pending === "timer" ? "first" : undefined);
+      act(() => vi.advanceTimersByTime(1));
+      expect(result.current.messages[0].content).toBe("first hidden");
+      act(() => {
+        fake.emit("visibility", { event: "delta", chat_id: "visibility", text: " returned" });
+        visibility("visible");
+      });
+      expect(result.current.messages[0].content).toBe("first hidden returned");
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      unmount();
+      requestFrame.mockRestore();
+      now.mockRestore();
+      if (descriptor) Object.defineProperty(document, "visibilityState", descriptor);
+      else delete (document as Document & { visibilityState?: string }).visibilityState;
+      vi.useRealTimers();
+    }
+  });
+
   it("coalesces hidden-tab deltas without scheduling paint frames", () => {
     vi.useFakeTimers();
     const visibilityDescriptor = Object.getOwnPropertyDescriptor(document, "visibilityState");


### PR DESCRIPTION
## Summary

- Pace visible WebUI streaming state updates at a minimum 50 ms interval before the next animation frame. Preserve the existing background cadence and immediate flushes on return, stop, and completion.
- Bound the visible reasoning label to 512 UTF-16 code units without splitting a surrogate pair. Stop the truncated label's sheen while keeping the active marker and complete keyboard/hover tooltip; retain the full underlying reasoning.
- Retain a TUI text node for conservatively recognized unformatted streaming paragraphs. Hand off to the existing Markdown renderer when formatting appears; leave static history, LaTeX conversion, and the existing 32 ms batching intact.
- Cover pacing, visibility transitions, full tooltip access, Unicode boundaries, retained nodes, and equivalence with the original Markdown character frames and style spans.

Related: [NAN-113](https://linear.app/nanobot-ai/issue/NAN-113). This does not change the Python helpers or classic Rich CLI covered by #5728.

## Draft: known TUI memory regression

**This is not ready for merge.** In an additional sequential workload (reasoning → plain paragraph → formula text → rich Markdown paragraphs), the final TUI phase regresses:

- Private-commit peak: **500.97 → 580.75 MiB (+15.92%)**.
- Working-set peak: **359.95 → 413.48 MiB (+14.87%)**.

Both exceed the 10% memory guard. Independent cold-process rich-Markdown runs have similar memory peaks (private commit 595.81 → 594.99 MiB; working set 414.73 → 415.73 MiB), suggesting sequence-sensitive initialization/collection effects, not a proven root cause. Cold rich-Markdown CPU is 0.484 → 0.578 seconds; there is no general Markdown CPU improvement claim.

Resolve the mixed-workload regression before making this PR ready, or split out the WebUI portion. No dependency patches, forced GC, or highlighter prewarming are used to shift work outside the measured window.

## Local resource measurements

Three fresh-process rounds per variant, medians below; unchanged base `aeb7b207d7e501b1dd5d8b68208813f493411331` versus this patch. The eight changed source/test files match the measured source snapshot.

| Workload | CPU seconds, before → after | CPU reduction | Private-commit peak, MiB | Working-set peak, MiB |
| --- | --- | --- | --- | --- |
| WebUI, 50k reasoning prefix | 2.938 → 0.938 | 68.09% | 588.3 → 483.8 | 852.0 → 769.3 |
| WebUI, 50k plain paragraph prefix | 5.328 → 2.453 | 53.96% | 667.8 → 606.8 | 933.4 → 882.8 |
| WebUI, 10k formula prefix | 2.547 → 1.406 | 44.79% | 644.8 → 632.5 | 937.8 → 924.5 |
| Native TUI, 50k plain paragraph prefix | 4.656 → 0.156 | 96.64% | 563.1 → 398.2 | 396.4 → 282.2 |
| Native TUI, 10k formula prefix | 1.078 → 0.766 | 28.99% | 525.6 → 440.8 | 378.6 → 322.4 |

- WebUI paragraph incremental private-commit peak: 153.83 → 88.89 MiB (**42.22% lower**), measured relative to the already-loaded prefix, not total browser RAM.
- Body delivery-to-display p95: WebUI **74.70 ms**, TUI **72.62 ms**. Actual advancing updates: **15.18/s** and **18.45/s**, respectively. All 400 deltas are retained.
- Original targets were ≥60% WebUI reasoning CPU reduction, ≥30% body CPU reduction in each UI, ≥25% WebUI incremental private-commit reduction, p95 ≤200 ms, and ≥10 visible updates/s. The three predefined workloads meet these budgets; the additional mixed rich-Markdown memory guard above does not.
- TUI 12-cycle completion/reset check: cycle-end private commit 384.59–398.10 MiB, falling to 380.00 MiB after 15 seconds idle. WebUI eight-cycle check: 547.37–651.88 MiB, falling to 417.62 MiB after the final reload/idle. These short checks do not prove absence of leaks.

### Measurement boundaries

Windows / Intel i5-13400 / 16 logical CPUs; Bun 1.3.6, OpenTUI 0.5.10. Production WebUI in a dedicated Chromium process tree; actual native TUI/highlighter in an 80×24 ConPTY, not TestRenderer timings. Native control/treatment process order alternates. The native control checkout at `d7de5d53` has byte-equivalent `tui/` and `packages/` sources to `aeb7b207`, and matching OpenTUI bundle hashes.

An external producer sends **400 × 8 characters at 100 deltas/s** over roughly four seconds after the prefix is loaded. This is ASCII-heavy synthetic delta traffic, not model tokens/s, typical daily usage, or full cold-start cost. CPU is Win32 user+kernel time (100% means one logical core); memory is sampled every 100 ms. Private commit is not physical resident RAM; summing browser working sets can double-count shared pages. Gateway, producer, sampler, terminal emulator, and ConPTY host are excluded. DOM mutation/native-frame latency is not final screen paint. Three medians are not a confidence interval, and the TUI plain-text speedup must not be generalized to rich Markdown.

The full comparison JSON, failed mixed-workload measurements, and measurement limitations are attached to NAN-113. Local experiment harnesses/raw samples remain outside the code diff; these are not CI performance assertions.

## Validation

- [x] WebUI full test suite: 1,287 tests.
- [x] WebUI production build.
- [x] TUI full test suite: 269 tests.
- [x] TUI TypeScript check and Windows native executable build.
- [x] Focused WebUI ESLint and `git diff --check`.
- [x] Production WebUI through an isolated real gateway: UTF-16 split deltas, completed/stop-buffered text and complete copy, short/long reasoning labels, keyboard and hover tooltips, Escape dismissal, completion marker, and composer input.
- [x] Real `/model` command persisted replay: `webui-thread` HTTP 200 before and after refresh; no browser console/runtime errors in the checked flow.
- [x] Isolated gateway/browser cleaned after verification.
- [ ] Resolve the additional TUI mixed-Markdown memory regression before marking ready.

Browser streaming checks inject synthetic events through the actual WebSocket client and capture Clipboard API writes; they do not use a paid LLM or modify the host clipboard. Native resource measurements and repetition checks were performed on this exact source snapshot before PR preparation; preparation reruns functional tests/builds and the production-browser flow, not the full resource benchmark.

Browser setup saw one initial `webui-thread` 404 for the not-yet-persisted new session. After `/model` persisted it, the checked replay/refresh flow returned HTTP 200 with no console/runtime errors.
