### PR TITLE
fix(email): disable intermediate progress delivery

### DIFF
--- a/nanobot/channels/email/runtime.py
+++ b/nanobot/channels/email/runtime.py
@@ -94,6 +94,8 @@ class EmailChannel(BaseChannel):
 
     name = "email"
     display_name = "Email"
+    send_progress = False
+    send_tool_hints = False
     _IMAP_MONTHS = (
         "Jan",
         "Feb",
@@ -127,6 +129,10 @@ class EmailChannel(BaseChannel):
     @classmethod
     def default_config(cls) -> dict[str, Any]:
         return EmailConfig().model_dump(by_alias=True)
+
+    def progress_transport_defaults(self) -> tuple[bool, bool]:
+        """Email delivers one final reply instead of intermediate trace messages."""
+        return False, False
 
     def __init__(self, config: Any, bus: MessageBus):
         if isinstance(config, dict):

--- a/nanobot/channels/email/tests/test_email_channel.py
+++ b/nanobot/channels/email/tests/test_email_channel.py
@@ -8,7 +8,10 @@ import pytest
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.outbound_events import ProgressEvent
 from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
 from nanobot.channels.email.runtime import EmailChannel, EmailConfig
+from nanobot.channels.manager import ChannelManager
+from nanobot.config.schema import Config
 
 
 def _make_config(**overrides) -> EmailConfig:
@@ -48,6 +51,19 @@ def _make_raw_email(
         msg["Authentication-Results"] = auth_results
     msg.set_content(body)
     return msg.as_bytes()
+
+
+def test_email_only_enables_final_reply_delivery() -> None:
+    manager = ChannelManager.__new__(ChannelManager)
+    manager.config = Config.model_validate({"channels": {"email": {"enabled": True}}})
+    manager.bus = MessageBus()
+
+    channel = manager._build_channel("email", EmailChannel, {"enabled": True})
+
+    assert channel.send_progress is False
+    assert channel.send_tool_hints is False
+    assert channel.supports_streaming is False
+    assert type(channel).send_reasoning_delta is BaseChannel.send_reasoning_delta
 
 
 def test_fetch_new_messages_parses_unseen_and_marks_seen(monkeypatch) -> None:


### PR DESCRIPTION
Email already dropped progress events at the SMTP edge, but the channel manager still enabled progress and tool-hint delivery from the global defaults. This made nanobot generate and queue intermediate events that an email transport cannot present.

Give Email channel-owned `false` defaults for both transports while keeping the existing send-time guard. Email now produces one final reply only; token streaming and reasoning remain unsupported by its base implementations.

Validation:
- `python -m pytest nanobot/channels/email/tests/test_email_channel.py -q` (50 passed)
- `ruff check nanobot/channels/email/runtime.py nanobot/channels/email/tests/test_email_channel.py`
- `basedpyright nanobot/channels/email/runtime.py nanobot/channels/email/tests/test_email_channel.py`
