### PR TITLE
fix(webui): omit binary data from tool progress

### DIFF
--- a/nanobot/channels/websocket/runtime.py
+++ b/nanobot/channels/websocket/runtime.py
@@ -49,7 +49,11 @@ from nanobot.webui.metadata import (
     WEBUI_TURN_METADATA_KEY,
 )
 from nanobot.webui.outbound_projection import WebUIOutboundProjector
-from nanobot.webui.outbound_wire import WebUIWirePayload, WebUIWirePersistence
+from nanobot.webui.outbound_wire import (
+    WebUIWirePayload,
+    WebUIWirePersistence,
+    project_tool_events,
+)
 from nanobot.webui.session_identity import is_valid_webui_chat_id
 from nanobot.webui.transcript import WEBUI_TRANSCRIPT_INCOMPLETE_KEY
 from nanobot.webui.websocket_logging import websockets_server_logger
@@ -1197,7 +1201,7 @@ class WebSocketChannel(BaseChannel):
         if isinstance(lat, (int, float)):
             payload["latency_ms"] = int(lat)
         if progress_event and progress_event.tool_events:
-            payload["tool_events"] = progress_event.tool_events
+            payload["tool_events"] = project_tool_events(progress_event.tool_events)
         agent_ui = msg.metadata.get(OUTBOUND_META_AGENT_UI)
         if agent_ui is not None:
             payload["agent_ui"] = agent_ui

--- a/nanobot/channels/websocket/tests/test_websocket_channel.py
+++ b/nanobot/channels/websocket/tests/test_websocket_channel.py
@@ -2316,6 +2316,56 @@ async def test_send_progress_includes_structured_tool_events() -> None:
 
 
 @pytest.mark.asyncio
+async def test_send_progress_omits_binary_tool_results_from_wire_and_transcript() -> None:
+    bus = MagicMock()
+    channel = WebSocketChannel({"enabled": True, "allowFrom": ["*"]}, bus, gateway=_basic_handler(bus))
+    mock_ws = AsyncMock()
+    channel._attach(mock_ws, "chat-binary-tool-result")
+    data_url = f"data:image/png;base64,{'A' * (2 * 1024 * 1024)}"
+    tool_events = [
+        {
+            "version": 1,
+            "phase": "end",
+            "call_id": "call-image",
+            "name": "read_file",
+            "arguments": {"path": "/media/screenshot.png"},
+            "result": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": data_url},
+                    "_meta": {"path": "/media/screenshot.png"},
+                },
+                {"type": "text", "text": "(Image file: /media/screenshot.png)"},
+            ],
+            "error": None,
+            "files": [],
+            "embeds": [],
+        }
+    ]
+
+    await channel.send(OutboundMessage(
+        channel="websocket",
+        chat_id="chat-binary-tool-result",
+        content="read_file completed",
+        event=ProgressEvent(content="read_file completed", tool_events=tool_events),
+    ))
+
+    payload = json.loads(mock_ws.send.await_args.args[0])
+    [wire_event] = payload["tool_events"]
+    assert wire_event["result"][0]["image_url"]["url"] == (
+        "[binary content omitted from WebUI]"
+    )
+    assert len(mock_ws.send.await_args.args[0].encode("utf-8")) < 4096
+
+    [persisted] = read_transcript_lines("websocket:chat-binary-tool-result")
+    assert persisted["tool_events"] == payload["tool_events"]
+    assert data_url not in json.dumps(persisted)
+
+    # WebUI projection must not alter the result that the runner sends back to the model.
+    assert tool_events[0]["result"][0]["image_url"]["url"] == data_url
+
+
+@pytest.mark.asyncio
 async def test_send_file_edit_progress_uses_file_edit_event() -> None:
     bus = MagicMock()
     channel = WebSocketChannel({"enabled": True, "allowFrom": ["*"]}, bus, gateway=_basic_handler(bus))

--- a/nanobot/webui/outbound_wire.py
+++ b/nanobot/webui/outbound_wire.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Literal, NotRequired, TypeAlias, TypedDict
+from typing import Any, Literal, NotRequired, TypeAlias, TypedDict, cast
 
 from nanobot.bus.outbound_events import (
     ContextCompactionEvent,
@@ -15,6 +15,49 @@ from nanobot.bus.outbound_events import (
 )
 from nanobot.events import AgentEvent
 from nanobot.webui.metadata import WEBUI_TURN_METADATA_KEY
+
+_JSONValue: TypeAlias = (
+    str | int | float | bool | None | list["_JSONValue"] | dict[str, "_JSONValue"]
+)
+
+_TOOL_EVENT_BINARY_OMISSION = "[binary content omitted from WebUI]"
+
+
+def _is_base64_data_url(value: str) -> bool:
+    candidate = value.lstrip()
+    return candidate[:5].casefold() == "data:" and ";base64," in candidate[:256].casefold()
+
+
+def _project_tool_event_value(value: object) -> _JSONValue:
+    """Copy one dynamic value while removing inline binary payloads."""
+    if value is None or isinstance(value, bool | int | float):
+        return value
+    if isinstance(value, str):
+        if _is_base64_data_url(value):
+            return _TOOL_EVENT_BINARY_OMISSION
+        return value
+    if isinstance(value, dict):
+        data = cast(dict[object, object], value)
+        return {
+            str(key): _project_tool_event_value(item)
+            for key, item in data.items()
+        }
+    if isinstance(value, list):
+        return [_project_tool_event_value(item) for item in cast(list[object], value)]
+    if isinstance(value, tuple):
+        return [_project_tool_event_value(item) for item in cast(tuple[object, ...], value)]
+    return str(value)
+
+
+def project_tool_events(events: list[dict[str, Any]]) -> list[dict[str, _JSONValue]]:
+    """Build WebUI-safe tool events without mutating model-facing results."""
+    projected_events: list[dict[str, _JSONValue]] = []
+    for event in events:
+        projected = _project_tool_event_value(cast(object, event))
+        if not isinstance(projected, dict):
+            continue
+        projected_events.append(projected)
+    return projected_events
 
 
 class _ChatWirePayload(TypedDict):


### PR DESCRIPTION
A read_file image result contains a base64 data URL so the model can inspect the image. The WebSocket adapter also copied that binary value into the browser progress frame and display transcript, turning a normal image read into a multi-megabyte WebUI record and consuming outbound/replay bandwidth.

Project tool events at the WebUI wire boundary and replace inline base64 data URLs with a small omission marker. The model-facing tool result remains unchanged, while ordinary structured tool results continue to reach the activity UI.

Validation:
- `pytest nanobot/channels/websocket/tests -q` (398 passed)
- `pytest tests/webui/test_outbound_wire.py -q` (6 passed)
- `ruff check nanobot/webui/outbound_wire.py nanobot/channels/websocket/runtime.py nanobot/channels/websocket/tests/test_websocket_channel.py`
- `uv run --no-sync basedpyright nanobot/webui/outbound_wire.py nanobot/channels/websocket/runtime.py`
