### PR TITLE
perf(webui): reduce long-text streaming refresh overhead

### DIFF
--- a/webui/src/components/thread/activity/ActivityStep.tsx
+++ b/webui/src/components/thread/activity/ActivityStep.tsx
@@ -12,8 +12,10 @@ export interface ActivityStepProps {
   marker?: ReactNode;
   showMarker?: boolean;
   label: ReactNode;
+  tooltipContent?: ReactNode;
   ariaLabel?: string;
   active?: boolean;
+  animateLabel?: boolean;
   tone?: ActivityStepTone;
   className?: string;
   contentClassName?: string;
@@ -27,8 +29,10 @@ export function ActivityStep({
   marker,
   showMarker = true,
   label,
+  tooltipContent,
   ariaLabel,
   active = false,
+  animateLabel = true,
   tone = active ? "active" : "neutral",
   className,
   contentClassName,
@@ -43,7 +47,7 @@ export function ActivityStep({
       className="flex min-w-0 items-center gap-1.5 overflow-hidden whitespace-nowrap"
     >
       <StreamingLabelSheen
-        active={active}
+        active={active && animateLabel}
         className={cn(
           "min-w-0 flex-1 truncate font-medium",
           tone === "error" ? "text-destructive/78" : "text-muted-foreground/85",
@@ -95,7 +99,7 @@ export function ActivityStep({
             <Tooltip>
               <TooltipTrigger asChild>{line}</TooltipTrigger>
               <TooltipContent side="top" className="max-w-[min(32rem,calc(100vw-2rem))] whitespace-pre-wrap break-words">
-                {label}
+                {tooltipContent ?? label}
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>

--- a/webui/src/components/thread/activity/ReasoningRow.tsx
+++ b/webui/src/components/thread/activity/ReasoningRow.tsx
@@ -21,12 +21,19 @@ export function ReasoningRow({
     ? t("message.reasoningStreaming", { defaultValue: "Thinking…" })
     : t("message.reasoning", { defaultValue: "Thinking" });
   const preview = compactReasoningPreview(text) || fallback;
+  // CSS ellipsis still lays out the full string, including the animated copy.
+  const truncated = preview.length > 512;
+  const label = truncated
+    ? preview.slice(0, 512).replace(/[\uD800-\uDBFF]$/, "") + "…"
+    : preview;
   return (
     <ActivityStep
       marker={<ReasoningMarker streaming={streaming} />}
       active={streaming}
+      animateLabel={!truncated}
       tone={streaming ? "active" : "success"}
-      label={preview}
+      label={label}
+      tooltipContent={preview}
       labelClassName="italic text-muted-foreground/78"
       contentClassName="overflow-hidden"
       className={className}

--- a/webui/src/hooks/useNanobotStream.ts
+++ b/webui/src/hooks/useNanobotStream.ts
@@ -63,6 +63,8 @@ type PendingStreamEvent =
   | { kind: "reasoning"; text: string; turn: UIMessageTurnFields };
 
 const BACKGROUND_STREAM_FLUSH_INTERVAL_MS = 1_000;
+// Markdown and layout work must leave room for input between visible updates.
+const VISIBLE_STREAM_FLUSH_INTERVAL_MS = 50;
 
 /**
  * Append a reasoning chunk to the last open reasoning stream in ``prev``.
@@ -303,6 +305,7 @@ export function useNanobotStream(
   const pendingStreamEventsRef = useRef<PendingStreamEvent[]>([]);
   const streamFrameRef = useRef<number | null>(null);
   const streamTimerRef = useRef<number | null>(null);
+  const lastStreamFlushRef = useRef(0);
   const suppressStreamUntilTurnEndRef = useRef(false);
   const sideChannelTurnIdsRef = useRef<Set<string>>(new Set());
 
@@ -328,6 +331,7 @@ export function useNanobotStream(
       streamTimerRef.current = null;
     }
     pendingStreamEventsRef.current = [];
+    lastStreamFlushRef.current = 0;
   }, []);
 
   const isSideChannelEvent = useCallback((ev: InboundEvent) => {
@@ -580,6 +584,7 @@ export function useNanobotStream(
     turn?: UIMessageTurnFields;
     source?: UIMessage["source"];
   }) => {
+    lastStreamFlushRef.current = 0;
     if (streamFrameRef.current !== null) {
       window.cancelAnimationFrame(streamFrameRef.current);
       streamFrameRef.current = null;
@@ -659,7 +664,7 @@ export function useNanobotStream(
     });
   }, [applyPendingStreamEvents, closeActiveAssistantStream, resolveActiveAssistantIndex]);
 
-  const schedulePendingStreamFlush = useCallback(() => {
+  const schedulePendingStreamFlush = useCallback(function schedule() {
     if (streamFrameRef.current !== null || streamTimerRef.current !== null) return;
     if (document.visibilityState === "hidden" || !threadVisibleRef.current) {
       streamTimerRef.current = window.setTimeout(() => {
@@ -671,11 +676,21 @@ export function useNanobotStream(
       }, BACKGROUND_STREAM_FLUSH_INTERVAL_MS);
       return;
     }
+    const delay = VISIBLE_STREAM_FLUSH_INTERVAL_MS
+      - (performance.now() - lastStreamFlushRef.current);
+    if (delay > 0) {
+      streamTimerRef.current = window.setTimeout(() => {
+        streamTimerRef.current = null;
+        schedule();
+      }, delay);
+      return;
+    }
     streamFrameRef.current = window.requestAnimationFrame(() => {
       streamFrameRef.current = null;
       const events = pendingStreamEventsRef.current;
       if (events.length === 0) return;
       pendingStreamEventsRef.current = [];
+      lastStreamFlushRef.current = performance.now();
       setMessages((prev) => applyPendingStreamEvents(prev, events));
     });
   }, [applyPendingStreamEvents]);
@@ -683,22 +698,31 @@ export function useNanobotStream(
   useEffect(() => {
     if (threadVisible) {
       flushPendingStreamEvents();
-    } else if (streamFrameRef.current !== null) {
-      window.cancelAnimationFrame(streamFrameRef.current);
+    } else if (streamFrameRef.current !== null || streamTimerRef.current !== null) {
+      if (streamFrameRef.current !== null) window.cancelAnimationFrame(streamFrameRef.current);
       streamFrameRef.current = null;
+      if (streamTimerRef.current !== null) window.clearTimeout(streamTimerRef.current);
+      streamTimerRef.current = null;
       schedulePendingStreamFlush();
     }
   }, [threadVisible, flushPendingStreamEvents, schedulePendingStreamFlush]);
 
   useEffect(() => {
-    const flushOnReturn = () => {
-      if (document.visibilityState !== "visible" || !threadVisibleRef.current) return;
+    const onVisibilityChange = () => {
       if (pendingStreamEventsRef.current.length === 0) return;
-      flushPendingStreamEvents();
+      if (document.visibilityState === "visible" && threadVisibleRef.current) {
+        flushPendingStreamEvents();
+      } else {
+        if (streamFrameRef.current !== null) window.cancelAnimationFrame(streamFrameRef.current);
+        streamFrameRef.current = null;
+        if (streamTimerRef.current !== null) window.clearTimeout(streamTimerRef.current);
+        streamTimerRef.current = null;
+        schedulePendingStreamFlush();
+      }
     };
-    document.addEventListener("visibilitychange", flushOnReturn);
-    return () => document.removeEventListener("visibilitychange", flushOnReturn);
-  }, [flushPendingStreamEvents]);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, [flushPendingStreamEvents, schedulePendingStreamFlush]);
 
   useEffect(() => {
     if (!chatId) return;

--- a/webui/src/tests/reasoning-row.test.tsx
+++ b/webui/src/tests/reasoning-row.test.tsx
@@ -20,3 +20,34 @@ it("shows the reasoning preview in the shared tooltip on hover and keyboard focu
   await user.keyboard("{Escape}");
   expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 });
+
+it("bounds reasoning text without repainting a truncated label and keeps the complete tooltip current", async () => {
+  const user = userEvent.setup();
+  const text = "A long reasoning paragraph. ".repeat(2_000) + "original tail";
+  const { container, rerender } = render(<ReasoningRow text={text} streaming />);
+  const line = screen.getByTestId("activity-line");
+
+  expect(line.textContent).toBe(text.slice(0, 512) + "…");
+  expect(container.querySelector("[data-sheen-text]")).toBeNull();
+  expect(screen.getByTestId("activity-reasoning-marker")).toHaveAttribute("data-state", "thinking");
+  expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+  await user.tab();
+  expect(line).toHaveFocus();
+  expect(await screen.findByRole("tooltip")).toHaveTextContent(text);
+  rerender(<ReasoningRow text={text + " latest tail"} streaming />);
+  expect(screen.getByRole("tooltip")).toHaveTextContent(text + " latest tail");
+  await user.keyboard("{Escape}");
+  expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  expect(line.textContent).toBe(text.slice(0, 512) + "…");
+});
+
+it("keeps the existing text animation for short active reasoning", () => {
+  const { container } = render(<ReasoningRow text="Short active reasoning" streaming />);
+  expect(container.querySelector("[data-sheen-text]")).toHaveAttribute("data-sheen-text", "Short active reasoning");
+});
+
+it("does not split a surrogate pair at the reasoning preview boundary", () => {
+  render(<ReasoningRow text={"x".repeat(511) + "🚀 tail"} streaming />);
+  expect(screen.getByTestId("activity-line").textContent).toBe("x".repeat(511) + "…");
+});

--- a/webui/src/tests/useNanobotStream.test.tsx
+++ b/webui/src/tests/useNanobotStream.test.tsx
@@ -296,6 +296,95 @@ describe("useNanobotStream", () => {
     requestFrame.mockRestore();
   });
 
+  it("paces visible updates and immediately flushes the final ordered text", () => {
+    vi.useFakeTimers();
+    const now = vi.spyOn(performance, "now").mockReturnValue(1_000);
+    const frames: FrameRequestCallback[] = [];
+    const requestFrame = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    const fake = fakeClient();
+    const { result, unmount } = renderHook(() => useNanobotStream("paced", EMPTY_MESSAGES), {
+      wrapper: wrap(fake.client),
+    });
+    try {
+      act(() => fake.emit("paced", { event: "delta", chat_id: "paced", text: "first" }));
+      expect(frames).toHaveLength(1);
+      act(() => frames.shift()!(1_000));
+      expect(result.current.messages[0].content).toBe("first");
+      act(() => {
+        fake.emit("paced", { event: "delta", chat_id: "paced", text: " 中文" });
+        fake.emit("paced", { event: "delta", chat_id: "paced", text: "🚀" });
+        vi.advanceTimersByTime(49);
+      });
+      expect(frames).toHaveLength(0);
+      expect(result.current.messages[0].content).toBe("first");
+      now.mockReturnValue(1_050);
+      act(() => vi.advanceTimersByTime(1));
+      expect(frames).toHaveLength(1);
+      act(() => frames.shift()!(1_050));
+      expect(result.current.messages[0].content).toBe("first 中文🚀");
+      act(() => {
+        fake.emit("paced", { event: "delta", chat_id: "paced", text: " tail" });
+        fake.emit("paced", { event: "stream_end", chat_id: "paced" });
+      });
+      expect(result.current.messages[0].content).toBe("first 中文🚀 tail");
+      act(() => fake.emit("paced", { event: "turn_end", chat_id: "paced" }));
+      expect(result.current.messages[0].isStreaming).toBe(false);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      unmount();
+      requestFrame.mockRestore();
+      now.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it.each(["frame", "timer"] as const)("moves a pending visible %s to background cadence and flushes on return", (pending) => {
+    vi.useFakeTimers();
+    const descriptor = Object.getOwnPropertyDescriptor(document, "visibilityState");
+    const now = vi.spyOn(performance, "now").mockReturnValue(1_000);
+    const frames: FrameRequestCallback[] = [];
+    const requestFrame = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    const fake = fakeClient();
+    const { result, unmount } = renderHook(() => useNanobotStream("visibility", EMPTY_MESSAGES), {
+      wrapper: wrap(fake.client),
+    });
+    const visibility = (value: string) => {
+      Object.defineProperty(document, "visibilityState", { configurable: true, value });
+      document.dispatchEvent(new Event("visibilitychange"));
+    };
+    try {
+      act(() => fake.emit("visibility", { event: "delta", chat_id: "visibility", text: "first" }));
+      if (pending === "timer") act(() => frames.shift()!(1_000));
+      act(() => {
+        fake.emit("visibility", { event: "delta", chat_id: "visibility", text: " hidden" });
+        visibility("hidden");
+        vi.advanceTimersByTime(999);
+      });
+      expect(result.current.messages[0]?.content).toBe(pending === "timer" ? "first" : undefined);
+      act(() => vi.advanceTimersByTime(1));
+      expect(result.current.messages[0].content).toBe("first hidden");
+      act(() => {
+        fake.emit("visibility", { event: "delta", chat_id: "visibility", text: " returned" });
+        visibility("visible");
+      });
+      expect(result.current.messages[0].content).toBe("first hidden returned");
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      unmount();
+      requestFrame.mockRestore();
+      now.mockRestore();
+      if (descriptor) Object.defineProperty(document, "visibilityState", descriptor);
+      else delete (document as Document & { visibilityState?: string }).visibilityState;
+      vi.useRealTimers();
+    }
+  });
+
   it("coalesces hidden-tab deltas without scheduling paint frames", () => {
     vi.useFakeTimers();
     const visibilityDescriptor = Object.getOwnPropertyDescriptor(document, "visibilityState");


### PR DESCRIPTION
## Summary

Extract the WebUI portion of #5732. Related: [NAN-113](https://linear.app/nanobot-ai/issue/NAN-113).

- Bound the visible reasoning preview to 512 UTF-16 code units plus an ellipsis, without splitting a surrogate pair. Keep the complete compacted preview in the keyboard/hover tooltip and retain the full underlying reasoning.
- Disable the sheen on truncated labels while preserving the active Thinking marker and short-label animation.
- Pace visible streaming state updates with a minimum 50 ms interval before the next animation frame. Preserve event order, the existing background cadence, and immediate flushes on return, stop, and completion.

The diff contains three production files and two test files: 35 net production lines and 120 added test lines. It introduces no dependency or parsing framework. Whole-string reasoning compaction still runs; this does not make parsing incremental.

No TUI, Python helper, or classic Rich CLI changes are included. The TUI retained-text experiment stays outside this PR because its narrow fast path and mixed-Markdown memory regression do not yet justify its maintenance cost.

## Historical resource measurements and tradeoffs

These measurements come from the original experiment on base `aeb7b207d7e501b1dd5d8b68208813f493411331`, not a new benchmark of this PR's newer base `90b889394fb7f71510b0a63ed6124eed5c77f628`. All five extracted WebUI files are byte-equivalent to the measured patch. The full comparison JSON and limitations are attached to NAN-113; #5732 preserves the combined experiment report.

Three fresh-process rounds per variant; medians:

| WebUI workload | CPU seconds, before → after | CPU reduction | Private-commit peak, MiB | Working-set peak, MiB |
| --- | --- | --- | --- | --- |
| 50k reasoning prefix | 2.938 → 0.938 | 68.09% | 588.3 → 483.8 | 852.0 → 769.3 |
| 50k plain paragraph prefix | 5.328 → 2.453 | 53.96% | 667.8 → 606.8 | 933.4 → 882.8 |
| 10k formula prefix | 2.547 → 1.406 | 44.79% | 644.8 → 632.5 | 937.8 → 924.5 |

Pacing trades refresh granularity for lower CPU use. Paragraph delivery-to-DOM p95 improved from **110.90 to 74.70 ms**, but formula p95 increased from **22.92 to 59.90 ms**. Advancing DOM updates fell from **42.89 to 15.18/s** for paragraphs and **59.85 to 15.21/s** for formulas. All 400 deltas were retained. Reasoning-preview latency is not comparable once its visible prefix is bounded; complete tooltip content was checked separately.

Paragraph incremental private-commit peak fell from 153.83 to 88.89 MiB (42.22%), relative to an already-loaded prefix. Total browser working-set peak fell only about 5.4%; this is not a claim of 42% less total RAM.

### Method and limits

Windows / Intel i5-13400 / 16 logical CPUs; production WebUI in a dedicated Chromium process tree. An external producer sent **400 × 8 characters at 100 deltas/s** over approximately four seconds after loading the prefix. CPU is Win32 user+kernel time; memory was sampled every 100 ms. Gateway, producer, and sampler were excluded. Private commit is not resident RAM; summed browser working sets may double-count shared pages. DOM mutation is not final screen paint, and three medians are not a confidence interval.

These are synthetic long-text stress cases, not model tokens/s or representative daily traffic. Preview bounding and pacing were measured together. No general claim is made about battery life, temperature, typing/scroll latency, faster model output, or uniformly smoother streaming. Shorter, normal-rate workloads still need characterization.

## Validation on the split branch

- [x] WebUI full suite: 1,327 tests across 86 files, including pacing, visibility transitions, complete tooltips, and Unicode boundaries.
- [x] Production build, changed-file ESLint, and `git diff --check`.
- [x] Built WebUI through an isolated real gateway: split UTF-16 deltas, complete source copy, stop-buffer flush, short/long reasoning, full keyboard/hover tooltips, Escape, completion marker, and composer input.
- [x] Real `/model` command persisted replay: `webui-thread` HTTP 200 before and after refresh; no console/runtime errors in the checked flow.
- [x] Isolated browser/gateway cleanup; runtime removed and ports released.

Browser streaming checks inject synthetic events into the actual WebSocket client and capture Clipboard API writes; they do not call a paid LLM or modify the host clipboard. This split reruns functional validation, not the resource benchmark. The unit suite emits KaTeX and React `act` warnings but has no failed tests.
