### PR TITLE
fix(cron): preserve pending runs when editing automation details

### DIFF
--- a/nanobot/channels/websocket/tests/test_websocket_http_routes.py
+++ b/nanobot/channels/websocket/tests/test_websocket_http_routes.py
@@ -2417,6 +2417,60 @@ async def test_session_delete_removes_unpersisted_new_chat(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["every", "cron", "at"])
+async def test_webui_automation_edit_keeps_pending_run(bus, tmp_path, monkeypatch, kind):
+    now = 1_900_000_000_000
+    monkeypatch.setattr("nanobot.cron.service._now_ms", lambda: now)
+    schedules = {
+        "every": CronSchedule(kind="every", every_ms=60_000),
+        "cron": CronSchedule(kind="cron", expr="* * * * *", tz="UTC"),
+        "at": CronSchedule(kind="at", at_ms=now + 60_000),
+    }
+    cron = CronService(tmp_path / "cron" / "jobs.json")
+    job = cron.add_job(
+        name="Report",
+        schedule=schedules[kind],
+        message="Write the report",
+        session_key="websocket:report",
+        origin_channel="websocket",
+        origin_chat_id="report",
+    )
+    due_at = job.state.next_run_at_ms
+    assert due_at is not None
+    now = due_at + 1_000
+    channel = _ch(bus, cron_service=cron, workspace_path=tmp_path)
+    try:
+        response = await _webui_mutate(
+            channel,
+            "automation.update",
+            {
+                "id": job.id,
+                "values": {
+                    "name": "Updated report",
+                    "message": "Include the latest figures",
+                    "schedule": {
+                        "kind": kind,
+                        "every_ms": job.schedule.every_ms,
+                        "at_ms": job.schedule.at_ms,
+                        "expr": job.schedule.expr,
+                        "tz": job.schedule.tz,
+                    },
+                },
+            },
+        )
+        assert response.status_code == 200
+        row = next(item for item in response.json()["jobs"] if item["id"] == job.id)
+        assert row["name"] == "Updated report"
+        assert row["payload"]["message"] == "Include the latest figures"
+        assert row["state"]["next_run_at_ms"] == due_at
+        persisted = CronService(cron.store_path).get_job(job.id)
+        assert persisted is not None
+        assert persisted.state.next_run_at_ms == due_at
+    finally:
+        await channel.stop()
+
+
+@pytest.mark.asyncio
 async def test_webui_automations_route_lists_all_jobs_and_allows_user_actions(
     bus: MagicMock, tmp_path: Path
 ) -> None:

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -809,6 +809,7 @@ class CronService:
 
         For ``channel`` and ``to``, pass an explicit value (including ``None``)
         to update; omit (sentinel ``...``) to leave unchanged.
+        Preserve the next occurrence unless the schedule actually changes.
         """
         store = self._require_store()
         job = next((j for j in store.jobs if j.id == job_id), None)
@@ -817,6 +818,7 @@ class CronService:
         if job.payload.kind == "system_event":
             return "protected"
 
+        schedule_changed = schedule is not None and schedule != job.schedule
         if schedule is not None:
             _validate_schedule_for_add(schedule)
             job.schedule = schedule
@@ -836,10 +838,10 @@ class CronService:
         self._enforce_agent_binding(job)
 
         job.updated_at_ms = _now_ms()
-        if job.enabled:
-            job.state.next_run_at_ms = _compute_next_run(job.schedule, _now_ms())
-        else:
+        if not job.enabled:
             job.state.next_run_at_ms = None
+        elif schedule_changed:
+            job.state.next_run_at_ms = _compute_next_run(job.schedule, _now_ms())
 
         if self._should_persist_store():
             self._save_store()

--- a/tests/cron/test_cron_edit_deadlines.py
+++ b/tests/cron/test_cron_edit_deadlines.py
@@ -1,0 +1,66 @@
+"""Editing task instructions must not postpone or drop an existing occurrence."""
+
+from dataclasses import replace
+
+import pytest
+
+from nanobot.cron.service import CronService
+from nanobot.cron.types import CronJob, CronSchedule
+
+
+@pytest.mark.parametrize("kind", ["every", "cron", "at"])
+@pytest.mark.parametrize("resend_schedule", [False, True])
+async def test_metadata_edit_preserves_due_occurrence(tmp_path, monkeypatch, kind, resend_schedule):
+    now = 1_900_000_000_000
+    monkeypatch.setattr("nanobot.cron.service._now_ms", lambda: now)
+    schedules = {
+        "every": CronSchedule(kind="every", every_ms=60_000),
+        "cron": CronSchedule(kind="cron", expr="* * * * *", tz="UTC"),
+        "at": CronSchedule(kind="at", at_ms=now + 60_000),
+    }
+    store_path = tmp_path / "cron" / "jobs.json"
+    service = CronService(store_path)
+    job = service.add_job(
+        name="Daily report",
+        schedule=schedules[kind],
+        message="Summarize yesterday",
+        session_key="websocket:report",
+        origin_channel="websocket",
+        origin_chat_id="report",
+        delete_after_run=kind == "at",
+    )
+    due_at = job.state.next_run_at_ms
+    assert due_at is not None
+    now = due_at + 1_000
+
+    updated = service.update_job(
+        job.id,
+        name="Updated report",
+        message="Include the latest figures",
+        schedule=replace(job.schedule) if resend_schedule else None,
+    )
+    assert isinstance(updated, CronJob)
+    assert updated.state.next_run_at_ms == due_at
+
+    calls = []
+
+    async def execute(job):
+        calls.append((job.id, job.name, job.payload.message))
+
+    # A separate service consumes the persisted edit, as the gateway does.
+    reader = CronService(store_path, on_job=execute)
+    loaded = reader.get_job(job.id)
+    assert loaded is not None
+    assert loaded.state.next_run_at_ms == due_at
+    await reader._on_timer()
+    await reader._on_timer()
+    assert calls == [(job.id, "Updated report", "Include the latest figures")]
+
+    finished = reader.get_job(job.id)
+    if kind == "at":
+        assert finished is None
+    else:
+        assert finished is not None
+        assert finished.state.next_run_at_ms > now
+        assert len(finished.state.run_history) == 1
+        assert finished.state.last_status == "ok"


### PR DESCRIPTION
Editing an automation's name or instructions currently recomputes its next occurrence even when its schedule has not changed. An interval task is postponed, a due cron occurrence is skipped, and a due one-time task gets `next_run_at_ms=None` and never executes. The WebUI accepts the edit and displays the changed task, so the lost occurrence is easy to miss.

For example, create a one-time report for 09:00, then edit its instructions just after 09:00 before the scheduler processes it. The original pending deadline should remain eligible; the current update path clears it instead.

## Changes

- Recompute the next occurrence only when the schedule actually changes. Metadata-only edits and resubmitting an equal `CronSchedule` preserve the existing deadline.
- Keep disabled jobs unscheduled and retain the existing validation and rescheduling behavior for genuine schedule edits.
- Add six service regression cases across interval, cron, and one-time jobs, with and without resubmitting the same schedule. They reload the persisted edit, execute the due job with the updated instructions, and verify it is not executed twice.
- Add three WebUI mutation regressions using the normal edit payload, checking both the response and reloaded task state.

This does not alter timer ownership, retry policies, or the treatment of newly created past-dated jobs. The separate open #5686 addresses timer cancellation during edits; this patch addresses the deadline recomputation in `update_job`.

## Validation

Windows, Python 3.12; base `19c3db55ce0343b15e5d013413f074dd982219ae`.

Before the production fix:

```text
pytest tests/cron/test_cron_edit_deadlines.py -q
6 failed

pytest nanobot/channels/websocket/tests/test_websocket_http_routes.py -k automation_edit_keeps_pending_run -q
3 failed, 103 deselected
```

All nine failures are deadline mismatches, including `None` for the one-time task. After the fix:

```text
pytest tests/cron nanobot/channels/websocket/tests/test_websocket_http_routes.py -q
233 passed

ruff check nanobot tests conftest.py
All checks passed!

basedpyright --pythonpath .venv/Scripts/python.exe nanobot/cron/service.py
0 errors, 0 warnings, 0 notes
```

Tests use a fixed clock, temporary job storage, and a local callback; they make no model requests or external channel sends. The WebUI tests exercise the gateway mutation handler in process, not a browser. The full repository suite and Linux/macOS execution were not run locally.

Found through source inspection; implemented and verified with AI assistance. No new dependencies, configuration options, or unrelated formatting changes.
