### PR TITLE
fix(webui): make headless login self-explanatory

### DIFF
--- a/nanobot/cli/webui.py
+++ b/nanobot/cli/webui.py
@@ -26,6 +26,7 @@ from nanobot.cli.webui_support import (
     _open_webui_browser,
     _prepare_webui_bundle_for_gateway,
     _print_foreground_port_conflict,
+    _print_webui_manual_access,
     _resolve_webui_config_path,
     _tcp_endpoint_reachable,
     _warn_webui_bind_scope,
@@ -147,7 +148,7 @@ def webui(
         console.print("Configure a provider and model in WebUI Settings → Models.")
 
     try:
-        changed_webui, generated_bootstrap_secret = _ensure_local_webui_channel(
+        changed_webui = _ensure_local_webui_channel(
             setup_config,
             port=port,
             yes=yes,
@@ -196,14 +197,8 @@ def webui(
     )
     if no_open:
         console.print("[dim]Browser opening disabled by --no-open.[/dim]")
-        if generated_bootstrap_secret:
-            console.print(
-                "[yellow]A WebUI bootstrap secret was generated and saved in this config.[/yellow]"
-            )
-            console.print(
-                "[dim]Open the WebUI and enter channels.websocket.tokenIssueSecret from "
-                f"{config_path}, or rerun without --no-open to open the authenticated URL.[/dim]"
-            )
+        if not dev:
+            _print_webui_manual_access(runtime_config, config_path, webui_url)
 
     if not dev:
         webui_bundle_mode = _webui_build_mode_for_interactive(yes=yes)
@@ -277,8 +272,8 @@ def webui(
                     "Restart the gateway if you need it to pick up local source changes: "
                     f"[cyan]{_gateway_instance_command('restart', config_path=config_path, workspace=workspace)}[/cyan]"
                 )
-                if not no_open:
-                    _open_webui_browser(webui_url, wait=False)
+                if not no_open and not _open_webui_browser(webui_url, wait=False):
+                    _print_webui_manual_access(runtime_config, config_path, webui_url)
                 if runtime.status().running:
                     _attach_to_background_gateway(runtime)
                 else:
@@ -352,8 +347,8 @@ def webui(
                 raise typer.Exit(1) from exc
             return
 
-        if not no_open:
-            _open_webui_browser(webui_url)
+        if not no_open and not _open_webui_browser(webui_url):
+            _print_webui_manual_access(runtime_config, config_path, webui_url)
         _attach_to_background_gateway(runtime)
     finally:
         lease.release(wait_for_stop=False)

--- a/nanobot/cli/webui_support.py
+++ b/nanobot/cli/webui_support.py
@@ -1,6 +1,7 @@
 """Shared WebUI setup, URL, health, and browser helpers."""
 
 import os
+import shutil
 import sys
 import time
 import webbrowser
@@ -47,6 +48,7 @@ __all__ = [
     "_open_webui_browser",
     "_prepare_webui_bundle_for_gateway",
     "_print_foreground_port_conflict",
+    "_print_webui_manual_access",
     "_print_webui_foreground_lifecycle",
     "_resolve_webui_config_path",
     "_tcp_endpoint_reachable",
@@ -62,6 +64,8 @@ __all__ = [
 
 console = Console()
 
+_TEXT_ONLY_BROWSERS = frozenset({"elinks", "links", "links2", "lynx", "w3m"})
+
 
 def _launch_browser(url: str) -> bool:
     """Open *url* and request a foreground browser window."""
@@ -72,6 +76,36 @@ def _launch_browser(url: str) -> bool:
 
         return launch_browser(url)
     return bool(webbrowser.open(url, new=2, autoraise=True))
+
+
+def _text_only_browser_name() -> str | None:
+    """Return the configured text browser name when it cannot run the WebUI."""
+    if sys.platform in {"darwin", "win32"}:
+        return None
+
+    try:
+        browser = webbrowser.get()
+    except webbrowser.Error:
+        return None
+
+    command = str(getattr(browser, "name", "") or "").strip()
+    if not command:
+        return None
+
+    import shlex
+
+    try:
+        executable = Path(shlex.split(command)[0])
+    except (IndexError, ValueError):
+        return None
+
+    names = {executable.name.lower()}
+    resolved_executable = Path(shutil.which(str(executable)) or executable)
+    try:
+        names.add(resolved_executable.resolve(strict=False).name.lower())
+    except OSError:
+        pass
+    return next((name for name in names if name in _TEXT_ONLY_BROWSERS), None)
 
 
 def _launch_macos_browser(url: str) -> bool:
@@ -209,8 +243,8 @@ def _validate_gateway_startup(config: Config) -> str | None:
             )
             console.print(
                 Text(
-                    f"If prompted, enter the configured channels.websocket.{secret_key} "
-                    f"value (see {config_path}).",
+                    f"If prompted, enter the WebUI password from "
+                    f"channels.websocket.{secret_key} in {config_path}.",
                     style="dim",
                 )
             )
@@ -309,27 +343,29 @@ def _ensure_local_webui_channel(
     *,
     port: int | None,
     yes: bool,
-) -> tuple[bool, bool]:
+) -> bool:
     """Enable the local WebUI channel with safe localhost defaults."""
     from nanobot.channels.websocket.runtime import WebSocketConfig
 
     current: Any = getattr(config.channels, "websocket", None) or {}
     model = WebSocketConfig.model_validate(current)
     changed = False
-    generated_secret = False
 
     needs_enable = not model.enabled
     needs_port = port is not None and model.port != port
     needs_secret = not model.token_issue_secret.strip() and not model.token.strip()
     if not needs_enable and not needs_port and not needs_secret:
-        return False, False
+        return False
 
     target_port = port if port is not None else model.port
     console.print()
     console.print("[bold]Local WebUI setup[/bold]")
     console.print(f"  URL: [cyan]http://127.0.0.1:{target_port}[/cyan]")
     console.print("  Bind: [cyan]127.0.0.1 only[/cyan] (not exposed to your LAN)")
-    console.print("  Auth: generated WebUI bootstrap secret stored in config")
+    if needs_secret:
+        console.print("  WebUI password: will be generated and stored in config")
+    else:
+        console.print("  WebUI password: already stored in config")
     console.print(
         "  LAN access requires an explicit host change plus a WebUI password in config."
     )
@@ -352,10 +388,9 @@ def _ensure_local_webui_channel(
 
         model.token_issue_secret = secrets.token_urlsafe(32)
         changed = True
-        generated_secret = True
 
     setattr(config.channels, "websocket", model.model_dump(by_alias=True, exclude_none=True))
-    return changed, generated_secret
+    return changed
 
 
 def _warn_webui_bind_scope(config: Config) -> None:
@@ -464,18 +499,55 @@ def _print_foreground_port_conflict(
     )
 
 
-def _open_webui_browser(url: str, *, wait: bool = True) -> None:
+def _open_webui_browser(url: str, *, wait: bool = True) -> bool:
     """Open the WebUI in the user's default browser, with a copyable fallback."""
     if wait:
         _wait_for_webui(url)
     display_url = _webui_display_url(url)
+    text_browser = _text_only_browser_name()
+    if text_browser:
+        console.print(
+            f"[yellow]The configured browser ({escape(text_browser)}) cannot run the WebUI "
+            "because it does not support JavaScript.[/yellow]"
+        )
+        return False
     try:
         if _launch_browser(url):
             console.print(f"[green]✓[/green] Opened WebUI: [cyan]{display_url}[/cyan]")
+            return True
         else:
-            console.print(f"[yellow]Could not open browser; visit {display_url}[/yellow]")
+            console.print("[yellow]Could not open a browser automatically.[/yellow]")
     except Exception as exc:
-        console.print(f"[yellow]Could not open browser ({exc}); visit {display_url}[/yellow]")
+        console.print(f"[yellow]Could not open a browser automatically ({escape(str(exc))}).[/yellow]")
+    return False
+
+
+def _print_webui_manual_access(config: Config, config_path: Path, url: str) -> None:
+    """Print a complete local or SSH-tunnel browser handoff without exposing credentials."""
+    from urllib.parse import urlparse
+
+    browser_url = url.split("/#/", 1)[0]
+    parsed = urlparse(browser_url)
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    ws_cfg = _webui_config_dict(config)
+    password_key = (
+        "tokenIssueSecret" if str(ws_cfg.get("tokenIssueSecret") or "").strip() else "token"
+    )
+
+    console.print()
+    console.print("[bold]Open the WebUI manually[/bold]")
+    console.print(f"  WebUI: [cyan]{browser_url}[/cyan]")
+    console.print(
+        "  WebUI password: "
+        f"[cyan]channels.websocket.{password_key}[/cyan] in [cyan]{config_path}[/cyan]"
+    )
+    console.print()
+    console.print("If nanobot is running on another machine, create an SSH tunnel from yours:")
+    console.print(
+        f"  [cyan]ssh -N -L {port}:127.0.0.1:{port} <user>@<server>[/cyan]"
+    )
+    console.print("Replace [cyan]<user>[/cyan] and [cyan]<server>[/cyan] and keep the tunnel open.")
+    console.print(f"Then open [cyan]{browser_url}[/cyan] on your computer.")
 
 
 def _print_webui_foreground_lifecycle(*, attached: bool) -> None:

--- a/nanobot/cli/webui_support.py
+++ b/nanobot/cli/webui_support.py
@@ -529,6 +529,8 @@ def _print_webui_manual_access(config: Config, config_path: Path, url: str) -> N
     browser_url = url.split("/#/", 1)[0]
     parsed = urlparse(browser_url)
     port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    tunnel_host = _host_for_local_browser(parsed.hostname or "127.0.0.1")
+    tunnel_url = f"{parsed.scheme}://127.0.0.1:{port}"
     ws_cfg = _webui_config_dict(config)
     password_key = (
         "tokenIssueSecret" if str(ws_cfg.get("tokenIssueSecret") or "").strip() else "token"
@@ -544,10 +546,10 @@ def _print_webui_manual_access(config: Config, config_path: Path, url: str) -> N
     console.print()
     console.print("If nanobot is running on another machine, create an SSH tunnel from yours:")
     console.print(
-        f"  [cyan]ssh -N -L {port}:127.0.0.1:{port} <user>@<server>[/cyan]"
+        f"  [cyan]ssh -N -L {port}:{tunnel_host}:{port} <user>@<server>[/cyan]"
     )
     console.print("Replace [cyan]<user>[/cyan] and [cyan]<server>[/cyan] and keep the tunnel open.")
-    console.print(f"Then open [cyan]{browser_url}[/cyan] on your computer.")
+    console.print(f"Then open [cyan]{tunnel_url}[/cyan] on your computer.")
 
 
 def _print_webui_foreground_lifecycle(*, attached: bool) -> None:

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -2598,21 +2598,36 @@ def test_text_only_browser_name_detects_links(monkeypatch) -> None:
     assert cli_webui_support._text_only_browser_name() == "links"
 
 
-def test_print_webui_manual_access_includes_password_source_and_ssh_tunnel(capsys) -> None:
-    config = Config(channels={"websocket": {"tokenIssueSecret": "do-not-print"}})
+@pytest.mark.parametrize(
+    ("host", "tunnel_host"),
+    [
+        ("127.0.0.1", "127.0.0.1"),
+        ("0.0.0.0", "127.0.0.1"),
+        ("::1", "[::1]"),
+        ("::", "[::1]"),
+        ("192.0.2.10", "192.0.2.10"),
+    ],
+)
+def test_print_webui_manual_access_includes_password_source_and_ssh_tunnel(
+    capsys, host: str, tunnel_host: str,
+) -> None:
+    config = Config(channels={"websocket": {
+        "host": host, "port": 8899, "tokenIssueSecret": "do-not-print",
+    }})
     config_path = Path("/srv/nanobot/config.json")
 
     cli_webui_support._print_webui_manual_access(
         config,
         config_path,
-        "http://127.0.0.1:8899/#/?bootstrapSecret=do-not-print",
+        cli_webui_support._webui_browser_url(config),
     )
 
     output = re.sub(r"\s+", " ", _strip_ansi(capsys.readouterr().out))
-    assert "WebUI: http://127.0.0.1:8899" in output
+    assert f"WebUI: http://{tunnel_host}:8899" in output
     assert "channels.websocket.tokenIssueSecret" in output
     assert str(config_path) in output
-    assert "ssh -N -L 8899:127.0.0.1:8899 <user>@<server>" in output
+    assert f"ssh -N -L 8899:{tunnel_host}:8899 <user>@<server>" in output
+    assert "Then open http://127.0.0.1:8899 on your computer." in output
     assert "do-not-print" not in output
 
 

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -2232,9 +2232,9 @@ def test_webui_yes_creates_config_and_enables_local_websocket(
     assert options.config_path == str(config_file.resolve(strict=False))
     assert options.workspace == str(workspace.resolve(strict=False))
     compact_output = re.sub(r"\s+", " ", _strip_ansi(result.stdout))
-    assert "bootstrap secret was generated" in compact_output
+    assert "Open the WebUI manually" in compact_output
     assert "channels.websocket.tokenIssueSecret" in compact_output
-    assert "rerun without --no-open" in compact_output
+    assert "ssh -N -L 8899:127.0.0.1:8899 <user>@<server>" in compact_output
     assert seen["lease_release_wait_for_stop"] is False
     assert "stop_timeout" not in seen
 
@@ -2540,13 +2540,14 @@ def test_webui_yes_opens_settings_for_incomplete_custom_model_setup(
 def test_open_webui_browser_redacts_bootstrap_secret(monkeypatch, capsys) -> None:
     opened: list[str] = []
     url = "http://127.0.0.1:8765/#/?bootstrapSecret=super-secret"
+    monkeypatch.setattr(cli_webui_support, "_text_only_browser_name", lambda: None)
     monkeypatch.setattr(
         cli_webui_support,
         "_launch_browser",
         lambda value: opened.append(value) or True,
     )
 
-    cli_webui_support._open_webui_browser(url, wait=False)
+    assert cli_webui_support._open_webui_browser(url, wait=False) is True
 
     assert opened == [url]
     output = _strip_ansi(capsys.readouterr().out)
@@ -2555,13 +2556,64 @@ def test_open_webui_browser_redacts_bootstrap_secret(monkeypatch, capsys) -> Non
 
 
 def test_open_webui_browser_reports_launch_failure(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cli_webui_support, "_text_only_browser_name", lambda: None)
     monkeypatch.setattr(cli_webui_support, "_launch_browser", lambda _value: False)
 
-    cli_webui_support._open_webui_browser("http://127.0.0.1:8765/", wait=False)
-
-    assert "Could not open browser; visit http://127.0.0.1:8765/" in _strip_ansi(
-        capsys.readouterr().out
+    opened = cli_webui_support._open_webui_browser(
+        "http://127.0.0.1:8765/",
+        wait=False,
     )
+
+    assert opened is False
+    assert "Could not open a browser automatically." in _strip_ansi(capsys.readouterr().out)
+
+
+def test_open_webui_browser_rejects_text_only_browser(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cli_webui_support, "_text_only_browser_name", lambda: "links")
+    monkeypatch.setattr(
+        cli_webui_support,
+        "_launch_browser",
+        lambda _value: pytest.fail("text-only browser must not be opened"),
+    )
+
+    opened = cli_webui_support._open_webui_browser(
+        "http://127.0.0.1:8765/",
+        wait=False,
+    )
+
+    output = re.sub(r"\s+", " ", _strip_ansi(capsys.readouterr().out))
+    assert opened is False
+    assert "links" in output
+    assert "does not support JavaScript" in output
+
+
+def test_text_only_browser_name_detects_links(monkeypatch) -> None:
+    monkeypatch.setattr(cli_webui_support.sys, "platform", "linux")
+    monkeypatch.setattr(
+        cli_webui_support.webbrowser,
+        "get",
+        lambda: SimpleNamespace(name="links"),
+    )
+
+    assert cli_webui_support._text_only_browser_name() == "links"
+
+
+def test_print_webui_manual_access_includes_password_source_and_ssh_tunnel(capsys) -> None:
+    config = Config(channels={"websocket": {"tokenIssueSecret": "do-not-print"}})
+    config_path = Path("/srv/nanobot/config.json")
+
+    cli_webui_support._print_webui_manual_access(
+        config,
+        config_path,
+        "http://127.0.0.1:8899/#/?bootstrapSecret=do-not-print",
+    )
+
+    output = re.sub(r"\s+", " ", _strip_ansi(capsys.readouterr().out))
+    assert "WebUI: http://127.0.0.1:8899" in output
+    assert "channels.websocket.tokenIssueSecret" in output
+    assert str(config_path) in output
+    assert "ssh -N -L 8899:127.0.0.1:8899 <user>@<server>" in output
+    assert "do-not-print" not in output
 
 
 def test_launch_browser_uses_macos_url_services(monkeypatch) -> None:

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -382,9 +382,20 @@ function AuthForm({
         className="flex w-full max-w-sm flex-col gap-4"
       >
         <div className="space-y-2">
-          <h1 className="text-sm font-medium text-foreground">
-            <label htmlFor="webui-access-password">{t("app.auth.label")}</label>
+          <h1 className="text-lg font-semibold text-foreground">
+            {t("app.auth.title")}
           </h1>
+          <p id="webui-auth-help" className="text-sm text-muted-foreground">
+            {t("app.auth.help")}
+          </p>
+        </div>
+        <div className="space-y-2">
+          <label
+            htmlFor="webui-access-password"
+            className="text-sm font-medium text-foreground"
+          >
+            {t("app.auth.label")}
+          </label>
           <div className="relative">
             <Input
               ref={inputRef}
@@ -399,7 +410,11 @@ function AuthForm({
               }}
               disabled={submitting}
               aria-invalid={validationError ? true : undefined}
-              aria-describedby={validationError ? "webui-auth-error" : undefined}
+              aria-describedby={
+                validationError
+                  ? "webui-auth-help webui-auth-error"
+                  : "webui-auth-help"
+              }
               className="pr-10"
               autoFocus
             />

--- a/webui/src/i18n/locales/en/common.json
+++ b/webui/src/i18n/locales/en/common.json
@@ -12,7 +12,7 @@
     "auth": {
       "title": "Connect to nanobot",
       "label": "WebUI password",
-      "help": "Find this password at channels.websocket.tokenIssueSecret in the nanobot config, usually ~/.nanobot/config.json.",
+      "help": "Find this password at channels.websocket.tokenIssueSecret in the nanobot config, usually ~/.nanobot/config.json. If that value is empty, use channels.websocket.token.",
       "showPassword": "Show password",
       "hidePassword": "Hide password",
       "submit": "Connect",

--- a/webui/src/i18n/locales/en/common.json
+++ b/webui/src/i18n/locales/en/common.json
@@ -7,15 +7,17 @@
     },
     "error": {
       "title": "Couldn't reach nanobot",
-      "gatewayHint": "Make sure the gateway is running (`nanobot gateway`) and that this page is open on the same machine."
+      "gatewayHint": "Make sure the gateway is running (`nanobot gateway`) and this browser can reach its WebUI address."
     },
     "auth": {
-      "label": "Password",
+      "title": "Connect to nanobot",
+      "label": "WebUI password",
+      "help": "Find this password at channels.websocket.tokenIssueSecret in the nanobot config, usually ~/.nanobot/config.json.",
       "showPassword": "Show password",
       "hidePassword": "Hide password",
       "submit": "Connect",
-      "required": "Enter your password.",
-      "invalid": "Incorrect password. Try again."
+      "required": "Enter the WebUI password.",
+      "invalid": "That WebUI password wasn't accepted. Copy it from the nanobot config and try again."
     },
     "account": {
       "section": "Account",

--- a/webui/src/i18n/locales/es/common.json
+++ b/webui/src/i18n/locales/es/common.json
@@ -7,15 +7,17 @@
     },
     "error": {
       "title": "No se pudo conectar con nanobot",
-      "gatewayHint": "Asegúrate de que la gateway esté en ejecución (`nanobot gateway`) y de que esta página esté abierta en la misma máquina."
+      "gatewayHint": "Asegúrate de que la gateway esté en ejecución (`nanobot gateway`) y de que este navegador pueda acceder a la dirección de la WebUI."
     },
     "auth": {
-      "label": "Contraseña",
+      "title": "Conectar con nanobot",
+      "label": "Contraseña de WebUI",
+      "help": "Busca esta contraseña en channels.websocket.tokenIssueSecret dentro de la configuración de nanobot, normalmente ~/.nanobot/config.json.",
       "showPassword": "Mostrar contraseña",
       "hidePassword": "Ocultar contraseña",
       "submit": "Conectar",
-      "required": "Introduce la contraseña.",
-      "invalid": "Contraseña incorrecta. Inténtalo de nuevo."
+      "required": "Introduce la contraseña de WebUI.",
+      "invalid": "No se aceptó esa contraseña de WebUI. Cópiala de la configuración de nanobot e inténtalo de nuevo."
     },
     "account": {
       "section": "Cuenta",

--- a/webui/src/i18n/locales/es/common.json
+++ b/webui/src/i18n/locales/es/common.json
@@ -12,7 +12,7 @@
     "auth": {
       "title": "Conectar con nanobot",
       "label": "Contraseña de WebUI",
-      "help": "Busca esta contraseña en channels.websocket.tokenIssueSecret dentro de la configuración de nanobot, normalmente ~/.nanobot/config.json.",
+      "help": "Busca esta contraseña en channels.websocket.tokenIssueSecret dentro de la configuración de nanobot, normalmente ~/.nanobot/config.json. Si ese valor está vacío, usa channels.websocket.token.",
       "showPassword": "Mostrar contraseña",
       "hidePassword": "Ocultar contraseña",
       "submit": "Conectar",

--- a/webui/src/i18n/locales/fr/common.json
+++ b/webui/src/i18n/locales/fr/common.json
@@ -7,15 +7,17 @@
     },
     "error": {
       "title": "Impossible de joindre nanobot",
-      "gatewayHint": "Assurez-vous que la gateway est en cours d’exécution (`nanobot gateway`) et que cette page est ouverte sur la même machine."
+      "gatewayHint": "Assurez-vous que la gateway est en cours d’exécution (`nanobot gateway`) et que ce navigateur peut atteindre son adresse WebUI."
     },
     "auth": {
-      "label": "Mot de passe",
+      "title": "Se connecter à nanobot",
+      "label": "Mot de passe de la WebUI",
+      "help": "Ce mot de passe se trouve dans channels.websocket.tokenIssueSecret dans la configuration de nanobot, généralement ~/.nanobot/config.json.",
       "showPassword": "Afficher le mot de passe",
       "hidePassword": "Masquer le mot de passe",
       "submit": "Se connecter",
-      "required": "Saisissez le mot de passe.",
-      "invalid": "Mot de passe incorrect. Réessayez."
+      "required": "Saisissez le mot de passe de la WebUI.",
+      "invalid": "Ce mot de passe de la WebUI n’a pas été accepté. Copiez-le depuis la configuration de nanobot et réessayez."
     },
     "account": {
       "section": "Compte",

--- a/webui/src/i18n/locales/fr/common.json
+++ b/webui/src/i18n/locales/fr/common.json
@@ -12,7 +12,7 @@
     "auth": {
       "title": "Se connecter à nanobot",
       "label": "Mot de passe de la WebUI",
-      "help": "Ce mot de passe se trouve dans channels.websocket.tokenIssueSecret dans la configuration de nanobot, généralement ~/.nanobot/config.json.",
+      "help": "Ce mot de passe se trouve dans channels.websocket.tokenIssueSecret dans la configuration de nanobot, généralement ~/.nanobot/config.json. Si cette valeur est vide, utilisez channels.websocket.token.",
       "showPassword": "Afficher le mot de passe",
       "hidePassword": "Masquer le mot de passe",
       "submit": "Se connecter",

--- a/webui/src/i18n/locales/id/common.json
+++ b/webui/src/i18n/locales/id/common.json
@@ -7,15 +7,17 @@
     },
     "error": {
       "title": "Tidak dapat menjangkau nanobot",
-      "gatewayHint": "Pastikan gateway sedang berjalan (`nanobot gateway`) dan halaman ini dibuka pada mesin yang sama."
+      "gatewayHint": "Pastikan gateway sedang berjalan (`nanobot gateway`) dan browser ini dapat menjangkau alamat WebUI-nya."
     },
     "auth": {
-      "label": "Kata sandi",
+      "title": "Hubungkan ke nanobot",
+      "label": "Kata sandi WebUI",
+      "help": "Temukan kata sandi ini di channels.websocket.tokenIssueSecret dalam konfigurasi nanobot, biasanya ~/.nanobot/config.json.",
       "showPassword": "Tampilkan kata sandi",
       "hidePassword": "Sembunyikan kata sandi",
       "submit": "Hubungkan",
-      "required": "Masukkan kata sandi.",
-      "invalid": "Kata sandi salah. Coba lagi."
+      "required": "Masukkan kata sandi WebUI.",
+      "invalid": "Kata sandi WebUI tersebut tidak diterima. Salin dari konfigurasi nanobot lalu coba lagi."
     },
     "account": {
       "section": "Akun",

--- a/webui/src/i18n/locales/id/common.json
+++ b/webui/src/i18n/locales/id/common.json
@@ -12,7 +12,7 @@
     "auth": {
       "title": "Hubungkan ke nanobot",
       "label": "Kata sandi WebUI",
-      "help": "Temukan kata sandi ini di channels.websocket.tokenIssueSecret dalam konfigurasi nanobot, biasanya ~/.nanobot/config.json.",
+      "help": "Temukan kata sandi ini di channels.websocket.tokenIssueSecret dalam konfigurasi nanobot, biasanya ~/.nanobot/config.json. Jika nilainya kosong, gunakan channels.websocket.token.",
       "showPassword": "Tampilkan kata sandi",
       "hidePassword": "Sembunyikan kata sandi",
       "submit": "Hubungkan",

--- a/webui/src/i18n/locales/ja/common.json
+++ b/webui/src/i18n/locales/ja/common.json
@@ -7,15 +7,17 @@
     },
     "error": {
       "title": "nanobot に接続できませんでした",
-      "gatewayHint": "gateway（`nanobot gateway`）が起動しており、このページが同じマシン上で開かれていることを確認してください。"
+      "gatewayHint": "gateway（`nanobot gateway`）が起動しており、このブラウザーから WebUI のアドレスに到達できることを確認してください。"
     },
     "auth": {
-      "label": "パスワード",
+      "title": "nanobot に接続",
+      "label": "WebUI パスワード",
+      "help": "このパスワードは nanobot の設定内の channels.websocket.tokenIssueSecret にあります。通常は ~/.nanobot/config.json です。",
       "showPassword": "パスワードを表示",
       "hidePassword": "パスワードを隠す",
       "submit": "接続",
-      "required": "パスワードを入力してください。",
-      "invalid": "パスワードが正しくありません。もう一度お試しください。"
+      "required": "WebUI パスワードを入力してください。",
+      "invalid": "その WebUI パスワードは受け付けられませんでした。nanobot の設定からコピーして、もう一度お試しください。"
     },
     "account": {
       "section": "アカウント",

--- a/webui/src/i18n/locales/ja/common.json
+++ b/webui/src/i18n/locales/ja/common.json
@@ -12,7 +12,7 @@
     "auth": {
       "title": "nanobot に接続",
       "label": "WebUI パスワード",
-      "help": "このパスワードは nanobot の設定内の channels.websocket.tokenIssueSecret にあります。通常は ~/.nanobot/config.json です。",
+      "help": "このパスワードは nanobot の設定内の channels.websocket.tokenIssueSecret にあります。通常は ~/.nanobot/config.json です。この値が空の場合は channels.websocket.token を使用してください。",
       "showPassword": "パスワードを表示",
       "hidePassword": "パスワードを隠す",
       "submit": "接続",

--- a/webui/src/i18n/locales/ko/common.json
+++ b/webui/src/i18n/locales/ko/common.json
@@ -12,7 +12,7 @@
     "auth": {
       "title": "nanobot에 연결",
       "label": "WebUI 비밀번호",
-      "help": "이 비밀번호는 nanobot 설정의 channels.websocket.tokenIssueSecret에 있으며, 일반적으로 ~/.nanobot/config.json에 저장됩니다.",
+      "help": "이 비밀번호는 nanobot 설정의 channels.websocket.tokenIssueSecret에 있으며, 일반적으로 ~/.nanobot/config.json에 저장됩니다. 이 값이 비어 있으면 channels.websocket.token을 사용하세요.",
       "showPassword": "비밀번호 표시",
       "hidePassword": "비밀번호 숨기기",
       "submit": "연결",

--- a/webui/src/i18n/locales/ko/common.json
+++ b/webui/src/i18n/locales/ko/common.json
@@ -7,15 +7,17 @@
     },
     "error": {
       "title": "nanobot에 연결할 수 없습니다",
-      "gatewayHint": "gateway(`nanobot gateway`)가 실행 중인지, 그리고 이 페이지가 같은 머신에서 열려 있는지 확인하세요."
+      "gatewayHint": "gateway(`nanobot gateway`)가 실행 중이고 이 브라우저에서 WebUI 주소에 접근할 수 있는지 확인하세요."
     },
     "auth": {
-      "label": "비밀번호",
+      "title": "nanobot에 연결",
+      "label": "WebUI 비밀번호",
+      "help": "이 비밀번호는 nanobot 설정의 channels.websocket.tokenIssueSecret에 있으며, 일반적으로 ~/.nanobot/config.json에 저장됩니다.",
       "showPassword": "비밀번호 표시",
       "hidePassword": "비밀번호 숨기기",
       "submit": "연결",
-      "required": "비밀번호를 입력하세요.",
-      "invalid": "비밀번호가 올바르지 않습니다. 다시 시도하세요."
+      "required": "WebUI 비밀번호를 입력하세요.",
+      "invalid": "해당 WebUI 비밀번호가 허용되지 않았습니다. nanobot 설정에서 복사한 후 다시 시도하세요."
     },
     "account": {
       "section": "계정",

--- a/webui/src/i18n/locales/pt-BR/common.json
+++ b/webui/src/i18n/locales/pt-BR/common.json
@@ -7,15 +7,17 @@
     },
     "error": {
       "title": "Não foi possível conectar-se com o nanobot",
-      "gatewayHint": "Verifique se o gateway está em execução (`nanobot gateway`) e se esta página está aberta na mesma máquina."
+      "gatewayHint": "Verifique se o gateway está em execução (`nanobot gateway`) e se este navegador consegue acessar o endereço da WebUI."
     },
     "auth": {
-      "label": "Senha",
+      "title": "Conectar ao nanobot",
+      "label": "Senha da WebUI",
+      "help": "Encontre esta senha em channels.websocket.tokenIssueSecret na configuração do nanobot, normalmente em ~/.nanobot/config.json.",
       "showPassword": "Mostrar senha",
       "hidePassword": "Ocultar senha",
       "submit": "Conectar",
-      "required": "Digite a senha.",
-      "invalid": "Senha incorreta. Tente novamente."
+      "required": "Digite a senha da WebUI.",
+      "invalid": "Essa senha da WebUI não foi aceita. Copie-a da configuração do nanobot e tente novamente."
     },
     "account": {
       "section": "Conta",

--- a/webui/src/i18n/locales/pt-BR/common.json
+++ b/webui/src/i18n/locales/pt-BR/common.json
@@ -12,7 +12,7 @@
     "auth": {
       "title": "Conectar ao nanobot",
       "label": "Senha da WebUI",
-      "help": "Encontre esta senha em channels.websocket.tokenIssueSecret na configuração do nanobot, normalmente em ~/.nanobot/config.json.",
+      "help": "Encontre esta senha em channels.websocket.tokenIssueSecret na configuração do nanobot, normalmente em ~/.nanobot/config.json. Se esse valor estiver vazio, use channels.websocket.token.",
       "showPassword": "Mostrar senha",
       "hidePassword": "Ocultar senha",
       "submit": "Conectar",

--- a/webui/src/i18n/locales/vi/common.json
+++ b/webui/src/i18n/locales/vi/common.json
@@ -7,15 +7,17 @@
     },
     "error": {
       "title": "Không thể kết nối tới nanobot",
-      "gatewayHint": "Hãy chắc chắn gateway đang chạy (`nanobot gateway`) và trang này được mở trên cùng máy."
+      "gatewayHint": "Hãy chắc chắn gateway đang chạy (`nanobot gateway`) và trình duyệt này có thể truy cập địa chỉ WebUI của gateway."
     },
     "auth": {
-      "label": "Mật khẩu",
+      "title": "Kết nối với nanobot",
+      "label": "Mật khẩu WebUI",
+      "help": "Tìm mật khẩu này tại channels.websocket.tokenIssueSecret trong cấu hình nanobot, thường là ~/.nanobot/config.json.",
       "showPassword": "Hiện mật khẩu",
       "hidePassword": "Ẩn mật khẩu",
       "submit": "Kết nối",
-      "required": "Nhập mật khẩu.",
-      "invalid": "Mật khẩu không đúng. Hãy thử lại."
+      "required": "Nhập mật khẩu WebUI.",
+      "invalid": "Mật khẩu WebUI đó không được chấp nhận. Hãy sao chép từ cấu hình nanobot rồi thử lại."
     },
     "account": {
       "section": "Tài khoản",

--- a/webui/src/i18n/locales/vi/common.json
+++ b/webui/src/i18n/locales/vi/common.json
@@ -12,7 +12,7 @@
     "auth": {
       "title": "Kết nối với nanobot",
       "label": "Mật khẩu WebUI",
-      "help": "Tìm mật khẩu này tại channels.websocket.tokenIssueSecret trong cấu hình nanobot, thường là ~/.nanobot/config.json.",
+      "help": "Tìm mật khẩu này tại channels.websocket.tokenIssueSecret trong cấu hình nanobot, thường là ~/.nanobot/config.json. Nếu giá trị này trống, hãy dùng channels.websocket.token.",
       "showPassword": "Hiện mật khẩu",
       "hidePassword": "Ẩn mật khẩu",
       "submit": "Kết nối",

--- a/webui/src/i18n/locales/zh-CN/common.json
+++ b/webui/src/i18n/locales/zh-CN/common.json
@@ -12,7 +12,7 @@
     "auth": {
       "title": "连接到 nanobot",
       "label": "WebUI 密码",
-      "help": "请在 nanobot 配置中的 channels.websocket.tokenIssueSecret 查找此密码，配置文件通常位于 ~/.nanobot/config.json。",
+      "help": "请在 nanobot 配置中的 channels.websocket.tokenIssueSecret 查找此密码，配置文件通常位于 ~/.nanobot/config.json。若该值为空，请使用 channels.websocket.token。",
       "showPassword": "显示密码",
       "hidePassword": "隐藏密码",
       "submit": "连接",

--- a/webui/src/i18n/locales/zh-CN/common.json
+++ b/webui/src/i18n/locales/zh-CN/common.json
@@ -7,15 +7,17 @@
     },
     "error": {
       "title": "无法连接到 nanobot",
-      "gatewayHint": "请确认网关已启动（`nanobot gateway`），并且当前页面与网关运行在同一台机器上。"
+      "gatewayHint": "请确认网关已启动（`nanobot gateway`），并且当前浏览器可以访问它的 WebUI 地址。"
     },
     "auth": {
-      "label": "密码",
+      "title": "连接到 nanobot",
+      "label": "WebUI 密码",
+      "help": "请在 nanobot 配置中的 channels.websocket.tokenIssueSecret 查找此密码，配置文件通常位于 ~/.nanobot/config.json。",
       "showPassword": "显示密码",
       "hidePassword": "隐藏密码",
       "submit": "连接",
-      "required": "请输入密码。",
-      "invalid": "密码错误，请重试。"
+      "required": "请输入 WebUI 密码。",
+      "invalid": "该 WebUI 密码未通过验证。请从 nanobot 配置中复制密码后重试。"
     },
     "account": {
       "section": "账户",

--- a/webui/src/i18n/locales/zh-TW/common.json
+++ b/webui/src/i18n/locales/zh-TW/common.json
@@ -7,15 +7,17 @@
     },
     "error": {
       "title": "無法連線到 nanobot",
-      "gatewayHint": "請確認閘道已啟動（`nanobot gateway`），並且目前頁面與閘道在同一台機器上開啟。"
+      "gatewayHint": "請確認閘道已啟動（`nanobot gateway`），並且目前瀏覽器可以存取它的 WebUI 位址。"
     },
     "auth": {
-      "label": "密碼",
+      "title": "連線到 nanobot",
+      "label": "WebUI 密碼",
+      "help": "請在 nanobot 設定中的 channels.websocket.tokenIssueSecret 尋找此密碼，設定檔通常位於 ~/.nanobot/config.json。",
       "showPassword": "顯示密碼",
       "hidePassword": "隱藏密碼",
       "submit": "連線",
-      "required": "請輸入密碼。",
-      "invalid": "密碼錯誤，請再試一次。"
+      "required": "請輸入 WebUI 密碼。",
+      "invalid": "該 WebUI 密碼未通過驗證。請從 nanobot 設定中複製密碼後再試一次。"
     },
     "account": {
       "section": "帳戶",

--- a/webui/src/i18n/locales/zh-TW/common.json
+++ b/webui/src/i18n/locales/zh-TW/common.json
@@ -12,7 +12,7 @@
     "auth": {
       "title": "連線到 nanobot",
       "label": "WebUI 密碼",
-      "help": "請在 nanobot 設定中的 channels.websocket.tokenIssueSecret 尋找此密碼，設定檔通常位於 ~/.nanobot/config.json。",
+      "help": "請在 nanobot 設定中的 channels.websocket.tokenIssueSecret 尋找此密碼，設定檔通常位於 ~/.nanobot/config.json。若該值為空，請使用 channels.websocket.token。",
       "showPassword": "顯示密碼",
       "hidePassword": "隱藏密碼",
       "submit": "連線",

--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -349,9 +349,11 @@ describe("App layout", () => {
 
     render(<App />);
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Password" }))
+    expect(await screen.findByRole("heading", { level: 1, name: "Connect to nanobot" }))
       .toBeInTheDocument();
-    const password = screen.getByLabelText("Password");
+    const password = screen.getByLabelText("WebUI password");
+    expect(screen.getByText(/channels\.websocket\.tokenIssueSecret/))
+      .toBeInTheDocument();
     expect(password).toHaveAttribute(
       "autocomplete",
       "current-password",
@@ -359,7 +361,7 @@ describe("App layout", () => {
     expect(password).not.toHaveAttribute("placeholder");
     expect(screen.queryByText("Authentication required")).not.toBeInTheDocument();
     expect(
-      screen.queryByText("Incorrect password. Try again."),
+      screen.queryByText(/WebUI password wasn't accepted/),
     ).not.toBeInTheDocument();
     expect(connectSpy).not.toHaveBeenCalled();
   });
@@ -372,7 +374,7 @@ describe("App layout", () => {
 
     render(<App />);
 
-    const password = await screen.findByLabelText("Password");
+    const password = await screen.findByLabelText("WebUI password");
     await user.type(password, "correct horse battery staple");
     expect(password).toHaveAttribute("type", "password");
 
@@ -397,16 +399,19 @@ describe("App layout", () => {
 
     render(<App />);
 
-    const password = await screen.findByLabelText("Password");
+    const password = await screen.findByLabelText("WebUI password");
     const connect = screen.getByRole("button", { name: "Connect" });
     expect(connect).toBeEnabled();
     fireEvent.click(connect);
 
     expect(await screen.findByRole("alert")).toHaveTextContent(
-      "Enter your password.",
+      "Enter the WebUI password.",
     );
     expect(password).toHaveAttribute("aria-invalid", "true");
-    expect(password).toHaveAttribute("aria-describedby", "webui-auth-error");
+    expect(password).toHaveAttribute(
+      "aria-describedby",
+      "webui-auth-help webui-auth-error",
+    );
     expect(password).toHaveFocus();
     expect(fetchBootstrap).toHaveBeenCalledTimes(1);
   });
@@ -420,10 +425,10 @@ describe("App layout", () => {
 
     render(<App />);
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Password" }))
+    expect(await screen.findByRole("heading", { level: 1, name: "Connect to nanobot" }))
       .toBeInTheDocument();
     expect(
-      screen.queryByText("Incorrect password. Try again."),
+      screen.queryByText(/WebUI password wasn't accepted/),
     ).not.toBeInTheDocument();
     expect(connectSpy).not.toHaveBeenCalled();
   });
@@ -435,13 +440,13 @@ describe("App layout", () => {
 
     render(<App />);
 
-    const password = await screen.findByLabelText("Password");
+    const password = await screen.findByLabelText("WebUI password");
     fireEvent.change(password, { target: { value: "wrong-password" } });
     fireEvent.click(screen.getByRole("button", { name: "Connect" }));
 
-    const retryPassword = await screen.findByLabelText("Password");
+    const retryPassword = await screen.findByLabelText("WebUI password");
     expect(await screen.findByRole("alert")).toHaveTextContent(
-      "Incorrect password. Try again.",
+      "That WebUI password wasn't accepted. Copy it from the nanobot config and try again.",
     );
     expect(retryPassword).toHaveAttribute("aria-invalid", "true");
     expect(retryPassword).toHaveFocus();

--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -354,6 +354,9 @@ describe("App layout", () => {
     const password = screen.getByLabelText("WebUI password");
     expect(screen.getByText(/channels\.websocket\.tokenIssueSecret/))
       .toBeInTheDocument();
+    expect(password).toHaveAccessibleDescription(
+      /If that value is empty, use channels\.websocket\.token\./,
+    );
     expect(password).toHaveAttribute(
       "autocomplete",
       "current-password",


### PR DESCRIPTION
## Summary

- detect text-only browsers such as `links`, `lynx`, and `w3m` before handing them the WebUI
- print a manual handoff when the standard WebUI launcher cannot open a browser or uses `--no-open`; derive the SSH target from the configured IPv4, IPv6, or interface address and open a localhost URL on the client
- make the WebUI login form explain both `tokenIssueSecret` and static `token` password sources, and how to recover from a rejected value, across every bundled locale
- keep the password help and validation feedback associated with the input for keyboard and screen-reader users

## Why

On a headless server, `nanobot webui` can open a text browser that cannot run the React app. When the user switches to a browser on another machine, the default localhost bind and the unexplained password prompt leave them without an in-flow recovery path. This change keeps the safe localhost default while making the SSH and password handoff self-contained, so the user does not need to discover the answer in documentation.

Fixes #5726.

This addresses the onboarding gap documented by #5727 at the product-flow level.

## Verification

- `python -m pytest tests/cli/test_commands.py -k "print_webui_manual_access or open_webui_browser or text_only_browser" -q` — 9 passed
- Bootstrap-route regressions for static-token fallback and localhost secret enforcement — 2 passed
- `python -m ruff check nanobot/cli/webui.py nanobot/cli/webui_support.py tests/cli/test_commands.py` — passed
- `python -m basedpyright nanobot/cli/webui.py nanobot/cli/webui_support.py` — 0 errors
- `cd webui && bun run test -- app-layout.test.tsx i18n.test.tsx` — 97 passed
- `cd webui && bun run lint` — passed
- `cd webui && bun run build` — passed
- Real gateway + Playwright: verified both password sources, empty/rejected password recovery, keyboard and ARIA behavior, WebSocket traffic, authentication after refresh, and all 10 locales without horizontal overflow at 320px
- Separate Linux host over real SSH tunnels: IPv4 loopback, IPv6 loopback, and a specific network interface all passed browser login, rejected-password recovery, WebSocket communication, and refresh; the IPv6 case used only the static `token`
