### PR TITLE
fix(webui): restore navigation after automation deletion

### DIFF
--- a/webui/src/components/settings/system/AutomationsSettings.tsx
+++ b/webui/src/components/settings/system/AutomationsSettings.tsx
@@ -553,7 +553,8 @@ function AutomationDetailPanel({
             {actionKey === `${job.enabled ? "disable" : "enable"}:${job.id}` ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" aria-hidden /> : null}
             {job.enabled ? tx("settings.automations.pause", "Pause") : tx("settings.automations.resume", "Resume")}
           </Button>
-          <DropdownMenu>
+          {/* The detail dialog owns modality, including during the delete handoff. */}
+          <DropdownMenu modal={false}>
             <DropdownMenuTrigger asChild>
               <Button variant="ghost" size="icon" className="h-8 w-8 rounded-full text-muted-foreground" disabled={busy} aria-label={tx("settings.automations.moreActions", "More actions")}>
                 <MoreHorizontal className="h-4 w-4" aria-hidden />

--- a/webui/src/tests/automations-settings.test.tsx
+++ b/webui/src/tests/automations-settings.test.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 
-import { AutomationEditDialog, AutomationsSettings } from "@/components/settings/system/AutomationsSettings";
+import { AutomationDeleteDialog, AutomationEditDialog, AutomationsSettings } from "@/components/settings/system/AutomationsSettings";
 import type { AutomationFilter, AutomationSort } from "@/components/settings/system/AutomationsSettings";
 import type { SessionAutomationJob } from "@/lib/types";
 
@@ -460,6 +460,66 @@ describe("Automation task list and detail sheet", () => {
     await user.click(screen.getByRole("menuitem", { name: "Delete" }));
     await waitFor(() => expect(remove).toHaveBeenCalledWith(task));
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it.each(["Cancel", "Delete"])("unlocks navigation after the real deletion flow ends with %s", async (operation) => {
+    const previousPointerEvents = document.body.style.pointerEvents;
+    onTestFinished(() => {
+      cleanup();
+      document.body.style.pointerEvents = previousPointerEvents;
+    });
+    // Exercise the real animated Radix presence lifecycle. The parent dialog
+    // may finish its exit before its nested menu; both must release modality.
+    const getStyle = window.getComputedStyle.bind(window);
+    vi.spyOn(window, "getComputedStyle").mockImplementation((node) => {
+      const style = getStyle(node);
+      if (!["menu", "dialog"].includes(node.getAttribute("role") ?? "")) return style;
+      return new Proxy(style, {
+        get(target, property) {
+          if (property === "animationName") return node.getAttribute("data-state") === "closed" ? "exit" : "enter";
+          const value = Reflect.get(target, property, target);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+    });
+    const finishExit = (node: HTMLElement) => {
+      const exit = new Event("animationend", { bubbles: true });
+      Object.defineProperty(exit, "animationName", { value: "exit" });
+      fireEvent(node, exit);
+    };
+    const user = userEvent.setup();
+    const navigate = vi.fn();
+    function DeletionHarness() {
+      const [jobs, setJobs] = useState([task, systemTask]);
+      const [pending, setPending] = useState<SessionAutomationJob | null>(null);
+      return <>
+        <button onClick={navigate}>Sidebar Apps</button>
+        <AutomationDeleteDialog job={pending} deleting={false}
+          onOpenChange={(open) => { if (!open) setPending(null); }}
+          onConfirm={(job) => {
+            setJobs((items) => items.filter((item) => item.id !== job.id));
+            setPending(null);
+          }} />
+        <Harness payload={{ jobs }} onRequestDelete={setPending} />
+      </>;
+    }
+    render(<DeletionHarness />);
+    await user.click(screen.getByRole("button", { name: /PR watch/ }));
+    const detail = screen.getByRole("dialog", { name: "PR watch" });
+    await user.click(screen.getByRole("button", { name: "More actions" }));
+    expect(document.body.style.pointerEvents).toBe("none");
+    await user.click(screen.getByRole("menuitem", { name: "Delete" }));
+    expect(detail).toHaveAttribute("data-state", "closed");
+    finishExit(detail);
+    const confirmation = await screen.findByRole("dialog", { name: "Delete automation" });
+    expect(document.body.style.pointerEvents).toBe("none");
+    await user.click(within(confirmation).getByRole("button", { name: operation, exact: true }));
+    finishExit(confirmation);
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(document.body.style.pointerEvents).not.toBe("none");
+    await user.click(screen.getByRole("button", { name: "Sidebar Apps" }));
+    expect(navigate).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("button", { name: /PR watch/ }) !== null).toBe(operation === "Cancel");
   });
 
   it("returns keyboard focus to the task after cancelling or saving the real editor", async () => {


### PR DESCRIPTION
## Summary

- Fix the sidebar and page becoming unclickable after deleting an automation.
- Let the detail dialog own the background interaction lock; its nested More actions menu is non-modal.
- Add regression tests for confirming and cancelling deletion with overlapping menu/dialog exit animations.

Closes [NAN-117](https://linear.app/nanobot-ai/issue/NAN-117/fixwebui-restore-navigation-after-automation-deletion).
Follow-up to #5740.

## Why

The nested menu and detail dialog both manage modal pointer locks. During the handoff to delete confirmation, their exit lifecycles can leave `body` with `pointer-events: none` after every popup is gone. This was reproduced in the production bundle but not in the development preview.

Only the menu inside the automation detail dialog changes. The parent dialog and delete confirmation remain modal, and there is no global pointer-style reset, dependency upgrade, or scheduler/data/API change.

## Validation

- Reproduced the failure before the fix in a production-built browser fixture and an animated Radix lifecycle regression test.
- `bun run test`: 1,368 tests across 89 files passed.
- `bun run lint`, `bun run build`, and `git diff --check` passed.
- Fixed production bundle: cancelled deletion, four consecutive deletions including the last personal task, subsequent outside-page button clicks, and Escape/Done cleanup all passed.

Browser checks used synthetic tasks only; no real scheduled tasks were changed. No breaking changes or data migration.
